### PR TITLE
Refactored Force Commander Logic & TOE Information Display

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -860,6 +860,8 @@ public class Campaign implements ITechManager {
                 lances.put(id, new Lance(force.getId(), this));
             }
         }
+
+        force.updateCommander(this);
     }
 
     public void moveForce(Force force, Force superForce) {

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -75,6 +75,7 @@ public class Force {
     private final Vector<UUID> units;
     private int scenarioId;
     private UUID forceCommanderID;
+    private UUID overrideForceCommanderID;
     protected UUID techId;
 
 
@@ -418,6 +419,14 @@ public class Force {
         forceCommanderID = commanderID;
     }
 
+    public UUID getOverrideForceCommanderID() {
+        return overrideForceCommanderID;
+    }
+
+    public void setOverrideForceCommanderID(UUID overrideForceCommanderID) {
+        this.overrideForceCommanderID = overrideForceCommanderID;
+    }
+
     /**
      * Returns a list of unit or force commanders eligible to be considered for the position of force commander.
      *
@@ -453,7 +462,22 @@ public class Force {
         List<UUID> eligibleCommanders = getEligibleCommanders(campaign);
 
         if (eligibleCommanders.isEmpty()) {
+            overrideForceCommanderID = null;
             return;
+        }
+
+        if (overrideForceCommanderID != null) {
+            if (eligibleCommanders.contains(overrideForceCommanderID)) {
+                forceCommanderID = overrideForceCommanderID;
+
+                if (getParentForce() != null) {
+                    getParentForce().updateCommander(campaign);
+                }
+
+                return;
+            } else {
+                overrideForceCommanderID = null;
+            }
         }
 
         Collections.shuffle(eligibleCommanders);

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -281,7 +281,8 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             }
         } else if (command.contains(TOEMouseAdapter.SET_LANCE_COMMANDER)) {
             if (null != singleForce) {
-                singleForce.setForceCommanderID(UUID.fromString(target));
+                singleForce.setOverrideForceCommanderID(UUID.fromString(target));
+                singleForce.updateCommander(gui.getCampaign());
                 gui.getTOETab().refreshForceView();
             }
         } else if (command.contains(TOEMouseAdapter.ASSIGN_TO_SHIP)) {
@@ -436,7 +437,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     if (JOptionPane.YES_OPTION != JOptionPane.showConfirmDialog(
                             null,
                             "Are you sure you want to delete "
-                                    + force.getFullName() + "?",
+                                    + force.getFullName() + '?',
                                     "Delete Force?", JOptionPane.YES_NO_OPTION)) {
                         return;
                     }
@@ -662,7 +663,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             Force force = forces.get(0);
             StringBuilder forceIds = new StringBuilder("" + force.getId());
             for (int i = 1; i < forces.size(); i++) {
-                forceIds.append("|").append(forces.get(i).getId());
+                forceIds.append('|').append(forces.get(i).getId());
             }
 
             if (!multipleSelection) {
@@ -775,8 +776,8 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                                 }
                             }
 
-                            menuItem = new JMenuItem(tech.getFullTitle() + " (" + tech.getRoleDesc() + ")");
-                            menuItem.setActionCommand(COMMAND_ADD_LANCE_TECH + tech.getId() + "|" + forceIds);
+                            menuItem = new JMenuItem(tech.getFullTitle() + " (" + tech.getRoleDesc() + ')');
+                            menuItem.setActionCommand(COMMAND_ADD_LANCE_TECH + tech.getId() + '|' + forceIds);
                             menuItem.addActionListener(this);
 
                             switch (tech.getSkillLevel(gui.getCampaign(), !tech.getPrimaryRole().isTech())) {
@@ -819,7 +820,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     JMenuHelpers.addMenuIfNonEmpty(popup, menu);
                 } else {
                     menuItem = new JMenuItem("Remove Tech from Force");
-                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_LANCE_TECH + force.getTechID() + "|" + forceIds);
+                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_LANCE_TECH + force.getTechID() + '|' + forceIds);
                     menuItem.addActionListener(this);
                     popup.add(menuItem);
                 }
@@ -845,7 +846,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
 
                         int weightClass = EntityWeightClass.getWeightClass(tonnage, unittype);
                         String displayname2 = EntityWeightClass.getClassName(weightClass, unittype, false);
-                        String weightClassMenuName = unittype + "_"
+                        String weightClassMenuName = unittype + '_'
                                 + EntityWeightClass.getClassName(weightClass, unittype, false);
                         weightClassForUnitType.put(weightClassMenuName, new JMenu(displayname2));
                         weightClassForUnitType.get(weightClassMenuName).setName(weightClassMenuName);
@@ -858,7 +859,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     for (int ut : svTypes) {
                         String typeName = UnitType.getTypeName(ut);
                         String wcName = EntityWeightClass.getClassName(wc, typeName, true);
-                        String menuName = typeName + "_" + wcName;
+                        String menuName = typeName + '_' + wcName;
                         JMenu m = new JMenu(wcName);
                         m.setName(menuName);
                         m.setEnabled(false);
@@ -878,12 +879,12 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                         Person p = u.getCommander();
                         if (p.getStatus().isActive() && (u.getForceId() < 1) && u.isPresent()) {
                             JMenuItem menuItem0 = new JMenuItem(p.getFullTitle() + ", " + u.getName());
-                            menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + "|" + forceIds);
+                            menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + '|' + forceIds);
                             menuItem0.addActionListener(this);
                             menuItem0.setEnabled(u.isAvailable());
-                            if (null != weightClassForUnitType.get(type + "_" + className)) {
-                                weightClassForUnitType.get(type + "_" + className).add(menuItem0);
-                                weightClassForUnitType.get(type + "_" + className).setEnabled(true);
+                            if (null != weightClassForUnitType.get(type + '_' + className)) {
+                                weightClassForUnitType.get(type + '_' + className).add(menuItem0);
+                                weightClassForUnitType.get(type + '_' + className).setEnabled(true);
                             } else {
                                 unsorted.add(menuItem0);
                             }
@@ -894,12 +895,12 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     if (u.getEntity() instanceof GunEmplacement) {
                         if (u.getForceId() < 1 && u.isPresent()) {
                             JMenuItem menuItem0 = new JMenuItem("AutoTurret, " + u.getName());
-                            menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + "|" + forceIds);
+                            menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + '|' + forceIds);
                             menuItem0.addActionListener(this);
                             menuItem0.setEnabled(u.isAvailable());
-                            if (null != weightClassForUnitType.get(type + "_" + className)) {
-                                weightClassForUnitType.get(type + "_" + className).add(menuItem0);
-                                weightClassForUnitType.get(type + "_" + className).setEnabled(true);
+                            if (null != weightClassForUnitType.get(type + '_' + className)) {
+                                weightClassForUnitType.get(type + '_' + className).add(menuItem0);
+                                weightClassForUnitType.get(type + '_' + className).setEnabled(true);
                             } else {
                                 unsorted.add(menuItem0);
                             }
@@ -920,7 +921,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                             }
 
                             int weightClass = EntityWeightClass.getWeightClass(tonnage, unittype);
-                            JMenu tmp2 = weightClassForUnitType.get(unittype + "_"
+                            JMenu tmp2 = weightClassForUnitType.get(unittype + '_'
                                     + EntityWeightClass.getClassName(weightClass, unittype, false));
                             if (tmp2.isEnabled()) {
                                 tmp.add(tmp2);
@@ -936,7 +937,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     if (tmp.isEnabled()) {
                         for (int wc = EntityWeightClass.WEIGHT_SMALL_SUPPORT;
                              wc <= EntityWeightClass.WEIGHT_LARGE_SUPPORT; wc++) {
-                            JMenu tmp2 = weightClassForUnitType.get(unittype + "_"
+                            JMenu tmp2 = weightClassForUnitType.get(unittype + '_'
                                     + EntityWeightClass.getClassName(wc, unittype, true));
                             if (tmp2.isEnabled()) {
                                 tmp.add(tmp2);
@@ -956,8 +957,8 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     for (UUID personID : eligibleCommanders) {
                         Person person = gui.getCampaign().getPerson(personID);
 
-                        JMenuItem commanderOption = new JMenuItem(person.getFullTitle() + " (" + person.getRoleDesc() + ")");
-                        commanderOption.setActionCommand(COMMAND_SET_LANCE_COMMANDER + personID + "|" + forceIds);
+                        JMenuItem commanderOption = new JMenuItem(person.getFullTitle() + " (" + person.getRoleDesc() + ')');
+                        commanderOption.setActionCommand(COMMAND_SET_LANCE_COMMANDER + personID + '|' + forceIds);
                         commanderOption.addActionListener(this);
                         menuItem.add(commanderOption);
                     }
@@ -1025,7 +1026,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                             continue;
                         }
                         menuItem = new JMenuItem(scenario.getName());
-                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DEPLOY_FORCE + scenario.getId() + "|" + forceIds);
+                        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DEPLOY_FORCE + scenario.getId() + '|' + forceIds);
                         menuItem.addActionListener(this);
                         missionMenu.add(menuItem);
                     }
@@ -1098,7 +1099,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                             double capacity = ship.getCorrectBayCapacity(singleUnitType, unitWeight);
                             if (capacity > 0) {
                                 JMenuItem shipMenuItem = new JMenuItem(ship.getName() + " , Space available: " + capacity);
-                                shipMenuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + "|" + unitIds);
+                                shipMenuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + '|' + unitIds);
                                 shipMenuItem.addActionListener(this);
                                 shipMenuItem.setEnabled(true);
                                 singleUnitMenu.add(shipMenuItem);
@@ -1202,7 +1203,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     if (nodesFree >= units.size()) {
                         menuItem = new JMenuItem(network[2] + ": " + network[1] + " nodes free");
                         menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_SLAVE
-                                + network[0] + "|" + unitIds);
+                                + network[0] + '|' + unitIds);
                         menuItem.addActionListener(this);
                         menuItem.setEnabled(true);
                         availMenu.add(menuItem);
@@ -1230,7 +1231,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     if (nodesFree >= units.size()) {
                         menuItem = new JMenuItem(network[2] + ": " + network[1] + " nodes free");
                         menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_SLAVE
-                                + network[0] + "|" + unitIds);
+                                + network[0] + '|' + unitIds);
                         menuItem.addActionListener(this);
                         menuItem.setEnabled(true);
                         availMenu.add(menuItem);
@@ -1279,7 +1280,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                         if (nodesFree >= units.size()) {
                             menuItem = new JMenuItem(network[0] + ": " + network[1] + " nodes free");
                             menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_TO_NETWORK
-                                    + network[0] + "|" + unitIds);
+                                    + network[0] + '|' + unitIds);
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(true);
                             availMenu.add(menuItem);
@@ -1328,7 +1329,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                         if (nodesFree >= units.size()) {
                             menuItem = new JMenuItem(network[0] + ": " + network[1] + " nodes free");
                             menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ADD_TO_NETWORK
-                                    + network[0] + "|" + unitIds);
+                                    + network[0] + '|' + unitIds);
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(true);
                             availMenu.add(menuItem);
@@ -1372,7 +1373,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                         }
                         menuItem = new JMenuItem(scenario.getName());
                         menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DEPLOY_UNIT
-                                + scenario.getId() + "|" + unitIds);
+                                + scenario.getId() + '|' + unitIds);
                         menuItem.addActionListener(this);
                         missionMenu.add(menuItem);
                     }
@@ -1424,7 +1425,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                             double capacity = ship.getCorrectBayCapacity(singleUnitType, unitWeight);
                             if (capacity > 0) {
                                 JMenuItem shipMenuItem = new JMenuItem(ship.getName() + " , Space available: " + capacity);
-                                shipMenuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + "|" + unitIds);
+                                shipMenuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + id + '|' + unitIds);
                                 shipMenuItem.addActionListener(this);
                                 shipMenuItem.setEnabled(true);
                                 singleUnitMenu.add(shipMenuItem);
@@ -1604,7 +1605,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
 
     private JMenuItem transportMenuItem(String shipName, UUID shipId, String unitIds, double capacity) {
         JMenuItem menuItem = new JMenuItem(shipName + " , Space available: " + capacity);
-        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + shipId + "|" + unitIds);
+        menuItem.setActionCommand(TOEMouseAdapter.COMMAND_ASSIGN_TO_SHIP + shipId + '|' + unitIds);
         menuItem.addActionListener(this);
 
         return menuItem;

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -390,7 +390,7 @@ public class ForceViewPanel extends JScrollablePanel {
         int nexty = 0;
         for (Force subForce : force.getSubForces()) {
             lblForce = new JLabel();
-            lblForce.setText(getSummaryFor(subForce));
+            lblForce.setText(getForceSummary(subForce));
             lblForce.setIcon(subForce.getForceIcon().getImageIcon(72));
             nexty++;
             gridBagConstraints = new GridBagConstraints();
@@ -428,7 +428,7 @@ public class ForceViewPanel extends JScrollablePanel {
             lblPerson = new JLabel();
             lblUnit = new JLabel();
             if (null != p) {
-                lblPerson.setText(getSummaryFor(p, unit));
+                lblPerson.setText(getForceSummary(p, unit));
                 lblPerson.setIcon(p.getPortrait().getImageIcon());
             } else {
                 lblPerson.getAccessibleContext().setAccessibleName("Unmanned Unit");
@@ -442,7 +442,7 @@ public class ForceViewPanel extends JScrollablePanel {
             gridBagConstraints.fill = GridBagConstraints.BOTH;
             gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
             pnlSubUnits.add(lblPerson, gridBagConstraints);
-            lblUnit.setText(getSummaryFor(unit));
+            lblUnit.setText(getForceSummary(unit));
             lblUnit.setIcon(new ImageIcon(unit.getImage(lblUnit)));
             lblPerson.setLabelFor(lblUnit);
             gridBagConstraints = new GridBagConstraints();
@@ -457,20 +457,20 @@ public class ForceViewPanel extends JScrollablePanel {
         }
     }
 
-    public String getSummaryFor(Person person, Unit unit) {
-        String toReturn = "<html><font size='2'><b>" + person.getFullTitle() + "</b><br/>";
+    public String getForceSummary(Person person, Unit unit) {
+        String toReturn = "<html><font size='3'><b>" + person.getFullTitle() + "</b><br/>";
         toReturn += person.getSkillLevel(campaign, false) + " " + person.getRoleDesc();
         if (null != unit && null != unit.getEntity()
                 && null != unit.getEntity().getCrew() && unit.getEntity().getCrew().getHits() > 0) {
-            toReturn += "<br><font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "' size='2'>" + unit.getEntity().getCrew().getHits() + " hit(s)";
+            toReturn += "<br><font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>" + unit.getEntity().getCrew().getHits() + " hit(s)";
         }
         toReturn += "</font></html>";
         return toReturn;
     }
 
-    public String getSummaryFor(Unit unit) {
-        String toReturn = "<html><font size='3'><b>" + unit.getName() + "</b></font><br/>";
-        toReturn += "<font size='2'><b>BV:</b> " + unit.getEntity().calculateBattleValue(true, null == unit.getEntity().getCrew()) + "<br/>";
+    public String getForceSummary(Unit unit) {
+        String toReturn = "<html><font size='4'><b>" + unit.getName() + "</b></font><br/>";
+        toReturn += "<font size='3'><b>BV:</b> " + unit.getEntity().calculateBattleValue(true, null == unit.getEntity().getCrew()) + "<br/>";
         toReturn += unit.getStatus();
         Entity entity = unit.getEntity();
         if (entity.hasNavalC3()) {
@@ -530,43 +530,54 @@ public class ForceViewPanel extends JScrollablePanel {
         return toReturn;
     }
 
-    public String getSummaryFor(Force f) {
-        // we are not going to use the campaign methods here because we can be more efficient
-        // by only traversing once
-        int bv = 0;
+    /**
+     * Returns a summary of the given Force in HTML format.
+     *
+     * @param force the Force to generate the summary for
+     * @return a summary of the Force in HTML format
+     */
+    public String getForceSummary(Force force) {
+        int battleValue = 0;
         Money cost = Money.zero();
-        double ton = 0;
+        double tonnage = 0;
         int number = 0;
         String commander = "No personnel found";
-        ArrayList<Person> people = new ArrayList<>();
-        for (UUID uid : f.getAllUnits(false)) {
-            Unit u = campaign.getUnit(uid);
-            if (null != u) {
-                Person p = u.getCommander();
+
+        for (UUID uid : force.getAllUnits(false)) {
+            Unit unit = campaign.getUnit(uid);
+            if (null != unit) {
+                boolean crewExists = unit.getCommander() != null;
+                battleValue += unit.getEntity().calculateBattleValue(true, !crewExists);
+                cost = cost.plus(unit.getEntity().getCost(true));
+                tonnage += unit.getEntity().getWeight();
                 number++;
-                if (p != null) {
-                    bv += u.getEntity().calculateBattleValue(true, false);
-                } else {
-                    bv += u.getEntity().calculateBattleValue(true, true);
-                }
-                cost = cost.plus(u.getEntity().getCost(true));
-                ton += u.getEntity().getWeight();
-                if (p != null) {
-                    people.add(p);
-                }
             }
         }
-        // sort person vector by rank
-        people.sort((p1, p2) -> ((Comparable<Integer>) p2.getRankNumeric()).compareTo(p1.getRankNumeric()));
-        if (!people.isEmpty()) {
-            commander = people.get(0).getFullTitle();
+
+        if (force.getForceCommanderID() != null) {
+            commander = campaign.getPerson(force.getForceCommanderID()).getFullTitle();
         }
-        String toReturn = "<html><font size='2'><b>" + f.getName() + "</b> (" + commander + ")<br/>";
-        toReturn += "<b>Number of Units:</b> " + number + "<br/>";
-        toReturn += bv + " BV, ";
-        toReturn += DecimalFormat.getInstance().format(ton) + " tons, ";
-        toReturn += cost.toAmountAndSymbolString();
-        toReturn += "</font></html>";
-        return toReturn;
+
+        StringBuilder summary = new StringBuilder();
+        summary.append("<html><font size='4'><b>").append(force.getName()).append("</b> (").append(commander).append(")</font><br/>");
+        summary.append("<font size='3'>");
+        appendSummary(summary, "Number of Units", number);
+        appendSummary(summary, "BV", battleValue);
+        appendSummary(summary, "Tonnage", DecimalFormat.getInstance().format(tonnage));
+        appendSummary(summary, "Value", cost.toAmountAndSymbolString());
+        summary.append("</font></html>");
+
+        return summary.toString();
+    }
+
+    /**
+     * Appends a summary line to the provided StringBuilder.
+     *
+     * @param string    the StringBuilder to append the summary line to
+     * @param attribute the attribute name to display in bold
+     * @param value     the value associated with the attribute
+     */
+    private void appendSummary(StringBuilder string, String attribute, Object value) {
+        string.append("<b>").append(attribute).append(":</b> ").append(value).append("<br/>");
     }
 }


### PR DESCRIPTION
Improved the logic for updating force commanders by refactoring the method to streamline the selection process. Used a list of eligible commanders based on units and sub-forces, and enhanced the selection by incorporating a tiebreaker mechanism.

Further, we now track force commander beyond the lance level, ensuring a proper chain of command is displayed throughout the TO&E. To that end force commander is now visible for nodes beyond lance and origin.

I also discovered we were re-calculating force commanders when viewing sub-forces in the side-bar. This meant that changes to force commander were not reflected when viewing sub-forces. Now sub-forces correctly display the current force commander.

Finally, I adjusted font sizes in a couple of places to improve readability.

### Closes #4607