### PR TITLE
Backport Fix for MHQ #4062 to 0.49.19.1

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -157,15 +157,21 @@ public class AtBGameThread extends GameThread {
                 Thread.sleep(MekHQ.getMHQOptions().getStartGameDelay());
 
                 PlanetaryConditions planetaryConditions = new PlanetaryConditions();
-                planetaryConditions.setLight(scenario.getLight());
-                planetaryConditions.setWeather(scenario.getWeather());
-                planetaryConditions.setWind(scenario.getWind());
-                planetaryConditions.setFog(scenario.getFog());
-                planetaryConditions.setAtmosphere(scenario.getAtmosphere());
-                planetaryConditions.setGravity(scenario.getGravity());
-                planetaryConditions.setEMI(scenario.getEMI());
-                planetaryConditions.setBlowingSand(scenario.getBlowingSand());
-                planetaryConditions.setTemperature(scenario.getModifiedTemperature());
+                if (campaign.getCampaignOptions().isUseLightConditions()) {
+                    planetaryConditions.setLight(scenario.getLight());
+                }
+                if (campaign.getCampaignOptions().isUseWeatherConditions()) {
+                    planetaryConditions.setWeather(scenario.getWeather());
+                    planetaryConditions.setWind(scenario.getWind());
+                    planetaryConditions.setFog(scenario.getFog());
+                    planetaryConditions.setEMI(scenario.getEMI());
+                    planetaryConditions.setBlowingSand(scenario.getBlowingSand());
+                    planetaryConditions.setTemperature(scenario.getModifiedTemperature());
+                }
+                if (campaign.getCampaignOptions().isUsePlanetaryConditions()) {
+                    planetaryConditions.setAtmosphere(scenario.getAtmosphere());
+                    planetaryConditions.setGravity(scenario.getGravity());
+                }
                 client.sendPlanetaryConditions(planetaryConditions);
                 Thread.sleep(MekHQ.getMHQOptions().getStartGameDelay());
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -720,7 +720,7 @@ public class AtBDynamicScenarioFactory {
      * @param scenario The scenario for which to set weather conditions.
      */
     private static void setWeather(AtBDynamicScenario scenario) {
-        scenario.setWeather();
+        scenario.setWeatherConditions();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -280,15 +280,15 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
      */
     private void initBattle(Campaign campaign) {
         setTerrain();
+        if (campaign.getCampaignOptions().isUsePlanetaryConditions() &&
+                null != campaign.getMission(getMissionId())) {
+            setPlanetaryConditions(campaign.getMission(getMissionId()), campaign);
+        }
         if (campaign.getCampaignOptions().isUseLightConditions()) {
             setLightConditions();
         }
         if (campaign.getCampaignOptions().isUseWeatherConditions()) {
-            setWeather();
-        }
-        if (campaign.getCampaignOptions().isUsePlanetaryConditions() &&
-                null != campaign.getMission(getMissionId())) {
-            setPlanetaryConditions(campaign.getMission(getMissionId()), campaign);
+            setWeatherConditions();
         }
         setMapSize();
         setMapFile();
@@ -324,7 +324,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         setLight(TCO.rollLightCondition(getTerrainType()));
     }
 
-    public void setWeather() {
+    public void setWeatherConditions() {
         // weather is irrelevant in these situations.
         if (getBoardType() == AtBScenario.T_SPACE ||
                 getBoardType() == AtBScenario.T_ATMOSPHERE) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
@@ -64,7 +64,7 @@ public class AceDuelBuiltInScenario extends AtBScenario {
     }
 
     @Override
-    public void setWeather() {
+    public void setWeatherConditions() {
         setWeather(Weather.CLEAR);
         setWind(Wind.CALM);
         setFog(Fog.FOG_NONE);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDuelBuiltInScenario.java
@@ -64,7 +64,7 @@ public class OfficerDuelBuiltInScenario extends AtBScenario {
     }
 
     @Override
-    public void setWeather() {
+    public void setWeatherConditions() {
         setWeather(Weather.CLEAR);
         setWind(Wind.CALM);
         setFog(Fog.FOG_NONE);

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -232,7 +232,7 @@ public class StratconRulesManager {
                 backingScenario.setMap(mapTypeList.get(Compute.randomInt(mapTypeList.size())));
             }
             backingScenario.setLightConditions();
-            backingScenario.setWeather();
+            backingScenario.setWeatherConditions();
         }
     }
 

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -821,7 +821,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
             lblLightDesc.setText(scenario.getLight().toString());
         }
         if (chkReroll[REROLL_WEATHER] != null && chkReroll[REROLL_WEATHER].isSelected()) {
-            scenario.setWeather();
+            scenario.setWeatherConditions();
             scenario.useReroll();
             chkReroll[REROLL_WEATHER].setSelected(false);
             lblWeatherDesc.setText(scenario.getWeather().toString());


### PR DESCRIPTION
Backports fix for #4062 into 0.49.19.1 from 0.49.20 code.

Testing:
- Ran all three projects' existing unit tests
- Loaded a known-good campaign, turned off Weather Conditions and Planetary Conditions but left Light Conditions enabled; confirmed only Light Conditions passed through to mission game in MM.