### PR TITLE
Automated Unit Site Location Change when Entering Transit and Arrival States

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3197,6 +3197,10 @@ public class Campaign implements ITechManager {
                 continue;
             }
 
+            if (getLocalDate().equals(contract.getStartDate())) {
+                getUnits().forEach(unit -> unit.setSite(contract.getRepairLocation(getUnitRatingMod())));
+            }
+
             if (getLocalDate().getDayOfWeek() == DayOfWeek.MONDAY) {
                 int deficit = getDeploymentDeficit(contract);
                 if (deficit > 0) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3197,10 +3197,6 @@ public class Campaign implements ITechManager {
                 continue;
             }
 
-            if (getLocalDate().equals(contract.getStartDate())) {
-                getUnits().forEach(unit -> unit.setSite(contract.getRepairLocation(getUnitRatingMod())));
-            }
-
             if (getLocalDate().getDayOfWeek() == DayOfWeek.MONDAY) {
                 int deficit = getDeploymentDeficit(contract);
                 if (deficit > 0) {

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -23,7 +23,6 @@ import mekhq.MekHQ;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.event.NewDayEvent;
 import mekhq.campaign.event.OptionsChangedEvent;
-import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.enums.MHQTabType;
@@ -35,7 +34,6 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.Objects;
 import java.util.ResourceBundle;
 
 /**
@@ -129,7 +127,7 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
 
         //the actual map
         panMap = new InterstellarMapPanel(getCampaign(), getCampaignGui());
-        // let's go ahead and zoom in on the current location
+        // lets go ahead and zoom in on the current location
         panMap.setSelectedSystem(getCampaign().getLocation().getCurrentSystem());
         panMapView.add(panMap, BorderLayout.CENTER);
 
@@ -179,29 +177,28 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
         if (panMap.getJumpPath().isEmpty()) {
             return;
         }
-
         getCampaign().getLocation().setJumpPath(panMap.getJumpPath());
-
         refreshPlanetView();
         getCampaignGui().refreshLocation();
-
         panMap.setJumpPath(new JumpPath());
         panMap.repaint();
-
-        getCampaign().getUnits().forEach(unit -> unit.setSite(Unit.SITE_BAY));
     }
 
     private void refreshSystemView() {
         JumpPath path = panMap.getJumpPath();
         if (null != path && !path.isEmpty()) {
             scrollPlanetView.setViewportView(new JumpPathViewPanel(path, getCampaign()));
-            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
+            SwingUtilities.invokeLater(() -> {
+                scrollPlanetView.getVerticalScrollBar().setValue(0);
+            });
             return;
         }
         PlanetarySystem system = panMap.getSelectedSystem();
         if (null != system) {
             scrollPlanetView.setViewportView(new PlanetViewPanel(system, getCampaign()));
-            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
+            SwingUtilities.invokeLater(() -> {
+                scrollPlanetView.getVerticalScrollBar().setValue(0);
+            });
         }
     }
 
@@ -209,14 +206,18 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
         JumpPath path = panMap.getJumpPath();
         if (null != path && !path.isEmpty()) {
             scrollPlanetView.setViewportView(new JumpPathViewPanel(path, getCampaign()));
-            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
+            SwingUtilities.invokeLater(() -> {
+                scrollPlanetView.getVerticalScrollBar().setValue(0);
+            });
             return;
         }
         int pos = panSystem.getSelectedPlanetPosition();
         PlanetarySystem system = panMap.getSelectedSystem();
         if (null != system) {
             scrollPlanetView.setViewportView(new PlanetViewPanel(system, getCampaign(), pos));
-            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
+            SwingUtilities.invokeLater(() -> {
+                scrollPlanetView.getVerticalScrollBar().setValue(0);
+            });
         }
     }
 
@@ -263,9 +264,9 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        if (Objects.equals(e.getSource(), panMap)) {
+        if (e.getSource() == panMap) {
             refreshSystemView();
-        } else if (Objects.equals(e.getSource(), panSystem)) {
+        } else if (e.getSource() == panSystem) {
             refreshPlanetView();
         }
     }

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -23,6 +23,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.event.NewDayEvent;
 import mekhq.campaign.event.OptionsChangedEvent;
+import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.enums.MHQTabType;
@@ -34,6 +35,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 /**
@@ -127,7 +129,7 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
 
         //the actual map
         panMap = new InterstellarMapPanel(getCampaign(), getCampaignGui());
-        // lets go ahead and zoom in on the current location
+        // let's go ahead and zoom in on the current location
         panMap.setSelectedSystem(getCampaign().getLocation().getCurrentSystem());
         panMapView.add(panMap, BorderLayout.CENTER);
 
@@ -177,47 +179,44 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
         if (panMap.getJumpPath().isEmpty()) {
             return;
         }
+
         getCampaign().getLocation().setJumpPath(panMap.getJumpPath());
+
         refreshPlanetView();
         getCampaignGui().refreshLocation();
+
         panMap.setJumpPath(new JumpPath());
         panMap.repaint();
+
+        getCampaign().getUnits().forEach(unit -> unit.setSite(Unit.SITE_BAY));
     }
 
-    protected void refreshSystemView() {
+    private void refreshSystemView() {
         JumpPath path = panMap.getJumpPath();
         if (null != path && !path.isEmpty()) {
             scrollPlanetView.setViewportView(new JumpPathViewPanel(path, getCampaign()));
-            SwingUtilities.invokeLater(() -> {
-                scrollPlanetView.getVerticalScrollBar().setValue(0);
-            });
+            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
             return;
         }
         PlanetarySystem system = panMap.getSelectedSystem();
         if (null != system) {
             scrollPlanetView.setViewportView(new PlanetViewPanel(system, getCampaign()));
-            SwingUtilities.invokeLater(() -> {
-                scrollPlanetView.getVerticalScrollBar().setValue(0);
-            });
+            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
         }
     }
 
-    protected void refreshPlanetView() {
+    private void refreshPlanetView() {
         JumpPath path = panMap.getJumpPath();
         if (null != path && !path.isEmpty()) {
             scrollPlanetView.setViewportView(new JumpPathViewPanel(path, getCampaign()));
-            SwingUtilities.invokeLater(() -> {
-                scrollPlanetView.getVerticalScrollBar().setValue(0);
-            });
+            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
             return;
         }
         int pos = panSystem.getSelectedPlanetPosition();
         PlanetarySystem system = panMap.getSelectedSystem();
         if (null != system) {
             scrollPlanetView.setViewportView(new PlanetViewPanel(system, getCampaign(), pos));
-            SwingUtilities.invokeLater(() -> {
-                scrollPlanetView.getVerticalScrollBar().setValue(0);
-            });
+            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
         }
     }
 
@@ -264,9 +263,9 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        if (e.getSource() == panMap) {
+        if (Objects.equals(e.getSource(), panMap)) {
             refreshSystemView();
-        } else if (e.getSource() == panSystem) {
+        } else if (Objects.equals(e.getSource(), panSystem)) {
             refreshPlanetView();
         }
     }


### PR DESCRIPTION
This update adds a function in the `MapTab` class that sets the site of each unit in the campaign to transport bay when first entering transit.

In the Campaign class, a function was added that sets the site of each unit to the appropriate repair location when an AtB Contract starts.

Closes #2563