### PR TITLE
Fixed NPE in Mass Enroll Filters

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -3007,8 +3007,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // find the first faction that accepts applications from all persons in personnel
                 Optional<String> suitableFaction = personnel.stream()
                         .map(person -> academy.getFilteredFaction(campaign, person, campaign.getCurrentSystem().getFactions(campaign.getLocalDate())))
-                        .filter(faction -> personnel.stream().allMatch(person -> faction.equals(academy.getFilteredFaction(campaign, person, campaign.getCurrentSystem().getFactions(campaign.getLocalDate())))))
+                        .filter(faction -> personnel.stream().allMatch(person ->
+                                Objects.equals(
+                                        faction,
+                                        academy.getFilteredFaction(campaign, person, campaign.getCurrentSystem().getFactions(campaign.getLocalDate()))
+                                )))
                         .distinct()
+                        .filter(Objects::nonNull)
                         .findFirst();
 
                 if (suitableFaction.isPresent()) {


### PR DESCRIPTION
This PR adds a null check to correctly handle situations where no suitable faction is found.

Closes #4532