### PR TITLE
Removed crew fatigue setting from Unit

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -9,6 +9,7 @@ import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.log.ServiceLogger;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
+import mekhq.campaign.universe.PlanetarySystem;
 import org.apache.logging.log4j.LogManager;
 
 import java.time.DayOfWeek;

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -3573,7 +3573,6 @@ public class Unit implements ITechnology {
             entity.getCrew().setPortrait(commander.getPortrait().clone(), 0);
             entity.getCrew().setExternalIdAsString(commander.getId().toString(), 0);
             entity.getCrew().setToughness(commander.getToughness(), 0);
-            entity.getCrew().setCrewFatigue(commander.getFatigue(), 0);
 
             if (entity instanceof Tank) {
                 ((Tank) entity).setCommanderHit(commander.getHits() > 0);
@@ -4005,12 +4004,6 @@ public class Unit implements ITechnology {
         entity.getCrew().setGunneryB(Math.min(Math.max(gunnery, 0), 7), slot);
         entity.getCrew().setArtillery(Math.min(Math.max(artillery, 0), 7), slot);
         entity.getCrew().setToughness(p.getToughness(), slot);
-
-        if (campaign.getCampaignOptions().isUseFatigue()) {
-            entity.getCrew().setCrewFatigue(p.getFatigue(), slot);
-        } else {
-            entity.getCrew().setCrewFatigue(0, slot);
-        }
 
         entity.getCrew().setExternalIdAsString(p.getId().toString(), slot);
         entity.getCrew().setMissing(false, slot);


### PR DESCRIPTION
The most recent batch of merges came with some oddities. Somehow an import got lost from EducationController.java and some rogue code snuck in from my Turnover and Retention module. That, at least, is probably mea culpa (even if I don't know _how_ those couple of lines snuck in).

- Removed crew fatigue setting from Unit.java
- Imported missing PlanetarySystem import in EducationController.java