### PR TITLE
Fix typos in identifiers for MEKWARRIOR and AtBUnitRatingMod

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -1527,7 +1527,7 @@ public class ResolveScenarioTracker {
                 // Then, we need to determine if they are a defector
                 if (prisonerStatus.isCurrentPrisoner()
                         && getCampaign().getCampaignOptions().isUseAtBPrisonerDefection()) {
-                    int campaignUnitRating = getCampaign().getUnitRatingMod();
+                    int campaignUnitRating = getCampaign().getAtBUnitRatingMod();
 
                     // if this isn't an AtB Contract, we use the individual's experience level,
                     // instead of enemy skill

--- a/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialogTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialogTest.java
@@ -14,9 +14,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-
 import static mekhq.gui.dialog.nagDialogs.UntreatedPersonnelNagDialog.isUntreatedInjury;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UntreatedPersonnelNagDialogTest {
     Campaign campaign;
@@ -37,7 +37,7 @@ class UntreatedPersonnelNagDialogTest {
     @BeforeEach
     public void init() {
         campaign = new Campaign();
-        person = campaign.newPerson(PersonnelRole.MECHWARRIOR);
+        person = campaign.newPerson(PersonnelRole.MEKWARRIOR);
         person.setHits(1);
     }
 


### PR DESCRIPTION
Corrected the role name from MECHWARRIOR to MEKWARRIOR in unit tests. Fixed the method name from getUnitRatingMod to getAtBUnitRatingMod in campaign tracker.