### PR TITLE
Fixed Missing Site Location Change Code & Turnover Information Storage

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1150,7 +1150,7 @@ public class Campaign implements ITechManager {
     public void importUnit(Unit u) {
         Objects.requireNonNull(u);
 
-        LogManager.getLogger().debug("Importing unit: (" + u.getId() + "): " + u.getName());
+        LogManager.getLogger().debug("Importing unit: ({}): {}", u.getId(), u.getName());
 
         getHangar().addUnit(u);
 
@@ -1175,7 +1175,7 @@ public class Campaign implements ITechManager {
      * @param unit - The ship we want to add to this Set
      */
     public void addTransportShip(Unit unit) {
-        LogManager.getLogger().debug("Adding DropShip/WarShip: " + unit.getId());
+        LogManager.getLogger().debug("Adding DropShip/WarShip: {}", unit.getId());
         transportShips.add(Objects.requireNonNull(unit));
     }
 
@@ -4687,7 +4687,7 @@ public class Campaign implements ITechManager {
                     pw1.println("]]></blk>");
                 }
                 catch (EntitySavingException e) {
-                    LogManager.getLogger().error("Failed to save custom entity " + en.getDisplayName(), e);
+                    LogManager.getLogger().error("Failed to save custom entity {}", en.getDisplayName(), e);
                 }
             }
             pw1.println("\t</custom>");
@@ -4725,7 +4725,7 @@ public class Campaign implements ITechManager {
 
     public void setRankSystem(final @Nullable RankSystem rankSystem) {
         // If they are the same object, there hasn't been a change and thus don't need to process further
-        if (getRankSystem() == rankSystem) {
+        if (Objects.equals(getRankSystem(), rankSystem)) {
             return;
         }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3241,6 +3241,10 @@ public class Campaign implements ITechManager {
                 continue;
             }
 
+            if (getLocalDate().equals(contract.getStartDate())) {
+                getUnits().forEach(unit -> unit.setSite(contract.getRepairLocation(getUnitRatingMod())));
+            }
+
             if (getLocalDate().getDayOfWeek() == DayOfWeek.MONDAY) {
                 int deficit = getDeploymentDeficit(contract);
                 if (deficit > 0) {
@@ -3621,6 +3625,9 @@ public class Campaign implements ITechManager {
      * @return <code>true</code> if the new day arrived
      */
     public boolean newDay() {
+        // clear previous retirement information
+        turnoverRetirementInformation.clear();
+
         // Refill Automated Pools, if the options are selected
         if (MekHQ.getMHQOptions().getNewDayAstechPoolFill() && requiresAdditionalAstechs()) {
             fillAstechPool();
@@ -5051,7 +5058,7 @@ public class Campaign implements ITechManager {
         // Unions
         if (noMech > 0) {
             leasedAverageMechDropships = noMech / (double) averageDropshipMechCapacity;
-            noMech -= leasedAverageMechDropships * averageDropshipMechCapacity;
+            noMech -= (int) (leasedAverageMechDropships * averageDropshipMechCapacity);
             mechCollars += (int) Math.ceil(leasedAverageMechDropships);
 
             // If we can fit in a smaller DropShip, lease one of those instead.
@@ -5074,7 +5081,7 @@ public class Campaign implements ITechManager {
 
             if (noASF > 0) {
                 leasedAverageASFDropships = noASF / (double) averageDropshipASFCapacity;
-                noASF -= leasedAverageASFDropships * averageDropshipASFCapacity;
+                noASF -= (int) (leasedAverageASFDropships * averageDropshipASFCapacity);
                 asfCollars += (int) Math.ceil(leasedAverageASFDropships);
 
                 if ((noASF > 0) && (noASF < (averageDropshipASFCapacity / 2))) {
@@ -5093,7 +5100,7 @@ public class Campaign implements ITechManager {
         // Triumphs
         if (noVehicles > averageDropshipVehicleCapacity) {
             leasedLargeVehicleDropships = noVehicles / (double) largeDropshipVehicleCapacity;
-            noVehicles -= leasedLargeVehicleDropships * largeDropshipVehicleCapacity;
+            noVehicles -= (int) (leasedLargeVehicleDropships * largeDropshipVehicleCapacity);
             vehicleCollars += (int) Math.ceil(leasedLargeVehicleDropships);
 
             if (noVehicles > averageDropshipVehicleCapacity) {
@@ -5128,7 +5135,7 @@ public class Campaign implements ITechManager {
         // Mules
         if (noCargo > averageDropshipCargoCapacity) {
             leasedLargeCargoDropships = noCargo / (double) largeDropshipCargoCapacity;
-            noCargo -= leasedLargeCargoDropships * largeDropshipCargoCapacity;
+            noCargo -= (int) (leasedLargeCargoDropships * largeDropshipCargoCapacity);
             cargoCollars += (int) Math.ceil(leasedLargeCargoDropships);
 
             if (noCargo > averageDropshipCargoCapacity) {
@@ -5142,7 +5149,7 @@ public class Campaign implements ITechManager {
         if (noCargo > 0) {
             leasedAverageCargoDropships = noCargo / (double) averageDropshipCargoCapacity;
             cargoCollars += (int) Math.ceil(leasedAverageCargoDropships);
-            noCargo -= leasedAverageCargoDropships * averageDropshipCargoCapacity;
+            noCargo -= (int) (leasedAverageCargoDropships * averageDropshipCargoCapacity);
 
             if (noCargo > 0 && noCargo < (averageDropshipCargoCapacity / 2)) {
                 leasedAverageCargoDropships += 0.5;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5040,7 +5040,7 @@ public class Campaign implements ITechManager {
         // If we're transporting more than a company, Overlord analogues are more efficient.
         if (noMech > 12) {
             leasedLargeMechDropships = noMech / (double) largeDropshipMechCapacity;
-            noMech -= leasedLargeMechDropships * largeDropshipMechCapacity;
+            noMech -= (int) (leasedLargeMechDropships * largeDropshipMechCapacity);
             mechCollars += (int) Math.ceil(leasedLargeMechDropships);
 
             // If there's more than a company left over, lease another Overlord. Otherwise
@@ -5052,7 +5052,7 @@ public class Campaign implements ITechManager {
             }
 
             leasedASFCapacity += (int) Math.floor(leasedLargeMechDropships * largeMechDropshipASFCapacity);
-            leasedCargoCapacity += (int) Math.floor(largeMechDropshipCargoCapacity);
+            leasedCargoCapacity += largeMechDropshipCargoCapacity;
         }
 
         // Unions

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -23,6 +23,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.event.NewDayEvent;
 import mekhq.campaign.event.OptionsChangedEvent;
+import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.enums.MHQTabType;
@@ -34,6 +35,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 /**
@@ -127,7 +129,7 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
 
         //the actual map
         panMap = new InterstellarMapPanel(getCampaign(), getCampaignGui());
-        // lets go ahead and zoom in on the current location
+        // let's go ahead and zoom in on the current location
         panMap.setSelectedSystem(getCampaign().getLocation().getCurrentSystem());
         panMapView.add(panMap, BorderLayout.CENTER);
 
@@ -177,47 +179,44 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
         if (panMap.getJumpPath().isEmpty()) {
             return;
         }
+
         getCampaign().getLocation().setJumpPath(panMap.getJumpPath());
+
         refreshPlanetView();
         getCampaignGui().refreshLocation();
+
         panMap.setJumpPath(new JumpPath());
         panMap.repaint();
+
+        getCampaign().getUnits().forEach(unit -> unit.setSite(Unit.SITE_BAY));
     }
 
-    protected void refreshSystemView() {
+    private void refreshSystemView() {
         JumpPath path = panMap.getJumpPath();
         if (null != path && !path.isEmpty()) {
             scrollPlanetView.setViewportView(new JumpPathViewPanel(path, getCampaign()));
-            SwingUtilities.invokeLater(() -> {
-                scrollPlanetView.getVerticalScrollBar().setValue(0);
-            });
+            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
             return;
         }
         PlanetarySystem system = panMap.getSelectedSystem();
         if (null != system) {
             scrollPlanetView.setViewportView(new PlanetViewPanel(system, getCampaign()));
-            SwingUtilities.invokeLater(() -> {
-                scrollPlanetView.getVerticalScrollBar().setValue(0);
-            });
+            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
         }
     }
 
-    protected void refreshPlanetView() {
+    private void refreshPlanetView() {
         JumpPath path = panMap.getJumpPath();
         if (null != path && !path.isEmpty()) {
             scrollPlanetView.setViewportView(new JumpPathViewPanel(path, getCampaign()));
-            SwingUtilities.invokeLater(() -> {
-                scrollPlanetView.getVerticalScrollBar().setValue(0);
-            });
+            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
             return;
         }
         int pos = panSystem.getSelectedPlanetPosition();
         PlanetarySystem system = panMap.getSelectedSystem();
         if (null != system) {
             scrollPlanetView.setViewportView(new PlanetViewPanel(system, getCampaign(), pos));
-            SwingUtilities.invokeLater(() -> {
-                scrollPlanetView.getVerticalScrollBar().setValue(0);
-            });
+            SwingUtilities.invokeLater(() -> scrollPlanetView.getVerticalScrollBar().setValue(0));
         }
     }
 
@@ -264,9 +263,9 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        if (e.getSource() == panMap) {
+        if (Objects.equals(e.getSource(), panMap)) {
             refreshSystemView();
-        } else if (e.getSource() == panSystem) {
+        } else if (Objects.equals(e.getSource(), panSystem)) {
             refreshPlanetView();
         }
     }


### PR DESCRIPTION
Somehow I managed to accidentally all but wipe #4462 prior to it getting merged. It's definitely a case of error between keyboard and chair, but either way, this PR restores the code.

Furthermore, an oversight in the storing of turnover results across days caused it to never be forgotten so users would get spammed with their turnover results every day. On the bright side, this means it was currently storing the information across new day events! Not ideal though, so this PR also fixes that.

I also spotted that the leasing of DropShips was using a lossy implicit cast in a number of places, so I corrected that. DropShip need calculations should now be a little more accurate. Eventually we probably want to move this from `Campaign.java` and give it a full review to make sure everything is being handled correctly. Especially as some of this code hasn't been touched for 7 years.