### PR TITLE
MekHQ 0.49.19.1 dot release

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -29,17 +29,18 @@ sourceSets {
 }
 
 dependencies {
-    implementation "org.megamek:megamek${mmBranchTag}:${version}"
-    implementation ("org.megamek:megameklab${mmlBranchTag}:${version}") {
+    implementation "org.megamek:megamek:${version}"
+    implementation ("org.megamek:megameklab:${version}") {
         // We may want to specify different branches for MM and MML, so we need to exclude the
         // transitive MM dependency
-        exclude group: 'org.megamek', module: "megameklab${mmlBranchTag}"
+        exclude group: 'org.megamek', module: "megameklab"
         // We don't need the python and javascript engine taking up space
         exclude group: 'org.python', module: 'jython'
         exclude group: 'org.mozilla', module: 'rhino'
-        // Eclipse IDE Multiple Dependency errors. 
+        // Eclipse IDE Multiple Dependency errors.
         exclude group: 'xml-apis'
     }
+    implementation "org.megamek:mekhq:${version}"
 
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
     implementation 'javax.vecmath:vecmath:1.5.2'
@@ -55,7 +56,7 @@ dependencies {
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.2'
     // Required for mml printing scaled vector graphics (SVG) - Eclipse IDE Compatability.
     runtimeOnly 'xml-apis:xml-apis-ext:1.3.04'
-    
+
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
     testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
@@ -598,7 +599,7 @@ task javadocJar(type: Jar) {
 publishing {
     publications {
         publishMMLibrary(MavenPublication) {
-            artifactId = "mekhq${mmBranchTag}"
+            artifactId = "mekhq"
             from components.java
             artifact sourcesJar
 //            artifact javadocJar

--- a/MekHQ/docs/history.txt
+++ b/MekHQ/docs/history.txt
@@ -1,5 +1,9 @@
 MEKHQ VERSION HISTORY:
 ---------------
+0.49.19.1 (2024-05-06 1744 UTC)
++ Fix #4023: Save boardType to XML
++ Fix #4052: Move modifiedTemperature to AtBScenario
+
 0.49.19 (2024-04-19 2030 UTC)
 + Bug #3958: No selling units in scenario resolution if campaign disallows selling
 + Fix #3949: Custom ScenarioObjectives do not change ScenarioStatus in ResolveScenarioWizardDialog
@@ -13,44 +17,44 @@ MEKHQ VERSION HISTORY:
 + Fix: #3815: StratCon Modifier BadEvent is broken and doesnt do anything
 + PR: #3874: Fixes MegaMek #4464 - StratCon Mapgen Fix
 + PR: #3866: Fixed Typo and Removed Indents
-+ Data: #3865: 499 new callsigns 
++ Data: #3865: 499 new callsigns
 + PR: #3878: Interstellar Map Hiring Hall Highlight
-+ PR: #3869: Fix issue #3839 to prevent loading clientsettings.xml instead of most recent campaign save 
-+ Fix #3730: Names of Victory Points (Stratcon) 
-+ PR #3867: Adjusted Retirement TN and Payout Values 
++ PR: #3869: Fix issue #3839 to prevent loading clientsettings.xml instead of most recent campaign save
++ Fix #3730: Names of Victory Points (Stratcon)
++ PR #3867: Adjusted Retirement TN and Payout Values
 + Fix #3877: MekHQ units aren't defaulting to active probes for sensors
-+ Fix #1812: AtB/StratCon] Base Attack (Defender) Objective Changes 
-+ PR #3892: Corrected Typo in Mass Repair Dialog 
-+ Fix #2990: Stratcon draw counts as loss 
-+ PR #3895: Correct Starting Cash Dice Count in Company Generator 
-+ PR #3900: Disconnect quietly from GameThread for MekHQ 
++ Fix #1812: AtB/StratCon] Base Attack (Defender) Objective Changes
++ PR #3892: Corrected Typo in Mass Repair Dialog
++ Fix #2990: Stratcon draw counts as loss
++ PR #3895: Correct Starting Cash Dice Count in Company Generator
++ PR #3900: Disconnect quietly from GameThread for MekHQ
 + PR #3834: Update planetary conditions chance logic
 + Fix #3803: MekHQ fix for WOB.pm/.PM mismatch and missing parent faction check
 + Fix #3932: Added Nag for Wounded Personnel without Doctor
-+ Fix #3890: Add Tech/Vessel Column to Tech Skills View 
++ Fix #3890: Add Tech/Vessel Column to Tech Skills View
 + PR #3951: Add OperationalVP variable to CommonObjectiveFactory.java (prep for later work)
 + Fix #3925: update Aerospace handling and reporting in MHQ (for #3882)
 + PR #3930: Prevent advancing day with pending vanilla scenarios
 + PR #3937: Added Nag for Wounded Personnel without Doctor
 + PR #3901: add lances to the force string when sending data to megamek for bot forces
-+ PR #3922: Add missing cockpit costs and weights 
-+ PR #3944: Added Nag Dialog for Pregnant Combatants 
++ PR #3922: Add missing cockpit costs and weights
++ PR #3944: Added Nag Dialog for Pregnant Combatants
 + Fix #3943: Unmaintained Unit Nag Dialog Suppressed for Units set to Salvage
-+ PR #3933: Fixes for #3729,#3817,#3753: Clamped Unit Rating Mod for CamOps (redux) 
-+ PR #3923: Hide Toughness When 0 
-+ PR #3915: Added Dialog to Confirm New Campaign (redux) 
-+ PR #3908: Adjusted Default Tech Counts 
-+ PR #3967: Adjusted Zoom Speed on Interstellar Map Panel 
++ PR #3933: Fixes for #3729,#3817,#3753: Clamped Unit Rating Mod for CamOps (redux)
++ PR #3923: Hide Toughness When 0
++ PR #3915: Added Dialog to Confirm New Campaign (redux)
++ PR #3908: Adjusted Default Tech Counts
++ PR #3967: Adjusted Zoom Speed on Interstellar Map Panel
 + Fix #3348: Added Ability to Collapse/Expand Logs, Missions and Kills in Personnel Unit Screen
-+ PR #3970: Reduced Personnel Table Right-Click Menu Clutter 
++ PR #3970: Reduced Personnel Table Right-Click Menu Clutter
 + Fix #3981: Removed Unnecessary Error Log
-+ PR #3988: Added Scenario & Mission Tracking to Kills, Added Ability to Assign Kills to Scenario and/or Mission 
++ PR #3988: Added Scenario & Mission Tracking to Kills, Added Ability to Assign Kills to Scenario and/or Mission
 + Fix #3989: Fixed Ship Search Overvaluing Ultra-Green Personnel
-+ PR #3996: Add new player deployment variables to Scenario 
++ PR #3996: Add new player deployment variables to Scenario
 + PR #3973: Move new lance creation to AtBGameThread
 + Fix #3978: Fix a bug with saving
 + PR #3983: Load bot entities in the chat lounge
-+ PR #3991: Add all deployment variables to BotForce 
++ PR #3991: Add all deployment variables to BotForce
 + Fix #3767: NPE while scouting Stratcon map due to non-applicable SPAs for enemy force
 + PR #3997: Set default MHQ theme to match MM GUIPreferences default (Flat Darcula currently)
 + Fix #4002: Infinite loop when assigning SPAs to enemies from generated Scenario locked game UI
@@ -62,16 +66,16 @@ MEKHQ VERSION HISTORY:
 + PR #3788: Adjust campaign creation dialogs to have correct jdialod owner
 + Fix #3540: Manually set TO&E force commander
 + PR #3818: MUL parser updates
-+ PR #3816: Show if unit is in repair or salvage mode in repair bay. 
++ PR #3816: Show if unit is in repair or salvage mode in repair bay.
 + PR #3823, #3827, #3833: Rework of the internal representation of Armor
 + PR #3826: Adaptation to Mek Clan name separation in MM
 + Fix #3740: Consistent messaging in Daily Activity Log: ComStar bill vs. C-Bill
 + PR #3821: Add max contract salvage percentage to campaign options
 + Fix #3763: Reversing quality names in unit set quality GM menu
-+ Fix #3194: Awarding non-stackable medals to multiple people 
++ Fix #3194: Awarding non-stackable medals to multiple people
 + Issue #3781: Force commanders can be picked from among highest-ranking individuals
 + Fix #3843: Fix chassis lookup
-+ Fix #3842: Can't load prefab campaigns  
++ Fix #3842: Can't load prefab campaigns
 + PR #3849: StratCon Heavy Battles, by PhoenixHeart.
 
 
@@ -98,16 +102,16 @@ MEKHQ VERSION HISTORY:
 + PR #3768: Arano Restoration Campaign - Planetary Control
 
 0.49.14 (2023-07-28 2100 UTC)
-+ PR #3676: Gradle build fixes 
++ PR #3676: Gradle build fixes
 + Issue #3682: Prevent NPE when changing bot config
 + Issue #3683 - fix issue preventing loading saved campaigns containing MASC
 + Issue #3621 - prevent NPE completing ship search immediately after loading campaign
 + PR #3692: Adaptations to MM's #4474 (BV calculation and reports update)
 + Issue #3402, #3715: Only hostile units are now displayed on the killboard during scenario resolution, Stratcon fixes
-+ PR #3694: New StratCon feature - tracks now have individual terrain hexes (with graphics) and average temperatures; 
++ PR #3694: New StratCon feature - tracks now have individual terrain hexes (with graphics) and average temperatures;
     the terrain influences the map presets used for tactical battles; temperature is passed to megamek (may be hot!)
 + PR #3724: "Clan Personnel" special flag now correctly sets the person's clan status
-+ PR #3731: Fix nightly build from a missed method rename in MegaMek. 
++ PR #3731: Fix nightly build from a missed method rename in MegaMek.
 + Issue #3713: allied turrets have upgraded network security; defeat in evacuation scenarios results in facility capture instead of destruction
 
 0.49.13 (2023-05-23 2000 UTC)
@@ -421,7 +425,7 @@ MEKHQ VERSION HISTORY:
 + PR #2862: Removing Useless Shares Sorter
 + Issue #2865: Specialist Infantry Salary Multiplier
 + PR #2844: AbstractIcon: Force Camouflage: Layering and Properly Sending to MegaMek
-+ Data: Adding UlyssessSockdrawer's excellent Co-op guide to docs folder. 
++ Data: Adding UlyssessSockdrawer's excellent Co-op guide to docs folder.
 + Issue #2873: Part doesn't serialize brandNew flag
 + Issue #2878: Prevent DropShip bay doors from continuously breaking down when loading saves
 + Issue #1236: Adding full support for Tripod 'Meks
@@ -461,7 +465,7 @@ MEKHQ VERSION HISTORY:
     more abstractly: capability to substitute player units for bot units in designated scenario force templates
     prevent "regenerate bot forces" button from displaying when editing completed scenarios
     allow contract completion for scenarios with remaining "fixed" objectives (useful for when the enemy morale goes to rout or you win a base of operations attack)
-    explicitly show that objectives in defensive contracts must be held until contract completion   
+    explicitly show that objectives in defensive contracts must be held until contract completion
         fix clicked hex detection on StratCon map when viewing anything other than top left corner when map doesn't fit on single screen (smaller resolutions/bigger maps)
         added scroll pane to info panel in case it has more data than can be displayed (important on smaller resolutions)
         do not un-deploy force from track if it's assigned to a scenario on the track until the scenario is resolved one way or another
@@ -698,10 +702,10 @@ MEKHQ VERSION HISTORY:
 + Issues #2217 #2219: Cannot save Campaign with Refits and cannot start new Refits
 + Issue #2220: Implementing AwardFileFactory to handle loading pngs that aren't handled by Toolkit
 
-0.47.13 (2020-11-09 1600 UTC) 
+0.47.13 (2020-11-09 1600 UTC)
 + Issue #2213: Fix disastrous bug in AmmoStorage::ctor
 
-0.47.12 (2020-11-08 2230 UTC) 
+0.47.12 (2020-11-08 2230 UTC)
 + Issue #1970: Workaround for single hex ecm causing Small Craft to be overweight
 + Issue #1079: Add refit time for moving a part between locations
 + PR #2117: Fixing New Personnel Market Report

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -123,7 +123,8 @@ public class AtBGameThread extends GameThread {
                 mapSettings.getBoardsSelectedVector().clear();
 
                 // if the scenario is taking place in space, do space settings instead
-                if (scenario.getBoardType() == Scenario.T_SPACE) {
+                if (scenario.getBoardType() == Scenario.T_SPACE
+                        || scenario.getTerrainType().equals("Space")) {
                     mapSettings.setMedium(MapSettings.MEDIUM_SPACE);
                     mapSettings.getBoardsSelectedVector().add(MapSettings.BOARD_GENERATED);
                 } else if (scenario.isUsingFixedMap()) {

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -179,7 +179,7 @@ class GameThread extends Thread implements CloseClientListener {
                 planetaryConditions.setWind(scenario.getWind());
                 planetaryConditions.setFog(scenario.getFog());
                 planetaryConditions.setAtmosphere(scenario.getAtmosphere());
-                planetaryConditions.setTemperature(scenario.getModifiedTemperature());
+                planetaryConditions.setTemperature(scenario.getTemperature());
                 planetaryConditions.setGravity(scenario.getGravity());
                 planetaryConditions.setEMI(scenario.getEMI());
                 planetaryConditions.setBlowingSand(scenario.getBlowingSand());

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -860,7 +860,11 @@ public class AtBDynamicScenarioFactory {
      * the given threshold, replace the scenario's generated map with a fixed map from data/boards
      */
     private static void setScenarioMap(AtBDynamicScenario scenario, int mapChance) {
-        if ((scenario.getMapSizeX() > 0) && (scenario.getMapSizeY() > 0) && (Compute.randomInt(100) <= mapChance)) {
+        if (scenario.getBoardType() != Scenario.T_SPACE
+                && scenario.getTerrainType().equals("Space")
+                && (scenario.getMapSizeX() > 0)
+                && (scenario.getMapSizeY() > 0)
+                && (Compute.randomInt(100) <= mapChance)) {
             BoardClassifier bc = BoardClassifier.getInstance();
             List<String> maps = bc.getMatchingBoards(scenario.getMapSizeX(), scenario.getMapSizeY(), 5, 5, new ArrayList<>());
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -183,6 +183,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
     private static TerrainConditionsOddsManifest TCO;
     private static StratconBiomeManifest SB;
+    private int modifiedTemperature;
     //endregion Variable Declarations
 
     public AtBScenario () {
@@ -303,6 +304,14 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 rerollsRemaining = getLance(campaign).getCommander(campaign).getSkill(SkillType.S_TACTICS).getLevel();
             }
         }
+    }
+
+    public int getModifiedTemperature() {
+        return modifiedTemperature;
+    }
+
+    public void setModifiedTemperature(int modifiedTemperature) {
+        this.modifiedTemperature = modifiedTemperature;
     }
 
     public void setTerrain() {
@@ -1505,6 +1514,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "deploymentDelay", deploymentDelay);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "lanceCount", lanceCount);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "rerollsRemaining", rerollsRemaining);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "modifiedTemperature", modifiedTemperature);
 
         if (null != bigBattleAllies && !bigBattleAllies.isEmpty()) {
             MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "bigBattleAllies");
@@ -1603,6 +1613,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                     lanceCount = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("rerollsRemaining")) {
                     rerollsRemaining = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("modifiedTemperature")) {
+                    modifiedTemperature = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("alliesPlayer")) {
                     NodeList nl2 = wn2.getChildNodes();
                     for (int i = 0; i < nl2.getLength(); i++) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -420,13 +420,17 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     }
 
     public void setMapFile(String terrainType) {
-        Map<String, StratconBiomeManifest.MapTypeList> mapTypes = SB.getBiomeMapTypes();
-        StratconBiomeManifest.MapTypeList value = mapTypes.get(terrainType);
-        if (value != null) {
-            List<String> mapTypeList = value.mapTypes;
-            setMap(mapTypeList.get(Compute.randomInt(mapTypeList.size())));
+        if (terrainType.equals("Space")) {
+            setMap("Space");
         } else {
-            setMap("Savannah");
+            Map<String, StratconBiomeManifest.MapTypeList> mapTypes = SB.getBiomeMapTypes();
+            StratconBiomeManifest.MapTypeList value = mapTypes.get(terrainType);
+            if (value != null) {
+                List<String> mapTypeList = value.mapTypes;
+                setMap(mapTypeList.get(Compute.randomInt(mapTypeList.size())));
+            } else {
+                setMap("Savannah");
+            }
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -104,7 +104,6 @@ public class Scenario {
     protected Fog fog;
     protected Atmosphere atmosphere;
     private int temperature;
-    private int modifiedTemperature;
     protected float gravity;
     private EMI emi;
     private BlowingSand blowingSand;
@@ -394,14 +393,6 @@ public class Scenario {
 
     public void setTemperature(int temperature) {
         this.temperature = temperature;
-    }
-
-    public int getModifiedTemperature() {
-        return modifiedTemperature;
-    }
-
-    public void setModifiedTemperature(int modifiedTemperature) {
-        this.modifiedTemperature = modifiedTemperature;
     }
 
     public float getGravity() {

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -875,6 +875,7 @@ public class Scenario {
 
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "date", date);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "cloaked", isCloaked());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "boardType", boardType);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "terrainType", terrainType);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "hasTrack", hasTrack);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "usingFixedMap", isUsingFixedMap());

--- a/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
@@ -475,7 +475,7 @@ public class ScenarioViewPanel extends JScrollablePanel {
         leftGbc.gridy++;
         pnlMap.add(lblTemperature, leftGbc);
 
-        JLabel lblTemperatureDesc = new JLabel(PlanetaryConditions.getTemperatureDisplayableName(scenario.getModifiedTemperature()));
+        JLabel lblTemperatureDesc = new JLabel(PlanetaryConditions.getTemperatureDisplayableName(scenario.getTemperature()));
         rightGbc.gridy++;
         pnlMap.add(lblTemperatureDesc, rightGbc);
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,9 @@ ext {
     mhqBranchTag = mhqBranch.equals('master') ? '' : '-' + mhqBranch
 
     // Allows setting a dependency on a different MM branch.
-    mmBranch = 'master'
+    mmBranch = '0.49.19.1'
     mmBranchTag = mmBranch.equals('master') ? '' : '-' + mmBranch
-    mmlBranch = 'master'
+    mmlBranch = '0.49.19.1'
     mmlBranchTag = mmlBranch.equals('master') ? '' : '-' + mmlBranch
 
     mmDir = "${rootDir}/../megamek"

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
 
 subprojects {
     group = 'org.megamek'
-    version = '0.49.19'
+    version = '0.49.19.1'
 }
 
 ext {
@@ -31,16 +31,16 @@ ext {
     mhqGitRoot = 'https://github.com/MegaMek/mekhq.git'
     // Work on MML or MHQ sometimes requires changes in MM as well. The maven publishing tasks use
     // these properties to append the branch name to the artifact id if the repo is not in the master
-    // branch, making it available separately to the child project. 
+    // branch, making it available separately to the child project.
     mhqBranch = grgit.branch.current().name
     mhqBranchTag = mhqBranch.equals('master') ? '' : '-' + mhqBranch
-    
+
     // Allows setting a dependency on a different MM branch.
     mmBranch = 'master'
     mmBranchTag = mmBranch.equals('master') ? '' : '-' + mmBranch
     mmlBranch = 'master'
     mmlBranchTag = mmlBranch.equals('master') ? '' : '-' + mmlBranch
-    
+
     mmDir = "${rootDir}/../megamek"
     mmlDir = "${rootDir}/../megameklab"
 }


### PR DESCRIPTION
Includes the following fixes back-ported from 0.49.20:

#4023
#4052 (first part; does not include updates from #4050)

Plus an update to MM's Version.java to support a 4th field in the version number (without this, bug reports would be quite difficult to keep track of).

Version is reported as 0.49.19.1

Testing:

- Ran all unit tests
- Verified C3i fix working in OP's save from #4034 (can load, advance, save)