### PR TITLE
Fixed Maintenance Interval Calculations

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7005,7 +7005,7 @@ public class Campaign implements ITechManager {
             tech.setMinutesLeft(tech.getMinutesLeft() - minutesUsed);
             astechPoolMinutes -= astechsUsed * minutesUsed;
         }
-        u.incrementDaysSinceMaintenance(maintained, astechsUsed);
+        u.incrementDaysSinceMaintenance(this, maintained, astechsUsed);
 
         int ruggedMultiplier = 1;
         if (u.getEntity().hasQuirk(OptionsConstants.QUIRK_POS_RUGGED_1)) {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -47,6 +47,8 @@ import mekhq.campaign.event.UnitArrivedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.log.ServiceLogger;
+import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.parts.*;
 import mekhq.campaign.parts.equipment.*;
@@ -135,9 +137,9 @@ public class Unit implements ITechnology {
     private int mothballTime;
     private boolean mothballed;
 
-    private int daysSinceMaintenance;
-    private int daysActivelyMaintained;
-    private int astechDaysMaintained;
+    private double daysSinceMaintenance;
+    private double daysActivelyMaintained;
+    private double astechDaysMaintained;
     private int maintenanceMultiplier;
 
     private Campaign campaign;
@@ -4989,11 +4991,24 @@ public class Unit implements ITechnology {
         return retVal * getMaintenanceMultiplier();
     }
 
-    public void incrementDaysSinceMaintenance(boolean maintained, int astechs) {
-        daysSinceMaintenance++;
-        astechDaysMaintained += astechs;
+    public void incrementDaysSinceMaintenance(Campaign campaign, boolean maintained, int astechs) {
+        List<Mission> activeMissions = campaign.getActiveMissions(false);
+        double timeIncrease = 0.25;
+
+        for (Mission mission: activeMissions) {
+            if (mission instanceof AtBContract) {
+                if (((AtBContract) mission).getContractType().isGarrisonDuty()) {
+                    continue;
+                }
+            }
+
+            timeIncrease = 1;
+        }
+
+        daysSinceMaintenance += timeIncrease;
+        astechDaysMaintained += astechs * timeIncrease;
         if (maintained) {
-            daysActivelyMaintained++;
+            daysActivelyMaintained += timeIncrease;
         }
     }
 
@@ -5003,7 +5018,7 @@ public class Unit implements ITechnology {
         astechDaysMaintained = 0;
     }
 
-    public int getDaysSinceMaintenance() {
+    public double getDaysSinceMaintenance() {
         return daysSinceMaintenance;
     }
 
@@ -5013,7 +5028,7 @@ public class Unit implements ITechnology {
     //also we will take the average rounded down of the number of astechs to figure out
     //shorthanded penalty
     public double getMaintainedPct() {
-        return (daysActivelyMaintained / (double) daysSinceMaintenance);
+        return (daysActivelyMaintained / daysSinceMaintenance);
     }
 
     public boolean isFullyMaintained() {
@@ -5021,7 +5036,7 @@ public class Unit implements ITechnology {
     }
 
     public int getAstechsMaintained() {
-        return (int) Math.floor((1.0 * astechDaysMaintained) / daysSinceMaintenance);
+        return (int) Math.floor((astechDaysMaintained) / daysSinceMaintenance);
     }
 
     public int getMaintenanceMultiplier() {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -5003,6 +5003,7 @@ public class Unit implements ITechnology {
             }
 
             timeIncrease = 1;
+            break;
         }
 
         daysSinceMaintenance += timeIncrease;
@@ -5036,7 +5037,7 @@ public class Unit implements ITechnology {
     }
 
     public int getAstechsMaintained() {
-        return (int) Math.floor((astechDaysMaintained) / daysSinceMaintenance);
+        return (int) Math.floor(astechDaysMaintained / daysSinceMaintenance);
     }
 
     public int getMaintenanceMultiplier() {


### PR DESCRIPTION
Updated the `incrementDaysSinceMaintenance` method to account for time scaling based on active missions, and changed maintenance time tracking from `integer` to `double`. This ensures maintenance frequency matches CamOps.

### Closes #4709