### PR TITLE
Generate contract modifiers when adding contracts individually

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
@@ -36,6 +36,9 @@ public class CamOpsContractMarket extends AbstractContractMarket {
 
     @Override
     public AtBContract addAtBContract(Campaign campaign) {
+        if (contractMods == null) {
+            contractMods = generateContractModifiers(campaign);
+        }
         Optional<AtBContract> c = generateContract(campaign);
         if (c.isPresent()) {
             AtBContract atbContract = c.get();


### PR DESCRIPTION
The CamOps contract market had a NPE when contracts were GM-added and the modifiers had not previously been populated on a monthly refresh. This PR populates the modifiers if a contract is added and they haven't been initialized.

Closes #4897 