### PR TITLE
Fixed Commanders Incorrectly Displaying 0 Loyalty

### DIFF
--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1434,9 +1434,17 @@ public class PersonViewPanel extends JScrollablePanel {
             firsty++;
         }
 
+        int loyaltyDisplayCap = 0;
+
+        // commanders dynamically improve their effective loyalty by 1,
+        // so loyalty 1 is the same as loyalty 0 for a non-commander
+        if (person.isCommander()) {
+            loyaltyDisplayCap++;
+        }
+
         if ((campaign.getCampaignOptions().isUseLoyaltyModifiers())
                 && (!campaign.getCampaignOptions().isUseHideLoyalty())
-                && (person.getLoyalty() != 0)) {
+                && (person.getLoyalty() != loyaltyDisplayCap)) {
             lblLoyalty1.setName("lblLoyalty1");
             lblLoyalty1.setText(resourceMap.getString("lblLoyalty1.text"));
             gridBagConstraints = new GridBagConstraints();


### PR DESCRIPTION
To reduce unnecessary clutter, personnel with 0 Loyalty are intentionally not meant to display their Loyalty in the Person View panel.

However, Commanders have a dynamic modifier that reduces their Loyalty by 1, without changing their actual Loyalty. For instance, a Commander with +1 Loyalty would display as having 0 Loyalty in the Person View panel.

This PR addresses this issue by hiding the Loyalty display for individuals with 0 Loyalty or for Commanders with +1 Loyalty.