### PR TITLE
Added Ability to Change Original Unit Assignment via Personnel Table

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -195,6 +195,7 @@ miMarriageable.text=Marriageable
 miMarriageable.toolTipText=If this is selected, then the person will be included as a potential spouse for marriages (married personnel will not be included even if this flag is selected, nor will characters under %s years old)
 miTryingToConceive.text=Trying to Conceive
 miTryingToConceive.toolTipText=If this is selected, the person has a chance to have children created through random procreation (this flag is ignored for personnel under 18 years old).
+
 ### Randomization Menu
 randomizationMenu.text=Randomization
 miRandomName.single.text=Randomize Name
@@ -213,6 +214,12 @@ miRandomOriginFaction.single.text=Randomize Origin Faction
 miRandomOriginFaction.bulk.text=Randomize Origin Factions
 miRandomOriginPlanet.single.text=Randomize Origin Planet
 miRandomOriginPlanet.bulk.text=Randomize Origin Planets
+
+### Original Unit Menu
+originalUnitMenu.text=Original Unit
+originalUnitToCurrent.text=Set the Current Unit as Original
+removeOriginalUnit.text=Wipe Original Unit Record
+
 ### GM Menu
 changePrisonerStatus.text=Change Prisoner Status
 removePerson.text=Remove Person

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -22,6 +22,7 @@ import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.ui.dialogs.PortraitChooserDialog;
 import megamek.common.Crew;
+import megamek.common.EntityWeightClass;
 import megamek.common.Mounted;
 import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
@@ -157,6 +158,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private static final String CMD_RANDOM_ORIGIN_FACTION = "RANDOM_ORIGIN_FACTION";
     private static final String CMD_RANDOM_ORIGIN_PLANET = "RANDOM_ORIGIN_PLANET";
     //endregion Randomization Menu
+
+    //region Original Unit
+    private static final String CMD_ORIGINAL_TO_CURRENT = "ORIGINAL_TO_CURRENT";
+    private static final String CMD_WIPE_ORIGINAL = "WIPE_ORIGINAL";
+
+    //endregion Original Unit
 
     private static final String SEPARATOR = "@";
     private static final String TRUE = String.valueOf(true);
@@ -1027,6 +1034,26 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     if (planet != null) {
                         person.setOriginPlanet(planet);
                         MekHQ.triggerEvent(new PersonChangedEvent(person));
+                    }
+                }
+                break;
+            }
+            case CMD_ORIGINAL_TO_CURRENT: {
+                for (final Person person : people) {
+                    Unit unit = person.getUnit();
+
+                    if (unit != null) {
+                        person.setOriginalUnit(person.getUnit());
+                    }
+                }
+                break;
+            }
+            case CMD_WIPE_ORIGINAL: {
+                for (final Person person : people) {
+                    if (person.getOriginalUnitId() != null) {
+                        person.setOriginalUnitId(null);
+                        person.setOriginalUnitTech(Person.TECH_IS1);
+                        person.setOriginalUnitWeight(EntityWeightClass.WEIGHT_ULTRA_LIGHT);
                     }
                 }
                 break;
@@ -2413,6 +2440,24 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         JMenuHelpers.addMenuIfNonEmpty(popup, menu);
         //endregion Randomization Menu
+
+        //region Original Unit
+        menu = new JMenu(resources.getString("originalUnitMenu.text"));
+
+        menuItem = new JMenuItem(resources.getString("originalUnitToCurrent.text"));
+        menuItem.setName("originalUnitToCurrent");
+        menuItem.setActionCommand(CMD_ORIGINAL_TO_CURRENT);
+        menuItem.addActionListener(this);
+        menu.add(menuItem);
+
+        menuItem = new JMenuItem(resources.getString("removeOriginalUnit.text"));
+        menuItem.setName("removeOriginalUnit");
+        menuItem.setActionCommand(CMD_WIPE_ORIGINAL);
+        menuItem.addActionListener(this);
+        menu.add(menuItem);
+
+        JMenuHelpers.addMenuIfNonEmpty(popup, menu);
+        //endregion Original Unit
 
         //region GM Menu
         if (gui.getCampaign().isGM()) {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1038,17 +1038,16 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 }
                 break;
             }
-            case CMD_ORIGINAL_TO_CURRENT: {
+            case CMD_ORIGINAL_TO_CURRENT:
                 for (final Person person : people) {
                     Unit unit = person.getUnit();
 
                     if (unit != null) {
-                        person.setOriginalUnit(person.getUnit());
+                        person.setOriginalUnit(unit);
                     }
                 }
                 break;
-            }
-            case CMD_WIPE_ORIGINAL: {
+            case CMD_WIPE_ORIGINAL:
                 for (final Person person : people) {
                     if (person.getOriginalUnitId() != null) {
                         person.setOriginalUnitId(null);
@@ -1057,7 +1056,6 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     }
                 }
                 break;
-            }
             //endregion Randomization Menu
 
             default: {


### PR DESCRIPTION
- Added the ability to reassign Original Unit to currently assigned unit via the personnel table mouse listener. If Person is not currently assigned to a Unit no change occurs.

- Added the ability to wipe Original Unit via the personnel table mouse listener.

Both of these allow users to reassign (or remove) original unit records en masse, rather than needing to do reassignments on an individual basis via the Edit Person dialog.

## Closes
Closes #4022