### PR TITLE
Set Default Edge Usage States to True

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -87,10 +87,10 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, TECH_FIXER, false);
         addOption(l3a, TECH_MAINTAINER, false);
 
-        addOption(edge, EDGE_MEDICAL, false);
-        addOption(edge, EDGE_REPAIR_BREAK_PART, false);
-        addOption(edge, EDGE_REPAIR_FAILED_REFIT, false);
-        addOption(edge, EDGE_ADMIN_ACQUIRE_FAIL, false);
+        addOption(edge, EDGE_MEDICAL, true);
+        addOption(edge, EDGE_REPAIR_BREAK_PART, true);
+        addOption(edge, EDGE_REPAIR_FAILED_REFIT, true);
+        addOption(edge, EDGE_ADMIN_ACQUIRE_FAIL, true);
 
         List<CustomOption> customs = CustomOption.getCustomAbilities();
         for (CustomOption option : customs) {
@@ -104,6 +104,8 @@ public class PersonnelOptions extends PilotOptions {
                 case PilotOptions.MD_ADVANTAGES:
                     addOption(md, option.getName(), option.getType(), option.getDefault());
                     break;
+                default:
+                    throw new IllegalStateException("Unexpected value in mekhq/campaign/personnel/PersonnelOptions.java/initialize: " + option.getGroup());
             }
         }
     }


### PR DESCRIPTION
This PR sets the default state of mhq exclusive Edge usages from _false_ to _true_. The logic is that if users have Edge enabled, they probably want to use it. It's my hope that this will reduce the amount of personnel editing required when Edge is enabled.

## Closes
Along with https://github.com/MegaMek/megamek/pull/5550, this PR closes #3984