### PR TITLE
Fix Mission XP Reward Setting

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -3840,7 +3840,7 @@ public class CampaignOptions {
     }
 
     public int getMissionXpSuccess() {
-        return missionXpFail;
+        return missionXpSuccess;
     }
 
     public void setMissionXpSuccess(final int missionXpSuccess) {


### PR DESCRIPTION
This fixes a typo related to Mission XP Rewards.

Closes #4790