### PR TITLE
Corrected Award File References

### DIFF
--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -380,6 +380,13 @@ public class PersonViewPanel extends JScrollablePanel {
         return boxRibbons;
     }
 
+    /**
+     * Returns the number of image tiers for an award based on the maximum number of tiers and the number of awards received.
+     *
+     * @param award The award for which to calculate the number of tiers.
+     * @param maximumTiers The maximum number of tiers allowed for the award.
+     * @return The number of tiers for the award. The value is clamped between 1 and the maximum number of tiers.
+     */
     private int getAwardTierCount(Award award, int maximumTiers) {
         int numAwards = person.getAwardController().getNumberOfAwards(award);
         int tierSize = campaign.getCampaignOptions().getAwardTierSize();
@@ -387,11 +394,10 @@ public class PersonViewPanel extends JScrollablePanel {
         int divisionResult = numAwards / tierSize;
         int addition = (tierSize == 1) ? 0 : 1;
 
-        int awardTierCount = MathUtility.clamp(
+        return MathUtility.clamp(
                 divisionResult + addition,
                 1, maximumTiers
         );
-        return awardTierCount;
     }
 
     /**
@@ -404,14 +410,14 @@ public class PersonViewPanel extends JScrollablePanel {
                 .getAwards()
                 .stream().filter(a -> a.getNumberOfMedalFiles() > 0)
                 .sorted()
-                .collect(Collectors.toList());
+                .toList();
 
         for (Award award : awards) {
             JLabel medalLabel = new JLabel();
 
             Image medal;
             try {
-                int maximumTiers = award.getNumberOfRibbonFiles();
+                int maximumTiers = award.getNumberOfMedalFiles();
                 int awardTierCount = getAwardTierCount(award, maximumTiers);
 
                 String medalFileName = award.getMedalFileName(awardTierCount);
@@ -460,7 +466,7 @@ public class PersonViewPanel extends JScrollablePanel {
 
             Image miscAward;
             try {
-                int maximumTiers = award.getNumberOfRibbonFiles();
+                int maximumTiers = award.getNumberOfMiscFiles();
                 int awardTierCount = getAwardTierCount(award, maximumTiers);
 
                 String miscFileName = award.getMiscFileName(awardTierCount);


### PR DESCRIPTION
References to RibbonFiles were corrected to MedalFiles and MiscFiles allowing the correct file to be fetched.

Closes #4448