### PR TITLE
Rename strat ops personnel market to campaign ops to reflect rulebook reorganization

### DIFF
--- a/MekHQ/mmconf/campaignPresets/Campaign Operations (StratCon).xml
+++ b/MekHQ/mmconf/campaignPresets/Campaign Operations (StratCon).xml
@@ -461,7 +461,7 @@
 		<sharesForAll>false</sharesForAll>
 		<useTaxes>false</useTaxes>
 		<taxesPercentage>30</taxesPercentage>
-		<personnelMarketName>Strat Ops</personnelMarketName>
+		<personnelMarketName>Campaign Ops</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
 		<personnelMarketRandomRemovalTargets>
 			<ULTRA_GREEN>4</ULTRA_GREEN>

--- a/MekHQ/mmconf/campaignPresets/Campaign Operations.xml
+++ b/MekHQ/mmconf/campaignPresets/Campaign Operations.xml
@@ -461,7 +461,7 @@
 		<sharesForAll>false</sharesForAll>
 		<useTaxes>false</useTaxes>
 		<taxesPercentage>30</taxesPercentage>
-		<personnelMarketName>Strat Ops</personnelMarketName>
+		<personnelMarketName>Campaign Ops</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
 		<personnelMarketRandomRemovalTargets>
 			<ULTRA_GREEN>4</ULTRA_GREEN>

--- a/MekHQ/mmconf/campaignPresets/Complete Experience.xml
+++ b/MekHQ/mmconf/campaignPresets/Complete Experience.xml
@@ -461,7 +461,7 @@
 		<sharesForAll>false</sharesForAll>
 		<useTaxes>false</useTaxes>
 		<taxesPercentage>30</taxesPercentage>
-		<personnelMarketName>Strat Ops</personnelMarketName>
+		<personnelMarketName>Campaign Ops</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
 		<personnelMarketRandomRemovalTargets>
 			<ULTRA_GREEN>4</ULTRA_GREEN>

--- a/MekHQ/mmconf/campaignPresets/New Pilot Program.xml
+++ b/MekHQ/mmconf/campaignPresets/New Pilot Program.xml
@@ -461,7 +461,7 @@
 		<sharesForAll>false</sharesForAll>
 		<useTaxes>false</useTaxes>
 		<taxesPercentage>30</taxesPercentage>
-		<personnelMarketName>Strat Ops</personnelMarketName>
+		<personnelMarketName>Campaign Ops</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
 		<personnelMarketRandomRemovalTargets>
 			<ULTRA_GREEN>4</ULTRA_GREEN>

--- a/MekHQ/resources/META-INF/services/mekhq.module.api.PersonnelMarketMethod
+++ b/MekHQ/resources/META-INF/services/mekhq.module.api.PersonnelMarketMethod
@@ -1,6 +1,6 @@
 mekhq.campaign.market.PersonnelMarketRandom
 mekhq.campaign.market.PersonnelMarketFMMr
-mekhq.campaign.market.PersonnelMarketStratOps
+mekhq.campaign.market.PersonnelMarketCampaignOps
 mekhq.campaign.market.PersonnelMarketDylan
 mekhq.campaign.market.PersonnelMarketDisabled
 mekhq.module.atb.PersonnelMarketAtB

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -5898,7 +5898,12 @@ public class CampaignOptions {
                     //region Markets Tab
                     //region Personnel Market
                 } else if (wn2.getNodeName().equalsIgnoreCase("personnelMarketName")) {
-                    retVal.setPersonnelMarketName(wn2.getTextContent().trim());
+                    String marketName = wn2.getTextContent().trim();
+                    // Backwards compatibility with saves from before these rules moved to Camops
+                    if (marketName.equals("Strat Ops")) {
+                        marketName = "Campaign Ops";
+                    }
+                    retVal.setPersonnelMarketName(marketName);
                 } else if (wn2.getNodeName().equalsIgnoreCase("personnelMarketReportRefresh")) {
                     retVal.setPersonnelMarketReportRefresh(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("personnelMarketRandomRemovalTargets")) {

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -51,7 +51,7 @@ public class PersonnelMarket {
     public static final int TYPE_RANDOM = 0;
     public static final int TYPE_DYLANS = 1;
     public static final int TYPE_FMMR = 2;
-    public static final int TYPE_STRAT_OPS = 3;
+    public static final int TYPE_CAMPAIGN_OPS = 3;
     public static final int TYPE_ATB = 4;
     public static final int TYPE_NONE = 5;
     public static final int TYPE_NUM = 6;
@@ -327,8 +327,8 @@ public class PersonnelMarket {
                 return "Dylan's Method";
             case TYPE_FMMR:
                 return "FM: Mercenaries Revised";
-            case TYPE_STRAT_OPS:
-                return "Strat Ops";
+            case TYPE_CAMPAIGN_OPS:
+                return "Campaign Ops";
             case TYPE_ATB:
                 return "Against the Bot";
             case TYPE_NONE:

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarketCampaignOps.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarketCampaignOps.java
@@ -35,12 +35,12 @@ import mekhq.module.api.PersonnelMarketMethod;
 /**
  * Method for personnel market generation given in the repair and maintenance section of Strategic Operations
  */
-public class PersonnelMarketStratOps implements PersonnelMarketMethod {
+public class PersonnelMarketCampaignOps implements PersonnelMarketMethod {
     private int daysSinceRolled = 0;
 
     @Override
     public String getModuleName() {
-        return "Strat Ops";
+        return "Campaign Ops";
     }
 
     @Override


### PR DESCRIPTION
This PR simply renames the Strat Ops personnel market method to "Campaign Ops" which reflects the fact that these rules moved to a different book. I added a check to the XML loader to automatically use Campaign Ops when saves contained the old Strat Ops string so backward compatibility works. 

As a sidenote, I doublechecked the personnel generation code and it matches what is in camops, although it doesn't seem to use the same skill generation method...or at least I couldn't find it. I will keep looking for that and push a separate PR once that's done.