### PR TITLE
Refactored Years of Service Calculation for autoAwards Time Awards

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1326,22 +1326,28 @@ public class Person {
                 .getDisplayFormattedOutput(getRecruitment(), today);
     }
 
-    public Integer getYearsInService(final Campaign campaign) {
+    /**
+     * @return how many years a character has spent employed in the campaign,
+     * factoring in date of death and retirement
+     *
+     * @param campaign the current Campaign
+     */
+    public long getYearsInService(final Campaign campaign) {
         // Get time in service based on year
         if (getRecruitment() == null) {
-            //use "" they haven't been recruited or are dependents
             return 0;
         }
 
         LocalDate today = campaign.getLocalDate();
 
-        // If the person is dead, we only care about how long they spent in service to the company
-        if (getDateOfDeath() != null) {
-            //use date of death instead of the current day
+        // If the person is dead or has left the unit, we only care about how long they spent in service to the company
+        if (getRetirement() != null) {
+            today = getRetirement();
+        } else if (getDateOfDeath() != null) {
             today = getDateOfDeath();
         }
 
-        return Math.toIntExact(ChronoUnit.YEARS.between(getRecruitment(), today));
+        return ChronoUnit.YEARS.between(getRecruitment(), today);
     }
 
     public @Nullable LocalDate getLastRankChangeDate() {

--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/TimeAwards.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/TimeAwards.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 public class TimeAwards {
     /**
@@ -21,7 +20,7 @@ public class TimeAwards {
     public static Map<Integer, List<Object>> TimeAwardsProcessor(Campaign campaign, UUID person, List<Award> awards) {
         int requiredYearsOfService;
         boolean isCumulative;
-        int yearsOfService;
+        long yearsOfService;
 
         List<Award> eligibleAwards = new ArrayList<>();
         List<Award> eligibleAwardsBestable = new ArrayList<>();
@@ -46,14 +45,10 @@ public class TimeAwards {
 
             if (award.canBeAwarded(campaign.getPerson(person))) {
                 try {
-                    yearsOfService = Integer.parseInt(Pattern.compile("\\s+")
-                            .splitAsStream(campaign.getPerson(person).getTimeInService(campaign))
-                            .findFirst()
-                            .orElseThrow());
+                    yearsOfService = campaign.getPerson(person).getYearsInService(campaign);
                 } catch (Exception e) {
-                    LogManager.getLogger().error("Unable to parse yearsOfService for {} while processing Award {} from the [{}] set." +
-                                    " This can be ignored if {} has 0 years Time in Service.",
-                            campaign.getPerson(person).getFullName(), award.getName(), award.getSet(), campaign.getPerson(person).getFullName());
+                    LogManager.getLogger().error("Unable to parse yearsOfService for {} while processing Award {} from the [{}] set.",
+                            campaign.getPerson(person).getFullName(), award.getName(), award.getSet());
                     continue;
                 }
 


### PR DESCRIPTION
Updated the `getYearsInService` method in the `Person` class to return a long instead of integer. This ensures accurate representation of service years even for extended durations and refactored related code in `TimeAwards` to take advantage of this method, as it didn't exist when TimeAwards were originally written.

### Closes #4624