### PR TITLE
Added Additional Turnover Fixes, Adjustments, and Adjusted autoAwards Award Ceremony Dialog Size

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -51,7 +51,11 @@ turnoverNotNow.text=Not Now
 turnoverCancel.text=Cancel Advance Day
 
 turnoverRollRequired.text=Employee Turnover Check Required
-turnoverDialogDescription.text=It is time for an Employee Turnover Check
+turnoverDialogDescription.text=<html>It is time for an Employee Turnover Check.\
+  <br>\
+  <br>If this is your first time using this screen, please read the documentation in <i>docs/personnel modules</i>.\
+  <br>\
+  <br>Seeing high target numbers? Select your personnel to see how the target number was calculated!</html>
 
 turnoverFinalPayments.text=Unresolved Final Payments
 turnoverPersonnelKilled.text=<html>You have personnel who have left the unit or been killed in action and have not received their final payout.\

--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -48,22 +48,20 @@ orphaned.text=has been orphaned.
 turnoverEmployeeTurnoverDialog.text=Employee Turnover
 turnoverPayoutDialog.text=Show Payout Dialog
 turnoverNotNow.text=Not Now
-turnoverCancel.text=Cancel
+turnoverCancel.text=Cancel Advance Day
 
 turnoverRollRequired.text=Employee Turnover Check Required
-turnoverDialogDescription.text=It has been a %s since the last Employee Turnover roll.
-
-turnoverWeekly.text=a week
-turnoverMonthly.text=a month
-turnoverAnnually.text=a year
+turnoverDialogDescription.text=It is time for an Employee Turnover Check
 
 turnoverFinalPayments.text=Unresolved Final Payments
-turnoverPersonnelKilled.text=<html><body style="max-width: 300px>You have personnel who have left the unit or been killed in action but have not received their final payout. You must deal with these payments before advancing the day.\
+turnoverPersonnelKilled.text=<html>You have personnel who have left the unit or been killed in action and have not received their final payout.\
+  <br>\
+  <br>You must address these payments before advancing the day.\
   <br>\
   <br>Here are some options:\
-  <ul><li>Sell off equipment to generate funds.\
-  <li>Pay one or more personnel in equipment.\
-  <li>Use GM mode to edit the settlement.</body></html>
+  <ul><li>Sell off equipment to generate funds.</li>\
+  <li>Pay one or more personnel in equipment.</li>\
+  <li>Use GM mode to edit the settlement.</li></ul></html>
 
 #### Unsorted Campaign Resources
 dependentLeavesForce.text=%s is no longer travelling with the force, and is thus no longer dependent on it.

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -263,7 +263,7 @@ public class Campaign implements ITechManager {
         player = new Player(0, "self");
         game.addPlayer(0, player);
         currentDay = LocalDate.ofYearDay(3067, 1);
-        campaignStartDate = currentDay;
+        campaignStartDate = null;
         CurrencyManager.getInstance().setCampaign(this);
         location = new CurrentLocation(Systems.getInstance().getSystems().get("Outreach"), 0);
         campaignOptions = new CampaignOptions();

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7030,8 +7030,6 @@ public class Campaign implements ITechManager {
     }
 
     public boolean checkTurnoverPrompt() {
-        String period = "";
-
         boolean triggerTurnoverPrompt = false;
 
         switch (campaignOptions.getTurnoverFrequency()) {
@@ -7039,15 +7037,12 @@ public class Campaign implements ITechManager {
                 return false;
             case WEEKLY:
                 triggerTurnoverPrompt = getLocalDate().getDayOfWeek().equals(DayOfWeek.MONDAY);
-                period = resources.getString("turnoverWeekly.text");
                 break;
             case MONTHLY:
                 triggerTurnoverPrompt = getLocalDate().getDayOfMonth() == 1;
-                period = resources.getString("turnoverMonthly.text");
                 break;
             case ANNUALLY:
                 triggerTurnoverPrompt = getLocalDate().getDayOfYear() == 1;
-                period = resources.getString("turnoverAnnually.text");
                 break;
         }
 
@@ -7059,8 +7054,7 @@ public class Campaign implements ITechManager {
 
             return JOptionPane.YES_OPTION == JOptionPane.showOptionDialog(
                     null,
-                    String.format(resources.getString("turnoverDialogDescription.text"),
-                            period),
+                    resources.getString("turnoverDialogDescription.text"),
                     resources.getString("turnoverRollRequired.text"),
                     JOptionPane.OK_CANCEL_OPTION,
                     JOptionPane.WARNING_MESSAGE,

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -263,7 +263,7 @@ public class Campaign implements ITechManager {
         player = new Player(0, "self");
         game.addPlayer(0, player);
         currentDay = LocalDate.ofYearDay(3067, 1);
-        campaignStartDate = null;
+        campaignStartDate = currentDay;
         CurrencyManager.getInstance().setCampaign(this);
         location = new CurrentLocation(Systems.getInstance().getSystems().get("Outreach"), 0);
         campaignOptions = new CampaignOptions();
@@ -7009,7 +7009,9 @@ public class Campaign implements ITechManager {
     }
 
     public boolean checkRetirementDefections() {
-        if (!getRetirementDefectionTracker().getRetirees().isEmpty()) {
+        if (getRetirementDefectionTracker().getRetirees().isEmpty()) {
+            return true;
+        } else {
             Object[] options = {
                     resources.getString("turnoverPayoutDialog.text"),
                     resources.getString("turnoverCancel.text")
@@ -7026,10 +7028,13 @@ public class Campaign implements ITechManager {
                     options[0]
             );
         }
-        return false;
     }
 
     public boolean checkTurnoverPrompt() {
+        if (getLocalDate().isBefore(getCampaignStartDate().plusDays(6))) {
+            return false;
+        }
+
         boolean triggerTurnoverPrompt = false;
 
         switch (campaignOptions.getTurnoverFrequency()) {

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -980,7 +980,7 @@ public class CampaignOptions {
         // Retirement
         setUseRetirementDateTracking(false);
         setUseRandomRetirement(true);
-        setTurnoverTargetNumberMethod(TurnoverTargetNumberMethod.NEGOTIATION);
+        setTurnoverTargetNumberMethod(TurnoverTargetNumberMethod.FIXED);
         setTurnoverDifficulty(SkillLevel.REGULAR);
         setTurnoverFrequency(TurnoverFrequency.MONTHLY);
         setTurnoverFixedTargetNumber(3);

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2418,7 +2418,7 @@ public class CampaignGUI extends JPanel {
             }
         }
 
-        if(getCampaign().checkScenariosDue()) {
+        if (getCampaign().checkScenariosDue()) {
             JOptionPane.showMessageDialog(null, getResourceMap().getString("dialogCheckDueScenarios.text"),
                     getResourceMap().getString("dialogCheckDueScenarios.title"), JOptionPane.WARNING_MESSAGE);
             evt.cancel();

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2404,8 +2404,15 @@ public class CampaignGUI extends JPanel {
             return;
         }
 
-        if ((getCampaign().getCampaignOptions().isUseRandomRetirement()) && (getCampaign().checkTurnoverPrompt())) {
-            if (!showRetirementDefectionDialog()) {
+        if (getCampaign().getCampaignOptions().isUseRandomRetirement()) {
+            if (getCampaign().checkTurnoverPrompt()) {
+                if (!showRetirementDefectionDialog()) {
+                    evt.cancel();
+                    return;
+                }
+            }
+
+            if (!getCampaign().checkRetirementDefections()) {
                 evt.cancel();
                 return;
             }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -666,9 +666,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 boolean showDialog = false;
                 List<Person> toRemove = new ArrayList<>();
                 for (Person person : people) {
-                    if (gui.getCampaign().getRetirementDefectionTracker().removeFromCampaign(
-                            person, false, true, gui.getCampaign(), null)) {
-                        showDialog = true;
+                    if (!person.getPrimaryRole().isCivilian()) {
+                        if (gui.getCampaign().getRetirementDefectionTracker().removeFromCampaign(
+                                person, false, true, gui.getCampaign(), null)) {
+                            showDialog = true;
+                        } else {
+                            toRemove.add(person);
+                        }
                     } else {
                         toRemove.add(person);
                     }

--- a/MekHQ/src/mekhq/gui/dialog/AutoAwardsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AutoAwardsDialog.java
@@ -79,7 +79,10 @@ public class AutoAwardsDialog extends JDialog {
         setTitle(resourceMap.getString("AutoAwardsDialog.title"));
 
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-        setSize((int) screenSize.getWidth(), (int) (screenSize.getHeight() * 0.94));
+        int screenWidth = (int) (screenSize.getWidth() * 0.75);
+        int screenHeight = (int) (screenSize.getHeight() * 0.94);
+
+        setSize(screenWidth, screenHeight);
 
         setLayout(new BorderLayout());
         CardLayout cardLayout = new CardLayout();
@@ -91,7 +94,7 @@ public class AutoAwardsDialog extends JDialog {
         JPanel imageAndInstructionsPanel = new JPanel(new BorderLayout());
 
         Image image = new ImageIcon("data/images/awards/awardceremony.png")
-                .getImage().getScaledInstance(screenSize.width, (screenSize.width / 7), Image.SCALE_FAST);
+                .getImage().getScaledInstance(screenWidth, (screenHeight / 7), Image.SCALE_FAST);
         JLabel lblImage = new JLabel(new ImageIcon(image));
         imageAndInstructionsPanel.add(lblImage, BorderLayout.CENTER);
 


### PR DESCRIPTION
## Default Turnover Target Number Method
Based on feedback from our QA team the default Turnover Target Number Method has been changed from `NEGOTIATION` to `FIXED`. This was chosen to better handle the transfer of old campaigns into 49.20.

## autoAwards Dialog Size
This accidentally got pushed to the wrong branch and I only just noticed, but based on feedback I reduced the width of the autoAwards award ceremony dialog.

## Sacking Dependents Fix
This change addressed a bug where sacking dependents would cause an NPE.

## Rewording
I added some rewording to the notification that alerts uses when a turnover check is required. I also restored a blocker that stops users advancing to a new day if payouts are due.

## Suppressed Turnover Checks on Campaign Start
Previously, if the campaign started on the 1st of the month (and monthly checks were enabled) the turnover check prompt would appear at the end of the first day. This was undesirable, so I used the newly saved campaign start date to suppress the turnover dialog for the first 7 days of the campaign. This also highlighted a bug with the aforementioned campaign start date not persisting between saves. I'm going to address that in a separate PR.