### PR TITLE
Fixed Invalid Parsing of Early Childhood when Loading Personnel

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/education/EducationLevel.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/education/EducationLevel.java
@@ -86,6 +86,7 @@ public enum EducationLevel {
     public static EducationLevel parseFromString(final String educationLevel) {
         switch (educationLevel) {
             case "None":
+            case "Early Childhood":
                 return EARLY_CHILDHOOD;
             case "High School":
                 return HIGH_SCHOOL;


### PR DESCRIPTION
This PR adds a single new switch case to correctly handle the 'Early Childhood' education level when loading personnel. Failure to include this case resulted in personnel failing to load (though, thankfully, not being deleted from the save file).

## Closes
Closes #4235