### PR TITLE
Updated Scenario Modifier Tooltips in CampaignOptionsDialog Properties

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -847,11 +847,11 @@ lblAtbCamOpsDivision.text=CamOps Unit Rating Modifier Divider
 lblAtbCamOpsDivision.toolTipText=<html><body style="width:200px">Many AtB systems modify rolls based on unit rating. Due to how CamOps unit rating is calculated, this can result in receiving the maximum modifier much sooner compared to using the FM:Mr unit rating. To address this, this value divides the CamOps unit rating to determine the modifier applied to AtB's systems.</body></html>
 lblScenarioMod.text=Random Scenario Modifiers
 lblScenarioModMax.text=Maximum:
-lblScenarioModMax.toolTipText=This is the maximum number of random scenario mods that can spawn on for a single Scenario. Excludes fixed modifiers.
+lblScenarioModMax.toolTipText=This is the maximum number of random scenario mods that can spawn on for a single Scenario. Excludes StratCon facility modifiers.
 lblScenarioModChance.text=Chance
-lblScenarioModChance.toolTipText=This is the percentage chance for a random scenario mod to appear for a Scenario.
+lblScenarioModChance.toolTipText=This is the percentage chance for a random scenario mod to appear for a Scenario. Excludes StratCon facility modifiers.
 lblScenarioModBV.text=BV Cap
-lblScenarioModBV.toolTipText=This is the percentage of total BV that can be used for each scenario mods. This affects fixed modifiers, but can be overridden by certain modifiers
+lblScenarioModBV.toolTipText=This is the percentage of total BV that can be used for each scenario mods. This affects StratCon facility modifiers, but can be overridden by certain modifiers.
 chkTrackOriginalUnit.text=Track Original Unit
 chkTrackOriginalUnit.toolTipText=MechWarriors, who have their own unit when recruited, will take the same unit when they go if it is still available.
 chkLimitLanceWeight.text=Limit lance deployment by weight


### PR DESCRIPTION
Tooltips for "lblScenarioModMax", "lblScenarioModChance", and "lblScenarioModBV" have been updated in the CampaignOptionsDialog properties file.

'Fixed' modifiers have been renamed to StratCon facility modifiers for more clarity (this was causing confusion among some users).

Closes #4316