### PR TITLE
Fixed Copy-Paste Error in End Mission Prisoner Nag

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -496,7 +496,7 @@ public final class BriefingTab extends CampaignGuiTab {
 
             if (!defectors.isEmpty()) {
                 // will return true if the prompt is canceled
-                if (prisonerPrompt(prisoners, "ransomDefectorsQ.format", resources)) {
+                if (prisonerPrompt(defectors, "ransomDefectorsQ.format", resources)) {
                     return;
                 }
             }


### PR DESCRIPTION
Changed the `prisonerPrompt` method to use `defectors` instead of `prisoners` within the defectors check. This ensures the correct list is passed to the prompt, preventing text errors when the prompt is displayed.

### Closes #4643