### PR TITLE
Added Education Level to Company Generator

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -30,7 +30,11 @@ import mekhq.campaign.ExtraData.StringKey;
 import mekhq.campaign.log.MedicalLogger;
 import mekhq.campaign.log.PersonalLogger;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.enums.*;
+import mekhq.campaign.personnel.enums.FamilialRelationshipType;
+import mekhq.campaign.personnel.enums.GenderDescriptors;
+import mekhq.campaign.personnel.enums.PrisonerStatus;
+import mekhq.campaign.personnel.enums.RandomProcreationMethod;
+import mekhq.campaign.personnel.enums.education.EducationLevel;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -348,6 +352,9 @@ public abstract class AbstractProcreation {
             } else if (campaign.getCampaignOptions().isAssignChildrenOfFoundersFounderTag()) {
                 baby.setFounder(baby.getGenealogy().getParents().stream().anyMatch(Person::isFounder));
             }
+
+            // set education
+            baby.setEduHighestEducation(EducationLevel.EARLY_CHILDHOOD);
 
             // Recruit the baby
             campaign.recruitPerson(baby, prisonerStatus, true, true);


### PR DESCRIPTION
When using the company generator, personnel will now be assigned a highest education based on their experience level and age. Children are given the 'Early Childhood' education level; ultra-green adults are assigned 'High School'; while all others are assumed to have graduated from college and have the 'college' education level.

This resolves the issue of children spawning with high school diplomas, when generated through the company generator.

Closes #4319