### PR TITLE
Fixed Post-Scenario Tracking System's Handling of Multiple Personnel in autoAwards

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -1432,20 +1432,28 @@ public class ResolveScenarioTracker {
             if (status.toRemove()) {
                 getCampaign().removePerson(person, false);
             }
+        }
 
-            if (getCampaign().getCampaignOptions().isEnableAutoAwards()) {
+        if (getCampaign().getCampaignOptions().isEnableAutoAwards()) {
+            HashMap<UUID, Integer> personnel = new HashMap<>();
+
+            for (UUID personId : peopleStatus.keySet()) {
+                Person person = campaign.getPerson(personId);
+                PersonStatus status = peopleStatus.get(personId);
+                int injuryCount = 0;
+
                 if (!person.getStatus().isDead() || getCampaign().getCampaignOptions().isIssuePosthumousAwards()) {
-                    int injuryCount = 0;
-
                     if (status.getHits() > person.getHits()) {
                         injuryCount = status.getHits() - person.getHits();
                     }
-
-                    AutoAwardsController autoAwardsController = new AutoAwardsController();
-
-                    autoAwardsController.PostScenarioController(campaign, scenario.getId(), person.getId(), injuryCount);
                 }
+
+                personnel.put(personId, injuryCount);
             }
+
+            AutoAwardsController autoAwardsController = new AutoAwardsController();
+
+            autoAwardsController.PostScenarioController(campaign, scenario.getId(), personnel);
         }
 
         //region Prisoners


### PR DESCRIPTION
This commit refactors the automatic awards tracking system to handle multiple personnel simultaneously, instead of one-by-one. This is achieved by changing the `person` parameter to a `HashMap` of UUIDs and injury counts in the `AutoAwardsController`'s `PostScenarioController`. Associated methods have been adjusted to handle the `HashMap` data, and the retrieval of kills has been consolidated within methods where necessary.

This resolves a bug discovered by our QA team, where faulty logic was causing auto-awards to trigger multiple times during post-scenario conditions.