### PR TITLE
Edited Commander Display in TO&E for Origin Node

### DIFF
--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -163,13 +163,16 @@ public class ForceViewPanel extends JScrollablePanel {
         long bv = 0;
         Money cost = Money.zero();
         double ton = 0;
-        String commander = "";
         String lanceTech = "";
         String assigned = "";
         String type = null;
 
         Person commanderPerson = campaign.getPerson(force.getForceCommanderID());
-        commander = commanderPerson != null ? commanderPerson.getFullTitle() : "";
+        String commander = commanderPerson != null ? commanderPerson.getFullTitle() : "";
+
+        if ((force.getId() == 0) && (campaign.getFlaggedCommander() != null)) {
+            commander = campaign.getFlaggedCommander().getFullTitle();
+        }
 
         for (UUID uid : force.getAllUnits(false)) {
             Unit u = campaign.getUnit(uid);
@@ -201,7 +204,7 @@ public class ForceViewPanel extends JScrollablePanel {
 
         if (null != type) {
             lblType.setName("lblCommander2");
-            String forceType = (force.isCombatForce() ? "" : "Non-Combat ") + type + " " + resourceMap.getString("unit");
+            String forceType = (force.isCombatForce() ? "" : "Non-Combat ") + type + ' ' + resourceMap.getString("unit");
             lblType.setText("<html><i>" + forceType + "</i></html>");
             lblType.getAccessibleContext().setAccessibleDescription("Force Type: " + forceType);
             gridBagConstraints = new GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -170,8 +170,8 @@ public class ForceViewPanel extends JScrollablePanel {
         Person commanderPerson = campaign.getPerson(force.getForceCommanderID());
         String commander = commanderPerson != null ? commanderPerson.getFullTitle() : "";
 
-        if ((force.getId() == 0) && (campaign.getFlaggedCommander() != null)) {
-            commander = campaign.getFlaggedCommander().getFullTitle();
+        if (force.getId() == 0) {
+            commander = campaign.getFlaggedCommander() != null ? campaign.getFlaggedCommander().getFullTitle() : "";
         }
 
         for (UUID uid : force.getAllUnits(false)) {


### PR DESCRIPTION
Updated the TO&E so that the origin node (the one that has the campaign name, by default) will always display the campaign commander if one has been set. Previously it would display the last person to be placed in the top level (usually some random character that got plonked there by accident).

In the event that there is no campaign commander, the field is left blank.

These changes are visual only.

Closes #4270

![image](https://github.com/user-attachments/assets/feb75ea0-0898-4aac-953a-bf0817e6da2d)
