### PR TITLE
Enhanced Academy Application Failure Report

### DIFF
--- a/MekHQ/resources/mekhq/resources/Education.properties
+++ b/MekHQ/resources/mekhq/resources/Education.properties
@@ -13,7 +13,7 @@ facultySkill.text=Faculty Skill:
 
 #### Application
 secondApplication.text=%s has previously failed the entry exam for the %s and so their application was automatically %s<b>rejected</b>%s.
-applicationFailure.text=%s has %s<b>failed</b>%s the entry exam for the %s.
+applicationFailure.text=%s has %s<b>failed</b>%s the entry exam for the %s (%s vs. TN %s).
 
 #### Payment
 insufficientFunds.text=Not enough funds to cover %s's tuition.

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -108,10 +108,12 @@ public class EducationController {
             // re-application
             person.addEduFailedApplications(academy);
             campaign.addReport(String.format(resources.getString("applicationFailure.text"),
-                    person.getHyperlinkedFullTitle(),
-                    ReportingUtilities.spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
-                    ReportingUtilities.CLOSING_SPAN_TAG,
-                    academyNameInSet));
+                person.getHyperlinkedFullTitle(),
+                ReportingUtilities.spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
+                ReportingUtilities.CLOSING_SPAN_TAG,
+                academyNameInSet,
+                roll,
+                targetNumber));
 
             ServiceLogger.eduFailedApplication(person, campaign.getLocalDate(), academyNameInSet);
 


### PR DESCRIPTION
Updated the application failure report to include the roll and target number, providing more context for failed educational applications. Modified the Education.properties file to reflect these changes in the failure message format.

###Closes #4874