### PR TITLE
Fixed Missing Personal Log Messages for Resign, Desert, and Defect

### DIFF
--- a/MekHQ/resources/mekhq/resources/LogEntries.properties
+++ b/MekHQ/resources/mekhq/resources/LogEntries.properties
@@ -1,11 +1,14 @@
 madeBondsmanBy.text=Made bondsman by {0}
 madePrisonerBy.text=Made prisoner by {0}
-joined.text=Joined {0}\u0020
+joined.text=Joined {0}
 freed.text=Freed
 freedBy.text=Freed by {0}
 madeBondsman.text=Made Bondsman
 madePrisoner.text=Made Prisoner
-retired.text=Retired from active duty
+retired.text=Retired
+resigned.text=Resigned
+deserted.text=Deserted
+defected.text=Defected
 recoveredMia.text=Recovered from MIA status
 recoveredPoW.text=Rescued from PoW camp
 returnedFromLeave.text=Returned from leave

--- a/MekHQ/src/mekhq/campaign/log/ServiceLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/ServiceLogger.java
@@ -174,6 +174,18 @@ public class ServiceLogger {
         person.addLogEntry(new ServiceLogEntry(date, logEntriesResourceMap.getString("retired.text")));
     }
 
+    public static void resigned(Person person, LocalDate date) {
+        person.addLogEntry(new ServiceLogEntry(date, logEntriesResourceMap.getString("resigned.text")));
+    }
+
+    public static void deserted(Person person, LocalDate date) {
+        person.addLogEntry(new ServiceLogEntry(date, logEntriesResourceMap.getString("deserted.text")));
+    }
+
+    public static void defected(Person person, LocalDate date) {
+        person.addLogEntry(new ServiceLogEntry(date, logEntriesResourceMap.getString("defected.text")));
+    }
+
     public static void promotedTo(Person person, LocalDate date) {
         String message = logEntriesResourceMap.getString("promotedTo.text");
         person.addLogEntry(new ServiceLogEntry(date, MessageFormat.format(message, person.getRankName())));

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -991,11 +991,29 @@ public class Person {
                 setRetirement(null);
                 break;
             case RETIRED:
-            case RESIGNED:
-            case DESERTED:
-            case DEFECTED:
                 campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
                 ServiceLogger.retired(this, today);
+                if (campaign.getCampaignOptions().isUseRetirementDateTracking()) {
+                    setRetirement(today);
+                }
+                break;
+            case RESIGNED:
+                campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
+                ServiceLogger.resigned(this, today);
+                if (campaign.getCampaignOptions().isUseRetirementDateTracking()) {
+                    setRetirement(today);
+                }
+                break;
+            case DESERTED:
+                campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
+                ServiceLogger.deserted(this, today);
+                if (campaign.getCampaignOptions().isUseRetirementDateTracking()) {
+                    setRetirement(today);
+                }
+                break;
+            case DEFECTED:
+                campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
+                ServiceLogger.defected(this, today);
                 if (campaign.getCampaignOptions().isUseRetirementDateTracking()) {
                     setRetirement(today);
                 }


### PR DESCRIPTION
This fixes an oversight where all four departure methods (retire, resign, desert, and defect) all used the same (retirement) log message.