### PR TITLE
clear out enemy name if we're changing enemy code

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -997,6 +997,7 @@ public class AtBContract extends Contract {
 
     public void setEnemyCode(String enemyCode) {
         this.enemyCode = enemyCode;
+        this.enemyName = ""; // better reset it if we're changing the enemy code
     }
 
     /**


### PR DESCRIPTION
Fix #4664 

The contract's enemy name was always being populated with some default value, which is fine, but it didn't get updated with the actual enemy name when the enemy code was being updated.