### PR TITLE
Add facility description capability to StratCon

### DIFF
--- a/MekHQ/data/stratconfacilities/AlliedAirBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedAirBase.xml
@@ -5,5 +5,6 @@
         <localModifiers>AlliedAirGarrison.xml</localModifiers>
         <owner>Allied</owner>
         <sharedModifiers>AlliedAirSupport.xml</sharedModifiers>
+	<userDescription>Allied aircraft will participate in scenarios on this track and defend this facility.</userDescription>
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedArtilleryBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedArtilleryBase.xml
@@ -5,5 +5,6 @@
         <localModifiers>AlliedArtyGarrison.xml</localModifiers>
         <owner>Allied</owner>
         <sharedModifiers>AlliedArtySupport.xml</sharedModifiers>
+	<userDescription>A force of allied artillery will participate in scenarios on this track and defend this facility.</userDescription>
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedBaseOfOperations.xml
+++ b/MekHQ/data/stratconfacilities/AlliedBaseOfOperations.xml
@@ -7,6 +7,7 @@
 	<localModifiers>GoodEquipment.xml</localModifiers>
 	<localModifiers>AlliedTurrets.xml</localModifiers>
 	<localModifiers>AlliedOfficerMech.xml</localModifiers>	
-        <sharedModifiers>AlliedOfficerMech.xml</sharedModifiers>		
+        <sharedModifiers>AlliedOfficerMech.xml</sharedModifiers>
+	<userDescription>This base is defended by well-equipped veteran troops, turrets and a commander in a mech. The commander will participate in scenarios on this track.</userDescription>		
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedBaseOfOperations.xml
+++ b/MekHQ/data/stratconfacilities/AlliedBaseOfOperations.xml
@@ -8,6 +8,7 @@
 	<localModifiers>AlliedTurrets.xml</localModifiers>
 	<localModifiers>AlliedOfficerMech.xml</localModifiers>	
         <sharedModifiers>AlliedOfficerMech.xml</sharedModifiers>
-	<userDescription>This base is defended by well-equipped veteran troops, turrets and a commander in a mech. The commander will participate in scenarios on this track.</userDescription>		
+	<userDescription>This base is defended by well-equipped veteran troops, turrets and a commander in a mech. &lt;br&gt;
+The commander will participate in scenarios on this track.</userDescription>		
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedCommsCenter.xml
+++ b/MekHQ/data/stratconfacilities/AlliedCommsCenter.xml
@@ -4,5 +4,6 @@
         <facilityType>CommandCenter</facilityType>
         <owner>Allied</owner>
 	<sharedModifiers>GoodEvent.xml</sharedModifiers>
+	<userDescription>This facility will coordinate additional allied reinforcements to scenarios on this track.</userDescription>
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedDataCenter.xml
+++ b/MekHQ/data/stratconfacilities/AlliedDataCenter.xml
@@ -4,5 +4,6 @@
         <facilityType>DataCenter</facilityType>
         <owner>Allied</owner>
 	<revealTrack>true</revealTrack>
+	<userDescription>This facility reveals all information about this track as long as it is active.</userDescription>
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedEarlyWarningSystem.xml
+++ b/MekHQ/data/stratconfacilities/AlliedEarlyWarningSystem.xml
@@ -5,5 +5,6 @@
         <owner>Allied</owner>
 	<localModifiers>ReinforcementDelayReductionAllied.xml</localModifiers>
         <sharedModifiers>ReinforcementDelayReductionAllied.xml</sharedModifiers>
+	<userDescription>Reduces reinforcement arrival times for allied and player forces.</userDescription>
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedMekBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedMekBase.xml
@@ -5,5 +5,6 @@
         <localModifiers>AlliedMechGarrison.xml</localModifiers>
         <owner>Allied</owner>
         <sharedModifiers>AlliedMechReinforcements.xml</sharedModifiers>
+	<userDescription>Allied mechs will participate in scenarios on this track and defend this facility.</userDescription>
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedOrbitalDefense.xml
+++ b/MekHQ/data/stratconfacilities/AlliedOrbitalDefense.xml
@@ -4,5 +4,6 @@
         <facilityType>OrbitalDefense</facilityType>
         <owner>Allied</owner>
 	<preventAerospace>true</preventAerospace>
+	<userDescription>Prevents hostile air units from operating on this track.</userDescription>
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedSupplyDepot.xml
+++ b/MekHQ/data/stratconfacilities/AlliedSupplyDepot.xml
@@ -4,5 +4,6 @@
         <facilityType>SupplyDepot</facilityType>
         <owner>Allied</owner>
 	<weeklySPModifier>1</weeklySPModifier>
+	<userDescription>Provides 1 SP/week of allied logistical support.</userDescription>
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedTankBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedTankBase.xml
@@ -5,5 +5,6 @@
         <localModifiers>AlliedTankGarrison.xml</localModifiers>
         <owner>Allied</owner>
         <sharedModifiers>AlliedTankReinforcements.xml</sharedModifiers>
+	<userDescription>Allied vehicles will participate in scenarios on this track and defend this facility.</userDescription>
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileAirBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileAirBase.xml
@@ -5,5 +5,6 @@
         <localModifiers>EnemyAirGarrison.xml</localModifiers>
         <owner>Opposing</owner>
         <sharedModifiers>EnemyAirSupport.xml</sharedModifiers>
+	<userDescription>Hostile aircraft will participate in scenarios on this track and defend this facility.</userDescription>
         <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileArtilleryBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileArtilleryBase.xml
@@ -5,5 +5,6 @@
         <localModifiers>EnemyArtyGarrison.xml</localModifiers>
         <owner>Opposing</owner>
         <sharedModifiers>EnemyArty.xml</sharedModifiers>
+	<userDescription>Hostile artillery will participate in scenarios on this track and defend this facility.</userDescription>
         <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileBaseOfOperations.xml
+++ b/MekHQ/data/stratconfacilities/HostileBaseOfOperations.xml
@@ -6,6 +6,7 @@
 	<localModifiers>Veterans.xml</localModifiers>
 	<localModifiers>GoodEquipment.xml</localModifiers>
 	<localModifiers>EnemyTurrets.xml</localModifiers>
-        <sharedModifiers>EnemyCommanderMech.xml</sharedModifiers>	
+        <sharedModifiers>EnemyCommanderMech.xml</sharedModifiers>
+	<userDescription>This base is defended by well-equipped veteran troops, turrets and a commander in a mech.</userDescription>		
         <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileCommsCenter.xml
+++ b/MekHQ/data/stratconfacilities/HostileCommsCenter.xml
@@ -4,5 +4,6 @@
         <facilityType>CommandCenter</facilityType>
         <owner>Opposing</owner>
 	<sharedModifiers>BadEvent.xml</sharedModifiers>
+	<userDescription>Coordinates additional hostile reinforcements for scenarios on this track.</userDescription>	
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileDataCenter.xml
+++ b/MekHQ/data/stratconfacilities/HostileDataCenter.xml
@@ -4,6 +4,7 @@
 	<displayableName>Data Center</displayableName>
         <facilityType>DataCenter</facilityType>
         <owner>Opposing</owner>
-        <sharedModifiers>EnemyMechPatrol.xml</sharedModifiers>		
+        <sharedModifiers>EnemyMechPatrol.xml</sharedModifiers>
+	<userDescription>An additional hostile mech patrol will sweep through scenarios on this track.</userDescription>	
         <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileEarlyWarningSystem.xml
+++ b/MekHQ/data/stratconfacilities/HostileEarlyWarningSystem.xml
@@ -5,5 +5,6 @@
         <owner>Opposing</owner>
 	<localModifiers>ReinforcementDelayReductionHostile.xml</localModifiers>
         <sharedModifiers>ReinforcementDelayReductionHostile.xml</sharedModifiers>
+	<userDescription>Reduces hostile reinforcement arrival time for scenarios on this track.</userDescription>	
         <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileIndustrialFacility.xml
+++ b/MekHQ/data/stratconfacilities/HostileIndustrialFacility.xml
@@ -3,6 +3,7 @@
 	<displayableName>Industrial Center</displayableName>
         <facilityType>IndustrialFacility</facilityType>
         <owner>Opposing</owner>
-        <sharedModifiers>ArmednArmored.xml</sharedModifiers>		
+        <sharedModifiers>ArmednArmored.xml</sharedModifiers>
+	<userDescription>Hostile forces on this track are larger and better equipped with factory-fresh units.</userDescription>	
         <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileMekBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileMekBase.xml
@@ -5,6 +5,7 @@
         <localModifiers>EnemyMechGarrison.xml</localModifiers>
         <owner>Opposing</owner>
         <sharedModifiers>EnemyMechReinforcements.xml</sharedModifiers>
+	<userDescription>Hostile mechs will participate in scenarios on this track and defend this facility.</userDescription>	
         <visible>false</visible>
 <biomes>
 	<biomeCategory>TerranFacility</biomeCategory>

--- a/MekHQ/data/stratconfacilities/HostileOrbitalDefense.xml
+++ b/MekHQ/data/stratconfacilities/HostileOrbitalDefense.xml
@@ -5,5 +5,6 @@
         <owner>Opposing</owner>
 	<preventAerospace>true</preventAerospace>
         <sharedModifiers>EnemyOfficerMech.xml</sharedModifiers>
+	<userDescription>Prevents allied aerospace unit operation on this track and supplies an additional hostile mech to ground scenarios.</userDescription>
         <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileSupplyDepot.xml
+++ b/MekHQ/data/stratconfacilities/HostileSupplyDepot.xml
@@ -6,5 +6,6 @@
         <sharedModifiers>HostileBVBudgetIncrease.xml</sharedModifiers>
         <facilityType>SupplyDepot</facilityType>
         <owner>Opposing</owner>
+	<userDescription>Hostile forces on this track are larger due to improved logistics.</userDescription>	
         <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileTankBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileTankBase.xml
@@ -5,5 +5,6 @@
         <localModifiers>EnemyTankGarrison.xml</localModifiers>
         <owner>Opposing</owner>
         <sharedModifiers>EnemyTankReinforcements.xml</sharedModifiers>
+	<userDescription>Hostile vehicles will participate in scenarios on this track and defend this facility.</userDescription>	
         <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconFacility.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconFacility.java
@@ -56,6 +56,7 @@ public class StratconFacility implements Cloneable {
     private ForceAlignment owner;
     private String displayableName;
     private FacilityType facilityType;
+    private String userDescription;
     private boolean visible;
     private int aggroRating;
     private List<String> sharedModifiers = new ArrayList<>();
@@ -92,6 +93,7 @@ public class StratconFacility implements Cloneable {
         clone.scenarioOddsModifier = scenarioOddsModifier;
         clone.weeklySPModifier = weeklySPModifier;
         clone.preventAerospace = preventAerospace;
+        clone.userDescription = userDescription;
         clone.biomes = new ArrayList<>(biomes);
         ReconstructTransientData(clone);
         return clone;
@@ -110,6 +112,7 @@ public class StratconFacility implements Cloneable {
         setWeeklySPModifier(facility.getWeeklySPModifier());
         setPreventAerospace(facility.preventAerospace());
         setBiomes(new ArrayList<>(facility.getBiomes()));
+        setUserDescription(facility.getUserDescription());
         ReconstructTransientData(this);
     }
 
@@ -299,5 +302,13 @@ public class StratconFacility implements Cloneable {
 
     public void setPreventAerospace(boolean preventAerospace) {
         this.preventAerospace = preventAerospace;
+    }
+
+    public String getUserDescription() {
+        return userDescription;
+    }
+
+    public void setUserDescription(String userDescription) {
+        this.userDescription = userDescription;
     }
 }

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -843,10 +843,14 @@ public class StratconPanel extends JPanel implements ActionListener {
                                 : MekHQ.getMHQOptions().getFontColorNegativeHexColor())
                         .append("'>")
                     .append("<br/>")
-                    .append(facility.getFormattedDisplayableName())
-                    .append("<br/>")
-                    .append(facility.getUserDescription())
-                    .append("<span>");
+                    .append(facility.getFormattedDisplayableName());
+                    
+                if (facility.getUserDescription() != null) {
+                   infoBuilder.append("<br/>")
+                   .append(facility.getUserDescription());
+                }
+                 
+                infoBuilder.append("<span>");
             }
 
         } else {

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -844,6 +844,8 @@ public class StratconPanel extends JPanel implements ActionListener {
                         .append("'>")
                     .append("<br/>")
                     .append(facility.getFormattedDisplayableName())
+                    .append("<br/>")
+                    .append(facility.getUserDescription())
                     .append("<span>");
             }
 


### PR DESCRIPTION
Fix #3974 - added a "user friendly description" field to the facility definition files and the capability to display it on the info tab.

Multi-line descriptions should be broken up by & l t ; br & g t ; ("< b r >", but without the spaces) due to the way that the xml files are read in ("<" and ">" must be escaped)

![image](https://github.com/MegaMek/mekhq/assets/29387808/b828d5e4-89ef-4817-b751-c0f5f88ac9ca)
