### PR TITLE
Null protection when generating forces from fixed scenarios like Base Defense

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1433,13 +1433,18 @@ public class AtBDynamicScenarioFactory {
         // Strip roles that are not infantry or battle armor, and remove the artillery role
         Map<Integer, Collection<MissionRole>> transportedRoles = new HashMap<>();
 
-        transportedRoles.put(UnitType.INFANTRY, requiredRoles.containsKey(UnitType.INFANTRY) ?
-                new ArrayList<>(requiredRoles.get(UnitType.INFANTRY)) : new ArrayList<>());
-        transportedRoles.get(UnitType.INFANTRY).remove((MissionRole.ARTILLERY));
+        if (requiredRoles != null) {
 
-        transportedRoles.put(UnitType.BATTLE_ARMOR, requiredRoles.containsKey(UnitType.BATTLE_ARMOR) ?
-                new ArrayList<>(requiredRoles.get(UnitType.BATTLE_ARMOR)) : new ArrayList<>());
-        transportedRoles.get(UnitType.BATTLE_ARMOR).remove((MissionRole.ARTILLERY));
+            transportedRoles.put(UnitType.INFANTRY, requiredRoles.containsKey(UnitType.INFANTRY) ?
+                    new ArrayList<>(requiredRoles.get(UnitType.INFANTRY)) :
+                    new ArrayList<>());
+            transportedRoles.get(UnitType.INFANTRY).remove((MissionRole.ARTILLERY));
+
+            transportedRoles.put(UnitType.BATTLE_ARMOR, requiredRoles.containsKey(UnitType.BATTLE_ARMOR) ?
+                    new ArrayList<>(requiredRoles.get(UnitType.BATTLE_ARMOR)) :
+                    new ArrayList<>());
+            transportedRoles.get(UnitType.BATTLE_ARMOR).remove((MissionRole.ARTILLERY));
+        }
 
         List<Entity> transportedUnits = new ArrayList<>();
 


### PR DESCRIPTION
Fixes #4429.

The 'fixed' scenarios like Base Defense, which are generated via code rather than using scenario template XMLs, call methods in AtBDynamicScenarioFactory so they do not have the same support for passing roles.  For now they pass null for the required roles parameter, which requires a bit of extra handling.

There should be some consideration to consolidating these scenario types to use the same template system as the standard scenarios, both for streamlining and to make it easier to customize them at the user/player level.