### PR TITLE
Changed Title of Basic Unit Information to Use Campaign Name

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -210,7 +210,6 @@ btnPersonnelOverview.text=Personnel Breakdown
 btnCargoCapacity.text=Cargo Capacity
 btnUnitRating.text=Unit Rating Details
 panReports.title=Available Reports
-panInfo.title=Basic Unit Information
 panObjectives.title=Current Objectives
 lblRating.text=<html><nobr><b>Unit Rating:</b></nobr></html>;
 lblPersonnel.text=<html><nobr><b>Personnel:</b></nobr></html>;

--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -335,7 +335,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
             panInfo.add(lblFacilityCapacities, gridBagConstraints);
         }
 
-        panInfo.setBorder(BorderFactory.createTitledBorder(resourceMap.getString("panInfo.title")));
+        panInfo.setBorder(BorderFactory.createTitledBorder(getCampaign().getName()));
     }
 
     /**


### PR DESCRIPTION
This PR updates the 'Basic Unit Information' panel to show the campaign name instead of 'Basic Unit Information'.