### PR TITLE
Streamlined Management Modifier Calculations in Turnover and Retention Module

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -184,7 +184,18 @@ public class RetirementDefectionTracker {
 
             // Management Skill Modifier
             if (campaign.getCampaignOptions().isUseManagementSkill()) {
-                targetNumber.addModifier(getManagementSkillModifier(person), resources.getString("managementSkill.text"));
+                int modifier = 0;
+                
+                if (campaign.getCampaignOptions().isUseCommanderLeadershipOnly()) {
+                    if (campaign.getFlaggedCommander().hasSkill((SkillType.S_LEADER))) {
+                        modifier += campaign.getCampaignOptions().getManagementSkillPenalty()
+                                + campaign.getFlaggedCommander().getSkill(SkillType.S_LEADER).getFinalSkillValue();
+                    }
+                } else {
+                    modifier = getManagementSkillModifier(person);
+                }
+                
+                targetNumber.addModifier(modifier, resources.getString("managementSkill.text"));
             }
 
             // Shares Modifiers
@@ -394,35 +405,7 @@ public class RetirementDefectionTracker {
      */
     private void getManagementSkillValues(Campaign campaign) {
         int baseModifier = campaign.getCampaignOptions().getManagementSkillPenalty();
-
-        if (campaign.getCampaignOptions().isUseCommanderLeadershipOnly()) {
-            Person commander = campaign.getFlaggedCommander();
-
-            if ((commander != null) && (commander.hasSkill(SkillType.S_LEADER))) {
-                int commanderSkill = baseModifier + commander.getSkill(SkillType.S_LEADER).getFinalSkillValue();
-
-                asfCommanderModifier = commanderSkill;
-                vehicleCrewCommanderModifier = commanderSkill;
-                infantryCommanderModifier = commanderSkill;
-                navalCommanderModifier = commanderSkill;
-                techCommanderModifier = commanderSkill;
-                medicalCommanderModifier = commanderSkill;
-                administrationCommanderModifier = commanderSkill;
-                mechWarriorCommanderModifier = commanderSkill;
-            } else {
-                asfCommanderModifier = baseModifier;
-                vehicleCrewCommanderModifier = baseModifier;
-                infantryCommanderModifier = baseModifier;
-                navalCommanderModifier = baseModifier;
-                techCommanderModifier = baseModifier;
-                medicalCommanderModifier = baseModifier;
-                administrationCommanderModifier = baseModifier;
-                mechWarriorCommanderModifier = baseModifier;
-            }
-
-            return;
-        }
-
+        
         for (Person person : campaign.getActivePersonnel()) {
             if ((person.getPrimaryRole().isCivilian())
                     || (person.getPrisonerStatus().isPrisoner())


### PR DESCRIPTION
This PR addresses a *really* weird issue where certain modifiers were persisting between instances of the turnover check dialog.

I'll be perfectly honest, I have no idea why this was a problem, nor what was causing it; but this PR fixes the issue by streamlining the modifier calculations for management skill. Which fixes the problem... somehow....