### PR TITLE
Fix NPE Resulting from Null Recruitment Date

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1864,7 +1864,7 @@ public class Person {
                         }
                         retVal.originPlanet = p;
                     } catch (NullPointerException e) {
-                        LogManager.getLogger().error("Error loading originPlanet for " + systemId + ", " + planetId, e);
+                        LogManager.getLogger().error("Error loading originPlanet for {}, {}", systemId, planetId, e);
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("phenotype")) {
                     retVal.phenotype = Phenotype.parseFromString(wn2.getTextContent().trim());
@@ -2168,7 +2168,7 @@ public class Person {
                     try {
                         retVal.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        LogManager.getLogger().error("Error restoring advantage: " + adv);
+                        LogManager.getLogger().error("Error restoring advantage: {}", adv);
                     }
                 }
             }
@@ -2183,7 +2183,7 @@ public class Person {
                     try {
                         retVal.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        LogManager.getLogger().error("Error restoring edge: " + adv);
+                        LogManager.getLogger().error("Error restoring edge: {}", adv);
                     }
                 }
             }
@@ -2198,7 +2198,7 @@ public class Person {
                     try {
                         retVal.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        LogManager.getLogger().error("Error restoring implants: " + adv);
+                        LogManager.getLogger().error("Error restoring implants: {}", adv);
                     }
                 }
             }
@@ -2207,8 +2207,14 @@ public class Person {
             if (retVal.getRankNumeric() < 0) {
                 retVal.setRank(0);
             }
+
+            // Fixing recruitment dates
+            // I don't know when this metric was added, so we check all versions
+            if (retVal.getRecruitment() == null) {
+                retVal.setRecruitment(c.getLocalDate());
+            }
         } catch (Exception e) {
-            LogManager.getLogger().error("Failed to read person " + retVal.getFullName() + " from file", e);
+            LogManager.getLogger().error("Failed to read person {} from file", retVal.getFullName(), e);
             retVal = null;
         }
 


### PR DESCRIPTION
This should only really affect personnel from very old campaigns that pre-date our tracking of recruitment date.

When reading the xml entries for personnel (i.e., on campaign load) if personnel have `null` recruitment dates, we set their recruitment date at the campaign's current date.

This was causing problems when our pre-made campaigns interacted with the new Turnover and Retention Module; but this issue will affect any instance where we call `getRecruitment()` for personnel from very old campaigns.

For example, the premade campaigns were last updated in `0.47.15` and presumably the personnel contained within are much older.