### PR TITLE
Added Quarterly Turnover Frequency Option

### DIFF
--- a/MekHQ/resources/mekhq/resources/Personnel.properties
+++ b/MekHQ/resources/mekhq/resources/Personnel.properties
@@ -543,6 +543,8 @@ TurnoverFrequency.WEEKLY.text=Weekly
 TurnoverFrequency.WEEKLY.toolTipText=Turnover check prompts occur weekly.
 TurnoverFrequency.MONTHLY.text=Monthly
 TurnoverFrequency.MONTHLY.toolTipText=Turnover check prompts occur monthly.
+TurnoverFrequency.QUARTERLY.text=Quarterly
+TurnoverFrequency.QUARTERLY.toolTipText=Turnover check prompts occur every three months.
 TurnoverFrequency.ANNUALLY.text=Annually
 TurnoverFrequency.ANNUALLY.toolTipText=Turnover check prompts occur annually.
 

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -18,10 +18,10 @@
  */
 package mekhq;
 
+import megamek.SuiteConstants;
+
 import java.time.LocalDate;
 import java.time.Month;
-
-import megamek.SuiteConstants;
 
 /**
  * These are constants that hold across MekHQ.
@@ -113,8 +113,6 @@ public final class MHQConstants extends SuiteConstants {
     public static final String HEALED_INJURIES_BACKGROUND = "healedInjuriesBackground";
     public static final String PREGNANT_FOREGROUND = "pregnantForeground";
     public static final String PREGNANT_BACKGROUND = "pregnantBackground";
-    public static final String PAID_RETIREMENT_FOREGROUND = "paidRetirementForeground";
-    public static final String PAID_RETIREMENT_BACKGROUND = "paidRetirementBackground";
     public static final String STRATCON_HEX_COORD_FOREGROUND = "stratconHexCoordForeground";
     public static final String FONT_COLOR_NEGATIVE = "fontColorNegative";
     public static final String FONT_COLOR_POSITIVE = "fontColorPositive";

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -132,6 +132,7 @@ import java.io.PrintWriter;
 import java.text.MessageFormat;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.Map.Entry;
@@ -7032,53 +7033,56 @@ public class Campaign implements ITechManager {
             return -1;
         }
 
-        boolean triggerTurnoverPrompt = false;
-
+        boolean triggerTurnoverPrompt;
         switch (campaignOptions.getTurnoverFrequency()) {
-            case NEVER:
-                return -1;
             case WEEKLY:
                 triggerTurnoverPrompt = getLocalDate().getDayOfWeek().equals(DayOfWeek.MONDAY);
                 break;
             case MONTHLY:
-                triggerTurnoverPrompt = getLocalDate().getDayOfMonth() == 1;
+                triggerTurnoverPrompt = getLocalDate().getDayOfMonth() == getLocalDate().lengthOfMonth();
+                break;
+            case QUARTERLY:
+                triggerTurnoverPrompt = (getLocalDate().getDayOfMonth() == getLocalDate().lengthOfMonth())
+                        && (List.of(Month.MARCH, Month.JUNE, Month.SEPTEMBER, Month.DECEMBER).contains(getLocalDate().getMonth()));
                 break;
             case ANNUALLY:
-                triggerTurnoverPrompt = getLocalDate().getDayOfYear() == 1;
+                triggerTurnoverPrompt = getLocalDate().getDayOfYear() == getLocalDate().lengthOfYear();
                 break;
+            default:
+                return -1;
         }
 
-        if (triggerTurnoverPrompt) {
-            String dialogTitle;
-            String dialogBody;
-
-            if (getRetirementDefectionTracker().getRetirees().isEmpty()) {
-                dialogTitle = resources.getString("turnoverRollRequired.text");
-                dialogBody = resources.getString("turnoverDialogDescription.text");
-            } else {
-                dialogTitle = resources.getString("turnoverFinalPayments.text");
-                dialogBody = resources.getString("turnoverPersonnelKilled.text");
-            }
-
-            Object[] options = {
-                    resources.getString("turnoverEmployeeTurnoverDialog.text"),
-                    resources.getString("turnoverAdvanceRegardless"),
-                    resources.getString("turnoverCancel.text")
-            };
-
-            return JOptionPane.showOptionDialog(
-                    null,
-                    dialogBody,
-                    dialogTitle,
-                    JOptionPane.YES_NO_CANCEL_OPTION,
-                    JOptionPane.INFORMATION_MESSAGE,
-                    null,
-                    options,
-                    options[0]
-            );
+        if (!triggerTurnoverPrompt) {
+            return -1;
         }
 
-        return -1;
+        String dialogTitle;
+        String dialogBody;
+
+        if (getRetirementDefectionTracker().getRetirees().isEmpty()) {
+            dialogTitle = resources.getString("turnoverRollRequired.text");
+            dialogBody = resources.getString("turnoverDialogDescription.text");
+        } else {
+            dialogTitle = resources.getString("turnoverFinalPayments.text");
+            dialogBody = resources.getString("turnoverPersonnelKilled.text");
+        }
+
+        Object[] options = {
+                resources.getString("turnoverEmployeeTurnoverDialog.text"),
+                resources.getString("turnoverAdvanceRegardless"),
+                resources.getString("turnoverCancel.text")
+        };
+
+        return JOptionPane.showOptionDialog(
+                null,
+                dialogBody,
+                dialogTitle,
+                JOptionPane.YES_NO_CANCEL_OPTION,
+                JOptionPane.INFORMATION_MESSAGE,
+                null,
+                options,
+                options[0]
+        );
     }
 
     public boolean checkScenariosDue() {

--- a/MekHQ/src/mekhq/campaign/personnel/enums/TurnoverFrequency.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/TurnoverFrequency.java
@@ -26,6 +26,7 @@ public enum TurnoverFrequency {
     NEVER("TurnoverFrequency.NEVER.text", "TurnoverFrequency.NEVER.toolTipText"),
     WEEKLY("TurnoverFrequency.WEEKLY.text", "TurnoverFrequency.WEEKLY.toolTipText"),
     MONTHLY("TurnoverFrequency.MONTHLY.text", "TurnoverFrequency.MONTHLY.toolTipText"),
+    QUARTERLY("TurnoverFrequency.QUARTERLY.text", "TurnoverFrequency.QUARTERLY.toolTipText"),
     ANNUALLY("TurnoverFrequency.ANNUALLY.text", "TurnoverFrequency.ANNUALLY.toolTipText");
 
     private final String name;
@@ -52,6 +53,10 @@ public enum TurnoverFrequency {
 
     public boolean isMonthly() {
         return this == MONTHLY;
+    }
+
+    public boolean isQuarterly() {
+        return this == QUARTERLY;
     }
 
     public boolean isAnnually() {

--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -696,7 +696,9 @@ public class RetirementDefectionDialog extends JDialog {
             }
         }
 
-        if (hqView.getCampaign().getCampaignOptions().getTurnoverFrequency().isMonthly()) {
+        if (hqView.getCampaign().getCampaignOptions().getTurnoverFrequency().isQuarterly()) {
+            retVal = retVal.dividedBy(3);
+        } else if (hqView.getCampaign().getCampaignOptions().getTurnoverFrequency().isMonthly()) {
             retVal = retVal.dividedBy(12);
         } else if (hqView.getCampaign().getCampaignOptions().getTurnoverFrequency().isWeekly()) {
             retVal = retVal.dividedBy(52);

--- a/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/RetirementTableModel.java
@@ -112,53 +112,28 @@ public class RetirementTableModel extends AbstractTableModel {
     }
 
     public int getColumnWidth(int c) {
-        switch (c) {
-            case COL_PERSON:
-            case COL_ASSIGN:
-            case COL_FORCE:
-            case COL_UNIT:
-                return 70;
-            case COL_BONUS_COST:
-            case COL_PAYOUT:
-            case COL_TARGET:
-            case COL_SHARES:
-            case COL_MISC_MOD:
-                return 50;
-            case COL_PAY_BONUS:
-            default:
-                return 20;
-        }
+        return switch (c) {
+            case COL_PERSON, COL_ASSIGN, COL_FORCE, COL_UNIT -> 70;
+            case COL_BONUS_COST, COL_PAYOUT, COL_TARGET, COL_SHARES, COL_MISC_MOD -> 50;
+            default -> 20;
+        };
     }
 
     public int getAlignment(int col) {
-        switch (col) {
-            case COL_PERSON:
-                return SwingConstants.LEFT;
-            case COL_ASSIGN:
-            case COL_FORCE:
-            case COL_UNIT:
-            case COL_BONUS_COST:
-            case COL_PAYOUT:
-            case COL_TARGET:
-            case COL_PAY_BONUS:
-            case COL_SHARES:
-            case COL_MISC_MOD:
-            default:
-                return SwingConstants.CENTER;
+        if (col == COL_PERSON) {
+            return SwingConstants.LEFT;
+        } else {
+            return SwingConstants.CENTER;
         }
     }
 
     @Override
     public boolean isCellEditable(int row, int col) {
-        switch (col) {
-            case COL_PAYOUT:
-                return editPayout;
-            case COL_PAY_BONUS:
-            case COL_MISC_MOD:
-                return true;
-            default:
-                return false;
-        }
+        return switch (col) {
+            case COL_PAYOUT -> editPayout;
+            case COL_PAY_BONUS, COL_MISC_MOD -> true;
+            default -> false;
+        };
     }
 
     @Override
@@ -236,7 +211,9 @@ public class RetirementTableModel extends AbstractTableModel {
             case COL_BONUS_COST:
                 Money bonusCost = RetirementDefectionTracker.getPayoutOrBonusValue(campaign, p);
 
-                if (campaign.getCampaignOptions().getTurnoverFrequency().isMonthly()) {
+                if (campaign.getCampaignOptions().getTurnoverFrequency().isQuarterly()) {
+                    return bonusCost.dividedBy(3).toAmountAndSymbolString();
+                } else if (campaign.getCampaignOptions().getTurnoverFrequency().isMonthly()) {
                     return bonusCost.dividedBy(12).toAmountAndSymbolString();
                 } else if (campaign.getCampaignOptions().getTurnoverFrequency().isWeekly()) {
                     return bonusCost.dividedBy(52).toAmountAndSymbolString();

--- a/MekHQ/userdata/data/universe/ranks.xml
+++ b/MekHQ/userdata/data/universe/ranks.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rankSystems version="0.49.20-SNAPSHOT">
+<rankSystems version="0.50.0-SNAPSHOT">
 </rankSystems>


### PR DESCRIPTION
The turnover frequency option of "quarterly" was implemented in addition to the existing "weekly", "monthly", and "annually" options. This new setting affects the retirement bonus calculation and the turnover check prompts accordingly.

This option was added at discord request and acts as a nice middle-ground between monthly and annual turnover checks.