### PR TITLE
Fixed Original Unit Value Being Deducted from Payout Sum When Personnel Resign/Retire

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -636,25 +636,10 @@ public class RetirementDefectionDialog extends JDialog {
             /* If no unit is required as part of the payout, the unit is part or all of the
              * final payout.
              */
-            if ((rdTracker.getPayout(id).getWeightClass() == 0 &&
-                    null != unitAssignments.get(id) &&
-                            null != hqView.getCampaign().getUnit(unitAssignments.get(id)))) {
-                payout = payout.minus(hqView.getCampaign().getUnit(unitAssignments.get(id)).getBuyCost());
-            } else if ((hqView.getCampaign().getCampaignOptions().isUseShareSystem()
-                    && hqView.getCampaign().getCampaignOptions().isTrackOriginalUnit()
-                    && Objects.equals(hqView.getCampaign().getPerson(id).getOriginalUnitId(), unitAssignments.get(id)))
-                    && hqView.getCampaign().getUnit(unitAssignments.get(id)) != null) {
-                payout = payout.minus(hqView.getCampaign().getUnit(unitAssignments.get(id)).getBuyCost());
-            }
-
-            /*  If using the share system and tracking the original unit,
-             * the payout is also reduced by the value of the unit.
-             */
-            if (hqView.getCampaign().getCampaignOptions().isUseShareSystem()
-                    && hqView.getCampaign().getCampaignOptions().isTrackOriginalUnit()
-                    && Objects.equals(hqView.getCampaign().getPerson(id).getOriginalUnitId(), unitAssignments.get(id))
-                    && hqView.getCampaign().getUnit(unitAssignments.get(id)) != null) {
-                payout = payout.minus(hqView.getCampaign().getUnit(unitAssignments.get(id)).getBuyCost());
+            if ((rdTracker.getPayout(id).getWeightClass() == 0)
+                    && (unitAssignments.get(id) != null)
+                    && (hqView.getCampaign().getUnit(unitAssignments.get(id)) != null)) {
+                payout = payout.minus(hqView.getCampaign().getUnit(unitAssignments.get(id)).getSellValue());
             }
 
             // If the person is still under contract, we don't care that they're owed a unit


### PR DESCRIPTION
This PR fixes an unintended interaction where personnel would reduce their payout value based on the value of the unit they are given, when resigning or retiring, even if that unit was a unit _they_  owned.

Furthermore, I adjusted the value of mechs being given as part-payment so that they use the sell value of the unit and not the buy price. This ensures mhq isn't treating half an atlas as equal to an intact atlas.