### PR TITLE
Remove unnecessary faction era modifier warning

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -372,10 +372,6 @@ public class Faction {
             }
         }
 
-        if ((retVal.eraMods != null) && (retVal.eraMods.length < 9)) {
-            LogManager.getLogger().warn("{} faction did not have a long enough eraMods vector", retVal.fullName);
-        }
-
         return retVal;
     }
 


### PR DESCRIPTION
The warning doesn't serve any useful purpose, as factions with fewer era modifiers (usually because they cease to exist) simply default to using 0 for later eras.