### PR TITLE
Added Scenario Awards to Post-Scenario autoAward Checks

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/AutoAwardsController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/AutoAwardsController.java
@@ -152,6 +152,16 @@ public class AutoAwardsController {
 
             if (processedData != null) {
                 allAwardData.put(allAwardDataKey, processedData);
+                allAwardDataKey++;
+            }
+        }
+
+        // beginning the processing & filtering of scenario awards
+        if (!scenarioAwards.isEmpty()) {
+            processedData = ScenarioAwardsManager(new ArrayList<>(personnel.keySet()));
+
+            if (processedData != null) {
+                allAwardData.put(allAwardDataKey, processedData);
             }
         }
 


### PR DESCRIPTION
autoAwards will now check for scenario awards at the conclusion of a scenario and not just at the conclusion of a mission. I have no idea why I implemented it that way in the first place, but here we are.