### PR TITLE
Restored ranks.xml

### DIFF
--- a/MekHQ/userdata/data/universe/ranks.xml
+++ b/MekHQ/userdata/data/universe/ranks.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rankSystems version="0.49.20-SNAPSHOT">
+</rankSystems>


### PR DESCRIPTION
Restored `ranks.xml` in the MekHQ/userdata/data/universe path. The file was accidentally deleted in a prior PR.

This prevents an error in mhq log when mhq is first run.

Turns out 'delete' in GitHub doesn't mean 'discard this change'. Now I know!