### PR TITLE
Added Conditional Check Before Showing 0 Personnel Eligible autoAwards Dialog

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/AutoAwardsController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/AutoAwardsController.java
@@ -83,10 +83,12 @@ public class AutoAwardsController {
             final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.AutoAwardsDialog",
                     MekHQ.getMHQOptions().getLocale());
 
-            JOptionPane.showMessageDialog(null,
-                    resources.getString("txtNoneEligible.text"),
-                    resources.getString("AutoAwardsDialog.title"),
-                    JOptionPane.INFORMATION_MESSAGE);
+            if (isManualPrompt) {
+                JOptionPane.showMessageDialog(null,
+                        resources.getString("txtNoneEligible.text"),
+                        resources.getString("AutoAwardsDialog.title"),
+                        JOptionPane.INFORMATION_MESSAGE);
+            }
         }
 
         logger.info("autoAwards (Manual) has finished");


### PR DESCRIPTION
Previously, the dialog showing no award eligibility appeared unconditionally. Now, it only shows if `isManualPrompt` is true, preventing unnecessary dialogs when not prompted manually.