### PR TITLE
Added Option to Restrict AtB Personnel Market to Hiring Halls Only

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -786,6 +786,8 @@ personnelMarketRandomRemovalTargetsPanel.title=Random & Dylan's Removal Targets
 personnelMarketRandomRemovalTargetsPanel.toolTipText=An individual daily removal roll that is beneath the relevant target number will cause an appropriately skilled person to leave the personnel market.
 lblPersonnelMarketDylansWeight.text=Dylan's Method Common Unit Type Weight
 lblPersonnelMarketDylansWeight.toolTipText=<html>This is the weight between 0 and 1 used by Dylan's Method to create a person with a primary role based on the most common unit type within the force's hangar, <br>instead of creating a person with a randomly determined role.</html>
+chkUsePersonnelHireHiringHallOnly.text=Hiring Halls Only
+chkUsePersonnelHireHiringHallOnly.toolTipText=Enabling this option disables the personnel market outside of hiring halls.
 
 # Unit Market
 unitMarketPanel.title=Unit Market

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -511,6 +511,7 @@ public class CampaignOptions {
     private boolean personnelMarketReportRefresh;
     private Map<SkillLevel, Integer> personnelMarketRandomRemovalTargets;
     private double personnelMarketDylansWeight;
+    private boolean usePersonnelHireHiringHallOnly;
 
     // Unit Market
     private UnitMarketMethod unitMarketMethod;
@@ -1117,6 +1118,7 @@ public class CampaignOptions {
         getPersonnelMarketRandomRemovalTargets().put(SkillLevel.HEROIC, 11);
         getPersonnelMarketRandomRemovalTargets().put(SkillLevel.LEGENDARY, 11);
         setPersonnelMarketDylansWeight(0.3);
+        setUsePersonnelHireHiringHallOnly(false);
 
         // Unit Market
         setUnitMarketMethod(UnitMarketMethod.NONE);
@@ -3357,6 +3359,14 @@ public class CampaignOptions {
     public void setPersonnelMarketDylansWeight(final double personnelMarketDylansWeight) {
         this.personnelMarketDylansWeight = personnelMarketDylansWeight;
     }
+
+    public boolean isUsePersonnelHireHiringHallOnly() {
+        return usePersonnelHireHiringHallOnly;
+    }
+
+    public void setUsePersonnelHireHiringHallOnly(final boolean usePersonnelHireHiringHallOnly) {
+        this.usePersonnelHireHiringHallOnly = usePersonnelHireHiringHallOnly;
+    }
     //endregion Personnel Market
 
     //region Unit Market
@@ -4819,6 +4829,7 @@ public class CampaignOptions {
         }
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "personnelMarketRandomRemovalTargets");
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "personnelMarketDylansWeight", getPersonnelMarketDylansWeight());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "usePersonnelHireHiringHallOnly", isUsePersonnelHireHiringHallOnly());
         //endregion Personnel Market
 
         //region Unit Market
@@ -5770,6 +5781,8 @@ public class CampaignOptions {
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("personnelMarketDylansWeight")) {
                     retVal.setPersonnelMarketDylansWeight(Double.parseDouble(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("usePersonnelHireHiringHallOnly")) {
+                    retVal.setUsePersonnelHireHiringHallOnly(Boolean.parseBoolean(wn2.getTextContent().trim()));
                     //endregion Personnel Market
 
                     //region Unit Market

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -596,6 +596,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private JCheckBox chkPersonnelMarketReportRefresh;
     private Map<SkillLevel, JSpinner> spnPersonnelMarketRandomRemovalTargets;
     private JSpinner spnPersonnelMarketDylansWeight;
+    private JCheckBox chkUsePersonnelHireHiringHallOnly;
 
     // Unit Market
     private MMComboBox<UnitMarketMethod> comboUnitMarketMethod;
@@ -7403,6 +7404,10 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnPersonnelMarketDylansWeight.setToolTipText(resources.getString("lblPersonnelMarketDylansWeight.toolTipText"));
         spnPersonnelMarketDylansWeight.setName("spnPersonnelMarketDylansWeight");
 
+        chkUsePersonnelHireHiringHallOnly = new JCheckBox(resources.getString("chkUsePersonnelHireHiringHallOnly.text"));
+        chkUsePersonnelHireHiringHallOnly.setToolTipText(resources.getString("chkUsePersonnelHireHiringHallOnly.toolTipText"));
+        chkUsePersonnelHireHiringHallOnly.setName("chkUsePersonnelHireHiringHallOnly");
+
         // Programmatically Assign Accessibility Labels
         lblPersonnelMarketType.setLabelFor(comboPersonnelMarketType);
         lblPersonnelMarketDylansWeight.setLabelFor(spnPersonnelMarketDylansWeight);
@@ -7427,6 +7432,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                         .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                                 .addComponent(lblPersonnelMarketDylansWeight)
                                 .addComponent(spnPersonnelMarketDylansWeight, Alignment.LEADING))
+                        .addComponent(chkUsePersonnelHireHiringHallOnly)
         );
 
         layout.setHorizontalGroup(
@@ -7439,6 +7445,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                         .addGroup(layout.createSequentialGroup()
                                 .addComponent(lblPersonnelMarketDylansWeight)
                                 .addComponent(spnPersonnelMarketDylansWeight))
+                        .addComponent(chkUsePersonnelHireHiringHallOnly)
         );
 
         return panel;
@@ -8389,6 +8396,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             entry.getValue().setValue(options.getPersonnelMarketRandomRemovalTargets().get(entry.getKey()));
         }
         spnPersonnelMarketDylansWeight.setValue(options.getPersonnelMarketDylansWeight());
+        chkUsePersonnelHireHiringHallOnly.setSelected(options.isUsePersonnelHireHiringHallOnly());
 
         // Unit Market
         comboUnitMarketMethod.setSelectedItem(options.getUnitMarketMethod());
@@ -8944,6 +8952,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                 options.getPersonnelMarketRandomRemovalTargets().put(entry.getKey(), (int) entry.getValue().getValue());
             }
             options.setPersonnelMarketDylansWeight((Double) spnPersonnelMarketDylansWeight.getValue());
+            options.setUsePersonnelHireHiringHallOnly(chkUsePersonnelHireHiringHallOnly.isSelected());
 
             // Unit Market
             options.setUnitMarketMethod(comboUnitMarketMethod.getSelectedItem());


### PR DESCRIPTION
This PR adds a campaign option to restrict the AtB personnel market to Hiring Halls only. When enabled (disabled by default) personnel will only appear in the personnel market while the campaign is stationed at a hiring hall. Furthermore, leaving the hiring hall will remove all personnel from the market.