### PR TITLE
Fix #4608: Relocate some methods and remove bad Part casting

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3150,7 +3150,7 @@ public class Campaign implements ITechManager {
             if (getCampaignOptions().isPayForRepairs()
                     && action.equals(" fix ")
                     && !(partWork instanceof Armor)) {
-                Money cost = ((Part) partWork).getActualValue().multipliedBy(0.2);
+                Money cost = partWork.getActualValue().multipliedBy(0.2);
                 report += "<br>Repairs cost " +
                         cost.toAmountAndSymbolString() +
                         " worth of parts.";

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -245,12 +245,6 @@ public abstract class Part implements IPartWork, ITechnology {
     }
 
     /**
-     * Sticker price is the value of the part according to the rulebooks
-     * @return the part's sticker price
-     */
-    public abstract Money getStickerPrice();
-
-    /**
      * This is the value of the part that may be affected by characteristics and campaign options
      * @return the part's actual value
      */

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -23,6 +23,7 @@ import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.PartChangedEvent;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.personnel.Person;
@@ -497,5 +498,27 @@ public class PodSpace implements IPartWork {
     @Override
     public PartRepairType getRepairPartType() {
         return PartRepairType.POD_SPACE;
+    }
+
+
+    /**
+     * Sticker price is the value of the part according to the rulebooks
+     * @return the part's sticker price
+     */
+    public Money getStickerPrice(){
+        return Money.of(0.0);
+    }
+
+    /**
+     * This is the value of the part that may be affected by characteristics and campaign options
+     * (Note: Pod Space, an abstraction, does not have value or price.
+     * @return the part's actual value
+     */
+    public Money getActualValue() {
+        return Money.of(0.0);
+    }
+
+    public boolean isPriceAdjustedForAmount(){
+        return false;
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -505,6 +505,7 @@ public class PodSpace implements IPartWork {
      * Sticker price is the value of the part according to the rulebooks
      * @return the part's sticker price
      */
+    @Override
     public Money getStickerPrice(){
         return Money.of(0.0);
     }
@@ -514,10 +515,12 @@ public class PodSpace implements IPartWork {
      * (Note: Pod Space, an abstraction, does not have value or price.
      * @return the part's actual value
      */
+    @Override
     public Money getActualValue() {
         return Money.of(0.0);
     }
 
+    @Override
     public boolean isPriceAdjustedForAmount(){
         return false;
     }

--- a/MekHQ/src/mekhq/campaign/work/IPartWork.java
+++ b/MekHQ/src/mekhq/campaign/work/IPartWork.java
@@ -25,6 +25,7 @@ import megamek.common.MiscType;
 import megamek.common.TargetRoll;
 import megamek.common.WeaponType;
 import megamek.common.annotations.Nullable;
+import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.MissingPart;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.equipment.EquipmentPart;
@@ -123,4 +124,19 @@ public interface IPartWork extends IWork {
             return part.getRepairPartType();
         }
     }
+
+
+    /**
+     * Sticker price is the value of the part according to the rulebooks
+     * @return the part's sticker price
+     */
+    public abstract Money getStickerPrice();
+
+    /**
+     * This is the value of the part that may be affected by characteristics and campaign options
+     * @return the part's actual value
+     */
+    public abstract Money getActualValue();
+
+    public abstract boolean isPriceAdjustedForAmount();
 }


### PR DESCRIPTION
Fix NPE when mass-repairing damaged pod space (only seen when "pay for repairs" is enabled).

Moves some methods up out of Part into IPartWork, which is fine because all Part child classes implement that interface and these methods already.
This allows us to remove the bad cast of IPartWork to Part, which was failing for PodSpace specifically.
Note that there is no canon price for PodSpace, as it is an abstraction we created to manage working on the parts of a unit that will take Pod-mounted hardware once repaired / replaced.
The price of Pod equipment is already built into the Pods, so Pod Space can be free without affecting anything.

Testing:
- Ran OP's campaign and confirmed NPE did not occur, and that Pod Space could be repaired.
- Ran all 3 projects' unit tests.

Close #4608 