### PR TITLE
Update static faction references with appropriate isX() call

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -332,11 +332,11 @@ public class AtBContract extends Contract {
         // Enemy type: Pirates: -2
         // Rebels/Mercs/Minor factions: -1
         // Clans: +2
-        if (enemyCode.equals("PIR")) {
+        if (Factions.getInstance().getFaction(enemyCode).isPirate()) {
             mod -= 2;
-        } else if (enemyCode.equals("REB") ||
+        } else if (Factions.getInstance().getFaction(enemyCode).isRebel() ||
                 isMinorPower(enemyCode) ||
-                enemyCode.equals("MERC")) {
+                Factions.getInstance().getFaction(enemyCode).isMercenary()) {
             mod -= 1;
         } else if (Factions.getInstance().getFaction(enemyCode).isClan()) {
             mod += 2;

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -656,7 +656,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         int numAttachedBot = 0;
         if (getContract(campaign).getContractType().isCadreDuty()) {
             numAttachedPlayer = 3;
-        } else if (campaign.getFactionCode().equals("MERC")) {
+	} else if (campaign.getFaction().isMercenary()) {
             switch (getContract(campaign).getCommandRights()) {
                 case INTEGRATED:
                     if (campaign.getCampaignOptions().isPlayerControlsAttachedUnits()) {

--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -35,6 +35,7 @@ import mekhq.campaign.stratcon.StratconContractInitializer;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.campaign.universe.RandomFactionGenerator;
 import mekhq.campaign.universe.Systems;
+import mekhq.campaign.universe.Factions;
 import mekhq.gui.FactionComboBox;
 import mekhq.gui.baseComponents.SortedComboBoxModel;
 import mekhq.gui.utilities.JSuggestField;
@@ -472,7 +473,7 @@ public class NewAtBContractDialog extends NewContractDialog {
         AtBContract contract = (AtBContract) this.contract;
         HashSet<String> systems = new HashSet<>();
         if (!contract.getContractType().isGarrisonType()
-                || getCurrentEnemyCode().equals("REB") || getCurrentEnemyCode().equals("PIR")) {
+                || Factions.getInstance().getFaction(getCurrentEnemyCode()).isRebelOrPirate()) {
             for (PlanetarySystem p : RandomFactionGenerator.getInstance().
                     getMissionTargetList(getCurrentEmployerCode(), getCurrentEnemyCode())) {
                 systems.add(p.getName(campaign.getLocalDate()));
@@ -480,7 +481,7 @@ public class NewAtBContractDialog extends NewContractDialog {
         }
 
         if ((contract.getContractType().isGarrisonType() || contract.getContractType().isReliefDuty())
-                && !contract.getEnemyCode().equals("REB")) {
+                && !contract.getEnemy().isRebel()) {
             for (PlanetarySystem p : RandomFactionGenerator.getInstance().
                     getMissionTargetList(getCurrentEnemyCode(), getCurrentEmployerCode())) {
                 systems.add(p.getName(campaign.getLocalDate()));

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -475,8 +475,8 @@ public class ContractSummaryPanel extends JPanel {
     private boolean hasCommandRerolls() {
         // Only allow command clause rerolls for mercenaries and pirates; house units are always integrated
         return allowRerolls
-                && (campaign.getFactionCode().equals("MERC")
-                    || campaign.getFactionCode().equals("PIR"))
+                && (campaign.getFaction().isMercenary()
+                    || campaign.getFaction().isPirate())
                 && (campaign.getContractMarket().getRerollsUsed(contract,
                     ContractMarket.CLAUSE_COMMAND) < cmdRerolls);
     }

--- a/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
+++ b/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
@@ -263,7 +263,7 @@ public class AtBEventProcessor {
     }
 
     public static String getRecruitFaction(Campaign c) {
-        if (c.getFactionCode().equals("MERC")) {
+        if (c.getFaction().isMercenary()) {
             if ((c.getGameYear() > 3055) && (Compute.randomInt(20) == 0)) {
                 ArrayList<String> clans = new ArrayList<>();
                 for (String f : RandomFactionGenerator.getInstance().getCurrentFactions()) {

--- a/MekHQ/unittests/mekhq/campaign/market/ContractMarketAtBGenerationTests.java
+++ b/MekHQ/unittests/mekhq/campaign/market/ContractMarketAtBGenerationTests.java
@@ -63,6 +63,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
         when(campaignOptions.getUnitRatingMethod()).thenReturn(UnitRatingMethod.FLD_MAN_MERCS_REV);
@@ -160,6 +164,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getUnitRatingMod()).thenReturn(unitRating);
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
 
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
@@ -262,6 +270,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
         when(campaignOptions.getUnitRatingMethod()).thenReturn(UnitRatingMethod.FLD_MAN_MERCS_REV);
@@ -362,6 +374,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getUnitRatingMod()).thenReturn(unitRating);
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
 
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
@@ -464,6 +480,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
         when(campaignOptions.getUnitRatingMethod()).thenReturn(UnitRatingMethod.FLD_MAN_MERCS_REV);
@@ -506,6 +526,10 @@ public class ContractMarketAtBGenerationTests {
 
         Faction rebels = mock(Faction.class);
         doReturn(rebels).when(factions).getFaction(eq("REB"));
+
+        Faction mercenary = mock(Faction.class);
+	when(mercenary.isMercenary()).thenReturn(true);
+        doReturn(mercenary).when(factions).getFaction(eq("MERC"));
 
         Systems systems = mock(Systems.class);
         Systems.setInstance(systems);
@@ -566,8 +590,18 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+
         Factions factions = mock(Factions.class);
         Factions.setInstance(factions);
+
+	// Make a fake "MERC" employer for getFaction purposes in the rfg
+        Faction employerFaction = mock(Faction.class);
+        when(employerFaction.isMercenary()).thenReturn(true);
+
+        doReturn(employerFaction).when(factions).getFaction(eq("MERC"));
 
         RandomFactionGenerator rfg = mock(RandomFactionGenerator.class);
         RandomFactionGenerator.setInstance(rfg);
@@ -590,6 +624,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getUnitRatingMod()).thenReturn(unitRating);
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
 
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
@@ -692,6 +730,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
         when(campaignOptions.getUnitRatingMethod()).thenReturn(UnitRatingMethod.FLD_MAN_MERCS_REV);
@@ -784,6 +826,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getUnitRatingMod()).thenReturn(unitRating);
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
 
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
@@ -886,6 +932,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
         when(campaignOptions.getUnitRatingMethod()).thenReturn(UnitRatingMethod.FLD_MAN_MERCS_REV);
@@ -981,6 +1031,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getUnitRatingMod()).thenReturn(unitRating);
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
 
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
@@ -1083,6 +1137,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
         when(campaignOptions.getUnitRatingMethod()).thenReturn(UnitRatingMethod.FLD_MAN_MERCS_REV);
@@ -1183,6 +1241,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getUnitRatingMod()).thenReturn(unitRating);
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
 
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
@@ -1285,6 +1347,10 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(true);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
         when(campaignOptions.getUnitRatingMethod()).thenReturn(UnitRatingMethod.FLD_MAN_MERCS_REV);
@@ -1384,6 +1450,11 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getUnitRatingMod()).thenReturn(unitRating);
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(false);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
 
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
@@ -1485,6 +1556,11 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(false);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
         when(campaignOptions.getUnitRatingMethod()).thenReturn(UnitRatingMethod.FLD_MAN_MERCS_REV);
@@ -1585,6 +1661,11 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
 
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(false);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);
         when(campaignOptions.getUnitRatingMethod()).thenReturn(UnitRatingMethod.FLD_MAN_MERCS_REV);
@@ -1684,6 +1765,11 @@ public class ContractMarketAtBGenerationTests {
         when(campaign.getUnitRatingMod()).thenReturn(unitRating);
         when(campaign.getLocalDate()).thenReturn(LocalDate.ofYearDay(gameYear, 1));
         when(campaign.getGameYear()).thenReturn(gameYear);
+
+        Faction campaignFaction = mock(Faction.class);
+        when(campaignFaction.isMercenary()).thenReturn(false);
+        when(campaignFaction.getShortName()).thenReturn(employer);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
 
         CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(campaignOptions.isVariableContractLength()).thenReturn(false);


### PR DESCRIPTION
In order to facilitate custom mercenary factions, update the mission and contract generation to use the isMercenary() function.

While I was making the changes, I also changed the "PIR" and "REB" references with isPirate and isRebel so as to avoid having mixed call styles.

Also added required mock functions to the unit tests.

resolves MegaMek/mekhq#4318