### PR TITLE
Corrected terminology in Academy XMLs

### DIFF
--- a/MekHQ/data/universe/academies/Local Academies.xml
+++ b/MekHQ/data/universe/academies/Local Academies.xml
@@ -150,7 +150,7 @@
         <curriculum>Astech, Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Battle Armor Technician Apprenticeship</qualification>
-        <curriculum>Astech, Tech/BA</curriculum>
+        <curriculum>Astech, Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Black Naval Apprenticeship</qualification>
         <curriculum>Astech, Tech/Vessel</curriculum>
@@ -277,7 +277,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Battle Armor Technology &amp; Development</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Black Naval Technologies</qualification>
         <curriculum>Tech/Vessel</curriculum>
@@ -303,7 +303,7 @@
         <curriculum>Negotiation, Scrounge</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Nursing School</qualification>
-        <curriculum>Medtech</curriculum>
+        <curriculum>MedTech</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
     </academy>
     <academy>
@@ -333,7 +333,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Battle Armor Technology &amp; Development</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Black Naval Technologies</qualification>
         <curriculum>Tech/Vessel</curriculum>
@@ -442,7 +442,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Academy</qualification>
+        <qualification>MechWarrior Academy</qualification>
         <curriculum>Gunnery/Mek, Piloting/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Mechanized Academy</qualification>
@@ -455,7 +455,7 @@
         <curriculum>Gunnery/Spacecraft, Piloting/Spacecraft</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Battle Armor Academy</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Artillery College</qualification>
         <curriculum>Small Arms, Artillery</curriculum>

--- a/MekHQ/data/universe/academies/Prestigious Academies.xml
+++ b/MekHQ/data/universe/academies/Prestigious Academies.xml
@@ -66,7 +66,7 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>Year One Curriculum</qualification>
-        <curriculum>Small Arms, Medtech</curriculum>
+        <curriculum>Small Arms, MedTech</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <baseAcademicSkillLevel>-1</baseAcademicSkillLevel>
     </academy>
@@ -119,7 +119,7 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>Year One Curriculum</qualification>
-        <curriculum>Small Arms, Medtech</curriculum>
+        <curriculum>Small Arms, MedTech</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <baseAcademicSkillLevel>-1</baseAcademicSkillLevel>
     </academy>
@@ -162,7 +162,7 @@
         <isMilitary>true</isMilitary>
         <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of
             anti-Marik sentiment. The academy emphasizes physical training and survival skills in
-            the first year, followed by advanced MekWarriorand Cavalry training. The aerospace
+            the first year, followed by advanced MechWarrior and Cavalry training. The aerospace
             program was discontinued after fatal accidents. Strict traditions and combat trials
             among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
         <factionDiscount>0</factionDiscount>
@@ -175,11 +175,11 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -195,7 +195,7 @@
         <isMilitary>true</isMilitary>
         <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of
             anti-Marik sentiment. The academy emphasizes physical training and survival skills in
-            the first year, followed by advanced MekWarrior and Cavalry training. The aerospace
+            the first year, followed by advanced MechWarrior and Cavalry training. The aerospace
             program was discontinued after fatal accidents. Strict traditions and combat trials
             among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
         <factionDiscount>0</factionDiscount>
@@ -219,7 +219,7 @@
         <isMilitary>true</isMilitary>
         <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of
             anti-Marik sentiment. The academy emphasizes physical training and survival skills in
-            the first year, followed by advanced MekWarrior and Cavalry training. The aerospace
+            the first year, followed by advanced MechWarrior and Cavalry training. The aerospace
             program was discontinued after fatal accidents. Strict traditions and combat trials
             among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
         <factionDiscount>0</factionDiscount>
@@ -232,11 +232,11 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -252,7 +252,7 @@
         <isMilitary>true</isMilitary>
         <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of
             anti-Marik sentiment. The academy emphasizes physical training and survival skills in
-            the first year, followed by advanced MekWarrior and Cavalry training. The aerospace
+            the first year, followed by advanced MechWarrior and Cavalry training. The aerospace
             program was discontinued after fatal accidents. Strict traditions and combat trials
             among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
         <factionDiscount>0</factionDiscount>
@@ -265,11 +265,11 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -336,7 +336,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -352,7 +352,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -376,7 +376,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel</curriculum>
@@ -403,7 +403,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -420,7 +420,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -444,7 +444,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -484,7 +484,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -492,16 +492,16 @@
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Allison MekWarrior Institute</name>
+        <name>Allison MechWarrior Institute</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Allison MekWarrior Institute stands as a premier training facility for
-            MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375
-            MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring
+        <description>The Allison MechWarrior Institute stands as a premier training facility for
+            MechWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375
+            MechWarrior graduates annually, the institute fosters a spirited rivalry with neighboring
             aerospace cadets, characterized by athletic contests and pranks that occasionally
             escalate into conflicts. Admission is highly competitive, influenced by political
             considerations, with a portion of spots reserved for families of Dispossessed
-            Mekwarriors to uphold loyalty.</description>
+            MechWarriors to uphold loyalty.</description>
         <locationSystem>New Olympia</locationSystem>
         <constructionYear>2465</constructionYear>
         <tuition>5250</tuition>
@@ -510,22 +510,22 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Allison MekWarrior Institute (Officer)</name>
+        <name>Allison MechWarrior Institute (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Allison MekWarrior Institute stands as a premier training facility for
-            MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375
-            MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring
+        <description>The Allison MechWarrior Institute stands as a premier training facility for
+            MechWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375
+            MechWarrior graduates annually, the institute fosters a spirited rivalry with neighboring
             aerospace cadets, characterized by athletic contests and pranks that occasionally
             escalate into conflicts. Admission is highly competitive, influenced by political
             considerations, with a portion of spots reserved for families of Dispossessed
-            Mekwarriors to uphold loyalty.</description>
+            MechWarriors to uphold loyalty.</description>
         <locationSystem>New Olympia</locationSystem>
         <constructionYear>2465</constructionYear>
         <tuition>13125</tuition>
@@ -534,7 +534,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -544,7 +544,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The An Ting University is a renowned military academy historically dedicated to
-            training MekWarriors. ATU, enjoying support from the DCMS and local government, provides
+            training MechWarriors. ATU, enjoying support from the DCMS and local government, provides
             rigorous training with a commitment to military reforms and a focus on loyalty and
             excellence.</description>
         <factionDiscount>0</factionDiscount>
@@ -558,11 +558,11 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
         <curriculum>Piloting/Aerospace, Gunnery/Aerospace</curriculum>
@@ -574,7 +574,7 @@
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
         <description>The An Ting University is a renowned military academy historically dedicated to
-            training MekWarriors. ATU, enjoying support from the DCMS and local government, provides
+            training MechWarriors. ATU, enjoying support from the DCMS and local government, provides
             rigorous training with a commitment to military reforms and a focus on loyalty and
             excellence.</description>
         <factionDiscount>0</factionDiscount>
@@ -588,11 +588,11 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Aerospace Command Graduate</qualification>
         <curriculum>Piloting/Aerospace, Gunnery/Aerospace, Tactics, Strategy, Leadership</curriculum>
@@ -604,13 +604,13 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The An Ting University, a renowned military academy historically dedicated to
-            training MekWarriors, faced significant damage from both external attacks and internal
+            training MechWarriors, faced significant damage from both external attacks and internal
             strife in 3015 from Sun Zhang Cadre alumni. The academy remained shuttered until 3055
             when it reopened with advancements from the Helm Memory Core. ATU, enjoying support from
             the DCMS and local government, provides rigorous training with a commitment to military
             reforms and a focus on loyalty and excellence. Despite past conflicts, it now produces
             capable graduates, reaffirming its status alongside prestigious institutions like the
-            Sun Zhang MekWarrior Academy.</description>
+            Sun Zhang MechWarrior Academy.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>An Ting</locationSystem>
@@ -621,11 +621,11 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
         <curriculum>Piloting/Aerospace, Gunnery/Aerospace</curriculum>
@@ -637,13 +637,13 @@
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
         <description>The An Ting University, a renowned military academy historically dedicated to
-            training MekWarriors, faced significant damage from both external attacks and internal
+            training MechWarriors, faced significant damage from both external attacks and internal
             strife in 3015 from Sun Zhang Cadre alumni. The academy remained shuttered until 3055
             when it reopened with advancements from the Helm Memory Core. ATU, enjoying support from
             the DCMS and local government, provides rigorous training with a commitment to military
             reforms and a focus on loyalty and excellence. Despite past conflicts, it now produces
             capable graduates, reaffirming its status alongside prestigious institutions like the
-            Sun Zhang MekWarrior Academy.</description>
+            Sun Zhang MechWarrior Academy.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>An Ting</locationSystem>
@@ -654,11 +654,11 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Aerospace Command Graduate</qualification>
         <curriculum>Piloting/Aerospace, Gunnery/Aerospace, Tactics, Strategy, Leadership</curriculum>
@@ -815,7 +815,7 @@
         <isMilitary>true</isMilitary>
         <description>Esteemed as the premier military institution of the Rim Worlds Republic, the
             Apollo Military Academy is located on the capital world of the Republic. Known for its
-            rigorous standards and distinguished graduates, AMA excels in producing MekWarriors of
+            rigorous standards and distinguished graduates, AMA excels in producing MechWarriors of
             superior leadership and combat skills, rivaling those from the most prestigious
             academies in the Inner Sphere.</description>
         <factionDiscount>0</factionDiscount>
@@ -829,7 +829,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -858,7 +858,7 @@
         <isMilitary>true</isMilitary>
         <description>Esteemed as the premier military institution of the Rim Worlds Republic, the
             Apollo Military Academy is located on the capital world of the Republic. Known for its
-            rigorous standards and distinguished graduates, AMA excels in producing MekWarriors of
+            rigorous standards and distinguished graduates, AMA excels in producing MechWarriors of
             superior leadership and combat skills, rivaling those from the most prestigious
             academies in the Inner Sphere.</description>
         <factionDiscount>0</factionDiscount>
@@ -872,7 +872,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -916,11 +916,11 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
         <curriculum>Piloting/Aerospace, Gunnery/Aerospace, Leadership</curriculum>
@@ -1026,7 +1026,7 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -1075,7 +1075,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Scrounge, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -1091,7 +1091,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Scrounge</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Scrounge</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Scrounge</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Scrounge, Artillery</curriculum>
@@ -1103,7 +1103,7 @@
         <curriculum>Tech/Mechanic, Scrounge</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Scrounge</curriculum>
+        <curriculum>Tech/BattleArmor, Scrounge</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -1127,7 +1127,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -1151,7 +1151,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -1161,9 +1161,9 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>Established to enhance the Magistracy Armed Forces' training programs, the
-            Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The
+            Canopian Institute of War draws inspiration from the Sun Zhang MechWarrior Academy. The
             rigorous program spans six months of basic training followed by four years of advanced
-            training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold,
+            training for MechWarriors or aerospace pilots. Graduates, distinguished by their gold,
             silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards
             or pursue further training at the Victoria Academy of Arms and Technology.</description>
         <factionDiscount>0</factionDiscount>
@@ -1177,7 +1177,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -1190,9 +1190,9 @@
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
         <description>Established to enhance the Magistracy Armed Forces' training programs, the
-            Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The
+            Canopian Institute of War draws inspiration from the Sun Zhang MechWarrior Academy. The
             rigorous program spans six months of basic training followed by four years of advanced
-            training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold,
+            training for MechWarriors or aerospace pilots. Graduates, distinguished by their gold,
             silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards
             or pursue further training at the Victoria Academy of Arms and Technology.</description>
         <factionDiscount>0</factionDiscount>
@@ -1205,7 +1205,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Command Graduate</qualification>
@@ -1218,9 +1218,9 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>Established to enhance the Magistracy Armed Forces' training programs, the
-            Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The
+            Canopian Institute of War draws inspiration from the Sun Zhang MechWarrior Academy. The
             rigorous program spans six months of basic training followed by four years of advanced
-            training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold,
+            training for MechWarriors or aerospace pilots. Graduates, distinguished by their gold,
             silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards
             or pursue further training at the Victoria Academy of Arms and Technology.</description>
         <factionDiscount>0</factionDiscount>
@@ -1233,7 +1233,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -1246,9 +1246,9 @@
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
         <description>Established to enhance the Magistracy Armed Forces' training programs, the
-            Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The
+            Canopian Institute of War draws inspiration from the Sun Zhang MechWarrior Academy. The
             rigorous program spans six months of basic training followed by four years of advanced
-            training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold,
+            training for MechWarriors or aerospace pilots. Graduates, distinguished by their gold,
             silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards
             or pursue further training at the Victoria Academy of Arms and Technology.</description>
         <factionDiscount>0</factionDiscount>
@@ -1261,7 +1261,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Command Graduate</qualification>
@@ -1286,7 +1286,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -1302,7 +1302,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -1329,7 +1329,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel</curriculum>
@@ -1353,7 +1353,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -1370,7 +1370,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -1397,7 +1397,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -1462,7 +1462,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -1498,7 +1498,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -1574,7 +1574,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>BattleMek Technician</qualification>
@@ -1599,7 +1599,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Senior BattleMek Technician</qualification>
@@ -1611,7 +1611,7 @@
         <name>Coventry Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally focused solely on training MekWarriors, its ties to Coventry Metal
+        <description>Originally focused solely on training MechWarriors, its ties to Coventry Metal
             Works drew criticism, but it persisted as a crucial training ground. During the Clan
             Invasion, cadets and instructors valiantly defended against Clan Jade Falcon,
             sacrificing parts of the academy to protect Coventry. Reborn as the Coventry Military
@@ -1627,7 +1627,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>BattleMek Technician</qualification>
@@ -1639,7 +1639,7 @@
         <name>Coventry Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally focused solely on training MekWarriors, its ties to Coventry Metal
+        <description>Originally focused solely on training MechWarriors, its ties to Coventry Metal
             Works drew criticism, but it persisted as a crucial training ground. During the Clan
             Invasion, cadets and instructors valiantly defended against Clan Jade Falcon,
             sacrificing parts of the academy to protect Coventry. Reborn as the Coventry Military
@@ -1655,7 +1655,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Senior BattleMek Technician</qualification>
@@ -1667,10 +1667,10 @@
         <name>Dieron District Gymnasium</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing
+        <description>The Dieron District Gymnasium shapes MechWarriors solely on merit. Prioritizing
             combat readiness over prestige, it employs an innovative regimen where study time earns
             simulator and 'Mek training, accelerating student advancement. Graduating fifteen to
-            twenty MekWarriors annually, the DDG is vital to the Dieron Military District.</description>
+            twenty MechWarriors annually, the DDG is vital to the Dieron Military District.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieron</locationSystem>
@@ -1682,7 +1682,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
@@ -1694,10 +1694,10 @@
         <name>Dieron District Gymnasium (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing
+        <description>The Dieron District Gymnasium shapes MechWarriors solely on merit. Prioritizing
             combat readiness over prestige, it employs an innovative regimen where study time earns
             simulator and 'Mek training, accelerating student advancement. Graduating fifteen to
-            twenty MekWarriors annually, the DDG is vital to the Dieron Military District.</description>
+            twenty MechWarriors annually, the DDG is vital to the Dieron Military District.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieron</locationSystem>
@@ -1709,7 +1709,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
@@ -1721,10 +1721,10 @@
         <name>Dieron District Gymnasium [3078]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing
+        <description>The Dieron District Gymnasium shapes MechWarriors solely on merit. Prioritizing
             combat readiness over prestige, it employs an innovative regimen where study time earns
             simulator and 'Mek training, accelerating student advancement. Graduating fifteen to
-            twenty MekWarriors annually, the DDG is vital to the Dieron Military District. Briefly
+            twenty MechWarriors annually, the DDG is vital to the Dieron Military District. Briefly
             closed in 3068; it reopened in 3078, attracting attention with its first class of
             battlesuit trainees, including a notable presence of ISF agents.</description>
         <factionDiscount>0</factionDiscount>
@@ -1737,11 +1737,11 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -1752,10 +1752,10 @@
         <name>Dieron District Gymnasium (Officer) [3078]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing
+        <description>The Dieron District Gymnasium shapes MechWarriors solely on merit. Prioritizing
             combat readiness over prestige, it employs an innovative regimen where study time earns
             simulator and 'Mek training, accelerating student advancement. Graduating fifteen to
-            twenty MekWarriors annually, the DDG is vital to the Dieron Military District. Briefly
+            twenty MechWarriors annually, the DDG is vital to the Dieron Military District. Briefly
             closed in 3068; it reopened in 3078, attracting attention with its first class of
             battlesuit trainees, including a notable presence of ISF agents.</description>
         <factionDiscount>0</factionDiscount>
@@ -1768,11 +1768,11 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -1783,10 +1783,10 @@
         <name>Dieron Warriors' Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron Warriors Academy on Shimonita annually produces skilled MekWarriors.
+        <description>The Dieron Warriors Academy on Shimonita annually produces skilled MechWarriors.
             Graduates are favored for recruitment into the renowned Dieron Regulars, showcasing the
             academy's pivotal role in regional military development. All five BattleMek regiment
-            commanders have roots in both the Dieron draft and Sun Zhang MekWarrior Academy,
+            commanders have roots in both the Dieron draft and Sun Zhang MechWarrior Academy,
             highlighting the DWA's lasting influence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
@@ -1799,7 +1799,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -1811,7 +1811,7 @@
         <description>The Dover Institute for Higher Learning rose from the ashes of the People's
             Reconstruction Effort University of Ashio, destroyed during the Shadow War of 2865.
             Established in 2910 under Coordinator Shinjiro Kurita's patronage, it prioritizes
-            scientific, technical education, and MekWarrior training. Enrollment is open to all
+            scientific, technical education, and MechWarrior training. Enrollment is open to all
             meeting basic criteria, with a rigorous five-month basic training followed by a
             four-year curriculum exposing cadets to diverse combat scenarios.</description>
         <factionDiscount>0</factionDiscount>
@@ -1824,7 +1824,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Medical Technician</qualification>
@@ -1841,7 +1841,7 @@
         <isMilitary>true</isMilitary>
         <description>The École Militaire stands as the most renowned academy in the Taurian
             Concordat, offering courses covering almost every form of modern warfare. Renowned for
-            producing elite MekWarriors, armor, and infantry units, the academy admits foreign
+            producing elite MechWarriors, armor, and infantry units, the academy admits foreign
             applicants with a preference for Taurians. </description>
         <locationSystem>Taurus</locationSystem>
         <constructionYear>2500</constructionYear>
@@ -1852,7 +1852,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -1868,7 +1868,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -1881,9 +1881,9 @@
         <isMilitary>true</isMilitary>
         <description>Devastated during the Jihad, the Ecole Militaire now relies on wounded troops
             as temporary instructors, reminding cadets of its loss. Renowned for producing elite
-            MekWarriors, armor, and infantry units, the academy admits foreign applicants with a
+            MechWarriors, armor, and infantry units, the academy admits foreign applicants with a
             preference for Taurians. Rigorous basic training precedes specialization in armor,
-            infantry, or MekWarrior tracks, emphasizing leadership and offering Officer Candidate
+            infantry, or MechWarrior tracks, emphasizing leadership and offering Officer Candidate
             School slots upon graduation.</description>
         <locationSystem>Taurus</locationSystem>
         <constructionYear>3130</constructionYear>
@@ -1892,7 +1892,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -1908,7 +1908,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -1933,7 +1933,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -1949,7 +1949,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -1974,7 +1974,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -1991,7 +1991,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -2019,7 +2019,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -2035,7 +2035,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -2063,7 +2063,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -2079,7 +2079,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -2349,7 +2349,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -2365,7 +2365,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -2388,7 +2388,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -2405,7 +2405,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -2430,7 +2430,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -2446,7 +2446,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -2471,7 +2471,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -2488,7 +2488,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -2534,7 +2534,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>3081</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -2550,7 +2550,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3081</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -2574,7 +2574,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -2590,7 +2590,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>2933</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -2614,7 +2614,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -2631,7 +2631,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2935</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -2658,7 +2658,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -2674,7 +2674,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -2704,7 +2704,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel</curriculum>
@@ -2731,7 +2731,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -2748,7 +2748,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -2778,7 +2778,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -2790,7 +2790,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The esteemed Gershwin Academy of Combat, a private institution founded by the
-            Gershwin Mining Collective, specializes in honing the skills of MekWarrior and armored
+            Gershwin Mining Collective, specializes in honing the skills of MechWarrior and armored
             cavalry. Graduates emerge well-equipped for diverse combat scenarios, instilled with
             discipline and strategic prowess. Aspiring warriors flock to GAC for its distinguished
             legacy and commitment to producing elite combat personnel.</description>
@@ -2802,7 +2802,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -2859,7 +2859,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -2883,7 +2883,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -2907,7 +2907,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -2958,7 +2958,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -2971,7 +2971,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Hero Training Institute offers an unconventional route to becoming a
-            MekWarrior, bypassing traditional credentials. Known for its high fees and extensive
+            MechWarrior, bypassing traditional credentials. Known for its high fees and extensive
             advertising, HTI provides subpar training with limited hands-on experience. Nonetheless,
             it allows graduates to enter mercenary units or non-commissioned positions in the Free
             Worlds League Military.</description>
@@ -2983,11 +2983,11 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -3013,7 +3013,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -3038,7 +3038,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -3062,7 +3062,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -3087,7 +3087,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -3113,7 +3113,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -3135,7 +3135,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution
-            for MekWarriors, providing comprehensive classes instructed by experienced lecturers.</description>
+            for MechWarriors, providing comprehensive classes instructed by experienced lecturers.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
@@ -3157,7 +3157,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution
-            for MekWarriors, providing comprehensive classes instructed by experienced lecturers.</description>
+            for MechWarriors, providing comprehensive classes instructed by experienced lecturers.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
@@ -3169,7 +3169,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>-1</baseAcademicSkillLevel>
@@ -3215,11 +3215,11 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
         <curriculum>Piloting/Aerospace, Gunnery/Aerospace</curriculum>
@@ -3303,7 +3303,7 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -3314,7 +3314,7 @@
         <name>Irian Academy of Combative Science</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Irian Academy trains MekWarriors and is highly regarded among schools.
+        <description>The Irian Academy trains MechWarriors and is highly regarded among schools.
             Students undergo instruction in history and combat, including live fire training in the
             Radner Proving Grounds.</description>
         <locationSystem>Irian</locationSystem>
@@ -3325,7 +3325,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>-1</baseAcademicSkillLevel>
@@ -3414,9 +3414,9 @@
         <name>Kensai Kami [Aix-la-Chapelle]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis
+        <description>The Kensai Kami is a graduate school for elite MechWarriors of the Draconis
             Combine Mustered Soldiery, modeled after the Star League's Gunslinger Program. It
-            challenges top DCMS MekWarriors against instructors and peers to reach new heights of
+            challenges top DCMS MechWarriors against instructors and peers to reach new heights of
             excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
@@ -3428,7 +3428,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -3437,9 +3437,9 @@
         <name>Kensai Kami [Luthien]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis
+        <description>The Kensai Kami is a graduate school for elite MechWarriors of the Draconis
             Combine Mustered Soldiery, modeled after the Star League's Gunslinger Program. It
-            challenges top DCMS MekWarriors against instructors and peers to reach new heights of
+            challenges top DCMS MechWarriors against instructors and peers to reach new heights of
             excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
@@ -3451,7 +3451,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -3460,9 +3460,9 @@
         <name>Kensai Kami [McAlister]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis
+        <description>The Kensai Kami is a graduate school for elite MechWarriors of the Draconis
             Combine Mustered Soldiery, modeled after the Star League's Gunslinger Program. It
-            challenges top DCMS MekWarriors against instructors and peers to reach new heights of
+            challenges top DCMS MechWarriors against instructors and peers to reach new heights of
             excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
@@ -3474,7 +3474,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarriorGraduate</qualification>
+        <qualification>MechWarriorGraduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -3497,7 +3497,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -3538,7 +3538,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Command Graduate</qualification>
@@ -3579,7 +3579,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -3596,7 +3596,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2935</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -3608,7 +3608,7 @@
         <curriculum>Tech/Mechanic, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -3680,7 +3680,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution
-            for MekWarriors, providing comprehensive classes instructed by experienced lecturers.
+            for MechWarriors, providing comprehensive classes instructed by experienced lecturers.
             Following the Andurien Secession, the Humphreys Training Academy became the Legionary
             Training Academy under the Free Worlds League.</description>
         <factionDiscount>0</factionDiscount>
@@ -3704,7 +3704,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution
-            for MekWarriors, providing comprehensive classes instructed by experienced lecturers.
+            for MechWarriors, providing comprehensive classes instructed by experienced lecturers.
             Following the Andurien Secession, the Humphreys Training Academy became the Legionary
             Training Academy under the Free Worlds League.</description>
         <factionDiscount>0</factionDiscount>
@@ -3718,7 +3718,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>-1</baseAcademicSkillLevel>
@@ -3742,7 +3742,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -3758,7 +3758,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -3787,7 +3787,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -3804,7 +3804,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -3833,7 +3833,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -3849,7 +3849,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -3878,7 +3878,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -3895,7 +3895,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -3925,7 +3925,7 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>Year One Curriculum</qualification>
-        <curriculum>Small Arms, Medtech</curriculum>
+        <curriculum>Small Arms, MedTech</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <baseAcademicSkillLevel>-1</baseAcademicSkillLevel>
     </academy>
@@ -4013,7 +4013,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -4097,7 +4097,7 @@
         <isMilitary>true</isMilitary>
         <description>The Magistracy Military Academy came into being following the separation of the
             Magistracy Armed Forces from the Star League Defense Force. The MMA's primary emphasis
-            lies in MekWarrior training, serving both fresh recruits and existing MAF personnel.
+            lies in MechWarrior training, serving both fresh recruits and existing MAF personnel.
             While it doesn't function as a combined arms academy, the MMA occasionally hosts
             seminars covering other branches of service, thereby offering a more comprehensive
             military education.</description>
@@ -4111,7 +4111,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, XP</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -4134,7 +4134,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -4169,7 +4169,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -4204,7 +4204,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Small Arms, Administration</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>-1</baseAcademicSkillLevel>
@@ -4226,7 +4226,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Small Arms, Strategy, Administration,
             Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
@@ -4283,7 +4283,7 @@
         <name>Meistmorn Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Meistmorn Academy is a renowned military academy known for training MekWarriors
+        <description>Meistmorn Academy is a renowned military academy known for training MechWarriors
             for the Armed Forces of the Federated Suns.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
@@ -4295,7 +4295,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -4319,7 +4319,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>3067</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -4335,7 +4335,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3067</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -4360,7 +4360,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -4395,7 +4395,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Command Graduate</qualification>
@@ -4563,7 +4563,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -4579,7 +4579,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -4612,7 +4612,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -4629,7 +4629,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -4663,7 +4663,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>3060</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
@@ -4690,7 +4690,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -4707,7 +4707,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -4734,7 +4734,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -4749,7 +4749,7 @@
             the Armed Forces of the Federated Suns after the Albion Military Academy became
             exclusive to the Star League Defense Force. NAMA swiftly rivaled AMA in training
             quality, emphasizing political loyalty to the First Prince. Despite challenges, NAIS
-            persists in producing top MekWarriors and officers, with graduates often joining
+            persists in producing top MechWarriors and officers, with graduates often joining
             mercenary units or returning to their home nations.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
@@ -4761,7 +4761,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -4778,7 +4778,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -4805,7 +4805,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -4830,7 +4830,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -4926,7 +4926,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -4942,7 +4942,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -4972,7 +4972,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel</curriculum>
@@ -4998,7 +4998,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -5015,7 +5015,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -5045,7 +5045,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -5057,7 +5057,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>The New Hope Military Academy specializes in training conventional forces while
-            also providing MekWarrior and aerospace pilot programs. The curriculum, developed by
+            also providing MechWarrior and aerospace pilot programs. The curriculum, developed by
             senior commanders of the First Taurian Pride, includes practical 'Mek instruction, even
             in the absence of simulators, and places a strong emphasis on tactical classroom
             instruction.</description>
@@ -5071,7 +5071,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Administration, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -5087,7 +5087,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Administration</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Administration</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Administration</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Administration, Artillery</curriculum>
@@ -5177,7 +5177,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -5193,7 +5193,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -5211,7 +5211,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -5234,7 +5234,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -5251,7 +5251,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -5269,7 +5269,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -5304,7 +5304,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -5357,7 +5357,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -5381,7 +5381,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -5397,7 +5397,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3061</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -5442,7 +5442,7 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>200-Grade Infantry Graduate</qualification>
-        <curriculum>Small Arms, Medtech</curriculum>
+        <curriculum>Small Arms, MedTech</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <baseAcademicSkillLevel>-1</baseAcademicSkillLevel>
     </academy>
@@ -5462,7 +5462,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>300-Grade MekWarrior Graduate</qualification>
+        <qualification>300-Grade MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>300-Grade Armored Graduate</qualification>
@@ -5478,7 +5478,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>300-Grade Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>300-Grade Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -5508,7 +5508,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>300-Grade Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>300-Grade Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel</curriculum>
@@ -5534,7 +5534,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>400-Grade MekWarrior Graduate</qualification>
+        <qualification>400-Grade MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>400-Grade Armored Graduate</qualification>
@@ -5551,7 +5551,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>400-Grade Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>400-Grade Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -5581,7 +5581,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>400-Grade Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>400-Grade Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -5596,7 +5596,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <description>Pacifica Training School stands as one of the Lyran Commonwealth’s foremost
-            MekWarrior training centers. Cadets engage in a series of solo cockpit missions, with
+            MechWarrior training centers. Cadets engage in a series of solo cockpit missions, with
             each mission increasing in difficulty. They pilot full-size, fully operational
             BattleMeks within a specially designed arena, which replicates genuine battlefield
             conditions.</description>
@@ -5610,8 +5610,8 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
-        <curriculum>Piloting/Mek, Gunnery/Mek, Small Arms, Astech, Medtech</curriculum>
+        <qualification>MechWarrior Graduate</qualification>
+        <curriculum>Piloting/Mek, Gunnery/Mek, Small Arms, Astech, MedTech</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -5658,7 +5658,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, XP, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -5674,7 +5674,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, XP</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, XP</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, XP</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, XP, Artillery</curriculum>
@@ -5746,7 +5746,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -5783,7 +5783,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -5822,7 +5822,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -5834,7 +5834,7 @@
         <curriculum>Tech/Mechanic, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -5856,7 +5856,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Strategy, Tactics, Small Arms, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -5873,7 +5873,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Strategy, Tactics, Small Arms</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Strategy, Tactics, Small Arms</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Strategy, Tactics, Small Arms</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Strategy, Tactics, Small Arms, Artillery</curriculum>
@@ -5901,7 +5901,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Small Arms,
             Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
@@ -5921,7 +5921,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership, Small Arms</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership, Small Arms</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership, Small Arms</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -5951,7 +5951,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -5997,7 +5997,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Command Graduate</qualification>
@@ -6075,7 +6075,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -6091,7 +6091,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -6122,7 +6122,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -6139,7 +6139,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -6167,7 +6167,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -6183,7 +6183,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6204,7 +6204,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -6220,7 +6220,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -6238,7 +6238,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6259,7 +6259,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -6276,7 +6276,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -6294,7 +6294,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6316,7 +6316,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -6333,7 +6333,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -6351,7 +6351,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6373,7 +6373,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -6390,7 +6390,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -6408,7 +6408,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6431,7 +6431,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -6448,7 +6448,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -6466,7 +6466,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6488,7 +6488,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -6505,7 +6505,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -6523,7 +6523,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6545,7 +6545,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -6561,7 +6561,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -6579,7 +6579,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6601,7 +6601,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -6617,7 +6617,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -6635,7 +6635,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6658,7 +6658,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -6674,7 +6674,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -6692,7 +6692,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6714,7 +6714,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -6730,7 +6730,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -6748,7 +6748,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -6768,7 +6768,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Astech, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -6784,7 +6784,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Astech</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Astech</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Astech</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Astech, Artillery</curriculum>
@@ -6807,7 +6807,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Astech, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -6825,7 +6825,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership, Astech</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership, Astech</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership, Astech</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Astech, Artillery</curriculum>
@@ -6850,7 +6850,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -6867,7 +6867,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2935</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -6893,7 +6893,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -6910,7 +6910,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -6934,7 +6934,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Strategy</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -6959,7 +6959,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Command Graduate</qualification>
@@ -6985,7 +6985,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -7001,7 +7001,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -7028,7 +7028,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel</curriculum>
@@ -7053,7 +7053,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -7070,7 +7070,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -7097,7 +7097,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -7122,7 +7122,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -7138,7 +7138,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -7165,7 +7165,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -7181,7 +7181,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -7211,7 +7211,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -7227,7 +7227,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -7253,7 +7253,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -7269,7 +7269,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -7293,7 +7293,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -7309,7 +7309,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -7335,7 +7335,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Negotiation</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -7359,7 +7359,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Negotiation</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
@@ -7406,7 +7406,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -7422,7 +7422,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -7443,7 +7443,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Junior Administrator</qualification>
         <curriculum>Administration, Negotiation</curriculum>
@@ -7467,7 +7467,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>High Path - MekWarrior</qualification>
+        <qualification>High Path - MechWarrior</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>High Path - Cavalry</qualification>
@@ -7484,7 +7484,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>High Path - Armored Infantry</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>High Path - Infantry</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -7505,7 +7505,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>High Path - Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>High Path - Administrator</qualification>
         <curriculum>Negotiation, Leadership</curriculum>
@@ -7530,7 +7530,7 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -7558,7 +7558,7 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>SLDF Advanced Tactics Operative</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Small Arms, Tech/BA, Tactics, Strategy,
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Small Arms, Tech/BattleArmor, Tactics, Strategy,
             Leadership</curriculum>
         <qualificationStartYear>2718</qualificationStartYear>
         <qualification>SLDF Special Forces Graduate</qualification>
@@ -7584,7 +7584,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -7601,7 +7601,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -7634,7 +7634,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -7651,7 +7651,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -7696,7 +7696,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -7720,7 +7720,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Strategy</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -7736,7 +7736,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Strategy</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Strategy</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Strategy</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Strategy</curriculum>
@@ -7763,7 +7763,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -7779,7 +7779,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -7790,11 +7790,11 @@
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Sun Zhang MekWarrior Academy</name>
+        <name>Sun Zhang MechWarrior Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sun Zhang MekWarrior Academy emphasizes bushido, and its graduates receive
-            a daishō as a symbol of their honor. The Academy trains over four hundred MekWarriors
+        <description>The Sun Zhang MechWarrior Academy emphasizes bushido, and its graduates receive
+            a daishō as a symbol of their honor. The Academy trains over four hundred MechWarriors
             annually, using abandoned cities for urban combat training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
@@ -7806,7 +7806,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -7815,11 +7815,11 @@
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Sun Zhang MekWarrior Academy (Officer)</name>
+        <name>Sun Zhang MechWarrior Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sun Zhang MekWarrior Academy emphasizes bushido, and its graduates receive
-            a daishō as a symbol of their honor. The Academy trains over four hundred MekWarriors
+        <description>The Sun Zhang MechWarrior Academy emphasizes bushido, and its graduates receive
+            a daishō as a symbol of their honor. The Academy trains over four hundred MechWarriors
             annually, using abandoned cities for urban combat training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
@@ -7831,7 +7831,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Command Graduate</qualification>
@@ -7858,7 +7858,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -7874,7 +7874,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -7958,7 +7958,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -7975,7 +7975,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -8005,7 +8005,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -8033,7 +8033,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -8050,7 +8050,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -8080,7 +8080,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -8104,7 +8104,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -8118,7 +8118,7 @@
         <isMilitary>true</isMilitary>
         <description>The Warrior's Hall started as an officers' club and evolved into a
             comprehensive military academy by 2765. Though it lacks the most advanced technology,
-            the academy produces some of the finest MekWarriors in the AFFS. It is known for its
+            the academy produces some of the finest MechWarriors in the AFFS. It is known for its
             emphasis on military skills, often at the expense of academic subjects.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
@@ -8130,7 +8130,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -8146,7 +8146,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -8164,7 +8164,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -8174,7 +8174,7 @@
         <isMilitary>true</isMilitary>
         <description>The Warrior's Hall started as an officers' club and evolved into a
             comprehensive military academy by 2765. Though it lacks the most advanced technology,
-            the academy produces some of the finest MekWarriors in the AFFS. It is known for its
+            the academy produces some of the finest MechWarriors in the AFFS. It is known for its
             emphasis on military skills, often at the expense of academic subjects.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
@@ -8186,7 +8186,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -8203,7 +8203,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -8221,7 +8221,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -8242,7 +8242,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -8258,7 +8258,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -8282,7 +8282,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -8299,7 +8299,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -8324,7 +8324,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -8340,7 +8340,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
@@ -8365,7 +8365,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -8382,7 +8382,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -8405,7 +8405,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>-1</baseAcademicSkillLevel>
@@ -8428,7 +8428,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -8472,7 +8472,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Command Graduate</qualification>
@@ -8687,11 +8687,11 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek</curriculum>
@@ -8709,7 +8709,7 @@
         <curriculum>Tech/Aero</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -8838,7 +8838,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Astech</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
@@ -8884,7 +8884,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -8901,7 +8901,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2935</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -8931,7 +8931,7 @@
         <curriculum>Tech/Aero, Leadership</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Senior Armored Infantry Technician</qualification>
-        <curriculum>Tech/BA, Leadership</curriculum>
+        <curriculum>Tech/BattleArmor, Leadership</curriculum>
         <qualificationStartYear>2935</qualificationStartYear>
         <qualification>Senior Advanced Vessel Technician</qualification>
         <curriculum>Tech/Vessel, Leadership</curriculum>
@@ -8942,9 +8942,9 @@
         <name>War College of Buena</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Buena initially focused on technician courses and MekWarrior
+        <description>The War College of Buena initially focused on technician courses and MechWarrior
             training. Over time, it expanded significantly, producing highly competent technicians,
-            MekWarriors, and aerospace pilots. Training emphasizes practical experience, with cadets
+            MechWarriors, and aerospace pilots. Training emphasizes practical experience, with cadets
             spending six months in the Buena Training Battalion engaged in live-fire exercises and
             anti-pirate missions.</description>
         <factionDiscount>0</factionDiscount>
@@ -8957,7 +8957,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Astech</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
@@ -8996,11 +8996,11 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
         <curriculum>Piloting/Aerospace, Gunnery/Aerospace, Leadership</curriculum>
@@ -9027,11 +9027,11 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Aerospace Graduate</qualification>
         <curriculum>Piloting/Aerospace, Gunnery/Aerospace, Leadership</curriculum>
@@ -9039,11 +9039,11 @@
         <baseAcademicSkillLevel>1</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Warner MekWarrior Academy</name>
+        <name>Warner MechWarrior Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Warner MekWarrior Academy on Solaris VII is a small and informal training
-            school for aspiring MekWarriors, founded by the second-rate arena fighter and con man
+        <description>The Warner MechWarrior Academy on Solaris VII is a small and informal training
+            school for aspiring MechWarriors, founded by the second-rate arena fighter and con man
             Clease Vanderholf. Training is conducted using four poorly maintained Chameleons.</description>
         <locationSystem>Solaris</locationSystem>
         <constructionYear>3000</constructionYear>
@@ -9054,7 +9054,7 @@
         <educationLevelMin>High School</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <baseAcademicSkillLevel>-2</baseAcademicSkillLevel>
@@ -9077,11 +9077,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9107,11 +9107,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry WarriorGraduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9135,11 +9135,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9165,11 +9165,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9194,11 +9194,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9222,11 +9222,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9251,11 +9251,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9281,11 +9281,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9311,11 +9311,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9341,11 +9341,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9369,11 +9369,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9399,11 +9399,11 @@
         <facultySkill>11</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Graduate</qualification>
+        <qualification>MechWarrior Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Armored Infantry Warrior Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Warrior Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -9428,7 +9428,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -9445,7 +9445,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2935</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership, Artillery</curriculum>
@@ -9469,7 +9469,7 @@
         <educationLevelMin>College</educationLevelMin>
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
-        <qualification>MekWarrior Command Graduate</qualification>
+        <qualification>MechWarrior Command Graduate</qualification>
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
@@ -9485,7 +9485,7 @@
         <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Command Graduate</qualification>
-        <curriculum>Gunnery/Battlesuit, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>3052</qualificationStartYear>
         <qualification>Advanced Infantry Command Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>

--- a/MekHQ/data/universe/academies/Unit Education.xml
+++ b/MekHQ/data/universe/academies/Unit Education.xml
@@ -49,7 +49,7 @@
         <facultySkill>9</facultySkill>
         <ageMin>10</ageMin>
         <ageMax>16</ageMax>
-        <qualification>MekWarrior Apprenticeship</qualification>
+        <qualification>MechWarrior Apprenticeship</qualification>
         <curriculum>Gunnery/Mek, Piloting/Mek</curriculum>
         <qualificationStartYear>2439</qualificationStartYear>
         <qualification>Mechanized Apprenticeship</qualification>
@@ -74,7 +74,7 @@
         <curriculum>Astech, Tech/Aero</curriculum>
         <qualificationStartYear>2314</qualificationStartYear>
         <qualification>Battle Armor Technician Apprenticeship</qualification>
-        <curriculum>Astech, Tech/BA</curriculum>
+        <curriculum>Astech, Tech/BattleArmor</curriculum>
         <qualificationStartYear>3050</qualificationStartYear>
         <qualification>Black Naval Tech Apprenticeship</qualification>
         <curriculum>Astech, Tech/Vessel</curriculum>
@@ -83,7 +83,7 @@
         <curriculum>Administration, Scrounge</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Medical Apprenticeship</qualification>
-        <curriculum>Medtech, Doctor</curriculum>
+        <curriculum>MedTech, Doctor</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <baseAcademicSkillLevel>1</baseAcademicSkillLevel>
     </academy>
@@ -127,7 +127,7 @@
         <durationDays>150</durationDays>
         <facultySkill>9</facultySkill>
         <ageMin>16</ageMin>
-        <qualification>Basic MekWarrior Training</qualification>
+        <qualification>Basic MechWarrior Training</qualification>
         <curriculum>Gunnery/Mek, Piloting/Mek</curriculum>
         <qualificationStartYear>2439</qualificationStartYear>
         <qualification>Basic Aerospace Training</qualification>
@@ -137,7 +137,7 @@
         <curriculum>Gunnery/Spacecraft, Piloting/Spacecraft</curriculum>
         <qualificationStartYear>2470</qualificationStartYear>
         <qualification>Basic Battle Armor Training</qualification>
-        <curriculum>Gunnery/Battlesuit</curriculum>
+        <curriculum>Gunnery/BattleArmor</curriculum>
         <qualificationStartYear>3050</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>


### PR DESCRIPTION
Standardized spelling of "MechWarrior" and "BattleArmor" across multiple academy entries. This reverted work done by the name consistency project as these names are covered by the 'fluff exception'