### PR TITLE
Removed Paid Retirement Color Options

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -109,8 +109,6 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     private ColourSelectorButton optionHealedInjuriesBackground;
     private ColourSelectorButton optionPregnantForeground;
     private ColourSelectorButton optionPregnantBackground;
-    private ColourSelectorButton optionPaidRetirementForeground;
-    private ColourSelectorButton optionPaidRetirementBackground;
     private ColourSelectorButton optionStratConHexCoordForeground;
     private ColourSelectorButton optionFontColorNegative;
     private ColourSelectorButton optionFontColorWarning;
@@ -485,10 +483,6 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
 
         optionPregnantBackground = new ColourSelectorButton(resources.getString("optionPregnantBackground.text"));
 
-        optionPaidRetirementForeground = new ColourSelectorButton(resources.getString("optionPaidRetirementForeground.text"));
-
-        optionPaidRetirementBackground = new ColourSelectorButton(resources.getString("optionPaidRetirementBackground.text"));
-
         optionStratConHexCoordForeground = new ColourSelectorButton(resources.getString("optionStratConHexCoordForeground.text"));
 
         optionFontColorNegative = new ColourSelectorButton(resources.getString("optionFontColorNegative.text"));
@@ -555,9 +549,6 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                 .addComponent(optionPregnantForeground)
                                 .addComponent(optionPregnantBackground, Alignment.TRAILING))
                         .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                .addComponent(optionPaidRetirementForeground)
-                                .addComponent(optionPaidRetirementBackground, Alignment.TRAILING))
-                        .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                                 .addComponent(optionStratConHexCoordForeground))
                         .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                                 .addComponent(optionFontColorNegative)
@@ -613,9 +604,6 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                         .addGroup(layout.createSequentialGroup()
                                 .addComponent(optionPregnantForeground)
                                 .addComponent(optionPregnantBackground))
-                        .addGroup(layout.createSequentialGroup()
-                                .addComponent(optionPaidRetirementForeground)
-                                .addComponent(optionPaidRetirementBackground))
                         .addGroup(layout.createSequentialGroup()
                                 .addComponent(optionStratConHexCoordForeground))
                         .addGroup(layout.createSequentialGroup()


### PR DESCRIPTION
The color options for paid retirement status in the MHQOptionsDialog were removed. This includes both the background and foreground options. These changes simplify the user interface and reduce clutter, as these options were vestigial their implementation having been removed in 49.20.