### PR TITLE
Adjusted UI layout and Improved Text Handling for Personnel Market

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/randomEvents/PersonalityController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/randomEvents/PersonalityController.java
@@ -121,7 +121,7 @@ public class PersonalityController {
 
         // next we build a string that contains all the descriptions
         // these CSS tags are needed to avoid overspilling on the AtB Personnel Market
-        StringBuilder personalityDescription = new StringBuilder("<html><span style='display: inline-block; width: 200px;'>");
+        StringBuilder personalityDescription = new StringBuilder();
 
         String firstName = person.getFirstName();
         String pronoun = GenderDescriptors.HE_SHE_THEY.getDescriptorCapitalized(person.getGender());
@@ -143,9 +143,6 @@ public class PersonalityController {
             personalityDescription.append(' ');
             personalityDescription.append(String.format(person.getPersonalityQuirk().getDescription(), firstName));
         }
-
-        // close off the CSS tags
-        personalityDescription.append("</span></html>");
 
         // finally we set the description in place
         person.setPersonalityDescription(personalityDescription.toString());

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -254,9 +254,9 @@ public class PersonnelMarketDialog extends JDialog {
         tablePersonnel.setShowGrid(false);
         scrollTablePersonnel.setViewportView(tablePersonnel);
 
-        scrollPersonnelView.setMinimumSize(new Dimension(500, 600));
-        scrollPersonnelView.setPreferredSize(new Dimension(500, 600));
-        scrollPersonnelView.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPersonnelView.setMinimumSize(new Dimension(200, 600));
+        scrollPersonnelView.setPreferredSize(new Dimension(200, 600));
+        scrollPersonnelView.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
         scrollPersonnelView.setViewportView(null);
 
         panelMain.setLayout(new BorderLayout());
@@ -508,7 +508,9 @@ public class PersonnelMarketDialog extends JDialog {
                  name = "Pilot";
              }
              tabUnit.add(name, new PersonViewPanel(selectedPerson, campaign, hqView));
-             MechViewPanel mvp = new MechViewPanel();
+             MechViewPanel mvp = new MechViewPanel(200, 400, true);
+             tabUnit.setMinimumSize(new Dimension(200, 400));
+             tabUnit.setPreferredSize(new Dimension(200, 400));
              mvp.setMech(en, true);
              tabUnit.add("Unit", mvp);
              scrollPersonnelView.setViewportView(tabUnit);

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static megamek.client.ui.WrapLayout.wordWrap;
 import static mekhq.campaign.personnel.Person.getLoyaltyName;
 
 /**
@@ -201,7 +202,7 @@ public class PersonViewPanel extends JScrollablePanel {
             txtDesc.setName("personalityDescription");
             txtDesc.setEditable(false);
             txtDesc.setContentType("text/html");
-            txtDesc.setText(MarkdownRenderer.getRenderedHtml(person.getPersonalityDescription()));
+            txtDesc.setText(MarkdownRenderer.getRenderedHtml(wordWrap(person.getPersonalityDescription(), 200)));
             txtDesc.setBorder(BorderFactory.createTitledBorder(resourceMap.getString("pnlPersonality.title")));
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 0;
@@ -219,7 +220,7 @@ public class PersonViewPanel extends JScrollablePanel {
             txtDesc.setName("txtDesc");
             txtDesc.setEditable(false);
             txtDesc.setContentType("text/html");
-            txtDesc.setText(MarkdownRenderer.getRenderedHtml(person.getBiography()));
+            txtDesc.setText(MarkdownRenderer.getRenderedHtml(wordWrap(person.getBiography(), 200)));
             txtDesc.setBorder(BorderFactory.createCompoundBorder(
                     BorderFactory.createTitledBorder(resourceMap.getString("pnlDescription.title")),
                     BorderFactory.createEmptyBorder(0, 2, 2, 2)));


### PR DESCRIPTION
Modified the dimensions of the PersonnelMarketDialog and the tabUnit in the MekHQ application interface to be more compact and user-friendly. Improved handling of text in both the PersonalityController and PersonViewPanel by removing inline CSS and incorporating word wrap.

This PR requires https://github.com/MegaMek/megamek/pull/5780 and will fail while that PR remains unmerged.

Closes #4474