### PR TITLE
Updated Post-Scenario Logging for Prisoners

### DIFF
--- a/MekHQ/resources/mekhq/resources/LogEntries.properties
+++ b/MekHQ/resources/mekhq/resources/LogEntries.properties
@@ -16,6 +16,7 @@ spouseKia.text=Spouse, {0}, was killed in action
 promotedTo.text=Promoted to {0}
 demotedTo.text=Demoted to {0}
 participatedInScenarioDuringMission.text=Participated in {0} during mission {1}
+capturedInScenarioDuringMission.text=Taken captive in {0} during mission {1}
 gainedXpFromMedWork.text=Gained {0} XP from successful medical work
 successfullyTreatedWithXp.text=Successfully treated {0} for {1} injuries, gaining {2} XP
 successfullyTreatedForXInjuries.text=Successfully treated {0} for {1} injuries

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -1486,7 +1486,7 @@ public class ResolveScenarioTracker {
                 person.setHits(status.getHits());
             }
 
-            ServiceLogger.participatedInScenarioDuringMission(person, campaign.getLocalDate(), scenario.getName(), mission.getName());
+            ServiceLogger.capturedInScenarioDuringMission(person, campaign.getLocalDate(), scenario.getName(), mission.getName());
 
             for (Kill k : status.getKills()) {
                 campaign.addKill(k);

--- a/MekHQ/src/mekhq/campaign/log/ServiceLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/ServiceLogger.java
@@ -131,6 +131,13 @@ public class ServiceLogger {
                 MessageFormat.format(message, scenarioName, missionName)));
     }
 
+    public static void capturedInScenarioDuringMission(Person person, LocalDate date,
+                                                           String scenarioName, String missionName) {
+        String message = logEntriesResourceMap.getString("capturedInScenarioDuringMission.text");
+        person.addLogEntry(new ServiceLogEntry(date,
+                MessageFormat.format(message, scenarioName, missionName)));
+    }
+
     public static void gainedXpFromMedWork(Person doctor, LocalDate date, int taskXP) {
         String message = logEntriesResourceMap.getString("gainedXpFromMedWork.text");
         doctor.addLogEntry(new ServiceLogEntry(date, MessageFormat.format(message, taskXP)));


### PR DESCRIPTION
This commit introduces a new `ServiceLogger` method to post to the personnel log when a character is captured in a scenario, instead of logging to the scenario log. This ensures that prisoners do not receive scenario credit for the scenario in which they were captured. The change modifies the existing log behavior and includes a new log entry text in the relevant resources file.

Logging in the personnel log ensures there is still a record of the scenario and mission, this feature was requested on Discord when removing the scenario log was discussed.

This PR addresses an oversight reported by our QA team, where prisoners were incorrectly receiving award credit for the scenario in which they were captured.