### PR TITLE
Marked 'FM: Mercenaries (rev)' Unit Rating Method as Deprecated

### DIFF
--- a/MekHQ/resources/mekhq/resources/Rating.properties
+++ b/MekHQ/resources/mekhq/resources/Rating.properties
@@ -6,4 +6,4 @@
 # UnitRatingMethod Enum
 UnitRatingMethod.NONE.text=Disabled
 UnitRatingMethod.CAMPAIGN_OPS.text=Campaign Ops
-UnitRatingMethod.FLD_MAN_MERCS_REV.text=FM: Mercenaries (rev)
+UnitRatingMethod.FLD_MAN_MERCS_REV.text=FM: Mercenaries (rev) [Depreciated]

--- a/MekHQ/resources/mekhq/resources/Rating.properties
+++ b/MekHQ/resources/mekhq/resources/Rating.properties
@@ -6,4 +6,4 @@
 # UnitRatingMethod Enum
 UnitRatingMethod.NONE.text=Disabled
 UnitRatingMethod.CAMPAIGN_OPS.text=Campaign Ops
-UnitRatingMethod.FLD_MAN_MERCS_REV.text=FM: Mercenaries (rev) [Depreciated]
+UnitRatingMethod.FLD_MAN_MERCS_REV.text=FM: Mercenaries (rev) [Deprecated]

--- a/MekHQ/src/mekhq/campaign/rating/UnitRatingMethod.java
+++ b/MekHQ/src/mekhq/campaign/rating/UnitRatingMethod.java
@@ -69,15 +69,10 @@ public enum UnitRatingMethod {
 
         }
 
-        switch (text) {
-            case "Campaign Ops":
-            case "Taharqa":
-            case "Interstellar Ops":
-                return CAMPAIGN_OPS;
-            case "FM: Mercenaries (rev)":
-            default:
-                return FLD_MAN_MERCS_REV;
-        }
+        return switch (text) {
+            case "Campaign Ops", "Taharqa", "Interstellar Ops" -> CAMPAIGN_OPS;
+            default -> FLD_MAN_MERCS_REV;
+        };
     }
     //endregion File IO
 


### PR DESCRIPTION
The 'FM: Mercenaries (rev)' unit rating method was marked as deprecated for the purposes of user-facing campaign options. Additionally, the switch statement in the UnitRatingMethod.java file was simplified to a more modern syntax to enhance readability and maintainability.

This is the first step in us moving away from supporting FM:Mr with a mind to more broadly adopting CamOps systems.