### PR TITLE
Refactored Kill Count and Personnel Filtering Methods

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/AutoAwardsController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/AutoAwardsController.java
@@ -194,42 +194,38 @@ public class AutoAwardsController {
      * Builds a list of personnel autoAwards should process
      */
     private List<UUID> getPersonnel() {
-        List<UUID> personnel = campaign.getActivePersonnel()
+        boolean issuePosthumous = campaign.getCampaignOptions().isIssuePosthumousAwards();
+
+        List<UUID> personnel = campaign.getPersonnel()
                 .stream()
+                .filter(person ->
+                        ((!person.getStatus().isDepartedUnit()) && (!person.getPrisonerStatus().isCurrentPrisoner()) && (!person.hasRole(PersonnelRole.DEPENDENT)))
+                                || ((issuePosthumous) && (person.getStatus().isDead()) && (filterOutPersonnel(person)))
+                )
                 .map(Person::getId)
                 .collect(Collectors.toList());
 
-        // if posthumous Awards are enabled, we add the relevant dead people
-        if (campaign.getCampaignOptions().isIssuePosthumousAwards()) {
-            List<UUID> deadPeople = campaign.getPersonnel()
-                    .stream().filter(person -> person.getStatus().isDead())
-                    .map(Person::getId)
-                    .collect(Collectors.toList());
+        LogManager.getLogger().debug("Personnel {}", personnel);
 
-            LogManager.getLogger().info("deadPeople {}", deadPeople);
-
-            if (!deadPeople.isEmpty()) {
-                personnel.addAll(deadPeople);
-            }
-        }
-
-        // Prisoners and Dependents are not eligible for Awards
-        if (!personnel.isEmpty()) {
-            removeDependentsAndPrisoners(personnel);
-        }
         return personnel;
     }
 
     /**
-     * Filters out anyone with the Prisoner status, or Dependent role
+     * Filters out personnel based on specific criteria.
      *
-     * @param personnel personnel to process
+     * @param person the person to be filtered
+     * @return true if the person should be filtered out, false otherwise
      */
-    private void removeDependentsAndPrisoners(List<UUID> personnel) {
-        if (!personnel.isEmpty()) {
-            personnel.removeIf(person -> (campaign.getPerson(person).hasRole(PersonnelRole.DEPENDENT))
-                    || (campaign.getPerson(person).getPrisonerStatus().isCurrentPrisoner()));
-        }
+    private boolean filterOutPersonnel(Person person) {
+        return !((person.getPrisonerStatus().isCurrentPrisoner()) || (person.hasRole(PersonnelRole.DEPENDENT)))
+                &&
+                !((person.getStatus().isRetired())
+                || (person.getStatus().isResigned())
+                || (person.getStatus().isSacked())
+                || (person.getStatus().isDeserted())
+                || (person.getStatus().isDefected())
+                || (person.getStatus().isMissing())
+                || (person.getStatus().isLeft()));
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/KillAwards.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/KillAwards.java
@@ -297,40 +297,21 @@ public class KillAwards {
          * @return the formation depth or -1 if an invalid size is provided or if the formation kill awards are disabled
          */
         private static int getFormation(Campaign campaign, Award award){
-            int formationDepth;
-
-            switch (award.getSize().toLowerCase()) {
-                case "individual":
-                    formationDepth = 0;
-                    break;
-                case "lance":
-                    formationDepth = 1;
-                    break;
-                case "company":
-                    formationDepth = 2;
-                    break;
-                case "battalion":
-                    formationDepth = 3;
-                    break;
-                case "regiment":
-                    formationDepth = 4;
-                    break;
-                case "brigade":
-                    formationDepth = 5;
-                    break;
-                case "division":
-                    formationDepth = 6;
-                    break;
-                case "corps":
-                    formationDepth = 7;
-                    break;
-                case "army":
-                    formationDepth = 8;
-                    break;
-                default:
+            int formationDepth = switch (award.getSize().toLowerCase()) {
+                case "individual" -> 0;
+                case "lance" -> 1;
+                case "company" -> 2;
+                case "battalion" -> 3;
+                case "regiment" -> 4;
+                case "brigade" -> 5;
+                case "division" -> 6;
+                case "corps" -> 7;
+                case "army" -> 8;
+                default -> {
                     LogManager.getLogger().warn("Award {} from the {} set has invalid size value {}", award.getName(), award.getSet(), award.getSize());
-                    formationDepth = -1;
-            }
+                    yield -1;
+                }
+            };
 
             switch (formationDepth) {
                 case -1:
@@ -405,7 +386,7 @@ public class KillAwards {
          * @param commander the unit commander whose kills are being counted
          * @param filterOtherMissionKills true, if we should only count kills from the mission just completed
          */
-        private static int getIndividualKills(Campaign campaign, Mission mission, UUID commander, boolean filterOtherMissionKills){
+        private static int getIndividualKills(Campaign campaign, Mission mission, UUID commander, boolean filterOtherMissionKills) {
             List<Kill> allKills;
 
             try {
@@ -414,10 +395,14 @@ public class KillAwards {
                 return 0;
             }
 
+            long count = 0;
+
             if (filterOtherMissionKills) {
-                allKills.removeIf(kill -> kill.getMissionId() != mission.getId());
+                count = allKills.stream()
+                        .filter(kill -> kill.getMissionId() == mission.getId())
+                        .count();
             }
 
-            return allKills.size();
+            return (int) count;
         }
     }


### PR DESCRIPTION
Updated the getIndividualKills method in KillAwards.java to use stream API for filtering mission kills. Improved the personnel filtering process in AutoAwardsController.java by combining all conditions into a single stream filter and removing the separate method for removing dependents and prisoners.

Closes #4408