### PR TITLE
Added Promotion-Based autoAwards Processing

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/PersonAwardController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonAwardController.java
@@ -188,6 +188,27 @@ public class PersonAwardController {
     }
 
     /**
+     * Removes an award given to this person (without logging the removal) based on:
+     * @param setName is the name of the set of the award
+     * @param awardName is the name of the award
+     * @param awardedDate is the date it was awarded, or null if it is to be bulk removed
+     */
+    public void removeAwardSilent(String setName, String awardName, LocalDate awardedDate) {
+        for (Award award : awards) {
+            if (award.equals(setName, awardName)) {
+                if ((awardedDate != null) && award.hasDates()) {
+                    award.removeDate(awardedDate);
+                } else {
+                    awards.remove(award);
+                }
+
+                MekHQ.triggerEvent(new PersonChangedEvent(person));
+                return;
+            }
+        }
+    }
+
+    /**
      * Adds an entry log for a given award.
      * @param award that was given.
      */

--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/RankAwards.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/RankAwards.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 public class RankAwards {
     //region Enum Declarations
     enum RankAwardsEnums {
-        IMPLICIT("Implicit"),
+        PROMOTION("Promotion"),
         INCLUSIVE("Inclusive"),
         EXCLUSIVE("Exclusive");
 
@@ -73,12 +73,13 @@ public class RankAwards {
             Person person = campaign.getPerson(personId);
 
             isEligible = switch (award.getRange()) {
-                case "Implicit" -> person.getRankNumeric() == requiredRankNumeric;
+                case "Promotion" -> (person.getRankNumeric() == requiredRankNumeric)
+                        && ((award.getSize() == null) || (award.getSize().equalsIgnoreCase(person.getRankSystem().getCode())));
                 case "Inclusive" -> person.getRankNumeric() >= requiredRankNumeric;
                 case "Exclusive" -> {
-                    if ((requiredRankNumeric <= 20 && person.getRankNumeric() <= 20)
-                            || (requiredRankNumeric <= 30 && person.getRankNumeric() <= 30)
-                            || (requiredRankNumeric >= 31 && person.getRankNumeric() >= 31)) {
+                    if (((requiredRankNumeric <= 20) && (person.getRankNumeric() <= 20))
+                            || ((requiredRankNumeric <= 30) && (person.getRankNumeric() <= 30))
+                            || ((requiredRankNumeric >= 31) && (person.getRankNumeric() >= 31))) {
                         yield person.getRankNumeric() >= requiredRankNumeric;
                     } else {
                         yield false;

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -249,11 +249,19 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_RANK: {
+                List<Person> promotedPersonnel = new ArrayList<>();
                 try {
                     final int rank = Integer.parseInt(data[1]);
                     final int level = (data.length > 2) ? Integer.parseInt(data[2]) : 0;
                     for (final Person person : people) {
                         person.changeRank(gui.getCampaign(), rank, level, true);
+
+                        promotedPersonnel.add(person);
+                    }
+
+                    if ((gui.getCampaign().getCampaignOptions().isEnableAutoAwards()) && (!promotedPersonnel.isEmpty())) {
+                        AutoAwardsController autoAwardsController = new AutoAwardsController();
+                        autoAwardsController.PromotionController(gui.getCampaign(), false);
                     }
                 } catch (Exception e) {
                     LogManager.getLogger().error("", e);


### PR DESCRIPTION
This has been a feature much requested since I first started work on autoAwards. Via this PR I have added a new 'promotion' sub-category of Rank Awards. These awards are triggered whenever someone changes rank, but rather than being tied to specific thresholds, each award is assigned a specific rank. It will only be issued to personnel with that specific rank and, when issued, all other promotion type awards will be removed.

The use case here is for users who want to use autoAwards to distribute and manage rank insignia. To that end, I have also added functionality so that users can optionally limit promotion awards to only be valid for specific Rank Systems. For example, you might have one set of rank insignia for the SLDF and another for the MAF.

Documentation has not been updated for this PR and will be included in a follow-up PR.

Closes #4336