### PR TITLE
Fix 4061: Failure to load older Campaign save

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5744,10 +5744,12 @@ public class Campaign implements ITechManager {
         entity.setShutDown(false);
         entity.setSearchlightState(false);
 
-        if (entity.hasBAP()) {
-            entity.setNextSensor(entity.getSensors().lastElement());
-        } else if (!entity.getSensors().isEmpty()) {
-            entity.setNextSensor(entity.getSensors().firstElement());
+        if (!entity.getSensors().isEmpty()) {
+            if (entity.hasBAP()) {
+                entity.setNextSensor(entity.getSensors().lastElement());
+            } else {
+                entity.setNextSensor(entity.getSensors().firstElement());
+            }
         }
 
         if (entity instanceof IBomber) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -31,6 +31,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.OptionsConstants;
 import mekhq.MekHQ;
+import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -1588,9 +1589,22 @@ public class Person {
                         retVal.setOriginFaction(Factions.getInstance().getFaction(wn2.getTextContent().trim()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("planetId")) {
-                    String systemId = wn2.getAttributes().getNamedItem("systemId").getTextContent().trim();
-                    String planetId = wn2.getTextContent().trim();
-                    retVal.originPlanet = c.getSystemById(systemId).getPlanetById(planetId);
+                    String systemId = "", planetId = "";
+                    try {
+                        systemId = wn2.getAttributes().getNamedItem("systemId").getTextContent().trim();
+                        planetId = wn2.getTextContent().trim();
+                        PlanetarySystem ps = c.getSystemById(systemId);
+                        Planet p = null;
+                        if (ps == null) {
+                            ps = c.getSystemByName(systemId);
+                        }
+                        if (ps != null) {
+                            p = ps.getPlanetById(planetId);
+                        }
+                        retVal.originPlanet = p;
+                    } catch (NullPointerException e) {
+                        LogManager.getLogger().error("Error loading originPlanet for " + systemId + ", " + planetId, e);
+                    }
                 } else if (wn2.getNodeName().equalsIgnoreCase("phenotype")) {
                     retVal.phenotype = Phenotype.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("bloodname")) {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3580,7 +3580,11 @@ public class Unit implements ITechnology {
         }
 
         // Clear any stale game data that may somehow have gotten set incorrectly
-        getCampaign().clearGameData(entity);
+        try {
+            getCampaign().clearGameData(entity);
+        } catch (NoSuchElementException e) {
+            LogManager.getLogger().error("Failure to reset entity " + entity.toString(), e);
+        }
         // Set up SPAs, Implants, Edge, etc
         if (getCampaign().getCampaignOptions().isUseAbilities()) {
             PilotOptions options = new PilotOptions(); // MegaMek-style as it is sent to MegaMek

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3580,11 +3580,7 @@ public class Unit implements ITechnology {
         }
 
         // Clear any stale game data that may somehow have gotten set incorrectly
-        try {
-            getCampaign().clearGameData(entity);
-        } catch (NoSuchElementException e) {
-            LogManager.getLogger().error("Failure to reset entity " + entity.toString(), e);
-        }
+        getCampaign().clearGameData(entity);
         // Set up SPAs, Implants, Edge, etc
         if (getCampaign().getCampaignOptions().isUseAbilities()) {
             PilotOptions options = new PilotOptions(); // MegaMek-style as it is sent to MegaMek

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -21,7 +21,9 @@
 package mekhq.campaign;
 
 import megamek.common.Dropship;
+import megamek.common.Entity;
 import megamek.common.EquipmentType;
+import megamek.common.Infantry;
 import megamek.common.enums.SkillLevel;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
@@ -145,6 +147,15 @@ public class CampaignTest {
         expected.add(mockTechActive);
         expected.add(mockTechActiveTwo);
         assertEquals(expected, testCampaign.getTechs(true));
+    }
+
+    @Test
+    public void testCampaignResetInfantry() {
+        // It is possible for Infantry to have BAP equal true, but empty Sensors vector.
+        Campaign campaign = new Campaign();
+        Entity infantry = spy(new Infantry());
+        when(infantry.hasBAP()).thenReturn(true);
+        campaign.clearGameData(infantry);
     }
 
     @Test


### PR DESCRIPTION
Issues for the reported campaign are twofold:
1. 3 Persons use a systemId that has changed in 0.49.19, causing the planetId lookup to fail.
2. At least one infantry unit has a quirk or ability that grants it BAP equivalent sensors, but no actual sensors; this causes a new-to-0.49.19 cleanup step to fail on loading the unit(s).

Fix is to add try/catch and better conditionals around the failing code blocks.

Testing:
- Ran all three projects' unit tests
- Added unit test for clearGameData() with affected Infantry unit instance.
- Loaded OP's previously-failing campaign save successfully.

Close #4061 