### PR TITLE
Change Logger Level from Error to Warn for SPA Loader

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2602,7 +2602,7 @@ public class Person {
                     try {
                         retVal.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        logger.error("Error restoring advantage: {}", adv);
+                        logger.warn("Error restoring advantage: {}", adv);
                     }
                 }
             }


### PR DESCRIPTION
Adjusted the logging level from error to warn when restoring an SPA fails. This avoids an error dialog appearing whenever a character with a no-longer existing SPA is loaded. Instead, it will report to the log and advance to the next SPA.

### Closes #4890