### PR TITLE
Added No Commander Nag Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -313,6 +313,10 @@ PrisonersNagDialog.text=You still have prisoners of war. Do you really wish to a
 UntreatedPersonnelNagDialog.title=Untreated Personnel
 UntreatedPersonnelNagDialog.text=You have untreated personnel. Do you really wish to advance the day?
 
+### NoCommanderNagDialog Class
+NoCommanderNagDialog.title=No Commander
+NoCommanderNagDialog.text=The campaign is missing an assigned commander. Do you really wish to advance the day?
+
 ### UnresolvedStratConContactsNagDialog Class
 UnresolvedStratConContactsNagDialog.title=Unresolved StratCon Contacts
 UnresolvedStratConContactsNagDialog.text=You have unresolved contacts on the StratCon interface:\n%s\nAdvance day anyway?
@@ -675,6 +679,8 @@ optionPrisonersNag.text=Hide Prisoners of War Nag
 optionPrisonersNag.toolTipText=This allows you to ignore the daily warning for when you have prisoners of war outside of a contract.
 optionUntreatedPersonnelNag.text=Hide Untreated Personnel Nag
 optionUntreatedPersonnelNag.toolTipText=This allows you to ignore the daily warning for when you have wounded personnel that have not been assigned to a doctor.
+optionNoCommanderNag.text=Hide No Commander Nag
+optionNoCommanderNag.toolTipText=This allows you to ignore the daily warning for when you do not have someone assigned as the overall force commander.
 optionInsufficientAstechsNag.text=Hide Insufficient Astechs Nag
 optionInsufficientAstechsNag.toolTipText=This allows you to ignore the daily warning for when you don't have enough astechs to support your techs.
 optionInsufficientAstechTimeNag.text=Hide Insufficient Astech Time Nag

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -166,6 +166,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String NAG_PREGNANT_COMBATANT = "nagPregnantCombatant";
     public static final String NAG_PRISONERS = "nagPrisoners";
     public static final String NAG_UNTREATED_PERSONNEL = "nagUntreatedPersonnel";
+    public static final String NAG_NO_COMMANDER = "nagNoCommander";
     public static final String NAG_INSUFFICIENT_ASTECHS = "nagInsufficientAstechs";
     public static final String NAG_INSUFFICIENT_ASTECH_TIME = "nagInsufficientAstechTime";
     public static final String NAG_INSUFFICIENT_MEDICS = "nagInsufficientMedics";

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2430,6 +2430,11 @@ public class CampaignGUI extends JPanel {
             return;
         }
 
+        if (new NoCommanderNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+            evt.cancel();
+            return;
+        }
+
         if (new CargoCapacityNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
             evt.cancel();
             return;

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -147,6 +147,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     private JCheckBox optionPregnantCombatantNag;
     private JCheckBox optionPrisonersNag;
     private JCheckBox optionUntreatedPersonnelNag;
+    private JCheckBox optionNoCommanderNag;
     private JCheckBox optionInsufficientAstechsNag;
     private JCheckBox optionInsufficientAstechTimeNag;
     private JCheckBox optionInsufficientMedicsNag;
@@ -858,6 +859,10 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         optionUntreatedPersonnelNag.setToolTipText(resources.getString("optionUntreatedPersonnelNag.toolTipText"));
         optionUntreatedPersonnelNag.setName("optionUntreatedPersonnelNag");
 
+        optionNoCommanderNag = new JCheckBox(resources.getString("optionNoCommanderNag.text"));
+        optionNoCommanderNag.setToolTipText(resources.getString("optionNoCommanderNag.toolTipText"));
+        optionNoCommanderNag.setName("optionNoCommanderNag");
+
         optionInsufficientAstechsNag = new JCheckBox(resources.getString("optionInsufficientAstechsNag.text"));
         optionInsufficientAstechsNag.setToolTipText(resources.getString("optionInsufficientAstechsNag.toolTipText"));
         optionInsufficientAstechsNag.setName("optionInsufficientAstechsNag");
@@ -900,6 +905,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                         .addComponent(optionPregnantCombatantNag)
                         .addComponent(optionPrisonersNag)
                         .addComponent(optionUntreatedPersonnelNag)
+                        .addComponent(optionNoCommanderNag)
                         .addComponent(optionInsufficientAstechsNag)
                         .addComponent(optionInsufficientAstechTimeNag)
                         .addComponent(optionInsufficientMedicsNag)
@@ -910,11 +916,12 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         );
 
         layout.setHorizontalGroup(
-                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                layout.createParallelGroup(Alignment.LEADING)
                         .addComponent(optionUnmaintainedUnitsNag)
                         .addComponent(optionPregnantCombatantNag)
                         .addComponent(optionPrisonersNag)
                         .addComponent(optionUntreatedPersonnelNag)
+                        .addComponent(optionNoCommanderNag)
                         .addComponent(optionInsufficientAstechsNag)
                         .addComponent(optionInsufficientAstechTimeNag)
                         .addComponent(optionInsufficientMedicsNag)
@@ -1171,6 +1178,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_PREGNANT_COMBATANT, optionPregnantCombatantNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_PRISONERS, optionPrisonersNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNTREATED_PERSONNEL, optionUntreatedPersonnelNag.isSelected());
+        MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_NO_COMMANDER, optionNoCommanderNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECHS, optionInsufficientAstechsNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME, optionInsufficientAstechTimeNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_MEDICS, optionInsufficientMedicsNag.isSelected());
@@ -1283,6 +1291,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         optionPregnantCombatantNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_PREGNANT_COMBATANT));
         optionPrisonersNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_PRISONERS));
         optionUntreatedPersonnelNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNTREATED_PERSONNEL));
+        optionNoCommanderNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_NO_COMMANDER));
         optionInsufficientAstechsNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECHS));
         optionInsufficientAstechTimeNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME));
         optionInsufficientMedicsNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_MEDICS));

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NoCommanderNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NoCommanderNagDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2021 - 2024 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NoCommanderNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NoCommanderNagDialog.java
@@ -25,23 +25,19 @@ import mekhq.gui.baseComponents.AbstractMHQNagDialog;
 
 import javax.swing.*;
 
-public class UntreatedPersonnelNagDialog extends AbstractMHQNagDialog {
-    private static boolean isUntreatedInjury (Campaign campaign) {
-        return campaign.getActivePersonnel().stream()
-                .filter(p -> (p.needsFixing()) && (p.getDoctorId() == null))
-                .anyMatch(p -> !p.getPrisonerStatus().isPrisoner());
+public class NoCommanderNagDialog extends AbstractMHQNagDialog {
+    private static boolean isCommanderMissing (Campaign campaign) {
+        return (campaign.getFlaggedCommander() == null);
     }
 
-    //region Constructors
-    public UntreatedPersonnelNagDialog(final JFrame frame, final Campaign campaign) {
-        super(frame, "UntreatedPersonnelNagDialog", "UntreatedPersonnelNagDialog.title",
-                "UntreatedPersonnelNagDialog.text", campaign, MHQConstants.NAG_UNTREATED_PERSONNEL);
+    public NoCommanderNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "NoCommanderNagDialog", "NoCommanderNagDialog.title",
+                "NoCommanderNagDialog.text", campaign, MHQConstants.NAG_NO_COMMANDER);
     }
-    //endregion Constructors
 
     @Override
     protected boolean checkNag() {
         return !MekHQ.getMHQOptions().getNagDialogIgnore(getKey())
-                && isUntreatedInjury(getCampaign());
+                && isCommanderMissing(getCampaign());
     }
 }


### PR DESCRIPTION
- Introduced new Nag dialog for when there's no overall assigned commander in the campaign
- Implemented checkbox option to ignore this reminder
- Updated GUI properties file with No Commander Nag related texts
- Optimized untreated injury check in UntreatedPersonnelNagDialog

Given how much of the turnover and retention module; and upcoming morale module; utilize the overall force commander, it seemed reasonable to have a nag that reminds users to set one.