### PR TITLE
Temporarily hide sell buttons from parts in use dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -84,8 +84,8 @@ public class PartsReportDialog extends JDialog {
         // Don't sort the buttons
         partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_BUY, false);
         partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_BUY_BULK, false);
-        partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_SELL, false);
-        partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_SELL_BULK, false);
+//        partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_SELL, false);
+//        partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_SELL_BULK, false);
         partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_GMADD, false);
         partsInUseSorter.setSortable(PartsInUseTableModel.COL_BUTTON_GMADD_BULK, false);
         // Numeric columns
@@ -201,9 +201,9 @@ public class PartsReportDialog extends JDialog {
         new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable, buy, PartsInUseTableModel.COL_BUTTON_BUY);
         new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable, buyInBulk,
                 PartsInUseTableModel.COL_BUTTON_BUY_BULK);
-        new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable, sell, PartsInUseTableModel.COL_BUTTON_SELL);
-        new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable, sellInBulk,
-            PartsInUseTableModel.COL_BUTTON_SELL_BULK);
+//        new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable, sell, PartsInUseTableModel.COL_BUTTON_SELL);
+//        new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable, sellInBulk,
+//            PartsInUseTableModel.COL_BUTTON_SELL_BULK);
         new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable, add, PartsInUseTableModel.COL_BUTTON_GMADD);
         new PartsInUseTableModel.ButtonColumn(overviewPartsInUseTable, addInBulk,
                 PartsInUseTableModel.COL_BUTTON_GMADD_BULK);

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -34,10 +34,12 @@ public class PartsInUseTableModel extends DataTableModel {
     public final static int COL_COST = 5;
     public final static int COL_BUTTON_BUY  = 6;
     public final static int COL_BUTTON_BUY_BULK  = 7;
-    public final static int COL_BUTTON_SELL = 8;
-    public final static int COL_BUTTON_SELL_BULK = 9;
-    public final static int COL_BUTTON_GMADD  = 10;
-    public final static int COL_BUTTON_GMADD_BULK  = 11;
+//    public final static int COL_BUTTON_SELL = 8;
+//    public final static int COL_BUTTON_SELL_BULK = 9;
+//    public final static int COL_BUTTON_GMADD  = 10;
+//    public final static int COL_BUTTON_GMADD_BULK  = 11;
+    public final static int COL_BUTTON_GMADD  = 8;
+    public final static int COL_BUTTON_GMADD_BULK  = 9;
 
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PartsInUseTableModel",
@@ -104,10 +106,10 @@ public class PartsInUseTableModel extends DataTableModel {
                 return resourceMap.getString("buy.text");
             case COL_BUTTON_BUY_BULK:
                 return resourceMap.getString("buyInBulk.text");
-            case COL_BUTTON_SELL:
-                return resourceMap.getString("sell.text");
-            case COL_BUTTON_SELL_BULK:
-                return resourceMap.getString("sellInBulk.text");
+//            case COL_BUTTON_SELL:
+//                return resourceMap.getString("sell.text");
+//            case COL_BUTTON_SELL_BULK:
+//                return resourceMap.getString("sellInBulk.text");
             case COL_BUTTON_GMADD:
                 return resourceMap.getString("add.text");
             case COL_BUTTON_GMADD_BULK:
@@ -127,8 +129,8 @@ public class PartsInUseTableModel extends DataTableModel {
         switch (col) {
             case COL_BUTTON_BUY:
             case COL_BUTTON_BUY_BULK:
-            case COL_BUTTON_SELL:
-            case COL_BUTTON_SELL_BULK:
+//            case COL_BUTTON_SELL:
+//            case COL_BUTTON_SELL_BULK:
             case COL_BUTTON_GMADD:
             case COL_BUTTON_GMADD_BULK:
                 return true;
@@ -185,12 +187,12 @@ public class PartsInUseTableModel extends DataTableModel {
             case COL_COST:
                 return 20;
             case COL_BUTTON_BUY:
-            case COL_BUTTON_SELL:
+//            case COL_BUTTON_SELL:
                 return 50;
             case COL_BUTTON_GMADD:
                 return 70;
             case COL_BUTTON_BUY_BULK:
-            case COL_BUTTON_SELL_BULK:
+//            case COL_BUTTON_SELL_BULK:
                 return 80;
             default:
                 return 100;
@@ -201,8 +203,8 @@ public class PartsInUseTableModel extends DataTableModel {
         switch (col) {
             case COL_BUTTON_BUY:
             case COL_BUTTON_BUY_BULK:
-            case COL_BUTTON_SELL:
-            case COL_BUTTON_SELL_BULK:
+//            case COL_BUTTON_SELL:
+//            case COL_BUTTON_SELL_BULK:
             case COL_BUTTON_GMADD:
             case COL_BUTTON_GMADD_BULK:
                 return true;
@@ -215,8 +217,8 @@ public class PartsInUseTableModel extends DataTableModel {
         switch (col) {
             case COL_BUTTON_BUY:
             case COL_BUTTON_BUY_BULK:
-            case COL_BUTTON_SELL:
-            case COL_BUTTON_SELL_BULK:
+//            case COL_BUTTON_SELL:
+//            case COL_BUTTON_SELL_BULK:
             case COL_BUTTON_GMADD:
             case COL_BUTTON_GMADD_BULK:
                 // Calculate from button width, respecting style


### PR DESCRIPTION
The implementation of selling parts from the parts in use dialog introduced in #4618 and #4665 unfortunately had a number of bugs uncovered by testers and I think my approach of trying to work around the limitations in this dialog ultimately isn't going to be successful due to a bunch of inconsistencies in part names and there not being a reliable way to map items in this report back to items in the warehouse. 

This PR temporarily hides the sell buttons/columns from the parts in use report until I can find a cleaner/more robust way to do it. This may require a bit of refactoring and I think it would be much safer to do after 0.50 than to try to get it done before and possibly introduce bugs.