### PR TITLE
Removed 'durationWeeks' Text from Education Tooltip

### DIFF
--- a/MekHQ/resources/mekhq/resources/Education.properties
+++ b/MekHQ/resources/mekhq/resources/Education.properties
@@ -4,7 +4,6 @@ educationLevel.text=Education Level:
 nothingToLearn.text=nothing to learn
 tuition.text=Tuition:
 duration.text=Duration:
-durationWeeks.text=weeks
 durationDays.text=days
 durationAge.text=until %s years old
 distance.text=Travel Time:

--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -926,11 +926,7 @@ public class Academy implements Comparable<Academy> {
                     .append("</b> ").append(' ').append(String.format(resources.getString("durationAge.text"), ageMax)).append("<br>");
         } else {
             tooltip.append("<b>").append(resources.getString("duration.text")).append("</b> ");
-            if ((durationDays / 7) < 1) {
-                tooltip.append(durationDays).append(' ').append(resources.getString("durationDays.text")).append("<br>");
-            } else {
-                tooltip.append(durationDays / 7).append(' ').append(resources.getString("durationWeeks.text")).append("<br>");
-            }
+            tooltip.append(durationDays).append(' ').append(resources.getString("durationDays.text")).append("<br>");
         }
 
         // we need to do a little extra work to get travel time, to cover academies with multiple campuses


### PR DESCRIPTION
The 'durationWeeks' text was removed from the Education properties and the corresponding code in the Academy.java class was updated. Now the education tooltip will always show qualification duration in days. This decision was based on Discord feedback.