### PR TITLE
Fixed Faction Discount to Tuition, Fixed autoAwards Triggering when Personnel Fail to Graduate

### DIFF
--- a/MekHQ/data/universe/academies/Prestigious Academies.xml
+++ b/MekHQ/data/universe/academies/Prestigious Academies.xml
@@ -5425,7 +5425,7 @@
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Republic Consertvatory</name>
+        <name>Republic Conservatory</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>Established in 3062, the Liao Conservatory of Military Arts is dedicated to training elite soldiers. Students oversee their own studies, balancing learning, practice, and specialized fields, preparing to join veteran or elite commands upon graduation. Despite being briefly renamed the Republic Conservatory, the academy remains steadfast in its mission, emphasizing the cultivation of individual motivation and excellence.</description>
@@ -5467,7 +5467,7 @@
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Republic Consertvatory (Officer)</name>
+        <name>Republic Conservatory (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
         <description>Established in 3062, the Liao Conservatory of Military Arts is dedicated to training elite soldiers. Students oversee their own studies, balancing learning, practice, and specialized fields, preparing to join veteran or elite commands upon graduation. Despite being briefly renamed the Republic Conservatory, the academy remains steadfast in its mission, emphasizing the cultivation of individual motivation and excellence.</description>

--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -702,8 +702,10 @@ public class Academy implements Comparable<Academy> {
         for (String campus : campuses) {
             List<String> factions = campaign.getSystemById(campus).getFactions(campaign.getLocalDate());
 
-            if (!Collections.disjoint(factions, relevantFactions)) {
-                return (double) (factionDiscount / 100);
+            if (Collections.disjoint(factions, relevantFactions)) {
+                return 1.00;
+            } else {
+                return 1 - ((double) factionDiscount / 100);
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -287,24 +287,24 @@ public class EducationController {
         EducationStage educationStage = person.getEduEducationStage();
 
         // is person in transit to the institution?
-        if (educationStage == EducationStage.JOURNEY_TO_CAMPUS) {
+        if (educationStage.isJourneyToCampus()) {
             journeyToAcademy(campaign, person, resources);
             return false;
         }
 
         // is the person on campus and undergoing education
-        if (educationStage == EducationStage.EDUCATION) {
+        if (educationStage.isEducation()) {
             return ongoingEducation(campaign, person, academy, ageBypass, resources);
         }
 
         // if education has concluded and the journey home hasn't started, we begin the journey
-        if ((educationStage == EducationStage.GRADUATING) || (educationStage == EducationStage.DROPPING_OUT)) {
+        if ((educationStage.isGraduating()) || (educationStage.isDroppingOut())) {
             beginJourneyHome(campaign, person, resources);
             return false;
         }
 
         // if we reach this point it means Person is already in transit, so we continue their journey
-        if (educationStage == EducationStage.JOURNEY_FROM_CAMPUS) {
+        if (educationStage.isJourneyFromCampus()) {
             processJourneyHome(campaign, person);
             return false;
         }
@@ -370,8 +370,7 @@ public class EducationController {
             // we use 2 as that would be the value prior the day's decrement
             if (daysOfEducation < 2) {
                 if (graduationPicker(campaign, person, academy, resources)) {
-                    person.setEduEducationStage(EducationStage.GRADUATING);
-                    return true;
+                    return person.getEduEducationStage().isGraduating();
                 } else {
                     return false;
                 }
@@ -393,11 +392,10 @@ public class EducationController {
     private static boolean graduationPicker(Campaign campaign, Person person, Academy academy, ResourceBundle resources) {
         if (academy.isPrepSchool()) {
             graduateChild(campaign, person, academy, resources);
+            return true;
         } else {
             return graduateAdult(campaign, person, academy, resources);
         }
-
-        return true;
     }
 
     /**
@@ -474,7 +472,7 @@ public class EducationController {
             }
         }
 
-        if (person.getEduEducationStage() != EducationStage.GRADUATING) {
+        if (!person.getEduEducationStage().isGraduating()) {
             // It's unlikely we'll ever get canonical destruction or closure dates for all the academies,
             // so no need to check these more than once a year
             if (campaign.getLocalDate().getDayOfYear() == 1) {
@@ -596,12 +594,10 @@ public class EducationController {
         if (diceSize > 0) {
             if ((diceSize == 1) || (roll == 0)) {
                 // we add this limiter to avoid a bad play experience when someone drops out in the final stretch
-                if (person.getEduEducationTime() >= 10) {
+                if (person.getEduEducationTime() < 10) {
                     campaign.addReport(person.getHyperlinkedName() + ' ' + resources.getString("dropOut.text"));
                     ServiceLogger.eduFailed(person, campaign.getLocalDate(), person.getEduAcademyName(), academy.getQualifications().get(person.getEduCourseIndex()));
                     person.setEduEducationStage(EducationStage.DROPPING_OUT);
-                } else {
-                    campaign.addReport(person.getHyperlinkedName() + ' ' + resources.getString("dropOutRejected.text"));
                 }
 
                 return true;
@@ -704,6 +700,8 @@ public class EducationController {
 
             improveSkills(campaign, person, academy, false);
 
+            person.setEduEducationStage(EducationStage.DROPPING_OUT);
+
             return true;
         }
 
@@ -734,6 +732,8 @@ public class EducationController {
                 reportMastersOrDoctorateGain(campaign, person, academy, resources);
             }
 
+            person.setEduEducationStage(EducationStage.GRADUATING);
+
             return true;
         }
 
@@ -756,6 +756,8 @@ public class EducationController {
                 reportMastersOrDoctorateGain(campaign, person, academy, resources);
             }
 
+            person.setEduEducationStage(EducationStage.GRADUATING);
+
             return true;
         }
 
@@ -774,6 +776,9 @@ public class EducationController {
         if (!academy.isMilitary()) {
             reportMastersOrDoctorateGain(campaign, person, academy, resources);
         }
+
+        person.setEduEducationStage(EducationStage.GRADUATING);
+
         return true;
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/enums/education/EducationStage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/education/EducationStage.java
@@ -57,7 +57,7 @@ public enum EducationStage {
         return this == NONE;
     }
 
-    public boolean isJournalToCampus() {
+    public boolean isJourneyToCampus() {
         return this == JOURNEY_TO_CAMPUS;
     }
 


### PR DESCRIPTION
This PR does five things:

- Fixes the faction discount multiplier applied to tuition costs if the person comes from the academy's faction. This was incorrectly applying a *0 multiplier, resulting in 0 c-bill tuitions.
- Fixes autoAwards triggering when personnel fail to graduate. This was caused by faulty logic: failing to graduate is a graduation event _technically_, and autoAwards didn't know that not all graduation events result in actual graduation.
- I optimized the ongoing education method to use booleans rather than enum checks.
- I corrected a typo in the `isJourneyToCampus` method
- I fixed a typo in the spelling of the word `Conservatory` in the prestigious academies xml