### PR TITLE
Corrected Scenario BV Allowance Calculations for Scenario Modifiers

### DIFF
--- a/MekHQ/data/stratconcontractdefinitions/GuerillaWarfare.xml
+++ b/MekHQ/data/stratconcontractdefinitions/GuerillaWarfare.xml
@@ -21,7 +21,8 @@
         <objectiveParameter>
 		<objectiveCount>-1</objectiveCount>
 		<objectiveType>AnyScenarioVictory</objectiveType>
-		<objectiveScenarioModifiers>										<objectiveScenarioModifier>OverwhelmingEnemyGroundReinforcements.xml</objectiveScenarioModifier>
+		<objectiveScenarioModifiers>
+            <objectiveScenarioModifier>OverwhelmingEnemyGroundReinforcements.xml</objectiveScenarioModifier>
 			<objectiveScenarioModifier>OverwhelmingEnemyAirReinforcements.xml</objectiveScenarioModifier>
 		</objectiveScenarioModifiers>
         </objectiveParameter>

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -380,7 +380,7 @@ public class AtBDynamicScenarioFactory {
         int forceBVBudget = (int) (effectiveBV * forceTemplate.getForceMultiplier());
 
         if (isScenarioModifier) {
-            forceBVBudget *= campaign.getCampaignOptions().getScenarioModBV();
+            forceBVBudget = (int) (forceBVBudget * ((double) campaign.getCampaignOptions().getScenarioModBV() / 100) * forceTemplate.getForceMultiplier());
         }
 
         int forceUnitBudget = 0;


### PR DESCRIPTION
Corrects calculation in scenario modifier BV allowance. The calculation now correctly incorporates forceMultiplier and correctly converts scenario mod BV cap into a multiplier. Either I forgot to do this, or I left in a test value. Either way, fixed now.

## Closes
Closes #4269