### PR TITLE
Fixed Monthly Unit Market Incorrectly Filtering Out Vehicles

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
@@ -153,10 +153,10 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
 
                 // this forces a chance artillery will be available.
                 // Otherwise, we have issues with artillery not appearing in the market.
-                if (Compute.randomInt(30) == 0) {
+                int roll = Compute.randomInt(30);
+
+                if (roll == 0) {
                     missionRoles.add(MissionRole.ARTILLERY);
-                } else {
-                    missionRoles.add(MissionRole.ANY);
                 }
             }
             final int percent = 100 - (Compute.d6(2) - priceTarget) * 5;

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
@@ -150,14 +150,6 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
             final Collection<MissionRole> missionRoles = new ArrayList<>();
             if (unitType == UnitType.TANK) {
                 movementModes.addAll(IUnitGenerator.MIXED_TANK_VTOL);
-
-                // this forces a chance artillery will be available.
-                // Otherwise, we have issues with artillery not appearing in the market.
-                int roll = Compute.randomInt(30);
-
-                if (roll == 0) {
-                    missionRoles.add(MissionRole.ARTILLERY);
-                }
             }
             final int percent = 100 - (Compute.d6(2) - priceTarget) * 5;
             addSingleUnit(campaign, market, unitType, faction, quality, movementModes, missionRoles, percent);

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
@@ -150,7 +150,14 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
             final Collection<MissionRole> missionRoles = new ArrayList<>();
             if (unitType == UnitType.TANK) {
                 movementModes.addAll(IUnitGenerator.MIXED_TANK_VTOL);
-                missionRoles.add(MissionRole.MIXED_ARTILLERY);
+
+                // this forces a chance artillery will be available.
+                // Otherwise, we have issues with artillery not appearing in the market.
+                if (Compute.randomInt(30) == 0) {
+                    missionRoles.add(MissionRole.ARTILLERY);
+                } else {
+                    missionRoles.add(MissionRole.ANY);
+                }
             }
             final int percent = 100 - (Compute.d6(2) - priceTarget) * 5;
             addSingleUnit(campaign, market, unitType, faction, quality, movementModes, missionRoles, percent);


### PR DESCRIPTION
The recent role overhaul unintentionally filtered out all vehicles from the AtB Monthly Unit Market. This PR restores vehicles to the unit market.

~~However, due to code changes, the original functionality of the Unit Market is no longer possible, meaning artillery cannot spawn in the Unit Market without intervention. To address this, I added a handler that replaces 1 in 30 vehicles for sale with an artillery unit. This should produce results similar to how it previously worked.~~ Due to this causing conflicts with #4160 I opted to add this functionality to that PR, instead.

## Closes
Closes #4203