### PR TITLE
Move terrainType to AtBScenario

### DIFF
--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -151,12 +151,12 @@ class GameThread extends Thread implements CloseClientListener {
                         if (scenario.getBoardType() == Scenario.T_ATMOSPHERE) {
                             mapSettings.setMedium(MapSettings.MEDIUM_ATMOSPHERE);
                         }
-                    } else if (scenario.getTerrainType() != null){
-                        File mapgenFile = new File("data/mapgen/" + scenario.getTerrainType() + ".xml"); // TODO : remove inline file path
+                    } else if (scenario.getMapGenerator() != null){
+                        File mapgenFile = new File("data/mapgen/" + scenario.getMapGenerator() + ".xml"); // TODO : remove inline file path
                         try (InputStream is = new FileInputStream(mapgenFile)) {
                             mapSettings = MapSettings.getInstance(is);
                         } catch (FileNotFoundException ex) {
-                            LogManager.getLogger().error("Could not load map file data/mapgen/" + scenario.getTerrainType() + ".xml", ex);  // TODO : remove inline file path
+                            LogManager.getLogger().error("Could not load map file data/mapgen/" + scenario.getMapGenerator() + ".xml", ex);  // TODO : remove inline file path
                         }
 
                         if (scenario.getBoardType() == Scenario.T_ATMOSPHERE) {

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -132,30 +132,31 @@ class GameThread extends Thread implements CloseClientListener {
                 MapSettings mapSettings = MapSettings.getInstance();
 
                 // check that we have valid conditions for setting the mapSettings
-                if ((scenario.getMapSizeX() > 1) && (scenario.getMapSizeY() > 1) && (null != scenario.getMap())) {
+                if ((scenario.getMapSizeX() > 1) && (scenario.getMapSizeY() > 1)) {
 
                     mapSettings.setBoardSize(scenario.getMapSizeX(), scenario.getMapSizeY());
                     mapSettings.setMapSize(1, 1);
-                    mapSettings.getBoardsSelectedVector().clear();
 
                     // if the scenario is taking place in space, do space settings instead
                     if (scenario.getBoardType() == Scenario.T_SPACE) {
                         mapSettings.setMedium(MapSettings.MEDIUM_SPACE);
+                        mapSettings.getBoardsSelectedVector().clear();
                         mapSettings.getBoardsSelectedVector().add(MapSettings.BOARD_GENERATED);
-                    } else if (scenario.isUsingFixedMap()) {
+                    } else if (scenario.isUsingFixedMap() && scenario.getMap() != null) {
                         String board = scenario.getMap().replace(".board", ""); // TODO : remove inline file type
                         board = board.replace("\\", "/");
+                        mapSettings.getBoardsSelectedVector().clear();
                         mapSettings.getBoardsSelectedVector().add(board);
 
                         if (scenario.getBoardType() == Scenario.T_ATMOSPHERE) {
                             mapSettings.setMedium(MapSettings.MEDIUM_ATMOSPHERE);
                         }
-                    } else {
-                        File mapgenFile = new File("data/mapgen/" + scenario.getMap() + ".xml"); // TODO : remove inline file path
+                    } else if (scenario.getTerrainType() != null){
+                        File mapgenFile = new File("data/mapgen/" + scenario.getTerrainType() + ".xml"); // TODO : remove inline file path
                         try (InputStream is = new FileInputStream(mapgenFile)) {
                             mapSettings = MapSettings.getInstance(is);
                         } catch (FileNotFoundException ex) {
-                            LogManager.getLogger().error("Could not load map file data/mapgen/" + scenario.getMap() + ".xml", ex);  // TODO : remove inline file path
+                            LogManager.getLogger().error("Could not load map file data/mapgen/" + scenario.getTerrainType() + ".xml", ex);  // TODO : remove inline file path
                         }
 
                         if (scenario.getBoardType() == Scenario.T_ATMOSPHERE) {
@@ -165,7 +166,10 @@ class GameThread extends Thread implements CloseClientListener {
                         // duplicate code, but getting a new instance of map settings resets the size parameters
                         mapSettings.setBoardSize(scenario.getMapSizeX(), scenario.getMapSizeY());
                         mapSettings.setMapSize(1, 1);
+                        mapSettings.getBoardsSelectedVector().clear();
                         mapSettings.getBoardsSelectedVector().add(MapSettings.BOARD_GENERATED);
+                    } else {
+                        LogManager.getLogger().error("invalid map settings provided for scenario " + scenario.getName());
                     }
                 } else {
                     LogManager.getLogger().error("invalid map settings provided for scenario " + scenario.getName());

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -132,31 +132,30 @@ class GameThread extends Thread implements CloseClientListener {
                 MapSettings mapSettings = MapSettings.getInstance();
 
                 // check that we have valid conditions for setting the mapSettings
-                if ((scenario.getMapSizeX() > 1) && (scenario.getMapSizeY() > 1)) {
+                if ((scenario.getMapSizeX() > 1) && (scenario.getMapSizeY() > 1) && (null != scenario.getMap())) {
 
                     mapSettings.setBoardSize(scenario.getMapSizeX(), scenario.getMapSizeY());
                     mapSettings.setMapSize(1, 1);
+                    mapSettings.getBoardsSelectedVector().clear();
 
                     // if the scenario is taking place in space, do space settings instead
                     if (scenario.getBoardType() == Scenario.T_SPACE) {
                         mapSettings.setMedium(MapSettings.MEDIUM_SPACE);
-                        mapSettings.getBoardsSelectedVector().clear();
                         mapSettings.getBoardsSelectedVector().add(MapSettings.BOARD_GENERATED);
-                    } else if (scenario.isUsingFixedMap() && scenario.getMap() != null) {
+                    } else if (scenario.isUsingFixedMap()) {
                         String board = scenario.getMap().replace(".board", ""); // TODO : remove inline file type
                         board = board.replace("\\", "/");
-                        mapSettings.getBoardsSelectedVector().clear();
                         mapSettings.getBoardsSelectedVector().add(board);
 
                         if (scenario.getBoardType() == Scenario.T_ATMOSPHERE) {
                             mapSettings.setMedium(MapSettings.MEDIUM_ATMOSPHERE);
                         }
-                    } else if (scenario.getMapGenerator() != null){
-                        File mapgenFile = new File("data/mapgen/" + scenario.getMapGenerator() + ".xml"); // TODO : remove inline file path
+                    } else {
+                        File mapgenFile = new File("data/mapgen/" + scenario.getMap() + ".xml"); // TODO : remove inline file path
                         try (InputStream is = new FileInputStream(mapgenFile)) {
                             mapSettings = MapSettings.getInstance(is);
                         } catch (FileNotFoundException ex) {
-                            LogManager.getLogger().error("Could not load map file data/mapgen/" + scenario.getMapGenerator() + ".xml", ex);  // TODO : remove inline file path
+                            LogManager.getLogger().error("Could not load map file data/mapgen/" + scenario.getMap() + ".xml", ex);  // TODO : remove inline file path
                         }
 
                         if (scenario.getBoardType() == Scenario.T_ATMOSPHERE) {
@@ -166,10 +165,7 @@ class GameThread extends Thread implements CloseClientListener {
                         // duplicate code, but getting a new instance of map settings resets the size parameters
                         mapSettings.setBoardSize(scenario.getMapSizeX(), scenario.getMapSizeY());
                         mapSettings.setMapSize(1, 1);
-                        mapSettings.getBoardsSelectedVector().clear();
                         mapSettings.getBoardsSelectedVector().add(MapSettings.BOARD_GENERATED);
-                    } else {
-                        LogManager.getLogger().error("invalid map settings provided for scenario " + scenario.getName());
                     }
                 } else {
                     LogManager.getLogger().error("invalid map settings provided for scenario " + scenario.getName());

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -178,6 +178,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
     private Map<Integer, Integer> numPlayerMinefields;
 
+    private String terrainType;
+
     protected final transient ResourceBundle defaultResourceBundle = ResourceBundle.getBundle("mekhq.resources.AtBScenarioBuiltIn",
             MekHQ.getMHQOptions().getLocale());
 
@@ -250,6 +252,14 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
     public String getDesc() {
         return getScenarioTypeDescription() + (isStandardScenario() ? (isAttacker() ? " (Attacker)" : " (Defender)") : "");
+    }
+
+    public String getTerrainType() {
+        return terrainType;
+    }
+
+    public void setTerrainType(String terrainType) {
+        this.terrainType = terrainType;
     }
 
     @Override
@@ -1505,6 +1515,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "deploymentDelay", deploymentDelay);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "lanceCount", lanceCount);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "rerollsRemaining", rerollsRemaining);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "terrainType", terrainType);
 
         if (null != bigBattleAllies && !bigBattleAllies.isEmpty()) {
             MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "bigBattleAllies");
@@ -1603,6 +1614,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                     lanceCount = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("rerollsRemaining")) {
                     rerollsRemaining = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("terrainType")) {
+                    terrainType = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("alliesPlayer")) {
                     NodeList nl2 = wn2.getChildNodes();
                     for (int i = 0; i < nl2.getLength(); i++) {

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -91,9 +91,9 @@ public class Scenario {
     private Map<String, Entity> externalIDLookup;
 
     /** map generation variables **/
-    private String mapGenerator;
     private int mapSizeX;
     private int mapSizeY;
+    // map can be used to represent both fixed and random maps
     private String map;
     private boolean usingFixedMap;
 
@@ -321,14 +321,6 @@ public class Scenario {
 
     public void setMap(String map) {
         this.map = map;
-    }
-
-    public String getMapGenerator() {
-        return mapGenerator;
-    }
-
-    public void setMapGenerator(String s) {
-        mapGenerator = s;
     }
 
     public String getMapForDisplay() {
@@ -876,7 +868,6 @@ public class Scenario {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "date", date);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "cloaked", isCloaked());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "boardType", boardType);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mapGenerator", mapGenerator);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "hasTrack", hasTrack);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "usingFixedMap", isUsingFixedMap());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mapSize", mapSizeX, mapSizeY);
@@ -1014,8 +1005,6 @@ public class Scenario {
                     retVal.setUsingFixedMap(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("boardType")) {
                     retVal.boardType = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("mapGenerator")) {
-                    retVal.mapGenerator = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("hasTrack")) {
                     retVal.hasTrack = Boolean.parseBoolean(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("mapSize")) {

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -91,7 +91,7 @@ public class Scenario {
     private Map<String, Entity> externalIDLookup;
 
     /** map generation variables **/
-    private String terrainType;
+    private String mapGenerator;
     private int mapSizeX;
     private int mapSizeY;
     private String map;
@@ -235,10 +235,6 @@ public class Scenario {
         this.cloaked = cloaked;
     }
 
-    public String getTerrainType() {
-        return terrainType;
-    }
-
     public int getStartingPos() {
         return startingPos;
     }
@@ -295,10 +291,6 @@ public class Scenario {
         this.startingAnySEy = startingAnySEy;
     }
 
-    public void setTerrainType(String terrainType) {
-        this.terrainType = terrainType;
-    }
-
     public void setBoardType(int boardType) {
         this.boardType = boardType;
     }
@@ -329,6 +321,14 @@ public class Scenario {
 
     public void setMap(String map) {
         this.map = map;
+    }
+
+    public String getMapGenerator() {
+        return mapGenerator;
+    }
+
+    public void setMapGenerator(String s) {
+        mapGenerator = s;
     }
 
     public String getMapForDisplay() {
@@ -876,7 +876,7 @@ public class Scenario {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "date", date);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "cloaked", isCloaked());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "boardType", boardType);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "terrainType", terrainType);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mapGenerator", mapGenerator);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "hasTrack", hasTrack);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "usingFixedMap", isUsingFixedMap());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mapSize", mapSizeX, mapSizeY);
@@ -1014,8 +1014,8 @@ public class Scenario {
                     retVal.setUsingFixedMap(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("boardType")) {
                     retVal.boardType = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("terrainType")) {
-                    retVal.terrainType = wn2.getTextContent();
+                } else if (wn2.getNodeName().equalsIgnoreCase("mapGenerator")) {
+                    retVal.mapGenerator = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("hasTrack")) {
                     retVal.hasTrack = Boolean.parseBoolean(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("mapSize")) {


### PR DESCRIPTION
We now have `terrainType` in `Scenario` (I think as part of the work by @kuronekochomusuke on weather), which references the preset map generation parameters in `data/mapgen`. However, the code in `GameThread` will not properly apply these mapgen settings because it uses:

```java
File mapgenFile = new File("data/mapgen/" + scenario.getMap() + ".xml"); // TODO : remove inline file path
```

The problem is that `scenario.getMap()` does not access `terrainType` which is what needs to be accessed. I believe this is because somewhere in the innards of AtB code, terrain type gets translated into the `map` variable. However, this does not happen in vanilla `Scenario`.

This PR fixes the problem by just switching the code above to directly call `scenario.getTerrainType()` rather than `scenario.getMap()`. It should not affect AtB because AtB uses a different game thread. I also had to update a few other things to get proper null checks into the code and to make sure we didn't erase the default map settings before we confirm that we are actually going to get new ones. 