### PR TITLE
Fixed a Bug Caused by Clan Creche Aspirants Incorrectly Washing Out of their Creches

### DIFF
--- a/MekHQ/data/universe/academies/Clan Education.xml
+++ b/MekHQ/data/universe/academies/Clan Education.xml
@@ -125,6 +125,27 @@
         <constructionYear>2807</constructionYear>
         <durationDays>300</durationDays>
         <ageMin>16</ageMin>
+        <qualification>MechWarrior Sibko</qualification>
+        <curriculum>Small Arms, Piloting/Mech, Gunnery/Mech, Leadership</curriculum>
+        <qualificationStartYear>2807</qualificationStartYear>
+        <qualification>ProtoMech Sibko</qualification>
+        <curriculum>Small Arms, Gunnery/ProtoMech</curriculum>
+        <qualificationStartYear>3060</qualificationStartYear>
+        <qualification>AeroSpace Sibko</qualification>
+        <curriculum>Small Arms, Piloting/Aerospace, Gunnery/Aerospace</curriculum>
+        <qualificationStartYear>2807</qualificationStartYear>
+        <qualification>Naval Sibko</qualification>
+        <curriculum>Small Arms, Piloting/Spacecraft, Gunnery/Spacecraft, Tech/Vessel</curriculum>
+        <qualificationStartYear>2807</qualificationStartYear>
+        <qualification>Elemental Sibko</qualification>
+        <curriculum>Small Arms, Gunnery/Battlesuit, Anti-Mech</curriculum>
+        <qualificationStartYear>2868</qualificationStartYear>
+        <qualification>Combat Infantry Sibko</qualification>
+        <curriculum>Small Arms, Anti-Mech, Medtech</curriculum>
+        <qualificationStartYear>2807</qualificationStartYear>
+        <qualification>Vehicle Sibko</qualification>
+        <curriculum>Small Arms, Piloting/VTOL, Piloting/Ground Vehicle, Gunnery/Vehicle</curriculum>
+        <qualificationStartYear>2807</qualificationStartYear>
         <qualification>Scientist Caste Reeducation</qualification>
         <curriculum>Doctor, Administration, Hyperspace Navigation</curriculum>
         <qualificationStartYear>2807</qualificationStartYear>
@@ -149,6 +170,27 @@
         <constructionYear>2807</constructionYear>
         <durationDays>300</durationDays>
         <ageMin>16</ageMin>
+        <qualification>MechWarrior Sibko</qualification>
+        <curriculum>Small Arms, Piloting/Mech, Gunnery/Mech, Leadership</curriculum>
+        <qualificationStartYear>2807</qualificationStartYear>
+        <qualification>ProtoMech Sibko</qualification>
+        <curriculum>Small Arms, Gunnery/ProtoMech</curriculum>
+        <qualificationStartYear>3060</qualificationStartYear>
+        <qualification>AeroSpace Sibko</qualification>
+        <curriculum>Small Arms, Piloting/Aerospace, Gunnery/Aerospace</curriculum>
+        <qualificationStartYear>2807</qualificationStartYear>
+        <qualification>Naval Sibko</qualification>
+        <curriculum>Small Arms, Piloting/Spacecraft, Gunnery/Spacecraft, Tech/Vessel</curriculum>
+        <qualificationStartYear>2807</qualificationStartYear>
+        <qualification>Elemental Sibko</qualification>
+        <curriculum>Small Arms, Gunnery/Battlesuit, Anti-Mech</curriculum>
+        <qualificationStartYear>2868</qualificationStartYear>
+        <qualification>Combat Infantry Sibko</qualification>
+        <curriculum>Small Arms, Anti-Mech, Medtech</curriculum>
+        <qualificationStartYear>2807</qualificationStartYear>
+        <qualification>Vehicle Sibko</qualification>
+        <curriculum>Small Arms, Piloting/VTOL, Piloting/Ground Vehicle, Gunnery/Vehicle</curriculum>
+        <qualificationStartYear>2807</qualificationStartYear>
         <qualification>Scientist Caste Reeducation</qualification>
         <curriculum>Doctor, Administration, Hyperspace Navigation</curriculum>
         <qualificationStartYear>2807</qualificationStartYear>

--- a/MekHQ/resources/mekhq/resources/LogEntries.properties
+++ b/MekHQ/resources/mekhq/resources/LogEntries.properties
@@ -84,4 +84,4 @@ eduClanWarrior.text=Scored {0} during their Trial of Position and entered the Wa
 eduClanFailed.text=Failed the {0} Caste's Trial of Position
 eduClanPassed.text={0} passed their Trial of Position into the {1} Caste
 eduClanLabor.text=Entered the Labor Caste
-eduClanCreche.text=Graduated from a Trueborn Crèche
+eduClanCreche.text=Graduated from a Trueborn Creche

--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -156,7 +156,7 @@ public class Academy implements Comparable<Academy> {
      * @param isMilitary              indicates if the academy is a military academy (true) or not (false)
      * @param isReeducationCamp       indicates if the academy is a reeducation camp (true) or not (false)
      * @param promotion               indicates the promotion rank earned for completing an academic course
-     * @param isClan                  indicates if the academy is a Clan Sibko or Crèche (true) or not (false)
+     * @param isClan                  indicates if the academy is a Clan Sibko or Creche (true) or not (false)
      * @param isTrueborn              indicates if the Sibko is intended for Trueborn (true) or not (false)
      * @param isPrepSchool            indicates if the academy is focused on children (true) or not (false)
      * @param description             the description of the academy
@@ -329,36 +329,36 @@ public class Academy implements Comparable<Academy> {
     }
 
     /**
-     * Checks if the academy is a Clan Sibko or Crèche.
+     * Checks if the academy is a Clan Sibko or Creche.
      *
-     * @return {@code true} if the academy is a Clan Sibko or Crèche, {@code false} otherwise.
+     * @return {@code true} if the academy is a Clan Sibko or Creche, {@code false} otherwise.
      */
     public Boolean isClan() {
         return isClan;
     }
 
     /**
-     * Sets the value indicating whether the academy is a Clan Sibko or Crèche.
+     * Sets the value indicating whether the academy is a Clan Sibko or Creche.
      *
-     * @param isClan true if the academy is a Clan Sibko or Crèche, false otherwise.
+     * @param isClan true if the academy is a Clan Sibko or Creche, false otherwise.
      */
     public void setIsClan(final boolean isClan) {
         this.isClan = isClan;
     }
 
     /**
-     * Checks if the academy is a Truenorn Sibko or Crèche.
+     * Checks if the academy is a Truenorn Sibko or Creche.
      *
-     * @return {@code true} if the academy is a Trueborn Sibko or Crèche, {@code false} otherwise.
+     * @return {@code true} if the academy is a Trueborn Sibko or Creche, {@code false} otherwise.
      */
     public Boolean isTrueborn() {
         return isTrueborn;
     }
 
     /**
-     * Sets the value indicating whether the academy is a Trueborn Sibko or Crèche.
+     * Sets the value indicating whether the academy is a Trueborn Sibko or Creche.
      *
-     * @param isTrueborn true if the academy is a Trueborn Sibko or Crèche, false otherwise.
+     * @param isTrueborn true if the academy is a Trueborn Sibko or Creche, false otherwise.
      */
     public void setIsTrueborn(final boolean isTrueborn) {
         this.isTrueborn = isTrueborn;

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -454,11 +454,11 @@ public class EducationController {
      * @param person the person to determine graduation for
      * @param academy the academy to determine graduation from
      * @param resources the resources to use for graduation
-     * @return true if the person successfully graduates; otherwise, false
+     * @return true, if the person successfully graduates; otherwise, false
      */
     private static boolean graduationPicker(Campaign campaign, Person person, Academy academy, ResourceBundle resources) {
         if ((academy.isClan()) && (academy.isPrepSchool())) {
-            if (person.getAge(campaign.getLocalDate()) < 10) {
+            if (person.getAge(campaign.getLocalDate()) == 10) {
                 graduateClanCreche(campaign, person, academy, resources);
             } else {
                 graduateClanSibko(campaign, person, academy, resources);

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -202,7 +202,7 @@ public class EducationController {
         }
 
         if (person.getAge(campaign.getLocalDate()) < 10) {
-            return "Crèche " + birthDate.getYear() + birthDate.getMonth().getValue() + birthDate.getDayOfMonth() + campaign.getFaction().getShortName() + " (";
+            return "Creche " + birthDate.getYear() + birthDate.getMonth().getValue() + birthDate.getDayOfMonth() + campaign.getFaction().getShortName() + " (";
         } else if (person.getAge(campaign.getLocalDate()) < 20) {
             return (caste + ' ' + birthDate.getYear() + birthDate.getMonth().getValue() + birthDate.getDayOfMonth() + campaign.getFaction().getShortName()) + " (";
         } else {
@@ -1192,14 +1192,14 @@ public class EducationController {
     }
 
     /**
-     * Graduates a person from the Clan Crèche in a campaign.
+     * Graduates a person from the Clan Creche in a campaign.
      * This method adds a report to the campaign, logs the event using the ServiceLogger,
      * improves the person's skills, and sets their highest education level to the education level
-     * obtained from the Crèche.
+     * obtained from the Creche.
      *
      * @param campaign   the campaign where the graduation is taking place
      * @param person     the person being graduated
-     * @param academy    the Crèche responsible for the graduation
+     * @param academy    the Creche responsible for the graduation
      * @param resources  the ResourceBundle containing localized text
      */
     private static void graduateClanCreche(Campaign campaign, Person person, Academy academy, ResourceBundle resources) {

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -729,7 +729,7 @@ public class EducationController {
 
         if (academy.isClan()) {
             // we don't want creche aspirants washing out
-            if (academy.isPrepSchool()) {
+            if (person.getAge(campaign.getLocalDate()) < 10) {
                 return false;
             }
 

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -728,6 +728,11 @@ public class EducationController {
         int clanOtherDiceSize = campaign.getCampaignOptions().getOtherCasteDropOutChance();
 
         if (academy.isClan()) {
+            // we don't want creche aspirants washing out
+            if (academy.isPrepSchool()) {
+                return false;
+            }
+
             if ((person.getAge(campaign.getLocalDate()) < 20) && (person.getEduCourseIndex() <= 6)) {
                 if (clanWarriorDiceSize > 1) {
                     roll = Compute.randomInt(clanWarriorDiceSize);

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -458,7 +458,7 @@ public class EducationController {
      */
     private static boolean graduationPicker(Campaign campaign, Person person, Academy academy, ResourceBundle resources) {
         if ((academy.isClan()) && (academy.isPrepSchool())) {
-            if (person.getAge(campaign.getLocalDate()) == 10) {
+            if (person.getAge(campaign.getLocalDate()) <= 10) {
                 graduateClanCreche(campaign, person, academy, resources);
             } else {
                 graduateClanSibko(campaign, person, academy, resources);

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -2620,7 +2620,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // are any of the local academies accepting applicants from person's Faction or campaign's Faction?
                 String faction = academy.getFilteredFaction(campaign, person, campaign.getCurrentSystem().getId());
 
-                // we add this exception so Clan players always have access to Trueborn Crèches and Sibkos.
+                // we add this exception so Clan players always have access to Trueborn Creches and Sibkos.
                 if (faction == null) {
                     if ((showIneligibleAcademies) && (campaign.getCampaignOptions().isEnableShowFactionConflict())) {
                         JMenuItem academyOption;


### PR DESCRIPTION
This PR fixes a bug in the clan washout logic that didn't correctly prohibit creche aspirants from washing out of daycare. Once the aspirant washed out, they were treated as if they were washing out of a Sibko. This caused a _slew_ of problems.

Anyone using Clan creches in a campaign saved prior to the nightly containing this fix will need to set their aspirants to 'Active' and then re-enroll them.

Unrelated to Clan Creches, I also expanded the qualifications offered by Clan Reeducation Camps to include Warrior Caste options, as there are Clans which embrace warriors from outside of Clan culture; so seemed appropriate that those qualifications should be offered, too.

## Closes
Closes #4193