### PR TITLE
Added Dedicated Awards Panel to Personnel Tab of Campaign Options

### DIFF
--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2021-2024 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -3144,6 +3144,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gbc.gridy++;
         personnelPanel.add(createAdministratorsPanel(), gbc);
 
+        gbc.gridx++;
+        personnelPanel.add(createAwardsPanel(), gbc);
+
         gbc.gridx = 0;
         gbc.gridy++;
         personnelPanel.add(createMedicalPanel(), gbc);
@@ -3395,9 +3398,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkUseTimeInRank.setSelected(true);
         chkUseTimeInRank.doClick();
 
-        // Hook Awards panel
-        final JPanel awardsPanel = createAwardsPanel();
-
         // Layout the Panel
         final JPanel panel = new JPanel();
         panel.setBorder(BorderFactory.createTitledBorder(resources.getString("expandedPersonnelInformationPanel.title")));
@@ -3421,7 +3421,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                         .addComponent(chkTrackTotalEarnings)
                         .addComponent(chkTrackTotalXPEarnings)
                         .addComponent(chkShowOriginFaction)
-                        .addComponent(awardsPanel)
         );
 
         layout.setHorizontalGroup(
@@ -3437,7 +3436,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                         .addComponent(chkTrackTotalEarnings)
                         .addComponent(chkTrackTotalXPEarnings)
                         .addComponent(chkShowOriginFaction)
-                        .addComponent(awardsPanel)
         );
 
         return panel;
@@ -7667,6 +7665,26 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             options.setAdminsHaveScrounge(chkAdminsHaveScrounge.isSelected());
             options.setAdminExperienceLevelIncludeScrounge(chkAdminExperienceLevelIncludeScrounge.isSelected());
 
+            // autoAwards
+            options.setEnableAutoAwards(chkEnableAutoAwards.isSelected());
+            options.setAwardBonusStyle(comboAwardBonusStyle.getSelectedItem());
+            options.setIssuePosthumousAwards(chkIssuePosthumousAwards.isSelected());
+            options.setIssueBestAwardOnly(chkIssueBestAwardOnly.isSelected());
+            options.setIgnoreStandardSet(chkIgnoreStandardSet.isSelected());
+            options.setAwardTierSize((int) spnAwardTierSize.getValue());
+            options.setEnableContractAwards(chkEnableContractAwards.isSelected());
+            options.setEnableFactionHunterAwards(chkEnableFactionHunterAwards.isSelected());
+            options.setEnableInjuryAwards(chkEnableInjuryAwards.isSelected());
+            options.setEnableIndividualKillAwards(chkEnableIndividualKillAwards.isSelected());
+            options.setEnableFormationKillAwards(chkEnableFormationKillAwards.isSelected());
+            options.setEnableRankAwards(chkEnableRankAwards.isSelected());
+            options.setEnableScenarioAwards(chkEnableScenarioAwards.isSelected());
+            options.setEnableSkillAwards(chkEnableSkillAwards.isSelected());
+            options.setEnableTheatreOfWarAwards(chkEnableTheatreOfWarAwards.isSelected());
+            options.setEnableTimeAwards(chkEnableTimeAwards.isSelected());
+            options.setEnableTimeAwards(chkEnableTrainingAwards.isSelected());
+            options.setEnableMiscAwards(chkEnableMiscAwards.isSelected());
+
             // Medical
             options.setUseAdvancedMedical(chkUseAdvancedMedical.isSelected());
             // we need to reset healing time options through the campaign because we may need to
@@ -7699,26 +7717,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             for (final PersonnelRole personnelRole : PersonnelRole.values()) {
                 options.setRoleBaseSalary(personnelRole, (double) spnBaseSalary[personnelRole.ordinal()].getValue());
             }
-
-            // Awards
-            options.setEnableAutoAwards(chkEnableAutoAwards.isSelected());
-            options.setAwardBonusStyle(comboAwardBonusStyle.getSelectedItem());
-            options.setIssuePosthumousAwards(chkIssuePosthumousAwards.isSelected());
-            options.setIssueBestAwardOnly(chkIssueBestAwardOnly.isSelected());
-            options.setIgnoreStandardSet(chkIgnoreStandardSet.isSelected());
-            options.setAwardTierSize((int) spnAwardTierSize.getValue());
-            options.setEnableContractAwards(chkEnableContractAwards.isSelected());
-            options.setEnableFactionHunterAwards(chkEnableFactionHunterAwards.isSelected());
-            options.setEnableInjuryAwards(chkEnableInjuryAwards.isSelected());
-            options.setEnableIndividualKillAwards(chkEnableIndividualKillAwards.isSelected());
-            options.setEnableFormationKillAwards(chkEnableFormationKillAwards.isSelected());
-            options.setEnableRankAwards(chkEnableRankAwards.isSelected());
-            options.setEnableScenarioAwards(chkEnableScenarioAwards.isSelected());
-            options.setEnableSkillAwards(chkEnableSkillAwards.isSelected());
-            options.setEnableTheatreOfWarAwards(chkEnableTheatreOfWarAwards.isSelected());
-            options.setEnableTimeAwards(chkEnableTimeAwards.isSelected());
-            options.setEnableTimeAwards(chkEnableTrainingAwards.isSelected());
-            options.setEnableMiscAwards(chkEnableMiscAwards.isSelected());
             //endregion Personnel Tab
 
             //region Life Paths Tab
@@ -7836,9 +7834,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                 options.getAgeRangeRandomDeathMaleValues().put(ageRange, (double) spnAgeRangeRandomDeathMaleValues.get(ageRange).getValue());
                 options.getAgeRangeRandomDeathFemaleValues().put(ageRange, (double) spnAgeRangeRandomDeathFemaleValues.get(ageRange).getValue());
             }
-
-            // Education
-            // TODO add education options
             //endregion Life Paths Tab
 
             //region Finances Tab


### PR DESCRIPTION
This PR moves the awards campaign settings into their own panel within the Personnel tab, rather than sitting at the bottom of the expanded personnel information panel.