### PR TITLE
Updated Turnover Frequency Logic in Turnover and Retention Module

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -52,9 +52,9 @@ turnoverCancel.text=Cancel
 turnoverRollRequired.text=Employee Turnover Check Required
 turnoverDialogDescription.text=It has been a %s since the last Employee Turnover roll.
 
-turnoverWeekly.text=7 days
-turnoverMonthly.text=28 days
-turnoverAnnually.text=356 days
+turnoverWeekly.text=a week
+turnoverMonthly.text=a month
+turnoverAnnually.text=a year
 
 turnoverFinalPayments.text=Unresolved Final Payments
 turnoverPersonnelKilled.text=<html><body style="max-width: 300px>You have personnel who have left the unit or been killed in action but have not received their final payout. You must deal with these payments before advancing the day.\

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6992,24 +6992,26 @@ public class Campaign implements ITechManager {
         int days = 0;
         String period = "";
 
+        boolean triggerTurnoverPrompt = false;
+
         switch (campaignOptions.getTurnoverFrequency()) {
             case NEVER:
                 return false;
             case WEEKLY:
-                days = 7;
+                triggerTurnoverPrompt = getLocalDate().getDayOfWeek().equals(DayOfWeek.MONDAY);
                 period = resources.getString("turnoverWeekly.text");
                 break;
             case MONTHLY:
-                days = 28;
+                triggerTurnoverPrompt = getLocalDate().getDayOfMonth() == 1;
                 period = resources.getString("turnoverMonthly.text");
                 break;
             case ANNUALLY:
-                days = 365;
+                triggerTurnoverPrompt = getLocalDate().getDayOfYear() == 1;
                 period = resources.getString("turnoverAnnually.text");
                 break;
         }
 
-        if (ChronoUnit.DAYS.between(getRetirementDefectionTracker().getLastRetirementRoll(), getLocalDate()) >= days) {
+        if (triggerTurnoverPrompt) {
             Object[] options = {
                     resources.getString("turnoverEmployeeTurnoverDialog.text"),
                     resources.getString("turnoverNotNow.text")
@@ -7027,6 +7029,7 @@ public class Campaign implements ITechManager {
                     options[0]
             );
         }
+
         return false;
     }
 


### PR DESCRIPTION
Following feedback from QA, I opted to change the logic that determines turnover check frequency from `x` days to every Monday; the 1st of every month; or the 1st of every year (campaign option dependent).