### PR TITLE
Improved Handling of Child Dependents When Attending Academies

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -212,6 +212,7 @@ public class Person {
     private int eduJourneyTime;
     private int eduEducationTime;
     private int eduDaysOfTravel;
+    private List<UUID> eduTagAlongs;
     //endregion Education
 
     //region Personality
@@ -372,6 +373,7 @@ public class Person {
         eduJourneyTime = 0;
         eduEducationTime = 0;
         eduDaysOfTravel = 0;
+        eduTagAlongs = new ArrayList<>();
         eduAcademySet = null;
         eduAcademyNameInSet = null;
         eduAcademyFaction = null;
@@ -1105,6 +1107,12 @@ public class Person {
         this.setEduJourneyTime(0);
         this.setEduDaysOfTravel(0);
 
+        for (UUID tagAlongId : eduTagAlongs) {
+            Person tagAlong = campaign.getPerson(tagAlongId);
+            tagAlong.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ACTIVE);
+        }
+        this.setEduTagAlongs(new ArrayList<>());
+
         MekHQ.triggerEvent(new PersonStatusChangedEvent(this));
     }
 
@@ -1595,6 +1603,18 @@ public class Person {
         this.eduDaysOfTravel = eduDaysOfTravel;
     }
 
+    public List<UUID> getEduTagAlongs() {
+        return eduTagAlongs;
+    }
+
+    public void setEduTagAlongs(final List<UUID> eduTagAlongs) {
+        this.eduTagAlongs = eduTagAlongs;
+    }
+
+    public void addEduTagAlong(final UUID tagAlong) {
+        this.eduTagAlongs.add(tagAlong);
+    }
+
     /**
      * Increments the number educational travel days by 1.
      */
@@ -2020,6 +2040,16 @@ public class Person {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "eduDaysOfTravel", eduDaysOfTravel);
             }
 
+            if (!eduTagAlongs.isEmpty()) {
+                MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "eduTagAlongs");
+
+                for (UUID tagAlong : eduTagAlongs) {
+                    MHQXMLUtility.writeSimpleXMLTag(pw, indent, "tagAlong", tagAlong.toString());
+                }
+
+                MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "eduTagAlongs");
+            }
+
             if (eduAcademySystem != null) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "eduAcademySystem", eduAcademySystem);
             }
@@ -2392,6 +2422,22 @@ public class Person {
                     retVal.eduJourneyTime = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduDaysOfTravel")) {
                     retVal.eduDaysOfTravel = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("eduTagAlongs")) {
+                    if (wn2.getNodeName().equalsIgnoreCase("eduTagAlongs")) {
+                        NodeList uuidNodes = wn2.getChildNodes();
+
+                        for (int j = 0; j < uuidNodes.getLength(); j++) {
+                            Node uuidNode = uuidNodes.item(j);
+
+                            if (uuidNode.getNodeName().equalsIgnoreCase("tagAlong")) {
+                                String uuidString = uuidNode.getTextContent();
+
+                                UUID uuid = UUID.fromString(uuidString);
+
+                                retVal.eduTagAlongs.add(uuid);
+                            }
+                        }
+                    }
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduAcademySystem")) {
                     retVal.eduAcademySystem = String.valueOf(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduAcademyName")) {

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -140,6 +140,13 @@ public class EducationController {
                 person.setEduJourneyTime(campaign.getSimplifiedTravelTime(campaign.getSystemById(campus)));
                 person.setEduAcademySystem(campus);
             }
+
+            for (Person child : person.getGenealogy().getChildren()) {
+                if ((child.getStatus().isActive()) && (child.isChild(campaign.getLocalDate()))) {
+                    person.addEduTagAlong(child.getId());
+                    child.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ON_LEAVE);
+                }
+            }
         }
 
         // this should already be 0, but we reset it just in case
@@ -487,6 +494,10 @@ public class EducationController {
         // has the person arrived home?
         if (person.getEduDaysOfTravel() >= person.getEduJourneyTime()) {
             person.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ACTIVE);
+
+            for (UUID tagAlong : person.getEduTagAlongs()) {
+                campaign.getPerson(tagAlong).changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ACTIVE);
+            }
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -30,10 +30,8 @@ import mekhq.campaign.ExtraData.StringKey;
 import mekhq.campaign.log.MedicalLogger;
 import mekhq.campaign.log.PersonalLogger;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.enums.FamilialRelationshipType;
-import mekhq.campaign.personnel.enums.GenderDescriptors;
-import mekhq.campaign.personnel.enums.PrisonerStatus;
-import mekhq.campaign.personnel.enums.RandomProcreationMethod;
+import mekhq.campaign.personnel.education.EducationController;
+import mekhq.campaign.personnel.enums.*;
 import mekhq.campaign.personnel.enums.education.EducationLevel;
 import mekhq.campaign.personnel.randomEvents.PersonalityController;
 
@@ -365,6 +363,14 @@ public abstract class AbstractProcreation {
 
             // Recruit the baby
             campaign.recruitPerson(baby, prisonerStatus, true, true);
+
+            // if the mother is at school, add the baby to the list of tag alongs
+            if ((!mother.getEduAcademyName().isBlank())
+                    && (!EducationController.getAcademy(mother.getEduAcademyName(), mother.getEduAcademyNameInSet()).isHomeSchool())) {
+
+                mother.addEduTagAlong(baby.getId());
+                baby.changeStatus(campaign, today, PersonnelStatus.ON_LEAVE);
+            }
         }
 
         // adjust parents' loyalty


### PR DESCRIPTION
Added tracking of child dependents when a character attends an out-of-unit education.

Now, when characters attend an outside-unit academy they will take any child dependents with them. This is true even if there is another parent remaining with the unit. The logic there is that academies are perceived as safer than an active military unit.

Any children tagging along in this way will have their status set to `On Leave` for the duration of the academic education, even if they cease being considered a child during that time. Babies born while the mother is at an academy are automatically factored into this system.

When the education concludes and the parent successfully returns to the unit all 'tag alongs' have their status set to `Active`.

### Closes #4522