### PR TITLE
Fixed Graduation Event Failing to Correctly Trigger autoAwards

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -47,7 +47,7 @@ public class Academy implements Comparable<Academy> {
     private String name = "Error: Name Missing";
 
     @XmlElement(name = "type")
-    private AcademyType type = AcademyType.NONE;
+    private String type = "None";
 
     @XmlElement(name = "isMilitary")
     private Boolean isMilitary = false;
@@ -155,7 +155,7 @@ public class Academy implements Comparable<Academy> {
      * @param baseAcademicSkillLevel  the base skill level provided by the academy
      * @param id                      the id number of the academy, used for sorting academies in mhq
      */
-    public Academy(String set, String name, AcademyType type, Boolean isMilitary, Boolean isReeducationCamp,
+    public Academy(String set, String name, String type, Boolean isMilitary, Boolean isReeducationCamp,
                    Boolean isPrepSchool, String description, Integer factionDiscount, Boolean isFactionRestricted,
                    List<String> locationSystems, Boolean isLocal, Integer constructionYear,
                    Integer destructionYear, Integer closureYear, Integer tuition, Integer durationDays,
@@ -233,7 +233,7 @@ public class Academy implements Comparable<Academy> {
      * @return The type of academy.
      */
     public AcademyType getType() {
-        return type;
+        return AcademyType.parseFromString(type);
     }
 
     /**
@@ -241,7 +241,7 @@ public class Academy implements Comparable<Academy> {
      *
      * @param type the type to be set.
      */
-    public void setType(final AcademyType type) {
+    public void setType(final String type) {
         this.type = type;
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/enums/education/AcademyType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/education/AcademyType.java
@@ -104,22 +104,31 @@ public enum AcademyType {
 //region File I/O
     public static AcademyType parseFromString(final String academyType) {
         switch (academyType) {
+            case "0":
             case "None":
                 return NONE;
+            case "1":
             case "High School":
                 return HIGH_SCHOOL;
+            case "2":
             case "College":
                 return COLLEGE;
+            case "3":
             case "University":
                 return UNIVERSITY;
+            case "4":
             case "Military Academy":
                 return MILITARY_ACADEMY;
+            case "5":
             case "Basic Training":
                 return BASIC_TRAINING;
+            case "6":
             case "NCO Academy":
                 return NCO_ACADEMY;
+            case "7":
             case "Warrant Officer Academy":
                 return WARRANT_OFFICER_ACADEMY;
+            case "8":
             case "Officer Academy":
                 return OFFICER_ACADEMY;
             default:

--- a/MekHQ/unittests/mekhq/campaign/personnel/education/AcademyTests.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/education/AcademyTests.java
@@ -60,7 +60,7 @@ class AcademyTests {
 
     @Test
     void testAcademyCreationAllFields() {
-        Academy academy = new Academy("MechWarrior", "MekWarrior Academy", AcademyType.COLLEGE, true,
+        Academy academy = new Academy("MechWarrior", "MekWarrior Academy", "College", true,
                 false, true, "Top level MechWarrior Training", 20, true,
                 Arrays.asList("Sol", "Terra"), false, 3045,
                 3089, 3099, 2000, 365, 10,


### PR DESCRIPTION
This bug was caused by two things:

- when I moved to enum from magic number I forgot to include integers-as-string when parsing from string, so autoAwards didn't know what academy type the award related to.
- the education module was failing to correctly unmarshel the 'type' field into a EducationType enum. I opted to just revert back to parsing a String into the EducationType enum as this was the easiest solution that required the least new code.