### PR TITLE
Added <50.01 Compatibility Handler for Removed Clan Tech Knowledge SPA

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5290,6 +5290,11 @@ public class Campaign implements ITechManager {
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "skillTypes");
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "specialAbilities");
         for (String key : SpecialAbility.getSpecialAbilities().keySet()) {
+            // <50.01 compatibility handler
+            if (Objects.equals(key, "clan_tech_knowledge")) {
+                continue;
+            }
+
             SpecialAbility.getAbility(key).writeToXML(pw, indent);
         }
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "specialAbilities");


### PR DESCRIPTION
Added a check to exclude the "clan_tech_knowledge" key from being written to the XML file. This ensures compatibility with versions before 50.01.

### Closes #4901