### PR TITLE
Fixed NPE in CamOps Mission Date Calculation

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/OtherModifiers.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/OtherModifiers.java
@@ -65,6 +65,10 @@ public class OtherModifiers {
                 .min(LocalDate::compareTo)
                 .orElse(today);
 
+        if (oldestMissionDate == null) {
+            oldestMissionDate = today;
+        }
+
         // Calculate and return the number of years between the oldest mission date and today
         return Math.max(0, (int) ChronoUnit.YEARS.between(today, oldestMissionDate));
     }


### PR DESCRIPTION
Previously, mission date calculation could throw a NullPointerException if there were no missions. Added a null check to ensure `oldestMissionDate` defaults to the current date if no missions exist. This prevents the exception.