### PR TITLE
Fixed Award Image Display in Person View

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -1187,21 +1187,29 @@ public class EducationController {
         // [0]MechWarrior, [1]ProtoMech, [2]AreoSpace, [3]Space, [4]BA, [5]CI, [6]Vehicle
         if (person.getEduCourseIndex() <= 6) {
             graduateWarriorCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [7]Scientist Caste
         if (person.getEduCourseIndex() == 7) {
             graduateScientistCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [8]Merchant Caste
         if (person.getEduCourseIndex() == 8) {
             graduateMerchantCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [9]Technician Caste
         if (person.getEduCourseIndex() == 9) {
             graduateTechnicianCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [10]Laborer Caste
@@ -1305,6 +1313,7 @@ public class EducationController {
             graduateLaborCaste(campaign, person, academy, resources);
         }
     }
+
     /**
      * Graduates a person from the labor caste.
      * Updates the person's education level and adds a report to the campaign.

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.view;
 
+import megamek.codeUtilities.MathUtility;
 import megamek.common.options.IOption;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
@@ -341,8 +342,11 @@ public class PersonViewPanel extends JScrollablePanel {
                 rowRibbonsBox.setBackground(Color.RED);
             }
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(
+                        person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(),
+                        1,
+                        award.getNumberOfRibbonFiles()
+                );
 
                 String ribbonFileName = award.getRibbonFileName(awardTierCount);
 
@@ -393,8 +397,11 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image medal;
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(
+                        person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(),
+                        1,
+                        award.getNumberOfMedalFiles()
+                );
 
                 String medalFileName = award.getMedalFileName(awardTierCount);
 
@@ -442,8 +449,11 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image miscAward;
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(
+                        person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(),
+                        1,
+                        award.getNumberOfMiscFiles()
+                );
 
                 String miscFileName = award.getMiscFileName(awardTierCount);
 

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -343,7 +343,7 @@ public class PersonViewPanel extends JScrollablePanel {
             }
             try {
                 int awardTierCount = MathUtility.clamp(
-                        person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(),
+                        (person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()) + 1,
                         1,
                         award.getNumberOfRibbonFiles()
                 );
@@ -398,7 +398,7 @@ public class PersonViewPanel extends JScrollablePanel {
             Image medal;
             try {
                 int awardTierCount = MathUtility.clamp(
-                        person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(),
+                        (person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()) + 1,
                         1,
                         award.getNumberOfMedalFiles()
                 );
@@ -450,7 +450,7 @@ public class PersonViewPanel extends JScrollablePanel {
             Image miscAward;
             try {
                 int awardTierCount = MathUtility.clamp(
-                        person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(),
+                        (person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()) + 1,
                         1,
                         award.getNumberOfMiscFiles()
                 );

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.view;
 
-import megamek.codeUtilities.MathUtility;
 import megamek.common.options.IOption;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
@@ -342,7 +341,8 @@ public class PersonViewPanel extends JScrollablePanel {
                 rowRibbonsBox.setBackground(Color.RED);
             }
             try {
-                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfRibbonFiles());
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
 
                 String ribbonFileName = award.getRibbonFileName(awardTierCount);
 
@@ -393,7 +393,8 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image medal;
             try {
-                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMedalFiles());
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
 
                 String medalFileName = award.getMedalFileName(awardTierCount);
 
@@ -441,7 +442,8 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image miscAward;
             try {
-                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMiscFiles());
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
 
                 String miscFileName = award.getMiscFileName(awardTierCount);
 

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.view;
 
+import megamek.codeUtilities.MathUtility;
 import megamek.common.options.IOption;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
@@ -341,8 +342,7 @@ public class PersonViewPanel extends JScrollablePanel {
                 rowRibbonsBox.setBackground(Color.RED);
             }
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfRibbonFiles());
 
                 String ribbonFileName = award.getRibbonFileName(awardTierCount);
 
@@ -393,8 +393,7 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image medal;
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMedalFiles());
 
                 String medalFileName = award.getMedalFileName(awardTierCount);
 
@@ -442,8 +441,7 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image miscAward;
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMiscFiles());
 
                 String miscFileName = award.getMiscFileName(awardTierCount);
 


### PR DESCRIPTION
This is another quick fix to the display of award ribbons, medals, and miscs in the person view panel. My previous fix appeared to resolve the issue, but instead it failed whenever 'person' had more than one issuance of the award. This adds better bounds by using the `MathUtility.clamp()`.