### PR TITLE
enable new network creation for units not in a network

### DIFF
--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -195,7 +195,7 @@ public class StaticChecks {
 
     public static boolean areAllUnitsNotC3iNetworked(Vector<Unit> units) {
         return units.stream().allMatch(u -> (u.getEntity() != null) && u.getEntity().hasC3i()
-                && (u.getEntity().calculateFreeC3Nodes() < 5));
+                && (u.getEntity().calculateFreeC3Nodes() == 5)); // 5 is the magic number for C3 network
     }
 
     public static boolean areAllUnitsC3iNetworked(Vector<Unit> units) {


### PR DESCRIPTION
I'm not really a big fan of how the C3 network management was implemented in the code, but it is what it is. This adjust the "are all units not c3i networked" check to actually check for that condition - a unit is not c3I networked if it's "free c3i nodes" count is 5 (6 - the 1 unit). If it has fewer than 5 free c3i nodes then it is obviously networked with at least one other unit.

fix #4103 