### PR TITLE
Fixed Intersected Conditions in CustomizePersonDialog.java

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1031,24 +1031,22 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             person.setEduHighestEducation(MathUtility.clamp(Integer.parseInt(textEducationLevel.getText()), 0, 4));
         } catch (NumberFormatException ignored) {}
 
+        try {
+            person.setFatigue(Integer.parseInt(textFatigue.getText()));
+        } catch (NumberFormatException ignored) {}
+
         if (null == choiceOriginalUnit.getSelectedItem()) {
-            try {
-                person.setFatigue(Integer.parseInt(textFatigue.getText()));
-            } catch (NumberFormatException ignored) {}
-
-            if (choiceOriginalUnit.getSelectedItem() == null) {
-                person.setOriginalUnit(null);
-                person.setOriginalUnitWeight(choiceUnitWeight.getSelectedIndex());
-                person.setOriginalUnitTech(choiceUnitTech.getSelectedIndex());
-            } else {
-                person.setOriginalUnitId(((Unit) choiceOriginalUnit.getSelectedItem()).getId());
-            }
-
-            person.setFounder(chkFounder.isSelected());
-            setSkills();
-            setOptions();
-            setVisible(false);
+            person.setOriginalUnit(null);
+            person.setOriginalUnitWeight(choiceUnitWeight.getSelectedIndex());
+            person.setOriginalUnitTech(choiceUnitTech.getSelectedIndex());
+        } else {
+            person.setOriginalUnit((Unit) choiceOriginalUnit.getSelectedItem());
         }
+
+        person.setFounder(chkFounder.isSelected());
+        setSkills();
+        setOptions();
+        setVisible(false);
     }
 
     private void randomName() {


### PR DESCRIPTION
This PR addresses a situation where a couple of lines got intersected (probably during merge) in our code to customizing personnel (the edit person dialogue). This caused the setting of fatigue and the saving of any other changes to be reliant on  the `null == choiceOriginalUnit.getSelectedItem()` conditional being `true`.