### PR TITLE
Update autoconfig calls to explicitly set ground/space state from scenario data, not game or map info

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -465,6 +465,7 @@ public class AtBDynamicScenarioFactory {
 
             if (campaign.getCampaignOptions().isAutoconfigMunitions() || forceTemplate.getAllowAeroBombs()) {
                 MapLocation mapLocation = scenario.getTemplate().mapParameters.getMapLocation();
+                boolean onGround = (mapLocation != MapLocation.LowAtmosphere && mapLocation != MapLocation.Space);
                 int ownerBaseQuality;
                 boolean isPirate = faction.isRebelOrPirate();
 
@@ -504,19 +505,22 @@ public class AtBDynamicScenarioFactory {
                             ((isPirate) ? TeamLoadoutGenerator.UNSET_FILL_RATIO : 1.0f)
                     );
                     rp.isPirate = isPirate;
+                    rp.groundMap = onGround;
+                    rp.spaceEnvironment = (mapLocation == MapLocation.Space);
                     MunitionTree mt = TeamLoadoutGenerator.generateMunitionTree(rp, arrayGeneratedLance, "");
                     tlg.reconfigureEntities(arrayGeneratedLance, factionCode, mt, rp);
                 } else {
                     // Load the fighters with bombs
                     TeamLoadoutGenerator.populateAeroBombs(generatedLance,
                             campaign.getGameYear(),
-                            (mapLocation != MapLocation.Space && mapLocation != MapLocation.LowAtmosphere),
+                            onGround,
                             ownerBaseQuality,
                             isPirate);
                 }
             }
 
             if (forceTemplate.getUseArtillery() && forceTemplate.getDeployOffboard()) {
+
                 deployArtilleryOffBoard(generatedLance);
             }
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -520,7 +520,6 @@ public class AtBDynamicScenarioFactory {
             }
 
             if (forceTemplate.getUseArtillery() && forceTemplate.getDeployOffboard()) {
-
                 deployArtilleryOffBoard(generatedLance);
             }
 

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -713,12 +713,13 @@ public final class BriefingTab extends CampaignGuiTab {
 
         if (getCampaign().getCampaignOptions().isUseAtB() && (scenario instanceof AtBScenario)) {
             ((AtBScenario) scenario).refresh(getCampaign());
+
+            // Autoconfigure munitions for all non-player forces once more, using finalized forces
+            if (getCampaign().getCampaignOptions().isAutoconfigMunitions()) {
+                autoconfigureBotMunitions(((AtBScenario) scenario), chosen);
+            }
         }
 
-        // Autoconfigure munitions for all non-player forces once more, using finalized forces
-        if (getCampaign().getCampaignOptions().isAutoconfigMunitions()) {
-            autoconfigureBotMunitions(scenario, chosen);
-        }
 
         if (!chosen.isEmpty()) {
             // Ensure that the MegaMek year GameOption matches the campaign year
@@ -733,8 +734,11 @@ public final class BriefingTab extends CampaignGuiTab {
      * @param scenario
      * @param chosen
      */
-    private void autoconfigureBotMunitions(Scenario scenario, List<Unit> chosen) {
+    private void autoconfigureBotMunitions(AtBScenario scenario, List<Unit> chosen) {
         Game cGame = getCampaign().getGame();
+        boolean groundMap = scenario.getBoardType() == AtBScenario.T_GROUND;
+        boolean spaceMap = scenario.getBoardType() == AtBScenario.T_SPACE;
+
         ArrayList<String> allyFactionCodes = new ArrayList<>();
         String opforFactionCode = "IS";
         String allyFaction = "IS";
@@ -791,6 +795,8 @@ public final class BriefingTab extends CampaignGuiTab {
                     ((isPirate) ? TeamLoadoutGenerator.UNSET_FILL_RATIO : 1.0f)
             );
             rp.isPirate = isPirate;
+            rp.groundMap = groundMap;
+            rp.spaceEnvironment = spaceMap;
             MunitionTree mt = TeamLoadoutGenerator.generateMunitionTree(rp, entityList, "");
             tlg.reconfigureEntities(entityList, opforFactionCode, mt, rp);
         }


### PR DESCRIPTION
Changes MHQ autoconfig to use the same information in all places.
Rather than relying on the game instance or its map settings, draw location data about Ground and Space maps from the scenario in all cases.
This may not be necessary, but I'd rather be sure here.

Testing:
- Ran all 3 projects' unit tests