### PR TITLE
Restored adminXPPeriod Option Parsing

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -5124,6 +5124,8 @@ public class CampaignOptions {
                     retVal.contractNegotiationXP = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("adminWeeklyXP")) {
                     retVal.adminXP = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("adminXPPeriod")) {
+                    retVal.adminXPPeriod = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("missionXpFail")) {
                     retVal.missionXpFail = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("missionXpSuccess")) {


### PR DESCRIPTION
Restored parsing for the `adminXPPeriod` option in the CampaignOptions class. This ensures that the setting is now correctly read and applied from configuration files.

### Closes #4619