### PR TITLE
Fixed Text Placeholders in CamOpsReputation.properties

### DIFF
--- a/MekHQ/resources/mekhq/resources/CamOpsReputation.properties
+++ b/MekHQ/resources/mekhq/resources/CamOpsReputation.properties
@@ -17,7 +17,7 @@ partialSuccesses.text=Partial Successes
 failures.text=Failures
 contractsBreached.text=Contracts Breached
 retainerDuration.text=Retainer Duration
-mission.text=<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;%s: </b>%d (+%d)
+mission.text=<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;%s: </b>%s (%s)
 
 transportationRating.text=<b><font size='6'>Transportation Rating: %s</font></b>
 hasJumpShipOrWarShip.text=<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Has JumpShip or WarShip: </b>+10


### PR DESCRIPTION
Changed mission text placeholders from integer to string format. This ensures the text is displayed correctly for various mission details.

### Closes #4635