### PR TITLE
Fixed Two Instances of NPE Related to the TO&E

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -504,6 +504,9 @@ public class Force {
 
         for (UUID eligibleCommanderId : eligibleCommanders) {
             Person eligibleCommander = campaign.getPerson(eligibleCommanderId);
+            if (eligibleCommander == null) {
+                continue;
+            }
 
             if (eligibleCommander.outRanksUsingSkillTiebreaker(campaign, highestRankedPerson)) {
                 highestRankedPerson = eligibleCommander;

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -555,7 +555,13 @@ public class ForceViewPanel extends JScrollablePanel {
         }
 
         if (force.getForceCommanderID() != null) {
-            commander = campaign.getPerson(force.getForceCommanderID()).getFullTitle();
+            Person forceCommander = campaign.getPerson(force.getForceCommanderID());
+
+            if (forceCommander != null) {
+                commander = forceCommander.getFullTitle();
+            } else {
+                commander = "No Commander";
+            }
         }
 
         StringBuilder summary = new StringBuilder();


### PR DESCRIPTION
Added checks to handle potential null `Person` objects in the `ForceViewPanel` and `Force` classes. This prevents the application from attempting to access methods on a null object and ensures default text is shown when no commander is found.

### Closes #4805