### PR TITLE
Updated Repair Tab Experience Level Requirement Text & Adjusted Font Sizes

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -115,10 +115,9 @@ public class Armor extends Part implements IAcquisitionWork {
         }
         String bonus = getAllMods(null).getValueAsString();
         if (getAllMods(null).getValue() > -1) {
-            bonus = "+" + bonus;
+            bonus = '+' + bonus;
         }
-        bonus = "(" + bonus + ")";
-        String toReturn = "<html><font size='2'";
+        String toReturn = "<html><font size='3'";
 
         String scheduled = "";
         if (getTech() != null) {
@@ -126,20 +125,27 @@ public class Armor extends Part implements IAcquisitionWork {
         }
 
         toReturn += ">";
-        toReturn += "<b>Replace " + getName() + "</b><br/>";
+        toReturn += "<b>Replace " + getName();
+
+        if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
+            toReturn += " - <b><span color='" + MekHQ.getMHQOptions().getFontColorWarningHexColor() + "'>"
+                    + SkillType.getExperienceLevelName(getSkillMin()) + '+'
+                    + "</span></b></b><br/>";
+        } else {
+            toReturn += "</b><br/>";
+        }
+
         toReturn += getDetails() + "<br/>";
         if (getAmountAvailable() > 0) {
-            toReturn += "" + getTimeLeft() + " minutes" + scheduled;
-            if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
-                toReturn += ", " + SkillType.getExperienceLevelName(getSkillMin());
-            }
-            toReturn += " " + bonus;
+            toReturn += getTimeLeft() + " minutes" + scheduled;
+            toReturn += " <b>TN:</b> " + bonus;
         }
         if (getMode() != WorkTime.NORMAL) {
-            toReturn += "<br/><i>" + getCurrentModeName() + "</i>";
+            toReturn += " <i>" + getCurrentModeName() + "</i>";
         }
         toReturn += "</font></html>";
         return toReturn;
+
     }
 
     @Override
@@ -504,7 +510,7 @@ public class Armor extends Part implements IAcquisitionWork {
         //availability mod
         int avail = getAvailability();
         int availabilityMod = Availability.getAvailabilityModifier(avail);
-        target.addModifier(availabilityMod, "availability (" + ITechnology.getRatingName(avail) + ")");
+        target.addModifier(availabilityMod, "availability (" + ITechnology.getRatingName(avail) + ')');
         return target;
     }
 
@@ -580,9 +586,9 @@ public class Armor extends Part implements IAcquisitionWork {
     @Override
     public String getQuantityName(int quan) {
         double totalTon = quan * getTonnage();
-        String report = "" + DecimalFormat.getInstance().format(totalTon) + " tons of " + getName();
+        String report = DecimalFormat.getInstance().format(totalTon) + " tons of " + getName();
         if (totalTon == 1.0) {
-            report = "" + DecimalFormat.getInstance().format(totalTon) + " ton of " + getName();
+            report = DecimalFormat.getInstance().format(totalTon) + " ton of " + getName();
         }
         return report;
     }

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -140,9 +140,9 @@ public class MekLocation extends Part {
         }
 
         if (EquipmentType.T_STRUCTURE_ENDO_STEEL == structureType) {
-            this.name += " (" + EquipmentType.getStructureTypeName(structureType, clan) + ")";
+            this.name += " (" + EquipmentType.getStructureTypeName(structureType, clan) + ')';
         } else if (structureType != EquipmentType.T_STRUCTURE_STANDARD) {
-            this.name += " (" + EquipmentType.getStructureTypeName(structureType) + ")";
+            this.name += " (" + EquipmentType.getStructureTypeName(structureType) + ')';
         }
 
         if (tsm) {
@@ -218,11 +218,10 @@ public class MekLocation extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        if (!(part instanceof MekLocation)) {
+        if (!(part instanceof MekLocation other)) {
             return false;
         }
 
-        MekLocation other = (MekLocation) part;
         return (getLoc() == other.getLoc())
                 && (getUnitTonnage() == other.getUnitTonnage())
                 && (isTsm() == other.isTsm())
@@ -573,7 +572,7 @@ public class MekLocation extends Part {
             }
 
             if (components.length() > 0) {
-                toReturn += " [" + components + "]";
+                toReturn += " [" + components + ']';
             }
         }
 
@@ -844,7 +843,7 @@ public class MekLocation extends Part {
         if ((!isBreached() && !isBlownOff()) || isSalvaging()) {
             return super.getDesc();
         }
-        String toReturn = "<html><font size='2'";
+        String toReturn = "<html><font size='3'";
         String scheduled = "";
         if (getTech() != null) {
             scheduled = " (scheduled) ";
@@ -852,27 +851,32 @@ public class MekLocation extends Part {
 
         toReturn += ">";
         if (isBlownOff()) {
-            toReturn += "<b>Re-attach " + getName() + "</b><br/>";
+            toReturn += "<b>Re-attach " + getName();
+
         } else {
-            toReturn += "<b>Seal " + getName() + "</b><br/>";
+            toReturn += "<b>Seal " + getName();
+
         }
-        toReturn += getDetails() + "<br/>";
+
         if (getSkillMin() > SkillType.EXP_ELITE) {
-            toReturn += "<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>Impossible</font>";
+            toReturn += " - <span color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>Impossible</b></span>";
         } else {
+            toReturn += " - <span color='" + MekHQ.getMHQOptions().getFontColorWarningHexColor() + "'>"
+                    + SkillType.getExperienceLevelName(getSkillMin()) + '+'
+                    + "</span></b></b><br/>";
+        }
+
+        toReturn += getDetails() + "<br/>";
+        if (getSkillMin() <= SkillType.EXP_ELITE) {
             toReturn += getTimeLeft() + " minutes" + scheduled;
             if (isBlownOff()) {
                 String bonus = getAllMods(null).getValueAsString();
                 if (getAllMods(null).getValue() > -1) {
                     bonus = '+' + bonus;
                 }
-                bonus = '(' + bonus + ')';
-                if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
-                    toReturn += ", " + SkillType.getExperienceLevelName(getSkillMin());
-                }
-                toReturn += ' ' + bonus;
+                toReturn += " <b>TN:</b> " + bonus;
                 if (getMode() != WorkTime.NORMAL) {
-                    toReturn += "<br/><i>" + getCurrentModeName() + "</i>";
+                    toReturn += " <i>" + getCurrentModeName() + "</i>";
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -86,26 +86,29 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
         if (getAllMods(null).getValue() > -1) {
             bonus = '+' + bonus;
         }
-        bonus = '(' + bonus + ')';
-        String toReturn = "<html><font size='2'";
+        String toReturn = "<html><font size='3'";
         String scheduled = "";
         if (getTech() != null) {
             scheduled = " (scheduled) ";
         }
 
         toReturn += ">";
-        toReturn += "<b>Replace " + getName() + "</b><br/>";
-        toReturn += getDetails() + "<br/>";
+        toReturn += "<b>Replace " + getName();
+
         if (getSkillMin() > SkillType.EXP_ELITE) {
-            toReturn += "<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>Impossible</font>";
+            toReturn += " - <span color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>Impossible</b></span>";
         } else {
+            toReturn += " - <span color='" + MekHQ.getMHQOptions().getFontColorWarningHexColor() + "'>"
+                    + SkillType.getExperienceLevelName(getSkillMin()) + '+'
+                    + "</span></b></b><br/>";
+        }
+
+        toReturn += getDetails() + "<br/>";
+        if (getSkillMin() <= SkillType.EXP_ELITE) {
             toReturn += getTimeLeft() + " minutes" + scheduled;
-            if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
-                toReturn += ", " + SkillType.getExperienceLevelName(getSkillMin());
-            }
-            toReturn += ' ' + bonus;
+            toReturn += " <b>TN:</b> " + bonus;
             if (getMode() != WorkTime.NORMAL) {
-                toReturn += "<br/><i>" + getCurrentModeName() + "</i>";
+                toReturn += " <i>" + getCurrentModeName() + "</i>";
             }
         }
         toReturn += "</font></html>";
@@ -268,7 +271,7 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
         //availability mod
         int avail = getAvailability();
         int availabilityMod = Availability.getAvailabilityModifier(avail);
-        target.addModifier(availabilityMod, "availability (" + ITechnology.getRatingName(avail) + ")");
+        target.addModifier(availabilityMod, "availability (" + ITechnology.getRatingName(avail) + ')');
 
         return target;
     }
@@ -309,10 +312,10 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
     public String getAcquisitionBonus() {
         String bonus = getAllAcquisitionMods().getValueAsString();
         if (getAllAcquisitionMods().getValue() > -1) {
-            bonus = "+" + bonus;
+            bonus = '+' + bonus;
         }
 
-        return "(" + bonus + ")";
+        return '(' + bonus + ')';
     }
 
     @Override
@@ -375,7 +378,7 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
     public String getAcquisitionName() {
         String details = getNewPart().getDetails();
         details = details.replaceFirst("\\d+\\shit\\(s\\)", "");
-        return getPartName() + " " + details;
+        return getPartName() + ' ' + details;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -409,7 +409,6 @@ public abstract class Part implements IPartWork, ITechnology {
         if (getAllMods(null).getValue() > -1) {
             bonus = '+' + bonus;
         }
-        bonus = '(' + bonus + ')';
         String toReturn = "<html><font size='3'";
         String action = "Repair ";
         if (isSalvaging()) {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -379,7 +379,7 @@ public abstract class Part implements IPartWork, ITechnology {
             if (getDaysToArrival() > 1) {
                 dayName += "s";
             }
-            toReturn = "In transit (" + getDaysToArrival() + " " + dayName + ")";
+            toReturn = "In transit (" + getDaysToArrival() + ' ' + dayName + ')';
         }
         return toReturn;
     }
@@ -410,7 +410,7 @@ public abstract class Part implements IPartWork, ITechnology {
             bonus = '+' + bonus;
         }
         bonus = '(' + bonus + ')';
-        String toReturn = "<html><font size='2'";
+        String toReturn = "<html><font size='3'";
         String action = "Repair ";
         if (isSalvaging()) {
             action = "Salvage ";
@@ -421,18 +421,24 @@ public abstract class Part implements IPartWork, ITechnology {
         }
 
         toReturn += ">";
-        toReturn += "<b>" + action + getName() + "</b><br/>";
+        toReturn += "<b>" + action + getName();
+
+        if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
+            toReturn += " - <b><span color='" + MekHQ.getMHQOptions().getFontColorWarningHexColor() + "'>"
+                    + SkillType.getExperienceLevelName(getSkillMin()) + '+'
+                    + "</span></b></b><br/>";
+        } else {
+            toReturn += "</b><br/>";
+        }
+
         toReturn += getDetails() + "<br/>";
         if (getSkillMin() > SkillType.EXP_ELITE) {
             toReturn += "<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>Impossible</font>";
         } else {
             toReturn += getTimeLeft() + " minutes" + scheduled;
-            if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
-                toReturn += ", " + SkillType.getExperienceLevelName(getSkillMin());
-            }
-            toReturn += ' ' + bonus;
+            toReturn += " <b>TN:</b> " + bonus;
             if (getMode() != WorkTime.NORMAL) {
-                toReturn += "<br/><i>" + getCurrentModeName() + "</i>";
+                toReturn += " <i>" + getCurrentModeName() + "</i>";
             }
         }
         toReturn += "</font></html>";
@@ -448,12 +454,18 @@ public abstract class Part implements IPartWork, ITechnology {
             }
             String bonus = getAllMods(null).getValueAsString();
             if (getAllMods(null).getValue() > -1) {
-                bonus = "+" + bonus;
+                bonus = '+' + bonus;
             }
-            bonus = "(" + bonus + ")";
+
             toReturn += getTimeLeft() + " minutes" + scheduled;
-            toReturn += ", " + SkillType.getExperienceLevelName(getSkillMin());
-            toReturn += " " + bonus;
+
+            if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
+                toReturn += ", <span color='" + MekHQ.getMHQOptions().getFontColorWarningHexColor() + "'>"
+                        + SkillType.getExperienceLevelName(getSkillMin()) + '+'
+                        + "</span>";
+            }
+
+            toReturn += ", TN: " + bonus;
             if (getMode() != WorkTime.NORMAL) {
                 toReturn += ", " + getCurrentModeName();
             }
@@ -1342,7 +1354,7 @@ public abstract class Part implements IPartWork, ITechnology {
     }
 
     public String getQuantityName(int quantity) {
-        String answer = "" + quantity + " " + getName();
+        String answer = String.valueOf(quantity) + ' ' + getName();
         if (quantity > 1) {
             answer += "s";
         }
@@ -1490,7 +1502,7 @@ public abstract class Part implements IPartWork, ITechnology {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(getName());
-        sb.append(" ");
+        sb.append(' ');
         sb.append(getDetails());
         sb.append(", q: ");
         sb.append(quantity);

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -177,7 +177,7 @@ public class PodSpace implements IPartWork {
                     }
                 }
                 return "There are no replacement parts available for "
-                    + unit.getEntity().getLocationName(location) + ".";
+                    + unit.getEntity().getLocationName(location) + '.';
             }
         }
         return null;
@@ -368,8 +368,7 @@ public class PodSpace implements IPartWork {
         if (getAllMods(null).getValue() > -1) {
             bonus = '+' + bonus;
         }
-        bonus = '(' + bonus + ')';
-        String toReturn = "<html><font size='2'";
+        String toReturn = "<html><font size='3'";
         String action = "Replace ";
         if (isSalvaging()) {
             action = "Salvage ";
@@ -380,16 +379,20 @@ public class PodSpace implements IPartWork {
         }
 
         toReturn += ">";
-        toReturn += "<b>" + action + getPartName() + " Equipment</b><br/>";
-        toReturn += getDetails() + "<br/>";
+        toReturn += "<b>" + action + getPartName() + " Equipment";
+
         if (getSkillMin() > SkillType.EXP_ELITE) {
-            toReturn += "<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>Impossible</font>";
+            toReturn += " - <span color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>Impossible</b></span>";
         } else {
+            toReturn += " - <span color='" + MekHQ.getMHQOptions().getFontColorWarningHexColor() + "'>"
+                    + SkillType.getExperienceLevelName(getSkillMin()) + '+'
+                    + "</span></b></b><br/>";
+        }
+
+        toReturn += getDetails() + "<br/>";
+        if (getSkillMin() <= SkillType.EXP_ELITE) {
             toReturn += getTimeLeft() + " minutes" + scheduled;
-            if (!campaign.getCampaignOptions().isDestroyByMargin()) {
-                toReturn += ", " + SkillType.getExperienceLevelName(getSkillMin());
-            }
-            toReturn += ' ' + bonus;
+            toReturn += " <b>TN:</b> " + bonus;
         }
         toReturn += "</font></html>";
         return toReturn;

--- a/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtomekLocation.java
@@ -558,7 +558,7 @@ public class ProtomekLocation extends Part {
         if ((!isBreached() && !isBlownOff()) || isSalvaging()) {
             return super.getDesc();
         }
-        String toReturn = "<html><font size='2'";
+        String toReturn = "<html><font size='3'";
         String scheduled = "";
         if (getTech() != null) {
             scheduled = " (scheduled) ";
@@ -566,27 +566,35 @@ public class ProtomekLocation extends Part {
 
         toReturn += ">";
         if (isBlownOff()) {
-            toReturn += "<b>Re-attach " + getName() + "</b><br/>";
+            toReturn += "<b>Re-attach " + getName();
         } else {
-            toReturn += "<b>Seal " + getName() + "</b><br/>";
+            toReturn += "<b>Seal " + getName();
+
         }
-        toReturn += getDetails() + "<br/>";
-        if (getSkillMin() > SkillType.EXP_ELITE) {
-            toReturn += "<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>Impossible</font>";
+
+        if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
+            if (getSkillMin() > SkillType.EXP_ELITE) {
+                toReturn += " - <span color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>Impossible</b></span>";
+            } else {
+            toReturn += " - <span color='" + MekHQ.getMHQOptions().getFontColorWarningHexColor() + "'>"
+                    + SkillType.getExperienceLevelName(getSkillMin()) + '+'
+                    + "</span></b></b><br/>";
+            }
         } else {
+            toReturn += "</b><br/>";
+        }
+
+        toReturn += getDetails() + "<br/>";
+        if (getSkillMin() <= SkillType.EXP_ELITE) {
             toReturn += getTimeLeft() + " minutes" + scheduled;
             if (isBlownOff()) {
                 String bonus = getAllMods(null).getValueAsString();
                 if (getAllMods(null).getValue() > -1) {
                     bonus = '+' + bonus;
                 }
-                bonus = '(' + bonus + ')';
-                if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
-                    toReturn += ", " + SkillType.getExperienceLevelName(getSkillMin());
-                }
-                toReturn += ' ' + bonus;
+                toReturn += " <b>TN:</b> " + bonus;
                 if (getMode() != WorkTime.NORMAL) {
-                    toReturn += "<br/><i>" + getCurrentModeName() + "</i>";
+                    toReturn += " <i>" + getCurrentModeName() + "</i>";
                 }
             }
         }

--- a/MekHQ/src/mekhq/gui/model/TechTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TechTableModel.java
@@ -52,8 +52,8 @@ public class TechTableModel extends DataTableModel {
         return tab.getCampaign();
     }
 
-    public TechTableModel.Renderer getRenderer() {
-        return new TechTableModel.Renderer();
+    public Renderer getRenderer() {
+        return new Renderer();
     }
 
     public class Renderer extends BasicInfo implements TableCellRenderer {
@@ -83,7 +83,7 @@ public class TechTableModel extends DataTableModel {
 
     public String getTechDesc(Person tech, boolean overtimeAllowed, IPartWork part) {
         StringBuilder toReturn = new StringBuilder(128);
-        toReturn.append("<html><font size='2'");
+        toReturn.append("<html><font size='3'");
         if ((null != part) && (null != part.getUnit()) && tech.getTechUnits().contains(part.getUnit())) {
             toReturn.append(" color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'><b>@");
         }
@@ -102,7 +102,7 @@ public class TechTableModel extends DataTableModel {
             }
 
             toReturn.append(SkillType.getExperienceLevelName(skill.getExperienceLevel()));
-            toReturn.append(" ").append(skillName);
+            toReturn.append(' ').append(skillName);
             first = false;
         }
 


### PR DESCRIPTION
This PR updates how we display repair tasks to the user. Specifically, it makes experience level requirements (used by CamOps repairs) more noticeable to reduce user confusion. In particular, among users coming fresh from FM:Mr. I also went and upped the font sizes used here and in the Tech list to make them more legible on smaller screens.

![image](https://github.com/user-attachments/assets/f9d8c715-fe9c-4842-a1ba-f10c835dd083)

As an aside, at some point we probably want to refactor the various `getDesc()` methods used across the `parts` package, as we're reusing a lot of code. I took a look at doing this myself, but I think it would be better suited for a more holistic approach rather than the bandaid I'd be capable of at this time.

### Closes #4537