### PR TITLE
Added Randomized Relationship History for Personnel

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -434,12 +434,25 @@ lifePathsPanel.title=Life Paths
 personnelRandomizationPanel.title=Personnel Randomization
 chkUseDylansRandomXP.text=Use Dylan's Random XP (Unofficial)
 chkUseDylansRandomXP.toolTipText=Use Dylan's optional random XP on creation of a new person (20% chance each of 0, 1, 2, 3, and randomized between 1 and 8 XP)
+
+# Random Histories
+randomHistoriesPanel.title=Random Histories
 chkUseRandomPersonalities.text=Use Random Personalities
 chkUseRandomPersonalities.toolTipText=<html>Personnel are generated with random personality traits, quirks and intelligence.\
   <br>\
-  <br>Intelligence affects a characters ability to graduate from education module academies.\
+  <br>Intelligence affects a character's ability to graduate from education module academies.\
   <br>\
   <br>While traits and quirks do not currently have a mechanical effect, they will be used by the upcoming Random Events module.</html>
+chkUseSimulatedRelationships.text=Simulate Relationship History
+chkUseSimulatedRelationships.toolTipText=<html>Personnel are generated with a random relationship history.\
+  <br>\
+  <br>If randomized marriages are enabled the various marriage settings (including chance) will be used to determine whether new personnel have been previously married.\
+  <br>\
+  <br>If randomized procreation is enabled the various procreation settings (including chance) will be used to determine whether new personnel have children traveling with them.\
+  <br>\
+  <br>If randomized divorce is enabled the various divorce settings (including chance) will be used to determine whether any marriages have ended in divorce.\
+  <br>\
+  <br>Any children and current spouses will travel alongside the unit.</html>
 
 # Family
 familyPanel.title=Family (Unofficial)

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1560,7 +1560,7 @@ public class Campaign implements ITechManager {
         p.setPrisonerStatus(this, prisonerStatus, log);
 
         if (getCampaignOptions().isUseSimulatedRelationships()) {
-            if ((prisonerStatus.isFree()) && (!p.getPrimaryRole().isDependent())) {
+            if ((prisonerStatus.isFree()) && (!p.getOriginFaction().isClan()) && (!p.getPrimaryRole().isDependent())) {
                 simulateRelationshipHistory(p);
             }
         }

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -272,58 +272,11 @@ public class CampaignOptions {
     // Personnel Randomization
     private boolean useDylansRandomXP; // Unofficial
     private RandomOriginOptions randomOriginOptions;
+
+    // Random Histories
     private boolean useRandomPersonalities;
+    private boolean useSimulatedRelationships;
 
-    // Retirement
-    private boolean useRandomRetirement;
-
-    private TurnoverTargetNumberMethod turnoverTargetNumberMethod;
-    private SkillLevel turnoverDifficulty;
-    private int turnoverFixedTargetNumber;
-    private boolean aeroRecruitsHaveUnits;
-    private boolean trackOriginalUnit;
-    private TurnoverFrequency turnoverFrequency;
-    private boolean useContractCompletionRandomRetirement;
-    private boolean useRandomFounderTurnover;
-    private boolean useFounderRetirement;
-    private boolean useSubContractSoldiers;
-    private int serviceContractDuration;
-    private int serviceContractModifier;
-    private boolean payBonusDefault;
-    private int payBonusDefaultThreshold;
-
-    private boolean useCustomRetirementModifiers;
-    private boolean useFatigueModifiers;
-    private boolean useSkillModifiers;
-    private boolean useAgeModifiers;
-    private boolean useUnitRatingModifiers;
-    private boolean useFactionModifiers;
-    private boolean useHostileTerritoryModifiers;
-    private boolean useMissionStatusModifiers;
-    private boolean useFamilyModifiers;
-    private boolean useLoyaltyModifiers;
-    private boolean useHideLoyalty;
-
-    private int payoutRateOfficer;
-    private int payoutRateEnlisted;
-    private int payoutRetirementMultiplier;
-    private boolean usePayoutServiceBonus;
-    private int payoutServiceBonusRate;
-
-    private boolean useAdministrativeStrain;
-    private int administrativeCapacity;
-    private int multiCrewStrainDivider;
-
-    private boolean useManagementSkill;
-    private boolean useCommanderLeadershipOnly;
-    private int managementSkillPenalty;
-
-    private boolean useFatigue;
-    private int fatigueRate;
-    private boolean useInjuryFatigue;
-    private int fieldKitchenCapacity;
-    private boolean fieldKitchenIgnoreNonCombatants;
-    private int fatigueLeaveThreshold;
 
     // Family
     private FamilialRelationshipDisplayLevel familyDisplayLevel;
@@ -410,6 +363,58 @@ public class CampaignOptions {
     private Map<TenYearAgeRange, Double> ageRangeRandomDeathMaleValues;
     private Map<TenYearAgeRange, Double> ageRangeRandomDeathFemaleValues;
     //endregion Life Paths Tab
+
+    //region Turnover and Retention
+    private boolean useRandomRetirement;
+
+    private TurnoverTargetNumberMethod turnoverTargetNumberMethod;
+    private SkillLevel turnoverDifficulty;
+    private int turnoverFixedTargetNumber;
+    private boolean aeroRecruitsHaveUnits;
+    private boolean trackOriginalUnit;
+    private TurnoverFrequency turnoverFrequency;
+    private boolean useContractCompletionRandomRetirement;
+    private boolean useRandomFounderTurnover;
+    private boolean useFounderRetirement;
+    private boolean useSubContractSoldiers;
+    private int serviceContractDuration;
+    private int serviceContractModifier;
+    private boolean payBonusDefault;
+    private int payBonusDefaultThreshold;
+
+    private boolean useCustomRetirementModifiers;
+    private boolean useFatigueModifiers;
+    private boolean useSkillModifiers;
+    private boolean useAgeModifiers;
+    private boolean useUnitRatingModifiers;
+    private boolean useFactionModifiers;
+    private boolean useHostileTerritoryModifiers;
+    private boolean useMissionStatusModifiers;
+    private boolean useFamilyModifiers;
+    private boolean useLoyaltyModifiers;
+    private boolean useHideLoyalty;
+
+    private int payoutRateOfficer;
+    private int payoutRateEnlisted;
+    private int payoutRetirementMultiplier;
+    private boolean usePayoutServiceBonus;
+    private int payoutServiceBonusRate;
+
+    private boolean useAdministrativeStrain;
+    private int administrativeCapacity;
+    private int multiCrewStrainDivider;
+
+    private boolean useManagementSkill;
+    private boolean useCommanderLeadershipOnly;
+    private int managementSkillPenalty;
+
+    private boolean useFatigue;
+    private int fatigueRate;
+    private boolean useInjuryFatigue;
+    private int fieldKitchenCapacity;
+    private boolean fieldKitchenIgnoreNonCombatants;
+    private int fatigueLeaveThreshold;
+    //endregion Turnover and Retention
 
     //region Finance tab
     private boolean payForParts;
@@ -820,7 +825,10 @@ public class CampaignOptions {
         // Personnel Randomization
         setUseDylansRandomXP(false);
         setRandomOriginOptions(new RandomOriginOptions(true));
+
+        // Random Histories
         setUseRandomPersonalities(false);
+        setUseSimulatedRelationships(false);
 
         // Family
         setFamilyDisplayLevel(FamilialRelationshipDisplayLevel.SPOUSE);
@@ -1825,7 +1833,9 @@ public class CampaignOptions {
     public void setRandomOriginOptions(final RandomOriginOptions randomOriginOptions) {
         this.randomOriginOptions = randomOriginOptions;
     }
+    //endregion Personnel Randomization
 
+    //region Random Histories
     public boolean isUseRandomPersonalities() {
         return useRandomPersonalities;
     }
@@ -1833,7 +1843,15 @@ public class CampaignOptions {
     public void setUseRandomPersonalities(final boolean useRandomPersonalities) {
         this.useRandomPersonalities = useRandomPersonalities;
     }
-    //endregion Personnel Randomization
+
+    public boolean isUseSimulatedRelationships() {
+        return useSimulatedRelationships;
+    }
+
+    public void setUseSimulatedRelationships(final boolean useSimulatedRelationships) {
+        this.useSimulatedRelationships = useSimulatedRelationships;
+    }
+    //endregion Random Histories
 
     //region Retirement
     public boolean isUseRandomRetirement() {
@@ -4633,8 +4651,12 @@ public class CampaignOptions {
         //region Personnel Randomization
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useDylansRandomXP", isUseDylansRandomXP());
         getRandomOriginOptions().writeToXML(pw, indent);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useRandomPersonalities", isUseRandomPersonalities());
         //endregion Personnel Randomization
+
+        //region Random Histories
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useRandomPersonalities", isUseRandomPersonalities());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useSimulatedRelationships", isUseSimulatedRelationships());
+        //endregion Random Histories
 
         //region Retirement
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useRandomRetirement", isUseRandomRetirement());
@@ -5374,9 +5396,14 @@ public class CampaignOptions {
                         continue;
                     }
                     retVal.setRandomOriginOptions(randomOriginOptions);
+                    //endregion Personnel Randomization
+
+                    //region Random Histories
                 } else if (wn2.getNodeName().equalsIgnoreCase("useRandomPersonalities")) {
                     retVal.setUseRandomPersonalities(Boolean.parseBoolean(wn2.getTextContent().trim()));
-                    //endregion Personnel Randomization
+                } else if (wn2.getNodeName().equalsIgnoreCase("useSimulatedRelationships")) {
+                    retVal.setUseSimulatedRelationships(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                    //endregion Random Histories
 
                     //region Family
                 } else if (wn2.getNodeName().equalsIgnoreCase("familyDisplayLevel")

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -24,6 +24,7 @@ package mekhq.campaign.mission;
 import megamek.client.generator.RandomUnitGenerator;
 import megamek.client.ui.swing.util.PlayerColour;
 import megamek.common.*;
+import megamek.common.enums.Gender;
 import megamek.common.enums.SkillLevel;
 import megamek.common.icons.Camouflage;
 import megamek.common.loaders.EntityLoadingException;
@@ -480,12 +481,12 @@ public class AtBContract extends Contract {
         int roll = Compute.d6();
         switch (roll) {
             case 1: /* 1d6 dependents */
-                if (c.getCampaignOptions().getRandomDependentMethod().isAgainstTheBot()
-                        && c.getCampaignOptions().isUseRandomDependentAddition()) {
+                if (c.getCampaignOptions().isUseRandomDependentAddition()) {
                     number = Compute.d6();
                     c.addReport("Bonus: " + number + " dependent" + ((number > 1) ? "s" : ""));
+
                     for (int i = 0; i < number; i++) {
-                        Person p = c.newDependent(false);
+                        Person p = c.newDependent(false, Gender.RANDOMIZE);
                         c.recruitPerson(p);
                     }
                 }
@@ -974,7 +975,7 @@ public class AtBContract extends Contract {
     }
 
     public String getEmployerName(int year) {
-        return isMercSubcontract() ? "Mercenary (" + getEmployerFaction().getFullName(year) + ")"
+        return isMercSubcontract() ? "Mercenary (" + getEmployerFaction().getFullName(year) + ')'
                 : getEmployerFaction().getFullName(year);
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/divorce/AbstractDivorce.java
+++ b/MekHQ/src/mekhq/campaign/personnel/divorce/AbstractDivorce.java
@@ -242,6 +242,33 @@ public abstract class AbstractDivorce {
         MekHQ.triggerEvent(new PersonChangedEvent(origin));
     }
 
+    /**
+     * This divorces two married people.
+     * This version is meant to be used to log historic divorces that occur during a characters' random background.
+     * It is a watered down version of divorce()
+     *
+     * @param campaign the campaign the two people are a part of
+     * @param today the current date
+     * @param origin the origin person being divorced
+     */
+    public void divorceHistoric(final Campaign campaign, final LocalDate today, final Person origin) {
+        final Person spouse = origin.getGenealogy().getSpouse();
+
+        SplittingSurnameStyle.WEIGHTED.apply(campaign, origin, spouse);
+
+        PersonalLogger.divorcedFrom(origin, spouse, today);
+        PersonalLogger.divorcedFrom(spouse, origin, today);
+
+        spouse.setMaidenName(null);
+        origin.setMaidenName(null);
+
+        spouse.getGenealogy().setSpouse(null);
+        origin.getGenealogy().setSpouse(null);
+
+        spouse.getGenealogy().addFormerSpouse(new FormerSpouse(origin, today, FormerSpouseReason.DIVORCE));
+        origin.getGenealogy().addFormerSpouse(new FormerSpouse(spouse, today, FormerSpouseReason.DIVORCE));
+    }
+
     //region New Day
     /**
      * Processes new day random divorce for an individual.

--- a/MekHQ/src/mekhq/campaign/personnel/familyTree/Genealogy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/familyTree/Genealogy.java
@@ -29,6 +29,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.io.PrintWriter;
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -192,6 +193,13 @@ public class Genealogy {
      */
     public boolean hasChildren() {
         return getFamily().get(FamilialRelationshipType.CHILD) != null;
+    }
+
+    /**
+     * @return true if the person has at least one kid, false otherwise
+     */
+    public boolean hasNonAdultChildren(LocalDate localDate) {
+        return getChildren().stream().anyMatch(child -> child.isChild(localDate));
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
@@ -189,6 +189,32 @@ public abstract class AbstractMarriage {
             return;
         }
 
+        performMarriageChanges(campaign, today, origin, spouse, surnameStyle);
+
+        campaign.addReport(String.format(resources.getString("marriage.report"), origin.getHyperlinkedName(),
+                spouse.getHyperlinkedName()));
+
+        // Process the loyalty change
+        if (campaign.getCampaignOptions().isUseLoyaltyModifiers()) {
+            origin.performRandomizedLoyaltyChange(campaign, false, true);
+            spouse.performRandomizedLoyaltyChange(campaign, false, true);
+        }
+
+        // And finally we trigger person changed events
+        MekHQ.triggerEvent(new PersonChangedEvent(origin));
+        MekHQ.triggerEvent(new PersonChangedEvent(spouse));
+    }
+
+    /**
+     * Updates the necessary information to perform a marriage between two individuals.
+     *
+     * @param campaign the campaign in which the marriage is taking place
+     * @param today the current date of the marriage
+     * @param origin the first person getting married
+     * @param spouse the second person getting married
+     * @param surnameStyle the style of surname changes to be applied
+     */
+    public static void performMarriageChanges(Campaign campaign, LocalDate today, Person origin, Person spouse, MergingSurnameStyle surnameStyle) {
         // Immediately set both Maiden Names, to avoid any divorce bugs (as the default is now an empty string)
         origin.setMaidenName(origin.getSurname());
         spouse.setMaidenName(spouse.getSurname());

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -21,6 +21,7 @@ package mekhq.campaign.personnel.procreation;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
+import megamek.common.enums.Gender;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -39,6 +40,8 @@ import mekhq.campaign.personnel.randomEvents.PersonalityController;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.ResourceBundle;
 import java.util.UUID;
 
@@ -243,38 +246,54 @@ public abstract class AbstractProcreation {
      * @param campaign the campaign the person is a part of
      * @param today the current date
      * @param mother the newly pregnant mother
+     * @param isNoReport true if no message should be posted to the daily report
      */
-    public void addPregnancy(final Campaign campaign, final LocalDate today, final Person mother) {
-        addPregnancy(campaign, today, mother, determineNumberOfBabies(
-                campaign.getCampaignOptions().getMultiplePregnancyOccurrences()));
+    public void addPregnancy(final Campaign campaign, final LocalDate today, final Person mother, boolean isNoReport) {
+        addPregnancy(
+                campaign,
+                today,
+                mother,
+                determineNumberOfBabies(campaign.getCampaignOptions().getMultiplePregnancyOccurrences()),
+                isNoReport
+        );
     }
 
     /**
      * This method is how a person becomes pregnant with the specified number of children. They have
-     * their due date set and the parentage of the pregnancy determined.
+     * their due date set, and the parentage of the pregnancy is determined.
      *
      * @param campaign the campaign the person is a part of
      * @param today the current date
      * @param mother the newly pregnant mother
      * @param size the number of children the mother is having
+     * @param isNoReport true if no message should be posted to the daily report
      */
     public void addPregnancy(final Campaign campaign, final LocalDate today, final Person mother,
-                             final int size) {
+                             final int size, boolean isNoReport) {
         if (size < 1) {
             return;
         }
 
         mother.setExpectedDueDate(today.plusDays(MHQConstants.PREGNANCY_STANDARD_DURATION));
+
         mother.setDueDate(today.plusDays(determinePregnancyDuration()));
+
         mother.getExtraData().set(PREGNANCY_CHILDREN_DATA, size);
+
         mother.getExtraData().set(PREGNANCY_FATHER_DATA, mother.getGenealogy().hasSpouse()
                 ? mother.getGenealogy().getSpouse().getId().toString() : null);
 
         final String babyAmount = resources.getString("babyAmount.text").split(",")[size - 1];
-        campaign.addReport(String.format(resources.getString("babyConceived.report"),
-                mother.getHyperlinkedName(), babyAmount).trim());
+
+        if (!isNoReport) {
+            campaign.addReport(String.format(resources.getString("babyConceived.report"),
+                    mother.getHyperlinkedName(),
+                    babyAmount).trim());
+        }
+
         if (campaign.getCampaignOptions().isLogProcreation()) {
             MedicalLogger.hasConceived(mother, today, babyAmount);
+
             if (mother.getGenealogy().hasSpouse()) {
                 PersonalLogger.spouseConceived(mother.getGenealogy().getSpouse(),
                         mother.getFullName(), today, babyAmount);
@@ -321,8 +340,8 @@ public abstract class AbstractProcreation {
 
         // Create Babies
         for (int i = 0; i < size; i++) {
-            // Create the specific baby
-            final Person baby = campaign.newDependent(true);
+            // Create a baby
+            final Person baby = campaign.newDependent(true, Gender.RANDOMIZE);
             baby.setSurname(campaign.getCampaignOptions().getBabySurnameStyle()
                     .generateBabySurname(mother, father, baby.getGender()));
             baby.setBirthday(today);
@@ -331,20 +350,7 @@ public abstract class AbstractProcreation {
             campaign.addReport(String.format(resources.getString("babyBorn.report"),
                     mother.getHyperlinkedName(), baby.getHyperlinkedName(),
                     GenderDescriptors.BOY_GIRL.getDescriptor(baby.getGender())));
-            if (campaign.getCampaignOptions().isLogProcreation()) {
-                MedicalLogger.deliveredBaby(mother, baby, today);
-                if (father != null) {
-                    PersonalLogger.ourChildBorn(father, baby, mother.getFullName(), today);
-                }
-            }
-
-            // Create genealogy information
-            baby.getGenealogy().addFamilyMember(FamilialRelationshipType.PARENT, mother);
-            mother.getGenealogy().addFamilyMember(FamilialRelationshipType.CHILD, baby);
-            if (father != null) {
-                baby.getGenealogy().addFamilyMember(FamilialRelationshipType.PARENT, father);
-                father.getGenealogy().addFamilyMember(FamilialRelationshipType.CHILD, baby);
-            }
+            logAndUpdateFamily(campaign, today, mother, baby, father);
 
             // Founder Tag Assignment
             if (campaign.getCampaignOptions().isAssignNonPrisonerBabiesFounderTag()
@@ -376,6 +382,80 @@ public abstract class AbstractProcreation {
 
         // Cleanup Data
         removePregnancy(mother);
+    }
+
+    /**
+     * Logs the birth of a baby and updates the genealogy information of the family.
+     *
+     * @param campaign the ongoing campaign
+     * @param today the current date
+     * @param mother the mother of the baby
+     * @param baby the newborn baby
+     * @param father the father of the baby, null if unknown
+     */
+    private static void logAndUpdateFamily(Campaign campaign, LocalDate today, Person mother, Person baby, Person father) {
+        if (campaign.getCampaignOptions().isLogProcreation()) {
+            MedicalLogger.deliveredBaby(mother, baby, today);
+            if (father != null) {
+                PersonalLogger.ourChildBorn(father, baby, mother.getFullName(), today);
+            }
+        }
+
+        // Create genealogy information
+        baby.getGenealogy().addFamilyMember(FamilialRelationshipType.PARENT, mother);
+        mother.getGenealogy().addFamilyMember(FamilialRelationshipType.CHILD, baby);
+        if (father != null) {
+            baby.getGenealogy().addFamilyMember(FamilialRelationshipType.PARENT, father);
+            father.getGenealogy().addFamilyMember(FamilialRelationshipType.CHILD, baby);
+        }
+    }
+
+    /**
+     * Creates baby/babies and performs any necessary operations such as setting birthdate, creating reports,
+     * updating genealogy, setting education, loyalty, personality, and recruiting the baby.
+     * This version is for historic births that occur as part of a character's background.
+     *
+     * @param campaign the campaign object
+     * @param today the current date
+     * @param mother the mother person object
+     * @param father the father person object, can be null if the father is unknown
+     * @return the babies
+     */
+    public List<Person> birthHistoric(final Campaign campaign, final LocalDate today, final Person mother, @Nullable final Person father) {
+        List<Person> babies = new ArrayList<>();
+
+        // Determine the number of children
+        final int size = mother.getExtraData().get(PREGNANCY_CHILDREN_DATA, 1);
+        // Create Babies
+        for (int i = 0; i < size; i++) {
+            // Create the babies
+            final Person baby = campaign.newDependent(true, Gender.RANDOMIZE);
+
+            baby.setSurname(campaign.getCampaignOptions().getBabySurnameStyle()
+                    .generateBabySurname(mother, father, baby.getGender()));
+
+            baby.setBirthday(today);
+
+            // Create reports and log the birth
+            logAndUpdateFamily(campaign, today, mother, baby, father);
+
+            // set education
+            baby.setEduHighestEducation(EducationLevel.EARLY_CHILDHOOD);
+
+            // set loyalty
+            baby.setLoyalty(Compute.d6(4, 3));
+
+            // set baby's personality
+            PersonalityController.generatePersonality(baby);
+
+            // add to the list of babies
+            babies.add(baby);
+        }
+
+        // Cleanup Data
+        removePregnancy(mother);
+
+        return babies;
     }
 
     /**
@@ -441,7 +521,7 @@ public abstract class AbstractProcreation {
 
         // Make the required checks for random procreation
         if (randomlyProcreates(today, person)) {
-            addPregnancy(campaign, today, person);
+            addPregnancy(campaign, today, person, false);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -327,7 +327,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                 gui.getCampaign().getLocalDate(), person, false) == null))
                         .forEach(person -> {
                             gui.getCampaign().getProcreation().addPregnancy(
-                                    gui.getCampaign(), gui.getCampaign().getLocalDate(), person);
+                                    gui.getCampaign(), gui.getCampaign().getLocalDate(), person, false);
                             MekHQ.triggerEvent(new PersonChangedEvent(person));
                         });
                 break;

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -358,7 +358,10 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     // Personnel Randomization
     private JCheckBox chkUseDylansRandomXP;
     private RandomOriginOptionsPanel randomOriginOptionsPanel;
+
+    // Random Histories
     private JCheckBox chkUseRandomPersonalities;
+    private JCheckBox chkUseSimulatedRelationships;
 
     // Marriage
     private JCheckBox chkUseManualMarriages;
@@ -3402,14 +3405,16 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         lifePathsPanel.add(createPersonnelRandomizationPanel(), gbc);
 
         gbc.gridx++;
-        lifePathsPanel.add(createAnniversaryPanel(), gbc);
+        lifePathsPanel.add(createRandomHistoriesPanel(), gbc);
 
         //
 
         gbc.gridx = 0;
         gbc.gridy++;
-        gbc.gridwidth = 2;
         lifePathsPanel.add(createFamilyPanel(), gbc);
+
+        gbc.gridx++;
+        lifePathsPanel.add(createAnniversaryPanel(), gbc);
 
         //
 
@@ -4978,10 +4983,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         randomOriginOptionsPanel = new RandomOriginOptionsPanel(getFrame(), campaign, comboFaction);
 
-        chkUseRandomPersonalities = new JCheckBox(resources.getString("chkUseRandomPersonalities.text"));
-        chkUseRandomPersonalities.setToolTipText(resources.getString("chkUseRandomPersonalities.toolTipText"));
-        chkUseRandomPersonalities.setName("chkUseRandomPersonalities");
-
         // Layout the Panel
         final JPanel panel = new JPanel();
         panel.setBorder(BorderFactory.createTitledBorder(resources.getString("personnelRandomizationPanel.title")));
@@ -4996,14 +4997,46 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                 layout.createSequentialGroup()
                         .addComponent(chkUseDylansRandomXP)
                         .addComponent(randomOriginOptionsPanel)
-                        .addComponent(chkUseRandomPersonalities)
         );
 
         layout.setHorizontalGroup(
                 layout.createParallelGroup(Alignment.LEADING)
                         .addComponent(chkUseDylansRandomXP)
                         .addComponent(randomOriginOptionsPanel)
+        );
+
+        return panel;
+    }
+
+    private JPanel createRandomHistoriesPanel() {
+        chkUseRandomPersonalities = new JCheckBox(resources.getString("chkUseRandomPersonalities.text"));
+        chkUseRandomPersonalities.setToolTipText(resources.getString("chkUseRandomPersonalities.toolTipText"));
+        chkUseRandomPersonalities.setName("chkUseRandomPersonalities");
+
+        chkUseSimulatedRelationships = new JCheckBox(resources.getString("chkUseSimulatedRelationships.text"));
+        chkUseSimulatedRelationships.setToolTipText(resources.getString("chkUseSimulatedRelationships.toolTipText"));
+        chkUseSimulatedRelationships.setName("chkUseSimulatedRelationships");
+
+        // Layout the Panel
+        final JPanel panel = new JPanel();
+        panel.setBorder(BorderFactory.createTitledBorder(resources.getString("randomHistoriesPanel.title")));
+        panel.setName("randomHistoriesPanel");
+
+        final GroupLayout layout = new GroupLayout(panel);
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+        panel.setLayout(layout);
+
+        layout.setVerticalGroup(
+                layout.createSequentialGroup()
                         .addComponent(chkUseRandomPersonalities)
+                        .addComponent(chkUseSimulatedRelationships)
+        );
+
+        layout.setHorizontalGroup(
+                layout.createParallelGroup(Alignment.LEADING)
+                        .addComponent(chkUseRandomPersonalities)
+                        .addComponent(chkUseSimulatedRelationships)
         );
 
         return panel;
@@ -8196,7 +8229,10 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         // Personnel Randomization
         chkUseDylansRandomXP.setSelected(options.isUseDylansRandomXP());
         randomOriginOptionsPanel.setOptions(options.getRandomOriginOptions());
+
+        // Random Histories
         chkUseRandomPersonalities.setSelected(options.isUseRandomPersonalities());
+        chkUseSimulatedRelationships.setSelected(options.isUseSimulatedRelationships());
 
         // Family
         comboFamilyDisplayLevel.setSelectedItem(options.getFamilyDisplayLevel());
@@ -8891,7 +8927,10 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             // Personnel Randomization
             options.setUseDylansRandomXP(chkUseDylansRandomXP.isSelected());
             options.setRandomOriginOptions(randomOriginOptionsPanel.createOptionsFromPanel());
+
+            // Random Histories
             options.setUseRandomPersonalities(chkUseRandomPersonalities.isSelected());
+            options.setUseSimulatedRelationships(chkUseSimulatedRelationships.isSelected());
 
             // Family
             options.setFamilyDisplayLevel(comboFamilyDisplayLevel.getSelectedItem());

--- a/MekHQ/unittests/mekhq/campaign/personnel/procreation/AbstractProcreationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/procreation/AbstractProcreationTest.java
@@ -299,20 +299,20 @@ public class AbstractProcreationTest {
 
     @Test
     public void testAddPregnancy() {
-        doCallRealMethod().when(mockProcreation).addPregnancy(any(), any(), any());
-        doCallRealMethod().when(mockProcreation).addPregnancy(any(), any(), any(), anyInt());
+        doCallRealMethod().when(mockProcreation).addPregnancy(any(), any(), any(), eq(false));
+        doCallRealMethod().when(mockProcreation).addPregnancy(any(), any(), any(), anyInt(), eq(false));
 
         final Person mother = new Person(mockCampaign);
         final Person father = new Person(mockCampaign);
 
         when(mockProcreation.determineNumberOfBabies(anyInt())).thenReturn(0);
-        mockProcreation.addPregnancy(mockCampaign, LocalDate.ofYearDay(3025, 1), mother);
+        mockProcreation.addPregnancy(mockCampaign, LocalDate.ofYearDay(3025, 1), mother, false);
         assertNull(mother.getExpectedDueDate());
         assertNull(mother.getDueDate());
         assertTrue(mother.getExtraData().isEmpty());
 
         when(mockCampaignOptions.isLogProcreation()).thenReturn(false);
-        mockProcreation.addPregnancy(mockCampaign, LocalDate.ofYearDay(3025, 1), mother, 1);
+        mockProcreation.addPregnancy(mockCampaign, LocalDate.ofYearDay(3025, 1), mother, 1, false);
         assertEquals(LocalDate.ofYearDay(3025, 281), mother.getExpectedDueDate());
         assertNotNull(mother.getDueDate());
         assertFalse(mother.getExtraData().isEmpty());
@@ -321,7 +321,7 @@ public class AbstractProcreationTest {
         assertEquals(1, mother.getExtraData().get(AbstractProcreation.PREGNANCY_CHILDREN_DATA));
 
         when(mockCampaignOptions.isLogProcreation()).thenReturn(true);
-        mockProcreation.addPregnancy(mockCampaign, LocalDate.ofYearDay(3025, 1), mother, 2);
+        mockProcreation.addPregnancy(mockCampaign, LocalDate.ofYearDay(3025, 1), mother, 2, false);
         assertEquals(LocalDate.ofYearDay(3025, 281), mother.getExpectedDueDate());
         assertNotNull(mother.getDueDate());
         assertFalse(mother.getExtraData().isEmpty());
@@ -330,7 +330,7 @@ public class AbstractProcreationTest {
         assertEquals(2, mother.getExtraData().get(AbstractProcreation.PREGNANCY_CHILDREN_DATA));
 
         mother.getGenealogy().setSpouse(father);
-        mockProcreation.addPregnancy(mockCampaign, LocalDate.ofYearDay(3025, 1), mother, 10);
+        mockProcreation.addPregnancy(mockCampaign, LocalDate.ofYearDay(3025, 1), mother, 10, false);
         assertEquals(LocalDate.ofYearDay(3025, 281), mother.getExpectedDueDate());
         assertNotNull(mother.getDueDate());
         assertFalse(mother.getExtraData().isEmpty());
@@ -450,7 +450,7 @@ public class AbstractProcreationTest {
     public void testProcessNewDay() {
         doCallRealMethod().when(mockProcreation).processNewDay(any(), any(), any());
         doNothing().when(mockProcreation).birth(any(), any(), any());
-        doNothing().when(mockProcreation).addPregnancy(any(), any(), any());
+        doNothing().when(mockProcreation).addPregnancy(any(), any(), any(), eq(false));
 
         final Person mockPerson = mock(Person.class);
 
@@ -481,7 +481,7 @@ public class AbstractProcreationTest {
         when(mockProcreation.randomlyProcreates(any(), any())).thenReturn(true);
         mockProcreation.processNewDay(mockCampaign, LocalDate.ofYearDay(3025, 1), mockPerson);
         verify(mockProcreation, times(2)).randomlyProcreates(any(), any());
-        verify(mockProcreation, times(1)).addPregnancy(any(), any(), any());
+        verify(mockProcreation, times(1)).addPregnancy(any(), any(), any(), eq(false));
     }
 
     //region Random Procreation


### PR DESCRIPTION
# Must be merged _before_ #4521

Implemented a new feature to simulate relationship histories, including marriage, procreation, and divorce for new campaign personnel. Enhanced the settings panel to include options for this new feature.

Should be merged after #4463. Originally this PR was just going to be a small extension to 4463, but it ballooned - as such things are want to do.
