### PR TITLE
Prevented Infinite Loop from Bulk Hiring Civilian or Assistant Roles

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -300,6 +300,13 @@ public enum PersonnelRole {
         return isDoctor() || isMedic();
     }
 
+    /**
+     * @return true if the person is an Astech or Medic, false otherwise.
+     */
+    public boolean isAssistant() {
+        return isAstech() || isMedic();
+    }
+
     public boolean isAdministrator() {
         return isAdministratorCommand() || isAdministratorLogistics()
                 || isAdministratorTransport() || isAdministratorHR();

--- a/MekHQ/src/mekhq/gui/dialog/HireBulkPersonnelDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/HireBulkPersonnelDialog.java
@@ -331,7 +331,7 @@ public class HireBulkPersonnelDialog extends JDialog {
 
             // while this isn't the most efficient way of doing this, we don't currently have a way
             // to generate personnel at specific skill levels
-            if (useSkill) {
+            if ((useSkill) && (!selectedItem.getRole().isCivilian()) && (!selectedItem.getRole().isAssistant())) {
                 while (person.getSkillLevel(campaign, false) != skillLevel.getSelectedItem()) {
                     person = campaign.newPerson(selectedItem.getRole());
                 }


### PR DESCRIPTION
This PR prevents an infinite loop caused by the new 'fixed skill level' parameter added to the Bulk Hire Personnel dialog.

Basically, when picking roles without skill levels (civilians, or assistants), the fixed skill level can never be reached so mhq gets into an infinite loop of generating persons and then throwing them away (because they don't meet the required skill level).

In addition to fixing this, I also added a new `isAssistant()` method to `PersonnelRole.java` which allows us to more efficiently check whether someone has the `Astech` or `Medic` roles.