### PR TITLE
Restored Missing Code for Scenario Modifier Options & Campaign Option Layout Tweaks

### DIFF
--- a/MekHQ/data/scenariomodifiers/OverwhelmingEnemyAirReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/OverwhelmingEnemyAirReinforcements.xml
@@ -28,6 +28,7 @@
 		</deploymentZones>
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
+        <overrideBvCap>true</overrideBvCap>
 		<forceAlignment>2</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
 		<forceName>Opfor Aerospace Reinforcements</forceName>

--- a/MekHQ/data/scenariomodifiers/OverwhelmingEnemyGroundReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/OverwhelmingEnemyGroundReinforcements.xml
@@ -28,6 +28,7 @@
 		</deploymentZones>
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
+        <overrideBvCap>true</overrideBvCap>
 		<forceAlignment>2</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
 		<forceName>Opfor Ground Reinforcements</forceName>

--- a/MekHQ/data/scenariomodifiers/PiratesIncomingAir.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesIncomingAir.xml
@@ -24,6 +24,7 @@
 		</deploymentZones>
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
+        <overrideBvCap>true</overrideBvCap>
 		<forceAlignment>3</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
 		<forceName>Unidentified Hostiles</forceName>

--- a/MekHQ/data/scenariomodifiers/PiratesIncomingGround.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesIncomingGround.xml
@@ -28,6 +28,7 @@
 		</deploymentZones>
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
+        <overrideBvCap>true</overrideBvCap>
 		<forceAlignment>3</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
 		<forceName>Unidentified Hostiles</forceName>

--- a/MekHQ/data/scenariomodifiers/PiratesPresentAir.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesPresentAir.xml
@@ -24,6 +24,7 @@
 		</deploymentZones>
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
+        <overrideBvCap>true</overrideBvCap>
 		<forceAlignment>3</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
 		<forceName>Unidentified Hostiles</forceName>

--- a/MekHQ/data/scenariomodifiers/PiratesPresentGround.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesPresentGround.xml
@@ -28,6 +28,7 @@
 		</deploymentZones>
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
+        <overrideBvCap>true</overrideBvCap>
 		<forceAlignment>3</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
 		<forceName>Unidentified Hostiles</forceName>

--- a/MekHQ/data/scenariomodifiers/PrimaryAlliesAir.xml
+++ b/MekHQ/data/scenariomodifiers/PrimaryAlliesAir.xml
@@ -15,6 +15,7 @@
 		<deploymentZones/>
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
+        <overrideBvCap>true</overrideBvCap>
 		<forceAlignment>1</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
 		<forceName>Allied Force</forceName>

--- a/MekHQ/data/scenariomodifiers/PrimaryAlliesGround.xml
+++ b/MekHQ/data/scenariomodifiers/PrimaryAlliesGround.xml
@@ -19,6 +19,7 @@
 		<deploymentZones/>
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
+        <overrideBvCap>true</overrideBvCap>
 		<forceAlignment>1</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
 		<forceName>Allied Force</forceName>

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -34,8 +34,10 @@ lblMaintenanceBonus.text=Maintenance modifier
 spnMaintenanceBonus.toolTipText=When checking by parts, Strat Ops applies a -1 bonus to the maintenance check target - you can change this modifier with this value
 useQualityMaintenance.text=Use quality modifiers in maintenance checks
 useQualityMaintenance.toolTipText=If checked, quality modifiers will be added to maintenance checks (WARNING: this will lead to unstable quality ratings over time)
-reverseQualityNames.text=Reverse quality names
-reverseQualityNames.toolTipText=<html>If checked, quality name reporting will be reversed so that A is the best and F is the worst. <b>Warning:</b> toggling this option will reset the Finances tab.
+reverseQualityNames.text=Reverse quality names (Resets Finance Tab)
+reverseQualityNames.toolTipText=<html>If checked, quality name reporting will be reversed so that A is the best and F is the worst.\
+  <br>\
+  <br>><b>Warning:</b> toggling this option will reset all options in the Finances tab to their last saved state.
 chkUseRandomUnitQualities.text=Random New Unit Quality
 chkUseRandomUnitQualities.toolTipText=If checked, the quality of new units is randomized when they are added to the campaign. Otherwise, quality will always default to D.
 useUnofficialMaintenance.text=Only damage parts that are already at worst quality (Unofficial)
@@ -236,6 +238,9 @@ chkUseImplants.text=Allow Implants
 chkUseImplants.toolTipText=Allow personnel to have implants (e.g. Manei Domini)
 chkUseAlternativeQualityAveraging.text=Use Higher-Precision Skill Level Averaging
 chkUseAlternativeQualityAveraging.toolTipText=Where quality is determined by two skills, attempt to average by number (e.g. 8/4), rather than product (e.g. Regular/Green), for greater precision.
+
+# Log Panel
+logPanel.title=Personnel Logs
 chkUseTransfers.text=Use Reassign Instead of Remove/Assign for Logging
 chkUseTransfers.toolTipText=<html>This saves space in the personnel log by logging a single reassignment instead of a removal and assignment. <br>It is highly recommended that this be kept on, especially for larger or longer campaigns.</html>
 chkUseExtendedTOEForceName.text=Use Extended TOE Force Names in Reassignment Log
@@ -541,9 +546,6 @@ educationPanel.title=Education
 
 chkUseEducationModule.text=Enable Education Module
 chkUseEducationModule.toolTip=Enables the Education Module.
-
-chkEduEnableAutoAwardsIntegration.text=Enable Awards Integration (Not Implemented)
-chkEduEnableAutoAwardsIntegration.toolTip=Enables the automatic tracking of award eligibility for students.
 
 lblMaximumJumpCount.text=Maximum Jump Radius
 lblMaximumJumpCount.toolTip=The maximum distance when searching for academies.
@@ -865,6 +867,13 @@ chkUseStratCon.text=Use StratCon campaign rules
 chkUseStratCon.toolTipText=An update of the AtB ruleset. Highly experimental.
 lblSkillLevel.text=Skill Level
 lblSkillLevel.toolTipText=<html>This is the difficulty level for generated scenarios. <br>Values above Elite are not recommended.</html>
+lblScenarioMod.text=Random Scenario Modifiers
+lblScenarioModMax.text=Maximum:
+lblScenarioModMax.toolTipText=This is the maximum number of random scenario mods that can spawn on for a single Scenario. Excludes fixed modifiers.
+lblScenarioModChance.text=Chance
+lblScenarioModChance.toolTipText=This is the percentage chance for a random scenario mod to appear for a Scenario.
+lblScenarioModBV.text=BV Cap
+lblScenarioModBV.toolTipText=This is the percentage of total BV that can be used for each scenario mods. This affects fixed modifiers, but can be overridden by certain modifiers
 chkTrackOriginalUnit.text=Track Original Unit
 chkTrackOriginalUnit.toolTipText=MechWarriors, who have their own unit when recruited, will take the same unit when they go if it is still available.
 chkLimitLanceWeight.text=Limit lance deployment by weight
@@ -877,7 +886,7 @@ chkUseStrategy.toolTipText=The maximum number of lances that can be assigned rol
 lblBaseStrategyDeployment.text=Base number of lances:
 spnBaseStrategyDeployment.toolTipText=The number of lances that can be deployed with a commander strategy of zero.
 chkAdjustPaymentForStrategy.text=Adjust contract payment for deployment limits
-chkAdjustPaymentForStrategy.toolTipText=<html>If the number of lances required to be deployed exceed the current commander's strategy skill, <br>reduce the number when calculating new contracts and reduce the payment proportionally</html>.
+chkAdjustPaymentForStrategy.toolTipText=<html>If the number of lances required to be deployed exceeds the current commander's strategy skill, <br>reduce the number when calculating new contracts and reduce the payment proportionally</html>.
 lblAdditionalStrategyDeployment.text=Per rank of strategy:
 spnAdditionalStrategyDeployment.toolTipText=The number of additional lances that can be deployed for each increase in strategy skill.
 chkUseVehicles.text=Use vehicles

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -588,6 +588,9 @@ public class CampaignOptions {
     private boolean usePlanetaryConditions;
     private int fixedMapChance;
     private int spaUpgradeIntensity;
+    private int scenarioModMax;
+    private int scenarioModChance;
+    private int scenarioModBV;
     //endregion Against the Bot Tab
     //endregion Variable Declarations
 
@@ -1205,6 +1208,9 @@ public class CampaignOptions {
         useWeatherConditions = true;
         useLightConditions = true;
         usePlanetaryConditions = false;
+        setScenarioModMax(3);
+        setScenarioModChance(25);
+        setScenarioModBV(50);
         //endregion Against the Bot Tab
     }
     //endregion Constructors
@@ -4467,6 +4473,30 @@ public class CampaignOptions {
         this.spaUpgradeIntensity = spaUpgradeIntensity;
     }
 
+    public int getScenarioModMax() {
+        return scenarioModMax;
+    }
+
+    public void setScenarioModMax(final int scenarioModMax) {
+        this.scenarioModMax = scenarioModMax;
+    }
+
+    public int getScenarioModChance() {
+        return scenarioModChance;
+    }
+
+    public void setScenarioModChance(final int scenarioModChance) {
+        this.scenarioModChance = scenarioModChance;
+    }
+
+    public int getScenarioModBV() {
+        return scenarioModBV;
+    }
+
+    public void setScenarioModBV(final int scenarioModBV) {
+        this.scenarioModBV = scenarioModBV;
+    }
+
     //region File IO
     public void writeToXml(final PrintWriter pw, int indent) {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "campaignOptions");
@@ -4967,6 +4997,9 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "opForLocalUnitChance", getOpForLocalUnitChance());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "fixedMapChance", fixedMapChance);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "spaUpgradeIntensity", spaUpgradeIntensity);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "scenarioModMax", scenarioModMax);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "scenarioModChance", scenarioModChance);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "scenarioModBV", scenarioModBV);
 
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "planetTechAcquisitionBonus", planetTechAcquisitionBonus);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "planetIndustryAcquisitionBonus", planetIndustryAcquisitionBonus);
@@ -6002,6 +6035,12 @@ public class CampaignOptions {
                     retVal.fixedMapChance = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("spaUpgradeIntensity")) {
                     retVal.setSpaUpgradeIntensity(Integer.parseInt(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("scenarioModMax")) {
+                    retVal.setScenarioModMax(Integer.parseInt(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("scenarioModChance")) {
+                    retVal.setScenarioModChance(Integer.parseInt(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("scenarioModBV")) {
+                    retVal.setScenarioModBV(Integer.parseInt(wn2.getTextContent().trim()));
 
                     //region Legacy
                     // Removed in 0.49.*

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
@@ -141,6 +141,12 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
         FixedUnitCount,
 
         /**
+         * Option to override the BV cap when generating the force. When the overrideBvCap option is true,
+         * the BV cap is ignored and the force is generated without any restriction on the BV value.
+         */
+        OverrideBvCap,
+
+        /**
          * Either assigned by player from TO&amp;E or a minimum fixed number of units;
          */
         PlayerOrFixedUnitCount,
@@ -311,6 +317,11 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
     private int fixedUnitCount = 0;
 
     /**
+     * Whether to override the Scenario Mod BV Cap, assigned in Campaign Options
+     */
+    private boolean overrideBvCap = false;
+
+    /**
      * The "generation bucket" to which this force template is assigned.
      * Forces within a particular "generation bucket" will be generated at the same time, taking into account
      * forces previously generated.
@@ -417,6 +428,7 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
         contributesToMapSize = forceDefinition.contributesToMapSize;
         actualDeploymentZone =  forceDefinition.actualDeploymentZone;
         fixedUnitCount = forceDefinition.fixedUnitCount;
+        overrideBvCap = forceDefinition.overrideBvCap;
         generationOrder = forceDefinition.generationOrder;
         allowAeroBombs = forceDefinition.allowAeroBombs;
         startingAltitude = forceDefinition.startingAltitude;
@@ -507,6 +519,10 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
 
     public int getFixedUnitCount() {
         return fixedUnitCount;
+    }
+
+    public boolean getOverrideBvCap() {
+        return overrideBvCap;
     }
 
     public boolean getAllowAeroBombs() {
@@ -603,6 +619,10 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
 
     public void setFixedUnitCount(int fixedUnitCount) {
         this.fixedUnitCount = fixedUnitCount;
+    }
+
+    public void setOverrideBvCap(boolean overrideBvCap) {
+        this.overrideBvCap = overrideBvCap;
     }
 
     public void setGenerationOrder(int generationOrder) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -64,7 +64,7 @@ public class AtBScenarioModifierApplicator {
         int deploymentZone = AtBDynamicScenarioFactory.calculateDeploymentZone(templateToApply, scenario, templateToApply.getForceName());
 
         AtBDynamicScenarioFactory.generateForce(scenario, scenario.getContract(campaign), campaign,
-                effectiveBV, effectiveUnitCount, EntityWeightClass.WEIGHT_ASSAULT, templateToApply);
+                effectiveBV, effectiveUnitCount, EntityWeightClass.WEIGHT_ASSAULT, templateToApply, true);
 
         // the most recently added bot force is the one we just generated
         BotForce generatedBotForce = scenario.getBotForce(scenario.getNumBots() - 1);

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -806,7 +806,7 @@ public class StratconRulesManager {
             scenario.setRequiredScenario(true);
         }
 
-        AtBDynamicScenarioFactory.setScenarioModifiers(scenario.getBackingScenario());
+        AtBDynamicScenarioFactory.setScenarioModifiers(campaign, scenario.getBackingScenario());
         scenario.setCurrentState(ScenarioState.UNRESOLVED);
         setScenarioDates(track, campaign, scenario);
 

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -690,6 +690,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private JCheckBox chkUseWeatherConditions;
     private JCheckBox chkUseLightConditions;
     private JCheckBox chkUsePlanetaryConditions;
+    private JSpinner spnScenarioModMax;
+    private JSpinner spnScenarioModChance;
+    private JSpinner spnScenarioModBV;
     //endregion Against the Bot Tab
     //endregion Variable Declarations
 
@@ -3221,6 +3224,56 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         panSubAtBScenario.add(panSPAUpgradeIntensity, gridBagConstraints);
 
+        JPanel panScenarioMod = new JPanel();
+        JLabel lblScenarioMod = new JLabel(resources.getString("lblScenarioMod.text"));
+        panScenarioMod.add(lblScenarioMod);
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = yTablePosition++;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.insets = new Insets(0, 5, 5, 5);
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        panSubAtBScenario.add(panScenarioMod, gridBagConstraints);
+
+        JLabel lblScenarioModMax = new JLabel(resources.getString("lblScenarioModMax.text"));
+        lblScenarioModMax.setToolTipText(resources.getString("lblScenarioModMax.toolTipText"));
+        spnScenarioModMax = new JSpinner(new SpinnerNumberModel(3, 0, 10, 1));
+        panScenarioMod.add(lblScenarioModMax);
+        panScenarioMod.add(spnScenarioModMax);
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = yTablePosition++;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.insets = new Insets(0, 5, 5, 5);
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        panSubAtBScenario.add(panScenarioMod, gridBagConstraints);
+
+        JLabel lblScenarioModChance = new JLabel(resources.getString("lblScenarioModChance.text"));
+        lblScenarioModChance.setToolTipText(resources.getString("lblScenarioModChance.toolTipText"));
+        spnScenarioModChance = new JSpinner(new SpinnerNumberModel(25, 5, 100, 5));
+        panScenarioMod.add(lblScenarioModChance);
+        panScenarioMod.add(spnScenarioModChance);
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = yTablePosition++;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.insets = new Insets(0, 5, 5, 5);
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        panSubAtBScenario.add(panScenarioMod, gridBagConstraints);
+
+        JLabel lblScenarioModBV = new JLabel(resources.getString("lblScenarioModBV.text"));
+        lblScenarioModBV.setToolTipText(resources.getString("lblScenarioModBV.toolTipText"));
+        spnScenarioModBV = new JSpinner(new SpinnerNumberModel(50, 5, 100, 5));
+        panScenarioMod.add(lblScenarioModBV);
+        panScenarioMod.add(spnScenarioModBV);
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = yTablePosition++;
+        gridBagConstraints.gridwidth = 2;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.insets = new Insets(0, 5, 5, 5);
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        panSubAtBScenario.add(panScenarioMod, gridBagConstraints);
+
         JScrollPane scrAtB = new JScrollPane(panAtB);
         scrAtB.setPreferredSize(new Dimension(500, 410));
         return scrAtB;
@@ -3237,29 +3290,41 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         final GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0;
         gbc.gridy = 0;
-        gbc.anchor = GridBagConstraints.NORTHWEST;
+        gbc.anchor = GridBagConstraints.CENTER;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         personnelPanel.add(createGeneralPersonnelPanel(), gbc);
 
         gbc.gridx++;
         personnelPanel.add(createExpandedPersonnelInformationPanel(), gbc);
 
+        //
+
         gbc.gridx = 0;
         gbc.gridy++;
+        personnelPanel.add(createLogPanel(), gbc);
+
+        gbc.gridx++;
         personnelPanel.add(createAdministratorsPanel(), gbc);
 
-        gbc.gridx++;
-        personnelPanel.add(createAwardsPanel(), gbc);
+        //
 
         gbc.gridx = 0;
         gbc.gridy++;
-        personnelPanel.add(createMedicalPanel(), gbc);
+        personnelPanel.add(createAwardsPanel(), gbc);
 
         gbc.gridx++;
+        personnelPanel.add(createMedicalPanel(), gbc);
+
+        //
+
+        gbc.gridx = 0;
+        gbc.gridy++;
         personnelPanel.add(createPrisonerPanel(), gbc);
 
         gbc.gridx++;
         personnelPanel.add(createDependentPanel(), gbc);
+
+        //
 
         gbc.gridx = 0;
         gbc.gridy++;
@@ -3282,7 +3347,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         gbc.gridx = 0;
         gbc.gridy = 0;
-        gbc.anchor = GridBagConstraints.NORTHWEST;
+        gbc.anchor = GridBagConstraints.CENTER;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         turnoverAndRetentionPanel.add(createTurnoverAndRetentionHeaderPanel(), gbc);
 
@@ -3319,22 +3384,29 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gbc.gridy = 0;
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.HORIZONTAL;
-
         lifePathsPanel.add(createPersonnelRandomizationPanel(), gbc);
-
-        gbc.gridx = 0;
-        gbc.gridy++;
-        lifePathsPanel.add(createFamilyPanel(), gbc);
 
         gbc.gridx++;
         lifePathsPanel.add(createAnniversaryPanel(), gbc);
 
+        //
+
         gbc.gridx = 0;
         gbc.gridy++;
+        gbc.gridwidth = 2;
+        lifePathsPanel.add(createFamilyPanel(), gbc);
+
+        //
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        gbc.gridwidth = 1;
         lifePathsPanel.add(createMarriagePanel(), gbc);
 
         gbc.gridx++;
         lifePathsPanel.add(createDivorcePanel(), gbc);
+
+        //
 
         gbc.gridx = 0;
         gbc.gridy++;
@@ -3343,8 +3415,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gbc.gridx++;
         lifePathsPanel.add(createProcreationPanel(), gbc);
 
+        //
+
         gbc.gridx = 0;
         gbc.gridy++;
+        gbc.gridwidth = 2;
         lifePathsPanel.add(createDeathPanel(), gbc);
 
         final JScrollPane scrollLifePaths = new JScrollPane(lifePathsPanel);
@@ -3392,6 +3467,46 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkUseAlternativeQualityAveraging.setToolTipText(resources.getString("chkUseAlternativeQualityAveraging.toolTipText"));
         chkUseAlternativeQualityAveraging.setName("chkUseAlternativeQualityAveraging");
 
+        // Layout the Panel
+        final JPanel panel = new JPanel();
+        panel.setBorder(BorderFactory.createTitledBorder(""));
+        panel.setName("generalPersonnelPanel");
+
+        final GroupLayout layout = new GroupLayout(panel);
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+        panel.setLayout(layout);
+
+        layout.setVerticalGroup(
+                layout.createSequentialGroup()
+                        .addComponent(chkUseTactics)
+                        .addComponent(chkUseInitiativeBonus)
+                        .addComponent(chkUseToughness)
+                        .addComponent(chkUseArtillery)
+                        .addComponent(chkUseAbilities)
+                        .addComponent(chkUseEdge)
+                        .addComponent(chkUseSupportEdge)
+                        .addComponent(chkUseImplants)
+                        .addComponent(chkUseAlternativeQualityAveraging)
+        );
+
+        layout.setHorizontalGroup(
+                layout.createParallelGroup(Alignment.LEADING)
+                        .addComponent(chkUseTactics)
+                        .addComponent(chkUseInitiativeBonus)
+                        .addComponent(chkUseToughness)
+                        .addComponent(chkUseArtillery)
+                        .addComponent(chkUseAbilities)
+                        .addComponent(chkUseEdge)
+                        .addComponent(chkUseSupportEdge)
+                        .addComponent(chkUseImplants)
+                        .addComponent(chkUseAlternativeQualityAveraging)
+        );
+
+        return panel;
+    }
+
+    private JPanel createLogPanel() {
         chkUseTransfers = new JCheckBox(resources.getString("chkUseTransfers.text"));
         chkUseTransfers.setToolTipText(resources.getString("chkUseTransfers.toolTipText"));
         chkUseTransfers.setName("chkUseTransfers");
@@ -3424,27 +3539,17 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkDisplayKillRecord.setToolTipText(resources.getString("chkDisplayKillRecord.toolTipText"));
         chkDisplayKillRecord.setName("chkDisplayKillRecord");
 
-        // Layout the Panel
-        final JPanel panel = new JPanel();
-        panel.setBorder(BorderFactory.createTitledBorder(""));
-        panel.setName("generalPersonnelPanel");
+        final JPanel logPanel = new JPanel();
+        logPanel.setBorder(BorderFactory.createTitledBorder(resources.getString("logPanel.title")));
+        logPanel.setName("logPanel");
 
-        final GroupLayout layout = new GroupLayout(panel);
+        final GroupLayout layout = new GroupLayout(logPanel);
         layout.setAutoCreateGaps(true);
         layout.setAutoCreateContainerGaps(true);
-        panel.setLayout(layout);
+        logPanel.setLayout(layout);
 
         layout.setVerticalGroup(
                 layout.createSequentialGroup()
-                        .addComponent(chkUseTactics)
-                        .addComponent(chkUseInitiativeBonus)
-                        .addComponent(chkUseToughness)
-                        .addComponent(chkUseArtillery)
-                        .addComponent(chkUseAbilities)
-                        .addComponent(chkUseEdge)
-                        .addComponent(chkUseSupportEdge)
-                        .addComponent(chkUseImplants)
-                        .addComponent(chkUseAlternativeQualityAveraging)
                         .addComponent(chkUseTransfers)
                         .addComponent(chkUseExtendedTOEForceName)
                         .addComponent(chkPersonnelLogSkillGain)
@@ -3457,15 +3562,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         layout.setHorizontalGroup(
                 layout.createParallelGroup(Alignment.LEADING)
-                        .addComponent(chkUseTactics)
-                        .addComponent(chkUseInitiativeBonus)
-                        .addComponent(chkUseToughness)
-                        .addComponent(chkUseArtillery)
-                        .addComponent(chkUseAbilities)
-                        .addComponent(chkUseEdge)
-                        .addComponent(chkUseSupportEdge)
-                        .addComponent(chkUseImplants)
-                        .addComponent(chkUseAlternativeQualityAveraging)
                         .addComponent(chkUseTransfers)
                         .addComponent(chkUseExtendedTOEForceName)
                         .addComponent(chkPersonnelLogSkillGain)
@@ -3476,7 +3572,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                         .addComponent(chkDisplayKillRecord)
         );
 
-        return panel;
+        return logPanel;
     }
 
     private void createFatigueSubPanel() {
@@ -7400,23 +7496,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkUseShareSystem = new JCheckBox(resources.getString("chkUseShareSystem.text"));
         chkUseShareSystem.setToolTipText(resources.getString("chkUseShareSystem.toolTipText"));
         chkUseShareSystem.setName("chkUseShareSystem");
-        chkUseShareSystem.addActionListener(evt -> {
-            final boolean isEnabled = chkUseShareSystem.isSelected();
-
-            // general handlers
-            for (Component component : sharesSubPanel.getComponents()) {
-                component.setEnabled(isEnabled);
-            }
-        });
 
         sharesSubPanel = createSharesSubPanel();
-        for (Component component : sharesSubPanel.getComponents()) {
-            component.setEnabled(campaign.getCampaignOptions().isUseShareSystem());
-        }
 
         sharesPanel = new JDisableablePanel("sharesPanel");
         sharesPanel.setBorder(BorderFactory.createTitledBorder(resources.getString("sharesPanel.title")));
-        sharesPanel.setEnabled(campaign.getCampaignOptions().isUseShareSystem());
 
         final GroupLayout layout = new GroupLayout(sharesPanel);
         sharesPanel.setLayout(layout);
@@ -8596,6 +8680,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkAdjustPlayerVehicles.setSelected(options.isAdjustPlayerVehicles());
         spnFixedMapChance.setValue(options.getFixedMapChance());
         spnSPAUpgradeIntensity.setValue(options.getSpaUpgradeIntensity());
+        spnScenarioModMax.setValue(options.getScenarioModMax());
+        spnScenarioModChance.setValue(options.getScenarioModChance());
+        spnScenarioModBV.setValue(options.getScenarioModBV());
         chkRegionalMechVariations.setSelected(options.isRegionalMechVariations());
         chkAttachedPlayerCamouflage.setSelected(options.isAttachedPlayerCamouflage());
         chkPlayerControlsAttachedUnits.setSelected(options.isPlayerControlsAttachedUnits());
@@ -9124,6 +9211,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             options.setOpForLocalUnitChance((Integer) spnOpForLocalForceChance.getValue());
             options.setFixedMapChance((Integer) spnFixedMapChance.getValue());
             options.setSpaUpgradeIntensity((Integer) spnSPAUpgradeIntensity.getValue());
+            options.setScenarioModMax((Integer) spnScenarioModMax.getValue());
+            options.setScenarioModChance((Integer) spnScenarioModChance.getValue());
+            options.setScenarioModBV((Integer) spnScenarioModBV.getValue());
             options.setUseDropShips(chkUseDropShips.isSelected());
 
             for (int i = 0; i < spnAtBBattleChance.length; i++) {
@@ -9449,17 +9539,21 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         sellPartsBox.setSelected(options.isSellParts());
         payForRecruitmentBox.setSelected(options.isPayForRecruitment());
         useLoanLimitsBox.setSelected(options.isUseLoanLimits());
-
         usePercentageMaintBox.setSelected(options.isUsePercentageMaint());
         useInfantryDontCountBox.setSelected(options.isInfantryDontCount());
-
         usePeacetimeCostBox.setSelected(options.isUsePeacetimeCost());
         useExtendedPartsModifierBox.setSelected(options.isUseExtendedPartsModifier());
         showPeacetimeCostBox.setSelected(options.isShowPeacetimeCost());
         comboFinancialYearDuration.setSelectedItem(options.getFinancialYearDuration());
         newFinancialYearFinancesToCSVExportBox.setSelected(options.isNewFinancialYearFinancesToCSVExport());
 
-        // Price Modifiers Panel
+        // Taxes
+        chkUseTaxes.setSelected(options.isUseTaxes());
+        spnTaxesPercentage.setValue(options.getTaxesPercentage());
+        chkUseClanExemption.setSelected(options.isUseClanExemption());
+        chkUseNotMercenaryExemption.setSelected(options.isUseNotMercenaryExemption());
+
+        // Price Multipliers Panel
         spnCommonPartPriceMultiplier.setValue(options.getCommonPartPriceMultiplier());
         spnInnerSphereUnitPriceMultiplier.setValue(options.getInnerSphereUnitPriceMultiplier());
         spnInnerSpherePartPriceMultiplier.setValue(options.getInnerSpherePartPriceMultiplier());
@@ -9474,6 +9568,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         for (int index = Part.QUALITY_A; index <= Part.QUALITY_F; index++) {
             spnUsedPartPriceMultipliers[index].setValue(options.getUsedPartPriceMultipliers()[index]);
         }
+
+        // Shares System
+        chkUseShareSystem.setSelected(options.isUseShareSystem());
+        chkSharesExcludeLargeCraft.setSelected(options.isSharesExcludeLargeCraft());
+        chkSharesForAll.setSelected(options.isSharesForAll());
     }
 
     private void enableAtBComponents(JPanel panel, boolean enabled) {

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -2229,13 +2229,19 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         tableXP = new JTable(getSkillCostsArray(SkillType.getSkillHash()), TABLE_XP_COLUMN_NAMES);
         tableXP.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        tableXP.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+        tableXP.setRowHeight(25);
         tableXP.setRowSelectionAllowed(false);
         tableXP.setColumnSelectionAllowed(false);
         tableXP.setCellSelectionEnabled(true);
+        tableXP.setShowGrid(true);
         final JScrollPane scrXP = new JScrollPane(tableXP);
-        scrXP.setMinimumSize(new Dimension(550, 140));
-        scrXP.setPreferredSize(new Dimension(550, 140));
+        scrXP.setMinimumSize(new Dimension(500, ((tableXP.getRowCount() * 25) + 50)));
+        scrXP.setPreferredSize(new Dimension(500, ((tableXP.getRowCount() * 25) + 50)));
         JTable rowTable = new RowNamesTable(tableXP);
+        rowTable.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+        rowTable.setShowGrid(true);
+        rowTable.setRowHeight(25);
         scrXP.setRowHeaderView(rowTable);
         scrXP.setCorner(JScrollPane.UPPER_LEFT_CORNER, rowTable.getTableHeader());
         gridBagConstraints = new GridBagConstraints();


### PR DESCRIPTION
This PR predominately restores missing code from my prior PR that added options to influence the number; frequency; and BV allowance of non-facility Scenario Modifiers. This code was lost due to an error between keyboard and chair on my side. Git is not a friend to the uneducated.

While I was at it, I also applied some minor formatting tweaks to campaign options. These tweaks were needed due to the large volume of new campaign options that were added over the past week.

Lastly, I updated my Finance Tab bug fix to include all the new finance tab options that were added over the week. These couldn't be added till the fix was merged, so were always going to need to be added in a separate PR, so why not now.