### PR TITLE
Include more information about available personnel in Camops Personnel Market Refresh Report

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -130,15 +130,15 @@ public class PersonnelMarket {
 
         if (updated && c.getCampaignOptions().isPersonnelMarketReportRefresh()) {
             StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.append("<a href='PERSONNEL_MARKET'>Personnel market updated</a>");
+            stringBuilder.append("<a href='PERSONNEL_MARKET'>Personnel market updated:</a>");
             if (c.getCampaignOptions().getPersonnelMarketName().equals("Campaign Ops") && !personnel.isEmpty()) {
                 Person person = personnel.get(0);
                 String expLevel = SkillType.getExperienceLevelName(person.getExperienceLevel(c, false));
                 stringBuilder.append("<br><br>A ")
                     .append("<b> ")
-                    .append(person.getExperienceLevel(c, false))
-                    .append(' ')
                     .append(expLevel)
+                    .append(' ')
+                    .append(person.getPrimaryRole().toString())
                     .append("</b>")
                     .append(" named ")
                     .append(person.getFullName())

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -130,11 +130,12 @@ public class PersonnelMarket {
 
         if (updated && c.getCampaignOptions().isPersonnelMarketReportRefresh()) {
             StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.append("<a href='PERSONNEL_MARKET'>Personnel market updated:</a>");
+            stringBuilder.append("<a href='PERSONNEL_MARKET'>Personnel market updated</a>");
             if (c.getCampaignOptions().getPersonnelMarketName().equals("Campaign Ops") && !personnel.isEmpty()) {
+                stringBuilder.append(':');
                 Person person = personnel.get(0);
                 String expLevel = SkillType.getExperienceLevelName(person.getExperienceLevel(c, false));
-                stringBuilder.append("<br><br>A ")
+                stringBuilder.append("<br>A ")
                     .append("<b> ")
                     .append(expLevel)
                     .append(' ')

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -129,7 +129,22 @@ public class PersonnelMarket {
         }
 
         if (updated && c.getCampaignOptions().isPersonnelMarketReportRefresh()) {
-            c.addReport("<a href='PERSONNEL_MARKET'>Personnel market updated</a>");
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append("<a href='PERSONNEL_MARKET'>Personnel market updated</a>");
+            if (c.getCampaignOptions().getPersonnelMarketName().equals("Campaign Ops") && !personnel.isEmpty()) {
+                Person person = personnel.get(0);
+                String expLevel = SkillType.getExperienceLevelName(person.getExperienceLevel(c, false));
+                stringBuilder.append("<br><br>A ")
+                    .append("<b> ")
+                    .append(person.getExperienceLevel(c, false))
+                    .append(' ')
+                    .append(expLevel)
+                    .append("</b>")
+                    .append(" named ")
+                    .append(person.getFullName())
+                    .append(" is available.");
+            }
+            c.addReport(stringBuilder.toString());
         }
     }
 


### PR DESCRIPTION
This adds a small amount of information about new personnel in the market refresh report when the CamOps market is being used. I decided to only do this for CamOps as it generates a single unit per day and thus won't flood the report with messages for "higher yield" methods.

This change was in response to player feedback in Discord that it was tedious to check the personnel market every day to see what was available. The intention here is to show the player at a glance the important information (exp level and role, mainly) so they can skip checking the market if they aren't interested.

Here's what the report looks like:

![camops-market-report](https://github.com/user-attachments/assets/991d2519-03e2-4dca-af77-19a8066a8d1c)
