### PR TITLE
Integrated Academy Information into Interstellar Map Tab

### DIFF
--- a/MekHQ/resources/mekhq/resources/PlanetViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/PlanetViewPanel.properties
@@ -14,6 +14,7 @@ lblComposition.text=<html><nobr><b>Atmospheric Composition:</b></nobr></html>
 lblAnimal1.text=<html><nobr><b>Highest Native Life:</b></nobr></html>
 lblLandMass1.text=<html><nobr><b>Landmasses (Capital City):</b></nobr></html>
 lblHPG1.text=<html><nobr><b>HPG Class Type:</b></nobr></html>
+lblAcademies.text=<html><nobr><b>Academies</b></nobr></html>
 lblSocioIndustrial1.text=<html><nobr><b>Socio-Industrial Levels:</b></nobr></html>
 lblPosition.text=<html><nobr><b>Position in System:</b></nobr></html>
 lblDiameter.text=<html><nobr><b>Diameter:</b></nobr></html>

--- a/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
+++ b/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
@@ -2,7 +2,7 @@
  * PlanetarySystem.java
  *
  * Copyright (c) 2011 - Jay Lawson (jaylawson39 at yahoo.com). All Rights Reserved.
- * Copyright (c) 2011-2022 - The MegaMek team. All Rights Reserved.
+ * Copyright (c) 2011-2024 - The MegaMek team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2011-2024 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/view/PlanetViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PlanetViewPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 - The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2009-2024 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *


### PR DESCRIPTION
This PR is another Hammer request: the academies present in a system are now visible in the system information, including their description.

Furthermore, I went ahead and implemented an 'academies' filter, so users can visually spy which systems have non-local, non-homeschool academies.

These changes are also designed to handle custom academy sets, so if users have one or more custom academy sets, those academies will appear in the filter and system description.

As always, I did some light refactoring in the files I edited. Nothing too exciting, just clean up where appropriate.