### PR TITLE
Revised Tuition and Faction discount Calculations

### DIFF
--- a/MekHQ/unittests/mekhq/campaign/personnel/education/AcademyTests.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/education/AcademyTests.java
@@ -139,6 +139,7 @@ class AcademyTests {
         when(campaign.getSystemById("Sol")).thenReturn(system);
         when(system.getFactions(Mockito.any())).thenReturn(Arrays.asList("Lyr"));
         when(person.getOriginFaction()).thenReturn(new Faction("FWL", ""));
+        when(campaign.getFaction()).thenReturn(new Faction("FWL", ""));
         assertEquals(1.0, academy.getFactionDiscountAdjusted(campaign, person));
     }
 


### PR DESCRIPTION
- Modified getTuitionAdjusted method to implement more precise calculation
- Revised getFactionDiscountAdjusted method for faction restricted cases
- Updated academy tooltip code to reflect the revised calculations

This PR addresses a bug where prestigious academies would not display a tuition cost if `factionDiscount` was 0. The issue stemmed from faulty logic that didn't account for academies with `isFactionRestricted` set to `true` having a faction discount of 0, resulting in the tuition fee incorrectly showing as 0, plus some modifiers.

Additionally, the tuition fee was being incorrectly multiplied by the education level instead of by the difference between the education level and the minimum education level.

While working on this part of the code, I also adjusted how education level affects tuition. The increase in tuition between education levels is now much less severe, mainly impacting universities.