### PR TITLE
Simplified Tech Personnel Checks

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3863,30 +3863,22 @@ public class Person {
     }
 
     public boolean isTechMek() {
-        boolean hasSkill = hasSkill(SkillType.S_TECH_MEK)
-                && getSkill(SkillType.S_TECH_MEK).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN;
-
+        boolean hasSkill = hasSkill(SkillType.S_TECH_MEK);
         return hasSkill && (getPrimaryRole().isMekTech() || getSecondaryRole().isMekTech());
     }
 
     public boolean isTechAero() {
-        boolean hasSkill = hasSkill(SkillType.S_TECH_AERO)
-                && getSkill(SkillType.S_TECH_AERO).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN;
-
+        boolean hasSkill = hasSkill(SkillType.S_TECH_AERO);
         return hasSkill && (getPrimaryRole().isAeroTek() || getSecondaryRole().isAeroTek());
     }
 
     public boolean isTechMechanic() {
-        boolean hasSkill = hasSkill(SkillType.S_TECH_MECHANIC)
-                && getSkill(SkillType.S_TECH_MECHANIC).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN;
-
+        boolean hasSkill = hasSkill(SkillType.S_TECH_MECHANIC);
         return hasSkill && (getPrimaryRole().isMechanic() || getSecondaryRole().isMechanic());
     }
 
     public boolean isTechBA() {
-        boolean hasSkill = hasSkill(SkillType.S_TECH_BA)
-                && getSkill(SkillType.S_TECH_BA).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN;
-
+        boolean hasSkill = hasSkill(SkillType.S_TECH_BA);
         return hasSkill && (getPrimaryRole().isBATech() || getSecondaryRole().isBATech());
     }
 


### PR DESCRIPTION
Removed experience level checks from tech personnel checks to streamline the determination of technician roles. This removes the really weird situation where ultra-green techs can't be assigned to units (or, in some cases, repair tasks). Whether they _should_ be assigned is something best left to the player. This was particularly odd, as this is the only role that had the 'must be Green or better' restriction.