### PR TITLE
Added the Tracking of Hits Obtained Prior to the Completion of a Scenario

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -21,29 +21,6 @@
  */
 package mekhq;
 
-import java.awt.FileDialog;
-import java.awt.Frame;
-import java.awt.Window;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.ObjectInputFilter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Stream;
-
-import javax.swing.InputMap;
-import javax.swing.JOptionPane;
-import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
-import javax.swing.text.DefaultEditorKit;
-
 import io.sentry.Sentry;
 import megamek.MMLoggingConstants;
 import megamek.MegaMek;
@@ -84,6 +61,22 @@ import mekhq.gui.preferences.StringPreference;
 import mekhq.gui.utilities.ObservableString;
 import mekhq.service.AutosaveService;
 import mekhq.service.IAutosaveService;
+
+import javax.swing.*;
+import javax.swing.text.DefaultEditorKit;
+import java.awt.*;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.ObjectInputFilter;
+import java.io.ObjectInputFilter.Config;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
  * The main class of the application.
@@ -273,7 +266,7 @@ public class MekHQ implements GameListener {
      * Main method launching the application.
      */
     public static void main(String... args) {
-        ObjectInputFilter.Config.setSerialFilter(sanityInputFilter);
+        Config.setSerialFilter(sanityInputFilter);
 
         // Configure Sentry with defaults. Although the client defaults to enabled, the
         // properties file is used to disable
@@ -539,8 +532,8 @@ public class MekHQ implements GameListener {
                     int injuryCount = 0;
 
                     if (!person.getStatus().isDead() || getCampaign().getCampaignOptions().isIssuePosthumousAwards()) {
-                        if (status.getHits() > person.getHits()) {
-                            injuryCount = status.getHits() - person.getHits();
+                        if (status.getHits() > person.getHitsPrior()) {
+                            injuryCount = status.getHits() - person.getHitsPrior();
                         }
                     }
 

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -1470,6 +1470,7 @@ public class ResolveScenarioTracker {
                             campaign.getCampaignOptions().getFatigueRate() * (status.getHits() - person.getHits()));
                 }
 
+                person.setHitsPrior(person.getHits());
                 person.setHits(status.getHits());
             }
 

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -19,20 +19,6 @@
  */
 package mekhq.campaign.personnel;
 
-import static java.lang.Math.abs;
-
-import java.io.PrintWriter;
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.Version;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.codeUtilities.StringUtility;
@@ -62,24 +48,11 @@ import mekhq.campaign.log.ServiceLogger;
 import mekhq.campaign.mod.am.InjuryUtil;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.education.Academy;
-import mekhq.campaign.personnel.enums.ManeiDominiClass;
-import mekhq.campaign.personnel.enums.ManeiDominiRank;
-import mekhq.campaign.personnel.enums.ModifierValue;
-import mekhq.campaign.personnel.enums.PersonnelRole;
-import mekhq.campaign.personnel.enums.PersonnelStatus;
-import mekhq.campaign.personnel.enums.Phenotype;
-import mekhq.campaign.personnel.enums.PrisonerStatus;
-import mekhq.campaign.personnel.enums.Profession;
-import mekhq.campaign.personnel.enums.ROMDesignation;
+import mekhq.campaign.personnel.enums.*;
 import mekhq.campaign.personnel.enums.education.EducationLevel;
 import mekhq.campaign.personnel.enums.education.EducationStage;
 import mekhq.campaign.personnel.familyTree.Genealogy;
-import mekhq.campaign.personnel.randomEvents.enums.personalities.Aggression;
-import mekhq.campaign.personnel.randomEvents.enums.personalities.Ambition;
-import mekhq.campaign.personnel.randomEvents.enums.personalities.Greed;
-import mekhq.campaign.personnel.randomEvents.enums.personalities.Intelligence;
-import mekhq.campaign.personnel.randomEvents.enums.personalities.PersonalityQuirk;
-import mekhq.campaign.personnel.randomEvents.enums.personalities.Social;
+import mekhq.campaign.personnel.randomEvents.enums.personalities.*;
 import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.personnel.ranks.RankValidator;
@@ -92,6 +65,19 @@ import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.campaign.work.IPartWork;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.utilities.ReportingUtilities;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.lang.Math.abs;
 
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
@@ -162,6 +148,7 @@ public class Person {
     private Money salary;
     private Money totalEarnings;
     private int hits;
+    private int hitsPrior;
     private PrisonerStatus prisonerStatus;
 
     // Supports edge usage by a ship's engineer composite crewman
@@ -368,6 +355,7 @@ public class Person {
         status = PersonnelStatus.ACTIVE;
         prisonerStatus = PrisonerStatus.FREE;
         hits = 0;
+        hitsPrior = 0;
         toughness = 0;
         resetMinutesLeft(); // this assigns minutesLeft and overtimeLeft
         dateOfDeath = null;
@@ -2031,6 +2019,10 @@ public class Person {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "hits", hits);
             }
 
+            if (hitsPrior > 0) {
+                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "hitsPrior", hitsPrior);
+            }
+
             if (toughness != 0) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "toughness", toughness);
             }
@@ -2331,6 +2323,8 @@ public class Person {
                     retVal.nTasks = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("hits")) {
                     retVal.hits = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("hitsPrior")) {
+                    retVal.hitsPrior = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("gender")) {
                     retVal.setGender(Gender.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("rankSystem")) {
@@ -3396,6 +3390,22 @@ public class Person {
 
     public void setHits(final int hits) {
         this.hits = hits;
+    }
+
+    /**
+     * @return the number of hits sustained prior to the last completed scenario.
+     */
+    public int getHitsPrior() {
+        return hitsPrior;
+    }
+
+    /**
+     * Sets the number of hits sustained prior to the last completed scenario.
+     *
+     * @param hitsPrior the new value for {@code hitsPrior}
+     */
+    public void setHitsPrior(final int hitsPrior) {
+        this.hitsPrior = hitsPrior;
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -18,28 +18,6 @@
  */
 package mekhq.gui;
 
-import static megamek.client.ratgenerator.ForceDescriptor.RATING_5;
-
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.ResourceBundle;
-import java.util.UUID;
-import java.util.Vector;
-import java.util.stream.Collectors;
-
-import javax.swing.*;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-
 import megamek.client.generator.ReconfigurationParameters;
 import megamek.client.generator.TeamLoadOutGenerator;
 import megamek.client.ui.baseComponents.MMComboBox;
@@ -61,13 +39,7 @@ import mekhq.campaign.event.*;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.force.Lance;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.Mission;
-import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
 import mekhq.campaign.mission.enums.MissionStatus;
 import mekhq.campaign.personnel.Person;
@@ -87,6 +59,17 @@ import mekhq.gui.view.AtBScenarioViewPanel;
 import mekhq.gui.view.LanceAssignmentView;
 import mekhq.gui.view.MissionViewPanel;
 import mekhq.gui.view.ScenarioViewPanel;
+
+import javax.swing.*;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+import java.awt.*;
+import java.io.File;
+import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static megamek.client.ratgenerator.ForceDescriptor.RATING_5;
 
 /**
  * Displays Mission/Contract and Scenario details.
@@ -762,8 +745,8 @@ public final class BriefingTab extends CampaignGuiTab {
                 int injuryCount = 0;
 
                 if (!person.getStatus().isDead() || getCampaign().getCampaignOptions().isIssuePosthumousAwards()) {
-                    if (status.getHits() > person.getHits()) {
-                        injuryCount = status.getHits() - person.getHits();
+                    if (status.getHits() > person.getHitsPrior()) {
+                        injuryCount = status.getHits() - person.getHitsPrior();
                     }
                 }
 
@@ -955,7 +938,7 @@ public final class BriefingTab extends CampaignGuiTab {
      * Designed to fully kit out all non-player-controlled forces prior to battle.
      * Does not do any checks for supplies, only for availability to each faction
      * during the current timeframe.
-     * 
+     *
      * @param scenario
      * @param chosen
      */


### PR DESCRIPTION
Added a new field `hitsPrior` in the `Person` class to capture hits sustained before the last completed scenario. Modified relevant methods and XML serialization/deserialization to handle this new field, ensuring accurate injury tracking. This resolves an issue present in autoAwards where new hits would not be properly tracked whenever Advanced Medical is disabled.

### Closes #4785