### PR TITLE
Removed TN Modifier for IS Techs working on Clan Tech, Removed Clan Tech Knowledge SPA and Effects

### DIFF
--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -460,21 +460,6 @@
 
     <!-- Tech SPA -->
     <ability>
-        <lookupName>clan_tech_knowledge</lookupName>
-        <displayName>Clan Tech Knowledge (Unofficial)</displayName>
-        <desc>Can work on clan equipment without penalty</desc>
-        <xpCost>4</xpCost>
-        <weight>2</weight>
-        <skillPrereq>
-            <skill>Tech/Mek</skill>
-            <skill>Tech/Mechanic</skill>
-            <skill>Tech/Aero</skill>
-            <skill>Tech/BA</skill>
-            <skill>Tech/Vessel</skill>
-        </skillPrereq>
-        <miscPrereq>clanperson:false</miscPrereq>
-    </ability>
-    <ability>
         <lookupName>tech_weapon_specialist</lookupName>
         <displayName>Tech Specialist, Weapon (Unofficial)</displayName>
         <desc>-1 to repair and maintenance checks when working with weapons</desc>

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -21,29 +21,8 @@
  */
 package mekhq.campaign.parts;
 
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.ResourceBundle;
-import java.util.StringJoiner;
-import java.util.UUID;
-
-import org.apache.commons.lang3.StringUtils;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.Version;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechnology;
-import megamek.common.SimpleTechLevel;
-import megamek.common.Tank;
-import megamek.common.TargetRoll;
-import megamek.common.TechAdvancement;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
 import megamek.logging.MMLogger;
@@ -62,6 +41,13 @@ import mekhq.campaign.work.IPartWork;
 import mekhq.campaign.work.WorkTime;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.utilities.ReportingUtilities;
+import org.apache.commons.lang3.StringUtils;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.*;
 
 /**
  * Parts do the lions share of the work of repairing, salvaging, reloading,
@@ -283,10 +269,12 @@ public abstract class Part implements IPartWork, ITechnology {
      *
      * @return the part's actual value
      */
+    @Override
     public Money getActualValue() {
         return adjustCostsForCampaignOptions(getStickerPrice());
     }
 
+    @Override
     public boolean isPriceAdjustedForAmount() {
         return false;
     }
@@ -893,13 +881,6 @@ public abstract class Part implements IPartWork, ITechnology {
         }
 
         if (tech != null) {
-            if ((isClanTechBase()
-                    || ((this instanceof MekLocation) && (getUnit() != null) && getUnit().getEntity().isClan()))
-                    && (!tech.isClanPersonnel()
-                            && !tech.getOptions().booleanOption(PersonnelOptions.TECH_CLAN_TECH_KNOWLEDGE))) {
-                mods.addModifier(2, "Clan tech");
-            }
-
             if (tech.getOptions().booleanOption(PersonnelOptions.TECH_WEAPON_SPECIALIST)
                     && ((IPartWork.findCorrectRepairType(this) == PartRepairType.WEAPON)
                             || (IPartWork.findCorrectMRMSType(this) == PartRepairType.PHYSICAL_WEAPON))) {
@@ -949,13 +930,6 @@ public abstract class Part implements IPartWork, ITechnology {
         }
 
         if (getUnit().getTech() != null) {
-            if ((isClanTechBase() || ((this instanceof MekLocation) && getUnit().getEntity().isClan()))
-                    && (!getUnit().getTech().isClanPersonnel()
-                            && !getUnit().getTech().getOptions()
-                                    .booleanOption(PersonnelOptions.TECH_CLAN_TECH_KNOWLEDGE))) {
-                mods.addModifier(2, "Clan tech");
-            }
-
             if (getUnit().getTech().getOptions().booleanOption(PersonnelOptions.TECH_WEAPON_SPECIALIST)
                     && ((IPartWork.findCorrectRepairType(this) == PartRepairType.WEAPON)
                             || (IPartWork.findCorrectMRMSType(this) == PartRepairType.PHYSICAL_WEAPON))) {

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -13,20 +13,14 @@
  */
 package mekhq.campaign.personnel;
 
+import megamek.common.annotations.Nullable;
+import megamek.common.options.*;
+import megamek.logging.MMLogger;
+
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
-
-import megamek.common.annotations.Nullable;
-import megamek.common.options.AbstractOptionsInfo;
-import megamek.common.options.IBasicOptionGroup;
-import megamek.common.options.IOption;
-import megamek.common.options.IOptionGroup;
-import megamek.common.options.IOptionInfo;
-import megamek.common.options.OptionsConstants;
-import megamek.common.options.PilotOptions;
-import megamek.logging.MMLogger;
 
 /**
  * An extension of PilotOptions that adds MekHQ-specific SPAs and edge triggers
@@ -45,7 +39,6 @@ public class PersonnelOptions extends PilotOptions {
     public static final String EDGE_REPAIR_FAILED_REFIT = "edge_when_fail_refit_check";
     public static final String EDGE_ADMIN_ACQUIRE_FAIL = "edge_when_admin_acquire_fail";
 
-    public static final String TECH_CLAN_TECH_KNOWLEDGE = "clan_tech_knowledge";
     public static final String TECH_WEAPON_SPECIALIST = "tech_weapon_specialist";
     public static final String TECH_ARMOR_SPECIALIST = "tech_armor_specialist";
     public static final String TECH_INTERNAL_SPECIALIST = "tech_internal_specialist";
@@ -89,7 +82,6 @@ public class PersonnelOptions extends PilotOptions {
         }
 
         // Add MekHQ-specific options
-        addOption(l3a, TECH_CLAN_TECH_KNOWLEDGE, false);
         addOption(l3a, TECH_WEAPON_SPECIALIST, false);
         addOption(l3a, TECH_ARMOR_SPECIALIST, false);
         addOption(l3a, TECH_INTERNAL_SPECIALIST, false);


### PR DESCRIPTION
Removed all instances of the 'Clan Tech Knowledge' SPA from `PersonnelOptions`, `Part`, and `defaultspa.xml`.

Recently, errata removed the +2 modifier to TNs when IS teams work on Clan-based equipment. This rendered the above SPA no longer relevant.

### Closes #4782