### PR TITLE
Fixed Re-enrollment Checks

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -808,7 +808,8 @@ public class Academy implements Comparable<Academy> {
                 if (faction.equals(originFaction) || faction.equals(campaignFaction)) {
                     return faction.getShortName();
                 }
-                continue;
+
+                return null;
             }
 
             if (!hints.isAtWarWith(originFaction, faction, campaign.getLocalDate())

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1711,7 +1711,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                     // here we check that the person will benefit from re-enrollment
                                     int improvementPossible = 0;
 
-                                    if (academy.getFilteredFaction(campaign, person, List.of(person.getEduAcademyFaction())) != null) {
+                                    String filteredFaction = academy.getFilteredFaction(campaign, person, List.of(person.getEduAcademyFaction()));
+
+                                    if (filteredFaction != null) {
                                         int educationLevel = academy.getEducationLevel(person);
 
                                         String[] skills = academy.getCurriculums().get(person.getEduCourseIndex()).split(",");
@@ -1737,26 +1739,26 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                                 }
                                             }
                                         }
+
+                                        JMenuItem reEnroll;
+
+                                        if (improvementPossible > 0) {
+                                            reEnroll = new JMenuItem(resources.getString("eduReEnroll.text"));
+                                            reEnroll.setToolTipText(resources.getString("eduReEnroll.toolTip"));
+                                            reEnroll.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_RE_ENROLLMENT,
+                                                    academy.getSet(),
+                                                    academy.getName(),
+                                                    String.valueOf(person.getEduCourseIndex()),
+                                                    person.getEduAcademySystem(),
+                                                    person.getEduAcademyFaction()));
+                                            reEnroll.addActionListener(this);
+                                        } else {
+                                            reEnroll = new JMenuItem(resources.getString("eduReEnrollImpossible.text"));
+                                            reEnroll.setToolTipText(resources.getString("eduReEnrollImpossible.toolTip"));
+                                        }
+
+                                        academyMenu.add(reEnroll);
                                     }
-
-                                    JMenuItem reEnroll;
-
-                                    if (improvementPossible > 0) {
-                                        reEnroll = new JMenuItem(resources.getString("eduReEnroll.text"));
-                                        reEnroll.setToolTipText(resources.getString("eduReEnroll.toolTip"));
-                                        reEnroll.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_RE_ENROLLMENT,
-                                                academy.getSet(),
-                                                academy.getName(),
-                                                String.valueOf(person.getEduCourseIndex()),
-                                                person.getEduAcademySystem(),
-                                                person.getEduAcademyFaction()));
-                                        reEnroll.addActionListener(this);
-                                    } else {
-                                        reEnroll = new JMenuItem(resources.getString("eduReEnrollImpossible.text"));
-                                        reEnroll.setToolTipText(resources.getString("eduReEnrollImpossible.toolTip"));
-                                    }
-
-                                    academyMenu.add(reEnroll);
                                 }
                             }
                         }
@@ -3017,7 +3019,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     JMenu academyOption = new JMenu(academy.getName());
                     educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                    buildEducationSubMenus(campaign, academy, personnel, academyOption, campaign.getCurrentSystem().getId(), String.valueOf(suitableFaction));
+                    buildEducationSubMenus(campaign, academy, personnel, academyOption, campaign.getCurrentSystem().getId(), suitableFaction.get());
                 }
             } else if (academy.isHomeSchool()) {
                 JMenu academyOption = new JMenu(academy.getName());
@@ -3049,7 +3051,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             JMenu academyOption = new JMenu(academy.getName());
                             educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                            buildEducationSubMenus(campaign, academy, personnel, academyOption, nearestCampus, String.valueOf(suitableFaction));
+                            buildEducationSubMenus(campaign, academy, personnel, academyOption, nearestCampus, suitableFaction.get());
                         }
                     }
                 }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1732,6 +1732,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                                                 if ((person.hasSkill(skillParsed)) && (person.getSkill(skillParsed).getExperienceLevel() < educationLevel)) {
                                                     improvementPossible++;
+                                                } else if (!person.hasSkill(skillParsed)) {
+                                                    improvementPossible++;
                                                 }
                                             }
                                         }


### PR DESCRIPTION
Previously, the re-enrollment eligibility counter was only incremented for existing skills with lower experience levels than those offered by the qualification. Now, it also increments when the skill is missing.

Furthermore, we were incorrectly parsing an `Optional` directly to `String` instead of using the `get()` which caused issues with re-enrollment, as well as any Education Module check that relied on `Faction`.

### Closes #4557