### PR TITLE
Changed "Operational Victory Points" to "Scenario Victory Points"

### DIFF
--- a/MekHQ/docs/AtB Stuff/stratcon-faq-2.5.txt
+++ b/MekHQ/docs/AtB Stuff/stratcon-faq-2.5.txt
@@ -80,7 +80,7 @@ Your Contract Score is no longer the sole metric of your success.
 
 * Stratcon contract VP's are only awarded for "required by employer" scenarios, and will show "deployment required by contract / -1 VP if lost/ignored; +1 VP if won" and are NOT necessarily Contract Objectives.  There is a screenshot sticky in the Stratcon channel for an example.
 
-* The information about whether a scenario gives VP/SP is stated in red on the scenario description in the StratCon tab. "Operational Victory Points" stated in the briefing tab are internal, meant for the game to find the effect (if any) of the battle.  So, VP discussed in a post-battle resolution screen and VP on the StratCon campaign tab are NOT the same.  The ones on the campaign tab are the only ones that count toward final contract score.
+* The information about whether a scenario gives VP/SP is stated in red on the scenario description in the StratCon tab. "Scenario Victory Points" stated in the briefing tab are internal, meant for the game to find the effect (if any) of the battle.  So, VP discussed in a post-battle resolution screen and VP on the StratCon campaign tab are NOT the same.  The ones on the campaign tab are the only ones that count toward final contract score.
 
 * Orange objectives mean completed, but on-going objectives. Finished strategic objectives turn green.
 

--- a/MekHQ/src/mekhq/campaign/mission/ObjectiveEffect.java
+++ b/MekHQ/src/mekhq/campaign/mission/ObjectiveEffect.java
@@ -51,13 +51,13 @@ public class ObjectiveEffect {
      */
     public enum ObjectiveEffectType {
         /*
-         *  contributes a "Operational Victory Point" towards the scenario's victory/defeat state
+         *  contributes a "Scenario Victory Point" towards the scenario's victory/defeat state
          */
-        ScenarioVictory("+%d Operational VP", true),
+        ScenarioVictory("+%d Scenario VP", true),
         /*
-         *  contributes a "negative Operational Victory Point/s" towards the scenario's victory/defeat state
+         *  contributes a "negative Scenario Victory Point/s" towards the scenario's victory/defeat state
          */
-        ScenarioDefeat("-%d Operational VP", true),
+        ScenarioDefeat("-%d Scenario VP", true),
         /*
          *  changes the contract score
          */

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
@@ -18,14 +18,6 @@
  */
 package mekhq.campaign.mission;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-
 import megamek.common.Entity;
 import megamek.common.OffBoardDirection;
 import mekhq.MHQConstants;
@@ -35,6 +27,8 @@ import mekhq.campaign.mission.ObjectiveEffect.EffectScalingType;
 import mekhq.campaign.mission.ObjectiveEffect.ObjectiveEffectType;
 import mekhq.campaign.mission.enums.ScenarioStatus;
 import mekhq.campaign.stratcon.StratconRulesManager;
+
+import java.util.*;
 
 /**
  * Handles processing for objectives for a scenario that has them
@@ -357,12 +351,12 @@ public class ScenarioObjectiveProcessor {
         switch (effect.effectType) {
             case ScenarioVictory:
                 if (dryRun) {
-                    return String.format("%d Operational Victory Point/s", effect.howMuch);
+                    return String.format("%d Scenario Victory Point/s", effect.howMuch);
                 }
                 break;
             case ScenarioDefeat:
                 if (dryRun) {
-                    return String.format("%d Operational Victory Point/s", -effect.howMuch);
+                    return String.format("%d Scenario Victory Point/s", -effect.howMuch);
                 }
                 break;
             case ContractScoreUpdate:


### PR DESCRIPTION
As per title, this PR renames 'operational victory points' to 'scenario victory points' to match terminology used elsewhere in mhq.

## Closes
Closes #4043