### PR TITLE
Fix hyperlink issue in payment text

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -79,7 +79,7 @@ public class EducationController {
                         campaign.getLocalDate(),
                         Money.of(tuition),
                         String.format(resources.getString("payment.text"),
-                                person.getHyperlinkedFullTitle()));
+                                person.getFullTitle()));
             }
         }
 


### PR DESCRIPTION
The EducationController was incorrectly trying to display hyperlinked titles in the finance table.

### Closes #4620