### PR TITLE
Updated Scenario Modifiers to More Consistently Contribute to Map Size

### DIFF
--- a/MekHQ/data/scenariomodifiers/AlliedAirSupport.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedAirSupport.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones/>

--- a/MekHQ/data/scenariomodifiers/AlliedAirSupportBombers.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedAirSupportBombers.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones/>

--- a/MekHQ/data/scenariomodifiers/AlliedGroundSupport.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedGroundSupport.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedMechReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMechReinforcements.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedReinforcements.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedTankReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTankReinforcements.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedTurrets.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTurrets.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/BadIntelAir.xml
+++ b/MekHQ/data/scenariomodifiers/BadIntelAir.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/BadIntelGround.xml
+++ b/MekHQ/data/scenariomodifiers/BadIntelGround.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/EnemyAirPatrol.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyAirPatrol.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>2</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/EnemyAirSupport.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyAirSupport.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/EnemyAirSupportBombers.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyAirSupportBombers.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/EnemyDropship.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyDropship.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones/>

--- a/MekHQ/data/scenariomodifiers/EnemyHotDrop.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyHotDrop.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/EnemyMechReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyMechReinforcements.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/EnemyReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyReinforcements.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/EnemyTankReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyTankReinforcements.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/EnemyTurrets.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyTurrets.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/GroundedEnemyDropship.xml
+++ b/MekHQ/data/scenariomodifiers/GroundedEnemyDropship.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones/>

--- a/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones/>

--- a/MekHQ/data/scenariomodifiers/IntegratedAlliesAir.xml
+++ b/MekHQ/data/scenariomodifiers/IntegratedAlliesAir.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones/>

--- a/MekHQ/data/scenariomodifiers/IntegratedAlliesGround.xml
+++ b/MekHQ/data/scenariomodifiers/IntegratedAlliesGround.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones/>

--- a/MekHQ/data/scenariomodifiers/LiaisonAir.xml
+++ b/MekHQ/data/scenariomodifiers/LiaisonAir.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones/>

--- a/MekHQ/data/scenariomodifiers/LiaisonGround.xml
+++ b/MekHQ/data/scenariomodifiers/LiaisonGround.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones/>

--- a/MekHQ/data/scenariomodifiers/LocalGarrisonBoats.xml
+++ b/MekHQ/data/scenariomodifiers/LocalGarrisonBoats.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>0</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/LocalGarrisonInfantry.xml
+++ b/MekHQ/data/scenariomodifiers/LocalGarrisonInfantry.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/LocalGarrisonTurrets.xml
+++ b/MekHQ/data/scenariomodifiers/LocalGarrisonTurrets.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/OverwhelmingEnemyAirReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/OverwhelmingEnemyAirReinforcements.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/OverwhelmingEnemyGroundReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/OverwhelmingEnemyGroundReinforcements.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/PiratesIncomingAir.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesIncomingAir.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/PiratesIncomingGround.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesIncomingGround.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/PiratesPresentAir.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesPresentAir.xml
@@ -9,7 +9,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/PiratesPresentGround.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesPresentGround.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/SearchAndRescue.xml
+++ b/MekHQ/data/scenariomodifiers/SearchAndRescue.xml
@@ -13,7 +13,7 @@
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
-		<contributesToMapSize>false</contributesToMapSize>
+		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>


### PR DESCRIPTION
As per the title, this is a relatively small PR that goes through and updates our scenario modifiers to more consistently contribute to map size. The logic I followed is that if a modifier adds units to the battle, and those units are not off-board (i.e. off-board artillery), then the units from that modifier should contribute to map size.

The main beneficiaries of this PR will be ASF, as larger maps will allow players to keep their ASF elements on-board longer.

## Closes
Potentially closes #1637.

While I don't think the small amount of map size increase offered by this PR precisely addresses what the user is requesting, I think this is a better solution. Increasing map size more uniformly, without over-inflating map size just because ASF is present.