### PR TITLE
Updated Tooltips for the Marriageable & Trying to Conceive Flags

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -178,7 +178,7 @@ miFounder.toolTipText=If this is selected then the person is a founding member o
 miImmortal.text=Immortal
 miImmortal.toolTipText=If this is selected then the person will not be processed during random death \n(standard checks still apply)
 miMarriageable.text=Marriageable
-miMarriageable.toolTipText=If this is selected, then the person will be included as a potential spouse for marriages (married personnel will not be included even if this flag is selected, nor will characters under 0 years old)
+miMarriageable.toolTipText=If this is selected, then the person will be included as a potential spouse for marriages (married personnel will not be included even if this flag is selected, nor will characters under %s years old)
 miTryingToConceive.text=Trying to Conceive
 miTryingToConceive.toolTipText=If this is selected, the person has a chance to have children created through random procreation (this flag is ignored for personnel under 18 years old).
 ### Randomization Menu

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -178,9 +178,9 @@ miFounder.toolTipText=If this is selected then the person is a founding member o
 miImmortal.text=Immortal
 miImmortal.toolTipText=If this is selected then the person will not be processed during random death \n(standard checks still apply)
 miMarriageable.text=Marriageable
-miMarriageable.toolTipText=If this is selected then the person will be included as a potential spouse for marriages \n(standard checks still apply, so married personnel will not be included even if this flag is selected)
+miMarriageable.toolTipText=If this is selected, then the person will be included as a potential spouse for marriages (married personnel will not be included even if this flag is selected, nor will characters under 0 years old)
 miTryingToConceive.text=Trying to Conceive
-miTryingToConceive.toolTipText=If this is selected the person has a chance to have children created through random procreation. \n(standard checks still apply)
+miTryingToConceive.toolTipText=If this is selected, the person has a chance to have children created through random procreation (this flag is ignored for personnel under 18 years old).
 ### Randomization Menu
 randomizationMenu.text=Randomization
 miRandomName.single.text=Randomize Name

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -2165,7 +2165,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 || !gui.getCampaign().getCampaignOptions().getRandomMarriageMethod().isNone())
                 && Stream.of(selected).allMatch(p -> p.isMarriageable() == person.isMarriageable())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miMarriageable.text"));
-            cbMenuItem.setToolTipText(resources.getString("miMarriageable.toolTipText"));
+            cbMenuItem.setToolTipText(MultiLineTooltip.splitToolTip(resources.getString("miMarriageable.toolTipText")
+                    .replaceAll("0", String.valueOf(gui.getCampaign().getCampaignOptions().getMinimumMarriageAge())), 100));
             cbMenuItem.setName("miMarriageable");
             cbMenuItem.setSelected(person.isMarriageable());
             cbMenuItem.addActionListener(evt -> {
@@ -2180,7 +2181,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 && Stream.of(selected).allMatch(p -> p.getGender().isFemale())
                 && Stream.of(selected).allMatch(p -> p.isTryingToConceive() == person.isTryingToConceive())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miTryingToConceive.text"));
-            cbMenuItem.setToolTipText(resources.getString("miTryingToConceive.toolTipText"));
+            cbMenuItem.setToolTipText(MultiLineTooltip.splitToolTip(resources.getString("miTryingToConceive.toolTipText"), 100));
             cbMenuItem.setName("miTryingToConceive");
             cbMenuItem.setSelected(person.isTryingToConceive());
             cbMenuItem.addActionListener(evt -> {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -2165,8 +2165,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 || !gui.getCampaign().getCampaignOptions().getRandomMarriageMethod().isNone())
                 && Stream.of(selected).allMatch(p -> p.isMarriageable() == person.isMarriageable())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miMarriageable.text"));
-            cbMenuItem.setToolTipText(MultiLineTooltip.splitToolTip(resources.getString("miMarriageable.toolTipText")
-                    .replaceAll("0", String.valueOf(gui.getCampaign().getCampaignOptions().getMinimumMarriageAge())), 100));
+            cbMenuItem.setToolTipText(MultiLineTooltip.splitToolTip(String.format(resources.getString("miMarriageable.toolTipText"),
+                    gui.getCampaign().getCampaignOptions().getMinimumMarriageAge()), 100));
             cbMenuItem.setName("miMarriageable");
             cbMenuItem.setSelected(person.isMarriageable());
             cbMenuItem.addActionListener(evt -> {


### PR DESCRIPTION
This PR modifies the 'Marriageable' and 'Trying to Conceive' flags to explicitly state that underage personnel will not be considered eligible for marriage or reproduction, even if these flags are enabled.

I also changed these tooltips to be multiline tooltips, as they're a little wordy.

closes #4080