### PR TITLE
Revert change to find parts by name when selling from parts in use

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -9,7 +9,7 @@ import mekhq.campaign.work.IAcquisitionWork;
 
 public class PartInUse {
     private String description;
-    private int id;
+    private String name;
     private IAcquisitionWork partToBuy;
     private int useCount;
     private int storeCount;
@@ -35,13 +35,14 @@ public class PartInUse {
             appendDetails(sb, part);
         }
         part.setUnit(u);
-        this.id = part.getId();
+        this.name = part.getName();
         this.description = sb.toString();
         this.partToBuy = part.getAcquisitionWork();
         this.tonnagePerItem = part.getTonnage();
         // AmmoBin are special: They aren't buyable (yet?), but instead buy you the ammo inside
         // We redo the description based on that
         if (partToBuy instanceof AmmoStorage) {
+            this.name = ((AmmoStorage) partToBuy).getName();
             sb.setLength(0);
             sb.append(((AmmoStorage) partToBuy).getName());
             appendDetails(sb, (Part) ((AmmoStorage) partToBuy).getAcquisitionWork());
@@ -76,8 +77,8 @@ public class PartInUse {
         return description;
     }
 
-    public int getId() {
-        return id;
+    public String getName() {
+        return name;
     }
 
     public IAcquisitionWork getPartToBuy() {

--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -34,6 +34,7 @@ import javax.swing.table.TableRowSorter;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.util.Collections;
+import java.util.Objects;
 
 /**
  * A dialog to show parts in use, ordered, in transit with actionable buttons for buying or adding more

--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -135,16 +135,11 @@ public class PartsReportDialog extends JDialog {
             public void actionPerformed(ActionEvent e) {
                 int row = Integer.parseInt(e.getActionCommand());
                 PartInUse partInUse = overviewPartsModel.getPartInUse(row);
-                Part part = campaign.getWarehouse().getPart(partInUse.getId());
-                if (part == null) {
-                    return;
-                }
-                Part spare = campaign.getWarehouse().checkForExistingSparePart(part);
-                if (spare != null) {
-                    campaign.getQuartermaster().sellPart(spare, 1);
-                }
+                campaign.getWarehouse().getSpareParts().stream().filter(p ->
+                    Objects.equals(p.getName(), partInUse.getName()))
+                    .findFirst()
+                    .ifPresent(p -> campaign.getQuartermaster().sellPart(p, 1));
                 refreshOverviewPartsInUse();
-
             }
         };
 
@@ -153,22 +148,20 @@ public class PartsReportDialog extends JDialog {
             public void actionPerformed(ActionEvent e) {
                 int row = Integer.parseInt(e.getActionCommand());
                 PartInUse partInUse = overviewPartsModel.getPartInUse(row);
-                Part part = campaign.getWarehouse().getPart(partInUse.getId());
-                if (part == null) {
-                    return;
-                }
-                Part spare = campaign.getWarehouse().checkForExistingSparePart(part);
-                if (spare != null) {
-                    int quantity = 1;
-                    PopupValueChoiceDialog popupValueChoiceDialog = new PopupValueChoiceDialog(gui.getFrame(), true,
-                        "Sell how many " + spare.getName(), quantity, 1, CampaignGUI.MAX_QUANTITY_SPINNER);
-                    popupValueChoiceDialog.setVisible(true);
-                    quantity = popupValueChoiceDialog.getValue();
-                    if (quantity <= 0) {
-                        return;
-                    }
-                    campaign.getQuartermaster().sellPart(spare, quantity);
-                }
+                campaign.getWarehouse().getSpareParts().stream().filter(p ->
+                                Objects.equals(p.getName(), partInUse.getName()))
+                        .findFirst()
+                        .ifPresent(p -> {
+                            int quantity = 1;
+                            PopupValueChoiceDialog popupValueChoiceDialog = new PopupValueChoiceDialog(gui.getFrame(), true,
+                                    "Sell how many " + p.getName(), quantity, 1, CampaignGUI.MAX_QUANTITY_SPINNER);
+                            popupValueChoiceDialog.setVisible(true);
+                            quantity = popupValueChoiceDialog.getValue();
+                            if (quantity <= 0) {
+                                return;
+                            }
+                            campaign.getQuartermaster().sellPart(p, quantity);
+                        });
                 refreshOverviewPartsInUse();
             }
         };


### PR DESCRIPTION
Commit a4cc0f9 introduced a bug where several types of parts could no longer be sold. This PR simply reverts it and goes back to looking up the target part by name rather than ID.

I agree with the original comment that it's not ideal to search by strings, but it appears there isn't really a better way to do it with how this dialog is constructed. I think there are some opportunities for refactoring it but I think those should be done in the future rather than now. Let me know what you think.

Closes #4663