### PR TITLE
Added Check for 'dead' Status in Various Personnel Filters

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
@@ -365,6 +365,8 @@ public enum PersonnelFilter {
 
     public boolean getFilteredInformation(final Person person, LocalDate currentDate) {
         final boolean active = person.getStatus().isActive() && !person.getPrisonerStatus().isCurrentPrisoner();
+        final boolean dead = person.getStatus().isDead();
+
         switch (this) {
             case ALL:
                 return true;
@@ -480,15 +482,15 @@ public enum PersonnelFilter {
                 return active && (MekHQ.getMHQOptions().getPersonnelFilterOnPrimaryRole()
                         ? person.getPrimaryRole().isAdministratorHR() : person.hasRole(PersonnelRole.ADMINISTRATOR_HR));
             case DEPENDENT:
-                return active && person.getPrimaryRole().isDependent();
+                return ((!dead) && (active && person.getPrimaryRole().isDependent()));
             case FOUNDER:
-                return person.isFounder();
+                return ((!dead) && (person.isFounder()));
             case KIDS:
-                return ((person.isChild(currentDate)) && (!person.getStatus().isLeft()));
+                return ((!dead) && (!person.getStatus().isLeft()) && (person.isChild(currentDate)));
             case PRISONER:
-                return ((person.getPrisonerStatus().isCurrentPrisoner()) || (person.getPrisonerStatus().isBondsman()));
+                return ((!dead) && ((person.getPrisonerStatus().isCurrentPrisoner()) || (person.getPrisonerStatus().isBondsman())));
             case INACTIVE:
-                return !person.getStatus().isActive();
+                return ((!dead) && (!person.getStatus().isActive()));
             case ON_LEAVE:
                 return person.getStatus().isOnLeave();
             case MIA:

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1434,17 +1434,9 @@ public class PersonViewPanel extends JScrollablePanel {
             firsty++;
         }
 
-        int loyaltyDisplayCap = 0;
-
-        // commanders dynamically improve their effective loyalty by 1,
-        // so loyalty 1 is the same as loyalty 0 for a non-commander
-        if (person.isCommander()) {
-            loyaltyDisplayCap++;
-        }
-
         if ((campaign.getCampaignOptions().isUseLoyaltyModifiers())
                 && (!campaign.getCampaignOptions().isUseHideLoyalty())
-                && (person.getLoyalty() != loyaltyDisplayCap)) {
+                && (person.getLoyalty() != 0)) {
             lblLoyalty1.setName("lblLoyalty1");
             lblLoyalty1.setText(resourceMap.getString("lblLoyalty1.text"));
             gridBagConstraints = new GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1434,9 +1434,17 @@ public class PersonViewPanel extends JScrollablePanel {
             firsty++;
         }
 
+        int loyaltyDisplayCap = 0;
+
+        // commanders dynamically improve their effective loyalty by 1,
+        // so loyalty 1 is the same as loyalty 0 for a non-commander
+        if (person.isCommander()) {
+            loyaltyDisplayCap++;
+        }
+
         if ((campaign.getCampaignOptions().isUseLoyaltyModifiers())
                 && (!campaign.getCampaignOptions().isUseHideLoyalty())
-                && (person.getLoyalty() != 0)) {
+                && (person.getLoyalty() != loyaltyDisplayCap)) {
             lblLoyalty1.setName("lblLoyalty1");
             lblLoyalty1.setText(resourceMap.getString("lblLoyalty1.text"));
             gridBagConstraints = new GridBagConstraints();


### PR DESCRIPTION
This PR adds a check to ensure personnel are not dead when filtering based on statuses, flags, or roles that wouldn't normally include deceased individuals. For example, our codebase can classify a person as both a prisoner and dead, or both a founder and dead.

This filter is particularly useful for Clan players who use the 'prisoners' filter to display their Bondsmen, as previously, dead Bondsmen made parsing the displayed information difficult.

This PR deliberately only affects the filter, not the base methods, to avoid potentially refactoring numerous uses of the base methods.

## Closes
Closes #4279