### PR TITLE
Added Clan Adoption (Abtakha)

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -93,6 +93,7 @@ changeStatus.text=Change Status
 imprison.text=Imprison
 free.text=Free
 recruit.text=Recruit
+abtakha.text=Adopt (Abtakha)
 changePrimaryRole.text=Change Primary Role
 changeSecondaryRole.text=Change Secondary Role
 setSalary.text=Set Salary

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -138,6 +138,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private static final String CMD_IMPRISON = "IMPRISON";
     private static final String CMD_FREE = "FREE";
     private static final String CMD_RECRUIT = "RECRUIT";
+    private static final String CMD_ABTAKHA = "ABTAKHA";
     private static final String CMD_RANSOM = "RANSOM";
 
     // MechWarrior Edge Options
@@ -629,6 +630,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_RECRUIT: {
                 for (Person person : people) {
                     if (person.getPrisonerStatus().isPrisonerDefector()) {
+                        person.setPrisonerStatus(gui.getCampaign(), PrisonerStatus.FREE, true);
+                    }
+                }
+                break;
+            }
+            case CMD_ABTAKHA: {
+                for (Person person : people) {
+                    if (person.getPrisonerStatus().isBondsman()) {
                         person.setPrisonerStatus(gui.getCampaign(), PrisonerStatus.FREE, true);
                     }
                 }
@@ -1262,6 +1271,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         if (StaticChecks.areAnyWillingToDefect(selected)) {
             popup.add(newMenuItem(resources.getString("recruit.text"), CMD_RECRUIT));
+        }
+
+        if ((gui.getCampaign().getFaction().isClan()) && (StaticChecks.areAnyBondsmen(selected))) {
+            popup.add(newMenuItem(resources.getString("abtakha.text"), CMD_ABTAKHA));
         }
 
         final PersonnelRole[] roles = PersonnelRole.values();

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -343,6 +343,10 @@ public class StaticChecks {
         return Stream.of(people).anyMatch(p -> p.getPrisonerStatus().isPrisonerDefector());
     }
 
+    public static boolean areAnyBondsmen(Person... people) {
+        return Stream.of(people).anyMatch(p -> p.getPrisonerStatus().isBondsman());
+    }
+
     public static boolean areAllSameSite(Unit... units) {
         return Stream.of(units).allMatch(u -> u.getSite() == units[0].getSite());
     }


### PR DESCRIPTION
This PR adds a Clan Adoption (Abtakha) option to the right-click personnel menu. This option is only available to Bondsmen within a campaign whose faction has the `Clan` tag.

While the ability to set the prisoner status of Bondsmen to `Free` already existed, this was locked behind GM mode. This PR adds that functionality to campaigns whose players prefer not to use GM mode.

This functionality was requested in #4279