### PR TITLE
Added Option to Include Non-Combatants in Field Kitchen Capacity Calculations

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -330,6 +330,8 @@ chkUseInjuryFatigue.text=Injuries Increase Fatigue (unofficial)
 chkUseInjuryFatigue.toolTipText=If enabled, personnel gain fatigue whenever they suffer injuries during a scenario.
 lblFieldKitchenCapacity.text=Field Kitchen Capacity
 lblFieldKitchenCapacity.toolTipText=How many personnel can be served per Field Kitchen? Reduces effective Fatigue by 1.
+chkFieldKitchenIgnoreNonCombatants.text=Ignore Non-Combatants
+chkFieldKitchenIgnoreNonCombatants.toolTipText=If enabled, non-combatants will not count towards the number of personnel being served by a field kitchen.
 lblFatigueLeaveThreshold.text=Automatic Leave Threshold (unofficial)
 lblFatigueLeaveThreshold.toolTipText=<html>Automatically assign personnel to Leave status once fatigue (including modifiers) has reached this value.<br>Personnel heal fatigue twice as fast while on leave and will automatically return to active duty once their fatigue has returned to 0.<br>Set to 0 to disable.<html>
 

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -75,33 +75,23 @@ public class CampaignOptions {
     public static final double MAXIMUM_WARSHIP_EQUIPMENT_PERCENT = 1.0;
 
     public static String getTechLevelName(final int techLevel) {
-        switch (techLevel) {
-            case TECH_INTRO:
-                return TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_INTRO];
-            case TECH_STANDARD:
-                return TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_STANDARD];
-            case TECH_ADVANCED:
-                return TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_ADVANCED];
-            case TECH_EXPERIMENTAL:
-                return TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_EXPERIMENTAL];
-            case TECH_UNOFFICIAL:
-                return TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_UNOFFICIAL];
-            default:
-                return "Unknown";
-        }
+        return switch (techLevel) {
+            case TECH_INTRO -> TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_INTRO];
+            case TECH_STANDARD -> TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_STANDARD];
+            case TECH_ADVANCED -> TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_ADVANCED];
+            case TECH_EXPERIMENTAL -> TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_EXPERIMENTAL];
+            case TECH_UNOFFICIAL -> TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_UNOFFICIAL];
+            default -> "Unknown";
+        };
     }
 
     public static String getTransitUnitName(final int unit) {
-        switch (unit) {
-            case TRANSIT_UNIT_DAY:
-                return "Days";
-            case TRANSIT_UNIT_WEEK:
-                return "Weeks";
-            case TRANSIT_UNIT_MONTH:
-                return "Months";
-            default:
-                return "Unknown";
-        }
+        return switch (unit) {
+            case TRANSIT_UNIT_DAY -> "Days";
+            case TRANSIT_UNIT_WEEK -> "Weeks";
+            case TRANSIT_UNIT_MONTH -> "Months";
+            default -> "Unknown";
+        };
     }
     //endregion Magic Numbers
 
@@ -325,6 +315,7 @@ public class CampaignOptions {
     private int fatigueRate;
     private boolean useInjuryFatigue;
     private int fieldKitchenCapacity;
+    private boolean fieldKitchenIgnoreNonCombatants;
     private int fatigueLeaveThreshold;
 
     // Family
@@ -998,6 +989,7 @@ public class CampaignOptions {
         setFatigueRate(1);
         setUseInjuryFatigue(true);
         setFieldKitchenCapacity(150);
+        setFieldKitchenIgnoreNonCombatants(true);
         setFatigueLeaveThreshold(13);
         //endregion Turnover and Retention
 
@@ -1548,6 +1540,14 @@ public class CampaignOptions {
 
     public void setFieldKitchenCapacity(final Integer fieldKitchenCapacity) {
         this.fieldKitchenCapacity = fieldKitchenCapacity;
+    }
+
+    public boolean isUseFieldKitchenIgnoreNonCombatants() {
+        return fieldKitchenIgnoreNonCombatants;
+    }
+
+    public void setFieldKitchenIgnoreNonCombatants (final boolean fieldKitchenIgnoreNonCombatants) {
+        this.fieldKitchenIgnoreNonCombatants = fieldKitchenIgnoreNonCombatants;
     }
 
     public Integer getFatigueLeaveThreshold() {
@@ -4626,6 +4626,7 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "fatigueRate", getFatigueRate());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useInjuryFatigue", isUseInjuryFatigue());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "fieldKitchenCapacity", getFieldKitchenCapacity());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "fieldKitchenIgnoreNonCombatants", isUseFieldKitchenIgnoreNonCombatants());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "fatigueLeaveThreshold", getFatigueLeaveThreshold());
         //endregion Retirement
 
@@ -5630,6 +5631,8 @@ public class CampaignOptions {
                     retVal.setUseInjuryFatigue(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("fieldKitchenCapacity")) {
                     retVal.setFieldKitchenCapacity(Integer.parseInt(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("fieldKitchenIgnoreNonCombatants")) {
+                    retVal.setFieldKitchenIgnoreNonCombatants(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("fatigueLeaveThreshold")) {
                     retVal.setFatigueLeaveThreshold(Integer.parseInt(wn2.getTextContent().trim()));
                 //endregion Turnover and Retention

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -341,6 +341,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private JCheckBox chkUseInjuryFatigue;
     private JLabel lblFieldKitchenCapacity;
     private JSpinner spnFieldKitchenCapacity;
+    private JCheckBox chkFieldKitchenIgnoreNonCombatants;
     private JLabel lblFatigueLeaveThreshold;
     private JSpinner spnFatigueLeaveThreshold;
     //endregion Turnover and Retention Tab
@@ -3593,6 +3594,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         chkUseInjuryFatigue = new JCheckBox(resources.getString("chkUseInjuryFatigue.text"));
         chkUseInjuryFatigue.setToolTipText(resources.getString("chkUseInjuryFatigue.toolTipText"));
         chkUseInjuryFatigue.setName("chkUseInjuryFatigue");
+        chkUseInjuryFatigue.setEnabled(campaign.getCampaignOptions().isUseFatigue());
 
         lblFieldKitchenCapacity = new JLabel(resources.getString("lblFieldKitchenCapacity.text"));
         lblFieldKitchenCapacity.setToolTipText(resources.getString("lblFieldKitchenCapacity.toolTipText"));
@@ -3603,6 +3605,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnFieldKitchenCapacity.setToolTipText(resources.getString("lblFieldKitchenCapacity.toolTipText"));
         spnFieldKitchenCapacity.setName("spnFieldKitchenCapacity");
         spnFieldKitchenCapacity.setEnabled(campaign.getCampaignOptions().isUseFatigue());
+
+        chkFieldKitchenIgnoreNonCombatants = new JCheckBox(resources.getString("chkFieldKitchenIgnoreNonCombatants.text"));
+        chkFieldKitchenIgnoreNonCombatants.setToolTipText(resources.getString("chkFieldKitchenIgnoreNonCombatants.toolTipText"));
+        chkFieldKitchenIgnoreNonCombatants.setName("chkFieldKitchenIgnoreNonCombatants");
+        chkFieldKitchenIgnoreNonCombatants.setEnabled(campaign.getCampaignOptions().isUseFatigue());
 
         lblFatigueLeaveThreshold = new JLabel(resources.getString("lblFatigueLeaveThreshold.text"));
         lblFatigueLeaveThreshold.setToolTipText(resources.getString("lblFatigueLeaveThreshold.toolTipText"));
@@ -3633,6 +3640,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                         .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                                 .addComponent(lblFieldKitchenCapacity)
                                 .addComponent(spnFieldKitchenCapacity, Alignment.LEADING))
+                        .addComponent(chkFieldKitchenIgnoreNonCombatants)
                         .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                                 .addComponent(lblFatigueLeaveThreshold)
                                 .addComponent(spnFatigueLeaveThreshold, Alignment.LEADING))
@@ -3648,6 +3656,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                         .addGroup(layout.createSequentialGroup()
                                 .addComponent(lblFieldKitchenCapacity)
                                 .addComponent(spnFieldKitchenCapacity))
+                        .addComponent(chkFieldKitchenIgnoreNonCombatants)
                         .addGroup(layout.createSequentialGroup()
                                 .addComponent(lblFatigueLeaveThreshold)
                                 .addComponent(spnFatigueLeaveThreshold))
@@ -8061,6 +8070,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnFatigueRate.setValue(options.getFatigueRate());
         chkUseInjuryFatigue.setVisible(options.isUseInjuryFatigue());
         spnFieldKitchenCapacity.setValue(options.getFieldKitchenCapacity());
+        chkFieldKitchenIgnoreNonCombatants.setSelected(options.isUseFieldKitchenIgnoreNonCombatants());
         spnFatigueLeaveThreshold.setValue(options.getFatigueLeaveThreshold());
         //endregion Turnover and Retention Tab
 
@@ -8748,6 +8758,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             options.setFatigueRate((Integer) spnFatigueRate.getValue());
             options.setUseInjuryFatigue(chkUseInjuryFatigue.isSelected());
             options.setFieldKitchenCapacity((Integer) spnFieldKitchenCapacity.getValue());
+            options.setFieldKitchenIgnoreNonCombatants(chkFieldKitchenIgnoreNonCombatants.isSelected());
             options.setFatigueLeaveThreshold((Integer) spnFatigueLeaveThreshold.getValue());
             //endregion Turnover and Retention
 
@@ -9397,8 +9408,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             super.addNotify();
             Component c = getParent();
             //  Keep scrolling of the row table in sync with the main table.
-            if (c instanceof JViewport) {
-                JViewport viewport = (JViewport) c;
+            if (c instanceof JViewport viewport) {
                 viewport.addChangeListener(this);
             }
         }


### PR DESCRIPTION
CamOps excludes support staff from field kitchen capacity calculations, which just doesn't feel right to me. Surely Bill the Admin/HR deserves to eat too!

The option added by this PR is enabled by default and prohibits non-combatants from eating at the field kitchen. This allows us to simulate CamOps, but still leave the option open for non-combatants getting served for users who want that (read: me).

Closes #4329

Addendum: while I was fiddling around in `Campaign.java` I figured I'd also do some light refactoring, to clean things up.