### PR TITLE
Updated Campaign Presets

### DIFF
--- a/MekHQ/mmconf/campaignPresets/Campaign Operations (StratCon).xml
+++ b/MekHQ/mmconf/campaignPresets/Campaign Operations (StratCon).xml
@@ -173,6 +173,7 @@
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>false</reverseQualityNames>
 		<useRandomUnitQualities>false</useRandomUnitQualities>
+        <usePlanetaryModifiers>true</usePlanetaryModifiers>
 		<useUnofficialMaintenance>false</useUnofficialMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<maxAcquisitions>1</maxAcquisitions>
@@ -211,6 +212,7 @@
 		<minimumHitsForVehicles>1</minimumHitsForVehicles>
 		<useRandomHitsForVehicles>false</useRandomHitsForVehicles>
 		<tougherHealing>false</tougherHealing>
+        <maximumPatients>25</maximumPatients>
 		<prisonerCaptureStyle>NONE</prisonerCaptureStyle>
 		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
 		<prisonerBabyStatus>true</prisonerBabyStatus>
@@ -266,6 +268,8 @@
 			<extraRandomOrigin>false</extraRandomOrigin>
 		</randomOriginOptions>
 		<useRandomPersonalities>false</useRandomPersonalities>
+        <useRandomPersonalityReputation>true</useRandomPersonalityReputation>
+        <useIntelligenceXpMultiplier>true</useIntelligenceXpMultiplier>
 		<useRandomRetirement>false</useRandomRetirement>
 		<turnoverBaseTn>3</turnoverBaseTn>
 		<turnoverFrequency>MONTHLY</turnoverFrequency>
@@ -380,6 +384,7 @@
 		<enableUnitEducation>true</enableUnitEducation>
 		<enableOverrideRequirements>false</enableOverrideRequirements>
 		<enableShowIneligibleAcademies>false</enableShowIneligibleAcademies>
+		<entranceExamBaseTargetNumber>14</entranceExamBaseTargetNumber>
 		<facultyXpRate>1.0</facultyXpRate>
 		<enableBonuses>true</enableBonuses>
 		<adultDropoutChance>1000</adultDropoutChance>
@@ -509,7 +514,7 @@
 		<regionalMechVariations>false</regionalMechVariations>
 		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
 		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
-		<atbBattleChance>0,0,0,0</atbBattleChance>
+		<atbBattleChance>40,20,60,10</atbBattleChance>
 		<generateChases>false</generateChases>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
@@ -532,7 +537,7 @@
 		<spaUpgradeIntensity>0</spaUpgradeIntensity>
 		<scenarioModMax>3</scenarioModMax>
 		<scenarioModChance>25</scenarioModChance>
-		<scenarioModBV>50</scenarioModBV>
+		<scenarioModBV>25</scenarioModBV>
 		<autoconfigMunitions>true</autoconfigMunitions>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
@@ -882,7 +887,7 @@
             <lookupName>specialist</lookupName>
             <desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
                 +1 to-hit modifier when using other types of weapons.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>4</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -902,7 +907,7 @@
             <displayName>Zweihander (CamOps)</displayName>
             <lookupName>zweihander</lookupName>
             <desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>6</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -917,7 +922,7 @@
             <lookupName>tm_frogman</lookupName>
             <desc>Movement in depth 2 or greater water costs 1 MP less.
                 Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -932,7 +937,7 @@
             <displayName>Hot Dog (CamOps)</displayName>
             <lookupName>hot_dog</lookupName>
             <desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -947,7 +952,7 @@
             <displayName>Blood Stalker (CamOps)</displayName>
             <lookupName>blood_stalker</lookupName>
             <desc>Unit has -1 bonus against designated target, +2 penalty against all others; lasts until target retreats, can only be used once per battle.</desc>
-            <xpCost>60</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -968,7 +973,7 @@
             <lookupName>sandblaster</lookupName>
             <desc>A pilot with this ability gets a +4, +3, or +2 to the cluster table
                 at short, medium, or long/extended range, respectively, but only with a specialized weapon.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -988,7 +993,7 @@
             <displayName>Oblique Artilleryman (CamOps)</displayName>
             <lookupName>oblique_artillery</lookupName>
             <desc>Reduces scatter distance by two hexes.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1009,7 +1014,7 @@
             <lookupName>melee_specialist</lookupName>
             <desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
                 Note: This ability is only used for BattleMeks.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1024,7 +1029,7 @@
             <displayName>Shaky Stick (CamOps)</displayName>
             <lookupName>shaky_stick</lookupName>
             <desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1042,7 +1047,7 @@
             <displayName>Multi-Tasker (CamOps)</displayName>
             <lookupName>multi_tasker</lookupName>
             <desc>Secondary target modifiers are reduced by one.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1065,7 +1070,7 @@
                 Quads can move laterally for 1 less MP.
                 Aerospace units can perform maneuvers for 1 less thrust point.
                 Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1086,7 +1091,7 @@
             <displayName>Oblique Attacker (CamOps)</displayName>
             <lookupName>oblique_attacker</lookupName>
             <desc>The penalty for indirect fire is reduced by one and can also use indirect fire with out a spotter.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1106,7 +1111,7 @@
             <displayName>Natural Aptitude, Gunnery (aToW)</displayName>
             <lookupName>aptitude_gunnery</lookupName>
             <desc>Roll 3d6 and take the best two for gunnery checks</desc>
-            <xpCost>250</xpCost>
+            <xpCost>0</xpCost>
             <weight>0</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1118,7 +1123,7 @@
             <lookupName>env_specialist</lookupName>
             <desc>Environmental specialists are adept in certain planetary conditions.
                 This gives the unit bonuses to PSR and movement penalties (halves MP / PSR) as well to hit rolls (-1).</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1148,7 +1153,7 @@
             <desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
                 The second roll must be accepted.
                 Note: Only one Tactical Genius may be utilized per team.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1176,7 +1181,7 @@
             <displayName>Natural Aptitude, Piloting (aToW)</displayName>
             <lookupName>aptitude_piloting</lookupName>
             <desc>Roll 3d6 and take the best two for piloting checks</desc>
-            <xpCost>250</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1187,7 +1192,7 @@
             <displayName>Human TRO (CamOps)</displayName>
             <lookupName>human_tro</lookupName>
             <desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1216,7 +1221,7 @@
             <lookupName>tm_swamp_beast</lookupName>
             <desc>Movement in mud or swamp costs 1 less MP.
                 Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1233,7 +1238,7 @@
             <displayName>Jumping Jack (CamOps)</displayName>
             <lookupName>jumping_jack</lookupName>
             <desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>6</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1250,7 +1255,7 @@
             <desc>Urban Guerrilla gives infantry a better chance of survival in urban or suburban environments (+1 to be hit)
                 It also keeps them from taking double damage in the open when in pavement or road terrain types.
                 Finally, urban guerrillas can call on local support once per scenario.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1267,7 +1272,7 @@
                 -1 MP per hex of Woods and Jungle terrain.
                 In addition quads gain a -1 to any quad related PSR check.
                 NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1282,7 +1287,7 @@
             <displayName>Sniper (CamOps)</displayName>
             <lookupName>sniper</lookupName>
             <desc>Range penalties are halved.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1302,7 +1307,7 @@
             <displayName>RangeMaster (CamOps)</displayName>
             <lookupName>range_master</lookupName>
             <desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1325,7 +1330,7 @@
                 This maneuver adds +2 to the BTH to physical attacks against the unit.
                 NOTE: The dodge maneuver is declared during the weapons phase.
                 Note: This ability is only used for BattleMeks.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1340,7 +1345,7 @@
             <displayName>Golden Goose (CamOps)</displayName>
             <lookupName>golden_goose</lookupName>
             <desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1357,7 +1362,7 @@
             <displayName>Cluster Hitter (CamOps)</displayName>
             <lookupName>cluster_hitter</lookupName>
             <desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities>oblique_attacker::sandblaster</invalidAbilities>
@@ -1379,7 +1384,7 @@
             <desc>Movement in woods or jungle costs 1 less MP.
                 Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
                 Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1396,7 +1401,7 @@
             <displayName>Terrain Master [Nightwalker] (CamOps)</displayName>
             <lookupName>tm_nightwalker</lookupName>
             <desc>Nightwalker ignores all darkness move penalties when using Walk / Cruise movement but does not affect gunnery modifiers for lighting conditions.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1413,7 +1418,7 @@
             <displayName>Weapon Specialist (CamOps)</displayName>
             <lookupName>weapon_specialist</lookupName>
             <desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1433,7 +1438,7 @@
             <displayName>Melee Master (CamOps)</displayName>
             <lookupName>melee_master</lookupName>
             <desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>6</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1449,7 +1454,7 @@
             <lookupName>tm_mountaineer</lookupName>
             <desc>Movement in rubble or rough cost 1 less MP and elevation changes also cost 1 MP less.
                 The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1466,7 +1471,7 @@
             <displayName>Eagle&apos;s Eyes (CamOps)</displayName>
             <lookupName>eagle_eyes</lookupName>
             <desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1494,7 +1499,7 @@
             <displayName>Forward Observer (CamOps)</displayName>
             <lookupName>forward_observer</lookupName>
             <desc>Improves the accuracy of your artillery. Fire Adjustment gets a -2 modifier. Spotting gets an additional -1 tohit modifier for each point of gunnery below 4.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1522,7 +1527,7 @@
             <displayName>Foot Cavalry (CamOps)</displayName>
             <lookupName>foot_cav</lookupName>
             <desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1536,7 +1541,7 @@
             <displayName>Cross-Country (CamOps)</displayName>
             <lookupName>cross_country</lookupName>
             <desc>Allows a unit to use terrain normally restricted to said unit at the cost of increased MP.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>

--- a/MekHQ/mmconf/campaignPresets/Campaign Operations.xml
+++ b/MekHQ/mmconf/campaignPresets/Campaign Operations.xml
@@ -173,6 +173,7 @@
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>false</reverseQualityNames>
 		<useRandomUnitQualities>false</useRandomUnitQualities>
+        <usePlanetaryModifiers>true</usePlanetaryModifiers>
 		<useUnofficialMaintenance>false</useUnofficialMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<maxAcquisitions>1</maxAcquisitions>
@@ -211,6 +212,7 @@
 		<minimumHitsForVehicles>1</minimumHitsForVehicles>
 		<useRandomHitsForVehicles>false</useRandomHitsForVehicles>
 		<tougherHealing>false</tougherHealing>
+        <maximumPatients>25</maximumPatients>
 		<prisonerCaptureStyle>NONE</prisonerCaptureStyle>
 		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
 		<prisonerBabyStatus>true</prisonerBabyStatus>
@@ -266,6 +268,8 @@
 			<extraRandomOrigin>false</extraRandomOrigin>
 		</randomOriginOptions>
 		<useRandomPersonalities>false</useRandomPersonalities>
+        <useRandomPersonalityReputation>true</useRandomPersonalityReputation>
+        <useIntelligenceXpMultiplier>true</useIntelligenceXpMultiplier>
 		<useRandomRetirement>false</useRandomRetirement>
 		<turnoverBaseTn>3</turnoverBaseTn>
 		<turnoverFrequency>MONTHLY</turnoverFrequency>
@@ -380,6 +384,7 @@
 		<enableUnitEducation>true</enableUnitEducation>
 		<enableOverrideRequirements>false</enableOverrideRequirements>
 		<enableShowIneligibleAcademies>false</enableShowIneligibleAcademies>
+		<entranceExamBaseTargetNumber>14</entranceExamBaseTargetNumber>
 		<facultyXpRate>1.0</facultyXpRate>
 		<enableBonuses>true</enableBonuses>
 		<adultDropoutChance>1000</adultDropoutChance>
@@ -509,11 +514,11 @@
 		<regionalMechVariations>false</regionalMechVariations>
 		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
 		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
-		<atbBattleChance>40,20,60,10</atbBattleChance>
-		<generateChases>true</generateChases>
+		<atbBattleChance>0,0,0,0</atbBattleChance>
+		<generateChases>false</generateChases>
 		<useWeatherConditions>true</useWeatherConditions>
 		<useLightConditions>true</useLightConditions>
-		<usePlanetaryConditions>false</usePlanetaryConditions>
+		<usePlanetaryConditions>true</usePlanetaryConditions>
 		<useStrategy>true</useStrategy>
 		<baseStrategyDeployment>3</baseStrategyDeployment>
 		<additionalStrategyDeployment>1</additionalStrategyDeployment>
@@ -532,7 +537,7 @@
 		<spaUpgradeIntensity>0</spaUpgradeIntensity>
 		<scenarioModMax>3</scenarioModMax>
 		<scenarioModChance>25</scenarioModChance>
-		<scenarioModBV>50</scenarioModBV>
+		<scenarioModBV>25</scenarioModBV>
 		<autoconfigMunitions>true</autoconfigMunitions>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
@@ -882,7 +887,7 @@
             <lookupName>specialist</lookupName>
             <desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
                 +1 to-hit modifier when using other types of weapons.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>4</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -902,7 +907,7 @@
             <displayName>Zweihander (CamOps)</displayName>
             <lookupName>zweihander</lookupName>
             <desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>6</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -917,7 +922,7 @@
             <lookupName>tm_frogman</lookupName>
             <desc>Movement in depth 2 or greater water costs 1 MP less.
                 Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -932,7 +937,7 @@
             <displayName>Hot Dog (CamOps)</displayName>
             <lookupName>hot_dog</lookupName>
             <desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -947,7 +952,7 @@
             <displayName>Blood Stalker (CamOps)</displayName>
             <lookupName>blood_stalker</lookupName>
             <desc>Unit has -1 bonus against designated target, +2 penalty against all others; lasts until target retreats, can only be used once per battle.</desc>
-            <xpCost>60</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -968,7 +973,7 @@
             <lookupName>sandblaster</lookupName>
             <desc>A pilot with this ability gets a +4, +3, or +2 to the cluster table
                 at short, medium, or long/extended range, respectively, but only with a specialized weapon.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -988,7 +993,7 @@
             <displayName>Oblique Artilleryman (CamOps)</displayName>
             <lookupName>oblique_artillery</lookupName>
             <desc>Reduces scatter distance by two hexes.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1009,7 +1014,7 @@
             <lookupName>melee_specialist</lookupName>
             <desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
                 Note: This ability is only used for BattleMeks.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1024,7 +1029,7 @@
             <displayName>Shaky Stick (CamOps)</displayName>
             <lookupName>shaky_stick</lookupName>
             <desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1042,7 +1047,7 @@
             <displayName>Multi-Tasker (CamOps)</displayName>
             <lookupName>multi_tasker</lookupName>
             <desc>Secondary target modifiers are reduced by one.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1065,7 +1070,7 @@
                 Quads can move laterally for 1 less MP.
                 Aerospace units can perform maneuvers for 1 less thrust point.
                 Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1086,7 +1091,7 @@
             <displayName>Oblique Attacker (CamOps)</displayName>
             <lookupName>oblique_attacker</lookupName>
             <desc>The penalty for indirect fire is reduced by one and can also use indirect fire with out a spotter.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1106,7 +1111,7 @@
             <displayName>Natural Aptitude, Gunnery (aToW)</displayName>
             <lookupName>aptitude_gunnery</lookupName>
             <desc>Roll 3d6 and take the best two for gunnery checks</desc>
-            <xpCost>250</xpCost>
+            <xpCost>0</xpCost>
             <weight>0</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1118,7 +1123,7 @@
             <lookupName>env_specialist</lookupName>
             <desc>Environmental specialists are adept in certain planetary conditions.
                 This gives the unit bonuses to PSR and movement penalties (halves MP / PSR) as well to hit rolls (-1).</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1148,7 +1153,7 @@
             <desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
                 The second roll must be accepted.
                 Note: Only one Tactical Genius may be utilized per team.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1176,7 +1181,7 @@
             <displayName>Natural Aptitude, Piloting (aToW)</displayName>
             <lookupName>aptitude_piloting</lookupName>
             <desc>Roll 3d6 and take the best two for piloting checks</desc>
-            <xpCost>250</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1187,7 +1192,7 @@
             <displayName>Human TRO (CamOps)</displayName>
             <lookupName>human_tro</lookupName>
             <desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1216,7 +1221,7 @@
             <lookupName>tm_swamp_beast</lookupName>
             <desc>Movement in mud or swamp costs 1 less MP.
                 Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1233,7 +1238,7 @@
             <displayName>Jumping Jack (CamOps)</displayName>
             <lookupName>jumping_jack</lookupName>
             <desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>6</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1250,7 +1255,7 @@
             <desc>Urban Guerrilla gives infantry a better chance of survival in urban or suburban environments (+1 to be hit)
                 It also keeps them from taking double damage in the open when in pavement or road terrain types.
                 Finally, urban guerrillas can call on local support once per scenario.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1267,7 +1272,7 @@
                 -1 MP per hex of Woods and Jungle terrain.
                 In addition quads gain a -1 to any quad related PSR check.
                 NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1282,7 +1287,7 @@
             <displayName>Sniper (CamOps)</displayName>
             <lookupName>sniper</lookupName>
             <desc>Range penalties are halved.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1302,7 +1307,7 @@
             <displayName>RangeMaster (CamOps)</displayName>
             <lookupName>range_master</lookupName>
             <desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1325,7 +1330,7 @@
                 This maneuver adds +2 to the BTH to physical attacks against the unit.
                 NOTE: The dodge maneuver is declared during the weapons phase.
                 Note: This ability is only used for BattleMeks.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1340,7 +1345,7 @@
             <displayName>Golden Goose (CamOps)</displayName>
             <lookupName>golden_goose</lookupName>
             <desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1357,7 +1362,7 @@
             <displayName>Cluster Hitter (CamOps)</displayName>
             <lookupName>cluster_hitter</lookupName>
             <desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities>oblique_attacker::sandblaster</invalidAbilities>
@@ -1379,7 +1384,7 @@
             <desc>Movement in woods or jungle costs 1 less MP.
                 Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
                 Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1396,7 +1401,7 @@
             <displayName>Terrain Master [Nightwalker] (CamOps)</displayName>
             <lookupName>tm_nightwalker</lookupName>
             <desc>Nightwalker ignores all darkness move penalties when using Walk / Cruise movement but does not affect gunnery modifiers for lighting conditions.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1413,7 +1418,7 @@
             <displayName>Weapon Specialist (CamOps)</displayName>
             <lookupName>weapon_specialist</lookupName>
             <desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1433,7 +1438,7 @@
             <displayName>Melee Master (CamOps)</displayName>
             <lookupName>melee_master</lookupName>
             <desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>6</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1449,7 +1454,7 @@
             <lookupName>tm_mountaineer</lookupName>
             <desc>Movement in rubble or rough cost 1 less MP and elevation changes also cost 1 MP less.
                 The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1466,7 +1471,7 @@
             <displayName>Eagle&apos;s Eyes (CamOps)</displayName>
             <lookupName>eagle_eyes</lookupName>
             <desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1494,7 +1499,7 @@
             <displayName>Forward Observer (CamOps)</displayName>
             <lookupName>forward_observer</lookupName>
             <desc>Improves the accuracy of your artillery. Fire Adjustment gets a -2 modifier. Spotting gets an additional -1 tohit modifier for each point of gunnery below 4.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1522,7 +1527,7 @@
             <displayName>Foot Cavalry (CamOps)</displayName>
             <lookupName>foot_cav</lookupName>
             <desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1536,7 +1541,7 @@
             <displayName>Cross-Country (CamOps)</displayName>
             <lookupName>cross_country</lookupName>
             <desc>Allows a unit to use terrain normally restricted to said unit at the cost of increased MP.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>

--- a/MekHQ/mmconf/campaignPresets/Complete Experience.xml
+++ b/MekHQ/mmconf/campaignPresets/Complete Experience.xml
@@ -173,6 +173,7 @@
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>false</reverseQualityNames>
 		<useRandomUnitQualities>true</useRandomUnitQualities>
+		<usePlanetaryModifiers>true</usePlanetaryModifiers>
 		<useUnofficialMaintenance>true</useUnofficialMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<maxAcquisitions>1</maxAcquisitions>
@@ -267,6 +268,8 @@
 			<extraRandomOrigin>true</extraRandomOrigin>
 		</randomOriginOptions>
 		<useRandomPersonalities>true</useRandomPersonalities>
+        <useRandomPersonalityReputation>true</useRandomPersonalityReputation>
+        <useIntelligenceXpMultiplier>true</useIntelligenceXpMultiplier>
 		<useRandomRetirement>true</useRandomRetirement>
 		<turnoverBaseTn>3</turnoverBaseTn>
 		<turnoverFrequency>MONTHLY</turnoverFrequency>
@@ -381,6 +384,7 @@
 		<enableUnitEducation>true</enableUnitEducation>
 		<enableOverrideRequirements>false</enableOverrideRequirements>
 		<enableShowIneligibleAcademies>false</enableShowIneligibleAcademies>
+		<entranceExamBaseTargetNumber>14</entranceExamBaseTargetNumber>
 		<facultyXpRate>1.0</facultyXpRate>
 		<enableBonuses>true</enableBonuses>
 		<adultDropoutChance>1000</adultDropoutChance>
@@ -479,7 +483,7 @@
 		<unitMarketMethod>ATB_MONTHLY</unitMarketMethod>
 		<unitMarketRegionalMechVariations>true</unitMarketRegionalMechVariations>
 		<unitMarketSpecialUnitChance>30</unitMarketSpecialUnitChance>
-		<unitMarketRarityModifier>0</unitMarketRarityModifier>
+        <unitMarketRarityModifier>0</unitMarketRarityModifier>
 		<instantUnitMarketDelivery>true</instantUnitMarketDelivery>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<contractMarketMethod>ATB_MONTHLY</contractMarketMethod>
@@ -512,9 +516,9 @@
 		<playerControlsAttachedUnits>true</playerControlsAttachedUnits>
 		<atbBattleChance>0,0,0,0</atbBattleChance>
 		<generateChases>false</generateChases>
-		<useWeatherConditions>false</useWeatherConditions>
-		<useLightConditions>false</useLightConditions>
-		<usePlanetaryConditions>false</usePlanetaryConditions>
+		<useWeatherConditions>true</useWeatherConditions>
+		<useLightConditions>true</useLightConditions>
+		<usePlanetaryConditions>true</usePlanetaryConditions>
 		<useStrategy>true</useStrategy>
 		<baseStrategyDeployment>3</baseStrategyDeployment>
 		<additionalStrategyDeployment>1</additionalStrategyDeployment>

--- a/MekHQ/mmconf/campaignPresets/New Pilot Program.xml
+++ b/MekHQ/mmconf/campaignPresets/New Pilot Program.xml
@@ -173,6 +173,7 @@
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>false</reverseQualityNames>
 		<useRandomUnitQualities>false</useRandomUnitQualities>
+        <usePlanetaryModifiers>false</usePlanetaryModifiers>
 		<useUnofficialMaintenance>true</useUnofficialMaintenance>
 		<checkMaintenance>true</checkMaintenance>
 		<maxAcquisitions>0</maxAcquisitions>
@@ -205,11 +206,11 @@
 		<adminsHaveScrounge>false</adminsHaveScrounge>
 		<adminExperienceLevelIncludeNegotiation>false</adminExperienceLevelIncludeNegotiation>
 		<adminExperienceLevelIncludeScrounge>false</adminExperienceLevelIncludeScrounge>
-		<useAdvancedMedical>false</useAdvancedMedical>
+		<useAdvancedMedical>true</useAdvancedMedical>
 		<healWaitingPeriod>1</healWaitingPeriod>
 		<naturalHealingWaitingPeriod>15</naturalHealingWaitingPeriod>
 		<minimumHitsForVehicles>1</minimumHitsForVehicles>
-		<useRandomHitsForVehicles>false</useRandomHitsForVehicles>
+		<useRandomHitsForVehicles>true</useRandomHitsForVehicles>
 		<tougherHealing>false</tougherHealing>
         <maximumPatients>25</maximumPatients>
 		<prisonerCaptureStyle>ATB</prisonerCaptureStyle>
@@ -267,8 +268,10 @@
 			<extraRandomOrigin>true</extraRandomOrigin>
 		</randomOriginOptions>
 		<useRandomPersonalities>true</useRandomPersonalities>
+        <useRandomPersonalityReputation>true</useRandomPersonalityReputation>
+        <useIntelligenceXpMultiplier>true</useIntelligenceXpMultiplier>
 		<useRandomRetirement>true</useRandomRetirement>
-		<turnoverBaseTn>2</turnoverBaseTn>
+		<turnoverBaseTn>1</turnoverBaseTn>
 		<turnoverFrequency>MONTHLY</turnoverFrequency>
 		<aeroRecruitsHaveUnits>true</aeroRecruitsHaveUnits>
 		<trackOriginalUnit>false</trackOriginalUnit>
@@ -381,6 +384,7 @@
 		<enableUnitEducation>true</enableUnitEducation>
 		<enableOverrideRequirements>false</enableOverrideRequirements>
 		<enableShowIneligibleAcademies>false</enableShowIneligibleAcademies>
+		<entranceExamBaseTargetNumber>14</entranceExamBaseTargetNumber>
 		<facultyXpRate>1.0</facultyXpRate>
 		<enableBonuses>true</enableBonuses>
 		<adultDropoutChance>1000</adultDropoutChance>

--- a/MekHQ/mmconf/campaignPresets/Tabula Rasa.xml
+++ b/MekHQ/mmconf/campaignPresets/Tabula Rasa.xml
@@ -150,18 +150,18 @@
 		<usePlanetaryAcquisition>false</usePlanetaryAcquisition>
 		<planetAcquisitionFactionLimit>NEUTRAL</planetAcquisitionFactionLimit>
 		<planetAcquisitionNoClanCrossover>true</planetAcquisitionNoClanCrossover>
-		<noClanPartsFromIS>true</noClanPartsFromIS>
+		<noClanPartsFromIS>false</noClanPartsFromIS>
 		<penaltyClanPartsFromIS>4</penaltyClanPartsFromIS>
 		<planetAcquisitionVerbose>false</planetAcquisitionVerbose>
 		<maxJumpsPlanetaryAcquisition>2</maxJumpsPlanetaryAcquisition>
 		<equipmentContractPercent>5.0</equipmentContractPercent>
-		<dropShipContractPercent>1.0</dropShipContractPercent>
+		<dropShipContractPercent>0.0</dropShipContractPercent>
 		<jumpShipContractPercent>0.0</jumpShipContractPercent>
 		<warShipContractPercent>0.0</warShipContractPercent>
 		<equipmentContractBase>true</equipmentContractBase>
 		<equipmentContractSaleValue>false</equipmentContractSaleValue>
 		<blcSaleValue>false</blcSaleValue>
-		<overageRepaymentInFinalPayment>false</overageRepaymentInFinalPayment>
+		<overageRepaymentInFinalPayment>true</overageRepaymentInFinalPayment>
 		<clanAcquisitionPenalty>0</clanAcquisitionPenalty>
 		<isAcquisitionPenalty>0</isAcquisitionPenalty>
 		<destroyByMargin>false</destroyByMargin>
@@ -173,6 +173,7 @@
 		<useQualityMaintenance>true</useQualityMaintenance>
 		<reverseQualityNames>false</reverseQualityNames>
 		<useRandomUnitQualities>true</useRandomUnitQualities>
+        <usePlanetaryModifiers>false</usePlanetaryModifiers>
 		<useUnofficialMaintenance>false</useUnofficialMaintenance>
 		<checkMaintenance>false</checkMaintenance>
 		<maxAcquisitions>0</maxAcquisitions>
@@ -211,6 +212,7 @@
 		<minimumHitsForVehicles>1</minimumHitsForVehicles>
 		<useRandomHitsForVehicles>false</useRandomHitsForVehicles>
 		<tougherHealing>false</tougherHealing>
+        <maximumPatients>25</maximumPatients>
 		<prisonerCaptureStyle>NONE</prisonerCaptureStyle>
 		<defaultPrisonerStatus>PRISONER</defaultPrisonerStatus>
 		<prisonerBabyStatus>true</prisonerBabyStatus>
@@ -254,6 +256,7 @@
 		<enableTimeAwards>true</enableTimeAwards>
 		<enableTrainingAwards>true</enableTrainingAwards>
 		<enableMiscAwards>true</enableMiscAwards>
+        <awardSetFilterList></awardSetFilterList>
 		<useDylansRandomXP>false</useDylansRandomXP>
 		<randomOriginOptions>
 			<randomizeOrigin>false</randomizeOrigin>
@@ -265,9 +268,9 @@
 			<extraRandomOrigin>false</extraRandomOrigin>
 		</randomOriginOptions>
 		<useRandomPersonalities>false</useRandomPersonalities>
+        <useRandomPersonalityReputation>true</useRandomPersonalityReputation>
+        <useIntelligenceXpMultiplier>true</useIntelligenceXpMultiplier>
 		<useRandomRetirement>false</useRandomRetirement>
-		<turnoverTargetNumberMethod>FIXED</turnoverTargetNumberMethod>
-		<turnoverDifficulty>REGULAR</turnoverDifficulty>
 		<turnoverBaseTn>3</turnoverBaseTn>
 		<turnoverFrequency>MONTHLY</turnoverFrequency>
 		<aeroRecruitsHaveUnits>false</aeroRecruitsHaveUnits>
@@ -309,7 +312,7 @@
 		<fieldKitchenIgnoreNonCombatants>true</fieldKitchenIgnoreNonCombatants>
 		<fatigueLeaveThreshold>13</fatigueLeaveThreshold>
 		<familyDisplayLevel>SPOUSE</familyDisplayLevel>
-		<announceBirthdays>true</announceBirthdays>
+		<announceBirthdays>false</announceBirthdays>
 		<announceOfficersOnly>true</announceOfficersOnly>
 		<announceChildBirthdays>true</announceChildBirthdays>
 		<useManualMarriages>true</useManualMarriages>
@@ -319,19 +322,19 @@
 		<checkMutualAncestorsDepth>4</checkMutualAncestorsDepth>
 		<logMarriageNameChanges>false</logMarriageNameChanges>
 		<marriageSurnameWeights>
-			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
-			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
-			<BOTH_SPACE_SPOUSE>5</BOTH_SPACE_SPOUSE>
-			<FEMALE>160</FEMALE>
-			<NO_CHANGE>100</NO_CHANGE>
-			<YOURS>55</YOURS>
-			<SPOUSE>55</SPOUSE>
 			<MALE>500</MALE>
-			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
+			<BOTH_HYPHEN_YOURS>20</BOTH_HYPHEN_YOURS>
 			<SPACE_SPOUSE>10</SPACE_SPOUSE>
-			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
-			<SPACE_YOURS>10</SPACE_YOURS>
+			<BOTH_SPACE_SPOUSE>5</BOTH_SPACE_SPOUSE>
+			<NO_CHANGE>100</NO_CHANGE>
+			<BOTH_SPACE_YOURS>5</BOTH_SPACE_YOURS>
+			<YOURS>55</YOURS>
+			<FEMALE>160</FEMALE>
 			<HYPHEN_YOURS>30</HYPHEN_YOURS>
+			<SPOUSE>55</SPOUSE>
+			<BOTH_HYPHEN_SPOUSE>20</BOTH_HYPHEN_SPOUSE>
+			<SPACE_YOURS>10</SPACE_YOURS>
+			<HYPHEN_SPOUSE>30</HYPHEN_SPOUSE>
 		</marriageSurnameWeights>
 		<randomMarriageMethod>NONE</randomMarriageMethod>
 		<useRandomSameSexMarriages>false</useRandomSameSexMarriages>
@@ -344,10 +347,10 @@
 		<useClanPersonnelDivorce>true</useClanPersonnelDivorce>
 		<usePrisonerDivorce>false</usePrisonerDivorce>
 		<divorceSurnameWeights>
-			<BOTH_CHANGE_SURNAME>30</BOTH_CHANGE_SURNAME>
-			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 			<ORIGIN_CHANGES_SURNAME>10</ORIGIN_CHANGES_SURNAME>
+			<BOTH_KEEP_SURNAME>50</BOTH_KEEP_SURNAME>
 			<SPOUSE_CHANGES_SURNAME>10</SPOUSE_CHANGES_SURNAME>
+			<BOTH_CHANGE_SURNAME>30</BOTH_CHANGE_SURNAME>
 		</divorceSurnameWeights>
 		<randomDivorceMethod>NONE</randomDivorceMethod>
 		<useRandomOppositeSexDivorce>true</useRandomOppositeSexDivorce>
@@ -366,12 +369,12 @@
 		<determineFatherAtBirth>false</determineFatherAtBirth>
 		<displayTrueDueDate>false</displayTrueDueDate>
 		<logProcreation>false</logProcreation>
-		<randomProcreationMethod>PERCENTAGE</randomProcreationMethod>
-		<useRelationshiplessRandomProcreation>false</useRelationshiplessRandomProcreation>
+		<randomProcreationMethod>NONE</randomProcreationMethod>
+		<useRelationshiplessRandomProcreation>true</useRelationshiplessRandomProcreation>
 		<useRandomClanPersonnelProcreation>false</useRandomClanPersonnelProcreation>
 		<useRandomPrisonerProcreation>true</useRandomPrisonerProcreation>
-		<percentageRandomProcreationRelationshipChance>5.0E-4</percentageRandomProcreationRelationshipChance>
-		<percentageRandomProcreationRelationshiplessChance>5.0E-5</percentageRandomProcreationRelationshiplessChance>
+		<percentageRandomProcreationRelationshipChance>1.0E-4</percentageRandomProcreationRelationshipChance>
+		<percentageRandomProcreationRelationshiplessChance>2.0E-5</percentageRandomProcreationRelationshiplessChance>
 		<useEducationModule>false</useEducationModule>
 		<curriculumXpRate>3</curriculumXpRate>
 		<maximumJumpCount>5</maximumJumpCount>
@@ -380,7 +383,8 @@
 		<enablePrestigiousAcademies>true</enablePrestigiousAcademies>
 		<enableUnitEducation>true</enableUnitEducation>
 		<enableOverrideRequirements>false</enableOverrideRequirements>
-		<enableShowIneligibleAcademies>true</enableShowIneligibleAcademies>
+		<enableShowIneligibleAcademies>false</enableShowIneligibleAcademies>
+		<entranceExamBaseTargetNumber>14</entranceExamBaseTargetNumber>
 		<facultyXpRate>1.0</facultyXpRate>
 		<enableBonuses>true</enableBonuses>
 		<adultDropoutChance>1000</adultDropoutChance>
@@ -390,13 +394,13 @@
 		<keepMarriedNameUponSpouseDeath>true</keepMarriedNameUponSpouseDeath>
 		<randomDeathMethod>NONE</randomDeathMethod>
 		<enabledRandomDeathAgeGroups>
-			<ADULT>true</ADULT>
+			<ELDER>true</ELDER>
+			<CHILD>false</CHILD>
 			<PRETEEN>false</PRETEEN>
+			<TODDLER>false</TODDLER>
 			<BABY>false</BABY>
 			<TEENAGER>true</TEENAGER>
-			<CHILD>false</CHILD>
-			<ELDER>true</ELDER>
-			<TODDLER>false</TODDLER>
+			<ADULT>true</ADULT>
 		</enabledRandomDeathAgeGroups>
 		<useRandomClanPersonnelDeath>true</useRandomClanPersonnelDeath>
 		<useRandomPrisonerDeath>true</useRandomPrisonerDeath>
@@ -405,30 +409,30 @@
 		<exponentialRandomDeathMaleValues>5.4757,-7.0,0.0709</exponentialRandomDeathMaleValues>
 		<exponentialRandomDeathFemaleValues>2.4641,-7.0,0.0752</exponentialRandomDeathFemaleValues>
 		<ageRangeRandomDeathMaleValues>
-			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
-			<FIFTY_FIVE_SIXTY_FOUR>1119.0</FIFTY_FIVE_SIXTY_FOUR>
-			<THIRTY_FIVE_FORTY_FOUR>249.5</THIRTY_FIVE_FORTY_FOUR>
+			<ONE_FOUR>27.5</ONE_FOUR>
 			<SIXTY_FIVE_SEVENTY_FOUR>2196.5</SIXTY_FIVE_SEVENTY_FOUR>
+			<EIGHTY_FIVE_OR_OLDER>14504.0</EIGHTY_FIVE_OR_OLDER>
 			<FIVE_FOURTEEN>14.7</FIVE_FOURTEEN>
+			<THIRTY_FIVE_FORTY_FOUR>249.5</THIRTY_FIVE_FORTY_FOUR>
+			<TWENTY_FIVE_THIRTY_FOUR>176.1</TWENTY_FIVE_THIRTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>491.8</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTY_FIVE_SIXTY_FOUR>1119.0</FIFTY_FIVE_SIXTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
 			<UNDER_ONE>613.1</UNDER_ONE>
 			<FIFTEEN_TWENTY_FOUR>100.1</FIFTEEN_TWENTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>5155.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<EIGHTY_FIVE_OR_OLDER>14504.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>27.5</ONE_FOUR>
 		</ageRangeRandomDeathMaleValues>
 		<ageRangeRandomDeathFemaleValues>
-			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
-			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
-			<FIFTY_FIVE_SIXTY_FOUR>670.0</FIFTY_FIVE_SIXTY_FOUR>
-			<THIRTY_FIVE_FORTY_FOUR>140.2</THIRTY_FIVE_FORTY_FOUR>
+			<ONE_FOUR>20.4</ONE_FOUR>
 			<SIXTY_FIVE_SEVENTY_FOUR>1421.0</SIXTY_FIVE_SEVENTY_FOUR>
+			<EIGHTY_FIVE_OR_OLDER>12870.0</EIGHTY_FIVE_OR_OLDER>
 			<FIVE_FOURTEEN>11.8</FIVE_FOURTEEN>
+			<THIRTY_FIVE_FORTY_FOUR>140.2</THIRTY_FIVE_FORTY_FOUR>
+			<TWENTY_FIVE_THIRTY_FOUR>80.0</TWENTY_FIVE_THIRTY_FOUR>
+			<FORTY_FIVE_FIFTY_FOUR>302.5</FORTY_FIVE_FIFTY_FOUR>
+			<FIFTY_FIVE_SIXTY_FOUR>670.0</FIFTY_FIVE_SIXTY_FOUR>
+			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
 			<UNDER_ONE>500.0</UNDER_ONE>
 			<FIFTEEN_TWENTY_FOUR>38.8</FIFTEEN_TWENTY_FOUR>
-			<SEVENTY_FIVE_EIGHTY_FOUR>3788.0</SEVENTY_FIVE_EIGHTY_FOUR>
-			<EIGHTY_FIVE_OR_OLDER>12870.0</EIGHTY_FIVE_OR_OLDER>
-			<ONE_FOUR>20.4</ONE_FOUR>
 		</ageRangeRandomDeathFemaleValues>
 		<payForParts>false</payForParts>
 		<payForRepairs>false</payForRepairs>
@@ -454,9 +458,9 @@
 		<clanUnitPriceMultiplier>1.0</clanUnitPriceMultiplier>
 		<clanPartPriceMultiplier>1.0</clanPartPriceMultiplier>
 		<mixedTechUnitPriceMultiplier>1.0</mixedTechUnitPriceMultiplier>
-        <usedPartPriceMultipliers>0.4,0.45,0.48,0.5,0.55,0.65</usedPartPriceMultipliers>
-        <damagedPartsValueMultiplier>0.2</damagedPartsValueMultiplier>
-        <unrepairablePartsValueMultiplier>0.0</unrepairablePartsValueMultiplier>
+		<usedPartPriceMultipliers>0.4,0.45,0.48,0.5,0.55,0.65</usedPartPriceMultipliers>
+		<damagedPartsValueMultiplier>0.2</damagedPartsValueMultiplier>
+		<unrepairablePartsValueMultiplier>0.0</unrepairablePartsValueMultiplier>
 		<cancelledOrderRefundMultiplier>0.5</cancelledOrderRefundMultiplier>
 		<useShareSystem>false</useShareSystem>
 		<sharesForAll>false</sharesForAll>
@@ -465,20 +469,21 @@
 		<personnelMarketName>Disabled</personnelMarketName>
 		<personnelMarketReportRefresh>true</personnelMarketReportRefresh>
 		<personnelMarketRandomRemovalTargets>
+			<ULTRA_GREEN>4</ULTRA_GREEN>
+			<HEROIC>11</HEROIC>
 			<NONE>3</NONE>
 			<GREEN>4</GREEN>
+			<VETERAN>8</VETERAN>
 			<ELITE>10</ELITE>
 			<LEGENDARY>11</LEGENDARY>
-			<ULTRA_GREEN>4</ULTRA_GREEN>
 			<REGULAR>6</REGULAR>
-			<VETERAN>8</VETERAN>
-			<HEROIC>11</HEROIC>
 		</personnelMarketRandomRemovalTargets>
 		<personnelMarketDylansWeight>0.3</personnelMarketDylansWeight>
 		<usePersonnelHireHiringHallOnly>false</usePersonnelHireHiringHallOnly>
 		<unitMarketMethod>NONE</unitMarketMethod>
 		<unitMarketRegionalMechVariations>true</unitMarketRegionalMechVariations>
 		<unitMarketSpecialUnitChance>30</unitMarketSpecialUnitChance>
+        <unitMarketRarityModifier>0</unitMarketRarityModifier>
 		<instantUnitMarketDelivery>false</instantUnitMarketDelivery>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<contractMarketMethod>NONE</contractMarketMethod>
@@ -486,6 +491,7 @@
 		<variableContractLength>false</variableContractLength>
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<contractMaxSalvagePercentage>100</contractMaxSalvagePercentage>
+		<dropShipBonusPercentage>0</dropShipBonusPercentage>
 		<useStaticRATs>false</useStaticRATs>
 		<rats>Xotl,Total Warfare</rats>
 		<ignoreRATEra>false</ignoreRATEra>
@@ -499,19 +505,19 @@
 		<atbCamOpsDivision>2.5</atbCamOpsDivision>
 		<doubleVehicles>false</doubleVehicles>
 		<adjustPlayerVehicles>false</adjustPlayerVehicles>
-		<opForLanceTypeMechs>1</opForLanceTypeMechs>
+		<opForLanceTypeMechs>5</opForLanceTypeMechs>
 		<opForLanceTypeMixed>2</opForLanceTypeMixed>
-		<opForLanceTypeVehicles>3</opForLanceTypeVehicles>
-		<opForUsesVTOLs>true</opForUsesVTOLs>
+		<opForLanceTypeVehicles>1</opForLanceTypeVehicles>
+		<opForUsesVTOLs>false</opForUsesVTOLs>
 		<useDropShips>false</useDropShips>
 		<mercSizeLimited>false</mercSizeLimited>
 		<regionalMechVariations>false</regionalMechVariations>
 		<attachedPlayerCamouflage>true</attachedPlayerCamouflage>
 		<playerControlsAttachedUnits>false</playerControlsAttachedUnits>
-		<atbBattleChance>40,20,60,10</atbBattleChance>
-		<generateChases>true</generateChases>
-		<useWeatherConditions>true</useWeatherConditions>
-		<useLightConditions>true</useLightConditions>
+		<atbBattleChance>0,0,0,0</atbBattleChance>
+		<generateChases>false</generateChases>
+		<useWeatherConditions>false</useWeatherConditions>
+		<useLightConditions>false</useLightConditions>
 		<usePlanetaryConditions>false</usePlanetaryConditions>
 		<useStrategy>true</useStrategy>
 		<baseStrategyDeployment>3</baseStrategyDeployment>
@@ -520,8 +526,8 @@
 		<restrictPartsByMission>true</restrictPartsByMission>
 		<bonusPartExchangeValue>500000</bonusPartExchangeValue>
 		<bonusPartMaxExchangeCount>10</bonusPartMaxExchangeCount>
-		<limitLanceWeight>true</limitLanceWeight>
-		<limitLanceNumUnits>true</limitLanceNumUnits>
+		<limitLanceWeight>false</limitLanceWeight>
+		<limitLanceNumUnits>false</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
 		<allowOpForAeros>false</allowOpForAeros>
 		<allowOpForLocalUnits>false</allowOpForLocalUnits>
@@ -531,12 +537,12 @@
 		<spaUpgradeIntensity>0</spaUpgradeIntensity>
 		<scenarioModMax>3</scenarioModMax>
 		<scenarioModChance>25</scenarioModChance>
-		<scenarioModBV>50</scenarioModBV>
+		<scenarioModBV>25</scenarioModBV>
 		<autoconfigMunitions>true</autoconfigMunitions>
 		<planetTechAcquisitionBonus>-1,0,1,2,4,8</planetTechAcquisitionBonus>
 		<planetIndustryAcquisitionBonus>0,0,0,0,0,0</planetIndustryAcquisitionBonus>
 		<planetOutputAcquisitionBonus>-1,0,1,2,4,8</planetOutputAcquisitionBonus>
-		<usePortraitForType>true,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false</usePortraitForType>
+		<usePortraitForType>true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true</usePortraitForType>
 	</campaignOptions>
 	<randomSkillPreferences>
 		<overallRecruitBonus>0</overallRecruitBonus>
@@ -881,7 +887,7 @@
             <lookupName>specialist</lookupName>
             <desc>A pilot who specializes in a type of weapon receives a -1 to-hit modifier when using weapons of that type and a
                 +1 to-hit modifier when using other types of weapons.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>4</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -901,7 +907,7 @@
             <displayName>Zweihander (CamOps)</displayName>
             <lookupName>zweihander</lookupName>
             <desc>You can do more damage with two-handed physical attacks at the risk of damaging yourself.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>6</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -916,7 +922,7 @@
             <lookupName>tm_frogman</lookupName>
             <desc>Movement in depth 2 or greater water costs 1 MP less.
                 Also grants -1 to all PSR checks (including physicals) as well as -2 to Crush Depth checks.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -931,7 +937,7 @@
             <displayName>Hot Dog (CamOps)</displayName>
             <lookupName>hot_dog</lookupName>
             <desc>Reduce heat-related target rolls (e.g ammo, damage, shutdown) by 1.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -946,7 +952,7 @@
             <displayName>Blood Stalker (CamOps)</displayName>
             <lookupName>blood_stalker</lookupName>
             <desc>Unit has -1 bonus against designated target, +2 penalty against all others; lasts until target retreats, can only be used once per battle.</desc>
-            <xpCost>60</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -967,7 +973,7 @@
             <lookupName>sandblaster</lookupName>
             <desc>A pilot with this ability gets a +4, +3, or +2 to the cluster table
                 at short, medium, or long/extended range, respectively, but only with a specialized weapon.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -987,7 +993,7 @@
             <displayName>Oblique Artilleryman (CamOps)</displayName>
             <lookupName>oblique_artillery</lookupName>
             <desc>Reduces scatter distance by two hexes.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1008,7 +1014,7 @@
             <lookupName>melee_specialist</lookupName>
             <desc>Enables the unit to do 1 additional point of damage with physical attacks and applies a -1 to-hit modifier to physical attacks.
                 Note: This ability is only used for BattleMeks.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1023,7 +1029,7 @@
             <displayName>Shaky Stick (CamOps)</displayName>
             <lookupName>shaky_stick</lookupName>
             <desc>Ground units have a harder time hitting this airborne target. Attacking units get a +1 tohit penalty</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1041,7 +1047,7 @@
             <displayName>Multi-Tasker (CamOps)</displayName>
             <lookupName>multi_tasker</lookupName>
             <desc>Secondary target modifiers are reduced by one.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1064,7 +1070,7 @@
                 Quads can move laterally for 1 less MP.
                 Aerospace units can perform maneuvers for 1 less thrust point.
                 Units also receive a -1 BTH to rolls against skidding, sideslipping, and going out of control.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1085,7 +1091,7 @@
             <displayName>Oblique Attacker (CamOps)</displayName>
             <lookupName>oblique_attacker</lookupName>
             <desc>The penalty for indirect fire is reduced by one and can also use indirect fire with out a spotter.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1105,7 +1111,7 @@
             <displayName>Natural Aptitude, Gunnery (aToW)</displayName>
             <lookupName>aptitude_gunnery</lookupName>
             <desc>Roll 3d6 and take the best two for gunnery checks</desc>
-            <xpCost>250</xpCost>
+            <xpCost>0</xpCost>
             <weight>0</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1117,7 +1123,7 @@
             <lookupName>env_specialist</lookupName>
             <desc>Environmental specialists are adept in certain planetary conditions.
                 This gives the unit bonuses to PSR and movement penalties (halves MP / PSR) as well to hit rolls (-1).</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1147,7 +1153,7 @@
             <desc>A pilot who has a Tactical Genius may reroll their initiative once per turn.
                 The second roll must be accepted.
                 Note: Only one Tactical Genius may be utilized per team.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1175,7 +1181,7 @@
             <displayName>Natural Aptitude, Piloting (aToW)</displayName>
             <lookupName>aptitude_piloting</lookupName>
             <desc>Roll 3d6 and take the best two for piloting checks</desc>
-            <xpCost>250</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1186,7 +1192,7 @@
             <displayName>Human TRO (CamOps)</displayName>
             <lookupName>human_tro</lookupName>
             <desc>The Human TRO has studied a given type of battlefield unit giving the pilot a bonus when rolling for critical hit. This applies a +1 when determining criticals for a specific unit type (Mek, Aero, etc.)</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1215,7 +1221,7 @@
             <lookupName>tm_swamp_beast</lookupName>
             <desc>Movement in mud or swamp costs 1 less MP.
                 Using run/flank MP while in mud/swamp gives +1 BTH when being attacked</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1232,7 +1238,7 @@
             <displayName>Jumping Jack (CamOps)</displayName>
             <lookupName>jumping_jack</lookupName>
             <desc>Unit only suffers a +1 to-hit penalty for jumping, rather than a +3 to-hit penalty.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>6</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1249,7 +1255,7 @@
             <desc>Urban Guerrilla gives infantry a better chance of survival in urban or suburban environments (+1 to be hit)
                 It also keeps them from taking double damage in the open when in pavement or road terrain types.
                 Finally, urban guerrillas can call on local support once per scenario.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1266,7 +1272,7 @@
                 -1 MP per hex of Woods and Jungle terrain.
                 In addition quads gain a -1 to any quad related PSR check.
                 NOTE: The quirk should be used only on bipedal units that have an animal like appearance.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1281,7 +1287,7 @@
             <displayName>Sniper (CamOps)</displayName>
             <lookupName>sniper</lookupName>
             <desc>Range penalties are halved.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1301,7 +1307,7 @@
             <displayName>RangeMaster (CamOps)</displayName>
             <lookupName>range_master</lookupName>
             <desc>Range modifiers are swapped with short range (Medium, Long, or Extreme).</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1324,7 +1330,7 @@
                 This maneuver adds +2 to the BTH to physical attacks against the unit.
                 NOTE: The dodge maneuver is declared during the weapons phase.
                 Note: This ability is only used for BattleMeks.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1339,7 +1345,7 @@
             <displayName>Golden Goose (CamOps)</displayName>
             <lookupName>golden_goose</lookupName>
             <desc>Ground attacks are easier. Strike gives -1 BTH and Bombing is -2. Also decreases scatter distance by 2 hexes</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1356,7 +1362,7 @@
             <displayName>Cluster Hitter (CamOps)</displayName>
             <lookupName>cluster_hitter</lookupName>
             <desc>A pilot with this ability gets a +1 to the cluster hit table</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities>oblique_attacker::sandblaster</invalidAbilities>
@@ -1378,7 +1384,7 @@
             <desc>Movement in woods or jungle costs 1 less MP.
                 Using walk/cruise MP while in woods/jungle gives +1 BTH when being attacked.
                 Additionally, you gain -1 to PSR checks in Jungle terrain.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1395,7 +1401,7 @@
             <displayName>Terrain Master [Nightwalker] (CamOps)</displayName>
             <lookupName>tm_nightwalker</lookupName>
             <desc>Nightwalker ignores all darkness move penalties when using Walk / Cruise movement but does not affect gunnery modifiers for lighting conditions.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1412,7 +1418,7 @@
             <displayName>Weapon Specialist (CamOps)</displayName>
             <lookupName>weapon_specialist</lookupName>
             <desc>A pilot who specializes in a particular weapon receives a -2 to hit modifier on all attacks with that weapon.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1432,7 +1438,7 @@
             <displayName>Melee Master (CamOps)</displayName>
             <lookupName>melee_master</lookupName>
             <desc>Enables the unit to do one additional kick, punch, or club attack on the same opponent.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>6</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1448,7 +1454,7 @@
             <lookupName>tm_mountaineer</lookupName>
             <desc>Movement in rubble or rough cost 1 less MP and elevation changes also cost 1 MP less.
                 The mountaineer also recieves a -1 to PSR checks for the given terrain.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1465,7 +1471,7 @@
             <displayName>Eagle&apos;s Eyes (CamOps)</displayName>
             <lookupName>eagle_eyes</lookupName>
             <desc>Acts as an active probe or extends range of existing active probe. Also makes avoiding minefields easier</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>2</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1493,7 +1499,7 @@
             <displayName>Forward Observer (CamOps)</displayName>
             <lookupName>forward_observer</lookupName>
             <desc>Improves the accuracy of your artillery. Fire Adjustment gets a -2 modifier. Spotting gets an additional -1 tohit modifier for each point of gunnery below 4.</desc>
-            <xpCost>75</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1521,7 +1527,7 @@
             <displayName>Foot Cavalry (CamOps)</displayName>
             <lookupName>foot_cav</lookupName>
             <desc>Foot Infantry gain 1 extra MP and allows for foot infantry to move and shoot when using two support weapons.</desc>
-            <xpCost>25</xpCost>
+            <xpCost>0</xpCost>
             <weight>3</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>
@@ -1535,7 +1541,7 @@
             <displayName>Cross-Country (CamOps)</displayName>
             <lookupName>cross_country</lookupName>
             <desc>Allows a unit to use terrain normally restricted to said unit at the cost of increased MP.</desc>
-            <xpCost>50</xpCost>
+            <xpCost>0</xpCost>
             <weight>1</weight>
             <prereqAbilities></prereqAbilities>
             <invalidAbilities></invalidAbilities>


### PR DESCRIPTION
Updated presets to account for recently added campaign options and changes.

Added requirements for Natural Aptitude traits to reduce the likelihood of personnel spawning with those Traits.

Adjusted experience point costs for SPAs for the CamOps based presets, as SPAs have no XP cost under CamOps.

### Closes #4707