### PR TITLE
Added Campaign Start Date Logging to Campaign

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -180,7 +180,7 @@ public class Campaign implements ITechManager {
 
     private String name;
     private LocalDate currentDay;
-    private LocalDate campaignStartDay;
+    private LocalDate campaignStartDate;
 
     // hierarchically structured Force object to define TO&E
     private Force forces;
@@ -262,7 +262,7 @@ public class Campaign implements ITechManager {
         player = new Player(0, "self");
         game.addPlayer(0, player);
         currentDay = LocalDate.ofYearDay(3067, 1);
-        campaignStartDay = null;
+        campaignStartDate = null;
         CurrencyManager.getInstance().setCampaign(this);
         location = new CurrentLocation(Systems.getInstance().getSystems().get("Outreach"), 0);
         campaignOptions = new CampaignOptions();
@@ -377,11 +377,11 @@ public class Campaign implements ITechManager {
     }
 
     public LocalDate getCampaignStartDay() {
-        return campaignStartDay;
+        return campaignStartDate;
     }
 
-    public void setCampaignStartDay(LocalDate campaignStartDay) {
-        this.campaignStartDay = campaignStartDay;
+    public void setCampaignStartDay(LocalDate campaignStartDate) {
+        this.campaignStartDate = campaignStartDate;
     }
 
     public PlanetarySystem getCurrentSystem() {
@@ -4305,10 +4305,10 @@ public class Campaign implements ITechManager {
         }
 
         // this handles campaigns that predate 49.20
-        if (campaignStartDay == null) {
+        if (campaignStartDate == null) {
             setCampaignStartDay(getLocalDate());
         }
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "campaignStartDay", getCampaignStartDay());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "campaignStartDate", getCampaignStartDay());
 
         getRankSystem().writeToXML(pw, indent, false);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "overtime", overtime);

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -376,11 +376,11 @@ public class Campaign implements ITechManager {
         this.currentDay = currentDay;
     }
 
-    public LocalDate getCampaignStartDay() {
+    public LocalDate getCampaignStartDate() {
         return campaignStartDate;
     }
 
-    public void setCampaignStartDay(LocalDate campaignStartDate) {
+    public void setCampaignStartDate(LocalDate campaignStartDate) {
         this.campaignStartDate = campaignStartDate;
     }
 
@@ -4306,9 +4306,9 @@ public class Campaign implements ITechManager {
 
         // this handles campaigns that predate 49.20
         if (campaignStartDate == null) {
-            setCampaignStartDay(getLocalDate());
+            setCampaignStartDate(getLocalDate());
         }
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "campaignStartDate", getCampaignStartDay());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "campaignStartDate", getCampaignStartDate());
 
         getRankSystem().writeToXML(pw, indent, false);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "overtime", overtime);

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -180,6 +180,7 @@ public class Campaign implements ITechManager {
 
     private String name;
     private LocalDate currentDay;
+    private LocalDate campaignStartDay;
 
     // hierarchically structured Force object to define TO&E
     private Force forces;
@@ -261,6 +262,7 @@ public class Campaign implements ITechManager {
         player = new Player(0, "self");
         game.addPlayer(0, player);
         currentDay = LocalDate.ofYearDay(3067, 1);
+        campaignStartDay = null;
         CurrencyManager.getInstance().setCampaign(this);
         location = new CurrentLocation(Systems.getInstance().getSystems().get("Outreach"), 0);
         campaignOptions = new CampaignOptions();
@@ -372,6 +374,14 @@ public class Campaign implements ITechManager {
 
     public void setLocalDate(LocalDate currentDay) {
         this.currentDay = currentDay;
+    }
+
+    public LocalDate getCampaignStartDay() {
+        return campaignStartDay;
+    }
+
+    public void setCampaignStartDay(LocalDate campaignStartDay) {
+        this.campaignStartDay = campaignStartDay;
     }
 
     public PlanetarySystem getCurrentSystem() {
@@ -4293,6 +4303,12 @@ public class Campaign implements ITechManager {
         if (retainerEmployerCode != null) {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "retainerEmployerCode", retainerEmployerCode);
         }
+
+        // this handles campaigns that predate 49.20
+        if (campaignStartDay == null) {
+            setCampaignStartDay(getLocalDate());
+        }
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "campaignStartDay", getCampaignStartDay());
 
         getRankSystem().writeToXML(pw, indent, false);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "overtime", overtime);

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -8608,8 +8608,8 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             }
             campaign.setLocalDate(date);
 
-            if (campaign.getCampaignStartDay() == null) {
-                campaign.setCampaignStartDay(date);
+            if (campaign.getCampaignStartDate() == null) {
+                campaign.setCampaignStartDate(date);
             }
             // Ensure that the MegaMek year GameOption matches the campaign year
             campaign.getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(campaign.getGameYear());

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -8607,6 +8607,10 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                 getCampaign().getForces().setName(getCampaign().getName());
             }
             campaign.setLocalDate(date);
+
+            if (campaign.getCampaignStartDay() == null) {
+                campaign.setCampaignStartDay(date);
+            }
             // Ensure that the MegaMek year GameOption matches the campaign year
             campaign.getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(campaign.getGameYear());
             // Null state handled during validation


### PR DESCRIPTION
This PR adds Campaign Start Date logging to the campaign class. Or, to put it another way, mhq now remembers what date the campaign started on.

I need this for the Turnover and Retention Module, but figured it would also be useful for Story Arcs and (if I ever do it) my RFE for campaign scoring. I also imagined there were other use-cases where knowing _when_ the campaign started might prove useful.

Existing campaigns with a `null` campaign start date have their start date set to whatever the current date is.