### PR TITLE
Fixed Award Tier Count Calculations in PersonViewPanel

### DIFF
--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -339,8 +339,9 @@ public class PersonViewPanel extends JScrollablePanel {
                 rowRibbonsBox.setBackground(Color.RED);
             }
             try {
-                int awardTierCount = person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize();
-                // Due to how mhq handles awards, this is going to give us one long string that contains all the filenames
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+
                 String ribbonFileName = award.getRibbonFileName(awardTierCount);
 
                 ribbon = (Image) MHQStaticDirectoryManager.getAwardIcons()
@@ -390,7 +391,9 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image medal;
             try {
-                int awardTierCount = person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize();
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+
                 String medalFileName = award.getMedalFileName(awardTierCount);
 
                 medal = (Image) MHQStaticDirectoryManager.getAwardIcons()
@@ -437,7 +440,9 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image miscAward;
             try {
-                int awardTierCount = person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize();
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+
                 String miscFileName = award.getMiscFileName(awardTierCount);
 
                 Image miscAwardBufferedImage = (Image) MHQStaticDirectoryManager.getAwardIcons()


### PR DESCRIPTION
This commit updates the calculation of `awardTierCount` in the `PersonViewPanel` class.

The new logic determines `awardTierCount` as the minimum between the number of medal files and the maximum of either 1 or the number of awards divided by the `AwardTierSize` specified in the campaign options.

These changes affect ribbons, medals, and miscellaneous awards.

This commit fixes a bug reported on Discord, where the award image getters were counting from 1 instead of 0. Additionally, extra binders have been added to ensure the index is always within bounds.