### PR TITLE
Extended 'Hiring Halls Only' Personnel Market Option to Capital Planets

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -790,8 +790,8 @@ personnelMarketRandomRemovalTargetsPanel.title=Random & Dylan's Removal Targets
 personnelMarketRandomRemovalTargetsPanel.toolTipText=An individual daily removal roll that is beneath the relevant target number will cause an appropriately skilled person to leave the personnel market.
 lblPersonnelMarketDylansWeight.text=Dylan's Method Common Unit Type Weight
 lblPersonnelMarketDylansWeight.toolTipText=<html>This is the weight between 0 and 1 used by Dylan's Method to create a person with a primary role based on the most common unit type within the force's hangar, <br>instead of creating a person with a randomly determined role.</html>
-chkUsePersonnelHireHiringHallOnly.text=Hiring Halls Only
-chkUsePersonnelHireHiringHallOnly.toolTipText=Enabling this option disables the personnel market outside of hiring halls.
+chkUsePersonnelHireHiringHallOnly.text=Hiring Halls & Capitals Only
+chkUsePersonnelHireHiringHallOnly.toolTipText=Enabling this option disables the personnel market outside of hiring halls or capital planets.
 
 # Unit Market
 unitMarketPanel.title=Unit Market


### PR DESCRIPTION
- Updated the Hiring Halls option text to "Hiring Halls & Capitals Only"
- Modified PersonnelMarket to include capital planets in personnel hiring process

When I initially introduced the option to limit hiring to hiring halls only, I didn't realize how few 'hiring halls' were actually defined in the AtB Config file. This PR expands the option to also allow personnel markets on capital planets.