### PR TITLE
Clear Assigned Forces when Removing StratCon Scenario

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1475,6 +1475,8 @@ public class StratconRulesManager {
                     processTrackForceReturnDates(track, rst.getCampaign());
 
                     track.removeScenario(scenario);
+
+                    scenario.getAssignedForces().clear();
                     break;
                 }
             }


### PR DESCRIPTION
Previously, when a scenario was removed, its assigned forces were not cleared, which could lead to inconsistencies. This commit ensures that the assigned forces of a scenario are properly cleared.

This fix is experimental and needs further testing.