### PR TITLE
Added ability to Pass CamOps Fatigue to MegaMek

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -1187,21 +1187,29 @@ public class EducationController {
         // [0]MechWarrior, [1]ProtoMech, [2]AreoSpace, [3]Space, [4]BA, [5]CI, [6]Vehicle
         if (person.getEduCourseIndex() <= 6) {
             graduateWarriorCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [7]Scientist Caste
         if (person.getEduCourseIndex() == 7) {
             graduateScientistCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [8]Merchant Caste
         if (person.getEduCourseIndex() == 8) {
             graduateMerchantCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [9]Technician Caste
         if (person.getEduCourseIndex() == 9) {
             graduateTechnicianCaste(campaign, person, academy, resources);
+
+            return;
         }
 
         // [10]Laborer Caste
@@ -1305,6 +1313,7 @@ public class EducationController {
             graduateLaborCaste(campaign, person, academy, resources);
         }
     }
+
     /**
      * Graduates a person from the labor caste.
      * Updates the person's education level and adds a report to the campaign.

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -36,7 +36,9 @@ import megamek.common.options.PilotOptions;
 import megamek.common.weapons.InfantryAttack;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
-import mekhq.*;
+import mekhq.MHQStaticDirectoryManager;
+import mekhq.MekHQ;
+import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.PersonCrewAssignmentEvent;
 import mekhq.campaign.event.PersonTechAssignmentEvent;
@@ -62,6 +64,7 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.swing.*;
 import java.awt.*;
 import java.io.PrintWriter;
 import java.math.BigInteger;
@@ -69,8 +72,6 @@ import java.util.List;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import javax.swing.UIManager;
 
 /**
  * This is a wrapper class for entity, so that we can add some functionality to it
@@ -3572,6 +3573,7 @@ public class Unit implements ITechnology {
             entity.getCrew().setPortrait(commander.getPortrait().clone(), 0);
             entity.getCrew().setExternalIdAsString(commander.getId().toString(), 0);
             entity.getCrew().setToughness(commander.getToughness(), 0);
+            entity.getCrew().setCrewFatigue(commander.getFatigue(), 0);
 
             if (entity instanceof Tank) {
                 ((Tank) entity).setCommanderHit(commander.getHits() > 0);
@@ -4003,6 +4005,13 @@ public class Unit implements ITechnology {
         entity.getCrew().setGunneryB(Math.min(Math.max(gunnery, 0), 7), slot);
         entity.getCrew().setArtillery(Math.min(Math.max(artillery, 0), 7), slot);
         entity.getCrew().setToughness(p.getToughness(), slot);
+
+        if (campaign.getCampaignOptions().isUseFatigue()) {
+            entity.getCrew().setCrewFatigue(p.getFatigue(), slot);
+        } else {
+            entity.getCrew().setCrewFatigue(0, slot);
+        }
+
         entity.getCrew().setExternalIdAsString(p.getId().toString(), slot);
         entity.getCrew().setMissing(false, slot);
     }

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -18,7 +18,6 @@
  */
 package mekhq.gui.view;
 
-import megamek.codeUtilities.MathUtility;
 import megamek.common.options.IOption;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
@@ -342,7 +341,8 @@ public class PersonViewPanel extends JScrollablePanel {
                 rowRibbonsBox.setBackground(Color.RED);
             }
             try {
-                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfRibbonFiles());
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
 
                 String ribbonFileName = award.getRibbonFileName(awardTierCount);
 
@@ -393,7 +393,8 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image medal;
             try {
-                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMedalFiles());
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
 
                 String medalFileName = award.getMedalFileName(awardTierCount);
 
@@ -441,7 +442,8 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image miscAward;
             try {
-                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMiscFiles());
+                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
+                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
 
                 String miscFileName = award.getMiscFileName(awardTierCount);
 

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.view;
 
+import megamek.codeUtilities.MathUtility;
 import megamek.common.options.IOption;
 import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
@@ -341,8 +342,7 @@ public class PersonViewPanel extends JScrollablePanel {
                 rowRibbonsBox.setBackground(Color.RED);
             }
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfRibbonFiles());
 
                 String ribbonFileName = award.getRibbonFileName(awardTierCount);
 
@@ -393,8 +393,7 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image medal;
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMedalFiles());
 
                 String medalFileName = award.getMedalFileName(awardTierCount);
 
@@ -442,8 +441,7 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image miscAward;
             try {
-                int awardTierCount = Math.min(award.getNumberOfMedalFiles(),
-                        Math.max(1, person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize()));
+                int awardTierCount = MathUtility.clamp(person.getAwardController().getNumberOfAwards(award) / campaign.getCampaignOptions().getAwardTierSize(), 1, award.getNumberOfMiscFiles());
 
                 String miscFileName = award.getMiscFileName(awardTierCount);
 

--- a/MekHQ/src/mekhq/utilities/MHQXMLUtility.java
+++ b/MekHQ/src/mekhq/utilities/MHQXMLUtility.java
@@ -488,6 +488,11 @@ public class MHQXMLUtility extends MMXMLUtility {
             if (tgtEnt.getCrew().getToughness(pos) != 0) {
                 crew.append("\" " + MULParser.ATTR_TOUGH + "=\"").append(tgtEnt.getCrew().getToughness(pos));
             }
+
+            if (tgtEnt.getCrew().getCrewFatigue(pos) != 0) {
+                crew.append("\" " + MULParser.ATTR_FATIGUE + "=\"").append(tgtEnt.getCrew().getCrewFatigue(pos));
+            }
+
             if (tgtEnt.getCrew().isDead(pos) || tgtEnt.getCrew().getHits(pos) >= Crew.DEATH) {
                 crew.append("\" " + MULParser.ATTR_HITS + "=\"" + MULParser.VALUE_DEAD + "");
             } else if (tgtEnt.getCrew().getHits(pos) > 0) {


### PR DESCRIPTION
### Description
This PR introduces the ability to pass CamOps Fatigue to mm, which is a required functionality for #4101.

### Dependencies
This PR depends on [#5516](https://github.com/MegaMek/megamek/pull/5516), which must be merged first. The test failures currently seen are due to this dependency.

### Changes
- Integrates CamOps Fatigue handling with the mm module.
- Updates relevant parts of the code to pass fatigue information.

### Testing
- Tests will pass once #5516 is merged.