### PR TITLE
Resaved Presets Under 49.19

### DIFF
--- a/MekHQ/mmconf/campaignPresets/AtB.xml
+++ b/MekHQ/mmconf/campaignPresets/AtB.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<campaignPreset version="0.49.12-SNAPSHOT">
+<campaignPreset version="0.49.19-SNAPSHOT">
 	<title>AtB - Official Options</title>
 	<description>(Release 2) These are the default settings for the Against the Bot campaign system. As always, please feel free to change them to what you like for your style of play. Also, note that using the AtB Starter Guide preset initially is highly recommended.</description>
 	<date>3025-01-01</date>
@@ -13,6 +13,97 @@
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
+		<mrmsUseRepair>true</mrmsUseRepair>
+		<mrmsUseSalvage>true</mrmsUseSalvage>
+		<mrmsUseExtraTime>true</mrmsUseExtraTime>
+		<mrmsUseRushJob>true</mrmsUseRushJob>
+		<mrmsAllowCarryover>true</mrmsAllowCarryover>
+		<mrmsOptimizeToCompleteToday>false</mrmsOptimizeToCompleteToday>
+		<mrmsScrapImpossible>false</mrmsScrapImpossible>
+		<mrmsUseAssignedTechsFirst>false</mrmsUseAssignedTechsFirst>
+		<mrmsReplacePod>true</mrmsReplacePod>
+		<mrmsOptions>
+			<mrmsOption>
+				<type>ARMOUR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>AMMUNITION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>WEAPON</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL_LOCATION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ENGINE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GYRO</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ACTUATOR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ELECTRONICS</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>POD_SPACE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+		</mrmsOptions>
 		<useFactionForNames>true</useFactionForNames>
 		<unitRatingMethod>FLD_MAN_MERCS_REV</unitRatingMethod>
 		<useEraMods>false</useEraMods>
@@ -61,9 +152,9 @@
 		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
 		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>5.0</equipmentContractPercent>
-		<dropshipContractPercent>1.0</dropshipContractPercent>
-		<jumpshipContractPercent>0.0</jumpshipContractPercent>
-		<warshipContractPercent>0.0</warshipContractPercent>
+		<dropShipContractPercent>1.0</dropShipContractPercent>
+		<jumpShipContractPercent>0.0</jumpShipContractPercent>
+		<warShipContractPercent>0.0</warShipContractPercent>
 		<equipmentContractBase>true</equipmentContractBase>
 		<equipmentContractSaleValue>true</equipmentContractSaleValue>
 		<blcSaleValue>true</blcSaleValue>
@@ -78,7 +169,7 @@
 		<maintenanceBonus>0</maintenanceBonus>
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>false</reverseQualityNames>
-		<useUnofficalMaintenance>true</useUnofficalMaintenance>
+		<useUnofficialMaintenance>true</useUnofficialMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<maxAcquisitions>2</maxAcquisitions>
 		<useTactics>true</useTactics>
@@ -130,7 +221,7 @@
 		<useCustomRetirementModifiers>true</useCustomRetirementModifiers>
 		<useRandomFounderRetirement>false</useRandomFounderRetirement>
 		<trackUnitFatigue>true</trackUnitFatigue>
-		<displayFamilyLevel>PARENTS_CHILDREN_SIBLINGS</displayFamilyLevel>
+		<familyDisplayLevel>PARENTS_CHILDREN_SIBLINGS</familyDisplayLevel>
 		<randomDependentMethod>AGAINST_THE_BOT</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
@@ -138,54 +229,63 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
+		<salaryXPMultipliers>
+			<VETERAN>1.6</VETERAN>
+			<ULTRA_GREEN>0.6</ULTRA_GREEN>
+			<LEGENDARY>12.8</LEGENDARY>
+			<ELITE>3.2</ELITE>
+			<GREEN>0.6</GREEN>
+			<NONE>0.5</NONE>
+			<HEROIC>6.4</HEROIC>
+			<REGULAR>1.0</REGULAR>
+		</salaryXPMultipliers>
 		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
-		<useClannerMarriages>false</useClannerMarriages>
+		<useClanPersonnelMarriages>false</useClanPersonnelMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChanges>true</logMarriageNameChanges>
 		<marriageSurnameWeights>
-			<SPACE_YOURS>10</SPACE_YOURS>
-			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
-			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
-			<SPACE_SPOUSE>10</SPACE_SPOUSE>
-			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
-			<NO_CHANGE>100</NO_CHANGE>
-			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
-			<SPOUSE>55</SPOUSE>
-			<HYPHEN_YOURS>30</HYPHEN_YOURS>
 			<YOURS>55</YOURS>
 			<MALE>500</MALE>
-			<FEMALE>160</FEMALE>
+			<SPOUSE>55</SPOUSE>
+			<NO_CHANGE>100</NO_CHANGE>
 			<BOTH_SPACE_SPOUSE>5</BOTH_SPACE_SPOUSE>
+			<FEMALE>160</FEMALE>
+			<HYPHEN_YOURS>30</HYPHEN_YOURS>
+			<SPACE_YOURS>10</SPACE_YOURS>
+			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
+			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
+			<SPACE_SPOUSE>10</SPACE_SPOUSE>
+			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
+			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
 		</marriageSurnameWeights>
 		<randomMarriageMethod>PERCENTAGE</randomMarriageMethod>
 		<useRandomSameSexMarriages>true</useRandomSameSexMarriages>
-		<useRandomClannerMarriages>false</useRandomClannerMarriages>
+		<useRandomClanPersonnelMarriages>false</useRandomClanPersonnelMarriages>
 		<useRandomPrisonerMarriages>true</useRandomPrisonerMarriages>
 		<randomMarriageAgeRange>10</randomMarriageAgeRange>
 		<percentageRandomMarriageOppositeSexChance>2.5E-4</percentageRandomMarriageOppositeSexChance>
 		<percentageRandomMarriageSameSexChance>2.0E-5</percentageRandomMarriageSameSexChance>
 		<useManualDivorce>true</useManualDivorce>
-		<useClannerDivorce>true</useClannerDivorce>
+		<useClanPersonnelDivorce>true</useClanPersonnelDivorce>
 		<usePrisonerDivorce>false</usePrisonerDivorce>
 		<divorceSurnameWeights>
-			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
-			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 			<SPOUSE_CHANGES_SURNAME>10</SPOUSE_CHANGES_SURNAME>
 			<BOTH_CHANGE_SURNAME>30</BOTH_CHANGE_SURNAME>
+			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
+			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 		</divorceSurnameWeights>
 		<randomDivorceMethod>NONE</randomDivorceMethod>
 		<useRandomOppositeSexDivorce>true</useRandomOppositeSexDivorce>
 		<useRandomSameSexDivorce>true</useRandomSameSexDivorce>
-		<useRandomClannerDivorce>true</useRandomClannerDivorce>
+		<useRandomClanPersonnelDivorce>true</useRandomClanPersonnelDivorce>
 		<useRandomPrisonerDivorce>false</useRandomPrisonerDivorce>
 		<percentageRandomDivorceOppositeSexChance>1.0E-6</percentageRandomDivorceOppositeSexChance>
 		<percentageRandomDivorceSameSexChance>1.0E-6</percentageRandomDivorceSameSexChance>
 		<useManualProcreation>true</useManualProcreation>
-		<useClannerProcreation>false</useClannerProcreation>
+		<useClanPersonnelProcreation>false</useClanPersonnelProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
 		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
@@ -196,20 +296,20 @@
 		<logProcreation>true</logProcreation>
 		<randomProcreationMethod>PERCENTAGE</randomProcreationMethod>
 		<useRelationshiplessRandomProcreation>true</useRelationshiplessRandomProcreation>
-		<useRandomClannerProcreation>false</useRandomClannerProcreation>
+		<useRandomClanPersonnelProcreation>false</useRandomClanPersonnelProcreation>
 		<useRandomPrisonerProcreation>true</useRandomPrisonerProcreation>
 		<percentageRandomProcreationRelationshipChance>5.0E-4</percentageRandomProcreationRelationshipChance>
 		<percentageRandomProcreationRelationshiplessChance>5.0E-5</percentageRandomProcreationRelationshiplessChance>
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
 		<randomDeathMethod>EXPONENTIAL</randomDeathMethod>
 		<enabledRandomDeathAgeGroups>
-			<CHILD>false</CHILD>
-			<ELDER>true</ELDER>
 			<TEENAGER>true</TEENAGER>
-			<BABY>false</BABY>
-			<TODDLER>false</TODDLER>
 			<PRETEEN>false</PRETEEN>
+			<CHILD>false</CHILD>
+			<TODDLER>false</TODDLER>
 			<ADULT>true</ADULT>
+			<ELDER>true</ELDER>
+			<BABY>false</BABY>
 		</enabledRandomDeathAgeGroups>
 		<useRandomClanPersonnelDeath>true</useRandomClanPersonnelDeath>
 		<useRandomPrisonerDeath>true</useRandomPrisonerDeath>
@@ -218,30 +318,30 @@
 		<exponentialRandomDeathMaleValues>5.4757,-7.0,0.0709</exponentialRandomDeathMaleValues>
 		<exponentialRandomDeathFemaleValues>2.4641,-7.0,0.0752</exponentialRandomDeathFemaleValues>
 		<ageRangeRandomDeathMaleValues>
-			<UNDER_ONE>613.1</UNDER_ONE>
+			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>249.5</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>27.5</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>613.1</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>1119.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>14504.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>27.5</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathMaleValues>
 		<ageRangeRandomDeathFemaleValues>
-			<UNDER_ONE>500.0</UNDER_ONE>
+			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>140.2</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>20.4</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>500.0</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>670.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>12870.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>20.4</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathFemaleValues>
 		<payForParts>true</payForParts>
 		<payForRepairs>false</payForRepairs>
@@ -273,21 +373,30 @@
 		<cancelledOrderRefundMultiplier>0.5</cancelledOrderRefundMultiplier>
 		<personnelMarketName>Against the Bot</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
-		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
-		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
-		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
-		<personnelMarketRandomGreenRemoval>4</personnelMarketRandomGreenRemoval>
-		<personnelMarketRandomUltraGreenRemoval>4</personnelMarketRandomUltraGreenRemoval>
+		<personnelMarketRandomRemovalTargets>
+			<VETERAN>8</VETERAN>
+			<ULTRA_GREEN>4</ULTRA_GREEN>
+			<LEGENDARY>11</LEGENDARY>
+			<ELITE>10</ELITE>
+			<GREEN>4</GREEN>
+			<NONE>3</NONE>
+			<HEROIC>11</HEROIC>
+			<REGULAR>6</REGULAR>
+		</personnelMarketRandomRemovalTargets>
 		<personnelMarketDylansWeight>0.3</personnelMarketDylansWeight>
 		<unitMarketMethod>ATB_MONTHLY</unitMarketMethod>
 		<unitMarketRegionalMechVariations>true</unitMarketRegionalMechVariations>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<contractMarketMethod>ATB_MONTHLY</contractMarketMethod>
+		<contractSearchRadius>800</contractSearchRadius>
+		<variableContractLength>true</variableContractLength>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
+		<contractMaxSalvagePercentage>100</contractMaxSalvagePercentage>
 		<useStaticRATs>false</useStaticRATs>
 		<rats>Xotl,Total Warfare</rats>
 		<ignoreRATEra>false</ignoreRATEra>
+		<skillLevel>REGULAR</skillLevel>
 		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<useAtB>true</useAtB>
 		<useStratCon>false</useStratCon>
@@ -296,12 +405,11 @@
 		<clanVehicles>true</clanVehicles>
 		<doubleVehicles>false</doubleVehicles>
 		<adjustPlayerVehicles>true</adjustPlayerVehicles>
-		<opforLanceTypeMechs>1</opforLanceTypeMechs>
-		<opforLanceTypeMixed>2</opforLanceTypeMixed>
-		<opforLanceTypeVehicles>3</opforLanceTypeVehicles>
-		<opforUsesVTOLs>true</opforUsesVTOLs>
+		<opForLanceTypeMechs>1</opForLanceTypeMechs>
+		<opForLanceTypeMixed>2</opForLanceTypeMixed>
+		<opForLanceTypeVehicles>3</opForLanceTypeVehicles>
+		<opForUsesVTOLs>true</opForUsesVTOLs>
 		<useDropShips>false</useDropShips>
-		<skillLevel>2</skillLevel>
 		<aeroRecruitsHaveUnits>true</aeroRecruitsHaveUnits>
 		<useShareSystem>true</useShareSystem>
 		<sharesExcludeLargeCraft>true</sharesExcludeLargeCraft>
@@ -311,10 +419,8 @@
 		<regionalMechVariations>true</regionalMechVariations>
 		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
 		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
-		<searchRadius>800</searchRadius>
 		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>true</generateChases>
-		<variableContractLength>true</variableContractLength>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
 		<usePlanetaryConditions>true</usePlanetaryConditions>
@@ -327,103 +433,12 @@
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>true</assignPortraitOnRoleChange>
-		<allowOpforAeros>false</allowOpforAeros>
-		<allowOpforLocalUnits>false</allowOpforLocalUnits>
-		<opforAeroChance>5</opforAeroChance>
-		<opforLocalUnitChance>5</opforLocalUnitChance>
+		<allowOpForAeros>false</allowOpForAeros>
+		<allowOpForLocalUnits>false</allowOpForLocalUnits>
+		<opForAeroChance>5</opForAeroChance>
+		<opForLocalUnitChance>5</opForLocalUnitChance>
 		<fixedMapChance>25</fixedMapChance>
 		<spaUpgradeIntensity>0</spaUpgradeIntensity>
-		<massRepairUseRepair>true</massRepairUseRepair>
-		<massRepairUseSalvage>true</massRepairUseSalvage>
-		<massRepairUseExtraTime>true</massRepairUseExtraTime>
-		<massRepairUseRushJob>true</massRepairUseRushJob>
-		<massRepairAllowCarryover>true</massRepairAllowCarryover>
-		<massRepairOptimizeToCompleteToday>false</massRepairOptimizeToCompleteToday>
-		<massRepairScrapImpossible>false</massRepairScrapImpossible>
-		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
-		<massRepairReplacePod>true</massRepairReplacePod>
-		<massRepairOptions>
-			<massRepairOption>
-				<type>ARMOUR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>AMMUNITION</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>WEAPON</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL_LOCATION</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ENGINE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GYRO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ACTUATOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ELECTRONICS</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>POD_SPACE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-		</massRepairOptions>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
 		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
@@ -768,209 +783,6 @@
 	</skillTypes>
 	<specialAbilities>
 		<ability>
-			<displayName>Eagle&apos;s Eyes (aToW)</displayName>
-			<lookupName>eagle_eyes</lookupName>
-			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
-			<xpCost>20</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>Jumping Jack (aToW)</displayName>
-			<lookupName>jumping_jack</lookupName>
-			<desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>40</xpCost>
-			<weight>10</weight>
-			<prereqAbilities>hopping_jack</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities>hopping_jack</removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>Multi-Tasker (aToW)</displayName>
-			<lookupName>multi_tasker</lookupName>
-			<desc>Secondary target modifiers are reduced by one.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Sandblaster (AToW)</displayName>
-			<lookupName>sandblaster</lookupName>
-			<desc>A pilot with this ability gets a +4, +3, or +2 to the cluster table
-at short, medium, or long/extended range, respectively, but only with a specialized weapon.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_hitter::cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Clan Tech Knowledge (Unofficial)</displayName>
-			<lookupName>clan_tech_knowledge</lookupName>
-			<desc>Can work on clan equipment without penalty</desc>
-			<xpCost>40</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel</skill>
-				<skill>Tech/Aero</skill>
-				<skill>Tech/BA</skill>
-				<skill>Tech/Mechanic</skill>
-				<skill>Tech/Mech</skill>
-			</skillPrereq>
-			<miscPrereq>clanperson:false</miscPrereq>
-		</ability>
-		<ability>
-			<displayName>Tactical Genius (aToW)</displayName>
-			<lookupName>tactical_genius</lookupName>
-			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
- The second roll must be accepted.
-Note: Only one Tactical Genius may be utilized per team.</desc>
-			<xpCost>-1</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tactics::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
-			<lookupName>tm_forest_ranger</lookupName>
-			<desc>Movement in woods or jungle costs 1 less MP.
-Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
-Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
-			<xpCost>60</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-				<skill>Gunnery/ProtoMech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Dodge (MaxTech)</displayName>
-			<lookupName>dodge_maneuver</lookupName>
-			<desc>Enables the unit to make a dodge maneuver instead of a physical attack.
-This maneuver adds +2 to the BTH to physical attacks against the unit.
-NOTE: The dodge maneuver is declared during the weapons phase.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>20</xpCost>
-			<weight>10</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
-			<lookupName>tech_armor_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with armor</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Golden Goose (aToW)</displayName>
-			<lookupName>golden_goose</lookupName>
-			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
-			<xpCost>40</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Sniper (aToW)</displayName>
-			<lookupName>sniper</lookupName>
-			<desc>Range penalties are halved.</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/ProtoMech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Mountaineer] (CamOps)</displayName>
-			<lookupName>tm_mountaineer</lookupName>
-			<desc>Movement in rubble or rough cost 1 less MP and elevation changes also cost 1 MP less.
-The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
-			<xpCost>40</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-				<skill>Gunnery/ProtoMech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Weapon Specialist (aToW)</displayName>
 			<lookupName>weapon_specialist</lookupName>
 			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
@@ -981,100 +793,13 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Natural Aptitude, Gunnery (aToW)</displayName>
-			<lookupName>aptitude_gunnery</lookupName>
-			<desc>Roll 3d6 and take the best two for gunnery checks</desc>
-			<xpCost>-1</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft</skill>
-				<skill>Gunnery/Battlesuit</skill>
-				<skill>Gunnery/Aerospace</skill>
-				<skill>Gunnery/Spacecraft</skill>
-				<skill>Gunnery/Mech</skill>
-				<skill>Gunnery/Vehicle</skill>
-				<skill>Gunnery/ProtoMech</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Mr/Ms Fix-it (unofficial)</displayName>
-			<lookupName>tech_fixer</lookupName>
-			<desc>Ignore first point of penalty for repair and maintenance on low quality equipment</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Forward Observer (aToW)</displayName>
-			<lookupName>forward_observer</lookupName>
-			<desc>Improves the accuracy of your artillery. Fire Adjustment gets a -2 modifier. Spotting gets an additional -1 tohit modifier for each point of gunnery below 4.</desc>
-			<xpCost>60</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Artillery::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Shaky Stick (aToW)</displayName>
-			<lookupName>shaky_stick</lookupName>
-			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
-			<xpCost>20</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Hitter (AToW)</displayName>
-			<lookupName>cluster_hitter</lookupName>
-			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1095,55 +820,55 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Weathered (Unofficial)</displayName>
-			<lookupName>weathered</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<displayName>Cluster Master (AToW)</displayName>
+			<lookupName>cluster_master</lookupName>
+			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
 			<xpCost>60</xpCost>
 			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
+			<prereqAbilities>cluster_hitter</prereqAbilities>
 			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
+			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
-			<lookupName>tm_frogman</lookupName>
-			<desc>Movement in depth 2 or greater water costs 1 MP less.
-Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
-			<xpCost>40</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/ProtoMech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Some Like It Hot (Unofficial)</displayName>
-			<lookupName>some_like_it_hot</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
+			<displayName>Natural Aptitude, Piloting (aToW)</displayName>
+			<lookupName>aptitude_piloting</lookupName>
+			<desc>Roll 3d6 and take the best two for piloting checks</desc>
+			<xpCost>-1</xpCost>
+			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Jumping Jack (aToW)</displayName>
+			<lookupName>jumping_jack</lookupName>
+			<desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
+			<xpCost>40</xpCost>
+			<weight>10</weight>
+			<prereqAbilities>hopping_jack</prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities>hopping_jack</removeAbilities>
+			<choiceValues></choiceValues>
 		</ability>
 		<ability>
 			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
@@ -1157,10 +882,379 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Multi-Tasker (aToW)</displayName>
+			<lookupName>multi_tasker</lookupName>
+			<desc>Secondary target modifiers are reduced by one.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Sandblaster (AToW)</displayName>
+			<lookupName>sandblaster</lookupName>
+			<desc>A pilot with this ability gets a +4, +3, or +2 to the cluster table
+at short, medium, or long/extended range, respectively, but only with a specialized weapon.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>cluster_hitter::cluster_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Clan Tech Knowledge (Unofficial)</displayName>
+			<lookupName>clan_tech_knowledge</lookupName>
+			<desc>Can work on clan equipment without penalty</desc>
+			<xpCost>40</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel</skill>
+				<skill>Tech/BA</skill>
+				<skill>Tech/Aero</skill>
+				<skill>Tech/Mechanic</skill>
+				<skill>Tech/Mech</skill>
+			</skillPrereq>
+			<miscPrereq>clanperson:false</miscPrereq>
+		</ability>
+		<ability>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>40</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Hot Dog (aToW)</displayName>
+			<lookupName>hot_dog</lookupName>
+			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Dodge (MaxTech)</displayName>
+			<lookupName>dodge_maneuver</lookupName>
+			<desc>Enables the unit to make a dodge maneuver instead of a physical attack.
+This maneuver adds +2 to the BTH to physical attacks against the unit.
+NOTE: The dodge maneuver is declared during the weapons phase.
+Note: This ability is only used for BattleMechs.</desc>
+			<xpCost>20</xpCost>
+			<weight>10</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Pain Resistance (MaxTech)</displayName>
+			<lookupName>pain_resistance</lookupName>
+			<desc>When making consciousness rolls,
+1 is added to all rolls.
+Also,
+damage received from ammo explosions is reduced to 1.
+Note: This ability is only used for BattleMechs.</desc>
+			<xpCost>20</xpCost>
+			<weight>10</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Sniper (aToW)</displayName>
+			<lookupName>sniper</lookupName>
+			<desc>Range penalties are halved.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/ProtoMech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Maneuvering Ace (aToW)</displayName>
+			<lookupName>maneuvering_ace</lookupName>
+			<desc>Enables the unit to move laterally like a Quad.
+Quads can move laterally for 1 less MP.
+Aerospace units can perform maneuvers for 1 less thrust point.
+Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Veteran</skill>
+				<skill>Piloting/Naval::Veteran</skill>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/VTOL::Veteran</skill>
+				<skill>Piloting/Aircraft::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Mountaineer] (CamOps)</displayName>
+			<lookupName>tm_mountaineer</lookupName>
+			<desc>Movement in rubble or rough cost 1 less MP and elevation changes also cost 1 MP less.
+The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
+			<xpCost>40</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Gunnery/ProtoMech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Mr/Ms Fix-it (unofficial)</displayName>
+			<lookupName>tech_fixer</lookupName>
+			<desc>Ignore first point of penalty for repair and maintenance on low quality equipment</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Eagle&apos;s Eyes (aToW)</displayName>
+			<lookupName>eagle_eyes</lookupName>
+			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
+			<xpCost>20</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+		</ability>
+		<ability>
+			<displayName>Oblique Artilleryman (aToW)</displayName>
+			<lookupName>oblique_artillery</lookupName>
+			<desc>Reduces scatter distance by two hexes.</desc>
+			<xpCost>20</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
+			<lookupName>tm_forest_ranger</lookupName>
+			<desc>Movement in woods or jungle costs 1 less MP.
+Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
+Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
+			<xpCost>60</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Gunnery/ProtoMech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Engineer (unofficial)</displayName>
+			<lookupName>tech_engineer</lookupName>
+			<desc>-2 on refit rolls</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Veteran</skill>
+				<skill>Tech/BA::Veteran</skill>
+				<skill>Tech/Aero::Veteran</skill>
+				<skill>Tech/Mechanic::Veteran</skill>
+				<skill>Tech/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Melee Master (aToW)</displayName>
+			<lookupName>melee_master</lookupName>
+			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
+			<xpCost>20</xpCost>
+			<weight>10</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Forward Observer (aToW)</displayName>
+			<lookupName>forward_observer</lookupName>
+			<desc>Improves the accuracy of your artillery. Fire Adjustment gets a -2 modifier. Spotting gets an additional -1 tohit modifier for each point of gunnery below 4.</desc>
+			<xpCost>60</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Artillery::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Human TRO (CamOps)</displayName>
+			<lookupName>human_tro</lookupName>
+			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Small Arms::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tactical Genius (aToW)</displayName>
+			<lookupName>tactical_genius</lookupName>
+			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
+ The second roll must be accepted.
+Note: Only one Tactical Genius may be utilized per team.</desc>
+			<xpCost>-1</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tactics::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1182,6 +1276,97 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Natural Aptitude, Gunnery (aToW)</displayName>
+			<lookupName>aptitude_gunnery</lookupName>
+			<desc>Roll 3d6 and take the best two for gunnery checks</desc>
+			<xpCost>-1</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit</skill>
+				<skill>Gunnery/Aircraft</skill>
+				<skill>Gunnery/Spacecraft</skill>
+				<skill>Gunnery/Aerospace</skill>
+				<skill>Gunnery/ProtoMech</skill>
+				<skill>Gunnery/Vehicle</skill>
+				<skill>Gunnery/Mech</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>20</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Weathered (Unofficial)</displayName>
+			<lookupName>weathered</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>All Weather (Unofficial)</displayName>
+			<lookupName>allweather</lookupName>
+			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1214,111 +1399,12 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Maneuvering Ace (aToW)</displayName>
-			<lookupName>maneuvering_ace</lookupName>
-			<desc>Enables the unit to move laterally like a Quad.
-Quads can move laterally for 1 less MP.
-Aerospace units can perform maneuvers for 1 less thrust point.
-Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Veteran</skill>
-				<skill>Piloting/Naval::Veteran</skill>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/VTOL::Veteran</skill>
-				<skill>Piloting/Aircraft::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Oblique Artilleryman (aToW)</displayName>
-			<lookupName>oblique_artillery</lookupName>
-			<desc>Reduces scatter distance by two hexes.</desc>
-			<xpCost>20</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>Melee Master (aToW)</displayName>
-			<lookupName>melee_master</lookupName>
-			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-			<xpCost>20</xpCost>
-			<weight>10</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Zweihander (CamOps)</displayName>
-			<lookupName>zweihander</lookupName>
-			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-			<xpCost>20</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities>melee_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Master (AToW)</displayName>
-			<lookupName>cluster_master</lookupName>
-			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities>cluster_hitter</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities>cluster_hitter</removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/ProtoMech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Animal Mimicry (CamOps)</displayName>
-			<lookupName>animal_mimic</lookupName>
-			<desc>Allows a Quad Mech or ProtoMech, or a bipedal Mech or ProtoMech with the animalistic quirk, the following benefits.
--1 MP per hex of Woods and Jungle terrain.
- In addition quads gain a -1 to any quad related PSR check.
-NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
-			<xpCost>40</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1337,120 +1423,6 @@ Note: This ability is only used for BattleMechs.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Gunnery Specialization (aToW)</displayName>
-			<lookupName>specialist</lookupName>
-			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
- +1 to-hit modifier when using other types of weapons.</desc>
-			<xpCost>40</xpCost>
-			<weight>12</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>weapon_specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Human TRO (CamOps)</displayName>
-			<lookupName>human_tro</lookupName>
-			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Small Arms::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Pain Resistance (MaxTech)</displayName>
-			<lookupName>pain_resistance</lookupName>
-			<desc>When making consciousness rolls,
-1 is added to all rolls.
-Also,
-damage received from ammo explosions is reduced to 1.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>20</xpCost>
-			<weight>10</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>All Weather (Unofficial)</displayName>
-			<lookupName>allweather</lookupName>
-			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hot Dog (aToW)</displayName>
-			<lookupName>hot_dog</lookupName>
-			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Engineer (unofficial)</displayName>
-			<lookupName>tech_engineer</lookupName>
-			<desc>-2 on refit rolls</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Veteran</skill>
-				<skill>Tech/Aero::Veteran</skill>
-				<skill>Tech/BA::Veteran</skill>
-				<skill>Tech/Mechanic::Veteran</skill>
-				<skill>Tech/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Terrain Master [Swamp Beast] (CamOps)</displayName>
 			<lookupName>tm_swamp_beast</lookupName>
 			<desc>Movement in mud or swamp costs 1 less MP.
@@ -1463,8 +1435,110 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
 				<skill>Gunnery/ProtoMech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Gunnery Specialization (aToW)</displayName>
+			<lookupName>specialist</lookupName>
+			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
+ +1 to-hit modifier when using other types of weapons.</desc>
+			<xpCost>40</xpCost>
+			<weight>12</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Hitter (AToW)</displayName>
+			<lookupName>cluster_hitter</lookupName>
+			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>cluster_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Some Like It Hot (Unofficial)</displayName>
+			<lookupName>some_like_it_hot</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Golden Goose (aToW)</displayName>
+			<lookupName>golden_goose</lookupName>
+			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
+			<xpCost>40</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
+			<lookupName>tm_frogman</lookupName>
+			<desc>Movement in depth 2 or greater water costs 1 MP less.
+Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
+			<xpCost>40</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/ProtoMech::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Shaky Stick (aToW)</displayName>
+			<lookupName>shaky_stick</lookupName>
+			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
+			<xpCost>20</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1482,80 +1556,21 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Natural Aptitude, Piloting (aToW)</displayName>
-			<lookupName>aptitude_piloting</lookupName>
-			<desc>Roll 3d6 and take the best two for piloting checks</desc>
-			<xpCost>-1</xpCost>
+			<displayName>Animal Mimicry (CamOps)</displayName>
+			<lookupName>animal_mimic</lookupName>
+			<desc>Allows a Quad Mech or ProtoMech, or a bipedal Mech or ProtoMech with the animalistic quirk, the following benefits.
+-1 MP per hex of Woods and Jungle terrain.
+ In addition quads gain a -1 to any quad related PSR check.
+NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
+			<xpCost>40</xpCost>
 			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-			<xpCost>40</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
-			<lookupName>tech_weapon_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with weapons</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>

--- a/MekHQ/mmconf/campaignPresets/AtBStarterGuidev40.xml
+++ b/MekHQ/mmconf/campaignPresets/AtBStarterGuidev40.xml
@@ -1,17 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<campaignPreset version="0.49.8-SNAPSHOT">
+<campaignPreset version="0.49.19-SNAPSHOT">
 	<title>AtB - Starter Guide v4.0</title>
-	<description>This is the AtB Starter Guide Preset, and highly recommend for new and learning players. It implements the options as per CampaignAnon's AtB Starter Guide v4.0, as found in \docs\AtB Stuff\. v4.0 Changes: Updating some options based on recent MekHQ changes, and providing a unified starting Year, Era, and Location</description>
+	<description>This is the AtB Starter Guide Preset, and highly recommend for new and learning players. It implements the options as per CampaignAnon&apos;s AtB Starter Guide v4.0, as found in \docs\AtB Stuff\. v4.0 Changes: Updating some options based on recent MekHQ changes, and providing a unified starting Year, Era, and Location</description>
 	<date>3035-01-01</date>
 	<faction>MERC</faction>
 	<planet system="Galatea">Galatea</planet>
 	<rankSystem>
 		<code>SLDF</code>
 	</rankSystem>
-	<contractCount>5</contractCount>
+	<contractCount>2</contractCount>
+	<gm>false</gm>
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
+		<mrmsUseRepair>true</mrmsUseRepair>
+		<mrmsUseSalvage>true</mrmsUseSalvage>
+		<mrmsUseExtraTime>true</mrmsUseExtraTime>
+		<mrmsUseRushJob>true</mrmsUseRushJob>
+		<mrmsAllowCarryover>true</mrmsAllowCarryover>
+		<mrmsOptimizeToCompleteToday>false</mrmsOptimizeToCompleteToday>
+		<mrmsScrapImpossible>false</mrmsScrapImpossible>
+		<mrmsUseAssignedTechsFirst>false</mrmsUseAssignedTechsFirst>
+		<mrmsReplacePod>true</mrmsReplacePod>
+		<mrmsOptions>
+			<mrmsOption>
+				<type>ARMOUR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>AMMUNITION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>WEAPON</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL_LOCATION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ENGINE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GYRO</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ACTUATOR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ELECTRONICS</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>POD_SPACE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+		</mrmsOptions>
 		<useFactionForNames>true</useFactionForNames>
 		<unitRatingMethod>CAMPAIGN_OPS</unitRatingMethod>
 		<useEraMods>false</useEraMods>
@@ -60,9 +152,9 @@
 		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
 		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>5.0</equipmentContractPercent>
-		<dropshipContractPercent>1.0</dropshipContractPercent>
-		<jumpshipContractPercent>0.0</jumpshipContractPercent>
-		<warshipContractPercent>0.0</warshipContractPercent>
+		<dropShipContractPercent>1.0</dropShipContractPercent>
+		<jumpShipContractPercent>0.0</jumpShipContractPercent>
+		<warShipContractPercent>0.0</warShipContractPercent>
 		<equipmentContractBase>true</equipmentContractBase>
 		<equipmentContractSaleValue>true</equipmentContractSaleValue>
 		<blcSaleValue>true</blcSaleValue>
@@ -77,7 +169,7 @@
 		<maintenanceBonus>-1</maintenanceBonus>
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>true</reverseQualityNames>
-		<useUnofficalMaintenance>true</useUnofficalMaintenance>
+		<useUnofficialMaintenance>true</useUnofficialMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<maxAcquisitions>10</maxAcquisitions>
 		<useTactics>true</useTactics>
@@ -130,7 +222,7 @@
 		<useCustomRetirementModifiers>true</useCustomRetirementModifiers>
 		<useRandomFounderRetirement>false</useRandomFounderRetirement>
 		<trackUnitFatigue>false</trackUnitFatigue>
-		<displayFamilyLevel>PARENTS_CHILDREN_SIBLINGS</displayFamilyLevel>
+		<familyDisplayLevel>PARENTS_CHILDREN_SIBLINGS</familyDisplayLevel>
 		<randomDependentMethod>AGAINST_THE_BOT</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
@@ -138,54 +230,63 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
+		<salaryXPMultipliers>
+			<VETERAN>1.6</VETERAN>
+			<ULTRA_GREEN>0.6</ULTRA_GREEN>
+			<LEGENDARY>12.8</LEGENDARY>
+			<ELITE>3.2</ELITE>
+			<GREEN>0.6</GREEN>
+			<NONE>0.5</NONE>
+			<HEROIC>6.4</HEROIC>
+			<REGULAR>1.0</REGULAR>
+		</salaryXPMultipliers>
 		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
-		<useClannerMarriages>false</useClannerMarriages>
+		<useClanPersonnelMarriages>false</useClanPersonnelMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>
 		<minimumMarriageAge>18</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChanges>false</logMarriageNameChanges>
 		<marriageSurnameWeights>
-			<HYP_YOURS>30</HYP_YOURS>
+			<YOURS>55</YOURS>
+			<MALE>500</MALE>
+			<SPOUSE>55</SPOUSE>
+			<NO_CHANGE>100</NO_CHANGE>
 			<BOTH_SPACE_SPOUSE>5</BOTH_SPACE_SPOUSE>
 			<FEMALE>160</FEMALE>
-			<MALE>500</MALE>
-			<SPACE_SPOUSE>10</SPACE_SPOUSE>
-			<SPOUSE>55</SPOUSE>
-			<BOTH_HYP_YOURS>20</BOTH_HYP_YOURS>
+			<HYPHEN_YOURS>30</HYPHEN_YOURS>
 			<SPACE_YOURS>10</SPACE_YOURS>
-			<HYP_SPOUSE>30</HYP_SPOUSE>
-			<BOTH_HYP_SPOUSE>20</BOTH_HYP_SPOUSE>
-			<NO_CHANGE>100</NO_CHANGE>
-			<YOURS>55</YOURS>
+			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
 			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
+			<SPACE_SPOUSE>10</SPACE_SPOUSE>
+			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
+			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
 		</marriageSurnameWeights>
 		<randomMarriageMethod>PERCENTAGE</randomMarriageMethod>
 		<useRandomSameSexMarriages>false</useRandomSameSexMarriages>
-		<useRandomClannerMarriages>false</useRandomClannerMarriages>
+		<useRandomClanPersonnelMarriages>false</useRandomClanPersonnelMarriages>
 		<useRandomPrisonerMarriages>false</useRandomPrisonerMarriages>
 		<randomMarriageAgeRange>10</randomMarriageAgeRange>
 		<percentageRandomMarriageOppositeSexChance>2.5E-4</percentageRandomMarriageOppositeSexChance>
 		<percentageRandomMarriageSameSexChance>2.0E-5</percentageRandomMarriageSameSexChance>
 		<useManualDivorce>true</useManualDivorce>
-		<useClannerDivorce>true</useClannerDivorce>
+		<useClanPersonnelDivorce>true</useClanPersonnelDivorce>
 		<usePrisonerDivorce>false</usePrisonerDivorce>
 		<divorceSurnameWeights>
-			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
-			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 			<SPOUSE_CHANGES_SURNAME>10</SPOUSE_CHANGES_SURNAME>
 			<BOTH_CHANGE_SURNAME>30</BOTH_CHANGE_SURNAME>
+			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
+			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 		</divorceSurnameWeights>
 		<randomDivorceMethod>NONE</randomDivorceMethod>
 		<useRandomOppositeSexDivorce>true</useRandomOppositeSexDivorce>
 		<useRandomSameSexDivorce>true</useRandomSameSexDivorce>
-		<useRandomClannerDivorce>true</useRandomClannerDivorce>
+		<useRandomClanPersonnelDivorce>true</useRandomClanPersonnelDivorce>
 		<useRandomPrisonerDivorce>false</useRandomPrisonerDivorce>
 		<percentageRandomDivorceOppositeSexChance>1.0E-6</percentageRandomDivorceOppositeSexChance>
 		<percentageRandomDivorceSameSexChance>1.0E-6</percentageRandomDivorceSameSexChance>
 		<useManualProcreation>true</useManualProcreation>
-		<useClannerProcreation>false</useClannerProcreation>
+		<useClanPersonnelProcreation>false</useClanPersonnelProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
 		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
@@ -196,20 +297,20 @@
 		<logProcreation>true</logProcreation>
 		<randomProcreationMethod>PERCENTAGE</randomProcreationMethod>
 		<useRelationshiplessRandomProcreation>true</useRelationshiplessRandomProcreation>
-		<useRandomClannerProcreation>false</useRandomClannerProcreation>
+		<useRandomClanPersonnelProcreation>false</useRandomClanPersonnelProcreation>
 		<useRandomPrisonerProcreation>true</useRandomPrisonerProcreation>
 		<percentageRandomProcreationRelationshipChance>5.0E-4</percentageRandomProcreationRelationshipChance>
 		<percentageRandomProcreationRelationshiplessChance>5.0E-5</percentageRandomProcreationRelationshiplessChance>
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
 		<randomDeathMethod>NONE</randomDeathMethod>
 		<enabledRandomDeathAgeGroups>
-			<CHILD>false</CHILD>
-			<ELDER>true</ELDER>
 			<TEENAGER>true</TEENAGER>
-			<BABY>false</BABY>
-			<TODDLER>false</TODDLER>
 			<PRETEEN>false</PRETEEN>
+			<CHILD>false</CHILD>
+			<TODDLER>false</TODDLER>
 			<ADULT>true</ADULT>
+			<ELDER>true</ELDER>
+			<BABY>false</BABY>
 		</enabledRandomDeathAgeGroups>
 		<useRandomClanPersonnelDeath>true</useRandomClanPersonnelDeath>
 		<useRandomPrisonerDeath>true</useRandomPrisonerDeath>
@@ -218,30 +319,30 @@
 		<exponentialRandomDeathMaleValues>5.4757,-7.0,0.0709</exponentialRandomDeathMaleValues>
 		<exponentialRandomDeathFemaleValues>2.4641,-7.0,0.0752</exponentialRandomDeathFemaleValues>
 		<ageRangeRandomDeathMaleValues>
-			<UNDER_ONE>613.1</UNDER_ONE>
+			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>249.5</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>27.5</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>613.1</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>1119.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>14504.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>27.5</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathMaleValues>
 		<ageRangeRandomDeathFemaleValues>
-			<UNDER_ONE>500.0</UNDER_ONE>
+			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>140.2</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>20.4</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>500.0</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>670.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>12870.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>20.4</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathFemaleValues>
 		<payForParts>true</payForParts>
 		<payForRepairs>false</payForRepairs>
@@ -273,21 +374,30 @@
 		<cancelledOrderRefundMultiplier>0.5</cancelledOrderRefundMultiplier>
 		<personnelMarketName>Dylan&apos;s Method</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
-		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
-		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
-		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
-		<personnelMarketRandomGreenRemoval>4</personnelMarketRandomGreenRemoval>
-		<personnelMarketRandomUltraGreenRemoval>4</personnelMarketRandomUltraGreenRemoval>
+		<personnelMarketRandomRemovalTargets>
+			<VETERAN>8</VETERAN>
+			<ULTRA_GREEN>4</ULTRA_GREEN>
+			<LEGENDARY>11</LEGENDARY>
+			<ELITE>10</ELITE>
+			<GREEN>4</GREEN>
+			<NONE>3</NONE>
+			<HEROIC>11</HEROIC>
+			<REGULAR>6</REGULAR>
+		</personnelMarketRandomRemovalTargets>
 		<personnelMarketDylansWeight>0.5</personnelMarketDylansWeight>
 		<unitMarketMethod>ATB_MONTHLY</unitMarketMethod>
 		<unitMarketRegionalMechVariations>true</unitMarketRegionalMechVariations>
 		<instantUnitMarketDelivery>true</instantUnitMarketDelivery>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<contractMarketMethod>ATB_MONTHLY</contractMarketMethod>
+		<contractSearchRadius>800</contractSearchRadius>
+		<variableContractLength>true</variableContractLength>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
+		<contractMaxSalvagePercentage>100</contractMaxSalvagePercentage>
 		<useStaticRATs>false</useStaticRATs>
 		<rats>Xotl,Total Warfare</rats>
 		<ignoreRATEra>false</ignoreRATEra>
+		<skillLevel>REGULAR</skillLevel>
 		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<useAtB>true</useAtB>
 		<useStratCon>false</useStratCon>
@@ -296,12 +406,11 @@
 		<clanVehicles>true</clanVehicles>
 		<doubleVehicles>false</doubleVehicles>
 		<adjustPlayerVehicles>true</adjustPlayerVehicles>
-		<opforLanceTypeMechs>1</opforLanceTypeMechs>
-		<opforLanceTypeMixed>2</opforLanceTypeMixed>
-		<opforLanceTypeVehicles>2</opforLanceTypeVehicles>
-		<opforUsesVTOLs>false</opforUsesVTOLs>
+		<opForLanceTypeMechs>1</opForLanceTypeMechs>
+		<opForLanceTypeMixed>2</opForLanceTypeMixed>
+		<opForLanceTypeVehicles>2</opForLanceTypeVehicles>
+		<opForUsesVTOLs>false</opForUsesVTOLs>
 		<useDropShips>false</useDropShips>
-		<skillLevel>2</skillLevel>
 		<aeroRecruitsHaveUnits>true</aeroRecruitsHaveUnits>
 		<useShareSystem>false</useShareSystem>
 		<sharesExcludeLargeCraft>false</sharesExcludeLargeCraft>
@@ -311,10 +420,8 @@
 		<regionalMechVariations>true</regionalMechVariations>
 		<attachedPlayerCamouflage>false</attachedPlayerCamouflage>
 		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
-		<searchRadius>800</searchRadius>
 		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>false</generateChases>
-		<variableContractLength>true</variableContractLength>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
 		<usePlanetaryConditions>true</usePlanetaryConditions>
@@ -327,102 +434,12 @@
 		<limitLanceWeight>false</limitLanceWeight>
 		<limitLanceNumUnits>false</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowOpforAeros>false</allowOpforAeros>
-		<allowOpforLocalUnits>true</allowOpforLocalUnits>
-		<opforAeroChance>6</opforAeroChance>
-		<opforLocalUnitChance>3</opforLocalUnitChance>
+		<allowOpForAeros>false</allowOpForAeros>
+		<allowOpForLocalUnits>true</allowOpForLocalUnits>
+		<opForAeroChance>6</opForAeroChance>
+		<opForLocalUnitChance>3</opForLocalUnitChance>
 		<fixedMapChance>25</fixedMapChance>
-		<massRepairUseRepair>true</massRepairUseRepair>
-		<massRepairUseSalvage>true</massRepairUseSalvage>
-		<massRepairUseExtraTime>true</massRepairUseExtraTime>
-		<massRepairUseRushJob>true</massRepairUseRushJob>
-		<massRepairAllowCarryover>true</massRepairAllowCarryover>
-		<massRepairOptimizeToCompleteToday>false</massRepairOptimizeToCompleteToday>
-		<massRepairScrapImpossible>false</massRepairScrapImpossible>
-		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
-		<massRepairReplacePod>true</massRepairReplacePod>
-		<massRepairOptions>
-			<massRepairOption>
-				<type>ARMOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>AMMO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>WEAPON</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL_LOCATION</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ENGINE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GYRO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ACTUATOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ELECTRONICS</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>POD_SPACE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-		</massRepairOptions>
+		<spaUpgradeIntensity>0</spaUpgradeIntensity>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
 		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
@@ -585,7 +602,7 @@
 			<costs>5,5,5,5,10,20,40,60,80,-1,-1</costs>
 		</skillType>
 		<skillType>
-			<name>Gunnery/Protomech</name>
+			<name>Gunnery/ProtoMech</name>
 			<target>8</target>
 			<countUp>false</countUp>
 			<greenLvl>2</greenLvl>
@@ -767,209 +784,6 @@
 	</skillTypes>
 	<specialAbilities>
 		<ability>
-			<displayName>Eagle&apos;s Eyes (aToW)</displayName>
-			<lookupName>eagle_eyes</lookupName>
-			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
-			<xpCost>20</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>Jumping Jack (aToW)</displayName>
-			<lookupName>jumping_jack</lookupName>
-			<desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>40</xpCost>
-			<weight>10</weight>
-			<prereqAbilities>hopping_jack</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities>hopping_jack</removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>Multi-Tasker (aToW)</displayName>
-			<lookupName>multi_tasker</lookupName>
-			<desc>Secondary target modifiers are reduced by one.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Sandblaster (AToW)</displayName>
-			<lookupName>sandblaster</lookupName>
-			<desc>A pilot with this ability gets a +4, +3, or +2 to the cluster table
-at short, medium, or long/extended range, respectively, but only with a specialized weapon.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_hitter::cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Clan Tech Knowledge (Unofficial)</displayName>
-			<lookupName>clan_tech_knowledge</lookupName>
-			<desc>Can work on clan equipment without penalty</desc>
-			<xpCost>40</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel</skill>
-				<skill>Tech/BA</skill>
-				<skill>Tech/Aero</skill>
-				<skill>Tech/Mechanic</skill>
-				<skill>Tech/Mech</skill>
-			</skillPrereq>
-			<miscPrereq>clanperson:false</miscPrereq>
-		</ability>
-		<ability>
-			<displayName>Tactical Genius (aToW)</displayName>
-			<lookupName>tactical_genius</lookupName>
-			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
- The second roll must be accepted.
-Note: Only one Tactical Genius may be utilized per team.</desc>
-			<xpCost>-1</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tactics::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
-			<lookupName>tm_forest_ranger</lookupName>
-			<desc>Movement in woods or jungle costs 1 less MP.
-Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
-Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
-			<xpCost>60</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Dodge (MaxTech)</displayName>
-			<lookupName>dodge_maneuver</lookupName>
-			<desc>Enables the unit to make a dodge maneuver instead of a physical attack.
-This maneuver adds +2 to the BTH to physical attacks against the unit.
-NOTE: The dodge maneuver is declared during the weapons phase.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>20</xpCost>
-			<weight>10</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
-			<lookupName>tech_armor_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with armor</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Golden Goose (aToW)</displayName>
-			<lookupName>golden_goose</lookupName>
-			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
-			<xpCost>40</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Sniper (aToW)</displayName>
-			<lookupName>sniper</lookupName>
-			<desc>Range penalties are halved.</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Mountaineer] (CamOps)</displayName>
-			<lookupName>tm_mountaineer</lookupName>
-			<desc>Movement in rubble or rough cost 1 less MP and elevation changes also cost 1 MP less.
-The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
-			<xpCost>40</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Weapon Specialist (aToW)</displayName>
 			<lookupName>weapon_specialist</lookupName>
 			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
@@ -980,100 +794,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Natural Aptitude, Gunnery (aToW)</displayName>
-			<lookupName>aptitude_gunnery</lookupName>
-			<desc>Roll 3d6 and take the best two for gunnery checks</desc>
-			<xpCost>-1</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit</skill>
-				<skill>Gunnery/Aircraft</skill>
-				<skill>Gunnery/Spacecraft</skill>
-				<skill>Gunnery/Aerospace</skill>
-				<skill>Gunnery/Vehicle</skill>
-				<skill>Gunnery/Mech</skill>
-				<skill>Gunnery/Protomech</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Mr/Ms Fix-it (unofficial)</displayName>
-			<lookupName>tech_fixer</lookupName>
-			<desc>Ignore first point of penalty for repair and maintenance on low quality equipment</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Forward Observer (aToW)</displayName>
-			<lookupName>forward_observer</lookupName>
-			<desc>Improves the accuracy of your artillery. Fire Adjustment gets a -2 modifier. Spotting gets an additional -1 tohit modifier for each point of gunnery below 4.</desc>
-			<xpCost>60</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Artillery::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Shaky Stick (aToW)</displayName>
-			<lookupName>shaky_stick</lookupName>
-			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
-			<xpCost>20</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Hitter (AToW)</displayName>
-			<lookupName>cluster_hitter</lookupName>
-			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1094,55 +820,54 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Weathered (Unofficial)</displayName>
-			<lookupName>weathered</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<displayName>Cluster Master (AToW)</displayName>
+			<lookupName>cluster_master</lookupName>
+			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
 			<xpCost>60</xpCost>
 			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
+			<prereqAbilities>cluster_hitter</prereqAbilities>
 			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
+			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
-			<lookupName>tm_frogman</lookupName>
-			<desc>Movement in depth 2 or greater water costs 1 MP less.
-Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
-			<xpCost>40</xpCost>
-			<weight>3</weight>
+			<displayName>Natural Aptitude, Piloting (aToW)</displayName>
+			<lookupName>aptitude_piloting</lookupName>
+			<desc>Roll 3d6 and take the best two for piloting checks</desc>
+			<xpCost>-1</xpCost>
+			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Some Like It Hot (Unofficial)</displayName>
-			<lookupName>some_like_it_hot</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
+			<displayName>Jumping Jack (aToW)</displayName>
+			<lookupName>jumping_jack</lookupName>
+			<desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
 			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
+			<weight>10</weight>
+			<prereqAbilities>hopping_jack</prereqAbilities>
 			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
+			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-			</skillPrereq>
 		</ability>
 		<ability>
 			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
@@ -1156,10 +881,371 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Multi-Tasker (aToW)</displayName>
+			<lookupName>multi_tasker</lookupName>
+			<desc>Secondary target modifiers are reduced by one.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Sandblaster (AToW)</displayName>
+			<lookupName>sandblaster</lookupName>
+			<desc>A pilot with this ability gets a +4, +3, or +2 to the cluster table
+at short, medium, or long/extended range, respectively, but only with a specialized weapon.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>cluster_hitter::cluster_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Clan Tech Knowledge (Unofficial)</displayName>
+			<lookupName>clan_tech_knowledge</lookupName>
+			<desc>Can work on clan equipment without penalty</desc>
+			<xpCost>40</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel</skill>
+				<skill>Tech/Aero</skill>
+				<skill>Tech/BA</skill>
+				<skill>Tech/Mechanic</skill>
+				<skill>Tech/Mech</skill>
+			</skillPrereq>
+			<miscPrereq>clanperson:false</miscPrereq>
+		</ability>
+		<ability>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>40</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Hot Dog (aToW)</displayName>
+			<lookupName>hot_dog</lookupName>
+			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Dodge (MaxTech)</displayName>
+			<lookupName>dodge_maneuver</lookupName>
+			<desc>Enables the unit to make a dodge maneuver instead of a physical attack.
+This maneuver adds +2 to the BTH to physical attacks against the unit.
+NOTE: The dodge maneuver is declared during the weapons phase.
+Note: This ability is only used for BattleMechs.</desc>
+			<xpCost>20</xpCost>
+			<weight>10</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Pain Resistance (MaxTech)</displayName>
+			<lookupName>pain_resistance</lookupName>
+			<desc>When making consciousness rolls,
+1 is added to all rolls.
+Also,
+damage received from ammo explosions is reduced to 1.
+Note: This ability is only used for BattleMechs.</desc>
+			<xpCost>20</xpCost>
+			<weight>10</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Sniper (aToW)</displayName>
+			<lookupName>sniper</lookupName>
+			<desc>Range penalties are halved.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Maneuvering Ace (aToW)</displayName>
+			<lookupName>maneuvering_ace</lookupName>
+			<desc>Enables the unit to move laterally like a Quad.
+Quads can move laterally for 1 less MP.
+Aerospace units can perform maneuvers for 1 less thrust point.
+Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Veteran</skill>
+				<skill>Piloting/Naval::Veteran</skill>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/VTOL::Veteran</skill>
+				<skill>Piloting/Aircraft::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Mountaineer] (CamOps)</displayName>
+			<lookupName>tm_mountaineer</lookupName>
+			<desc>Movement in rubble or rough cost 1 less MP and elevation changes also cost 1 MP less.
+The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
+			<xpCost>40</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Mr/Ms Fix-it (unofficial)</displayName>
+			<lookupName>tech_fixer</lookupName>
+			<desc>Ignore first point of penalty for repair and maintenance on low quality equipment</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Eagle&apos;s Eyes (aToW)</displayName>
+			<lookupName>eagle_eyes</lookupName>
+			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
+			<xpCost>20</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+		</ability>
+		<ability>
+			<displayName>Oblique Artilleryman (aToW)</displayName>
+			<lookupName>oblique_artillery</lookupName>
+			<desc>Reduces scatter distance by two hexes.</desc>
+			<xpCost>20</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
+			<lookupName>tm_forest_ranger</lookupName>
+			<desc>Movement in woods or jungle costs 1 less MP.
+Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
+Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
+			<xpCost>60</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Engineer (unofficial)</displayName>
+			<lookupName>tech_engineer</lookupName>
+			<desc>-2 on refit rolls</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Veteran</skill>
+				<skill>Tech/Aero::Veteran</skill>
+				<skill>Tech/BA::Veteran</skill>
+				<skill>Tech/Mechanic::Veteran</skill>
+				<skill>Tech/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Melee Master (aToW)</displayName>
+			<lookupName>melee_master</lookupName>
+			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
+			<xpCost>20</xpCost>
+			<weight>10</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Forward Observer (aToW)</displayName>
+			<lookupName>forward_observer</lookupName>
+			<desc>Improves the accuracy of your artillery. Fire Adjustment gets a -2 modifier. Spotting gets an additional -1 tohit modifier for each point of gunnery below 4.</desc>
+			<xpCost>60</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Artillery::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Human TRO (CamOps)</displayName>
+			<lookupName>human_tro</lookupName>
+			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Small Arms::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tactical Genius (aToW)</displayName>
+			<lookupName>tactical_genius</lookupName>
+			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
+ The second roll must be accepted.
+Note: Only one Tactical Genius may be utilized per team.</desc>
+			<xpCost>-1</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tactics::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1181,6 +1267,95 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Natural Aptitude, Gunnery (aToW)</displayName>
+			<lookupName>aptitude_gunnery</lookupName>
+			<desc>Roll 3d6 and take the best two for gunnery checks</desc>
+			<xpCost>-1</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft</skill>
+				<skill>Gunnery/Battlesuit</skill>
+				<skill>Gunnery/Aerospace</skill>
+				<skill>Gunnery/Spacecraft</skill>
+				<skill>Gunnery/Mech</skill>
+				<skill>Gunnery/Vehicle</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>20</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Weathered (Unofficial)</displayName>
+			<lookupName>weathered</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>All Weather (Unofficial)</displayName>
+			<lookupName>allweather</lookupName>
+			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1213,111 +1388,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Maneuvering Ace (aToW)</displayName>
-			<lookupName>maneuvering_ace</lookupName>
-			<desc>Enables the unit to move laterally like a Quad.
-Quads can move laterally for 1 less MP.
-Aerospace units can perform maneuvers for 1 less thrust point.
-Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Veteran</skill>
-				<skill>Piloting/Naval::Veteran</skill>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/VTOL::Veteran</skill>
-				<skill>Piloting/Aircraft::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Oblique Artilleryman (aToW)</displayName>
-			<lookupName>oblique_artillery</lookupName>
-			<desc>Reduces scatter distance by two hexes.</desc>
-			<xpCost>20</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>Melee Master (aToW)</displayName>
-			<lookupName>melee_master</lookupName>
-			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-			<xpCost>20</xpCost>
-			<weight>10</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Zweihander (CamOps)</displayName>
-			<lookupName>zweihander</lookupName>
-			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-			<xpCost>20</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities>melee_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Master (AToW)</displayName>
-			<lookupName>cluster_master</lookupName>
-			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities>cluster_hitter</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities>cluster_hitter</removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Animal Mimicry (CamOps)</displayName>
-			<lookupName>animal_mimic</lookupName>
-			<desc>Allows a Quad Mech or ProtoMech, or a bipedal Mech or ProtoMech with the animalistic quirk, the following benefits.
--1 MP per hex of Woods and Jungle terrain.
- In addition quads gain a -1 to any quad related PSR check.
-NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
-			<xpCost>40</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1336,120 +1411,6 @@ Note: This ability is only used for BattleMechs.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Gunnery Specialization (aToW)</displayName>
-			<lookupName>specialist</lookupName>
-			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
- +1 to-hit modifier when using other types of weapons.</desc>
-			<xpCost>40</xpCost>
-			<weight>12</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>weapon_specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Human TRO (CamOps)</displayName>
-			<lookupName>human_tro</lookupName>
-			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Small Arms::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Pain Resistance (MaxTech)</displayName>
-			<lookupName>pain_resistance</lookupName>
-			<desc>When making consciousness rolls,
-1 is added to all rolls.
-Also,
-damage received from ammo explosions is reduced to 1.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>20</xpCost>
-			<weight>10</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>All Weather (Unofficial)</displayName>
-			<lookupName>allweather</lookupName>
-			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hot Dog (aToW)</displayName>
-			<lookupName>hot_dog</lookupName>
-			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Engineer (unofficial)</displayName>
-			<lookupName>tech_engineer</lookupName>
-			<desc>-2 on refit rolls</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Veteran</skill>
-				<skill>Tech/BA::Veteran</skill>
-				<skill>Tech/Aero::Veteran</skill>
-				<skill>Tech/Mechanic::Veteran</skill>
-				<skill>Tech/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Terrain Master [Swamp Beast] (CamOps)</displayName>
 			<lookupName>tm_swamp_beast</lookupName>
 			<desc>Movement in mud or swamp costs 1 less MP.
@@ -1462,14 +1423,83 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<displayName>Gunnery Specialization (aToW)</displayName>
+			<lookupName>specialist</lookupName>
+			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
+ +1 to-hit modifier when using other types of weapons.</desc>
+			<xpCost>40</xpCost>
+			<weight>12</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Hitter (AToW)</displayName>
+			<lookupName>cluster_hitter</lookupName>
+			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>cluster_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Some Like It Hot (Unofficial)</displayName>
+			<lookupName>some_like_it_hot</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Golden Goose (aToW)</displayName>
+			<lookupName>golden_goose</lookupName>
+			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
+			<xpCost>40</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
+			<lookupName>tm_frogman</lookupName>
+			<desc>Movement in depth 2 or greater water costs 1 MP less.
+Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
 			<xpCost>40</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
@@ -1477,52 +1507,22 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Piloting/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Natural Aptitude, Piloting (aToW)</displayName>
-			<lookupName>aptitude_piloting</lookupName>
-			<desc>Roll 3d6 and take the best two for piloting checks</desc>
-			<xpCost>-1</xpCost>
+			<displayName>Shaky Stick (aToW)</displayName>
+			<lookupName>shaky_stick</lookupName>
+			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
+			<xpCost>20</xpCost>
 			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1540,21 +1540,20 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
-			<lookupName>tech_weapon_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with weapons</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
+			<displayName>Animal Mimicry (CamOps)</displayName>
+			<lookupName>animal_mimic</lookupName>
+			<desc>Allows a Quad Mech or ProtoMech, or a bipedal Mech or ProtoMech with the animalistic quirk, the following benefits.
+-1 MP per hex of Woods and Jungle terrain.
+ In addition quads gain a -1 to any quad related PSR check.
+NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
+			<xpCost>40</xpCost>
+			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>

--- a/MekHQ/mmconf/campaignPresets/CamOps.xml
+++ b/MekHQ/mmconf/campaignPresets/CamOps.xml
@@ -1,10 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<campaignPreset version="0.49.8-SNAPSHOT">
+<campaignPreset version="0.49.19-SNAPSHOT">
 	<title>Campaign Operations</title>
 	<description>Options to run a unit using the Campaign Operations rules. This preset uses the basic rules and rating system. Optional rules are off by default as well as SPAs, Implants, and Quirks. For games using the older Field Manual Mercenaries system use the Total Warfare (TW) preset instead.</description>
+	<date>3067-01-01</date>
+	<faction>MERC</faction>
+	<planet system="Galatea">Galatea</planet>
+	<rankSystem>
+		<code>SSLDF</code>
+	</rankSystem>
+	<contractCount>2</contractCount>
+	<gm>false</gm>
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
+		<mrmsUseRepair>true</mrmsUseRepair>
+		<mrmsUseSalvage>true</mrmsUseSalvage>
+		<mrmsUseExtraTime>true</mrmsUseExtraTime>
+		<mrmsUseRushJob>true</mrmsUseRushJob>
+		<mrmsAllowCarryover>true</mrmsAllowCarryover>
+		<mrmsOptimizeToCompleteToday>false</mrmsOptimizeToCompleteToday>
+		<mrmsScrapImpossible>false</mrmsScrapImpossible>
+		<mrmsUseAssignedTechsFirst>false</mrmsUseAssignedTechsFirst>
+		<mrmsReplacePod>true</mrmsReplacePod>
+		<mrmsOptions>
+			<mrmsOption>
+				<type>ARMOUR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>AMMUNITION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>WEAPON</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL_LOCATION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ENGINE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GYRO</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ACTUATOR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ELECTRONICS</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>POD_SPACE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+		</mrmsOptions>
 		<useFactionForNames>true</useFactionForNames>
 		<unitRatingMethod>CAMPAIGN_OPS</unitRatingMethod>
 		<useEraMods>false</useEraMods>
@@ -53,9 +152,9 @@
 		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
 		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>5.0</equipmentContractPercent>
-		<dropshipContractPercent>0.0</dropshipContractPercent>
-		<jumpshipContractPercent>0.0</jumpshipContractPercent>
-		<warshipContractPercent>0.0</warshipContractPercent>
+		<dropShipContractPercent>0.0</dropShipContractPercent>
+		<jumpShipContractPercent>0.0</jumpShipContractPercent>
+		<warShipContractPercent>0.0</warShipContractPercent>
 		<equipmentContractBase>true</equipmentContractBase>
 		<equipmentContractSaleValue>false</equipmentContractSaleValue>
 		<blcSaleValue>false</blcSaleValue>
@@ -70,7 +169,7 @@
 		<maintenanceBonus>-1</maintenanceBonus>
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>false</reverseQualityNames>
-		<useUnofficalMaintenance>false</useUnofficalMaintenance>
+		<useUnofficialMaintenance>false</useUnofficialMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<maxAcquisitions>0</maxAcquisitions>
 		<useTactics>false</useTactics>
@@ -122,7 +221,7 @@
 		<useCustomRetirementModifiers>false</useCustomRetirementModifiers>
 		<useRandomFounderRetirement>false</useRandomFounderRetirement>
 		<trackUnitFatigue>false</trackUnitFatigue>
-		<displayFamilyLevel>PARENTS_CHILDREN_SIBLINGS</displayFamilyLevel>
+		<familyDisplayLevel>PARENTS_CHILDREN_SIBLINGS</familyDisplayLevel>
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
@@ -130,54 +229,63 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
+		<salaryXPMultipliers>
+			<VETERAN>1.6</VETERAN>
+			<ULTRA_GREEN>0.6</ULTRA_GREEN>
+			<LEGENDARY>12.8</LEGENDARY>
+			<ELITE>3.2</ELITE>
+			<GREEN>0.6</GREEN>
+			<NONE>0.5</NONE>
+			<HEROIC>6.4</HEROIC>
+			<REGULAR>1.0</REGULAR>
+		</salaryXPMultipliers>
 		<salaryTypeBase>1500 CSB,0 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
-		<useClannerMarriages>false</useClannerMarriages>
+		<useClanPersonnelMarriages>false</useClanPersonnelMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChanges>false</logMarriageNameChanges>
 		<marriageSurnameWeights>
-			<HYP_YOURS>30</HYP_YOURS>
+			<YOURS>55</YOURS>
+			<MALE>500</MALE>
+			<SPOUSE>55</SPOUSE>
+			<NO_CHANGE>100</NO_CHANGE>
 			<BOTH_SPACE_SPOUSE>5</BOTH_SPACE_SPOUSE>
 			<FEMALE>160</FEMALE>
-			<MALE>500</MALE>
-			<SPACE_SPOUSE>10</SPACE_SPOUSE>
-			<SPOUSE>55</SPOUSE>
-			<BOTH_HYP_YOURS>20</BOTH_HYP_YOURS>
+			<HYPHEN_YOURS>30</HYPHEN_YOURS>
 			<SPACE_YOURS>10</SPACE_YOURS>
-			<HYP_SPOUSE>30</HYP_SPOUSE>
-			<BOTH_HYP_SPOUSE>20</BOTH_HYP_SPOUSE>
-			<NO_CHANGE>100</NO_CHANGE>
-			<YOURS>55</YOURS>
+			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
 			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
+			<SPACE_SPOUSE>10</SPACE_SPOUSE>
+			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
+			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
 		</marriageSurnameWeights>
 		<randomMarriageMethod>NONE</randomMarriageMethod>
 		<useRandomSameSexMarriages>false</useRandomSameSexMarriages>
-		<useRandomClannerMarriages>false</useRandomClannerMarriages>
+		<useRandomClanPersonnelMarriages>false</useRandomClanPersonnelMarriages>
 		<useRandomPrisonerMarriages>true</useRandomPrisonerMarriages>
 		<randomMarriageAgeRange>10</randomMarriageAgeRange>
 		<percentageRandomMarriageOppositeSexChance>2.5E-4</percentageRandomMarriageOppositeSexChance>
 		<percentageRandomMarriageSameSexChance>2.0E-5</percentageRandomMarriageSameSexChance>
 		<useManualDivorce>true</useManualDivorce>
-		<useClannerDivorce>true</useClannerDivorce>
+		<useClanPersonnelDivorce>true</useClanPersonnelDivorce>
 		<usePrisonerDivorce>false</usePrisonerDivorce>
 		<divorceSurnameWeights>
-			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
-			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 			<SPOUSE_CHANGES_SURNAME>10</SPOUSE_CHANGES_SURNAME>
 			<BOTH_CHANGE_SURNAME>30</BOTH_CHANGE_SURNAME>
+			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
+			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 		</divorceSurnameWeights>
 		<randomDivorceMethod>NONE</randomDivorceMethod>
 		<useRandomOppositeSexDivorce>true</useRandomOppositeSexDivorce>
 		<useRandomSameSexDivorce>true</useRandomSameSexDivorce>
-		<useRandomClannerDivorce>true</useRandomClannerDivorce>
+		<useRandomClanPersonnelDivorce>true</useRandomClanPersonnelDivorce>
 		<useRandomPrisonerDivorce>false</useRandomPrisonerDivorce>
 		<percentageRandomDivorceOppositeSexChance>1.0E-6</percentageRandomDivorceOppositeSexChance>
 		<percentageRandomDivorceSameSexChance>1.0E-6</percentageRandomDivorceSameSexChance>
 		<useManualProcreation>true</useManualProcreation>
-		<useClannerProcreation>false</useClannerProcreation>
+		<useClanPersonnelProcreation>false</useClanPersonnelProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
 		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
@@ -188,20 +296,20 @@
 		<logProcreation>false</logProcreation>
 		<randomProcreationMethod>PERCENTAGE</randomProcreationMethod>
 		<useRelationshiplessRandomProcreation>true</useRelationshiplessRandomProcreation>
-		<useRandomClannerProcreation>false</useRandomClannerProcreation>
+		<useRandomClanPersonnelProcreation>false</useRandomClanPersonnelProcreation>
 		<useRandomPrisonerProcreation>true</useRandomPrisonerProcreation>
 		<percentageRandomProcreationRelationshipChance>5.0E-4</percentageRandomProcreationRelationshipChance>
 		<percentageRandomProcreationRelationshiplessChance>5.0E-5</percentageRandomProcreationRelationshiplessChance>
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
 		<randomDeathMethod>NONE</randomDeathMethod>
 		<enabledRandomDeathAgeGroups>
-			<CHILD>false</CHILD>
-			<ELDER>true</ELDER>
 			<TEENAGER>true</TEENAGER>
-			<BABY>false</BABY>
-			<TODDLER>false</TODDLER>
 			<PRETEEN>false</PRETEEN>
+			<CHILD>false</CHILD>
+			<TODDLER>false</TODDLER>
 			<ADULT>true</ADULT>
+			<ELDER>true</ELDER>
+			<BABY>false</BABY>
 		</enabledRandomDeathAgeGroups>
 		<useRandomClanPersonnelDeath>true</useRandomClanPersonnelDeath>
 		<useRandomPrisonerDeath>true</useRandomPrisonerDeath>
@@ -210,30 +318,30 @@
 		<exponentialRandomDeathMaleValues>5.4757,-7.0,0.0709</exponentialRandomDeathMaleValues>
 		<exponentialRandomDeathFemaleValues>2.4641,-7.0,0.0752</exponentialRandomDeathFemaleValues>
 		<ageRangeRandomDeathMaleValues>
-			<UNDER_ONE>613.1</UNDER_ONE>
+			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>249.5</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>27.5</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>613.1</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>1119.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>14504.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>27.5</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathMaleValues>
 		<ageRangeRandomDeathFemaleValues>
-			<UNDER_ONE>500.0</UNDER_ONE>
+			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>140.2</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>20.4</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>500.0</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>670.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>12870.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>20.4</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathFemaleValues>
 		<payForParts>true</payForParts>
 		<payForRepairs>false</payForRepairs>
@@ -265,21 +373,30 @@
 		<cancelledOrderRefundMultiplier>0.5</cancelledOrderRefundMultiplier>
 		<personnelMarketName>Strat Ops</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
-		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
-		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
-		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
-		<personnelMarketRandomGreenRemoval>4</personnelMarketRandomGreenRemoval>
-		<personnelMarketRandomUltraGreenRemoval>4</personnelMarketRandomUltraGreenRemoval>
+		<personnelMarketRandomRemovalTargets>
+			<VETERAN>8</VETERAN>
+			<ULTRA_GREEN>4</ULTRA_GREEN>
+			<LEGENDARY>11</LEGENDARY>
+			<ELITE>10</ELITE>
+			<GREEN>4</GREEN>
+			<NONE>3</NONE>
+			<HEROIC>11</HEROIC>
+			<REGULAR>6</REGULAR>
+		</personnelMarketRandomRemovalTargets>
 		<personnelMarketDylansWeight>0.3</personnelMarketDylansWeight>
 		<unitMarketMethod>NONE</unitMarketMethod>
 		<unitMarketRegionalMechVariations>true</unitMarketRegionalMechVariations>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<contractMarketMethod>NONE</contractMarketMethod>
+		<contractSearchRadius>800</contractSearchRadius>
+		<variableContractLength>false</variableContractLength>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
+		<contractMaxSalvagePercentage>100</contractMaxSalvagePercentage>
 		<useStaticRATs>false</useStaticRATs>
 		<rats>Xotl,Total Warfare</rats>
 		<ignoreRATEra>false</ignoreRATEra>
+		<skillLevel>REGULAR</skillLevel>
 		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<useAtB>false</useAtB>
 		<useStratCon>false</useStratCon>
@@ -288,12 +405,11 @@
 		<clanVehicles>true</clanVehicles>
 		<doubleVehicles>false</doubleVehicles>
 		<adjustPlayerVehicles>false</adjustPlayerVehicles>
-		<opforLanceTypeMechs>1</opforLanceTypeMechs>
-		<opforLanceTypeMixed>2</opforLanceTypeMixed>
-		<opforLanceTypeVehicles>3</opforLanceTypeVehicles>
-		<opforUsesVTOLs>true</opforUsesVTOLs>
+		<opForLanceTypeMechs>1</opForLanceTypeMechs>
+		<opForLanceTypeMixed>2</opForLanceTypeMixed>
+		<opForLanceTypeVehicles>3</opForLanceTypeVehicles>
+		<opForUsesVTOLs>true</opForUsesVTOLs>
 		<useDropShips>false</useDropShips>
-		<skillLevel>2</skillLevel>
 		<aeroRecruitsHaveUnits>false</aeroRecruitsHaveUnits>
 		<useShareSystem>false</useShareSystem>
 		<sharesExcludeLargeCraft>false</sharesExcludeLargeCraft>
@@ -303,10 +419,8 @@
 		<regionalMechVariations>false</regionalMechVariations>
 		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
 		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
-		<searchRadius>800</searchRadius>
 		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>true</generateChases>
-		<variableContractLength>false</variableContractLength>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
 		<usePlanetaryConditions>false</usePlanetaryConditions>
@@ -319,102 +433,12 @@
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowOpforAeros>false</allowOpforAeros>
-		<allowOpforLocalUnits>false</allowOpforLocalUnits>
-		<opforAeroChance>5</opforAeroChance>
-		<opforLocalUnitChance>5</opforLocalUnitChance>
+		<allowOpForAeros>false</allowOpForAeros>
+		<allowOpForLocalUnits>false</allowOpForLocalUnits>
+		<opForAeroChance>5</opForAeroChance>
+		<opForLocalUnitChance>5</opForLocalUnitChance>
 		<fixedMapChance>25</fixedMapChance>
-		<massRepairUseRepair>true</massRepairUseRepair>
-		<massRepairUseSalvage>true</massRepairUseSalvage>
-		<massRepairUseExtraTime>true</massRepairUseExtraTime>
-		<massRepairUseRushJob>true</massRepairUseRushJob>
-		<massRepairAllowCarryover>true</massRepairAllowCarryover>
-		<massRepairOptimizeToCompleteToday>false</massRepairOptimizeToCompleteToday>
-		<massRepairScrapImpossible>false</massRepairScrapImpossible>
-		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
-		<massRepairReplacePod>true</massRepairReplacePod>
-		<massRepairOptions>
-			<massRepairOption>
-				<type>ARMOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>AMMO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>WEAPON</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL_LOCATION</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ENGINE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GYRO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ACTUATOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ELECTRONICS</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>POD_SPACE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-		</massRepairOptions>
+		<spaUpgradeIntensity>0</spaUpgradeIntensity>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
 		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
@@ -577,7 +601,7 @@
 			<costs>16,8,8,8,8,8,8,8,-1,-1,-1</costs>
 		</skillType>
 		<skillType>
-			<name>Gunnery/Protomech</name>
+			<name>Gunnery/ProtoMech</name>
 			<target>7</target>
 			<countUp>false</countUp>
 			<greenLvl>2</greenLvl>
@@ -759,26 +783,55 @@
 	</skillTypes>
 	<specialAbilities>
 		<ability>
-			<displayName>Eagle&apos;s Eyes (CamOps)</displayName>
-			<lookupName>eagle_eyes</lookupName>
-			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
-			<xpCost>10</xpCost>
+			<displayName>Weapon Specialist (CamOps)</displayName>
+			<lookupName>weapon_specialist</lookupName>
+			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
+			<xpCost>15</xpCost>
 			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Foot Cavalry (CamOps)</displayName>
+			<lookupName>foot_cav</lookupName>
+			<desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
+			<xpCost>5</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
 				<skill>Small Arms::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Master (Unofficial)</displayName>
+			<lookupName>cluster_master</lookupName>
+			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
+			<xpCost>5</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>cluster_hitter</prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities>cluster_hitter</removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -792,8 +845,25 @@
 			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
+			<lookupName>tech_internal_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -807,13 +877,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -828,13 +897,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -849,45 +917,45 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/BA</skill>
 				<skill>Tech/Aero</skill>
+				<skill>Tech/BA</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
 			<miscPrereq>clanperson:false</miscPrereq>
 		</ability>
 		<ability>
-			<displayName>Tactical Genius (CamOps)</displayName>
-			<lookupName>tactical_genius</lookupName>
-			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
- The second roll must be accepted.
-Note: Only one Tactical Genius may be utilized per team.</desc>
-			<xpCost>15</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tactics::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
-			<lookupName>tm_forest_ranger</lookupName>
-			<desc>Movement in woods or jungle costs 1 less MP.
-Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
-Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
-			<xpCost>15</xpCost>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>10</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Hot Dog (CamOps)</displayName>
+			<lookupName>hot_dog</lookupName>
+			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
+			<xpCost>5</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -904,42 +972,23 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
-			<lookupName>tech_armor_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<displayName>Pain Resistance (MaxTech)</displayName>
+			<lookupName>pain_resistance</lookupName>
+			<desc>When making consciousness rolls,
+1 is added to all rolls.
+Also,
+damage received from ammo explosions is reduced to 1.
+Note: This ability is only used for BattleMechs.</desc>
 			<xpCost>4</xpCost>
 			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Golden Goose (CamOps)</displayName>
-			<lookupName>golden_goose</lookupName>
-			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-			</skillPrereq>
 		</ability>
 		<ability>
 			<displayName>Sniper (CamOps)</displayName>
@@ -952,13 +1001,52 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Maneuvering Ace (CamOps)</displayName>
+			<lookupName>maneuvering_ace</lookupName>
+			<desc>Enables the unit to move laterally like a Quad.
+Quads can move laterally for 1 less MP.
+Aerospace units can perform maneuvers for 1 less thrust point.
+Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -974,28 +1062,7 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Weapon Specialist (CamOps)</displayName>
-			<lookupName>weapon_specialist</lookupName>
-			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
-			<xpCost>15</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1010,10 +1077,117 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Eagle&apos;s Eyes (CamOps)</displayName>
+			<lookupName>eagle_eyes</lookupName>
+			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Small Arms::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Oblique Artilleryman (CamOps)</displayName>
+			<lookupName>oblique_artillery</lookupName>
+			<desc>Reduces scatter distance by two hexes.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
+			<lookupName>tm_forest_ranger</lookupName>
+			<desc>Movement in woods or jungle costs 1 less MP.
+Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
+Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
+			<xpCost>15</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Engineer (unofficial)</displayName>
+			<lookupName>tech_engineer</lookupName>
+			<desc>-2 on refit rolls</desc>
+			<xpCost>8</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Veteran</skill>
+				<skill>Tech/BA::Veteran</skill>
+				<skill>Tech/Aero::Veteran</skill>
+				<skill>Tech/Mechanic::Veteran</skill>
+				<skill>Tech/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Melee Master (CamOps)</displayName>
+			<lookupName>melee_master</lookupName>
+			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
+			<xpCost>15</xpCost>
+			<weight>6</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1032,7 +1206,6 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 				<skill>Piloting/Spacecraft::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Aerospace::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Small Arms::Regular</skill>
@@ -1040,122 +1213,41 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Shaky Stick (CamOps)</displayName>
-			<lookupName>shaky_stick</lookupName>
-			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
+			<displayName>Human TRO (CamOps)</displayName>
+			<lookupName>human_tro</lookupName>
+			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
+			<xpCost>5</xpCost>
+			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Hitter (CamOps)</displayName>
-			<lookupName>cluster_hitter</lookupName>
-			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Foot Cavalry (CamOps)</displayName>
-			<lookupName>foot_cav</lookupName>
-			<desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
-			<xpCost>5</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
 				<skill>Small Arms::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Weathered (Unofficial)</displayName>
-			<lookupName>weathered</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
-			<lookupName>tm_frogman</lookupName>
-			<desc>Movement in depth 2 or greater water costs 1 MP less.
-Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
+			<displayName>Tactical Genius (CamOps)</displayName>
+			<lookupName>tactical_genius</lookupName>
+			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
+ The second roll must be accepted.
+Note: Only one Tactical Genius may be utilized per team.</desc>
 			<xpCost>15</xpCost>
-			<weight>3</weight>
+			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Some Like It Hot (Unofficial)</displayName>
-			<lookupName>some_like_it_hot</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
-			<xpCost>5</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
-			<lookupName>tech_internal_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
-			<xpCost>6</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
+				<skill>Tactics::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1176,8 +1268,77 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>10</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Weathered (Unofficial)</displayName>
+			<lookupName>weathered</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>All Weather (Unofficial)</displayName>
+			<lookupName>allweather</lookupName>
+			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1208,21 +1369,112 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Maneuvering Ace (CamOps)</displayName>
-			<lookupName>maneuvering_ace</lookupName>
-			<desc>Enables the unit to move laterally like a Quad.
-Quads can move laterally for 1 less MP.
-Aerospace units can perform maneuvers for 1 less thrust point.
-Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
+			<displayName>Melee Specialist (CamOps)</displayName>
+			<lookupName>melee_specialist</lookupName>
+			<desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
+Note: This ability is only used for BattleMechs.</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Swamp Beast] (CamOps)</displayName>
+			<lookupName>tm_swamp_beast</lookupName>
+			<desc>Movement in mud or swamp costs 1 less MP.
+Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
+			<xpCost>15</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Hitter (CamOps)</displayName>
+			<lookupName>cluster_hitter</lookupName>
+			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>cluster_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Some Like It Hot (Unofficial)</displayName>
+			<lookupName>some_like_it_hot</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
+			<xpCost>5</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Golden Goose (CamOps)</displayName>
+			<lookupName>golden_goose</lookupName>
+			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
+			<lookupName>tm_frogman</lookupName>
+			<desc>Movement in depth 2 or greater water costs 1 MP less.
+Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
+			<xpCost>15</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Shaky Stick (CamOps)</displayName>
+			<lookupName>shaky_stick</lookupName>
+			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
 			<xpCost>10</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
@@ -1231,80 +1483,22 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Oblique Artilleryman (CamOps)</displayName>
-			<lookupName>oblique_artillery</lookupName>
-			<desc>Reduces scatter distance by two hexes.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Melee Master (CamOps)</displayName>
-			<lookupName>melee_master</lookupName>
-			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-			<xpCost>15</xpCost>
-			<weight>6</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Zweihander (CamOps)</displayName>
-			<lookupName>zweihander</lookupName>
-			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-			<xpCost>10</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities>melee_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Master (Unofficial)</displayName>
-			<lookupName>cluster_master</lookupName>
-			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
+			<displayName>Hopping Jack (Unofficial)</displayName>
+			<lookupName>hopping_jack</lookupName>
+			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
 			<xpCost>5</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>cluster_hitter</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities>cluster_hitter</removeAbilities>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>jumping_jack</invalidAbilities>
+			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1321,204 +1515,7 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Melee Specialist (CamOps)</displayName>
-			<lookupName>melee_specialist</lookupName>
-			<desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Human TRO (CamOps)</displayName>
-			<lookupName>human_tro</lookupName>
-			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
-			<xpCost>5</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Small Arms::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Pain Resistance (MaxTech)</displayName>
-			<lookupName>pain_resistance</lookupName>
-			<desc>When making consciousness rolls,
-1 is added to all rolls.
-Also,
-damage received from ammo explosions is reduced to 1.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>All Weather (Unofficial)</displayName>
-			<lookupName>allweather</lookupName>
-			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hot Dog (CamOps)</displayName>
-			<lookupName>hot_dog</lookupName>
-			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-			<xpCost>5</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Engineer (unofficial)</displayName>
-			<lookupName>tech_engineer</lookupName>
-			<desc>-2 on refit rolls</desc>
-			<xpCost>8</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Veteran</skill>
-				<skill>Tech/Aero::Veteran</skill>
-				<skill>Tech/BA::Veteran</skill>
-				<skill>Tech/Mechanic::Veteran</skill>
-				<skill>Tech/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Swamp Beast] (CamOps)</displayName>
-			<lookupName>tm_swamp_beast</lookupName>
-			<desc>Movement in mud or swamp costs 1 less MP.
-Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
-			<xpCost>15</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hopping Jack (Unofficial)</displayName>
-			<lookupName>hopping_jack</lookupName>
-			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>5</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>jumping_jack</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
-			<lookupName>tech_weapon_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with weapons</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>

--- a/MekHQ/mmconf/campaignPresets/DefaultTotalWarfare.xml
+++ b/MekHQ/mmconf/campaignPresets/DefaultTotalWarfare.xml
@@ -1,10 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<campaignPreset version="0.49.8-SNAPSHOT">
+<campaignPreset version="0.49.19-SNAPSHOT">
 	<title>TW Standard Default</title>
 	<description>This is the default settings used by MHQ. It is intended to follow the Total Warfare line of rulebooks whenever possible, and for rules outside of this scope it uses Field Manual: Mercenaries, revised rules.</description>
+	<date>3067-01-01</date>
+	<faction>MERC</faction>
+	<planet system="Galatea">Galatea</planet>
+	<rankSystem>
+		<code>SSLDF</code>
+	</rankSystem>
+	<contractCount>2</contractCount>
+	<gm>false</gm>
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
+		<mrmsUseRepair>true</mrmsUseRepair>
+		<mrmsUseSalvage>true</mrmsUseSalvage>
+		<mrmsUseExtraTime>true</mrmsUseExtraTime>
+		<mrmsUseRushJob>true</mrmsUseRushJob>
+		<mrmsAllowCarryover>true</mrmsAllowCarryover>
+		<mrmsOptimizeToCompleteToday>false</mrmsOptimizeToCompleteToday>
+		<mrmsScrapImpossible>false</mrmsScrapImpossible>
+		<mrmsUseAssignedTechsFirst>false</mrmsUseAssignedTechsFirst>
+		<mrmsReplacePod>true</mrmsReplacePod>
+		<mrmsOptions>
+			<mrmsOption>
+				<type>ARMOUR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>AMMUNITION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>WEAPON</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL_LOCATION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ENGINE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GYRO</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ACTUATOR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ELECTRONICS</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>POD_SPACE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+		</mrmsOptions>
 		<useFactionForNames>true</useFactionForNames>
 		<unitRatingMethod>FLD_MAN_MERCS_REV</unitRatingMethod>
 		<useEraMods>false</useEraMods>
@@ -53,9 +152,9 @@
 		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
 		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>5.0</equipmentContractPercent>
-		<dropshipContractPercent>1.0</dropshipContractPercent>
-		<jumpshipContractPercent>0.0</jumpshipContractPercent>
-		<warshipContractPercent>0.0</warshipContractPercent>
+		<dropShipContractPercent>1.0</dropShipContractPercent>
+		<jumpShipContractPercent>0.0</jumpShipContractPercent>
+		<warShipContractPercent>0.0</warShipContractPercent>
 		<equipmentContractBase>false</equipmentContractBase>
 		<equipmentContractSaleValue>false</equipmentContractSaleValue>
 		<blcSaleValue>false</blcSaleValue>
@@ -70,7 +169,7 @@
 		<maintenanceBonus>-1</maintenanceBonus>
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>false</reverseQualityNames>
-		<useUnofficalMaintenance>false</useUnofficalMaintenance>
+		<useUnofficialMaintenance>false</useUnofficialMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<maxAcquisitions>0</maxAcquisitions>
 		<useTactics>false</useTactics>
@@ -122,7 +221,7 @@
 		<useCustomRetirementModifiers>false</useCustomRetirementModifiers>
 		<useRandomFounderRetirement>false</useRandomFounderRetirement>
 		<trackUnitFatigue>false</trackUnitFatigue>
-		<displayFamilyLevel>PARENTS_CHILDREN_SIBLINGS</displayFamilyLevel>
+		<familyDisplayLevel>PARENTS_CHILDREN_SIBLINGS</familyDisplayLevel>
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
@@ -130,54 +229,63 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
+		<salaryXPMultipliers>
+			<VETERAN>1.6</VETERAN>
+			<ULTRA_GREEN>0.6</ULTRA_GREEN>
+			<LEGENDARY>12.8</LEGENDARY>
+			<ELITE>3.2</ELITE>
+			<GREEN>0.6</GREEN>
+			<NONE>0.5</NONE>
+			<HEROIC>6.4</HEROIC>
+			<REGULAR>1.0</REGULAR>
+		</salaryXPMultipliers>
 		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
-		<useClannerMarriages>false</useClannerMarriages>
+		<useClanPersonnelMarriages>false</useClanPersonnelMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChanges>false</logMarriageNameChanges>
 		<marriageSurnameWeights>
-			<HYP_YOURS>30</HYP_YOURS>
+			<YOURS>55</YOURS>
+			<MALE>500</MALE>
+			<SPOUSE>55</SPOUSE>
+			<NO_CHANGE>100</NO_CHANGE>
 			<BOTH_SPACE_SPOUSE>5</BOTH_SPACE_SPOUSE>
 			<FEMALE>160</FEMALE>
-			<MALE>500</MALE>
-			<SPACE_SPOUSE>10</SPACE_SPOUSE>
-			<SPOUSE>55</SPOUSE>
-			<BOTH_HYP_YOURS>20</BOTH_HYP_YOURS>
+			<HYPHEN_YOURS>30</HYPHEN_YOURS>
 			<SPACE_YOURS>10</SPACE_YOURS>
-			<HYP_SPOUSE>30</HYP_SPOUSE>
-			<BOTH_HYP_SPOUSE>20</BOTH_HYP_SPOUSE>
-			<NO_CHANGE>100</NO_CHANGE>
-			<YOURS>55</YOURS>
+			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
 			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
+			<SPACE_SPOUSE>10</SPACE_SPOUSE>
+			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
+			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
 		</marriageSurnameWeights>
 		<randomMarriageMethod>NONE</randomMarriageMethod>
 		<useRandomSameSexMarriages>false</useRandomSameSexMarriages>
-		<useRandomClannerMarriages>false</useRandomClannerMarriages>
+		<useRandomClanPersonnelMarriages>false</useRandomClanPersonnelMarriages>
 		<useRandomPrisonerMarriages>true</useRandomPrisonerMarriages>
 		<randomMarriageAgeRange>10</randomMarriageAgeRange>
 		<percentageRandomMarriageOppositeSexChance>2.5E-4</percentageRandomMarriageOppositeSexChance>
 		<percentageRandomMarriageSameSexChance>2.0E-5</percentageRandomMarriageSameSexChance>
 		<useManualDivorce>true</useManualDivorce>
-		<useClannerDivorce>true</useClannerDivorce>
+		<useClanPersonnelDivorce>true</useClanPersonnelDivorce>
 		<usePrisonerDivorce>false</usePrisonerDivorce>
 		<divorceSurnameWeights>
-			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
-			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 			<SPOUSE_CHANGES_SURNAME>10</SPOUSE_CHANGES_SURNAME>
 			<BOTH_CHANGE_SURNAME>30</BOTH_CHANGE_SURNAME>
+			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
+			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 		</divorceSurnameWeights>
 		<randomDivorceMethod>NONE</randomDivorceMethod>
 		<useRandomOppositeSexDivorce>true</useRandomOppositeSexDivorce>
 		<useRandomSameSexDivorce>true</useRandomSameSexDivorce>
-		<useRandomClannerDivorce>true</useRandomClannerDivorce>
+		<useRandomClanPersonnelDivorce>true</useRandomClanPersonnelDivorce>
 		<useRandomPrisonerDivorce>false</useRandomPrisonerDivorce>
 		<percentageRandomDivorceOppositeSexChance>1.0E-6</percentageRandomDivorceOppositeSexChance>
 		<percentageRandomDivorceSameSexChance>1.0E-6</percentageRandomDivorceSameSexChance>
 		<useManualProcreation>true</useManualProcreation>
-		<useClannerProcreation>false</useClannerProcreation>
+		<useClanPersonnelProcreation>false</useClanPersonnelProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
 		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
@@ -188,20 +296,20 @@
 		<logProcreation>false</logProcreation>
 		<randomProcreationMethod>PERCENTAGE</randomProcreationMethod>
 		<useRelationshiplessRandomProcreation>false</useRelationshiplessRandomProcreation>
-		<useRandomClannerProcreation>false</useRandomClannerProcreation>
+		<useRandomClanPersonnelProcreation>false</useRandomClanPersonnelProcreation>
 		<useRandomPrisonerProcreation>true</useRandomPrisonerProcreation>
 		<percentageRandomProcreationRelationshipChance>5.0E-4</percentageRandomProcreationRelationshipChance>
 		<percentageRandomProcreationRelationshiplessChance>5.0E-5</percentageRandomProcreationRelationshiplessChance>
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
 		<randomDeathMethod>NONE</randomDeathMethod>
 		<enabledRandomDeathAgeGroups>
-			<CHILD>false</CHILD>
-			<ELDER>true</ELDER>
 			<TEENAGER>true</TEENAGER>
-			<BABY>false</BABY>
-			<TODDLER>false</TODDLER>
 			<PRETEEN>false</PRETEEN>
+			<CHILD>false</CHILD>
+			<TODDLER>false</TODDLER>
 			<ADULT>true</ADULT>
+			<ELDER>true</ELDER>
+			<BABY>false</BABY>
 		</enabledRandomDeathAgeGroups>
 		<useRandomClanPersonnelDeath>true</useRandomClanPersonnelDeath>
 		<useRandomPrisonerDeath>true</useRandomPrisonerDeath>
@@ -210,30 +318,30 @@
 		<exponentialRandomDeathMaleValues>5.4757,-7.0,0.0709</exponentialRandomDeathMaleValues>
 		<exponentialRandomDeathFemaleValues>2.4641,-7.0,0.0752</exponentialRandomDeathFemaleValues>
 		<ageRangeRandomDeathMaleValues>
-			<UNDER_ONE>613.1</UNDER_ONE>
+			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>249.5</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>27.5</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>613.1</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>1119.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>14504.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>27.5</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathMaleValues>
 		<ageRangeRandomDeathFemaleValues>
-			<UNDER_ONE>500.0</UNDER_ONE>
+			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>140.2</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>20.4</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>500.0</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>670.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>12870.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>20.4</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathFemaleValues>
 		<payForParts>false</payForParts>
 		<payForRepairs>false</payForRepairs>
@@ -265,21 +373,30 @@
 		<cancelledOrderRefundMultiplier>0.5</cancelledOrderRefundMultiplier>
 		<personnelMarketName>FM: Mercenaries Revised</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
-		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
-		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
-		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
-		<personnelMarketRandomGreenRemoval>4</personnelMarketRandomGreenRemoval>
-		<personnelMarketRandomUltraGreenRemoval>4</personnelMarketRandomUltraGreenRemoval>
+		<personnelMarketRandomRemovalTargets>
+			<VETERAN>8</VETERAN>
+			<ULTRA_GREEN>4</ULTRA_GREEN>
+			<LEGENDARY>11</LEGENDARY>
+			<ELITE>10</ELITE>
+			<GREEN>4</GREEN>
+			<NONE>3</NONE>
+			<HEROIC>11</HEROIC>
+			<REGULAR>6</REGULAR>
+		</personnelMarketRandomRemovalTargets>
 		<personnelMarketDylansWeight>0.3</personnelMarketDylansWeight>
 		<unitMarketMethod>NONE</unitMarketMethod>
 		<unitMarketRegionalMechVariations>true</unitMarketRegionalMechVariations>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<contractMarketMethod>NONE</contractMarketMethod>
+		<contractSearchRadius>800</contractSearchRadius>
+		<variableContractLength>false</variableContractLength>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
+		<contractMaxSalvagePercentage>100</contractMaxSalvagePercentage>
 		<useStaticRATs>false</useStaticRATs>
 		<rats>Xotl,Total Warfare</rats>
 		<ignoreRATEra>false</ignoreRATEra>
+		<skillLevel>REGULAR</skillLevel>
 		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<useAtB>false</useAtB>
 		<useStratCon>false</useStratCon>
@@ -288,12 +405,11 @@
 		<clanVehicles>true</clanVehicles>
 		<doubleVehicles>false</doubleVehicles>
 		<adjustPlayerVehicles>false</adjustPlayerVehicles>
-		<opforLanceTypeMechs>1</opforLanceTypeMechs>
-		<opforLanceTypeMixed>2</opforLanceTypeMixed>
-		<opforLanceTypeVehicles>3</opforLanceTypeVehicles>
-		<opforUsesVTOLs>true</opforUsesVTOLs>
+		<opForLanceTypeMechs>1</opForLanceTypeMechs>
+		<opForLanceTypeMixed>2</opForLanceTypeMixed>
+		<opForLanceTypeVehicles>3</opForLanceTypeVehicles>
+		<opForUsesVTOLs>true</opForUsesVTOLs>
 		<useDropShips>false</useDropShips>
-		<skillLevel>2</skillLevel>
 		<aeroRecruitsHaveUnits>false</aeroRecruitsHaveUnits>
 		<useShareSystem>false</useShareSystem>
 		<sharesExcludeLargeCraft>false</sharesExcludeLargeCraft>
@@ -303,10 +419,8 @@
 		<regionalMechVariations>false</regionalMechVariations>
 		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
 		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
-		<searchRadius>800</searchRadius>
 		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>true</generateChases>
-		<variableContractLength>false</variableContractLength>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
 		<usePlanetaryConditions>false</usePlanetaryConditions>
@@ -319,102 +433,12 @@
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowOpforAeros>false</allowOpforAeros>
-		<allowOpforLocalUnits>false</allowOpforLocalUnits>
-		<opforAeroChance>5</opforAeroChance>
-		<opforLocalUnitChance>5</opforLocalUnitChance>
+		<allowOpForAeros>false</allowOpForAeros>
+		<allowOpForLocalUnits>false</allowOpForLocalUnits>
+		<opForAeroChance>5</opForAeroChance>
+		<opForLocalUnitChance>5</opForLocalUnitChance>
 		<fixedMapChance>25</fixedMapChance>
-		<massRepairUseRepair>true</massRepairUseRepair>
-		<massRepairUseSalvage>true</massRepairUseSalvage>
-		<massRepairUseExtraTime>true</massRepairUseExtraTime>
-		<massRepairUseRushJob>true</massRepairUseRushJob>
-		<massRepairAllowCarryover>true</massRepairAllowCarryover>
-		<massRepairOptimizeToCompleteToday>false</massRepairOptimizeToCompleteToday>
-		<massRepairScrapImpossible>false</massRepairScrapImpossible>
-		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
-		<massRepairReplacePod>true</massRepairReplacePod>
-		<massRepairOptions>
-			<massRepairOption>
-				<type>ARMOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>AMMO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>WEAPON</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL_LOCATION</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ENGINE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GYRO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ACTUATOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ELECTRONICS</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>POD_SPACE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-		</massRepairOptions>
+		<spaUpgradeIntensity>0</spaUpgradeIntensity>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
 		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
@@ -577,7 +601,7 @@
 			<costs>16,8,8,8,8,8,8,8,-1,-1,-1</costs>
 		</skillType>
 		<skillType>
-			<name>Gunnery/Protomech</name>
+			<name>Gunnery/ProtoMech</name>
 			<target>7</target>
 			<countUp>false</countUp>
 			<greenLvl>2</greenLvl>
@@ -759,26 +783,55 @@
 	</skillTypes>
 	<specialAbilities>
 		<ability>
-			<displayName>Eagle&apos;s Eyes (CamOps)</displayName>
-			<lookupName>eagle_eyes</lookupName>
-			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
-			<xpCost>10</xpCost>
+			<displayName>Weapon Specialist (CamOps)</displayName>
+			<lookupName>weapon_specialist</lookupName>
+			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
+			<xpCost>15</xpCost>
 			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Foot Cavalry (CamOps)</displayName>
+			<lookupName>foot_cav</lookupName>
+			<desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
+			<xpCost>5</xpCost>
+			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Small Arms::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Master (Unofficial)</displayName>
+			<lookupName>cluster_master</lookupName>
+			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
+			<xpCost>5</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>cluster_hitter</prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities>cluster_hitter</removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -792,8 +845,25 @@
 			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
+			<lookupName>tech_internal_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -807,13 +877,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -828,13 +897,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -849,45 +917,45 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/BA</skill>
 				<skill>Tech/Aero</skill>
+				<skill>Tech/BA</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
 			<miscPrereq>clanperson:false</miscPrereq>
 		</ability>
 		<ability>
-			<displayName>Tactical Genius (CamOps)</displayName>
-			<lookupName>tactical_genius</lookupName>
-			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
- The second roll must be accepted.
-Note: Only one Tactical Genius may be utilized per team.</desc>
-			<xpCost>15</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tactics::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
-			<lookupName>tm_forest_ranger</lookupName>
-			<desc>Movement in woods or jungle costs 1 less MP.
-Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
-Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
-			<xpCost>15</xpCost>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>10</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Hot Dog (CamOps)</displayName>
+			<lookupName>hot_dog</lookupName>
+			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
+			<xpCost>5</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -904,42 +972,23 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
-			<lookupName>tech_armor_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<displayName>Pain Resistance (MaxTech)</displayName>
+			<lookupName>pain_resistance</lookupName>
+			<desc>When making consciousness rolls,
+1 is added to all rolls.
+Also,
+damage received from ammo explosions is reduced to 1.
+Note: This ability is only used for BattleMechs.</desc>
 			<xpCost>4</xpCost>
 			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Golden Goose (CamOps)</displayName>
-			<lookupName>golden_goose</lookupName>
-			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-			</skillPrereq>
 		</ability>
 		<ability>
 			<displayName>Sniper (CamOps)</displayName>
@@ -952,13 +1001,52 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
 				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
 				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Maneuvering Ace (CamOps)</displayName>
+			<lookupName>maneuvering_ace</lookupName>
+			<desc>Enables the unit to move laterally like a Quad.
+Quads can move laterally for 1 less MP.
+Aerospace units can perform maneuvers for 1 less thrust point.
+Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -974,48 +1062,7 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Weapon Specialist (CamOps)</displayName>
-			<lookupName>weapon_specialist</lookupName>
-			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
-			<xpCost>15</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Natural Aptitude, Gunnery (aToW)</displayName>
-			<lookupName>aptitude_gunnery</lookupName>
-			<desc>Roll 3d6 and take the best two for gunnery checks</desc>
-			<xpCost>40</xpCost>
-			<weight>0</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit</skill>
-				<skill>Gunnery/Aircraft</skill>
-				<skill>Gunnery/Spacecraft</skill>
-				<skill>Gunnery/Aerospace</skill>
-				<skill>Gunnery/Vehicle</skill>
-				<skill>Gunnery/Mech</skill>
-				<skill>Gunnery/Protomech</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1030,10 +1077,117 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Eagle&apos;s Eyes (CamOps)</displayName>
+			<lookupName>eagle_eyes</lookupName>
+			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Small Arms::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Oblique Artilleryman (CamOps)</displayName>
+			<lookupName>oblique_artillery</lookupName>
+			<desc>Reduces scatter distance by two hexes.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
+			<lookupName>tm_forest_ranger</lookupName>
+			<desc>Movement in woods or jungle costs 1 less MP.
+Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
+Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
+			<xpCost>15</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Engineer (unofficial)</displayName>
+			<lookupName>tech_engineer</lookupName>
+			<desc>-2 on refit rolls</desc>
+			<xpCost>8</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Veteran</skill>
+				<skill>Tech/BA::Veteran</skill>
+				<skill>Tech/Aero::Veteran</skill>
+				<skill>Tech/Mechanic::Veteran</skill>
+				<skill>Tech/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Melee Master (CamOps)</displayName>
+			<lookupName>melee_master</lookupName>
+			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
+			<xpCost>15</xpCost>
+			<weight>6</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1052,7 +1206,6 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 				<skill>Piloting/Spacecraft::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Aerospace::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Small Arms::Regular</skill>
@@ -1060,123 +1213,41 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Shaky Stick (CamOps)</displayName>
-			<lookupName>shaky_stick</lookupName>
-			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
+			<displayName>Human TRO (CamOps)</displayName>
+			<lookupName>human_tro</lookupName>
+			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
+			<xpCost>5</xpCost>
+			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Hitter (CamOps)</displayName>
-			<lookupName>cluster_hitter</lookupName>
-			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Foot Cavalry (CamOps)</displayName>
-			<lookupName>foot_cav</lookupName>
-			<desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
-			<xpCost>5</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
 				<skill>Small Arms::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Weathered (Unofficial)</displayName>
-			<lookupName>weathered</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
-			<lookupName>tm_frogman</lookupName>
-			<desc>Movement in depth 2 or greater water costs 1 MP less.
-Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
+			<displayName>Tactical Genius (CamOps)</displayName>
+			<lookupName>tactical_genius</lookupName>
+			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
+ The second roll must be accepted.
+Note: Only one Tactical Genius may be utilized per team.</desc>
 			<xpCost>15</xpCost>
-			<weight>3</weight>
+			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Some Like It Hot (Unofficial)</displayName>
-			<lookupName>some_like_it_hot</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
-			<xpCost>5</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
-			<lookupName>tech_internal_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
-			<xpCost>6</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
+				<skill>Tactics::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1197,8 +1268,96 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Natural Aptitude, Gunnery (aToW)</displayName>
+			<lookupName>aptitude_gunnery</lookupName>
+			<desc>Roll 3d6 and take the best two for gunnery checks</desc>
+			<xpCost>40</xpCost>
+			<weight>0</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft</skill>
+				<skill>Gunnery/Battlesuit</skill>
+				<skill>Gunnery/Aerospace</skill>
+				<skill>Gunnery/Spacecraft</skill>
+				<skill>Gunnery/Mech</skill>
+				<skill>Gunnery/Vehicle</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>10</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Weathered (Unofficial)</displayName>
+			<lookupName>weathered</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>All Weather (Unofficial)</displayName>
+			<lookupName>allweather</lookupName>
+			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1229,21 +1388,133 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Maneuvering Ace (CamOps)</displayName>
-			<lookupName>maneuvering_ace</lookupName>
-			<desc>Enables the unit to move laterally like a Quad.
-Quads can move laterally for 1 less MP.
-Aerospace units can perform maneuvers for 1 less thrust point.
-Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
+			<displayName>Melee Specialist (CamOps)</displayName>
+			<lookupName>melee_specialist</lookupName>
+			<desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
+Note: This ability is only used for BattleMechs and Protomechs.</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Swamp Beast] (CamOps)</displayName>
+			<lookupName>tm_swamp_beast</lookupName>
+			<desc>Movement in mud or swamp costs 1 less MP.
+Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
+			<xpCost>15</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Gunnery Specialization (aToW)</displayName>
+			<lookupName>specialist</lookupName>
+			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
+ +1 to-hit modifier when using other types of weapons.</desc>
+			<xpCost>6</xpCost>
+			<weight>4</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Hitter (CamOps)</displayName>
+			<lookupName>cluster_hitter</lookupName>
+			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>cluster_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Some Like It Hot (Unofficial)</displayName>
+			<lookupName>some_like_it_hot</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
+			<xpCost>5</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Golden Goose (CamOps)</displayName>
+			<lookupName>golden_goose</lookupName>
+			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
+			<lookupName>tm_frogman</lookupName>
+			<desc>Movement in depth 2 or greater water costs 1 MP less.
+Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
+			<xpCost>15</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Shaky Stick (CamOps)</displayName>
+			<lookupName>shaky_stick</lookupName>
+			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
 			<xpCost>10</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
@@ -1252,80 +1523,22 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Oblique Artilleryman (CamOps)</displayName>
-			<lookupName>oblique_artillery</lookupName>
-			<desc>Reduces scatter distance by two hexes.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Melee Master (CamOps)</displayName>
-			<lookupName>melee_master</lookupName>
-			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-			<xpCost>15</xpCost>
-			<weight>6</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Zweihander (CamOps)</displayName>
-			<lookupName>zweihander</lookupName>
-			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-			<xpCost>10</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities>melee_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Master (Unofficial)</displayName>
-			<lookupName>cluster_master</lookupName>
-			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
+			<displayName>Hopping Jack (Unofficial)</displayName>
+			<lookupName>hopping_jack</lookupName>
+			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
 			<xpCost>5</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>cluster_hitter</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities>cluster_hitter</removeAbilities>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>jumping_jack</invalidAbilities>
+			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1342,225 +1555,7 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Melee Specialist (CamOps)</displayName>
-			<lookupName>melee_specialist</lookupName>
-			<desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
-Note: This ability is only used for BattleMechs and Protomechs.</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Gunnery Specialization (aToW)</displayName>
-			<lookupName>specialist</lookupName>
-			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
- +1 to-hit modifier when using other types of weapons.</desc>
-			<xpCost>6</xpCost>
-			<weight>4</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>weapon_specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Human TRO (CamOps)</displayName>
-			<lookupName>human_tro</lookupName>
-			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
-			<xpCost>5</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Small Arms::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Pain Resistance (MaxTech)</displayName>
-			<lookupName>pain_resistance</lookupName>
-			<desc>When making consciousness rolls,
-1 is added to all rolls.
-Also,
-damage received from ammo explosions is reduced to 1.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>All Weather (Unofficial)</displayName>
-			<lookupName>allweather</lookupName>
-			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hot Dog (CamOps)</displayName>
-			<lookupName>hot_dog</lookupName>
-			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-			<xpCost>5</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Engineer (unofficial)</displayName>
-			<lookupName>tech_engineer</lookupName>
-			<desc>-2 on refit rolls</desc>
-			<xpCost>8</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Veteran</skill>
-				<skill>Tech/Aero::Veteran</skill>
-				<skill>Tech/BA::Veteran</skill>
-				<skill>Tech/Mechanic::Veteran</skill>
-				<skill>Tech/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Swamp Beast] (CamOps)</displayName>
-			<lookupName>tm_swamp_beast</lookupName>
-			<desc>Movement in mud or swamp costs 1 less MP.
-Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
-			<xpCost>15</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hopping Jack (Unofficial)</displayName>
-			<lookupName>hopping_jack</lookupName>
-			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>5</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>jumping_jack</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
-			<lookupName>tech_weapon_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with weapons</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>

--- a/MekHQ/mmconf/campaignPresets/SimpleOptions.xml
+++ b/MekHQ/mmconf/campaignPresets/SimpleOptions.xml
@@ -1,10 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<campaignPreset version="0.49.8-SNAPSHOT">
+<campaignPreset version="0.49.19-SNAPSHOT">
 	<title>Simple Presets</title>
 	<description>This set of presets attempts to provide the simplest rules settings possible for those who just want to get into the action. Acquisitions are automatic and maintenance is turned off.</description>
+	<date>3067-01-01</date>
+	<faction>MERC</faction>
+	<planet system="Galatea">Galatea</planet>
+	<rankSystem>
+		<code>SSLDF</code>
+	</rankSystem>
+	<contractCount>2</contractCount>
+	<gm>false</gm>
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
+		<mrmsUseRepair>true</mrmsUseRepair>
+		<mrmsUseSalvage>true</mrmsUseSalvage>
+		<mrmsUseExtraTime>true</mrmsUseExtraTime>
+		<mrmsUseRushJob>true</mrmsUseRushJob>
+		<mrmsAllowCarryover>true</mrmsAllowCarryover>
+		<mrmsOptimizeToCompleteToday>false</mrmsOptimizeToCompleteToday>
+		<mrmsScrapImpossible>false</mrmsScrapImpossible>
+		<mrmsUseAssignedTechsFirst>false</mrmsUseAssignedTechsFirst>
+		<mrmsReplacePod>true</mrmsReplacePod>
+		<mrmsOptions>
+			<mrmsOption>
+				<type>ARMOUR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>AMMUNITION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>WEAPON</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL_LOCATION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ENGINE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GYRO</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ACTUATOR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ELECTRONICS</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>POD_SPACE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+		</mrmsOptions>
 		<useFactionForNames>true</useFactionForNames>
 		<unitRatingMethod>CAMPAIGN_OPS</unitRatingMethod>
 		<useEraMods>false</useEraMods>
@@ -53,9 +152,9 @@
 		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
 		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>5.0</equipmentContractPercent>
-		<dropshipContractPercent>1.0</dropshipContractPercent>
-		<jumpshipContractPercent>0.0</jumpshipContractPercent>
-		<warshipContractPercent>0.0</warshipContractPercent>
+		<dropShipContractPercent>1.0</dropShipContractPercent>
+		<jumpShipContractPercent>0.0</jumpShipContractPercent>
+		<warShipContractPercent>0.0</warShipContractPercent>
 		<equipmentContractBase>false</equipmentContractBase>
 		<equipmentContractSaleValue>false</equipmentContractSaleValue>
 		<blcSaleValue>false</blcSaleValue>
@@ -70,7 +169,7 @@
 		<maintenanceBonus>-1</maintenanceBonus>
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>false</reverseQualityNames>
-		<useUnofficalMaintenance>false</useUnofficalMaintenance>
+		<useUnofficialMaintenance>false</useUnofficialMaintenance>
 		<checkMaintenance>false</checkMaintenance>
 		<maxAcquisitions>0</maxAcquisitions>
 		<useTactics>false</useTactics>
@@ -122,7 +221,7 @@
 		<useCustomRetirementModifiers>false</useCustomRetirementModifiers>
 		<useRandomFounderRetirement>false</useRandomFounderRetirement>
 		<trackUnitFatigue>false</trackUnitFatigue>
-		<displayFamilyLevel>PARENTS_CHILDREN_SIBLINGS</displayFamilyLevel>
+		<familyDisplayLevel>PARENTS_CHILDREN_SIBLINGS</familyDisplayLevel>
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
@@ -130,54 +229,63 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
+		<salaryXPMultipliers>
+			<VETERAN>1.6</VETERAN>
+			<ULTRA_GREEN>0.6</ULTRA_GREEN>
+			<LEGENDARY>12.8</LEGENDARY>
+			<ELITE>3.2</ELITE>
+			<GREEN>0.6</GREEN>
+			<NONE>0.5</NONE>
+			<HEROIC>6.4</HEROIC>
+			<REGULAR>1.0</REGULAR>
+		</salaryXPMultipliers>
 		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
-		<useClannerMarriages>false</useClannerMarriages>
+		<useClanPersonnelMarriages>false</useClanPersonnelMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChanges>false</logMarriageNameChanges>
 		<marriageSurnameWeights>
-			<HYP_YOURS>30</HYP_YOURS>
+			<YOURS>55</YOURS>
+			<MALE>500</MALE>
+			<SPOUSE>55</SPOUSE>
+			<NO_CHANGE>100</NO_CHANGE>
 			<BOTH_SPACE_SPOUSE>5</BOTH_SPACE_SPOUSE>
 			<FEMALE>160</FEMALE>
-			<MALE>500</MALE>
-			<SPACE_SPOUSE>10</SPACE_SPOUSE>
-			<SPOUSE>55</SPOUSE>
-			<BOTH_HYP_YOURS>20</BOTH_HYP_YOURS>
+			<HYPHEN_YOURS>30</HYPHEN_YOURS>
 			<SPACE_YOURS>10</SPACE_YOURS>
-			<HYP_SPOUSE>30</HYP_SPOUSE>
-			<BOTH_HYP_SPOUSE>20</BOTH_HYP_SPOUSE>
-			<NO_CHANGE>100</NO_CHANGE>
-			<YOURS>55</YOURS>
+			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
 			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
+			<SPACE_SPOUSE>10</SPACE_SPOUSE>
+			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
+			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
 		</marriageSurnameWeights>
 		<randomMarriageMethod>NONE</randomMarriageMethod>
 		<useRandomSameSexMarriages>false</useRandomSameSexMarriages>
-		<useRandomClannerMarriages>false</useRandomClannerMarriages>
+		<useRandomClanPersonnelMarriages>false</useRandomClanPersonnelMarriages>
 		<useRandomPrisonerMarriages>true</useRandomPrisonerMarriages>
 		<randomMarriageAgeRange>10</randomMarriageAgeRange>
 		<percentageRandomMarriageOppositeSexChance>2.5E-4</percentageRandomMarriageOppositeSexChance>
 		<percentageRandomMarriageSameSexChance>2.0E-5</percentageRandomMarriageSameSexChance>
 		<useManualDivorce>true</useManualDivorce>
-		<useClannerDivorce>true</useClannerDivorce>
+		<useClanPersonnelDivorce>true</useClanPersonnelDivorce>
 		<usePrisonerDivorce>false</usePrisonerDivorce>
 		<divorceSurnameWeights>
-			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
-			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 			<SPOUSE_CHANGES_SURNAME>10</SPOUSE_CHANGES_SURNAME>
 			<BOTH_CHANGE_SURNAME>30</BOTH_CHANGE_SURNAME>
+			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
+			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 		</divorceSurnameWeights>
 		<randomDivorceMethod>NONE</randomDivorceMethod>
 		<useRandomOppositeSexDivorce>true</useRandomOppositeSexDivorce>
 		<useRandomSameSexDivorce>true</useRandomSameSexDivorce>
-		<useRandomClannerDivorce>true</useRandomClannerDivorce>
+		<useRandomClanPersonnelDivorce>true</useRandomClanPersonnelDivorce>
 		<useRandomPrisonerDivorce>false</useRandomPrisonerDivorce>
 		<percentageRandomDivorceOppositeSexChance>1.0E-6</percentageRandomDivorceOppositeSexChance>
 		<percentageRandomDivorceSameSexChance>1.0E-6</percentageRandomDivorceSameSexChance>
 		<useManualProcreation>true</useManualProcreation>
-		<useClannerProcreation>false</useClannerProcreation>
+		<useClanPersonnelProcreation>false</useClanPersonnelProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
 		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
@@ -188,20 +296,20 @@
 		<logProcreation>false</logProcreation>
 		<randomProcreationMethod>PERCENTAGE</randomProcreationMethod>
 		<useRelationshiplessRandomProcreation>false</useRelationshiplessRandomProcreation>
-		<useRandomClannerProcreation>false</useRandomClannerProcreation>
+		<useRandomClanPersonnelProcreation>false</useRandomClanPersonnelProcreation>
 		<useRandomPrisonerProcreation>true</useRandomPrisonerProcreation>
 		<percentageRandomProcreationRelationshipChance>5.0E-4</percentageRandomProcreationRelationshipChance>
 		<percentageRandomProcreationRelationshiplessChance>5.0E-5</percentageRandomProcreationRelationshiplessChance>
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
 		<randomDeathMethod>NONE</randomDeathMethod>
 		<enabledRandomDeathAgeGroups>
-			<CHILD>false</CHILD>
-			<ELDER>true</ELDER>
 			<TEENAGER>true</TEENAGER>
-			<BABY>false</BABY>
-			<TODDLER>false</TODDLER>
 			<PRETEEN>false</PRETEEN>
+			<CHILD>false</CHILD>
+			<TODDLER>false</TODDLER>
 			<ADULT>true</ADULT>
+			<ELDER>true</ELDER>
+			<BABY>false</BABY>
 		</enabledRandomDeathAgeGroups>
 		<useRandomClanPersonnelDeath>true</useRandomClanPersonnelDeath>
 		<useRandomPrisonerDeath>true</useRandomPrisonerDeath>
@@ -210,30 +318,30 @@
 		<exponentialRandomDeathMaleValues>5.4757,-7.0,0.0709</exponentialRandomDeathMaleValues>
 		<exponentialRandomDeathFemaleValues>2.4641,-7.0,0.0752</exponentialRandomDeathFemaleValues>
 		<ageRangeRandomDeathMaleValues>
-			<UNDER_ONE>613.1</UNDER_ONE>
+			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>249.5</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>27.5</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>613.1</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>1119.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>14504.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>27.5</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathMaleValues>
 		<ageRangeRandomDeathFemaleValues>
-			<UNDER_ONE>500.0</UNDER_ONE>
+			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>140.2</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>20.4</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>500.0</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>670.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>12870.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>20.4</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathFemaleValues>
 		<payForParts>false</payForParts>
 		<payForRepairs>false</payForRepairs>
@@ -265,21 +373,30 @@
 		<cancelledOrderRefundMultiplier>0.5</cancelledOrderRefundMultiplier>
 		<personnelMarketName>Strat Ops</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
-		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
-		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
-		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
-		<personnelMarketRandomGreenRemoval>4</personnelMarketRandomGreenRemoval>
-		<personnelMarketRandomUltraGreenRemoval>4</personnelMarketRandomUltraGreenRemoval>
+		<personnelMarketRandomRemovalTargets>
+			<VETERAN>8</VETERAN>
+			<ULTRA_GREEN>4</ULTRA_GREEN>
+			<LEGENDARY>11</LEGENDARY>
+			<ELITE>10</ELITE>
+			<GREEN>4</GREEN>
+			<NONE>3</NONE>
+			<HEROIC>11</HEROIC>
+			<REGULAR>6</REGULAR>
+		</personnelMarketRandomRemovalTargets>
 		<personnelMarketDylansWeight>0.3</personnelMarketDylansWeight>
 		<unitMarketMethod>NONE</unitMarketMethod>
 		<unitMarketRegionalMechVariations>true</unitMarketRegionalMechVariations>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<contractMarketMethod>NONE</contractMarketMethod>
+		<contractSearchRadius>800</contractSearchRadius>
+		<variableContractLength>false</variableContractLength>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
+		<contractMaxSalvagePercentage>100</contractMaxSalvagePercentage>
 		<useStaticRATs>false</useStaticRATs>
 		<rats>Xotl,Total Warfare</rats>
 		<ignoreRATEra>false</ignoreRATEra>
+		<skillLevel>REGULAR</skillLevel>
 		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<useAtB>false</useAtB>
 		<useStratCon>false</useStratCon>
@@ -288,12 +405,11 @@
 		<clanVehicles>true</clanVehicles>
 		<doubleVehicles>false</doubleVehicles>
 		<adjustPlayerVehicles>false</adjustPlayerVehicles>
-		<opforLanceTypeMechs>1</opforLanceTypeMechs>
-		<opforLanceTypeMixed>2</opforLanceTypeMixed>
-		<opforLanceTypeVehicles>3</opforLanceTypeVehicles>
-		<opforUsesVTOLs>true</opforUsesVTOLs>
+		<opForLanceTypeMechs>1</opForLanceTypeMechs>
+		<opForLanceTypeMixed>2</opForLanceTypeMixed>
+		<opForLanceTypeVehicles>3</opForLanceTypeVehicles>
+		<opForUsesVTOLs>true</opForUsesVTOLs>
 		<useDropShips>false</useDropShips>
-		<skillLevel>2</skillLevel>
 		<aeroRecruitsHaveUnits>false</aeroRecruitsHaveUnits>
 		<useShareSystem>false</useShareSystem>
 		<sharesExcludeLargeCraft>false</sharesExcludeLargeCraft>
@@ -303,10 +419,8 @@
 		<regionalMechVariations>false</regionalMechVariations>
 		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
 		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
-		<searchRadius>800</searchRadius>
 		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>true</generateChases>
-		<variableContractLength>false</variableContractLength>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
 		<usePlanetaryConditions>false</usePlanetaryConditions>
@@ -319,102 +433,12 @@
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowOpforAeros>false</allowOpforAeros>
-		<allowOpforLocalUnits>false</allowOpforLocalUnits>
-		<opforAeroChance>5</opforAeroChance>
-		<opforLocalUnitChance>5</opforLocalUnitChance>
+		<allowOpForAeros>false</allowOpForAeros>
+		<allowOpForLocalUnits>false</allowOpForLocalUnits>
+		<opForAeroChance>5</opForAeroChance>
+		<opForLocalUnitChance>5</opForLocalUnitChance>
 		<fixedMapChance>25</fixedMapChance>
-		<massRepairUseRepair>true</massRepairUseRepair>
-		<massRepairUseSalvage>true</massRepairUseSalvage>
-		<massRepairUseExtraTime>true</massRepairUseExtraTime>
-		<massRepairUseRushJob>true</massRepairUseRushJob>
-		<massRepairAllowCarryover>true</massRepairAllowCarryover>
-		<massRepairOptimizeToCompleteToday>false</massRepairOptimizeToCompleteToday>
-		<massRepairScrapImpossible>false</massRepairScrapImpossible>
-		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
-		<massRepairReplacePod>true</massRepairReplacePod>
-		<massRepairOptions>
-			<massRepairOption>
-				<type>ARMOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>AMMO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>WEAPON</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL_LOCATION</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ENGINE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GYRO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ACTUATOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ELECTRONICS</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>POD_SPACE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-		</massRepairOptions>
+		<spaUpgradeIntensity>0</spaUpgradeIntensity>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
 		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
@@ -577,7 +601,7 @@
 			<costs>16,8,8,8,8,8,8,8,-1,-1,-1</costs>
 		</skillType>
 		<skillType>
-			<name>Gunnery/Protomech</name>
+			<name>Gunnery/ProtoMech</name>
 			<target>7</target>
 			<countUp>false</countUp>
 			<greenLvl>2</greenLvl>
@@ -759,26 +783,55 @@
 	</skillTypes>
 	<specialAbilities>
 		<ability>
-			<displayName>Eagle&apos;s Eyes (CamOps)</displayName>
-			<lookupName>eagle_eyes</lookupName>
-			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
-			<xpCost>10</xpCost>
+			<displayName>Weapon Specialist (CamOps)</displayName>
+			<lookupName>weapon_specialist</lookupName>
+			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
+			<xpCost>15</xpCost>
 			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Foot Cavalry (CamOps)</displayName>
+			<lookupName>foot_cav</lookupName>
+			<desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
+			<xpCost>5</xpCost>
+			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Small Arms::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Master (Unofficial)</displayName>
+			<lookupName>cluster_master</lookupName>
+			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
+			<xpCost>5</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>cluster_hitter</prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities>cluster_hitter</removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -793,7 +846,24 @@
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
+			<lookupName>tech_internal_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -807,13 +877,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -828,13 +897,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -849,45 +917,45 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/Aero</skill>
 				<skill>Tech/BA</skill>
+				<skill>Tech/Aero</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
 			<miscPrereq>clanperson:false</miscPrereq>
 		</ability>
 		<ability>
-			<displayName>Tactical Genius (CamOps)</displayName>
-			<lookupName>tactical_genius</lookupName>
-			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
- The second roll must be accepted.
-Note: Only one Tactical Genius may be utilized per team.</desc>
-			<xpCost>15</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tactics::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
-			<lookupName>tm_forest_ranger</lookupName>
-			<desc>Movement in woods or jungle costs 1 less MP.
-Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
-Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
-			<xpCost>15</xpCost>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>10</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Hot Dog (CamOps)</displayName>
+			<lookupName>hot_dog</lookupName>
+			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
+			<xpCost>5</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -905,41 +973,22 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
-			<lookupName>tech_armor_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<displayName>Pain Resistance (MaxTech)</displayName>
+			<lookupName>pain_resistance</lookupName>
+			<desc>When making consciousness rolls,
+1 is added to all rolls.
+Also,
+damage received from ammo explosions is reduced to 1.
+Note: This ability is only used for BattleMechs.</desc>
 			<xpCost>4</xpCost>
 			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Golden Goose (CamOps)</displayName>
-			<lookupName>golden_goose</lookupName>
-			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-			</skillPrereq>
 		</ability>
 		<ability>
 			<displayName>Sniper (CamOps)</displayName>
@@ -952,13 +1001,52 @@ Note: This ability is only used for BattleMechs.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
 				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
 				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Maneuvering Ace (CamOps)</displayName>
+			<lookupName>maneuvering_ace</lookupName>
+			<desc>Enables the unit to move laterally like a Quad.
+Quads can move laterally for 1 less MP.
+Aerospace units can perform maneuvers for 1 less thrust point.
+Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -975,47 +1063,6 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Veteran</skill>
 				<skill>Piloting/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Weapon Specialist (CamOps)</displayName>
-			<lookupName>weapon_specialist</lookupName>
-			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
-			<xpCost>15</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Natural Aptitude, Gunnery (aToW)</displayName>
-			<lookupName>aptitude_gunnery</lookupName>
-			<desc>Roll 3d6 and take the best two for gunnery checks</desc>
-			<xpCost>40</xpCost>
-			<weight>0</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft</skill>
-				<skill>Gunnery/Battlesuit</skill>
-				<skill>Gunnery/Aerospace</skill>
-				<skill>Gunnery/Spacecraft</skill>
-				<skill>Gunnery/Mech</skill>
-				<skill>Gunnery/Vehicle</skill>
-				<skill>Gunnery/Protomech</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1030,10 +1077,117 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Eagle&apos;s Eyes (CamOps)</displayName>
+			<lookupName>eagle_eyes</lookupName>
+			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Small Arms::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Oblique Artilleryman (CamOps)</displayName>
+			<lookupName>oblique_artillery</lookupName>
+			<desc>Reduces scatter distance by two hexes.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
+			<lookupName>tm_forest_ranger</lookupName>
+			<desc>Movement in woods or jungle costs 1 less MP.
+Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
+Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
+			<xpCost>15</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Engineer (unofficial)</displayName>
+			<lookupName>tech_engineer</lookupName>
+			<desc>-2 on refit rolls</desc>
+			<xpCost>8</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Veteran</skill>
+				<skill>Tech/BA::Veteran</skill>
+				<skill>Tech/Aero::Veteran</skill>
+				<skill>Tech/Mechanic::Veteran</skill>
+				<skill>Tech/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
 				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Melee Master (CamOps)</displayName>
+			<lookupName>melee_master</lookupName>
+			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
+			<xpCost>15</xpCost>
+			<weight>6</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1052,7 +1206,6 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 				<skill>Piloting/Spacecraft::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 				<skill>Piloting/Aerospace::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Small Arms::Regular</skill>
@@ -1060,123 +1213,41 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Shaky Stick (CamOps)</displayName>
-			<lookupName>shaky_stick</lookupName>
-			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
+			<displayName>Human TRO (CamOps)</displayName>
+			<lookupName>human_tro</lookupName>
+			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
+			<xpCost>5</xpCost>
+			<weight>2</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Hitter (CamOps)</displayName>
-			<lookupName>cluster_hitter</lookupName>
-			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Foot Cavalry (CamOps)</displayName>
-			<lookupName>foot_cav</lookupName>
-			<desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
-			<xpCost>5</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
 				<skill>Small Arms::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Weathered (Unofficial)</displayName>
-			<lookupName>weathered</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
-			<lookupName>tm_frogman</lookupName>
-			<desc>Movement in depth 2 or greater water costs 1 MP less.
-Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
+			<displayName>Tactical Genius (CamOps)</displayName>
+			<lookupName>tactical_genius</lookupName>
+			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
+ The second roll must be accepted.
+Note: Only one Tactical Genius may be utilized per team.</desc>
 			<xpCost>15</xpCost>
-			<weight>3</weight>
+			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Some Like It Hot (Unofficial)</displayName>
-			<lookupName>some_like_it_hot</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
-			<xpCost>5</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
-			<lookupName>tech_internal_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
-			<xpCost>6</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
+				<skill>Tactics::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1198,7 +1269,95 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Natural Aptitude, Gunnery (aToW)</displayName>
+			<lookupName>aptitude_gunnery</lookupName>
+			<desc>Roll 3d6 and take the best two for gunnery checks</desc>
+			<xpCost>40</xpCost>
+			<weight>0</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit</skill>
+				<skill>Gunnery/Aircraft</skill>
+				<skill>Gunnery/Spacecraft</skill>
+				<skill>Gunnery/Aerospace</skill>
+				<skill>Gunnery/Vehicle</skill>
+				<skill>Gunnery/Mech</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>10</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Weathered (Unofficial)</displayName>
+			<lookupName>weathered</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>All Weather (Unofficial)</displayName>
+			<lookupName>allweather</lookupName>
+			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
+			<xpCost>10</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1229,21 +1388,133 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
 				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Maneuvering Ace (CamOps)</displayName>
-			<lookupName>maneuvering_ace</lookupName>
-			<desc>Enables the unit to move laterally like a Quad.
-Quads can move laterally for 1 less MP.
-Aerospace units can perform maneuvers for 1 less thrust point.
-Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
+			<displayName>Melee Specialist (CamOps)</displayName>
+			<lookupName>melee_specialist</lookupName>
+			<desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
+Note: This ability is only used for BattleMechs and Protomechs.</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Swamp Beast] (CamOps)</displayName>
+			<lookupName>tm_swamp_beast</lookupName>
+			<desc>Movement in mud or swamp costs 1 less MP.
+Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
+			<xpCost>15</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Gunnery Specialization (aToW)</displayName>
+			<lookupName>specialist</lookupName>
+			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
+ +1 to-hit modifier when using other types of weapons.</desc>
+			<xpCost>6</xpCost>
+			<weight>4</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Hitter (CamOps)</displayName>
+			<lookupName>cluster_hitter</lookupName>
+			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>cluster_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Some Like It Hot (Unofficial)</displayName>
+			<lookupName>some_like_it_hot</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
+			<xpCost>5</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Golden Goose (CamOps)</displayName>
+			<lookupName>golden_goose</lookupName>
+			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
+			<xpCost>10</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
+			<lookupName>tm_frogman</lookupName>
+			<desc>Movement in depth 2 or greater water costs 1 MP less.
+Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
+			<xpCost>15</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Shaky Stick (CamOps)</displayName>
+			<lookupName>shaky_stick</lookupName>
+			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
 			<xpCost>10</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
@@ -1252,80 +1523,22 @@ Units also receive a -1 BTH to rolls against skidding, sideslipping, and going o
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
 				<skill>Piloting/VTOL::Regular</skill>
 				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Oblique Artilleryman (CamOps)</displayName>
-			<lookupName>oblique_artillery</lookupName>
-			<desc>Reduces scatter distance by two hexes.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Melee Master (CamOps)</displayName>
-			<lookupName>melee_master</lookupName>
-			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-			<xpCost>15</xpCost>
-			<weight>6</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Zweihander (CamOps)</displayName>
-			<lookupName>zweihander</lookupName>
-			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-			<xpCost>10</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities>melee_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Master (Unofficial)</displayName>
-			<lookupName>cluster_master</lookupName>
-			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
+			<displayName>Hopping Jack (Unofficial)</displayName>
+			<lookupName>hopping_jack</lookupName>
+			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
 			<xpCost>5</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>cluster_hitter</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities>cluster_hitter</removeAbilities>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>jumping_jack</invalidAbilities>
+			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1343,224 +1556,6 @@ NOTE: The quirk should be used only on bipedal units that have an animal like ap
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Melee Specialist (CamOps)</displayName>
-			<lookupName>melee_specialist</lookupName>
-			<desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
-Note: This ability is only used for BattleMechs and Protomechs.</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Gunnery Specialization (aToW)</displayName>
-			<lookupName>specialist</lookupName>
-			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
- +1 to-hit modifier when using other types of weapons.</desc>
-			<xpCost>6</xpCost>
-			<weight>4</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>weapon_specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Human TRO (CamOps)</displayName>
-			<lookupName>human_tro</lookupName>
-			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
-			<xpCost>5</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Small Arms::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Pain Resistance (MaxTech)</displayName>
-			<lookupName>pain_resistance</lookupName>
-			<desc>When making consciousness rolls,
-1 is added to all rolls.
-Also,
-damage received from ammo explosions is reduced to 1.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>All Weather (Unofficial)</displayName>
-			<lookupName>allweather</lookupName>
-			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hot Dog (CamOps)</displayName>
-			<lookupName>hot_dog</lookupName>
-			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-			<xpCost>5</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Engineer (unofficial)</displayName>
-			<lookupName>tech_engineer</lookupName>
-			<desc>-2 on refit rolls</desc>
-			<xpCost>8</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Veteran</skill>
-				<skill>Tech/Aero::Veteran</skill>
-				<skill>Tech/BA::Veteran</skill>
-				<skill>Tech/Mechanic::Veteran</skill>
-				<skill>Tech/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Swamp Beast] (CamOps)</displayName>
-			<lookupName>tm_swamp_beast</lookupName>
-			<desc>Movement in mud or swamp costs 1 less MP.
-Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
-			<xpCost>15</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-				<skill>Gunnery/Protomech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
-			<xpCost>10</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-			<xpCost>10</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hopping Jack (Unofficial)</displayName>
-			<lookupName>hopping_jack</lookupName>
-			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>5</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>jumping_jack</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Gunnery/Protomech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
-			<lookupName>tech_weapon_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with weapons</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>

--- a/MekHQ/mmconf/campaignPresets/StratConAlpha.xml
+++ b/MekHQ/mmconf/campaignPresets/StratConAlpha.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<campaignPreset version="0.49.12-SNAPSHOT">
+<campaignPreset version="0.49.19-SNAPSHOT">
 	<title>StratCon Alpha</title>
 	<description>These are basic settings for running the StratCon Alpha. It is based on the AtB Preset, with some newer personnel options enabled.</description>
 	<date>3035-01-01</date>
@@ -13,6 +13,97 @@
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
+		<mrmsUseRepair>true</mrmsUseRepair>
+		<mrmsUseSalvage>true</mrmsUseSalvage>
+		<mrmsUseExtraTime>true</mrmsUseExtraTime>
+		<mrmsUseRushJob>true</mrmsUseRushJob>
+		<mrmsAllowCarryover>true</mrmsAllowCarryover>
+		<mrmsOptimizeToCompleteToday>false</mrmsOptimizeToCompleteToday>
+		<mrmsScrapImpossible>false</mrmsScrapImpossible>
+		<mrmsUseAssignedTechsFirst>false</mrmsUseAssignedTechsFirst>
+		<mrmsReplacePod>true</mrmsReplacePod>
+		<mrmsOptions>
+			<mrmsOption>
+				<type>ARMOUR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>AMMUNITION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>WEAPON</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL_LOCATION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ENGINE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GYRO</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ACTUATOR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ELECTRONICS</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>POD_SPACE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+		</mrmsOptions>
 		<useFactionForNames>true</useFactionForNames>
 		<unitRatingMethod>FLD_MAN_MERCS_REV</unitRatingMethod>
 		<useEraMods>false</useEraMods>
@@ -61,9 +152,9 @@
 		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
 		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>5.0</equipmentContractPercent>
-		<dropshipContractPercent>1.0</dropshipContractPercent>
-		<jumpshipContractPercent>0.0</jumpshipContractPercent>
-		<warshipContractPercent>0.0</warshipContractPercent>
+		<dropShipContractPercent>1.0</dropShipContractPercent>
+		<jumpShipContractPercent>0.0</jumpShipContractPercent>
+		<warShipContractPercent>0.0</warShipContractPercent>
 		<equipmentContractBase>true</equipmentContractBase>
 		<equipmentContractSaleValue>true</equipmentContractSaleValue>
 		<blcSaleValue>true</blcSaleValue>
@@ -78,7 +169,7 @@
 		<maintenanceBonus>0</maintenanceBonus>
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>false</reverseQualityNames>
-		<useUnofficalMaintenance>true</useUnofficalMaintenance>
+		<useUnofficialMaintenance>true</useUnofficialMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<maxAcquisitions>2</maxAcquisitions>
 		<useTactics>true</useTactics>
@@ -130,7 +221,7 @@
 		<useCustomRetirementModifiers>true</useCustomRetirementModifiers>
 		<useRandomFounderRetirement>false</useRandomFounderRetirement>
 		<trackUnitFatigue>true</trackUnitFatigue>
-		<displayFamilyLevel>PARENTS_CHILDREN_SIBLINGS</displayFamilyLevel>
+		<familyDisplayLevel>PARENTS_CHILDREN_SIBLINGS</familyDisplayLevel>
 		<randomDependentMethod>AGAINST_THE_BOT</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
@@ -138,54 +229,63 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
+		<salaryXPMultipliers>
+			<VETERAN>1.6</VETERAN>
+			<ULTRA_GREEN>0.6</ULTRA_GREEN>
+			<LEGENDARY>12.8</LEGENDARY>
+			<ELITE>3.2</ELITE>
+			<GREEN>0.6</GREEN>
+			<NONE>0.5</NONE>
+			<HEROIC>6.4</HEROIC>
+			<REGULAR>1.0</REGULAR>
+		</salaryXPMultipliers>
 		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
-		<useClannerMarriages>false</useClannerMarriages>
+		<useClanPersonnelMarriages>false</useClanPersonnelMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChanges>true</logMarriageNameChanges>
 		<marriageSurnameWeights>
-			<SPACE_YOURS>10</SPACE_YOURS>
-			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
-			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
-			<SPACE_SPOUSE>10</SPACE_SPOUSE>
-			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
-			<NO_CHANGE>100</NO_CHANGE>
-			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
-			<SPOUSE>55</SPOUSE>
-			<HYPHEN_YOURS>30</HYPHEN_YOURS>
 			<YOURS>55</YOURS>
 			<MALE>500</MALE>
-			<FEMALE>160</FEMALE>
+			<SPOUSE>55</SPOUSE>
+			<NO_CHANGE>100</NO_CHANGE>
 			<BOTH_SPACE_SPOUSE>5</BOTH_SPACE_SPOUSE>
+			<FEMALE>160</FEMALE>
+			<HYPHEN_YOURS>30</HYPHEN_YOURS>
+			<SPACE_YOURS>10</SPACE_YOURS>
+			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
+			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
+			<SPACE_SPOUSE>10</SPACE_SPOUSE>
+			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
+			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
 		</marriageSurnameWeights>
 		<randomMarriageMethod>PERCENTAGE</randomMarriageMethod>
 		<useRandomSameSexMarriages>true</useRandomSameSexMarriages>
-		<useRandomClannerMarriages>false</useRandomClannerMarriages>
+		<useRandomClanPersonnelMarriages>false</useRandomClanPersonnelMarriages>
 		<useRandomPrisonerMarriages>true</useRandomPrisonerMarriages>
 		<randomMarriageAgeRange>10</randomMarriageAgeRange>
 		<percentageRandomMarriageOppositeSexChance>2.5E-4</percentageRandomMarriageOppositeSexChance>
 		<percentageRandomMarriageSameSexChance>2.0E-5</percentageRandomMarriageSameSexChance>
 		<useManualDivorce>true</useManualDivorce>
-		<useClannerDivorce>true</useClannerDivorce>
+		<useClanPersonnelDivorce>true</useClanPersonnelDivorce>
 		<usePrisonerDivorce>false</usePrisonerDivorce>
 		<divorceSurnameWeights>
-			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
-			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
-			<BOTH_CHANGE_SURNAME>30</BOTH_CHANGE_SURNAME>
 			<SPOUSE_CHANGES_SURNAME>10</SPOUSE_CHANGES_SURNAME>
+			<BOTH_CHANGE_SURNAME>30</BOTH_CHANGE_SURNAME>
+			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
+			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 		</divorceSurnameWeights>
 		<randomDivorceMethod>NONE</randomDivorceMethod>
 		<useRandomOppositeSexDivorce>true</useRandomOppositeSexDivorce>
 		<useRandomSameSexDivorce>true</useRandomSameSexDivorce>
-		<useRandomClannerDivorce>true</useRandomClannerDivorce>
+		<useRandomClanPersonnelDivorce>true</useRandomClanPersonnelDivorce>
 		<useRandomPrisonerDivorce>false</useRandomPrisonerDivorce>
 		<percentageRandomDivorceOppositeSexChance>1.0E-6</percentageRandomDivorceOppositeSexChance>
 		<percentageRandomDivorceSameSexChance>1.0E-6</percentageRandomDivorceSameSexChance>
 		<useManualProcreation>true</useManualProcreation>
-		<useClannerProcreation>false</useClannerProcreation>
+		<useClanPersonnelProcreation>false</useClanPersonnelProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
 		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
@@ -196,20 +296,20 @@
 		<logProcreation>true</logProcreation>
 		<randomProcreationMethod>PERCENTAGE</randomProcreationMethod>
 		<useRelationshiplessRandomProcreation>true</useRelationshiplessRandomProcreation>
-		<useRandomClannerProcreation>false</useRandomClannerProcreation>
+		<useRandomClanPersonnelProcreation>false</useRandomClanPersonnelProcreation>
 		<useRandomPrisonerProcreation>true</useRandomPrisonerProcreation>
 		<percentageRandomProcreationRelationshipChance>5.0E-4</percentageRandomProcreationRelationshipChance>
 		<percentageRandomProcreationRelationshiplessChance>5.0E-5</percentageRandomProcreationRelationshiplessChance>
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
 		<randomDeathMethod>EXPONENTIAL</randomDeathMethod>
 		<enabledRandomDeathAgeGroups>
+			<TEENAGER>true</TEENAGER>
+			<PRETEEN>false</PRETEEN>
+			<CHILD>false</CHILD>
 			<TODDLER>false</TODDLER>
 			<ADULT>true</ADULT>
-			<CHILD>false</CHILD>
-			<BABY>false</BABY>
-			<TEENAGER>true</TEENAGER>
 			<ELDER>true</ELDER>
-			<PRETEEN>false</PRETEEN>
+			<BABY>false</BABY>
 		</enabledRandomDeathAgeGroups>
 		<useRandomClanPersonnelDeath>true</useRandomClanPersonnelDeath>
 		<useRandomPrisonerDeath>true</useRandomPrisonerDeath>
@@ -218,30 +318,30 @@
 		<exponentialRandomDeathMaleValues>5.4757,-7.0,0.0709</exponentialRandomDeathMaleValues>
 		<exponentialRandomDeathFemaleValues>2.4641,-7.0,0.0752</exponentialRandomDeathFemaleValues>
 		<ageRangeRandomDeathMaleValues>
-			<THIRTY_FIVE_FORTY_FOUR>249.5</THIRTY_FIVE_FORTY_FOUR>
-			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
-			<UNDER_ONE>613.1</UNDER_ONE>
 			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
-			<ONE_FOUR>27.5</ONE_FOUR>
-			<FIFTY_FIVE_SIXTY_FOUR>1119.0</FIFTY_FIVE_SIXTY_FOUR>
+			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
+			<THIRTY_FIVE_FORTY_FOUR>249.5</THIRTY_FIVE_FORTY_FOUR>
 			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
+			<ONE_FOUR>27.5</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>613.1</UNDER_ONE>
+			<FIFTY_FIVE_SIXTY_FOUR>1119.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>14504.0</EIGHTY_FIVE_OR_OLDER>
 			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathMaleValues>
 		<ageRangeRandomDeathFemaleValues>
-			<THIRTY_FIVE_FORTY_FOUR>140.2</THIRTY_FIVE_FORTY_FOUR>
-			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
-			<UNDER_ONE>500.0</UNDER_ONE>
 			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
-			<ONE_FOUR>20.4</ONE_FOUR>
-			<FIFTY_FIVE_SIXTY_FOUR>670.0</FIFTY_FIVE_SIXTY_FOUR>
+			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
+			<THIRTY_FIVE_FORTY_FOUR>140.2</THIRTY_FIVE_FORTY_FOUR>
 			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
+			<ONE_FOUR>20.4</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>500.0</UNDER_ONE>
+			<FIFTY_FIVE_SIXTY_FOUR>670.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>12870.0</EIGHTY_FIVE_OR_OLDER>
 			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathFemaleValues>
 		<payForParts>true</payForParts>
 		<payForRepairs>false</payForRepairs>
@@ -273,21 +373,30 @@
 		<cancelledOrderRefundMultiplier>0.5</cancelledOrderRefundMultiplier>
 		<personnelMarketName>Against the Bot</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
-		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
-		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
-		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
-		<personnelMarketRandomGreenRemoval>4</personnelMarketRandomGreenRemoval>
-		<personnelMarketRandomUltraGreenRemoval>4</personnelMarketRandomUltraGreenRemoval>
+		<personnelMarketRandomRemovalTargets>
+			<VETERAN>8</VETERAN>
+			<ULTRA_GREEN>4</ULTRA_GREEN>
+			<LEGENDARY>11</LEGENDARY>
+			<ELITE>10</ELITE>
+			<GREEN>4</GREEN>
+			<NONE>3</NONE>
+			<HEROIC>11</HEROIC>
+			<REGULAR>6</REGULAR>
+		</personnelMarketRandomRemovalTargets>
 		<personnelMarketDylansWeight>0.3</personnelMarketDylansWeight>
 		<unitMarketMethod>ATB_MONTHLY</unitMarketMethod>
 		<unitMarketRegionalMechVariations>true</unitMarketRegionalMechVariations>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<contractMarketMethod>ATB_MONTHLY</contractMarketMethod>
+		<contractSearchRadius>800</contractSearchRadius>
+		<variableContractLength>true</variableContractLength>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
+		<contractMaxSalvagePercentage>100</contractMaxSalvagePercentage>
 		<useStaticRATs>false</useStaticRATs>
 		<rats>Xotl,Total Warfare</rats>
 		<ignoreRATEra>false</ignoreRATEra>
+		<skillLevel>REGULAR</skillLevel>
 		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<useAtB>true</useAtB>
 		<useStratCon>true</useStratCon>
@@ -296,12 +405,11 @@
 		<clanVehicles>true</clanVehicles>
 		<doubleVehicles>false</doubleVehicles>
 		<adjustPlayerVehicles>true</adjustPlayerVehicles>
-		<opforLanceTypeMechs>1</opforLanceTypeMechs>
-		<opforLanceTypeMixed>2</opforLanceTypeMixed>
-		<opforLanceTypeVehicles>3</opforLanceTypeVehicles>
-		<opforUsesVTOLs>true</opforUsesVTOLs>
+		<opForLanceTypeMechs>1</opForLanceTypeMechs>
+		<opForLanceTypeMixed>2</opForLanceTypeMixed>
+		<opForLanceTypeVehicles>3</opForLanceTypeVehicles>
+		<opForUsesVTOLs>true</opForUsesVTOLs>
 		<useDropShips>false</useDropShips>
-		<skillLevel>2</skillLevel>
 		<aeroRecruitsHaveUnits>true</aeroRecruitsHaveUnits>
 		<useShareSystem>true</useShareSystem>
 		<sharesExcludeLargeCraft>true</sharesExcludeLargeCraft>
@@ -311,10 +419,8 @@
 		<regionalMechVariations>true</regionalMechVariations>
 		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
 		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
-		<searchRadius>800</searchRadius>
 		<atbBattleChance>0,0,0,0</atbBattleChance>
 		<generateChases>true</generateChases>
-		<variableContractLength>true</variableContractLength>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
 		<usePlanetaryConditions>true</usePlanetaryConditions>
@@ -327,103 +433,12 @@
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>true</assignPortraitOnRoleChange>
-		<allowOpforAeros>false</allowOpforAeros>
-		<allowOpforLocalUnits>false</allowOpforLocalUnits>
-		<opforAeroChance>5</opforAeroChance>
-		<opforLocalUnitChance>5</opforLocalUnitChance>
+		<allowOpForAeros>false</allowOpForAeros>
+		<allowOpForLocalUnits>false</allowOpForLocalUnits>
+		<opForAeroChance>5</opForAeroChance>
+		<opForLocalUnitChance>5</opForLocalUnitChance>
 		<fixedMapChance>25</fixedMapChance>
 		<spaUpgradeIntensity>0</spaUpgradeIntensity>
-		<massRepairUseRepair>true</massRepairUseRepair>
-		<massRepairUseSalvage>true</massRepairUseSalvage>
-		<massRepairUseExtraTime>true</massRepairUseExtraTime>
-		<massRepairUseRushJob>true</massRepairUseRushJob>
-		<massRepairAllowCarryover>true</massRepairAllowCarryover>
-		<massRepairOptimizeToCompleteToday>false</massRepairOptimizeToCompleteToday>
-		<massRepairScrapImpossible>false</massRepairScrapImpossible>
-		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
-		<massRepairReplacePod>true</massRepairReplacePod>
-		<massRepairOptions>
-			<massRepairOption>
-				<type>ARMOUR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>AMMUNITION</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>WEAPON</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL_LOCATION</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ENGINE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GYRO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ACTUATOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ELECTRONICS</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>POD_SPACE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-		</massRepairOptions>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
 		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
@@ -768,206 +783,6 @@
 	</skillTypes>
 	<specialAbilities>
 		<ability>
-			<displayName>Eagle&apos;s Eyes (aToW)</displayName>
-			<lookupName>eagle_eyes</lookupName>
-			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
-			<xpCost>20</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>Jumping Jack (aToW)</displayName>
-			<lookupName>jumping_jack</lookupName>
-			<desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-			<xpCost>40</xpCost>
-			<weight>10</weight>
-			<prereqAbilities>hopping_jack</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities>hopping_jack</removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>Multi-Tasker (aToW)</displayName>
-			<lookupName>multi_tasker</lookupName>
-			<desc>Secondary target modifiers are reduced by one.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Sandblaster (AToW)</displayName>
-			<lookupName>sandblaster</lookupName>
-			<desc>A pilot with this ability gets a +4, +3, or +2 to the cluster table
-at short, medium, or long/extended range, respectively, but only with a specialized weapon.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_hitter::cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-				<skill>Gunnery/ProtoMech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Clan Tech Knowledge (Unofficial)</displayName>
-			<lookupName>clan_tech_knowledge</lookupName>
-			<desc>Can work on clan equipment without penalty</desc>
-			<xpCost>40</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel</skill>
-				<skill>Tech/BA</skill>
-				<skill>Tech/Aero</skill>
-				<skill>Tech/Mechanic</skill>
-				<skill>Tech/Mech</skill>
-			</skillPrereq>
-			<miscPrereq>clanperson:false</miscPrereq>
-		</ability>
-		<ability>
-			<displayName>Tactical Genius (aToW)</displayName>
-			<lookupName>tactical_genius</lookupName>
-			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
- The second roll must be accepted.
-Note: Only one Tactical Genius may be utilized per team.</desc>
-			<xpCost>-1</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tactics::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
-			<lookupName>tm_forest_ranger</lookupName>
-			<desc>Movement in woods or jungle costs 1 less MP.
-Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
-Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
-			<xpCost>60</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Dodge (MaxTech)</displayName>
-			<lookupName>dodge_maneuver</lookupName>
-			<desc>Enables the unit to make a dodge maneuver instead of a physical attack.
-This maneuver adds +2 to the BTH to physical attacks against the unit.
-NOTE: The dodge maneuver is declared during the weapons phase.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>20</xpCost>
-			<weight>10</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
-			<lookupName>tech_armor_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with armor</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Golden Goose (aToW)</displayName>
-			<lookupName>golden_goose</lookupName>
-			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
-			<xpCost>40</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Sniper (aToW)</displayName>
-			<lookupName>sniper</lookupName>
-			<desc>Range penalties are halved.</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Mountaineer] (CamOps)</displayName>
-			<lookupName>tm_mountaineer</lookupName>
-			<desc>Movement in rubble or rough cost 1 less MP and elevation changes also cost 1 MP less.
-The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
-			<xpCost>40</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Weapon Specialist (aToW)</displayName>
 			<lookupName>weapon_specialist</lookupName>
 			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
@@ -978,97 +793,12 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Natural Aptitude, Gunnery (aToW)</displayName>
-			<lookupName>aptitude_gunnery</lookupName>
-			<desc>Roll 3d6 and take the best two for gunnery checks</desc>
-			<xpCost>-1</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit</skill>
-				<skill>Gunnery/Aircraft</skill>
-				<skill>Gunnery/Spacecraft</skill>
-				<skill>Gunnery/Aerospace</skill>
-				<skill>Gunnery/Vehicle</skill>
-				<skill>Gunnery/Mech</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Mr/Ms Fix-it (unofficial)</displayName>
-			<lookupName>tech_fixer</lookupName>
-			<desc>Ignore first point of penalty for repair and maintenance on low quality equipment</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Forward Observer (aToW)</displayName>
-			<lookupName>forward_observer</lookupName>
-			<desc>Improves the accuracy of your artillery. Fire Adjustment gets a -2 modifier. Spotting gets an additional -1 tohit modifier for each point of gunnery below 4.</desc>
-			<xpCost>60</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Artillery::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Shaky Stick (aToW)</displayName>
-			<lookupName>shaky_stick</lookupName>
-			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
-			<xpCost>20</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Hitter (AToW)</displayName>
-			<lookupName>cluster_hitter</lookupName>
-			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
 				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1089,53 +819,55 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Weathered (Unofficial)</displayName>
-			<lookupName>weathered</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<displayName>Cluster Master (AToW)</displayName>
+			<lookupName>cluster_master</lookupName>
+			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
 			<xpCost>60</xpCost>
 			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
+			<prereqAbilities>cluster_hitter</prereqAbilities>
 			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
+			<removeAbilities>cluster_hitter</removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/ProtoMech::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
-			<lookupName>tm_frogman</lookupName>
-			<desc>Movement in depth 2 or greater water costs 1 MP less.
-Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
-			<xpCost>40</xpCost>
-			<weight>3</weight>
+			<displayName>Natural Aptitude, Piloting (aToW)</displayName>
+			<lookupName>aptitude_piloting</lookupName>
+			<desc>Roll 3d6 and take the best two for piloting checks</desc>
+			<xpCost>-1</xpCost>
+			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Veteran</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Some Like It Hot (Unofficial)</displayName>
-			<lookupName>some_like_it_hot</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
+			<displayName>Jumping Jack (aToW)</displayName>
+			<lookupName>jumping_jack</lookupName>
+			<desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
 			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
+			<weight>10</weight>
+			<prereqAbilities>hopping_jack</prereqAbilities>
 			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
+			<removeAbilities>hopping_jack</removeAbilities>
 			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-			</skillPrereq>
 		</ability>
 		<ability>
 			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
@@ -1149,10 +881,373 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
 				<skill>Tech/Mechanic::Regular</skill>
 				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Multi-Tasker (aToW)</displayName>
+			<lookupName>multi_tasker</lookupName>
+			<desc>Secondary target modifiers are reduced by one.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Sandblaster (AToW)</displayName>
+			<lookupName>sandblaster</lookupName>
+			<desc>A pilot with this ability gets a +4, +3, or +2 to the cluster table
+at short, medium, or long/extended range, respectively, but only with a specialized weapon.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>cluster_hitter::cluster_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/ProtoMech::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Clan Tech Knowledge (Unofficial)</displayName>
+			<lookupName>clan_tech_knowledge</lookupName>
+			<desc>Can work on clan equipment without penalty</desc>
+			<xpCost>40</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel</skill>
+				<skill>Tech/Aero</skill>
+				<skill>Tech/BA</skill>
+				<skill>Tech/Mechanic</skill>
+				<skill>Tech/Mech</skill>
+			</skillPrereq>
+			<miscPrereq>clanperson:false</miscPrereq>
+		</ability>
+		<ability>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
+			<xpCost>40</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Hot Dog (aToW)</displayName>
+			<lookupName>hot_dog</lookupName>
+			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Dodge (MaxTech)</displayName>
+			<lookupName>dodge_maneuver</lookupName>
+			<desc>Enables the unit to make a dodge maneuver instead of a physical attack.
+This maneuver adds +2 to the BTH to physical attacks against the unit.
+NOTE: The dodge maneuver is declared during the weapons phase.
+Note: This ability is only used for BattleMechs.</desc>
+			<xpCost>20</xpCost>
+			<weight>10</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Pain Resistance (MaxTech)</displayName>
+			<lookupName>pain_resistance</lookupName>
+			<desc>When making consciousness rolls,
+1 is added to all rolls.
+Also,
+damage received from ammo explosions is reduced to 1.
+Note: This ability is only used for BattleMechs.</desc>
+			<xpCost>20</xpCost>
+			<weight>10</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Sniper (aToW)</displayName>
+			<lookupName>sniper</lookupName>
+			<desc>Range penalties are halved.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Veteran</skill>
+				<skill>Gunnery/Battlesuit::Veteran</skill>
+				<skill>Gunnery/Aerospace::Veteran</skill>
+				<skill>Gunnery/Spacecraft::Veteran</skill>
+				<skill>Gunnery/Mech::Veteran</skill>
+				<skill>Gunnery/Vehicle::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Maneuvering Ace (aToW)</displayName>
+			<lookupName>maneuvering_ace</lookupName>
+			<desc>Enables the unit to move laterally like a Quad.
+Quads can move laterally for 1 less MP.
+Aerospace units can perform maneuvers for 1 less thrust point.
+Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Veteran</skill>
+				<skill>Piloting/Naval::Veteran</skill>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/VTOL::Veteran</skill>
+				<skill>Piloting/Aircraft::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Mountaineer] (CamOps)</displayName>
+			<lookupName>tm_mountaineer</lookupName>
+			<desc>Movement in rubble or rough cost 1 less MP and elevation changes also cost 1 MP less.
+The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
+			<xpCost>40</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Mr/Ms Fix-it (unofficial)</displayName>
+			<lookupName>tech_fixer</lookupName>
+			<desc>Ignore first point of penalty for repair and maintenance on low quality equipment</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Eagle&apos;s Eyes (aToW)</displayName>
+			<lookupName>eagle_eyes</lookupName>
+			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
+			<xpCost>20</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+		</ability>
+		<ability>
+			<displayName>Oblique Artilleryman (aToW)</displayName>
+			<lookupName>oblique_artillery</lookupName>
+			<desc>Reduces scatter distance by two hexes.</desc>
+			<xpCost>20</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
+			<lookupName>tm_forest_ranger</lookupName>
+			<desc>Movement in woods or jungle costs 1 less MP.
+Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
+Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
+			<xpCost>60</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Veteran</skill>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Engineer (unofficial)</displayName>
+			<lookupName>tech_engineer</lookupName>
+			<desc>-2 on refit rolls</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Veteran</skill>
+				<skill>Tech/Aero::Veteran</skill>
+				<skill>Tech/BA::Veteran</skill>
+				<skill>Tech/Mechanic::Veteran</skill>
+				<skill>Tech/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Melee Master (aToW)</displayName>
+			<lookupName>melee_master</lookupName>
+			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
+			<xpCost>20</xpCost>
+			<weight>10</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Forward Observer (aToW)</displayName>
+			<lookupName>forward_observer</lookupName>
+			<desc>Improves the accuracy of your artillery. Fire Adjustment gets a -2 modifier. Spotting gets an additional -1 tohit modifier for each point of gunnery below 4.</desc>
+			<xpCost>60</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Artillery::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Human TRO (CamOps)</displayName>
+			<lookupName>human_tro</lookupName>
+			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Spacecraft::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Small Arms::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tactical Genius (aToW)</displayName>
+			<lookupName>tactical_genius</lookupName>
+			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
+ The second roll must be accepted.
+Note: Only one Tactical Genius may be utilized per team.</desc>
+			<xpCost>-1</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tactics::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1174,6 +1269,95 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Natural Aptitude, Gunnery (aToW)</displayName>
+			<lookupName>aptitude_gunnery</lookupName>
+			<desc>Roll 3d6 and take the best two for gunnery checks</desc>
+			<xpCost>-1</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft</skill>
+				<skill>Gunnery/Battlesuit</skill>
+				<skill>Gunnery/Aerospace</skill>
+				<skill>Gunnery/Spacecraft</skill>
+				<skill>Gunnery/Mech</skill>
+				<skill>Gunnery/Vehicle</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>20</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Regular</skill>
+				<skill>Tech/Aero::Regular</skill>
+				<skill>Tech/BA::Regular</skill>
+				<skill>Tech/Mechanic::Regular</skill>
+				<skill>Tech/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>20</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Weathered (Unofficial)</displayName>
+			<lookupName>weathered</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>All Weather (Unofficial)</displayName>
+			<lookupName>allweather</lookupName>
+			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
+			<xpCost>60</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Regular</skill>
+				<skill>Piloting/Naval::Regular</skill>
+				<skill>Piloting/Ground Vehicle::Regular</skill>
+				<skill>Piloting/VTOL::Regular</skill>
+				<skill>Piloting/Aircraft::Regular</skill>
+				<skill>Piloting/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1206,109 +1390,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
 				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
 				<skill>Gunnery/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Maneuvering Ace (aToW)</displayName>
-			<lookupName>maneuvering_ace</lookupName>
-			<desc>Enables the unit to move laterally like a Quad.
-Quads can move laterally for 1 less MP.
-Aerospace units can perform maneuvers for 1 less thrust point.
-Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Veteran</skill>
-				<skill>Piloting/Naval::Veteran</skill>
-				<skill>Piloting/Ground Vehicle::Veteran</skill>
-				<skill>Piloting/VTOL::Veteran</skill>
-				<skill>Piloting/Aircraft::Veteran</skill>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Oblique Artilleryman (aToW)</displayName>
-			<lookupName>oblique_artillery</lookupName>
-			<desc>Reduces scatter distance by two hexes.</desc>
-			<xpCost>20</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-		</ability>
-		<ability>
-			<displayName>Melee Master (aToW)</displayName>
-			<lookupName>melee_master</lookupName>
-			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-			<xpCost>20</xpCost>
-			<weight>10</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Zweihander (CamOps)</displayName>
-			<lookupName>zweihander</lookupName>
-			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-			<xpCost>20</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities>melee_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Master (AToW)</displayName>
-			<lookupName>cluster_master</lookupName>
-			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities>cluster_hitter</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities>cluster_hitter</removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Veteran</skill>
-				<skill>Gunnery/Aircraft::Veteran</skill>
-				<skill>Gunnery/Spacecraft::Veteran</skill>
-				<skill>Gunnery/Aerospace::Veteran</skill>
-				<skill>Gunnery/Vehicle::Veteran</skill>
-				<skill>Gunnery/Mech::Veteran</skill>
-				<skill>Gunnery/ProtoMech::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Animal Mimicry (CamOps)</displayName>
-			<lookupName>animal_mimic</lookupName>
-			<desc>Allows a Quad Mech or ProtoMech, or a bipedal Mech or ProtoMech with the animalistic quirk, the following benefits.
--1 MP per hex of Woods and Jungle terrain.
- In addition quads gain a -1 to any quad related PSR check.
-NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
-			<xpCost>40</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1324,118 +1410,6 @@ Note: This ability is only used for BattleMechs.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Gunnery Specialization (aToW)</displayName>
-			<lookupName>specialist</lookupName>
-			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
- +1 to-hit modifier when using other types of weapons.</desc>
-			<xpCost>40</xpCost>
-			<weight>12</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>weapon_specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Human TRO (CamOps)</displayName>
-			<lookupName>human_tro</lookupName>
-			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Small Arms::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Pain Resistance (MaxTech)</displayName>
-			<lookupName>pain_resistance</lookupName>
-			<desc>When making consciousness rolls,
-1 is added to all rolls.
-Also,
-damage received from ammo explosions is reduced to 1.
-Note: This ability is only used for BattleMechs.</desc>
-			<xpCost>20</xpCost>
-			<weight>10</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>All Weather (Unofficial)</displayName>
-			<lookupName>allweather</lookupName>
-			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hot Dog (aToW)</displayName>
-			<lookupName>hot_dog</lookupName>
-			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-			<xpCost>40</xpCost>
-			<weight>5</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Engineer (unofficial)</displayName>
-			<lookupName>tech_engineer</lookupName>
-			<desc>-2 on refit rolls</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Veteran</skill>
-				<skill>Tech/BA::Veteran</skill>
-				<skill>Tech/Aero::Veteran</skill>
-				<skill>Tech/Mechanic::Veteran</skill>
-				<skill>Tech/Mech::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1455,6 +1429,105 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
+			<displayName>Gunnery Specialization (aToW)</displayName>
+			<lookupName>specialist</lookupName>
+			<desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
+ +1 to-hit modifier when using other types of weapons.</desc>
+			<xpCost>40</xpCost>
+			<weight>12</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Hitter (AToW)</displayName>
+			<lookupName>cluster_hitter</lookupName>
+			<desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>cluster_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Regular</skill>
+				<skill>Gunnery/Battlesuit::Regular</skill>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Spacecraft::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+				<skill>Gunnery/Vehicle::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Some Like It Hot (Unofficial)</displayName>
+			<lookupName>some_like_it_hot</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
+			<xpCost>40</xpCost>
+			<weight>5</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aerospace::Regular</skill>
+				<skill>Gunnery/Mech::Regular</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Golden Goose (aToW)</displayName>
+			<lookupName>golden_goose</lookupName>
+			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
+			<xpCost>40</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
+			<lookupName>tm_frogman</lookupName>
+			<desc>Movement in depth 2 or greater water costs 1 MP less.
+Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
+			<xpCost>40</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Veteran</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Shaky Stick (aToW)</displayName>
+			<lookupName>shaky_stick</lookupName>
+			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
+			<xpCost>20</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
 			<displayName>Hopping Jack (Unofficial)</displayName>
 			<lookupName>hopping_jack</lookupName>
 			<desc>Unit only suffers a +2 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
@@ -1469,78 +1542,20 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Natural Aptitude, Piloting (aToW)</displayName>
-			<lookupName>aptitude_piloting</lookupName>
-			<desc>Roll 3d6 and take the best two for piloting checks</desc>
-			<xpCost>-1</xpCost>
+			<displayName>Animal Mimicry (CamOps)</displayName>
+			<lookupName>animal_mimic</lookupName>
+			<desc>Allows a Quad Mech or ProtoMech, or a bipedal Mech or ProtoMech with the animalistic quirk, the following benefits.
+-1 MP per hex of Woods and Jungle terrain.
+ In addition quads gain a -1 to any quad related PSR check.
+NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
+			<xpCost>40</xpCost>
 			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Aerospace::Regular</skill>
-				<skill>Piloting/Naval::Regular</skill>
-				<skill>Piloting/Ground Vehicle::Regular</skill>
-				<skill>Piloting/Spacecraft::Regular</skill>
-				<skill>Piloting/VTOL::Regular</skill>
-				<skill>Piloting/Aircraft::Regular</skill>
 				<skill>Piloting/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
-			<xpCost>60</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-			<xpCost>40</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Regular</skill>
-				<skill>Gunnery/Aircraft::Regular</skill>
-				<skill>Gunnery/Spacecraft::Regular</skill>
-				<skill>Gunnery/Aerospace::Regular</skill>
-				<skill>Gunnery/Vehicle::Regular</skill>
-				<skill>Gunnery/Mech::Regular</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
-			<lookupName>tech_weapon_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with weapons</desc>
-			<xpCost>20</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Regular</skill>
-				<skill>Tech/BA::Regular</skill>
-				<skill>Tech/Aero::Regular</skill>
-				<skill>Tech/Mechanic::Regular</skill>
-				<skill>Tech/Mech::Regular</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>

--- a/MekHQ/mmconf/campaignPresets/TaharqaMW2ish.xml
+++ b/MekHQ/mmconf/campaignPresets/TaharqaMW2ish.xml
@@ -1,10 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<campaignPreset version="0.49.8-SNAPSHOT">
+<campaignPreset version="0.49.19-SNAPSHOT">
 	<title>Taharqa&apos;s MW2ish Presets</title>
 	<description>This preset largely affects skill levels and XP costs. Namely, all skills range from level 0 to level 6 and XP costs rise with the level of the skill such that, for example, it costs more XP to advance from Regular to Veteran than from Green to Regular. Special abilities have also been tweaked with these costs in mind.</description>
+	<date>3067-01-01</date>
+	<faction>MERC</faction>
+	<planet system="Galatea">Galatea</planet>
+	<rankSystem>
+		<code>SSLDF</code>
+	</rankSystem>
+	<contractCount>2</contractCount>
+	<gm>false</gm>
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
 		<logMaintenance>false</logMaintenance>
+		<mrmsUseRepair>true</mrmsUseRepair>
+		<mrmsUseSalvage>true</mrmsUseSalvage>
+		<mrmsUseExtraTime>true</mrmsUseExtraTime>
+		<mrmsUseRushJob>true</mrmsUseRushJob>
+		<mrmsAllowCarryover>true</mrmsAllowCarryover>
+		<mrmsOptimizeToCompleteToday>false</mrmsOptimizeToCompleteToday>
+		<mrmsScrapImpossible>false</mrmsScrapImpossible>
+		<mrmsUseAssignedTechsFirst>false</mrmsUseAssignedTechsFirst>
+		<mrmsReplacePod>true</mrmsReplacePod>
+		<mrmsOptions>
+			<mrmsOption>
+				<type>ARMOUR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>AMMUNITION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>WEAPON</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL_LOCATION</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ENGINE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GYRO</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ACTUATOR</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>ELECTRONICS</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>GENERAL</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+			<mrmsOption>
+				<type>POD_SPACE</type>
+				<active>0</active>
+				<skillMin>0</skillMin>
+				<skillMax>4</skillMax>
+				<btnMin>4</btnMin>
+				<btnMax>4</btnMax>
+			</mrmsOption>
+		</mrmsOptions>
 		<useFactionForNames>true</useFactionForNames>
 		<unitRatingMethod>CAMPAIGN_OPS</unitRatingMethod>
 		<useEraMods>false</useEraMods>
@@ -53,9 +152,9 @@
 		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
 		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>2.5</equipmentContractPercent>
-		<dropshipContractPercent>1.0</dropshipContractPercent>
-		<jumpshipContractPercent>0.0</jumpshipContractPercent>
-		<warshipContractPercent>0.0</warshipContractPercent>
+		<dropShipContractPercent>1.0</dropShipContractPercent>
+		<jumpShipContractPercent>0.0</jumpShipContractPercent>
+		<warShipContractPercent>0.0</warShipContractPercent>
 		<equipmentContractBase>true</equipmentContractBase>
 		<equipmentContractSaleValue>true</equipmentContractSaleValue>
 		<blcSaleValue>true</blcSaleValue>
@@ -70,7 +169,7 @@
 		<maintenanceBonus>-1</maintenanceBonus>
 		<useQualityMaintenance>false</useQualityMaintenance>
 		<reverseQualityNames>true</reverseQualityNames>
-		<useUnofficalMaintenance>false</useUnofficalMaintenance>
+		<useUnofficialMaintenance>false</useUnofficialMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<maxAcquisitions>0</maxAcquisitions>
 		<useTactics>true</useTactics>
@@ -122,7 +221,7 @@
 		<useCustomRetirementModifiers>false</useCustomRetirementModifiers>
 		<useRandomFounderRetirement>false</useRandomFounderRetirement>
 		<trackUnitFatigue>false</trackUnitFatigue>
-		<displayFamilyLevel>PARENTS_CHILDREN_SIBLINGS</displayFamilyLevel>
+		<familyDisplayLevel>PARENTS_CHILDREN_SIBLINGS</familyDisplayLevel>
 		<randomDependentMethod>NONE</randomDependentMethod>
 		<useRandomDependentAddition>true</useRandomDependentAddition>
 		<useRandomDependentRemoval>true</useRandomDependentRemoval>
@@ -130,54 +229,63 @@
 		<salaryEnlistedMultiplier>1.0</salaryEnlistedMultiplier>
 		<salaryAntiMekMultiplier>1.5</salaryAntiMekMultiplier>
 		<salarySpecialistInfantryMultiplier>1.0</salarySpecialistInfantryMultiplier>
-		<salaryXPMultiplier>0.6,0.6,1.0,1.6,3.2</salaryXPMultiplier>
+		<salaryXPMultipliers>
+			<VETERAN>1.6</VETERAN>
+			<ULTRA_GREEN>0.6</ULTRA_GREEN>
+			<LEGENDARY>12.8</LEGENDARY>
+			<ELITE>3.2</ELITE>
+			<GREEN>0.6</GREEN>
+			<NONE>0.5</NONE>
+			<HEROIC>6.4</HEROIC>
+			<REGULAR>1.0</REGULAR>
+		</salaryXPMultipliers>
 		<salaryTypeBase>1500 CSB,3000 CSB,900 CSB,900 CSB,900 CSB,900 CSB,900 CSB,1500 CSB,900 CSB,960 CSB,960 CSB,750 CSB,1000 CSB,1000 CSB,1000 CSB,1000 CSB,800 CSB,800 CSB,800 CSB,800 CSB,400 CSB,1500 CSB,400 CSB,500 CSB,500 CSB,500 CSB,500 CSB,0 CSB,0 CSB</salaryTypeBase>
 		<useManualMarriages>true</useManualMarriages>
-		<useClannerMarriages>false</useClannerMarriages>
+		<useClanPersonnelMarriages>false</useClanPersonnelMarriages>
 		<usePrisonerMarriages>true</usePrisonerMarriages>
 		<minimumMarriageAge>16</minimumMarriageAge>
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChanges>false</logMarriageNameChanges>
 		<marriageSurnameWeights>
-			<HYP_YOURS>30</HYP_YOURS>
+			<YOURS>55</YOURS>
+			<MALE>500</MALE>
+			<SPOUSE>55</SPOUSE>
+			<NO_CHANGE>100</NO_CHANGE>
 			<BOTH_SPACE_SPOUSE>5</BOTH_SPACE_SPOUSE>
 			<FEMALE>160</FEMALE>
-			<MALE>500</MALE>
-			<SPACE_SPOUSE>10</SPACE_SPOUSE>
-			<SPOUSE>55</SPOUSE>
-			<BOTH_HYP_YOURS>20</BOTH_HYP_YOURS>
+			<HYPHEN_YOURS>30</HYPHEN_YOURS>
 			<SPACE_YOURS>10</SPACE_YOURS>
-			<HYP_SPOUSE>30</HYP_SPOUSE>
-			<BOTH_HYP_SPOUSE>20</BOTH_HYP_SPOUSE>
-			<NO_CHANGE>100</NO_CHANGE>
-			<YOURS>55</YOURS>
+			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
 			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
+			<SPACE_SPOUSE>10</SPACE_SPOUSE>
+			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
+			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
 		</marriageSurnameWeights>
 		<randomMarriageMethod>NONE</randomMarriageMethod>
 		<useRandomSameSexMarriages>false</useRandomSameSexMarriages>
-		<useRandomClannerMarriages>false</useRandomClannerMarriages>
+		<useRandomClanPersonnelMarriages>false</useRandomClanPersonnelMarriages>
 		<useRandomPrisonerMarriages>true</useRandomPrisonerMarriages>
 		<randomMarriageAgeRange>10</randomMarriageAgeRange>
 		<percentageRandomMarriageOppositeSexChance>2.5E-4</percentageRandomMarriageOppositeSexChance>
 		<percentageRandomMarriageSameSexChance>2.0E-5</percentageRandomMarriageSameSexChance>
 		<useManualDivorce>true</useManualDivorce>
-		<useClannerDivorce>true</useClannerDivorce>
+		<useClanPersonnelDivorce>true</useClanPersonnelDivorce>
 		<usePrisonerDivorce>false</usePrisonerDivorce>
 		<divorceSurnameWeights>
-			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
-			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 			<SPOUSE_CHANGES_SURNAME>10</SPOUSE_CHANGES_SURNAME>
 			<BOTH_CHANGE_SURNAME>30</BOTH_CHANGE_SURNAME>
+			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
+			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 		</divorceSurnameWeights>
 		<randomDivorceMethod>NONE</randomDivorceMethod>
 		<useRandomOppositeSexDivorce>true</useRandomOppositeSexDivorce>
 		<useRandomSameSexDivorce>true</useRandomSameSexDivorce>
-		<useRandomClannerDivorce>true</useRandomClannerDivorce>
+		<useRandomClanPersonnelDivorce>true</useRandomClanPersonnelDivorce>
 		<useRandomPrisonerDivorce>false</useRandomPrisonerDivorce>
 		<percentageRandomDivorceOppositeSexChance>1.0E-6</percentageRandomDivorceOppositeSexChance>
 		<percentageRandomDivorceSameSexChance>1.0E-6</percentageRandomDivorceSameSexChance>
 		<useManualProcreation>true</useManualProcreation>
-		<useClannerProcreation>false</useClannerProcreation>
+		<useClanPersonnelProcreation>false</useClanPersonnelProcreation>
 		<usePrisonerProcreation>true</usePrisonerProcreation>
 		<multiplePregnancyOccurrences>50</multiplePregnancyOccurrences>
 		<babySurnameStyle>MOTHERS</babySurnameStyle>
@@ -188,20 +296,20 @@
 		<logProcreation>false</logProcreation>
 		<randomProcreationMethod>PERCENTAGE</randomProcreationMethod>
 		<useRelationshiplessRandomProcreation>false</useRelationshiplessRandomProcreation>
-		<useRandomClannerProcreation>false</useRandomClannerProcreation>
+		<useRandomClanPersonnelProcreation>false</useRandomClanPersonnelProcreation>
 		<useRandomPrisonerProcreation>true</useRandomPrisonerProcreation>
 		<percentageRandomProcreationRelationshipChance>5.0E-4</percentageRandomProcreationRelationshipChance>
 		<percentageRandomProcreationRelationshiplessChance>5.0E-5</percentageRandomProcreationRelationshiplessChance>
 		<keepMarriedNameUponSpouseDeath>false</keepMarriedNameUponSpouseDeath>
 		<randomDeathMethod>NONE</randomDeathMethod>
 		<enabledRandomDeathAgeGroups>
-			<CHILD>false</CHILD>
-			<ELDER>true</ELDER>
 			<TEENAGER>true</TEENAGER>
-			<BABY>false</BABY>
-			<TODDLER>false</TODDLER>
 			<PRETEEN>false</PRETEEN>
+			<CHILD>false</CHILD>
+			<TODDLER>false</TODDLER>
 			<ADULT>true</ADULT>
+			<ELDER>true</ELDER>
+			<BABY>false</BABY>
 		</enabledRandomDeathAgeGroups>
 		<useRandomClanPersonnelDeath>true</useRandomClanPersonnelDeath>
 		<useRandomPrisonerDeath>true</useRandomPrisonerDeath>
@@ -210,30 +318,30 @@
 		<exponentialRandomDeathMaleValues>5.4757,-7.0,0.0709</exponentialRandomDeathMaleValues>
 		<exponentialRandomDeathFemaleValues>2.4641,-7.0,0.0752</exponentialRandomDeathFemaleValues>
 		<ageRangeRandomDeathMaleValues>
-			<UNDER_ONE>613.1</UNDER_ONE>
+			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>249.5</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>27.5</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>613.1</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>1119.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>14504.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>27.5</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathMaleValues>
 		<ageRangeRandomDeathFemaleValues>
-			<UNDER_ONE>500.0</UNDER_ONE>
+			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
+			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
 			<THIRTY_FIVE_FORTY_FOUR>140.2</THIRTY_FIVE_FORTY_FOUR>
-			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
-			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
+			<ONE_FOUR>20.4</ONE_FOUR>
+			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<UNDER_ONE>500.0</UNDER_ONE>
 			<FIFTY_FIVE_SIXTY_FOUR>670.0</FIFTY_FIVE_SIXTY_FOUR>
 			<EIGHTY_FIVE_OR_OLDER>12870.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>20.4</ONE_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
-			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
 		</ageRangeRandomDeathFemaleValues>
 		<payForParts>true</payForParts>
 		<payForRepairs>false</payForRepairs>
@@ -265,21 +373,30 @@
 		<cancelledOrderRefundMultiplier>0.5</cancelledOrderRefundMultiplier>
 		<personnelMarketName>FM: Mercenaries Revised</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
-		<personnelMarketRandomEliteRemoval>10</personnelMarketRandomEliteRemoval>
-		<personnelMarketRandomVeteranRemoval>8</personnelMarketRandomVeteranRemoval>
-		<personnelMarketRandomRegularRemoval>6</personnelMarketRandomRegularRemoval>
-		<personnelMarketRandomGreenRemoval>4</personnelMarketRandomGreenRemoval>
-		<personnelMarketRandomUltraGreenRemoval>4</personnelMarketRandomUltraGreenRemoval>
+		<personnelMarketRandomRemovalTargets>
+			<VETERAN>8</VETERAN>
+			<ULTRA_GREEN>4</ULTRA_GREEN>
+			<LEGENDARY>11</LEGENDARY>
+			<ELITE>10</ELITE>
+			<GREEN>4</GREEN>
+			<NONE>3</NONE>
+			<HEROIC>11</HEROIC>
+			<REGULAR>6</REGULAR>
+		</personnelMarketRandomRemovalTargets>
 		<personnelMarketDylansWeight>0.3</personnelMarketDylansWeight>
 		<unitMarketMethod>NONE</unitMarketMethod>
 		<unitMarketRegionalMechVariations>true</unitMarketRegionalMechVariations>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<contractMarketMethod>NONE</contractMarketMethod>
+		<contractSearchRadius>800</contractSearchRadius>
+		<variableContractLength>false</variableContractLength>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
+		<contractMaxSalvagePercentage>100</contractMaxSalvagePercentage>
 		<useStaticRATs>false</useStaticRATs>
 		<rats>Xotl,Total Warfare</rats>
 		<ignoreRATEra>false</ignoreRATEra>
+		<skillLevel>REGULAR</skillLevel>
 		<phenotypeProbabilities>95,100,95,0,95,25</phenotypeProbabilities>
 		<useAtB>false</useAtB>
 		<useStratCon>false</useStratCon>
@@ -288,12 +405,11 @@
 		<clanVehicles>true</clanVehicles>
 		<doubleVehicles>false</doubleVehicles>
 		<adjustPlayerVehicles>false</adjustPlayerVehicles>
-		<opforLanceTypeMechs>1</opforLanceTypeMechs>
-		<opforLanceTypeMixed>2</opforLanceTypeMixed>
-		<opforLanceTypeVehicles>3</opforLanceTypeVehicles>
-		<opforUsesVTOLs>true</opforUsesVTOLs>
+		<opForLanceTypeMechs>1</opForLanceTypeMechs>
+		<opForLanceTypeMixed>2</opForLanceTypeMixed>
+		<opForLanceTypeVehicles>3</opForLanceTypeVehicles>
+		<opForUsesVTOLs>true</opForUsesVTOLs>
 		<useDropShips>false</useDropShips>
-		<skillLevel>2</skillLevel>
 		<aeroRecruitsHaveUnits>false</aeroRecruitsHaveUnits>
 		<useShareSystem>false</useShareSystem>
 		<sharesExcludeLargeCraft>false</sharesExcludeLargeCraft>
@@ -303,10 +419,8 @@
 		<regionalMechVariations>false</regionalMechVariations>
 		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
 		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
-		<searchRadius>800</searchRadius>
 		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>true</generateChases>
-		<variableContractLength>false</variableContractLength>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
 		<usePlanetaryConditions>false</usePlanetaryConditions>
@@ -319,102 +433,12 @@
 		<limitLanceWeight>true</limitLanceWeight>
 		<limitLanceNumUnits>true</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowOpforAeros>false</allowOpforAeros>
-		<allowOpforLocalUnits>false</allowOpforLocalUnits>
-		<opforAeroChance>5</opforAeroChance>
-		<opforLocalUnitChance>5</opforLocalUnitChance>
+		<allowOpForAeros>false</allowOpForAeros>
+		<allowOpForLocalUnits>false</allowOpForLocalUnits>
+		<opForAeroChance>5</opForAeroChance>
+		<opForLocalUnitChance>5</opForLocalUnitChance>
 		<fixedMapChance>25</fixedMapChance>
-		<massRepairUseRepair>true</massRepairUseRepair>
-		<massRepairUseSalvage>true</massRepairUseSalvage>
-		<massRepairUseExtraTime>true</massRepairUseExtraTime>
-		<massRepairUseRushJob>true</massRepairUseRushJob>
-		<massRepairAllowCarryover>true</massRepairAllowCarryover>
-		<massRepairOptimizeToCompleteToday>false</massRepairOptimizeToCompleteToday>
-		<massRepairScrapImpossible>false</massRepairScrapImpossible>
-		<massRepairUseAssignedTechsFirst>false</massRepairUseAssignedTechsFirst>
-		<massRepairReplacePod>true</massRepairReplacePod>
-		<massRepairOptions>
-			<massRepairOption>
-				<type>ARMOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>AMMO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>WEAPON</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL_LOCATION</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ENGINE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GYRO</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ACTUATOR</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>ELECTRONICS</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>GENERAL</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-			<massRepairOption>
-				<type>POD_SPACE</type>
-				<active>0</active>
-				<skillMin>0</skillMin>
-				<skillMax>4</skillMax>
-				<btnMin>4</btnMin>
-				<btnMax>4</btnMax>
-			</massRepairOption>
-		</massRepairOptions>
+		<spaUpgradeIntensity>0</spaUpgradeIntensity>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
 		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
@@ -577,7 +601,7 @@
 			<costs>4,2,4,6,8,10,12,-1,-1,-1,-1</costs>
 		</skillType>
 		<skillType>
-			<name>Gunnery/Protomech</name>
+			<name>Gunnery/ProtoMech</name>
 			<target>7</target>
 			<countUp>false</countUp>
 			<greenLvl>2</greenLvl>
@@ -759,26 +783,77 @@
 	</skillTypes>
 	<specialAbilities>
 		<ability>
-			<displayName>Eagle&apos;s Eyes (CamOps)</displayName>
-			<lookupName>eagle_eyes</lookupName>
-			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
-			<xpCost>4</xpCost>
+			<displayName>Weapon Specialist (aToW)</displayName>
+			<lookupName>weapon_specialist</lookupName>
+			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
+			<xpCost>12</xpCost>
 			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>gunnery_laser::gunnery_missile::gunnery_ballistic</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Foot Cavalry (CamOps)</displayName>
+			<lookupName>foot_cav</lookupName>
+			<desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
+			<xpCost>4</xpCost>
+			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Piloting/Spacecraft::Green</skill>
-				<skill>Piloting/VTOL::Green</skill>
-				<skill>Piloting/Naval::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Small Arms::Green</skill>
-				<skill>Piloting/Ground Vehicle::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Gunnery/Energy (Unofficial)</displayName>
+			<lookupName>gunnery_laser</lookupName>
+			<desc>NOTE: This is a unofficial rule.
+Pilot gets a -1 to-hit bonus on all energy-based weapons (Laser,
+PPC,
+Plasma and Flamer).</desc>
+			<xpCost>6</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Cluster Master (AToW)</displayName>
+			<lookupName>cluster_master</lookupName>
+			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
+			<xpCost>6</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>cluster_hitter</prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities>cluster_hitter</removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -796,6 +871,24 @@
 			</skillPrereq>
 		</ability>
 		<ability>
+			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
+			<lookupName>tech_internal_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Green</skill>
+				<skill>Tech/BA::Green</skill>
+				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/Mechanic::Green</skill>
+				<skill>Tech/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
 			<displayName>Multi-Tasker (aToW)</displayName>
 			<lookupName>multi_tasker</lookupName>
 			<desc>Secondary target modifiers are reduced by one.</desc>
@@ -806,13 +899,12 @@
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -827,13 +919,12 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -848,35 +939,17 @@ at short, medium, or long/extended range, respectively, but only with a speciali
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel</skill>
-				<skill>Tech/Aero</skill>
 				<skill>Tech/BA</skill>
+				<skill>Tech/Aero</skill>
 				<skill>Tech/Mechanic</skill>
 				<skill>Tech/Mech</skill>
 			</skillPrereq>
 			<miscPrereq>clanperson:false</miscPrereq>
 		</ability>
 		<ability>
-			<displayName>Tactical Genius (CamOps)</displayName>
-			<lookupName>tactical_genius</lookupName>
-			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
- The second roll must be accepted.
-Note: Only one Tactical Genius may be utilized per team.</desc>
-			<xpCost>8</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tactics::Veteran</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
-			<lookupName>tm_forest_ranger</lookupName>
-			<desc>Movement in woods or jungle costs 1 less MP.
-Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
-Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
+			<displayName>RangeMaster (CamOps)</displayName>
+			<lookupName>range_master</lookupName>
+			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
 			<xpCost>6</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
@@ -884,9 +957,28 @@ Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Piloting/Ground Vehicle::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Hot Dog (aToW)</displayName>
+			<lookupName>hot_dog</lookupName>
+			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
+			<xpCost>2</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -907,85 +999,6 @@ Note: This ability is only used for BattleMechs.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
-			<lookupName>tech_armor_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with armor</desc>
-			<xpCost>6</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/Aero::Green</skill>
-				<skill>Tech/BA::Green</skill>
-				<skill>Tech/Mechanic::Green</skill>
-				<skill>Tech/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Golden Goose (CamOps)</displayName>
-			<lookupName>golden_goose</lookupName>
-			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
-			<xpCost>6</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Gunnery/Energy (Unofficial)</displayName>
-			<lookupName>gunnery_laser</lookupName>
-			<desc>NOTE: This is a unofficial rule.
-Pilot gets a -1 to-hit bonus on all energy-based weapons (Laser,
-PPC,
-Plasma and Flamer).</desc>
-			<xpCost>6</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>weapon_specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Gunnery/Missile (Unofficial)</displayName>
-			<lookupName>gunnery_missile</lookupName>
-			<desc>Pilot gets a -1 to-hit bonus on all missile weapons (LRM,
-SRM,
-MRM,
-RL and ATM).</desc>
-			<xpCost>6</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>weapon_specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Sniper (aToW)</displayName>
 			<lookupName>sniper</lookupName>
 			<desc>Range penalties are halved.</desc>
@@ -996,13 +1009,52 @@ RL and ATM).</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Maneuvering Ace (aToW)</displayName>
+			<lookupName>maneuvering_ace</lookupName>
+			<desc>Enables the unit to move laterally like a Quad.
+Quads can move laterally for 1 less MP.
+Aerospace units can perform maneuvers for 1 less thrust point.
+Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
+			<xpCost>6</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Piloting/Naval::Green</skill>
+				<skill>Piloting/Ground Vehicle::Green</skill>
+				<skill>Piloting/VTOL::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Blind Fighter (Unofficial)</displayName>
+			<lookupName>blind_fighter</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1019,27 +1071,6 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Weapon Specialist (aToW)</displayName>
-			<lookupName>weapon_specialist</lookupName>
-			<desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
-			<xpCost>12</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>gunnery_laser::gunnery_missile::gunnery_ballistic</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1054,10 +1085,118 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/Aero::Green</skill>
 				<skill>Tech/BA::Green</skill>
+				<skill>Tech/Aero::Green</skill>
 				<skill>Tech/Mechanic::Green</skill>
 				<skill>Tech/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Eagle&apos;s Eyes (CamOps)</displayName>
+			<lookupName>eagle_eyes</lookupName>
+			<desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+				<skill>Piloting/Spacecraft::Green</skill>
+				<skill>Piloting/VTOL::Green</skill>
+				<skill>Piloting/Naval::Green</skill>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Small Arms::Green</skill>
+				<skill>Piloting/Ground Vehicle::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Oblique Artilleryman (CamOps)</displayName>
+			<lookupName>oblique_artillery</lookupName>
+			<desc>Reduces scatter distance by two hexes.</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Artillery::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Forest Ranger] (CamOps)</displayName>
+			<lookupName>tm_forest_ranger</lookupName>
+			<desc>Movement in woods or jungle costs 1 less MP.
+Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
+Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
+			<xpCost>6</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Ground Vehicle::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Engineer (unofficial)</displayName>
+			<lookupName>tech_engineer</lookupName>
+			<desc>-2 on refit rolls</desc>
+			<xpCost>8</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Green</skill>
+				<skill>Tech/BA::Green</skill>
+				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/Mechanic::Green</skill>
+				<skill>Tech/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
+			<lookupName>tech_weapon_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Green</skill>
+				<skill>Tech/BA::Green</skill>
+				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/Mechanic::Green</skill>
+				<skill>Tech/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Melee Master (aToW)</displayName>
+			<lookupName>melee_master</lookupName>
+			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
+			<xpCost>6</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>zweihander</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1076,7 +1215,6 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 				<skill>Piloting/Spacecraft::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Naval::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 				<skill>Piloting/Aerospace::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Small Arms::Green</skill>
@@ -1084,123 +1222,41 @@ The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Shaky Stick (CamOps)</displayName>
-			<lookupName>shaky_stick</lookupName>
-			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
-			<xpCost>4</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Piloting/VTOL::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Hitter (AToW)</displayName>
-			<lookupName>cluster_hitter</lookupName>
-			<desc>A pilot with this ability gets a +1 to the cluster hit table </desc>
-			<xpCost>4</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>cluster_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Foot Cavalry (CamOps)</displayName>
-			<lookupName>foot_cav</lookupName>
-			<desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
-			<xpCost>4</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Small Arms::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Weathered (Unofficial)</displayName>
-			<lookupName>weathered</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<displayName>Human TRO (CamOps)</displayName>
+			<lookupName>human_tro</lookupName>
+			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
 			<xpCost>4</xpCost>
 			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
-			<lookupName>tm_frogman</lookupName>
-			<desc>Movement in depth 2 or greater water costs 1 MP less.
-Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
-			<xpCost>4</xpCost>
-			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
 				<skill>Piloting/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+				<skill>Piloting/Spacecraft::Green</skill>
+				<skill>Piloting/VTOL::Green</skill>
+				<skill>Piloting/Naval::Green</skill>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Small Arms::Green</skill>
+				<skill>Piloting/Ground Vehicle::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Some Like It Hot (Unofficial)</displayName>
-			<lookupName>some_like_it_hot</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
+			<displayName>Tactical Genius (CamOps)</displayName>
+			<lookupName>tactical_genius</lookupName>
+			<desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
+ The second roll must be accepted.
+Note: Only one Tactical Genius may be utilized per team.</desc>
+			<xpCost>8</xpCost>
+			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Tech Specialist, Internal (Unofficial)</displayName>
-			<lookupName>tech_internal_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with internal systems</desc>
-			<xpCost>6</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/Aero::Green</skill>
-				<skill>Tech/BA::Green</skill>
-				<skill>Tech/Mechanic::Green</skill>
-				<skill>Tech/Mech::Green</skill>
+				<skill>Tactics::Veteran</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1219,6 +1275,97 @@ Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush De
 				<skill>Piloting/Naval::Green</skill>
 				<skill>Piloting/Ground Vehicle::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Piloting/VTOL::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Gunnery/Ballistic (Unofficial)</displayName>
+			<lookupName>gunnery_ballistic</lookupName>
+			<desc>Pilot gets a -1 to-hit bonus on all ballistic weapons (MGs,
+all ACs,
+Gaussrifles).</desc>
+			<xpCost>6</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Tech Specialist, Armor (Unofficial)</displayName>
+			<lookupName>tech_armor_specialist</lookupName>
+			<desc>-1 to repair and maintenance checks when working with armor</desc>
+			<xpCost>6</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Tech/Vessel::Green</skill>
+				<skill>Tech/BA::Green</skill>
+				<skill>Tech/Aero::Green</skill>
+				<skill>Tech/Mechanic::Green</skill>
+				<skill>Tech/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Zweihander (CamOps)</displayName>
+			<lookupName>zweihander</lookupName>
+			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
+			<xpCost>6</xpCost>
+			<weight>6</weight>
+			<prereqAbilities>melee_specialist</prereqAbilities>
+			<invalidAbilities>melee_master</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Weathered (Unofficial)</displayName>
+			<lookupName>weathered</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to weather conditions.</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>All Weather (Unofficial)</displayName>
+			<lookupName>allweather</lookupName>
+			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Piloting/Naval::Green</skill>
+				<skill>Piloting/Ground Vehicle::Green</skill>
 				<skill>Piloting/VTOL::Green</skill>
 				<skill>Piloting/Aircraft::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
@@ -1252,120 +1399,11 @@ Finally, urban guerrillas can call on local support once per scenario.</desc>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Maneuvering Ace (aToW)</displayName>
-			<lookupName>maneuvering_ace</lookupName>
-			<desc>Enables the unit to move laterally like a Quad.
-Quads can move laterally for 1 less MP.
-Aerospace units can perform maneuvers for 1 less thrust point.
-Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
-			<xpCost>6</xpCost>
-			<weight>3</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Piloting/Naval::Green</skill>
-				<skill>Piloting/Ground Vehicle::Green</skill>
-				<skill>Piloting/VTOL::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Piloting/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Oblique Artilleryman (CamOps)</displayName>
-			<lookupName>oblique_artillery</lookupName>
-			<desc>Reduces scatter distance by two hexes.</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
 				<skill>Gunnery/Aircraft::Green</skill>
 				<skill>Gunnery/Battlesuit::Green</skill>
 				<skill>Gunnery/Aerospace::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-				<skill>Artillery::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Melee Master (aToW)</displayName>
-			<lookupName>melee_master</lookupName>
-			<desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-			<xpCost>6</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities>zweihander</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Zweihander (CamOps)</displayName>
-			<lookupName>zweihander</lookupName>
-			<desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-			<xpCost>6</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>melee_specialist</prereqAbilities>
-			<invalidAbilities>melee_master</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Cluster Master (AToW)</displayName>
-			<lookupName>cluster_master</lookupName>
-			<desc>A pilot with this ability gets a +2 to the cluster hit table</desc>
-			<xpCost>6</xpCost>
-			<weight>6</weight>
-			<prereqAbilities>cluster_hitter</prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities>cluster_hitter</removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Animal Mimicry (CamOps)</displayName>
-			<lookupName>animal_mimic</lookupName>
-			<desc>Allows a Quad Mech or ProtoMech, or a bipedal Mech or ProtoMech with the animalistic quirk, the following benefits.
--1 MP per hex of Woods and Jungle terrain.
- In addition quads gain a -1 to any quad related PSR check.
-NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
-			<xpCost>6</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1384,82 +1422,6 @@ Note: This ability is only used for BattleMechs.</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Human TRO (CamOps)</displayName>
-			<lookupName>human_tro</lookupName>
-			<desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Mech::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Piloting/Spacecraft::Green</skill>
-				<skill>Piloting/VTOL::Green</skill>
-				<skill>Piloting/Naval::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Small Arms::Green</skill>
-				<skill>Piloting/Ground Vehicle::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>All Weather (Unofficial)</displayName>
-			<lookupName>allweather</lookupName>
-			<desc>A pilot with this ability does not suffer the PSR penalties due to weather.</desc>
-			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Piloting/Naval::Green</skill>
-				<skill>Piloting/Ground Vehicle::Green</skill>
-				<skill>Piloting/VTOL::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Piloting/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Hot Dog (aToW)</displayName>
-			<lookupName>hot_dog</lookupName>
-			<desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-			<xpCost>2</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Piloting/Aerospace::Green</skill>
-				<skill>Piloting/Aircraft::Green</skill>
-				<skill>Piloting/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Engineer (unofficial)</displayName>
-			<lookupName>tech_engineer</lookupName>
-			<desc>-2 on refit rolls</desc>
-			<xpCost>8</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/Aero::Green</skill>
-				<skill>Tech/BA::Green</skill>
-				<skill>Tech/Mechanic::Green</skill>
-				<skill>Tech/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
 			<displayName>Terrain Master [Swamp Beast] (CamOps)</displayName>
 			<lookupName>tm_swamp_beast</lookupName>
 			<desc>Movement in mud or swamp costs 1 less MP.
@@ -1473,36 +1435,16 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			<skillPrereq>
 				<skill>Piloting/Ground Vehicle::Green</skill>
 				<skill>Piloting/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Blind Fighter (Unofficial)</displayName>
-			<lookupName>blind_fighter</lookupName>
-			<desc>A pilot with this ability does not suffer the initial -1 to hit due to darkness.</desc>
+			<displayName>Cluster Hitter (AToW)</displayName>
+			<lookupName>cluster_hitter</lookupName>
+			<desc>A pilot with this ability gets a +1 to the cluster hit table </desc>
 			<xpCost>4</xpCost>
-			<weight>2</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>RangeMaster (CamOps)</displayName>
-			<lookupName>range_master</lookupName>
-			<desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-			<xpCost>6</xpCost>
 			<weight>3</weight>
 			<prereqAbilities></prereqAbilities>
-			<invalidAbilities></invalidAbilities>
+			<invalidAbilities>cluster_master</invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
@@ -1512,7 +1454,90 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 				<skill>Gunnery/Spacecraft::Green</skill>
 				<skill>Gunnery/Mech::Green</skill>
 				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Some Like It Hot (Unofficial)</displayName>
+			<lookupName>some_like_it_hot</lookupName>
+			<desc>A pilot with this ability does not suffer the initial -1 to hit due to heat.</desc>
+			<xpCost>4</xpCost>
+			<weight>2</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Golden Goose (CamOps)</displayName>
+			<lookupName>golden_goose</lookupName>
+			<desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
+			<xpCost>6</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Gunnery/Missile (Unofficial)</displayName>
+			<lookupName>gunnery_missile</lookupName>
+			<desc>Pilot gets a -1 to-hit bonus on all missile weapons (LRM,
+SRM,
+MRM,
+RL and ATM).</desc>
+			<xpCost>6</xpCost>
+			<weight>1</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities>weapon_specialist</invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Gunnery/Battlesuit::Green</skill>
+				<skill>Gunnery/Aircraft::Green</skill>
+				<skill>Gunnery/Spacecraft::Green</skill>
+				<skill>Gunnery/Aerospace::Green</skill>
+				<skill>Gunnery/Vehicle::Green</skill>
+				<skill>Gunnery/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Terrain Master [Frogman] (CamOps)</displayName>
+			<lookupName>tm_frogman</lookupName>
+			<desc>Movement in depth 2 or greater water costs 1 MP less.
+Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
+			<xpCost>4</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Mech::Green</skill>
+			</skillPrereq>
+		</ability>
+		<ability>
+			<displayName>Shaky Stick (CamOps)</displayName>
+			<lookupName>shaky_stick</lookupName>
+			<desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
+			<xpCost>4</xpCost>
+			<weight>3</weight>
+			<prereqAbilities></prereqAbilities>
+			<invalidAbilities></invalidAbilities>
+			<removeAbilities></removeAbilities>
+			<choiceValues></choiceValues>
+			<skillPrereq>
+				<skill>Piloting/Aerospace::Green</skill>
+				<skill>Piloting/VTOL::Green</skill>
+				<skill>Piloting/Aircraft::Green</skill>
 			</skillPrereq>
 		</ability>
 		<ability>
@@ -1530,43 +1555,20 @@ Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
 			</skillPrereq>
 		</ability>
 		<ability>
-			<displayName>Tech Specialist, Weapon (Unofficial)</displayName>
-			<lookupName>tech_weapon_specialist</lookupName>
-			<desc>-1 to repair and maintenance checks when working with weapons</desc>
+			<displayName>Animal Mimicry (CamOps)</displayName>
+			<lookupName>animal_mimic</lookupName>
+			<desc>Allows a Quad Mech or ProtoMech, or a bipedal Mech or ProtoMech with the animalistic quirk, the following benefits.
+-1 MP per hex of Woods and Jungle terrain.
+ In addition quads gain a -1 to any quad related PSR check.
+NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
 			<xpCost>6</xpCost>
-			<weight>2</weight>
+			<weight>1</weight>
 			<prereqAbilities></prereqAbilities>
 			<invalidAbilities></invalidAbilities>
 			<removeAbilities></removeAbilities>
 			<choiceValues></choiceValues>
 			<skillPrereq>
-				<skill>Tech/Vessel::Green</skill>
-				<skill>Tech/Aero::Green</skill>
-				<skill>Tech/BA::Green</skill>
-				<skill>Tech/Mechanic::Green</skill>
-				<skill>Tech/Mech::Green</skill>
-			</skillPrereq>
-		</ability>
-		<ability>
-			<displayName>Gunnery/Ballistic (Unofficial)</displayName>
-			<lookupName>gunnery_ballistic</lookupName>
-			<desc>Pilot gets a -1 to-hit bonus on all ballistic weapons (MGs,
-all ACs,
-Gaussrifles).</desc>
-			<xpCost>6</xpCost>
-			<weight>1</weight>
-			<prereqAbilities></prereqAbilities>
-			<invalidAbilities>weapon_specialist</invalidAbilities>
-			<removeAbilities></removeAbilities>
-			<choiceValues></choiceValues>
-			<skillPrereq>
-				<skill>Gunnery/Aircraft::Green</skill>
-				<skill>Gunnery/Battlesuit::Green</skill>
-				<skill>Gunnery/Aerospace::Green</skill>
-				<skill>Gunnery/Spacecraft::Green</skill>
-				<skill>Gunnery/Mech::Green</skill>
-				<skill>Gunnery/Vehicle::Green</skill>
-				<skill>Gunnery/Protomech::Green</skill>
+				<skill>Piloting/Mech::Green</skill>
 			</skillPrereq>
 		</ability>
 	</specialAbilities>


### PR DESCRIPTION
## Problems
A number of our Presets are getting quite long in the tooth. A fair few not having been resaved since 49.8. A lot has changed since 49.8, including a bunch of new SPAs.

We've also been getting reports of issues with the Presets, or at least some values resetting to the default. While I'm not anticipating this PR to resolve those problems, bringing our Presets up-to-date likely isn't going to hurt.

## Solution
All presets have been re-saved under 49.19

## Note
This is probably something we should do before the release of each new version.