### PR TITLE
Fix 4728: Safety getBay, add unit test, turn down logging in one location

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -368,6 +368,7 @@ public class CampaignXmlParser {
         timestamp = System.currentTimeMillis();
 
         // Process parts...
+        // Note: Units must have their Entities set prior to reaching this point!
         postProcessParts(retVal, version);
 
         LogManager.getLogger().info(String.format("[Campaign Load] Parts processed in %dms",

--- a/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
@@ -57,7 +57,7 @@ public class TransportBayPart extends Part {
     }
 
     public Bay getBay() {
-        if (null != unit) {
+        if (null != unit && null != unit.getEntity()) {
             return unit.getEntity().getBayById(bayNumber);
         }
         return null;

--- a/MekHQ/src/mekhq/campaign/personnel/enums/Profession.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Profession.java
@@ -226,7 +226,7 @@ public enum Profession {
             case "--CIVILIAN":
                 return CIVILIAN;
             default:
-                LogManager.getLogger().error("Cannot get alternate profession for unknown alternative "
+                LogManager.getLogger().debug("Cannot get alternate profession for unknown alternative "
                         + name + " returning MECHWARRIOR.");
                 return MECHWARRIOR;
         }

--- a/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
@@ -345,4 +345,14 @@ public class PartTest {
         assertTrue(part.getChildParts().isEmpty());
         verify(childPart0, times(1)).setParentPart(eq(null));
     }
+
+    @Test
+    public void testTransportBayPartNameNoEntity() {
+        Campaign mockCampaign = mock(Campaign.class);
+        Unit mockUnit = mock(Unit.class);
+        int size = 1000;
+        TransportBayPart tbp = new TransportBayPart(size, 1, size, mockCampaign);
+        // Should return default name, _not_ throw NPE here
+        assertNotNull(tbp.getName());
+    }
 }

--- a/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/PartTest.java
@@ -349,7 +349,6 @@ public class PartTest {
     @Test
     public void testTransportBayPartNameNoEntity() {
         Campaign mockCampaign = mock(Campaign.class);
-        Unit mockUnit = mock(Unit.class);
         int size = 1000;
         TransportBayPart tbp = new TransportBayPart(size, 1, size, mockCampaign);
         // Should return default name, _not_ throw NPE here


### PR DESCRIPTION
Adds an additional anti-null check when getting the Bay name for a Part for a Unit that may not have its Entity set yet.
This info should be corrected later in the campaign loading process anyhow.

NOTE: the save file in #4728 did display missing/destroyed DS bay doors and cubicles on my system following this fix, but I was not able to repro that with a brand new save replicating the TOE layout.  This save may be useful for replicating this bug in the future.

Testing:
- Loaded OP's campaign save
- Added a unit test for the specific failure
- Ran all 3 projects' unit tests.

Close #4728 