### PR TITLE
Fixed Administrative Capacity Displaying while Turnover is Disabled

### DIFF
--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -247,7 +247,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
         gridBagConstraints.weightx = 1.0;
         panInfo.add(lblPersonnel, gridBagConstraints);
 
-        if (getCampaign().getCampaignOptions().isUseAdministrativeStrain()) {
+        if ((getCampaign().getCampaignOptions().isUseRandomRetirement()) && (getCampaign().getCampaignOptions().isUseAdministrativeStrain())) {
             JLabel lblAdministrativeCapacityHead = new JLabel(resourceMap.getString("lblAdministrativeCapacity.text"));
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 0;


### PR DESCRIPTION
This fixes a visual bug that caused Administrative Capacity to still display if the Admin Cap option is enabled, but the global turnover option wasn't.