### PR TITLE
Update GameManager package/class to new name

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -60,7 +60,7 @@ import megamek.client.ui.swing.gameConnectionDialogs.HostDialog;
 import megamek.server.Server;
 import megamek.common.event.*;
 import megamek.common.net.marshalling.SanityInputFilter;
-import megamek.server.GameManager;
+import megamek.server.totalwarfare.TWGameManager;
 import megameklab.MegaMekLab;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignController;
@@ -406,7 +406,7 @@ public class MekHQ implements GameListener {
         hostDialog.dispose();
 
         try {
-            myServer = new Server(password, port, new GameManager(), register, metaserver);
+            myServer = new Server(password, port, new TWGameManager(), register, metaserver);
             if (loadSavegame) {
                 FileDialog f = new FileDialog(campaignGUI.getFrame(), "Load Savegame");
                 f.setDirectory(System.getProperty("user.dir") + "/savegames");

--- a/MekHQ/src/mekhq/gui/dialog/EditMapSettingsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditMapSettingsDialog.java
@@ -25,7 +25,7 @@ import megamek.common.BoardDimensions;
 import megamek.common.Configuration;
 import megamek.common.MapSettings;
 import megamek.common.util.fileUtils.MegaMekFile;
-import megamek.server.GameManager;
+import megamek.server.totalwarfare.TWGameManager;
 import megamek.server.ServerBoardHelper;
 import mekhq.MekHQ;
 import mekhq.campaign.mission.Scenario;
@@ -147,7 +147,7 @@ public class EditMapSettingsDialog extends JDialog {
         panSizeRandom.add(spnMapY);
 
         comboMapSize = new JComboBox<>();
-        for (BoardDimensions size : GameManager.getBoardSizes()) {
+        for (BoardDimensions size : TWGameManager.getBoardSizes()) {
             comboMapSize.addItem(size);
         }
         if (mapSizeX > 0 & mapSizeY > 0) {


### PR DESCRIPTION
GameManager in Megamek was refactored into `megamek.server.totalwarfare.TWGameManager` recently, which caused MekHQ to fail to compile. There were only two instances I found that needed to be updated, and all MekHQ unit tests were still passing.