### PR TITLE
Removed Flavor Text from Breach of Contract Departure in Turnover and Retention Module

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -39,10 +39,8 @@ LayeredForceIconLayer.LOGO.text=Logos
 LayeredForceIconLayer.LOGO.toolTipText=This tab contains canon faction logos that can be added to the center of a force icon.
 
 #### Turnover and Retention
-turnoverBurnedOut.text=burnt out.
-turnoverPoached.text=was poached by another force.
 turnoverJointDeparture.text=departed with their spouse.
-turnoverJointDepartureChild.text=departed with their parent.
+turnoverJointDepartureChild.text=departed with a parent.
 
 turnoverEmployeeTurnoverDialog.text=Employee Turnover
 turnoverPayoutDialog.text=Show Payout Dialog

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -692,25 +692,14 @@ public class Campaign implements ITechManager {
 
                     if (!person.getStatus().isDead()) {
                         if (isBreakingContract(person, getLocalDate(), getCampaignOptions().getServiceContractDuration())) {
-                            int roll = Compute.d6(1);
+                            if (!getActiveContracts().isEmpty()) {
+                                int roll = Compute.randomInt(20);
 
-                            switch (roll) {
-                                case 1:
-                                    getPerson(pid).changeStatus(this, getLocalDate(), PersonnelStatus.RESIGNED);
-                                    break;
-                                case 2:
-                                case 3:
-                                    addReport(getPerson(pid).getHyperlinkedFullTitle() + ' ' + resources.getString("turnoverPoached.text"));
-                                    getPerson(pid).changeStatus(this, getLocalDate(), PersonnelStatus.RESIGNED);
-                                    break;
-                                case 4:
-                                case 5:
-                                case 6:
-                                    addReport(getPerson(pid).getHyperlinkedFullTitle() + ' ' + resources.getString("turnoverBurnedOut.text"));
-                                    getPerson(pid).changeStatus(this, getLocalDate(), PersonnelStatus.RESIGNED);
-                                    break;
-                                default:
-                                    throw new IllegalStateException("Unexpected value in applyRetirement: " + roll);
+                                if (roll == 0) {
+                                    getPerson(pid).changeStatus(this, getLocalDate(), PersonnelStatus.DEFECTED);
+                                }
+                            } else {
+                                getPerson(pid).changeStatus(this, getLocalDate(), PersonnelStatus.RESIGNED);
                             }
                         } else if (person.getAge(getLocalDate()) >= 50) {
                             getPerson(pid).changeStatus(this, getLocalDate(), PersonnelStatus.RETIRED);


### PR DESCRIPTION
Based on QA feedback, flavor text messages for breach of contract departures have been removed.

These have been replaced with a 1in20 chance of defection if the breach occurs during an active contract.

This middle-ground still leaves room for flavor, without spamming up the daily report.