### PR TITLE
Reordered Asset Removal and Event Trigger in ManageAssetsDialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/ManageAssetsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ManageAssetsDialog.java
@@ -209,18 +209,13 @@ public class ManageAssetsDialog extends JDialog {
 
         @Override
         public String getColumnName(int column) {
-            switch (column) {
-                case COL_NAME:
-                    return "Name";
-                case COL_VALUE:
-                    return "Value";
-                case COL_SCHEDULE:
-                    return "Pay Frequency";
-                case COL_INCOME:
-                    return "Income";
-                default:
-                    return "?";
-            }
+            return switch (column) {
+                case COL_NAME -> "Name";
+                case COL_VALUE -> "Value";
+                case COL_SCHEDULE -> "Pay Frequency";
+                case COL_INCOME -> "Income";
+                default -> "?";
+            };
         }
 
         @Override
@@ -256,26 +251,18 @@ public class ManageAssetsDialog extends JDialog {
         }
 
         public int getColumnWidth(int c) {
-            switch (c) {
-                default:
-                    return 10;
-            }
+            return 10;
         }
 
         public int getAlignment(int col) {
-            switch (col) {
-                case COL_NAME:
-                    return SwingConstants.LEFT;
-                default:
-                    return SwingConstants.RIGHT;
+            if (col == COL_NAME) {
+                return SwingConstants.LEFT;
             }
+            return SwingConstants.RIGHT;
         }
 
         public String getTooltip(int row, int col) {
-            switch (col) {
-                default:
-                    return null;
-            }
+            return null;
         }
 
         public Renderer getRenderer() {

--- a/MekHQ/src/mekhq/gui/dialog/ManageAssetsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ManageAssetsDialog.java
@@ -163,14 +163,15 @@ public class ManageAssetsDialog extends JDialog {
     }
 
     private void deleteAsset() {
-        campaign.getFinances().getAssets().remove(assetTable.getSelectedRow());
         MekHQ.triggerEvent(new AssetRemovedEvent(assetModel.getAssetAt(assetTable.getSelectedRow())));
+        campaign.getFinances().getAssets().remove(assetTable.getSelectedRow());
         refreshTable();
     }
 
     private void refreshTable() {
         int selectedRow = assetTable.getSelectedRow();
         assetModel.setData(campaign.getFinances().getAssets());
+
         if (selectedRow != -1) {
             if (assetTable.getRowCount() > 0) {
                 if (assetTable.getRowCount() == selectedRow) {
@@ -277,8 +278,8 @@ public class ManageAssetsDialog extends JDialog {
             }
         }
 
-        public AssetTableModel.Renderer getRenderer() {
-            return new AssetTableModel.Renderer();
+        public Renderer getRenderer() {
+            return new Renderer();
         }
 
         public class Renderer extends DefaultTableCellRenderer {


### PR DESCRIPTION
The asset removal event was being called after the asset had been removed, resulting in an out-of-index error. This PR just re-orders them so that the object still exists at the called index when the event occurs, it is then removed once processing has been completed.

Closes #4437