### PR TITLE
Further Adjusted FM:M Dragoon Rating to CamOps Reputation Conversion

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5837,7 +5837,7 @@ public class Campaign implements ITechManager {
         }
         IUnitRating rating = getUnitRating();
         return getCampaignOptions().getUnitRatingMethod().isFMMR() ? rating.getUnitRatingAsInteger()
-                : MathUtility.clamp((rating.getModifier() / 3), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR);
+                : MathUtility.clamp((int) (rating.getModifier() / 2.5), IUnitRating.DRAGOON_F, IUnitRating.DRAGOON_ASTAR);
     }
 
     /**


### PR DESCRIPTION
This further adjusts the Dragoon to Reputation conversion we use to allow users with CamOps enabled to still interact with AtB systems. In an attempt to bring them roughly close to one another I have reduced the amount the CamOps modifier is divided by from 3 to 2.5 (parsed as an int).

As with previous adjustments, this is only a bandaid. As we move to better support CamOps, eventually we're going to need to figure out a way to decouple AtB from FM:M entirely, but that is no small feat and outside the scope of this PR.