### PR TITLE
Prevent Rapid unplanned disassembly (band-aid)

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -2034,7 +2034,6 @@ public class Unit implements ITechnology {
             }
         } catch (Exception ex) {
             LogManager.getLogger().error("Could not parse unit {}", idNode.getTextContent().trim(), ex);
-            return null;
         }
 
         if (version.isLowerThan("0.49.3")) {


### PR DESCRIPTION
Prevents Rapid unplanned disassembly of units by removing one line. Shameless (band-aid solution, as the real cause of the problem is that the number of days since last maintenance check is being stored with a decimal. I'm 99% sure that we don't have any need to measures how many fractions of a day since last maintenance, since it can only ever occur once per day at max.

Ran MHQ unit tests
Saved and loaded several times

Fixes https://github.com/MegaMek/mekhq/issues/4742