### PR TITLE
Refactor ChoiceStoryPoint and NarrativeStoryPoint with underlying abstract DialogStoryPoint class

### DIFF
--- a/MekHQ/src/mekhq/campaign/storyarc/StoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyarc/StoryPoint.java
@@ -73,14 +73,6 @@ public abstract class StoryPoint {
     /** A boolean that tracks whether the story point is currently active **/
     private boolean active;
 
-    /** A StorySplash image to display in a dialog. It can return a null image */
-    private StorySplash storySplash;
-
-    /**
-     * The id of a personality who is associated with this StoryPoint. May be null.
-     */
-    private UUID personalityId;
-
     /**
      * The id of the next story point to start when this one is completed. It can be null if a new story point should not be
      * triggered. It can also be overwritten by a StoryOutcome
@@ -97,7 +89,6 @@ public abstract class StoryPoint {
         active = false;
         storyOutcomes =  new LinkedHashMap<>();
         storyTriggers = new ArrayList<>();
-        storySplash = new StorySplash();
     }
 
     public void setStoryArc(StoryArc a) {
@@ -132,13 +123,6 @@ public abstract class StoryPoint {
 
     public String getName() {
         return name;
-    }
-
-    public Image getImage() {
-        if(storySplash.isDefault()) {
-            return null;
-        }
-        return storySplash.getImage();
     }
 
     /**
@@ -218,18 +202,6 @@ public abstract class StoryPoint {
         return storyArc.getStoryPoint(nextStoryPointId);
     }
 
-
-    /**
-     * Get the {@link Personality Personality} associated with this StoryPoint.
-     * @return A {@link Personality Personality} or null if no Personality is associated with the StoryPoint.
-     */
-    public Personality getPersonality() {
-        if (null == personalityId) {
-            return null;
-        }
-        return storyArc.getPersonality(personalityId);
-    }
-
     public Campaign getCampaign() {
         return getStoryArc().getCampaign();
     }
@@ -241,7 +213,6 @@ public abstract class StoryPoint {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw1, indent++, "storyPoint", "name", name,"type", this.getClass());
         MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "id", id);
         MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "active", active);
-        MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "personalityId", personalityId);
         MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "nextStoryPointId", nextStoryPointId);
         if (!storyOutcomes.isEmpty()) {
             MHQXMLUtility.writeSimpleXMLOpenTag(pw1, indent++, "storyOutcomes");
@@ -255,7 +226,6 @@ public abstract class StoryPoint {
                 trigger.writeToXml(pw1, indent);
             }
         }
-        storySplash.writeToXML(pw1, indent);
     }
 
     protected void writeToXmlEnd(PrintWriter pw1, int indent) {
@@ -289,15 +259,11 @@ public abstract class StoryPoint {
                     retVal.id = UUID.fromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("nextStoryPointId")) {
                     retVal.nextStoryPointId = UUID.fromString(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("personalityId")) {
-                    retVal.personalityId = UUID.fromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("active")) {
                     retVal.active = Boolean.parseBoolean(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("storyTrigger")) {
                     StoryTrigger trigger = StoryTrigger.generateInstanceFromXML(wn2, c, version);
                     retVal.storyTriggers.add(trigger);
-                } else if (wn2.getNodeName().equalsIgnoreCase(StorySplash.XML_TAG)) {
-                    retVal.storySplash = StorySplash.parseFromXML(wn2);
                 } else if (wn2.getNodeName().equalsIgnoreCase("storyOutcomes")) {
                     NodeList nl2 = wn2.getChildNodes();
                     for (int y = 0; y < nl2.getLength(); y++) {

--- a/MekHQ/src/mekhq/campaign/storyarc/storypoint/ChoiceStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyarc/storypoint/ChoiceStoryPoint.java
@@ -39,7 +39,7 @@ import java.util.Map.Entry;
  * This StoryPoint creates a {@link StoryChoiceDialog StoryChoiceDialog} which offers the player
  * potentially more than one possible choice or response.
  */
-public class ChoiceStoryPoint extends StoryPoint {
+public class ChoiceStoryPoint extends DialogStoryPoint {
 
     private String title;
     private String question;
@@ -100,6 +100,7 @@ public class ChoiceStoryPoint extends StoryPoint {
 
     @Override
     protected void loadFieldsFromXmlNode(Node wn, Campaign c, Version version) throws ParseException {
+        super.loadFieldsFromXmlNode(wn, c, version);
         NodeList nl = wn.getChildNodes();
 
         for (int x = 0; x < nl.getLength(); x++) {

--- a/MekHQ/src/mekhq/campaign/storyarc/storypoint/DialogStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyarc/storypoint/DialogStoryPoint.java
@@ -1,3 +1,23 @@
+/*
+ * ChoiceStoryPoint.java
+ *
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package mekhq.campaign.storyarc.storypoint;
 
 import megamek.Version;

--- a/MekHQ/src/mekhq/campaign/storyarc/storypoint/DialogStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyarc/storypoint/DialogStoryPoint.java
@@ -1,0 +1,77 @@
+package mekhq.campaign.storyarc.storypoint;
+
+import megamek.Version;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.storyarc.Personality;
+import mekhq.campaign.storyarc.StoryPoint;
+import mekhq.campaign.storyarc.StorySplash;
+import mekhq.utilities.MHQXMLUtility;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.awt.*;
+import java.io.PrintWriter;
+import java.text.ParseException;
+import java.util.UUID;
+
+public abstract class DialogStoryPoint extends StoryPoint {
+
+    /** A StorySplash image to display in a dialog. It can return a null image */
+    private StorySplash storySplash;
+
+    /**
+     * The id of a personality who is associated with this StoryPoint. May be null.
+     */
+    private UUID personalityId;
+
+    public DialogStoryPoint() {
+        super();
+        storySplash = new StorySplash();
+    }
+
+
+    public Image getImage() {
+        if(storySplash.isDefault()) {
+            return null;
+        }
+        return storySplash.getImage();
+    }
+
+    /**
+     * Get the {@link Personality Personality} associated with this StoryPoint.
+     * @return A {@link Personality Personality} or null if no Personality is associated with the StoryPoint.
+     */
+    public Personality getPersonality() {
+        if (null == personalityId) {
+            return null;
+        }
+        return getStoryArc().getPersonality(personalityId);
+    }
+
+    @Override
+    protected void writeToXmlBegin(PrintWriter pw1, int indent) {
+        super.writeToXmlBegin(pw1, indent);
+        MHQXMLUtility.writeSimpleXMLTag(pw1, ++indent, "personalityId", personalityId);
+        storySplash.writeToXML(pw1, indent);
+    }
+
+    @Override
+    protected void loadFieldsFromXmlNode(Node wn, Campaign c, Version version) throws ParseException {
+        NodeList nl = wn.getChildNodes();
+
+        for (int x = 0; x < nl.getLength(); x++) {
+            Node wn2 = nl.item(x);
+            try {
+                if (wn2.getNodeName().equalsIgnoreCase("personalityId")) {
+                    personalityId = UUID.fromString(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase(StorySplash.XML_TAG)) {
+                    storySplash = StorySplash.parseFromXML(wn2);
+                }
+            } catch (Exception e) {
+                LogManager.getLogger().error(e);
+            }
+        }
+    }
+
+}

--- a/MekHQ/src/mekhq/campaign/storyarc/storypoint/NarrativeStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyarc/storypoint/NarrativeStoryPoint.java
@@ -35,7 +35,7 @@ import java.text.ParseException;
 /**
  * This story point creates a {@link StoryNarrativeDialog StoryNarrativeDialog} with a simple narrative description.
  */
-public class NarrativeStoryPoint extends StoryPoint {
+public class NarrativeStoryPoint extends DialogStoryPoint {
 
     String title;
     String narrative;
@@ -76,7 +76,8 @@ public class NarrativeStoryPoint extends StoryPoint {
     }
 
     @Override
-    public void loadFieldsFromXmlNode(Node wn, Campaign c, Version version) throws ParseException {
+    protected void loadFieldsFromXmlNode(Node wn, Campaign c, Version version) throws ParseException {
+        super.loadFieldsFromXmlNode(wn, c, version);
         NodeList nl = wn.getChildNodes();
 
         for (int x = 0; x < nl.getLength(); x++) {

--- a/MekHQ/src/mekhq/gui/dialog/StoryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/StoryDialog.java
@@ -20,6 +20,7 @@ package mekhq.gui.dialog;
 
 import mekhq.campaign.storyarc.Personality;
 import mekhq.campaign.storyarc.StoryPoint;
+import mekhq.campaign.storyarc.storypoint.DialogStoryPoint;
 
 import javax.swing.*;
 import java.awt.*;
@@ -37,9 +38,9 @@ public abstract class StoryDialog extends JDialog implements ActionListener {
 
     private int imgWidth;
 
-    private StoryPoint storyPoint;
+    private DialogStoryPoint storyPoint;
 
-    public StoryDialog(final JFrame parent, StoryPoint sEvent) {
+    public StoryDialog(final JFrame parent, DialogStoryPoint sEvent) {
         super(parent, sEvent.getTitle(), true);
         this.storyPoint = sEvent;
     }
@@ -69,7 +70,7 @@ public abstract class StoryDialog extends JDialog implements ActionListener {
     protected abstract Container getMainPanel();
     //endregion initialization
 
-    protected StoryPoint getStoryPoint() {
+    protected DialogStoryPoint getStoryPoint() {
         return storyPoint;
     }
 


### PR DESCRIPTION
This is a slight tweak to the StoryPoint classes that create dialogs (ChoiceStoryPoint and NarrativeStoryPoint). I was previously tracking the image used for the dialog in StoryPoint itself, but I think it makes more sense to create an intermediate abstract `DialogStoryPoint` that tracks this and which ChoiceStoryPoint and NarrativeStoryPoint inherit.