### PR TITLE
Regenerate Personality Descriptions for NPCs

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -56,6 +56,8 @@ import java.awt.event.*;
 import java.util.List;
 import java.util.*;
 
+import static mekhq.campaign.personnel.randomEvents.PersonalityController.writeDescription;
+
 /**
  * @author Taharqa
  */
@@ -513,6 +515,14 @@ public class ResolveScenarioWizardDialog extends JDialog {
                 }
                 prisonerCapturedCheck.setSelected(wasCaptured);
             }
+
+            // When generating NPC personnel, we use placeholder characters and then later re-assign
+            // their details to match expected values.
+            // This causes a disconnect between their name, at point of creation, and the name
+            // presented to the user.
+            // We therefore need to re-generate the personality description at this point,
+            // as this is the earliest point in which that description is visible to the user
+            writeDescription(status.getPerson());
         }
         pnlMain.add(pnlPrisonerStatus, PRISONERPANEL);
         //endregion Prisoner Status Panel


### PR DESCRIPTION
Fixed an issue where NPC personnel had placeholder names at point of creation leading to a disconnect between the name used in descriptions.

The placeholder name is a necessary byproduct of how we generate OpFors, however now we regenerate their description at the point in which is becomes visible to the user, preventing the prior issue.

### Closes #4736