### PR TITLE
Added Return Statements to Clan Warrior Caste Graduations in Education Module

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -1187,21 +1187,29 @@ public class EducationController {
         // [0]MechWarrior, [1]ProtoMech, [2]AreoSpace, [3]Space, [4]BA, [5]CI, [6]Vehicle
         if (person.getEduCourseIndex() <= 6) {
             graduateWarriorCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [7]Scientist Caste
         if (person.getEduCourseIndex() == 7) {
             graduateScientistCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [8]Merchant Caste
         if (person.getEduCourseIndex() == 8) {
             graduateMerchantCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [9]Technician Caste
         if (person.getEduCourseIndex() == 9) {
             graduateTechnicianCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [10]Laborer Caste
@@ -1305,6 +1313,7 @@ public class EducationController {
             graduateLaborCaste(campaign, person, academy, resources);
         }
     }
+
     /**
      * Graduates a person from the labor caste.
      * Updates the person's education level and adds a report to the campaign.

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.view;
 
-import megamek.codeUtilities.MathUtility;
 import megamek.common.options.IOption;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
@@ -342,7 +341,8 @@ public class PersonViewPanel extends JScrollablePanel {
                 rowRibbonsBox.setBackground(Color.RED);
             }
             try {
-                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfRibbonFiles());
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
 
                 String ribbonFileName = award.getRibbonFileName(awardTierCount);
 
@@ -393,7 +393,8 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image medal;
             try {
-                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMedalFiles());
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
 
                 String medalFileName = award.getMedalFileName(awardTierCount);
 
@@ -441,7 +442,8 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image miscAward;
             try {
-                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMiscFiles());
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
 
                 String miscFileName = award.getMiscFileName(awardTierCount);
 

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.view;
 
+import megamek.codeUtilities.MathUtility;
 import megamek.common.options.IOption;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
@@ -341,8 +342,7 @@ public class PersonViewPanel extends JScrollablePanel {
                 rowRibbonsBox.setBackground(Color.RED);
             }
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfRibbonFiles());
 
                 String ribbonFileName = award.getRibbonFileName(awardTierCount);
 
@@ -393,8 +393,7 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image medal;
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMedalFiles());
 
                 String medalFileName = award.getMedalFileName(awardTierCount);
 
@@ -442,8 +441,7 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image miscAward;
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMiscFiles());
 
                 String miscFileName = award.getMiscFileName(awardTierCount);
 


### PR DESCRIPTION
Each graduateCaste method in the EducationController has been adjusted to include a return statement following the method call, thereby preventing the execution of multiple graduateCaste calls within a single instance.

The update eliminates the errors caused by unintended multiple gradations discovered by QA.