### PR TITLE
Add missing angle bracket in Independent Command Rights tooltip text

### DIFF
--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -84,7 +84,7 @@ ContractCommandRights.LIAISON.toolTipText=<html><body style="width: 300px;">- Ma
 ContractCommandRights.LIAISON.stratConText=Complete required scenarios and strategic objectives to fulfill contract conditions.
 
 ContractCommandRights.INDEPENDENT.text=Independent
-ContractCommandRights.INDEPENDENT.toolTipText=html><body style="width: 300px;">- Complete strategic objectives; disregard Campaign Victory Points.\
+ContractCommandRights.INDEPENDENT.toolTipText=<html><body style="width: 300px;">- Complete strategic objectives; disregard Campaign Victory Points.\
   <br>- Scout the map to locate objectives.\
   <br>- Terminate the contract early upon completing all objectives, except for Garrison or Cadre contracts.\
   <br>\


### PR DESCRIPTION
closes #4660

There was a typo in the independent command rights tooltip text in the contract market which broke the formatting. This PR adds it and I've confirmed the formatting works as expected.