### PR TITLE
Updated Tooltip Text for Contract Command Rights to Include Clearer Game Mechanics

### DIFF
--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -59,16 +59,36 @@ AtBMoraleLevel.UNBREAKABLE.toolTipText=The unit's trust in their leadership and 
 
 # ContractCommandRights Enum
 ContractCommandRights.INTEGRATED.text=Integrated
-ContractCommandRights.INTEGRATED.toolTipText=<html>The force's command positions are largely filled by officers provided by the employer. <br>By doing so the employer takes on full legal responsibility for the actions of the force, provided that the force does not willfully disobey the orders of the officer in the legally questionable action or actions. <br>This is normally used when hiring mercenaries to bolster the employer's forces before a large assault or raid. <br>This is the standard for government forces and is widely avoided by all other forces.</html>
-ContractCommandRights.INTEGRATED.stratConText=Lance assignments will be made by the employer. Complete required scenarios to fulfill contract conditions.
+ContractCommandRights.INTEGRATED.toolTipText=<html><body style="width: 300px;">- Keep your Campaign Victory Points (CVP) positive. Winning a scenario: +1 CVP. Losing a scenario: -1 CVP.\
+  <br>- Your employer selects deployments from your TOE.\
+  <br>- No map scouting (StratCon).\
+  <br>\
+  <br><i>Integrated command rights, standard for government forces, streamline command and control, particularly in large-scale operations involving multiple forces, ensuring effective collaboration without inter-service rivalry or confusion over command authority.</i></body></html>
+ContractCommandRights.INTEGRATED.stratConText=The employer will make Lance assignments. Complete required scenarios to fulfill contract conditions.
+
 ContractCommandRights.HOUSE.text=House
-ContractCommandRights.HOUSE.toolTipText=<html>The force is placed under the direct authority of an employer-provided military officer. This officer may dictate tactics and strategies to the force, but the force otherwise retains its command structure. <br>By doing so the employer takes on full legal responsibility for the actions of the force, provided that the force does not willfully disobey the orders of the officer in the legally questionable action or actions. <br>This may be required by the employer for closely coordinated raids, planetary assaults, and garrison duties, as this allows the government to ensure the force is properly deployed within the larger battle plan.</html>
+ContractCommandRights.HOUSE.toolTipText=<html><body style="width: 300px;">- Keep your Campaign Victory Points (CVP) positive. Winning a non-initiated scenario: +1 CVP. Losing a non-initiated scenario: -1 CVP.\
+  <br>- You can scout the map (StratCon).\
+  <br>\
+  <br><i>House command rights empower noble scions and military leaders with autonomy over allied forces, enabling them to strategize and expand their House's power while balancing loyalty to their lineage and House interests.</i></body></html>
 ContractCommandRights.HOUSE.stratConText=Complete required scenarios to fulfill contract conditions.
+
 ContractCommandRights.LIAISON.text=Liaison
-ContractCommandRights.LIAISON.toolTipText=<html>The force has an employer-provided liaison that both represents the employer and accompanies the force during the contract. <br>By doing so the employer takes on limited legal responsibility for the actions of the force, as their decisions are being monitored by the liaison.</html>
+ContractCommandRights.LIAISON.toolTipText=<html><body style="width: 300px;">- Maintain positive Campaign Victory Points (CVP).\
+  <br>- Fulfill the specified strategic objectives.\
+  <br>- CVP changes only in scenarios with a liaison: Win: +1 CVP, Lose: -1 CVP.\
+  <br>- Scout the map to locate objectives (StratCon).\
+  <br>- Terminate the contract early upon completing all objectives, except for Garrison or Cadre contracts.\
+  <br>\
+  <br><i>Liaison command rights empower trusted officers to coordinate cooperation between allied factions, streamlining communication and joint operations on the battlefield. These officers serve as crucial links between factions, enhancing unity and effectiveness against shared adversaries.</i></body></html>
 ContractCommandRights.LIAISON.stratConText=Complete required scenarios and strategic objectives to fulfill contract conditions.
+
 ContractCommandRights.INDEPENDENT.text=Independent
-ContractCommandRights.INDEPENDENT.toolTipText=<html>The force has full battlefield autonomy, with no interference from their employer. However, the employer will provide limited if any support to the force. <br>The force is still bound to answer for any questionable actions they take to their employer and/or an outside authority/arbitrator (e.g. the Mercenary Review and Bonding Commission) following the contract. <br>Employers may, especially for covert missions, sign contracts with independent command rights to shield them from legal responsibility from the force's actions while undertaking the contract. <br>This is the standard for pirate contracts.</html>
+ContractCommandRights.INDEPENDENT.toolTipText=html><body style="width: 300px;">- Complete strategic objectives; disregard Campaign Victory Points.\
+  <br>- Scout the map to locate objectives.\
+  <br>- Terminate the contract early upon completing all objectives, except for Garrison or Cadre contracts.\
+  <br>\
+  <br><i>Independent command rights afford skilled commanders autonomy over their forces, enabling them to make critical decisions and adapt swiftly to achieve objectives efficiently. However, this autonomy necessitates balancing personal discretion with the employer's broader goals.</i></body></html>
 ContractCommandRights.INDEPENDENT.stratConText=Complete strategic objectives to fulfill contract conditions.
 
 # MissionStatus Enum


### PR DESCRIPTION
The tooltips text for contract command rights have long been a source of confusion. The original descriptions were all in-universe which, while thematic, made it difficult for users to intuit exactly what each command right actually meant. This also led to many, many questions about which contracts can be ended early and when.

This PR aims to clear up a lot of this confusion by replacing the tooltip text with more plain language.

## Closes
Closes #4042