### PR TITLE
Introduced a New Morale Level to Curb Invincible Morale Spikes in AtB & StratCon

### DIFF
--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -52,6 +52,8 @@ AtBMoraleLevel.NORMAL.text=Normal
 AtBMoraleLevel.NORMAL.toolTipText=The unit is ready to fight.
 AtBMoraleLevel.HIGH.text=High
 AtBMoraleLevel.HIGH.toolTipText=The unit is ready and glad to fight.
+AtBMoraleLevel.VERY_HIGH.text=Very High
+AtBMoraleLevel.VERY_HIGH.toolTipText=The unit is dedicated to their cause.
 AtBMoraleLevel.INVINCIBLE.text=Invincible
 AtBMoraleLevel.INVINCIBLE.toolTipText=The unit's trust in their leadership and dedication to their cause is nigh-on unbreakable, and they look forward to fighting their enemies.
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -318,7 +318,7 @@ public class AtBContract extends Contract {
         // Player Dragoon/MRBC rating: F +2, D +1, B -1, A -2
         mod -= dragoonRating - IUnitRating.DRAGOON_C;
 
-        // For every 5 player victories in last month: -1
+        // For every 2 player victories in last month: -1
         mod -= victories / 5;
 
         // For every 2 player defeats in last month: +1

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -318,7 +318,7 @@ public class AtBContract extends Contract {
         // Player Dragoon/MRBC rating: F +2, D +1, B -1, A -2
         mod -= dragoonRating - IUnitRating.DRAGOON_C;
 
-        // For every 2 player victories in last month: -1
+        // For every 5 player victories in last month: -1
         mod -= victories / 5;
 
         // For every 2 player defeats in last month: +1

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBMoraleLevel.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBMoraleLevel.java
@@ -30,6 +30,7 @@ public enum AtBMoraleLevel {
     LOW("AtBMoraleLevel.LOW.text", "AtBMoraleLevel.LOW.toolTipText"),
     NORMAL("AtBMoraleLevel.NORMAL.text", "AtBMoraleLevel.NORMAL.toolTipText"),
     HIGH("AtBMoraleLevel.HIGH.text", "AtBMoraleLevel.HIGH.toolTipText"),
+    VERY_HIGH("AtBMoraleLevel.VERY_HIGH.text", "AtBMoraleLevel.VERY_HIGH.toolTipText"),
     INVINCIBLE("AtBMoraleLevel.INVINCIBLE.text", "AtBMoraleLevel.INVINCIBLE.toolTipText");
     //endregion Enum Declarations
 
@@ -74,6 +75,10 @@ public enum AtBMoraleLevel {
         return this == HIGH;
     }
 
+    public boolean isVeryHigh() {
+        return this == VERY_HIGH;
+    }
+
     public boolean isInvincible() {
         return this == INVINCIBLE;
     }
@@ -104,6 +109,8 @@ public enum AtBMoraleLevel {
                 case 4:
                     return HIGH;
                 case 5:
+                    return VERY_HIGH;
+                case 6:
                     return INVINCIBLE;
                 default:
                     break;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1356,8 +1356,11 @@ public class StratconRulesManager {
             case HIGH:
                 moraleModifier = 5;
                 break;
-            case INVINCIBLE:
+            case VERY_HIGH:
                 moraleModifier = 10;
+                break;
+            case INVINCIBLE:
+                moraleModifier = 15;
                 break;
             default:
                 break;


### PR DESCRIPTION
### Current Implementation
In the Against the Bot (AtB) system, there are six Morale Levels (Rout, Very Low, Low, Normal, High, and Invincible). Each month begins with a morale roll, which includes various modifiers. If the roll is 13 or higher, morale increases by two ranks.

However, the system faces a significant issue when the morale roll results in 13 or higher. This can lead to morale jumping two levels, potentially skyrocketing from Normal to Invincible morale in a single roll. Conversely, if the roll is low enough to cause a two-level drop in morale, it won't transition directly from Normal to Rout due to the existence of the Very Low level.

### Solutions
1. **Introduction of Very High Morale Level:** To address this issue, a new Very High morale level was introduced. This means morale must be High before it can jump to Invincible in a single roll. Contracts must now go a minimum of two months before they can reach Invincible morale, rather than just one.
2. **Adjustments in StratCon:** To reflect this addition, the +10 scenario chance modifier (previously applied to Invincible morale) was applied to Very High morale. Additionally, a +15 scenario chance modifier was applied to Invincible morale.