### PR TITLE
Fixed Prisoner of War Award Categorization

### DIFF
--- a/MekHQ/data/universe/awards/standard.xml
+++ b/MekHQ/data/universe/awards/standard.xml
@@ -111,7 +111,7 @@
     <award>
         <name>Prisoner of War</name>
         <description>Taken prisoner during combat.</description>
-        <group>Manual Awards</group>
+        <group>Personal Awards</group>
         <medal>POWM.png</medal>
         <ribbon>3-01-1-PrisonerOfWar.png</ribbon>
         <xp>1</xp>


### PR DESCRIPTION
In what must be the smallest PR I've done to date: I've reclassified 'Prisoner of War' award grouping from 'Manual Awards' to 'Personal Awards'.