### PR TITLE
Fixed Null Check for Education Tag Alongs

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -365,7 +365,7 @@ public abstract class AbstractProcreation {
             campaign.recruitPerson(baby, prisonerStatus, true, true);
 
             // if the mother is at school, add the baby to the list of tag alongs
-            if ((!mother.getEduAcademyName().isBlank())
+            if ((mother.getEduAcademyName() != null)
                     && (!EducationController.getAcademy(mother.getEduAcademyName(), mother.getEduAcademyNameInSet()).isHomeSchool())) {
 
                 mother.addEduTagAlong(baby.getId());


### PR DESCRIPTION
When personnel give birth while at an academy, their child is added to a list of 'tag alongs' so that mhq knows who is being simulated as 'away from the unit' and doesn't just teleport the baby back to the unit. I included a check to ensure this wasn't done if the mother wasn't attending an academy, however this was done using `isBlank`. I wasn't aware blank xml tags are not included in personnel save data, as they are in other parts of our codebase (campaign options, for example). This caused the check to hit a NPE. Switching to check for `null` instead does the same thing, but prevents the NPE.

### Closes #4594