### PR TITLE
Added Window Closing Event to PersonnelMarketDialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -48,6 +48,8 @@ import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.List;
 import java.util.*;
 
@@ -125,6 +127,13 @@ public class PersonnelMarketDialog extends JDialog {
         setTitle("Personnel Market");
         setName("Form");
         getContentPane().setLayout(new BorderLayout());
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                closeOrCancelActionPerformed();
+            }
+        });
 
         panelFilterBtns.setLayout(new GridBagLayout());
 
@@ -235,7 +244,7 @@ public class PersonnelMarketDialog extends JDialog {
             }
             final SortOrder sortOrder = column.getDefaultSortOrder();
             if (sortOrder != null) {
-                sortKeys.add(new RowSorter.SortKey(column.ordinal(), sortOrder));
+                sortKeys.add(new SortKey(column.ordinal(), sortOrder));
             }
         }
         sorter.setSortKeys(sortKeys);
@@ -413,11 +422,19 @@ public class PersonnelMarketDialog extends JDialog {
     }
 
     private void btnCloseActionPerformed(ActionEvent evt) {
+        LogManager.getLogger().info("btnClose");
+        closeOrCancelActionPerformed();
+    }
+
+    private void closeOrCancelActionPerformed() {
         selectedPerson = null;
+
         personnelMarket.setPaidRecruitment(radioPaidRecruitment.isSelected());
+
         if (radioPaidRecruitment.isSelected()) {
             personnelMarket.setPaidRecruitRole((PersonnelRole) comboRecruitRole.getSelectedItem());
         }
+
         setVisible(false);
     }
 


### PR DESCRIPTION
A `WindowAdapter` was added to the `PersonnelMarketDialog` class, which triggers an update to paid recruitment when the window is closed.

This action, `closeOrCancelActionPerformed()`, was extracted from `btnCloseActionPerformed()` to be reusable. This method ensures that certain cleanup activities are performed whether the dialog is closed via the close button or by manually closing the window. Previously, they would only run when the window was closed via the close button.

Closes #4335