### PR TITLE
Fixed Random-Camouflage Path Handling for Alternate Directory Format

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -215,10 +215,6 @@ public class AtBContract extends Contract {
         // Define the root directory and get the faction-specific camouflage directory
         final String ROOT_DIRECTORY = "data/images/camo/";
 
-        // Some operating systems use `\`, so when we sanitize the file path later,
-        // we need to be able to account for that.
-        final String ROOT_DIRECTORY_ALTERNATE = "data\\\\images\\\\camo\\\\";
-
         String camouflageDirectory = getCamouflageDirectory(currentYear, factionCode);
 
         // Use Java File to represent directories
@@ -247,8 +243,8 @@ public class AtBContract extends Contract {
             File randomFile = allFiles.get(new Random().nextInt(allFiles.size()));
 
             String fileName = randomFile.getName();
-            String fileCategory = randomFile.getParent().replaceAll(ROOT_DIRECTORY, "");
-            fileCategory = fileCategory.replaceAll(ROOT_DIRECTORY_ALTERNATE, "");
+            String fileCategory = randomFile.getParent().replaceAll("\\\\", "");
+            fileCategory = fileCategory.replaceAll(ROOT_DIRECTORY, "");
 
             return new Camouflage(fileCategory, fileName);
         } else {

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -243,7 +243,7 @@ public class AtBContract extends Contract {
             File randomFile = allFiles.get(new Random().nextInt(allFiles.size()));
 
             String fileName = randomFile.getName();
-            String fileCategory = randomFile.getParent().replaceAll("\\\\", "");
+            String fileCategory = randomFile.getParent().replaceAll("\\\\", "/");
             fileCategory = fileCategory.replaceAll(ROOT_DIRECTORY, "");
 
             return new Camouflage(fileCategory, fileName);

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -214,6 +214,11 @@ public class AtBContract extends Contract {
     public static Camouflage pickRandomCamouflage(int currentYear, String factionCode) {
         // Define the root directory and get the faction-specific camouflage directory
         final String ROOT_DIRECTORY = "data/images/camo/";
+
+        // Some operating systems use `\`, so when we sanitize the file path later,
+        // we need to be able to account for that.
+        final String ROOT_DIRECTORY_ALTERNATE = "data\\\\mages\\\\camo\\\\";
+
         String camouflageDirectory = getCamouflageDirectory(currentYear, factionCode);
 
         // Use Java File to represent directories
@@ -243,6 +248,7 @@ public class AtBContract extends Contract {
 
             String fileName = randomFile.getName();
             String fileCategory = randomFile.getParent().replaceAll(ROOT_DIRECTORY, "");
+            fileCategory = fileCategory.replaceAll(ROOT_DIRECTORY_ALTERNATE, "");
 
             return new Camouflage(fileCategory, fileName);
         } else {

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -217,7 +217,7 @@ public class AtBContract extends Contract {
 
         // Some operating systems use `\`, so when we sanitize the file path later,
         // we need to be able to account for that.
-        final String ROOT_DIRECTORY_ALTERNATE = "data\\\\mages\\\\camo\\\\";
+        final String ROOT_DIRECTORY_ALTERNATE = "data\\\\images\\\\camo\\\\";
 
         String camouflageDirectory = getCamouflageDirectory(currentYear, factionCode);
 


### PR DESCRIPTION
Accounted for backslash escape sequences in camouflage file paths to ensure compatibility across different operating systems. Added an alternate root directory constant and updated the path sanitization to replace the alternate format correctly.

### Closes #4895