### PR TITLE
Added Nag for Inability to Afford Next Jump

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -346,6 +346,11 @@ UnresolvedStratConContactsNagDialog.text=You have unresolved contacts on the Str
 InvalidFactionNagDialog.title=Invalid Faction
 InvalidFactionNagDialog.text=Your campaign faction is invalid. Either it has not yet been created, or it has been destroyed.\n\nPlease pick a new faction in campaign options.\nAdvance day anyway?
 
+
+### UnableToAffordJumpNagDialog Class
+UnableToAffordJumpNagDialog.title=Unable to Afford Jump
+UnableToAffordJumpNagDialog.text=You are unable to afford your next jump.\n\nAdvance day anyway?
+
 #### Report Dialogs
 ### CargoReportDialog Class
 CargoReportDialog.title=Cargo Report
@@ -723,10 +728,10 @@ optionUnresolvedStratConContactsNag.text=Hide StratCon Unresolved Contacts Nag
 optionUnresolvedStratConContactsNag.toolTipText=This allows you to ignore the daily warning for not having resolved all active contacts.
 optionOutstandingScenariosNag.text=Hide Outstanding Scenarios Nag
 optionOutstandingScenariosNag.toolTipText=This allows you to ignore the daily warning for having unfinished scenarios on the current day.
-optionCargoCapacityNag.text=Hide Exceeded Cargo Capacity Nag
-optionCargoCapacityNag.toolTipText=This allows you to ignore the daily warning for having exceeded your available cargo capacity.
 optionInvalidFactionNag.text=Hide Invalid Faction Nag
 optionInvalidFactionNag.toolTipText=This allows you to ignore the daily warning for having an invalid faction.
+optionUnableToAffordJumpNag.text=Hide Unable to Afford Next Jump Nag
+optionUnableToAffordJumpNag.toolTipText=This allows you to ignore the daily warning when unable to afford a jump.
 ## Miscellaneous Tab
 miscellaneousTab.title=Miscellaneous Options
 lblUserDir.text=User Files Directory:

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -176,6 +176,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String NAG_UNRESOLVED_STRATCON_CONTACTS = "nagUnresolvedStratConContacts";
     public static final String NAG_OUTSTANDING_SCENARIOS = "nagOutstandingScenarios";
     public static final String NAG_INVALID_FACTION = "nagInvalidFaction";
+    public static final String NAG_UNABLE_TO_AFFORD_JUMP = "nagUnableToAffordJump";
     // endregion Nag Tab
 
     // region Miscellaneous Options

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2447,6 +2447,11 @@ public class CampaignGUI extends JPanel {
             return;
         }
 
+        if (new UnableToAffordJumpNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
+            evt.cancel();
+            return;
+        }
+
         if (new InsufficientAstechsNagDialog(getFrame(), getCampaign()).showDialog().isCancelled()) {
             evt.cancel();
             return;

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -159,6 +159,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     private JCheckBox optionUnresolvedStratConContactsNag;
     private JCheckBox optionOutstandingScenariosNag;
     private JCheckBox optionInvalidFactionNag;
+    private JCheckBox optionUnableToAffordJumpNag;
     //endregion Nag Tab
 
     //region Miscellaneous
@@ -915,6 +916,10 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         optionInvalidFactionNag.setToolTipText(resources.getString("optionInvalidFactionNag.toolTipText"));
         optionInvalidFactionNag.setName("optionInvalidFactionNag");
 
+        optionUnableToAffordJumpNag = new JCheckBox(resources.getString("optionUnableToAffordJumpNag.text"));
+        optionUnableToAffordJumpNag.setToolTipText(resources.getString("optionUnableToAffordJumpNag.toolTipText"));
+        optionUnableToAffordJumpNag.setName("optionUnableToAffordJumpNag");
+
         // Layout the UI
         final JPanel panel = new JPanel();
         panel.setName("nagPanel");
@@ -938,6 +943,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                         .addComponent(optionUnresolvedStratConContactsNag)
                         .addComponent(optionOutstandingScenariosNag)
                         .addComponent(optionInvalidFactionNag)
+                        .addComponent(optionUnableToAffordJumpNag)
         );
 
         layout.setHorizontalGroup(
@@ -955,6 +961,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                         .addComponent(optionUnresolvedStratConContactsNag)
                         .addComponent(optionOutstandingScenariosNag)
                         .addComponent(optionInvalidFactionNag)
+                        .addComponent(optionUnableToAffordJumpNag)
         );
 
         return panel;
@@ -1215,6 +1222,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS, optionUnresolvedStratConContactsNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_OUTSTANDING_SCENARIOS, optionOutstandingScenariosNag.isSelected());
         MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INVALID_FACTION, optionInvalidFactionNag.isSelected());
+        MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP, optionUnableToAffordJumpNag.isSelected());
 
         PreferenceManager.getClientPreferences().setUserDir(txtUserDir.getText());
         PreferenceManager.getInstance().save();
@@ -1330,6 +1338,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         optionUnresolvedStratConContactsNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS));
         optionOutstandingScenariosNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_OUTSTANDING_SCENARIOS));
         optionInvalidFactionNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INVALID_FACTION));
+        optionUnableToAffordJumpNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP));
 
         txtUserDir.setText(PreferenceManager.getClientPreferences().getUserDir());
         spnStartGameDelay.setValue(MekHQ.getMHQOptions().getStartGameDelay());

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog.nagDialogs;
+
+import mekhq.MHQConstants;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.gui.baseComponents.AbstractMHQNagDialog;
+
+import javax.swing.*;
+
+public class UnableToAffordJumpNagDialog extends AbstractMHQNagDialog {
+    private static boolean isUnableToAffordNextJump (Campaign campaign) {
+        return campaign.getFunds().isLessThan(campaign.calculateCostPerJump(true, campaign.getCampaignOptions().isEquipmentContractBase()));
+    }
+
+    //region Constructors
+    public UnableToAffordJumpNagDialog(final JFrame frame, final Campaign campaign) {
+        super(frame, "UnableToAffordJumpNagDialog", "UnableToAffordJumpNagDialog.title",
+                "UnableToAffordJumpNagDialog.text", campaign, MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP);
+    }
+    //endregion Constructors
+
+    @Override
+    protected boolean checkNag() {
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(getKey())
+                && isUnableToAffordNextJump(getCampaign());
+    }
+}


### PR DESCRIPTION
A new nag warning has been implemented when the campaign cannot afford the next jump. This includes adding a new checkbox option in the MHQOptionsDialog, creating a new UnableToAffordJumpNagDialog class, and appropriate constant and GUI property updates for the new nag option.

This will assist players in being aware of their campaign fund status related to jump affordability. Previously, days would just keep advancing until the user noticed the report error. This was particularly frustrating when using advance multiple days, as there is no way to cancel out of the day advance to address the issue.

Closes #4327