### PR TITLE
Refactored Batchall Logic and Enhanced Bidding Report

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBContract.properties
+++ b/MekHQ/resources/mekhq/resources/AtBContract.properties
@@ -7,6 +7,7 @@ batchallCloser.text=<br><br><b>Do you accept the Batchall?</b></center></html>
 responseAccept.text=Accept Batchall
 responseAccept.tooltip=The scenarios for this contract will be balanced to roughly match your forces.
 responseRefuse.text=Refuse Batchall
+responseFirstEncounter.text=Is this some kind of joke?
 responseRefuse.tooltip=You will face the full strength of the Clans during this contract, and they will regard you less favorably in future dealings.
 responseBringItOn.text=Bring It On
 responseBringItOn.tooltip=You will face the full strength of the Clans during this contract.

--- a/MekHQ/resources/mekhq/resources/AtBDynamicScenarioFactory.properties
+++ b/MekHQ/resources/mekhq/resources/AtBDynamicScenarioFactory.properties
@@ -1,7 +1,9 @@
 # reportResultsOfBidding
 bidAwayForcesVerbose.text=%s (<b>%s/%s</b>) has bid away the following forces:<br><br>%s<br>
-bidAwayForces.text=%s (<b>%s/%s</b>) has bid away %s units.
-addedBattleArmorNewReport.text=%s (<b>%s/%s</b>) has supplemented their force with %s additional unit/s of Battle Armor.
-addedBattleArmorContinueReport.text=<br>They also supplemented their force with %s additional unit/s of Battle Armor.
-batchallConcludedVersion1.text=<br><br>"Bargained Well and Done.</html>"
-batchallConcludedVersion2.text=<br><br>"Well-Bargained and Done.</html>"
+bidAwayForcesLogger.text=%s (%s/%s) has bid away the following forces:
+bidAwayForces.text=%s (<b>%s/%s</b>) has bid away %s unit%s.
+nothingBidAway.text=%s (%s/%s) has not bid away any forces.<br>
+addedBattleArmorNewReport.text=%s (<b>%s/%s</b>) has supplemented their force with %s additional unit%s of Battle Armor.
+addedBattleArmorContinueReport.text=<br>They also supplemented their force with %s additional unit%s of Battle Armor.
+batchallConcludedVersion1.text=<br><br>"Bargained Well and Done."<br>
+batchallConcludedVersion2.text=<br><br>"Well-Bargained and Done."<br>

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3738,7 +3738,8 @@ public class Campaign implements ITechManager {
         for (AtBContract contract : getActiveAtBContracts()) {
             if (campaignOptions.isUseGenericBattleValue()) {
                 if (contract.getStartDate().equals(getLocalDate()) && getLocation().isOnPlanet()) {
-                    if (BatchallFactions.usesBatchalls(contract.getEnemyCode())) {
+                    if (getCampaignOptions().isUseGenericBattleValue()
+                        && BatchallFactions.usesBatchalls(contract.getEnemyCode())) {
                         contract.setBatchallAccepted(contract.initiateBatchall(this));
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/universe/fameAndInfamy/BatchallFactions.java
+++ b/MekHQ/src/mekhq/campaign/universe/fameAndInfamy/BatchallFactions.java
@@ -21,6 +21,10 @@ public class BatchallFactions {
         "mekhq.resources.FameAndInfamy",
         MekHQ.getMHQOptions().getLocale());
 
+    public static final List<String> BATCHALL_FACTIONS = List.of("CBS", "CB", "CCC", "CCO",
+        "CDS", "CFM", "CGB", "CGS", "CHH", "CIH", "CJF", "CMG", "CNC", "CSJ", "CSR", "CSA", "CSV",
+        "CSL", "CWI", "CW", "CWE", "CWIE", "CEI", "RD", "RA", "CP", "AML", "CLAN");
+
     /**
      * Determines whether a given faction engages in batchalling.
      *
@@ -32,11 +36,7 @@ public class BatchallFactions {
             return false;
         }
 
-        List<String> factionCodes = List.of("CBS", "CB", "CCC", "CCO", "CDS", "CFM", "CGB",
-            "CGS", "CHH", "CIH", "CJF", "CMG", "CNC", "CSJ", "CSR", "CSA", "CSV", "CSL", "CWI", "CW",
-            "CWE", "CWIE", "CEI", "RD", "RA", "CP", "AML", "CLAN");
-
-        return factionCodes.contains(factionCode);
+        return BATCHALL_FACTIONS.contains(factionCode);
     }
 
     /**


### PR DESCRIPTION
Centralized Batchall faction list and ensured consistent checking throughout the codebase. Improved the reporting mechanism by differentiating between strict, opportunistic, and liberal honor levels, and added more informative logging to the bidding process. Added a fun Easter Egg for non-Clan factions encountering the Clans for the first time prior to the Outreach Summit of January 3051.