### PR TITLE
Fixed & Optimized Total Profits Calculation & Removed Exemptions

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -448,8 +448,6 @@ public class CampaignOptions {
     // Taxes
     private boolean useTaxes;
     private int taxesPercentage;
-    private boolean useNotMercenaryExemption;
-    private boolean useClanExemption;
 
     // Shares
     private boolean useShareSystem;
@@ -1037,8 +1035,6 @@ public class CampaignOptions {
         // Taxes
         setUseTaxes(false);
         setTaxesPercentage(30);
-        setUseNotMercenaryExemption(true);
-        setUseClanExemption(true);
 
         // Shares
         setUseShareSystem(false);
@@ -3287,22 +3283,6 @@ public class CampaignOptions {
     public void setTaxesPercentage(final int taxesPercentage) {
         this.taxesPercentage = taxesPercentage;
     }
-
-    public boolean isUseNotMercenaryExemption() {
-        return useNotMercenaryExemption;
-    }
-
-    public void setUseNotMercenaryExemption(boolean useNotMercenaryExemption) {
-        this.useNotMercenaryExemption = useNotMercenaryExemption;
-    }
-
-    public boolean isUseClanExemption() {
-        return useClanExemption;
-    }
-
-    public void setUseClanExemption(final boolean useClanExemption) {
-        this.useClanExemption = useClanExemption;
-    }
     // endregion Taxes
     //endregion Finances Tab
 
@@ -4791,8 +4771,6 @@ public class CampaignOptions {
 
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useTaxes", isUseTaxes());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "taxesPercentage", getTaxesPercentage());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useNotMercenaryExemption", isUseNotMercenaryExemption());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useClanExemption", isUseClanExemption());
         //region Taxes
         //endregion Taxes
         //endregion Finances Tab
@@ -5718,10 +5696,6 @@ public class CampaignOptions {
                     retVal.setUseTaxes(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("taxesPercentage")) {
                     retVal.setTaxesPercentage(Integer.parseInt(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("useNotMercenaryExemption")) {
-                    retVal.setUseNotMercenaryExemption(Boolean.parseBoolean(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("useClanExemption")) {
-                    retVal.setUseClanExemption(Boolean.parseBoolean(wn2.getTextContent().trim()));
                     //endregion Taxes
                     //endregion Finances Tab
 

--- a/MekHQ/src/mekhq/campaign/finances/Money.java
+++ b/MekHQ/src/mekhq/campaign/finances/Money.java
@@ -130,6 +130,10 @@ public class Money implements Comparable<Money> {
         return new Money(getWrapped().minus(amount));
     }
 
+    public Money minus(List<Money> amounts) {
+        return new Money(getWrapped().minus((Iterable<BigMoney>) (amounts.stream().map(Money::getWrapped)::iterator)));
+    }
+
     public Money multipliedBy(long amount) {
         return new Money(getWrapped().multipliedBy(amount));
     }

--- a/MekHQ/src/mekhq/campaign/finances/Money.java
+++ b/MekHQ/src/mekhq/campaign/finances/Money.java
@@ -2,7 +2,7 @@
  * Money.java
  *
  * Copyright (c) 2019 - Vicente Cartas Espinel (vicente.cartas at outlook.com). All Rights Reserved.
- * Copyright (c) 2020-2021 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2020-2024 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -504,8 +504,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private JPanel taxesSubPanel = new JPanel();
     private JLabel lblTaxesPercentage;
     private JSpinner spnTaxesPercentage;
-    private JCheckBox chkUseNotMercenaryExemption;
-    private JCheckBox chkUseClanExemption;
 
     private JPanel sharesPanel;
     private JCheckBox chkUseShareSystem;
@@ -7195,16 +7193,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnTaxesPercentage.setName("spnTaxesPercentage");
         spnTaxesPercentage.setEnabled(isEnabled);
 
-        chkUseNotMercenaryExemption = new JCheckBox(resources.getString("chkUseNotMercenaryExemption.text"));
-        chkUseNotMercenaryExemption.setToolTipText(resources.getString("chkUseNotMercenaryExemption.toolTipText"));
-        chkUseNotMercenaryExemption.setName("chkUseNotMercenaryExemption");
-        chkUseNotMercenaryExemption.setEnabled(isEnabled);
-
-        chkUseClanExemption = new JCheckBox(resources.getString("chkUseClanExemption.text"));
-        chkUseClanExemption.setToolTipText(resources.getString("chkUseClanExemption.toolTipText"));
-        chkUseClanExemption.setName("chkUseClanExemption");
-        chkUseClanExemption.setEnabled(isEnabled);
-
         taxesSubPanel.setBorder(BorderFactory.createTitledBorder(""));
         taxesSubPanel.setName("taxesSubPanel");
 
@@ -7218,8 +7206,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                         .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                                 .addComponent(lblTaxesPercentage)
                                 .addComponent(spnTaxesPercentage, Alignment.LEADING))
-                        .addComponent(chkUseNotMercenaryExemption)
-                        .addComponent(chkUseClanExemption)
         );
 
         layout.setHorizontalGroup(
@@ -7227,8 +7213,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                         .addGroup(layout.createSequentialGroup()
                                 .addComponent(lblTaxesPercentage)
                                 .addComponent(spnTaxesPercentage))
-                        .addComponent(chkUseNotMercenaryExemption)
-                        .addComponent(chkUseClanExemption)
         );
 
         return taxesSubPanel;
@@ -8241,8 +8225,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         // Taxes
         chkUseTaxes.setSelected(options.isUseTaxes());
         spnTaxesPercentage.setValue(options.getTaxesPercentage());
-        chkUseNotMercenaryExemption.setSelected(options.isUseNotMercenaryExemption());
-        chkUseClanExemption.setSelected(options.isUseClanExemption());
         //endregion Finances Tab
 
         //region Mercenary Tab
@@ -8884,8 +8866,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             //region Taxes
             options.setUseTaxes(chkUseTaxes.isSelected());
             options.setTaxesPercentage((Integer) spnTaxesPercentage.getValue());
-            options.setUseNotMercenaryExemption(chkUseNotMercenaryExemption.isSelected());
-            options.setUseClanExemption(chkUseClanExemption.isSelected());
             //endregion Taxes
             //endregion Finances Tab
 
@@ -9293,8 +9273,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         // Taxes
         chkUseTaxes.setSelected(options.isUseTaxes());
         spnTaxesPercentage.setValue(options.getTaxesPercentage());
-        chkUseClanExemption.setSelected(options.isUseClanExemption());
-        chkUseNotMercenaryExemption.setSelected(options.isUseNotMercenaryExemption());
 
         // Price Multipliers Panel
         spnCommonPartPriceMultiplier.setValue(options.getCommonPartPriceMultiplier());


### PR DESCRIPTION
This PR addresses and optimizes a calculation error in the profits method. Previously, profits were incorrectly failing to discount `Starting Capital` and `Financial Term End Carry Over`, resulting in higher-than-intended taxes and Shares payouts. While fixing this, I also optimized the calculation to better handle large volumes of financial transactions.

Additionally, following a conversation with Nick about Campaign Options (see #4281), I removed the two tax exemption campaign options. The reasoning is that users who want their campaign to be exempt from taxes can simply choose not to enable taxes.