### PR TITLE
Set Minimum Size for CustomizePersonDialog UI element

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -161,6 +161,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
 
     private void initComponents() {
         GridBagConstraints gridBagConstraints;
+        setMinimumSize(new Dimension(1100, 500));
 
         JPanel panDemog = new JPanel(new GridBagLayout());
         JTabbedPane tabStats = new JTabbedPane();


### PR DESCRIPTION
Added a minimum size of 1100x500 to CustomizePersonDialog to ensure consistent layout and prevent UI elements from being truncated.

This is the mhq half of #5939

### Closes #4622