### PR TITLE
Refresh camops personnel market daily

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarketCampaignOps.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarketCampaignOps.java
@@ -18,16 +18,13 @@
  */
 package mekhq.campaign.market;
 
-import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
 import mekhq.campaign.personnel.enums.PersonnelRole;
-import org.w3c.dom.Node;
 
 import megamek.common.Compute;
-import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.module.api.PersonnelMarketMethod;
@@ -36,8 +33,6 @@ import mekhq.module.api.PersonnelMarketMethod;
  * Method for personnel market generation given in the replacement personnel section of Campaign Operations
  */
 public class PersonnelMarketCampaignOps implements PersonnelMarketMethod {
-    private int daysSinceRolled = 0;
-
     @Override
     public String getModuleName() {
         return "Campaign Ops";
@@ -45,57 +40,40 @@ public class PersonnelMarketCampaignOps implements PersonnelMarketMethod {
 
     @Override
     public List<Person> generatePersonnelForDay(Campaign c) {
-        if (daysSinceRolled == c.getCampaignOptions().getMaintenanceCycleDays()) {
-            final List<PersonnelRole> techRoles = PersonnelRole.getTechRoles();
-            final List<PersonnelRole> vesselRoles = PersonnelRole.getVesselRoles();
+        final List<PersonnelRole> techRoles = PersonnelRole.getTechRoles();
+        final List<PersonnelRole> vesselRoles = PersonnelRole.getVesselRoles();
 
-            Person p = null;
-            int roll = Compute.d6(2);
-            if (roll == 2) { // Medical
-                p = c.newPerson(PersonnelRole.DOCTOR);
-            } else if (roll == 3) { // ASF or Proto Pilot
-                if (c.getFaction().isClan() && c.getLocalDate().isAfter(LocalDate.of(3059, 1, 1))
-                        && Compute.d6(2) < 6) {
-                    p = c.newPerson(PersonnelRole.PROTOMECH_PILOT);
-                } else {
-                    p = c.newPerson(PersonnelRole.AEROSPACE_PILOT);
-                }
-            } else if (roll == 4 || roll == 10) { // MW
-                p = c.newPerson(PersonnelRole.MECHWARRIOR);
-            } else if (roll == 5 || roll == 9) { // Vehicle Crews
-                p = c.newPerson((Compute.d6() < 3) ? PersonnelRole.GROUND_VEHICLE_DRIVER : PersonnelRole.VEHICLE_GUNNER);
-            } else if (roll == 6 || roll == 8) { // Infantry
-                p = c.newPerson((c.getFaction().isClan() && Compute.d6(2) > 3)
-                        ? PersonnelRole.BATTLE_ARMOUR : PersonnelRole.SOLDIER);
-            } else if (roll == 11) { // Tech
-                p = c.newPerson(techRoles.get(Compute.randomInt(techRoles.size())));
-            } else if (roll == 12) { // Vessel Crew
-                p = c.newPerson(vesselRoles.get(Compute.randomInt(vesselRoles.size())));
+        Person p = null;
+        int roll = Compute.d6(2);
+        if (roll == 2) { // Medical
+            p = c.newPerson(PersonnelRole.DOCTOR);
+        } else if (roll == 3) { // ASF or Proto Pilot
+            if (c.getFaction().isClan() && c.getLocalDate().isAfter(LocalDate.of(3059, 1, 1))
+                    && Compute.d6(2) < 6) {
+                p = c.newPerson(PersonnelRole.PROTOMECH_PILOT);
+            } else {
+                p = c.newPerson(PersonnelRole.AEROSPACE_PILOT);
             }
-            daysSinceRolled = 0;
-            if (p != null)  {
-                return Collections.singletonList(p);
-            }
-        } else {
-            daysSinceRolled++;
+        } else if (roll == 4 || roll == 10) { // MW
+            p = c.newPerson(PersonnelRole.MECHWARRIOR);
+        } else if (roll == 5 || roll == 9) { // Vehicle Crews
+            p = c.newPerson((Compute.d6() < 3) ? PersonnelRole.GROUND_VEHICLE_DRIVER : PersonnelRole.VEHICLE_GUNNER);
+        } else if (roll == 6 || roll == 8) { // Infantry
+            p = c.newPerson((c.getFaction().isClan() && Compute.d6(2) > 3)
+                    ? PersonnelRole.BATTLE_ARMOUR : PersonnelRole.SOLDIER);
+        } else if (roll == 11) { // Tech
+            p = c.newPerson(techRoles.get(Compute.randomInt(techRoles.size())));
+        } else if (roll == 12) { // Vessel Crew
+            p = c.newPerson(vesselRoles.get(Compute.randomInt(vesselRoles.size())));
+        }
+        if (p != null) {
+            return Collections.singletonList(p);
         }
         return null;
     }
 
     @Override
     public List<Person> removePersonnelForDay(Campaign c, List<Person> current) {
-        return (daysSinceRolled == c.getCampaignOptions().getMaintenanceCycleDays()) ? current : null;
-    }
-
-    @Override
-    public void loadFieldsFromXml(Node node) {
-        if (node.getNodeName().equals("daysSinceRolled")) {
-            daysSinceRolled = Integer.parseInt(node.getTextContent());
-        }
-    }
-
-    @Override
-    public void writeToXML(final PrintWriter pw, int indent) {
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "daysSinceRolled", daysSinceRolled);
+        return current;
     }
 }


### PR DESCRIPTION
Per CamOps rules, forces can attempt to recruit new personnel every maintenance/repair cycle, which is defined as 1 day. This PR makes the CamOps personnel market refresh daily. The serialization methods have been removed as it's no longer necessary to store the `daysSinceRolled` value in the XML, and previous and current saves load just fine.

Future refactoring could remove the `removePersonnelForDay()` override since it doesn't actually do anything except return the list that was passed in, but I don't think it's a good idea to mess with the interface at the moment.

@IllianiCBT  Feel free to hold off until 0.50 if you'd rather not introduce this now. Thanks!