### PR TITLE
Updated Repair Site Names to Match CamOps

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -399,18 +399,18 @@ public class AtBContract extends Contract {
     public int getRepairLocation(final int unitRating) {
         int repairLocation;
         if (getContractType().isGuerrillaWarfare() || getContractType().isRaidType()) {
-            repairLocation = Unit.SITE_FIELD;
+            repairLocation = Unit.SITE_IMPROVISED;
         } else if (!getContractType().isGarrisonType()) {
-            repairLocation = Unit.SITE_MOBILE_BASE;
+            repairLocation = Unit.SITE_FIELD_WORKSHOP;
         } else {
-            repairLocation = Unit.SITE_BAY;
+            repairLocation = Unit.SITE_FACILITY_BASIC;
         }
 
         if (unitRating >= IUnitRating.DRAGOON_B) {
             repairLocation++;
         }
 
-        return Math.min(repairLocation, Unit.SITE_BAY);
+        return Math.min(repairLocation, Unit.SITE_FACILITY_BASIC);
     }
 
     public void addMoraleMod(int mod) {
@@ -974,7 +974,7 @@ public class AtBContract extends Contract {
     }
 
     public String getEmployerName(int year) {
-        return isMercSubcontract() ? "Mercenary (" + getEmployerFaction().getFullName(year) + ")"
+        return isMercSubcontract() ? "Mercenary (" + getEmployerFaction().getFullName(year) + ')'
                 : getEmployerFaction().getFullName(year);
     }
 

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -81,12 +81,12 @@ import java.util.stream.Collectors;
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
 public class Unit implements ITechnology {
-    public static final int SITE_FIELD = 0;
-    public static final int SITE_MOBILE_BASE = 1;
-    public static final int SITE_BAY = 2;
-    public static final int SITE_FACILITY = 3;
-    public static final int SITE_FACTORY = 4;
-    public static final int SITE_N = 5;
+    public static final int SITE_IMPROVISED = 0;
+    public static final int SITE_FIELD_WORKSHOP = 1;
+    public static final int SITE_FACILITY_BASIC = 2;
+    public static final int SITE_FACILITY_MAINTENANCE = 3;
+    public static final int SITE_FACTORY_CONDITIONS = 4;
+    public static final int SITE_UNKNOWN = 5;
 
     // To be used for transport and cargo reports
     public static final int ETYPE_MOTHBALLED = -9876;
@@ -165,7 +165,7 @@ public class Unit implements ITechnology {
         if (entity != null) {
             entity.setCamouflage(new Camouflage());
         }
-        this.site = SITE_BAY;
+        this.site = SITE_FACILITY_BASIC;
         this.campaign = c;
         this.parts = new ArrayList<>();
         this.podSpace = new ArrayList<>();
@@ -804,23 +804,34 @@ public class Unit implements ITechnology {
 
     public TargetRoll getSiteMod() {
         return switch (site) {
-            case SITE_FIELD -> new TargetRoll(2, "Improvised");
-            case SITE_MOBILE_BASE -> new TargetRoll(1, "Field Workshop");
-            case SITE_BAY -> new TargetRoll(0, "Facility - Basic");
-            case SITE_FACILITY -> new TargetRoll(-2, "Facility - Maintenance");
-            case SITE_FACTORY -> new TargetRoll(-4, "Factory Conditions");
+            case SITE_IMPROVISED -> new TargetRoll(2, "Improvised");
+            case SITE_FIELD_WORKSHOP -> new TargetRoll(1, "Field Workshop");
+            case SITE_FACILITY_BASIC -> new TargetRoll(0, "Facility - Basic");
+            case SITE_FACILITY_MAINTENANCE -> new TargetRoll(-2, "Facility - Maintenance");
+            case SITE_FACTORY_CONDITIONS -> new TargetRoll(-4, "Factory Conditions");
             default -> new TargetRoll(0, "Unknown Location");
         };
     }
 
     public static String getSiteName(int loc) {
         return switch (loc) {
-            case SITE_FIELD -> "Improvised";
-            case SITE_MOBILE_BASE -> "Field Workshop";
-            case SITE_BAY -> "Facility - Basic";
-            case SITE_FACILITY -> "Facility - Maintenance";
-            case SITE_FACTORY -> "Factory Conditions";
+            case SITE_IMPROVISED -> "Improvised";
+            case SITE_FIELD_WORKSHOP -> "Field Workshop";
+            case SITE_FACILITY_BASIC -> "Facility - Basic";
+            case SITE_FACILITY_MAINTENANCE -> "Facility - Maintenance";
+            case SITE_FACTORY_CONDITIONS -> "Factory Conditions";
             default -> "Unknown";
+        };
+    }
+
+    public static String getSiteToolTipText(int loc) {
+        return switch (loc) {
+            case SITE_IMPROVISED -> "Battle-worn structures and improvised tools; survival depends on ingenuity and determination. Barely enough to keep units operational.";
+            case SITE_FIELD_WORKSHOP -> "Mobile units with essential gear; repairs are quick but rudimentary. Vital for frontline operations.";
+            case SITE_FACILITY_BASIC -> "Reliable shelter with all necessary tools for routine maintenance. Adequate but not exceptional.";
+            case SITE_FACILITY_MAINTENANCE -> "Well-equipped base with specialized machinery. Enables thorough repairs and maintenance, vital for prolonged campaigns.";
+            case SITE_FACTORY_CONDITIONS -> "State-of-the-art facility with advanced equipment. Peak efficiency for production and maintenance, ensuring top performance.";
+            default -> "";
         };
     }
 
@@ -1827,7 +1838,7 @@ public class Unit implements ITechnology {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "salvaged", true);
         }
 
-        if (site != SITE_BAY) {
+        if (site != SITE_FACILITY_BASIC) {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "site", site);
         }
 

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -804,22 +804,22 @@ public class Unit implements ITechnology {
 
     public TargetRoll getSiteMod() {
         return switch (site) {
-            case SITE_FIELD -> new TargetRoll(2, "in the field");
-            case SITE_MOBILE_BASE -> new TargetRoll(1, "field workshop");
-            case SITE_BAY -> new TargetRoll(0, "transport bay");
-            case SITE_FACILITY -> new TargetRoll(-2, "maintenance facility");
-            case SITE_FACTORY -> new TargetRoll(-4, "factory");
-            default -> new TargetRoll(0, "unknown location");
+            case SITE_FIELD -> new TargetRoll(2, "Improvised");
+            case SITE_MOBILE_BASE -> new TargetRoll(1, "Field Workshop");
+            case SITE_BAY -> new TargetRoll(0, "Facility - Basic");
+            case SITE_FACILITY -> new TargetRoll(-2, "Facility - Maintenance");
+            case SITE_FACTORY -> new TargetRoll(-4, "Factory Conditions");
+            default -> new TargetRoll(0, "Unknown Location");
         };
     }
 
     public static String getSiteName(int loc) {
         return switch (loc) {
-            case SITE_FIELD -> "In the Field";
+            case SITE_FIELD -> "Improvised";
             case SITE_MOBILE_BASE -> "Field Workshop";
-            case SITE_BAY -> "Transport Bay";
-            case SITE_FACILITY -> "Maintenance Facility";
-            case SITE_FACTORY -> "Factory";
+            case SITE_BAY -> "Facility - Basic";
+            case SITE_FACILITY -> "Facility - Maintenance";
+            case SITE_FACTORY -> "Factory Conditions";
             default -> "Unknown";
         };
     }

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -46,7 +46,6 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
     private JPanel panMapView;
     private InterstellarMapPanel panMap;
     private PlanetarySystemMapPanel panSystem;
-    private JSplitPane splitMap;
     private JScrollPane scrollPlanetView;
     JSuggestField suggestPlanet;
 
@@ -142,7 +141,7 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
         scrollPlanetView.setPreferredSize(new Dimension(400, 600));
         scrollPlanetView.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
         scrollPlanetView.setViewportView(null);
-        splitMap = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, mapView, scrollPlanetView);
+        JSplitPane splitMap = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, mapView, scrollPlanetView);
         splitMap.setOneTouchExpandable(true);
         splitMap.setResizeWeight(1.0);
         splitMap.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, ev -> refreshPlanetView());
@@ -188,7 +187,7 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
         panMap.setJumpPath(new JumpPath());
         panMap.repaint();
 
-        getCampaign().getUnits().forEach(unit -> unit.setSite(Unit.SITE_BAY));
+        getCampaign().getUnits().forEach(unit -> unit.setSite(Unit.SITE_FACILITY_BASIC));
     }
 
     private void refreshSystemView() {

--- a/MekHQ/src/mekhq/gui/adapter/ServicedUnitsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ServicedUnitsTableMouseAdapter.java
@@ -78,7 +78,7 @@ public class ServicedUnitsTableMouseAdapter extends JPopupMenuAdapter {
                 if (!unit.isDeployed()) {
                     String sel = command.split(":")[1];
                     int selected = Integer.parseInt(sel);
-                    if ((selected > -1) && (selected < Unit.SITE_N)) {
+                    if ((selected > -1) && (selected < Unit.SITE_UNKNOWN)) {
                         unit.setSite(selected);
                         MekHQ.triggerEvent(new RepairStatusChangedEvent(unit));
                     }
@@ -135,13 +135,12 @@ public class ServicedUnitsTableMouseAdapter extends JPopupMenuAdapter {
                     .convertRowIndexToModel(rows[i]));
         }
         JMenuItem menuItem;
-        JMenu menu;
         JCheckBoxMenuItem cbMenuItem;
         // **lets fill the pop up menu**//
         // change the location
-        menu = new JMenu("Change site");
+        JMenu menu = new JMenu("Change site");
         int i;
-        for (i = 0; i < Unit.SITE_N; i++) {
+        for (i = 0; i < Unit.SITE_UNKNOWN; i++) {
             cbMenuItem = new JCheckBoxMenuItem(Unit.getSiteName(i));
             if (StaticChecks.areAllSameSite(units) && unit.getSite() == i) {
                 cbMenuItem.setSelected(true);

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -65,6 +65,8 @@ import java.io.PrintStream;
 import java.util.*;
 import java.util.stream.Stream;
 
+import static megamek.client.ui.WrapLayout.wordWrap;
+
 public class UnitTableMouseAdapter extends JPopupMenuAdapter {
     //region Variable Declarations
     private CampaignGUI gui;
@@ -244,7 +246,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                 int selected = Integer.parseInt(command.split(":")[1]);
                 for (Unit unit : units) {
                     if (!unit.isDeployed()) {
-                        if ((selected > -1) && (selected < Unit.SITE_N)) {
+                        if ((selected > -1) && (selected < Unit.SITE_UNKNOWN)) {
                             unit.setSite(selected);
                             MekHQ.triggerEvent(new RepairStatusChangedEvent(unit));
                         }
@@ -634,8 +636,10 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
             // change the location
             menu = new JMenu("Change site");
             boolean allSameSite = StaticChecks.areAllSameSite(units);
-            for (int i = 0; i < Unit.SITE_N; i++) {
+
+            for (int i = 0; i < Unit.SITE_UNKNOWN; i++) {
                 cbMenuItem = new JCheckBoxMenuItem(Unit.getSiteName(i));
+                cbMenuItem.setToolTipText(wordWrap(Unit.getSiteToolTipText(i)));
                 if (allSameSite && unit.getSite() == i) {
                     cbMenuItem.setSelected(true);
                 } else {


### PR DESCRIPTION
Standardized the names for various repair sites in the `getSiteMod` and `getSiteName` methods to match CamOps. I also added tooltips to the options when picking a repair site.