### PR TITLE
Corrected Errors in Post-Grad & Doctorate Graduation Handler

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -975,10 +975,6 @@ public class EducationController {
 
             processGraduation(campaign, person, academy, 2, resources);
 
-            if (!academy.isMilitary()) {
-                reportMastersOrDoctorateGain(campaign, person, academy, resources);
-            }
-
             person.setEduEducationStage(EducationStage.GRADUATING);
 
             person.changeLoyalty(academy.getDurationDays() / 300);
@@ -1034,10 +1030,6 @@ public class EducationController {
 
             processGraduation(campaign, person, academy, 1, resources);
 
-            if (!academy.isMilitary()) {
-                reportMastersOrDoctorateGain(campaign, person, academy, resources);
-            }
-
             person.setEduEducationStage(EducationStage.GRADUATING);
 
             person.changeLoyalty(academy.getDurationDays() / 300);
@@ -1086,10 +1078,6 @@ public class EducationController {
 
         processGraduation(campaign, person, academy, 0, resources);
 
-        if (!academy.isMilitary()) {
-            reportMastersOrDoctorateGain(campaign, person, academy, resources);
-        }
-
         person.setEduEducationStage(EducationStage.GRADUATING);
 
         person.changeLoyalty(academy.getDurationDays() / 300);
@@ -1100,33 +1088,52 @@ public class EducationController {
     /**
      * This method generates a report for individuals who have completed either a Master's or Doctorate degree.
      *
-     * @param campaign   the campaign to add the report to
-     * @param person     the person who completed the degree
-     * @param resources  the resource bundle containing localized strings
+     * @param campaign       the campaign to add the report to
+     * @param person         the person who completed the degree
+     * @param education the education level taught by the academy
+     * @param resources      the resource bundle containing localized strings
      */
-    private static void reportMastersOrDoctorateGain(Campaign campaign, Person person, Academy academy, ResourceBundle resources) {
-        int education = academy.getEducationLevel(person) - 1; // we reduce by 1 to account for the +1 level from graduating
-
+    private static void reportMastersOrDoctorateGain(Campaign campaign, Person person, Academy academy,
+                                                     int education, ResourceBundle resources) {
         EducationLevel educationLevel = EducationLevel.parseFromInt(education);
 
         String qualification = academy.getQualifications().get(person.getEduCourseIndex());
         String personName = person.getHyperlinkedFullTitle();
 
-        String graduationLevel = "";
-
         if (educationLevel.isPostGraduate()) {
-            graduationLevel = resources.getString("graduatedMasters.text");
+            ServiceLogger.eduGraduatedMasters(
+                    person,
+                    campaign.getLocalDate(),
+                    person.getEduAcademyName(),
+                    qualification
+            );
 
-            ServiceLogger.eduGraduatedMasters(person, campaign.getLocalDate(), person.getEduAcademyName(), qualification);
+            generatePostGradGraduationReport(
+                    campaign,
+                    personName,
+                    resources.getString("graduatedMasters.text"),
+                    qualification,
+                    resources
+            );
+
         } else if (educationLevel.isDoctorate()) {
-            graduationLevel = resources.getString("graduatedDoctorate.text");
-
-            ServiceLogger.eduGraduatedDoctorate(person, campaign.getLocalDate(), person.getEduAcademyName(), qualification);
+            ServiceLogger.eduGraduatedDoctorate(
+                    person,
+                    campaign.getLocalDate(),
+                    person.getEduAcademyName(),
+                    qualification
+            );
 
             person.setPreNominal("Dr");
-        }
 
-        generatePostGradGraduationReport(campaign, personName, graduationLevel, qualification, resources);
+            generatePostGradGraduationReport(
+                    campaign,
+                    personName,
+                    resources.getString("graduatedDoctorate.text"),
+                    qualification,
+                    resources
+            );
+        }
     }
 
     /**
@@ -1141,7 +1148,7 @@ public class EducationController {
                                                          String graduationText, String qualification, ResourceBundle resources) {
         campaign.addReport(String.format(resources.getString("graduatedPostGradReport.text"),
                 personName,
-                "<span color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>",
+                "<span color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'>",
                 graduationText,
                 "</span>",
                 qualification));
@@ -1246,7 +1253,6 @@ public class EducationController {
         int educationLevel = academy.getEducationLevel(person);
 
         if (EducationLevel.parseToInt(person.getEduHighestEducation()) < educationLevel) {
-            LogManager.getLogger().info(educationLevel);
             person.setEduHighestEducation(EducationLevel.parseFromInt(educationLevel));
         }
 
@@ -1267,6 +1273,10 @@ public class EducationController {
             person.setLoyalty(rolls.get(1) + rolls.get(2) + rolls.get(3));
         } else {
             adjustLoyalty(person);
+        }
+
+        if (!academy.isMilitary()) {
+            reportMastersOrDoctorateGain(campaign, person, academy, educationLevel, resources);
         }
     }
 
@@ -1293,9 +1303,6 @@ public class EducationController {
         }
 
         for (String skill : curriculum) {
-            LogManager.getLogger().info(skill);
-            LogManager.getLogger().info(educationLevel);
-
             if (skill.equalsIgnoreCase("none")) {
                 return;
             }


### PR DESCRIPTION
This PR addresses a small bug that caused errors when personnel were graduating from Education Level 0 (Early Education) academies, and when graduating from Post-Graduate and Doctorate academies.

I also fixed the color of the highlight text used when getting a Master's or Doctorate degree. MekHQ no longer thinks they are negative events.

### Closes #4544