### PR TITLE
Fixed Intelligence XP Cost Calculations and Minor Logic Issues

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -80,6 +80,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static java.lang.Math.abs;
+
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  * @author Justin "Windchild" Bowen
@@ -1170,7 +1172,7 @@ public class Person {
 
         // if this is a major change, we use whichever result is furthest from the midpoint (9)
         if (isMajor) {
-            roll = Math.abs(roll - 9) > Math.abs(secondRoll - 9) ? roll : secondRoll;
+            roll = abs(roll - 9) > abs(secondRoll - 9) ? roll : secondRoll;
         }
 
         applyLoyaltyChange.accept(roll);
@@ -4267,9 +4269,14 @@ public class Person {
         if (campaignOptions.isUseRandomPersonalities() && campaignOptions.isUseIntelligenceXpMultiplier()) {
             double intelligenceMultiplier = 0.025; // each rank in Intelligence should adjust costs by 2.5%
 
-            double intelligenceScore = getIntelligence().getIntelligenceScore() * intelligenceMultiplier;
+            int intelligence = getIntelligence().getIntelligenceScore();
+            double intelligenceScore = intelligence * intelligenceMultiplier;
 
-            return intelligenceScore - 1;
+            if (intelligenceScore == 0) {
+                return 1;
+            } else {
+                return 1 - intelligenceScore;
+            }
         }
 
         return 1;

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1823,9 +1823,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     if (!spa.isEligible(person)) {
                         continue;
                     }
-                    cost = (int) (spa.getCost()
+                    cost = (int) Math.round((spa.getCost()
                             * person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions())
-                            * gui.getCampaign().getCampaignOptions().getXpCostMultiplier());
+                            * gui.getCampaign().getCampaignOptions().getXpCostMultiplier()));
                     String costDesc;
                     if (cost < 0) {
                         costDesc = resources.getString("costNotPossible.text");
@@ -2072,8 +2072,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             for (int i = 0; i < SkillType.getSkillList().length; i++) {
                 String type = SkillType.getSkillList()[i];
                 int cost = person.hasSkill(type) ? person.getSkill(type).getCostToImprove() : SkillType.getType(type).getCost(0);
-                cost *= (int) (person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions())
+                cost = (int) Math.round(cost * person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions())
                         * gui.getCampaign().getCampaignOptions().getXpCostMultiplier());
+
                 if (cost >= 0) {
                     String desc = String.format(resources.getString("skillDesc.format"), type, cost);
                     menuItem = new JMenuItem(desc);
@@ -2093,7 +2094,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             // Edge Purchasing
             if (gui.getCampaign().getCampaignOptions().isUseEdge()) {
                 JMenu edgeMenu = new JMenu(resources.getString("edge.text"));
-                int cost = (int) (gui.getCampaign().getCampaignOptions().getEdgeCost()
+                int cost = (int) Math.round(gui.getCampaign().getCampaignOptions().getEdgeCost()
                         * person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions())
                         * gui.getCampaign().getCampaignOptions().getXpCostMultiplier());
 


### PR DESCRIPTION
Rounded XP costs to nearest integer to improve accuracy and consistency. Corrected handling of zero intelligence scores to avoid division anomalies.

### Closes #4653