### PR TITLE
Fix Piloting/Ground Vehicle Parsing in Education Module

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -990,7 +990,7 @@ public class Academy implements Comparable<Academy> {
                 return SkillType.S_PILOT_AERO;
             case "gunnery/aerospace":
                 return SkillType.S_GUN_AERO;
-            case "piloting/groundvehicle":
+            case "piloting/ground vehicle":
                 return SkillType.S_PILOT_GVEE;
             case "piloting/vtol":
                 return SkillType.S_PILOT_VTOL;

--- a/MekHQ/unittests/mekhq/campaign/personnel/education/AcademyTests.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/education/AcademyTests.java
@@ -127,7 +127,7 @@ class AcademyTests {
         assertEquals(SkillType.S_GUN_MECH, Academy.skillParser("gunnery/mech"));
         assertEquals(SkillType.S_PILOT_AERO, Academy.skillParser("piloting/aerospace"));
         assertEquals(SkillType.S_GUN_AERO, Academy.skillParser("gunnery/aerospace"));
-        assertEquals(SkillType.S_PILOT_GVEE, Academy.skillParser("piloting/groundvehicle"));
+        assertEquals(SkillType.S_PILOT_GVEE, Academy.skillParser("piloting/ground vehicle"));
         assertEquals(SkillType.S_PILOT_VTOL, Academy.skillParser("piloting/vtol"));
         assertEquals(SkillType.S_PILOT_NVEE, Academy.skillParser("piloting/naval"));
         assertEquals(SkillType.S_GUN_VEE, Academy.skillParser("gunnery/vehicle"));


### PR DESCRIPTION
Another case broken by the move to trim()