### PR TITLE
Backport fix for MHQ #4061 to 0.49.19.1

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5691,10 +5691,12 @@ public class Campaign implements ITechManager {
         entity.setShutDown(false);
         entity.setSearchlightState(false);
 
-        if (entity.hasBAP()) {
-            entity.setNextSensor(entity.getSensors().lastElement());
-        } else if (!entity.getSensors().isEmpty()) {
-            entity.setNextSensor(entity.getSensors().firstElement());
+        if (!entity.getSensors().isEmpty()) {
+            if (entity.hasBAP()) {
+                entity.setNextSensor(entity.getSensors().lastElement());
+            } else {
+                entity.setNextSensor(entity.getSensors().firstElement());
+            }
         }
 
         if (entity instanceof IBomber) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -31,6 +31,7 @@ import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.OptionsConstants;
 import mekhq.MekHQ;
+import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -1587,9 +1588,22 @@ public class Person {
                         retVal.setOriginFaction(Factions.getInstance().getFaction(wn2.getTextContent().trim()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("planetId")) {
-                    String systemId = wn2.getAttributes().getNamedItem("systemId").getTextContent().trim();
-                    String planetId = wn2.getTextContent().trim();
-                    retVal.originPlanet = c.getSystemById(systemId).getPlanetById(planetId);
+                    String systemId = "", planetId = "";
+                    try {
+                        systemId = wn2.getAttributes().getNamedItem("systemId").getTextContent().trim();
+                        planetId = wn2.getTextContent().trim();
+                        PlanetarySystem ps = c.getSystemById(systemId);
+                        Planet p = null;
+                        if (ps == null) {
+                            ps = c.getSystemByName(systemId);
+                        }
+                        if (ps != null) {
+                            p = ps.getPlanetById(planetId);
+                        }
+                        retVal.originPlanet = p;
+                    } catch (NullPointerException e) {
+                        LogManager.getLogger().error("Error loading originPlanet for " + systemId + ", " + planetId, e);
+                    }
                 } else if (wn2.getNodeName().equalsIgnoreCase("phenotype")) {
                     retVal.phenotype = Phenotype.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("bloodname")) {

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -21,7 +21,9 @@
 package mekhq.campaign;
 
 import megamek.common.Dropship;
+import megamek.common.Entity;
 import megamek.common.EquipmentType;
+import megamek.common.Infantry;
 import megamek.common.enums.SkillLevel;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
@@ -145,6 +147,15 @@ public class CampaignTest {
         expected.add(mockTechActive);
         expected.add(mockTechActiveTwo);
         assertEquals(expected, testCampaign.getTechs(true));
+    }
+
+    @Test
+    public void testCampaignResetInfantry() {
+        // It is possible for Infantry to have BAP equal true, but empty Sensors vector.
+        Campaign campaign = new Campaign();
+        Entity infantry = spy(new Infantry());
+        when(infantry.hasBAP()).thenReturn(true);
+        campaign.clearGameData(infantry);
     }
 
     @Test


### PR DESCRIPTION
Fix for #4061 , tested and proven in .20 code.

Testing done in 0.49.19.1:
- Ran all existing unit tests for all three projects,
- Added a unit test of clearGameData() on Infantry with quirks or abilities that add BAP functionality,
- Loaded OP's previously-failing campaign save successfully.