### PR TITLE
Remove untreated personnel nag for prisoner-defectors and add unit tests

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
@@ -26,10 +26,10 @@ import mekhq.gui.baseComponents.AbstractMHQNagDialog;
 import javax.swing.*;
 
 public class UntreatedPersonnelNagDialog extends AbstractMHQNagDialog {
-    private static boolean isUntreatedInjury (Campaign campaign) {
+    static boolean isUntreatedInjury(Campaign campaign) {
         return campaign.getActivePersonnel().stream()
                 .filter(p -> (p.needsFixing()) && (p.getDoctorId() == null))
-                .anyMatch(p -> !p.getPrisonerStatus().isPrisoner());
+                .anyMatch(p -> !p.getPrisonerStatus().isCurrentPrisoner());
     }
 
     //region Constructors

--- a/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialogTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialogTest.java
@@ -1,0 +1,78 @@
+package mekhq.gui.dialog.nagDialogs;
+
+import megamek.common.EquipmentType;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.enums.PersonnelStatus;
+import mekhq.campaign.personnel.enums.PrisonerStatus;
+import mekhq.campaign.personnel.ranks.Ranks;
+import mekhq.campaign.universe.Systems;
+import org.apache.logging.log4j.LogManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+import static mekhq.gui.dialog.nagDialogs.UntreatedPersonnelNagDialog.isUntreatedInjury;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UntreatedPersonnelNagDialogTest {
+    Campaign campaign;
+    Person person;
+
+    @BeforeAll
+    public static void setup() {
+        EquipmentType.initializeTypes();
+        SkillType.initializeTypes();
+        Ranks.initializeRankSystems();
+        try {
+            Systems.setInstance(Systems.loadDefault());
+        } catch (Exception ex) {
+            LogManager.getLogger().error("", ex);
+        }
+    }
+
+    @BeforeEach
+    public void init() {
+        campaign = new Campaign();
+        person = campaign.newPerson(PersonnelRole.MECHWARRIOR);
+        person.setHits(1);
+    }
+
+    @Test
+    public void isUntreatedInjuryIncludesNonPrisonersTest() {
+        person.setPrisonerStatus(campaign, PrisonerStatus.FREE, false);
+        campaign.importPerson(person);
+        assertTrue(isUntreatedInjury(campaign));
+    }
+
+    @Test
+    public void isUntreatedInjuryExcludesPrisonersTest() {
+        person.setPrisonerStatus(campaign, PrisonerStatus.PRISONER, false);
+        campaign.importPerson(person);
+        assertFalse(isUntreatedInjury(campaign));
+    }
+
+    @Test
+    public void isUntreatedInjuryExcludesPrisonerDefectorsTest() {
+        person.setPrisonerStatus(campaign, PrisonerStatus.PRISONER_DEFECTOR, false);
+        campaign.importPerson(person);
+        assertFalse(isUntreatedInjury(campaign));
+    }
+
+    @Test
+    public void isUntreatedInjuryExcludesBondsmenTest() {
+        person.setPrisonerStatus(campaign, PrisonerStatus.BONDSMAN, false);
+        campaign.importPerson(person);
+        assertTrue(isUntreatedInjury(campaign));
+    }
+
+    @Test
+    public void isUntreatedInjuryExcludesInactivePersonnelTest() {
+        person.setStatus(PersonnelStatus.AWOL);
+        campaign.importPerson(person);
+        assertFalse(isUntreatedInjury(campaign));
+    }
+}


### PR DESCRIPTION
This fixes the "untreated personnel" nag by having it exclude defectors. Illiani suggested making sure that bondsmen are also excluded, so I added unit tests to cover that as well as other cases. Note I had to make `isUntreatedInjury()` "package-private" instead of fully private in order to test it, but I don't think that should have any impact since only classes in the exact same package can access it. 

Closes #4789