### PR TITLE
Updated Education Tooltip Properties to Better Handle Mass Enroll

### DIFF
--- a/MekHQ/resources/mekhq/resources/Education.properties
+++ b/MekHQ/resources/mekhq/resources/Education.properties
@@ -8,7 +8,6 @@ durationWeeks.text=weeks
 durationDays.text=days
 durationAge.text=until %s years old
 distance.text=Travel Time:
-promotion.text=Promotion:
 reeducation.text=Reeducation:
 reeducationNoChange.text=no change
 facultySkill.text=Faculty Skill:

--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -888,6 +888,10 @@ public class Academy implements Comparable<Academy> {
                     }
                 }
             }
+        } else {
+            for (String skill : skills) {
+                tooltip.append(skill).append("<br>");
+            }
         }
 
         tooltip.append("<br>");
@@ -925,7 +929,7 @@ public class Academy implements Comparable<Academy> {
 
         tooltip.append(" (").append(destination.getName(campaign.getLocalDate())).append(")<br>");
 
-        // with travel time out the way; all that's left is to add the last couple of entries
+        // with travel time out the way, all that's left is to add the last couple of entries
         if ((isReeducationCamp) && (campaign.getCampaignOptions().isUseReeducationCamps())) {
             tooltip.append("<b>").append(resources.getString("reeducation.text")).append("</b> ");
 
@@ -935,6 +939,8 @@ public class Academy implements Comparable<Academy> {
                 } else {
                     tooltip.append(resources.getString("reeducationNoChange.text")).append("<br>");
                 }
+            } else {
+                tooltip.append(campaign.getFaction().getFullName(campaign.getGameYear())).append("<br>");
             }
 
             tooltip.append("<br>");
@@ -945,7 +951,7 @@ public class Academy implements Comparable<Academy> {
 
         if (personnel.size() == 1) {
             tooltip.append("<b>").append(resources.getString("educationLevel.text")).append("</b> ")
-                    .append(getEducationLevel(person)).append("<br>");
+                    .append(EducationLevel.parseFromInt(getEducationLevel(person))).append("<br>");
         }
 
         return tooltip.append("</html>").toString();


### PR DESCRIPTION
Removed the unused 'promotion.text' from Education properties.

Updated academy tooltips to display education level descriptions instead of integers (e.g., 'College' instead of '2').

Enhanced the education tooltip to show the destination faction for reeducation camps during mass enrollment. Previously, nothing was shown.

Adjusted the education tooltip to display curriculums during mass enrollment. Previously, nothing was shown.