### PR TITLE
Added CamOps Planetary Condition Modifiers to Maintenance Checks

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -141,6 +141,7 @@ import java.util.stream.Collectors;
 
 import static mekhq.campaign.personnel.education.EducationController.getAcademy;
 import static mekhq.campaign.personnel.turnoverAndRetention.RetirementDefectionTracker.Payout.isBreakingContract;
+import static mekhq.campaign.unit.Unit.SITE_FACILITY_MAINTENANCE;
 
 /**
  * The main campaign class, keeps track of teams and units
@@ -5408,6 +5409,37 @@ public class Campaign implements ITechManager {
 
         if (getCampaignOptions().isUseEraMods()) {
             target.addModifier(getFaction().getEraMod(getGameYear()), "era");
+        }
+
+        if (partWork.getUnit().getSite() < SITE_FACILITY_MAINTENANCE) {
+            if (getLocation().isOnPlanet()) {
+                Planet planet = getLocation().getPlanet();
+                Atmosphere atmosphere = planet.getAtmosphere(getLocalDate());
+                megamek.common.planetaryconditions.Atmosphere planetaryConditions = megamek.common.planetaryconditions.Atmosphere.getAtmosphere(planet.getPressure(getLocalDate()));
+                int temperature = planet.getTemperature(getLocalDate());
+
+                if (planet.getGravity() < 0.8) {
+                    target.addModifier(2, "Low Gravity");
+                } else if (planet.getGravity() >= 2.0) {
+                    target.addModifier(4, "Very High Gravity");
+                } else if (planet.getGravity() > 1.2) {
+                    target.addModifier(1, "High Gravity");
+                }
+
+                if (atmosphere.isTainted() || atmosphere.isToxic()) {
+                    target.addModifier(2, "Tainted or Toxic Atmosphere");
+                } else if (planetaryConditions.isVacuum()) {
+                    target.addModifier(2, "Vacuum");
+                }
+
+                if (planetaryConditions.isTrace() || planetaryConditions.isVeryHigh()) {
+                    target.addModifier(1, "Trace or Very High Pressure Atmosphere");
+                }
+
+                if (temperature < -30 || temperature > 50) {
+                    target.addModifier(1, "Extreme Temperature");
+                }
+            }
         }
 
         if (null != partWork.getUnit() && null != tech) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5412,7 +5412,7 @@ public class Campaign implements ITechManager {
         }
 
         if (partWork.getUnit().getSite() < SITE_FACILITY_MAINTENANCE) {
-            if (getLocation().isOnPlanet()) {
+            if (getLocation().isOnPlanet() && campaignOptions.isUsePlanetaryModifiers()) {
                 Planet planet = getLocation().getPlanet();
                 Atmosphere atmosphere = planet.getAtmosphere(getLocalDate());
                 megamek.common.planetaryconditions.Atmosphere planetaryConditions = megamek.common.planetaryconditions.Atmosphere.getAtmosphere(planet.getPressure(getLocalDate()));

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -119,6 +119,7 @@ public class CampaignOptions {
     private boolean useQualityMaintenance;
     private boolean reverseQualityNames;
     private boolean useRandomUnitQualities;
+    private boolean usePlanetaryModifiers;
     private boolean useUnofficialMaintenance;
     private boolean logMaintenance;
 
@@ -615,6 +616,7 @@ public class CampaignOptions {
         useQualityMaintenance = true;
         reverseQualityNames = false;
         setUseRandomUnitQualities(true);
+        setUsePlanetaryModifiers(true);
         useUnofficialMaintenance = false;
         logMaintenance = false;
 
@@ -1285,6 +1287,14 @@ public class CampaignOptions {
 
     public void setUseRandomUnitQualities(final boolean useRandomUnitQualities) {
         this.useRandomUnitQualities = useRandomUnitQualities;
+    }
+
+    public boolean isUsePlanetaryModifiers() {
+        return usePlanetaryModifiers;
+    }
+
+    public void setUsePlanetaryModifiers(final boolean usePlanetaryModifiers) {
+        this.usePlanetaryModifiers = usePlanetaryModifiers;
     }
 
     public boolean isUseUnofficialMaintenance() {
@@ -4588,6 +4598,7 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useQualityMaintenance", useQualityMaintenance);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "reverseQualityNames", reverseQualityNames);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useRandomUnitQualities", isUseRandomUnitQualities());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "usePlanetaryModifiers", isUsePlanetaryModifiers());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useUnofficialMaintenance", isUseUnofficialMaintenance());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "checkMaintenance", checkMaintenance);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "maxAcquisitions", maxAcquisitions);
@@ -5035,6 +5046,8 @@ public class CampaignOptions {
                     retVal.reverseQualityNames = Boolean.parseBoolean(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("useRandomUnitQualities")) {
                     retVal.setUseRandomUnitQualities(Boolean.parseBoolean(wn2.getTextContent()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("usePlanetaryModifiers")) {
+                    retVal.setUsePlanetaryModifiers(Boolean.parseBoolean(wn2.getTextContent()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("useUnofficialMaintenance")
                         || wn2.getNodeName().equalsIgnoreCase("useUnofficalMaintenance")) { // Legacy, 0.49.12 Removal
                     retVal.setUseUnofficialMaintenance(Boolean.parseBoolean(wn2.getTextContent()));

--- a/MekHQ/src/mekhq/campaign/universe/Atmosphere.java
+++ b/MekHQ/src/mekhq/campaign/universe/Atmosphere.java
@@ -26,21 +26,71 @@ public enum Atmosphere {
 
     // For old life form data
     public static Atmosphere parseAtmosphere(String val) {
-        switch (val.toLowerCase()) {
-            case "tainted (poisonous)": return TAINTEDPOISON;
-            case "tainted (caustic)": return TAINTEDCAUSTIC;
-            case "tainted (flammable)": return TAINTEDFLAME;
-            case "toxic (poisonous)": return TOXICPOISON;
-            case "toxic (caustic)": return TOXICCAUSTIC;
-            case "toxic (flammable)": return TOXICFLAME;
-            case "breathable": return BREATHABLE;
-            default: return NONE;
-        }
+        return switch (val.toLowerCase()) {
+            case "tainted (poisonous)" -> TAINTEDPOISON;
+            case "tainted (caustic)" -> TAINTEDCAUSTIC;
+            case "tainted (flammable)" -> TAINTEDFLAME;
+            case "toxic (poisonous)" -> TOXICPOISON;
+            case "toxic (caustic)" -> TOXICCAUSTIC;
+            case "toxic (flammable)" -> TOXICFLAME;
+            case "breathable" -> BREATHABLE;
+            default -> NONE;
+        };
     }
 
     public final String name;
 
-    private Atmosphere(String name) {
+    Atmosphere(String name) {
         this.name = name;
+    }
+
+    @SuppressWarnings(value = "unused")
+    public boolean isNone() {
+        return this == NONE;
+    }
+
+    @SuppressWarnings(value = "unused")
+    public boolean isTaintedPoison() {
+        return this == TAINTEDPOISON;
+    }
+
+    @SuppressWarnings(value = "unused")
+    public boolean isTaintedCaustic() {
+        return this == TAINTEDCAUSTIC;
+    }
+
+    @SuppressWarnings(value = "unused")
+    public boolean isTaintedFlame() {
+        return this == TAINTEDFLAME;
+    }
+
+    @SuppressWarnings(value = "unused")
+    public boolean isToxicPoison() {
+        return this == TOXICPOISON;
+    }
+
+    @SuppressWarnings(value = "unused")
+    public boolean isToxicCaustic() {
+        return this == TOXICCAUSTIC;
+    }
+
+    @SuppressWarnings(value = "unused")
+    public boolean isToxicFlame() {
+        return this == TOXICFLAME;
+    }
+
+    @SuppressWarnings(value = "unused")
+    public boolean isBreathable() {
+        return this == BREATHABLE;
+    }
+
+    @SuppressWarnings(value = "unused")
+    public boolean isTainted() {
+        return isTaintedPoison() || isTaintedCaustic() || isTaintedFlame();
+    }
+
+    @SuppressWarnings(value = "unused")
+    public boolean isToxic() {
+        return isToxicPoison() || isToxicCaustic() || isToxicFlame();
     }
 }

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -146,6 +146,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private JCheckBox useQualityMaintenance;
     private JCheckBox reverseQualityNames;
     private JCheckBox chkUseRandomUnitQualities;
+    private JCheckBox chkUsePlanetaryModifiers;
     private JCheckBox useUnofficialMaintenance;
     private JCheckBox logMaintenance;
     //endregion Repair and Maintenance Tab
@@ -1024,6 +1025,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                 useUnofficialMaintenance.setEnabled(true);
                 reverseQualityNames.setEnabled(true);
                 chkUseRandomUnitQualities.setEnabled(true);
+                chkUsePlanetaryModifiers.setEnabled(true);
                 spnMaintenanceBonus.setEnabled(true);
                 logMaintenance.setEnabled(true);
             } else {
@@ -1032,6 +1034,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                 useUnofficialMaintenance.setEnabled(false);
                 reverseQualityNames.setEnabled(false);
                 chkUseRandomUnitQualities.setEnabled(false);
+                chkUsePlanetaryModifiers.setEnabled(false);
                 spnMaintenanceBonus.setEnabled(false);
                 logMaintenance.setEnabled(false);
             }
@@ -1090,6 +1093,8 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         panSubMaintenance.add(reverseQualityNames, gridBagConstraints);
 
+        reverseQualityNames.addActionListener(evt -> recreateFinancesPanel(reverseQualityNames.isSelected()));
+
         chkUseRandomUnitQualities = new JCheckBox(resources.getString("chkUseRandomUnitQualities.text"));
         chkUseRandomUnitQualities.setToolTipText(resources.getString("chkUseRandomUnitQualities.toolTipText"));
         gridBagConstraints = new GridBagConstraints();
@@ -1101,13 +1106,22 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         panSubMaintenance.add(chkUseRandomUnitQualities, gridBagConstraints);
 
-        reverseQualityNames.addActionListener(evt -> recreateFinancesPanel(reverseQualityNames.isSelected()));
+        chkUsePlanetaryModifiers = new JCheckBox(resources.getString("chkUsePlanetaryModifiers.text"));
+        chkUsePlanetaryModifiers.setToolTipText(resources.getString("chkUsePlanetaryModifiers.toolTipText"));
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.weightx = 0.0;
+        gridBagConstraints.weighty = 0.0;
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        panSubMaintenance.add(chkUsePlanetaryModifiers, gridBagConstraints);
 
         useUnofficialMaintenance = new JCheckBox(resources.getString("useUnofficialMaintenance.text"));
         useUnofficialMaintenance.setToolTipText(resources.getString("useUnofficialMaintenance.toolTipText"));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 6;
+        gridBagConstraints.gridy = 7;
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.weightx = 0.0;
         gridBagConstraints.weighty = 0.0;
@@ -1117,7 +1131,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         logMaintenance = new JCheckBox(resources.getString("logMaintenance.text"));
         logMaintenance.setToolTipText(resources.getString("logMaintenance.toolTipText"));
         logMaintenance.setName("logMaintenance");
-        gridBagConstraints.gridy = 7;
+        gridBagConstraints.gridy = 8;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
         panSubMaintenance.add(logMaintenance, gridBagConstraints);
@@ -8071,6 +8085,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         useQualityMaintenance.setSelected(options.isUseQualityMaintenance());
         reverseQualityNames.setSelected(options.isReverseQualityNames());
         chkUseRandomUnitQualities.setSelected(options.isUseRandomUnitQualities());
+        chkUsePlanetaryModifiers.setSelected(options.isUsePlanetaryModifiers());
         useUnofficialMaintenance.setSelected(options.isUseUnofficialMaintenance());
         logMaintenance.setSelected(options.isLogMaintenance());
         //endregion Repair and Maintenance Tab
@@ -8699,6 +8714,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             options.setUseQualityMaintenance(useQualityMaintenance.isSelected());
             options.setReverseQualityNames(reverseQualityNames.isSelected());
             options.setUseRandomUnitQualities(chkUseRandomUnitQualities.isSelected());
+            options.setUsePlanetaryModifiers(chkUsePlanetaryModifiers.isSelected());
             options.setUseUnofficialMaintenance(useUnofficialMaintenance.isSelected());
             options.setLogMaintenance(logMaintenance.isSelected());
             options.setMaintenanceBonus((Integer) spnMaintenanceBonus.getValue());


### PR DESCRIPTION
Integrated various planetary conditions (such as gravity, atmosphere, pressure, and temperature) into the campaign's targeting calculations. Improved the Atmosphere class by adding methods to check specific atmospheres and refactoring the parseAtmosphere method using a switch expression.

### Closes #4575