### PR TITLE
Added Parsing for "campaignStartDate" on Campaign Load

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -716,12 +716,12 @@ public class CampaignXmlParser {
                         retVal.setName(val);
                     }
                 } else if (xn.equalsIgnoreCase("campaignStartDate")) {
-                    String val = wn.getTextContent().trim();
+                    String campaignStartDate = wn.getTextContent().trim();
 
-                    if (val.equals("null")) {
+                    if (campaignStartDate.equals("null")) {
                         retVal.setCampaignStartDate(null);
                     } else {
-                        retVal.setCampaignStartDate(LocalDate.parse(wn.getTextContent().trim()));
+                        retVal.setCampaignStartDate(LocalDate.parse(campaignStartDate));
                     }
                 } else if (xn.equalsIgnoreCase("overtime")) {
                     retVal.setOvertime(Boolean.parseBoolean(wn.getTextContent().trim()));

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -73,6 +73,7 @@ import org.w3c.dom.*;
 
 import javax.xml.parsers.DocumentBuilder;
 import java.io.*;
+import java.time.LocalDate;
 import java.util.*;
 
 public class CampaignXmlParser {
@@ -713,6 +714,14 @@ public class CampaignXmlParser {
                         retVal.setName(null);
                     } else {
                         retVal.setName(val);
+                    }
+                } else if (xn.equalsIgnoreCase("campaignStartDate")) {
+                    String val = wn.getTextContent().trim();
+
+                    if (val.equals("null")) {
+                        retVal.setCampaignStartDate(null);
+                    } else {
+                        retVal.setCampaignStartDate(LocalDate.parse(wn.getTextContent().trim()));
                     }
                 } else if (xn.equalsIgnoreCase("overtime")) {
                     retVal.setOvertime(Boolean.parseBoolean(wn.getTextContent().trim()));


### PR DESCRIPTION
This PR fixes a missed instance of XML parsing during campaign load, which prevented the campaign start date from being loaded.

Without this fix, MHQ thinks there's no campaign start date, so it helpfully saves the current date as the start date. This behavior was implemented to support campaigns predating 49.20, and hey, it works!