### PR TITLE
Add "Buy in Bulk" Button to Parts Acquisition in Repair Bay

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
@@ -487,32 +487,42 @@ public class AcquisitionsDialog extends JDialog {
             btnUseBonus.addActionListener(ev -> useBonusPart());
             actionButtons.add(btnUseBonus, gbcActions);
             gbcActions.gridy++;
-
+            JButton btnOrderOne;
+            JButton btnOrderInBulk;
             if (partCountInfo.isCanBeAcquired()) {
-                JButton btnOrderOne = new JButton("Order One");
-                btnOrderOne.setToolTipText("Order one item");
-                btnOrderOne.setName("btnOrderOne");
-                btnOrderOne.addActionListener(ev -> {
-                    campaignGUI.getCampaign().getShoppingList().addShoppingItem(part.getAcquisitionWork(),
-                            1, campaignGUI.getCampaign());
-                    refresh();
-                });
-                actionButtons.add(btnOrderOne, gbcActions);
-                gbcActions.gridy++;
+                btnOrderOne = new JButton("Order One");
+                btnOrderInBulk = new JButton("Order in Bulk");
+            } else {
+                btnOrderOne = new JButton("Order One (TN: Impossible)");
+                btnOrderInBulk = new JButton("Order in Bulk (TN: Impossible)");
             }
+            btnOrderOne.setToolTipText("Order one item");
+            btnOrderOne.setName("btnOrderOne");
+            btnOrderOne.addActionListener(ev -> {
+                campaignGUI.getCampaign().getShoppingList().addShoppingItem(part.getAcquisitionWork(),
+                        1, campaignGUI.getCampaign());
+                refresh();
+            });
+            actionButtons.add(btnOrderOne, gbcActions);
+            gbcActions.gridy++;
 
-            if (!partCountInfo.isCanBeAcquired()) {
-                JButton btnOrderOne = new JButton("Order One (TN: Impossible)");
-                btnOrderOne.setToolTipText("Order one item");
-                btnOrderOne.setName("btnOrderOne");
-                btnOrderOne.addActionListener(ev -> {
-                    campaignGUI.getCampaign().getShoppingList().addShoppingItem(part.getAcquisitionWork(),
-                            1, campaignGUI.getCampaign());
+            btnOrderInBulk.setToolTipText("Order item in bulk");
+            btnOrderInBulk.setName("btnOrderInBulk");
+            btnOrderInBulk.addActionListener(ev -> {
+                int quantity = 1;
+                PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(campaignGUI.getFrame(),
+                    true, "How Many " + part.getName() + '?', quantity,
+                    1, CampaignGUI.MAX_QUANTITY_SPINNER);
+                pcd.setVisible(true);
+                quantity = pcd.getValue();
+                if (quantity > 0) {
+                    campaignGUI.getCampaign().getShoppingList()
+                        .addShoppingItem(part.getAcquisitionWork(), quantity, campaignGUI.getCampaign());
                     refresh();
-                });
-                actionButtons.add(btnOrderOne, gbcActions);
-                gbcActions.gridy++;
-            }
+                }
+            });
+            actionButtons.add(btnOrderInBulk, gbcActions);
+            gbcActions.gridy++;
 
             btnOrderAll = new JButton("Order All (" + partCountInfo.getMissingCount() + ")");
             btnOrderAll.setToolTipText("Order all missing");


### PR DESCRIPTION
This PR adds a "Buy in Bulk" button to the Parts Acquisition dialog in the Repair Bay, closing #2925.

I re-used the "Buy in Bulk" dialog from the CampaignGUI so very little new logic had to be implemented. The user clicks the "Buy in Bulk" button, a prompt opens up with a text box asking how many, and then the parts are added to the procurement list like normal:

![buyinbulk1](https://github.com/user-attachments/assets/4db2d83e-c0ce-46d2-a466-7b2e12b17887)

View from the main Campaign GUI after ordering multiple parts:

![buyinbulk2](https://github.com/user-attachments/assets/e8f7ae87-f8e3-4a07-91c5-9700942f228b)

Note that I also simplified/removed some redundant code when determining the text to display on the order button.

I did not touch the properties files in resources, although I think this is necessary for translations to work. Just let me know what I need to do there and I'll be happy to take care of it.