### PR TITLE
Added Support for Handling Medical Discharge

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -729,7 +729,9 @@ public class Campaign implements ITechManager {
                     boolean wasSacked = getRetirementDefectionTracker().getPayout(pid).isWasSacked();
 
                     if ((!wasKilled) && (!wasSacked)) {
-                        if (isBreakingContract(person, getLocalDate(), getCampaignOptions().getServiceContractDuration())) {
+                        if (!person.getPermanentInjuries().isEmpty()) {
+                            person.changeStatus(this, getLocalDate(), PersonnelStatus.RETIRED);
+                        } if (isBreakingContract(person, getLocalDate(), getCampaignOptions().getServiceContractDuration())) {
                             if (!getActiveContracts().isEmpty()) {
                                 int roll = Compute.randomInt(20);
 
@@ -751,7 +753,11 @@ public class Campaign implements ITechManager {
                     }
 
                     if (wasSacked) {
-                        person.changeStatus(this, getLocalDate(), PersonnelStatus.SACKED);
+                        if (person.getPermanentInjuries().isEmpty()) {
+                            person.changeStatus(this, getLocalDate(), PersonnelStatus.SACKED);
+                        } else {
+                            person.changeStatus(this, getLocalDate(), PersonnelStatus.RETIRED);
+                        }
                     }
 
                     // civilian spouses follow their partner in departing

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3877,6 +3877,12 @@ public class Person {
         return new ArrayList<>(injuries);
     }
 
+    public List<Injury> getPermanentInjuries() {
+        return injuries.stream()
+                .filter(Injury::isPermanent)
+                .collect(Collectors.toList());
+    }
+
     public void clearInjuries() {
         injuries.clear();
 

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -966,15 +966,18 @@ public class RetirementDefectionTracker {
             // person was killed
             if (killed) {
                 payoutAmount = getPayoutOrBonusValue(campaign, person).multipliedBy(campaign.getCampaignOptions().getPayoutRetirementMultiplier());
-            // person was sacked
-            } else if (sacked) {
-                payoutAmount = Money.of(0);
+            // person is getting medically discharged
+            } else if (!person.getPermanentInjuries().isEmpty()) {
+                payoutAmount = getPayoutOrBonusValue(campaign, person).multipliedBy(campaign.getCampaignOptions().getPayoutRetirementMultiplier());
             // person is defecting
             } else if (isBreakingContract(person, campaign.getLocalDate(), campaign.getCampaignOptions().getServiceContractDuration())) {
                 payoutAmount = Money.of(0);
             // person is retiring
             } else if (person.getAge(campaign.getLocalDate()) >= 50) {
                 payoutAmount = getPayoutOrBonusValue(campaign, person).multipliedBy(campaign.getCampaignOptions().getPayoutRetirementMultiplier());
+            // person was sacked
+            } else if (sacked) {
+                payoutAmount = Money.of(0);
             // person is resigning
             } else {
                 payoutAmount = getPayoutOrBonusValue(campaign, person);


### PR DESCRIPTION
Updated `Person` class to include method for retrieving permanent injuries.

Modified `Campaign` to retire personnel with permanent injuries instead of sacking them, bypassing contract breaches. Adjusted `RetirementDefectionTracker` to provide the appropriate payout for medically discharged personnel. Medical Discharge occurs if the character resigns while possessing a permanent injury.

Fixed a bug in the payout logic that would cause personnel to always receive a 0 c-bill payout if they were sacked. Now the payout value correctly factors in whether the character is eligible for retirement or medical discharge.

### Closes #4599