### PR TITLE
Expanded autoAwards Coverage to Include 'Prisoner of War'

### DIFF
--- a/MekHQ/data/universe/awards/standard.xml
+++ b/MekHQ/data/universe/awards/standard.xml
@@ -24,17 +24,6 @@
         <item>Ignore</item>
     </award>
     <award>
-        <name>Prisoner of War</name>
-        <description>Taken prisoner during combat.</description>
-        <group>Manual Awards</group>
-        <medal>POWM.png</medal>
-        <ribbon>3-01-1-PrisonerOfWar.png</ribbon>
-        <xp>1</xp>
-        <edge>1</edge>
-        <stackable>true</stackable>
-        <item>Ignore</item>
-    </award>
-    <award>
         <name>Support Person Of The Year</name>
         <description>Awarded to the most outstanding non-combat member of the year.</description>
         <group>Manual Awards</group>
@@ -132,9 +121,21 @@
         <item>Time</item>
     </award>
     <award>
+        <name>Prisoner of War</name>
+        <description>Taken prisoner during combat.</description>
+        <group>Manual Awards</group>
+        <medal>POWM.png</medal>
+        <ribbon>3-01-1-PrisonerOfWar.png</ribbon>
+        <xp>1</xp>
+        <edge>1</edge>
+        <stackable>true</stackable>
+        <item>Misc</item>
+        <range>Prisoner of War</range>
+    </award>
+    <award>
         <name>Medal of Honor</name>
         <description>Distinguished oneself conspicuously by gallantry and intrepidity at the risk of life above and beyond the call of duty.</description>
-        <group>Manual Awards</group>
+        <group>Personal Awards</group>
         <medal>MedalOfHonorM.png</medal>
         <ribbon>1-01-1-MedalOfHonor.png</ribbon>
         <xp>10</xp>
@@ -276,7 +277,7 @@
     <award>
         <name>Ceremonial Duty</name>
         <description>Served as honor guard.</description>
-        <group>Manual Awards</group>
+        <group>Mission Awards</group>
         <ribbon>4-05-1-CeremonialDuty.png</ribbon>
         <xp>1</xp>
         <item>Ceremonial Duty</item>

--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/MiscAwards.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/MiscAwards.java
@@ -70,6 +70,10 @@ public class MiscAwards {
                     if (CeremonialDuty(campaign, award, person, mission)) {
                         eligibleAwards.add(award);
                     }
+                case "prisonerofwar":
+                    if (prisonerOfWar(campaign, award, person)) {
+                        eligibleAwards.add(award);
+                    }
                 default:
             }
         }
@@ -195,6 +199,22 @@ public class MiscAwards {
                 }
             }
         }
+        return false;
+    }
+
+    /**
+     * Checks if a person is a prisoner of war in a given campaign and is eligible to receive an award.
+     *
+     * @param campaign the campaign in which the person is participating
+     * @param award the award to be given
+     * @param person the unique identifier of the person to check
+     * @return true if the person is a prisoner of war and is eligible to receive the award, false otherwise
+     */
+    private static boolean prisonerOfWar(Campaign campaign, Award award, UUID person) {
+        if (award.canBeAwarded(campaign.getPerson(person))) {
+            return campaign.getPerson(person).getStatus().isPoW();
+        }
+
         return false;
     }
 }


### PR DESCRIPTION
Added checks for 'Prisoner of War' eligibility in 'MiscAwards.java'.

The 'Prisoner of War' award was relocated in the 'standard.xml' file for better organization. Additionally, changed group categorizations for 'Medal of Honor' and 'Ceremonial Duty' as these haven't been manual for a while and I must have just forgotten to move them. 