### PR TITLE
Updated Default Support Personnel Counts in Company Generator

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/companyGeneration/CompanyGenerationOptions.java
+++ b/MekHQ/src/mekhq/campaign/universe/companyGeneration/CompanyGenerationOptions.java
@@ -22,12 +22,12 @@ import megamek.Version;
 import megamek.common.EntityWeightClass;
 import megamek.common.annotations.Nullable;
 import mekhq.MHQConstants;
-import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.Factions;
-import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.RandomOriginOptions;
 import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.enums.*;
+import mekhq.utilities.MHQXMLUtility;
 import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -153,12 +153,12 @@ public class CompanyGenerationOptions {
         // Personnel
         final Map<PersonnelRole, Integer> supportPersonnel = new HashMap<>();
         if (method.isWindchild()) {
-            supportPersonnel.put(PersonnelRole.MECH_TECH, 7);
+            supportPersonnel.put(PersonnelRole.MECH_TECH, 12);
             supportPersonnel.put(PersonnelRole.MECHANIC, 0);
             supportPersonnel.put(PersonnelRole.AERO_TECH, 0);
             supportPersonnel.put(PersonnelRole.DOCTOR, 1);
             supportPersonnel.put(PersonnelRole.ADMINISTRATOR_COMMAND, 1);
-            supportPersonnel.put(PersonnelRole.ADMINISTRATOR_LOGISTICS, 1);
+            supportPersonnel.put(PersonnelRole.ADMINISTRATOR_LOGISTICS, 2);
             supportPersonnel.put(PersonnelRole.ADMINISTRATOR_TRANSPORT, 1);
             supportPersonnel.put(PersonnelRole.ADMINISTRATOR_HR, 1);
         } else { // Defaults to AtB

--- a/MekHQ/src/mekhq/gui/panels/CompanyGenerationOptionsPanel.java
+++ b/MekHQ/src/mekhq/gui/panels/CompanyGenerationOptionsPanel.java
@@ -18,6 +18,7 @@
  */
 package mekhq.gui.panels;
 
+import megamek.client.ui.baseComponents.JDisableablePanel;
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.enums.ValidationState;
 import megamek.common.EntityWeightClass;
@@ -30,7 +31,6 @@ import mekhq.campaign.universe.companyGeneration.CompanyGenerationOptions;
 import mekhq.campaign.universe.enums.*;
 import mekhq.gui.FileDialogs;
 import mekhq.gui.baseComponents.AbstractMHQScrollablePanel;
-import megamek.client.ui.baseComponents.JDisableablePanel;
 import mekhq.gui.displayWrappers.FactionDisplay;
 
 import javax.swing.*;
@@ -2270,27 +2270,27 @@ public class CompanyGenerationOptionsPanel extends AbstractMHQScrollablePanel {
 
         //region Warnings
         // Only need to check these if they are to be displayed
-        if (display) {
-            // Support Personnel Count:
-            // 1) Above Recommended Maximum Support Personnel Count
-            // 2) Below Half of Recommended Maximum Support Personnel Count
-            final int maximumSupportPersonnelCount = determineMaximumSupportPersonnel();
-            final int currentSupportPersonnelCount = getSpnSupportPersonnelNumbers().values().stream()
-                    .mapToInt(spinner -> (int) spinner.getValue()).sum();
-            if ((maximumSupportPersonnelCount < currentSupportPersonnelCount)
-                    && (JOptionPane.showConfirmDialog(getFrame(),
-                    resources.getString("CompanyGenerationOptionsPanel.OverMaximumSupportPersonnel.text"),
-                    resources.getString("CompanyGenerationOptionsPanel.OverMaximumSupportPersonnel.title"),
-                    JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE) == JOptionPane.NO_OPTION)) {
-                return ValidationState.WARNING;
-            } else if ((currentSupportPersonnelCount < (maximumSupportPersonnelCount / 2.0))
-                    && (JOptionPane.showConfirmDialog(getFrame(),
-                    resources.getString("CompanyGenerationOptionsPanel.UnderHalfMaximumSupportPersonnel.text"),
-                    resources.getString("CompanyGenerationOptionsPanel.UnderHalfMaximumSupportPersonnel.title"),
-                    JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE) == JOptionPane.NO_OPTION)) {
-                return ValidationState.WARNING;
-            }
-        }
+//        if (display) {
+//            // Support Personnel Count:
+//            // 1) Above Recommended Maximum Support Personnel Count
+//            // 2) Below Half of Recommended Maximum Support Personnel Count
+//            final int maximumSupportPersonnelCount = determineMaximumSupportPersonnel();
+//            final int currentSupportPersonnelCount = getSpnSupportPersonnelNumbers().values().stream()
+//                    .mapToInt(spinner -> (int) spinner.getValue()).sum();
+//            if ((maximumSupportPersonnelCount < currentSupportPersonnelCount)
+//                    && (JOptionPane.showConfirmDialog(getFrame(),
+//                    resources.getString("CompanyGenerationOptionsPanel.OverMaximumSupportPersonnel.text"),
+//                    resources.getString("CompanyGenerationOptionsPanel.OverMaximumSupportPersonnel.title"),
+//                    JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE) == JOptionPane.NO_OPTION)) {
+//                return ValidationState.WARNING;
+//            } else if ((currentSupportPersonnelCount < (maximumSupportPersonnelCount / 2.0))
+//                    && (JOptionPane.showConfirmDialog(getFrame(),
+//                    resources.getString("CompanyGenerationOptionsPanel.UnderHalfMaximumSupportPersonnel.text"),
+//                    resources.getString("CompanyGenerationOptionsPanel.UnderHalfMaximumSupportPersonnel.title"),
+//                    JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE) == JOptionPane.NO_OPTION)) {
+//                return ValidationState.WARNING;
+//            }
+//        }
         //endregion Warnings
 
         // The options specified are correct, and thus can be saved


### PR DESCRIPTION
This PR updates the default support personnel counts, in our company generator, to better support users using CamOps reputation (instead of FM:M unit rating). As FM:M grows continually ever older and out-of-date, we need to better support users who prefer to use the current rules found in CamOps.

This is only a bandaid, put in place to stop users having their CamOps Reputation tanked due to low support personnel counts when the company is generated. As always, users can adjust these values in the company generator dialog.

Increased Mech Techs from 7 to 12.
Increased Admin/Logistics personnel from 1 to 2

I also commented out the warning dialog that prompts users when they are above, or under, the recommended support personnel count. This check hasn't worked for a couple of years, and I don't have time to fix it. Commenting it out seemed the best move, with a mind towards my eventual full review of the company generator.

This PR was prompted by discussion among our QA team.