### PR TITLE
Mark Medical settings as unofficial

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -296,7 +296,7 @@ chkAdminExperienceLevelIncludeScrounge.toolTipText=All admin personnel will fact
 
 
 # Medical
-medicalPanel.title=Medical
+medicalPanel.title=Medical (Unofficial)
 chkUseAdvancedMedical.text=Use Advanced Medical Rules (Unofficial)
 chkUseAdvancedMedical.toolTipText=Use the Advanced Medical Rules created by Jayof9s (See Advanced_Medical.doc in the docs folder)
 lblHealWaitingPeriod.text=Days to Wait Between Healing Checks by Doctors


### PR DESCRIPTION
I initially thought that MekHQ didn't implement the damage-tracking system Campaign Operations uses for infantry and vehicle crew, only to realize upon opening the code that it does. The confusion lies in the fact that those settings are not marked as unofficial even though changing them violates official rules.

Since I doubt I'm the only person to assume those were optional official rules, I'm updating the label.