### PR TITLE
Fix AtBMonthlyContractMarket payment multiplier

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6851,16 +6851,6 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Retrieves the unit rating modifier as described in Campaign Operations. This value is equal
-     * to the total reputation score divided by ten, rounded down to the nearest whole number.
-     *
-     * @return The unit rating modifier as described in Campaign Operations.
-     */
-    public int getCamOpsUnitRatingMod() {
-        return getReputation().getReputationRating() / 10;
-    }
-
-    /**
      * Retrieves the unit reputation factor based on the rating method defined in the Campaign Options.
      *
      * @return the reputation factor for the selected unit rating method.
@@ -6869,7 +6859,7 @@ public class Campaign implements ITechManager {
         return switch (campaignOptions.getUnitRatingMethod()) {
             case NONE -> 5;
             case FLD_MAN_MERCS_REV -> getAtBUnitRatingMod() * 2;
-            case CAMPAIGN_OPS -> (int) ((getCamOpsUnitRatingMod() * 0.2) + 0.5);
+            case CAMPAIGN_OPS -> (int) ((getReputation().getReputationModifier() * 0.2) + 0.5);
         };
     }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6835,10 +6835,9 @@ public class Campaign implements ITechManager {
     /**
      * Retrieves the unit rating modifier based on campaign options.
      * If the unit rating method is not enabled, it returns the default value of
-     * IUnitRating.DRAGOON_C.
-     * If the unit rating method uses FMMR, it returns the unit rating as an
-     * integer.
-     * Otherwise, it calculates the modifier using the getAtBModifier method.
+     * IUnitRating.DRAGOON_C. If the unit rating method uses FMMR, it returns the
+     * unit rating as an integer. Otherwise, it calculates the modifier using the
+     * getAtBModifier method.
      *
      * @return The unit rating modifier based on the campaign options.
      */
@@ -6851,11 +6850,26 @@ public class Campaign implements ITechManager {
                 : reputation.getAtbModifier();
     }
 
+    /**
+     * Retrieves the unit rating modifier as described in Campaign Operations. This value is equal
+     * to the total reputation score divided by ten, rounded down to the nearest whole number.
+     *
+     * @return The unit rating modifier as described in Campaign Operations.
+     */
+    public int getCamOpsUnitRatingMod() {
+        return getReputation().getReputationRating() / 10;
+    }
+
+    /**
+     * Retrieves the unit reputation factor based on the rating method defined in the Campaign Options.
+     *
+     * @return the reputation factor for the selected unit rating method.
+     */
     public int getReputationFactor() {
         return switch (campaignOptions.getUnitRatingMethod()) {
             case NONE -> 5;
             case FLD_MAN_MERCS_REV -> getAtBUnitRatingMod() * 2;
-            case CAMPAIGN_OPS -> (int) ((getReputation().getReputationRating() * 0.2) + 0.5);
+            case CAMPAIGN_OPS -> (int) ((getCamOpsUnitRatingMod() * 0.2) + 0.5);
         };
     }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6859,7 +6859,7 @@ public class Campaign implements ITechManager {
         return switch (campaignOptions.getUnitRatingMethod()) {
             case NONE -> 5;
             case FLD_MAN_MERCS_REV -> getAtBUnitRatingMod() * 2;
-            case CAMPAIGN_OPS -> (int) ((getReputation().getReputationModifier() * 0.2) + 0.5);
+            case CAMPAIGN_OPS -> (int) (getReputation().getReputationModifier() * 0.2 + 0.5);
         };
     }
 

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -460,7 +460,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         double multiplier = 1.0;
         // IntOps reputation factor then Dragoons rating
         if (campaign.getCampaignOptions().getUnitRatingMethod().isCampaignOperations()) {
-            multiplier *= campaign.getReputationFactor();
+            multiplier *= (unitRatingMod * 0.2) + 0.5;
         } else {
             if (unitRatingMod >= IUnitRating.DRAGOON_A) {
                 multiplier *= 2.0;

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
@@ -18,8 +18,6 @@
  */
 package mekhq.campaign.rating.CamOpsReputation;
 
-import java.util.function.Consumer;
-
 import megamek.codeUtilities.MathUtility;
 import megamek.common.Crew;
 import megamek.common.Entity;
@@ -70,13 +68,13 @@ public class AverageExperienceRating {
     }
 
     /**
-     * Retrieves the reputation modifier.
+     * Retrieves the average experience level of the campaign. Useful for AtB Systems.
      *
-     * @param averageSkillLevel the average skill level to calculate the reputation
-     *                          modifier for
+     * @param averageSkillLevel the average skill level for which to calculate the reputation
+     *                          modifier
      * @return the reputation modifier for the camera operator
      */
-    protected static int getReputationModifier(SkillLevel averageSkillLevel) {
+    protected static int getAverageExperienceModifier(SkillLevel averageSkillLevel) {
         int modifier = switch (averageSkillLevel) {
             case NONE, ULTRA_GREEN, GREEN -> 5;
             case REGULAR -> 10;
@@ -85,8 +83,8 @@ public class AverageExperienceRating {
         };
 
         logger.debug("Reputation Rating = {}, +{}",
-                averageSkillLevel.toString(),
-                modifier);
+            averageSkillLevel.toString(),
+            modifier);
 
         return modifier;
     }

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/ReputationController.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/ReputationController.java
@@ -33,7 +33,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static mekhq.campaign.rating.CamOpsReputation.AverageExperienceRating.getAtBModifier;
-import static mekhq.campaign.rating.CamOpsReputation.AverageExperienceRating.getReputationModifier;
+import static mekhq.campaign.rating.CamOpsReputation.AverageExperienceRating.getAverageExperienceModifier;
 import static mekhq.campaign.rating.CamOpsReputation.AverageExperienceRating.getSkillLevel;
 import static mekhq.campaign.rating.CamOpsReputation.CombatRecordRating.calculateCombatRecordRating;
 import static mekhq.campaign.rating.CamOpsReputation.CommandRating.calculateCommanderRating;
@@ -120,7 +120,7 @@ public class ReputationController {
     public void initializeReputation(Campaign campaign) {
         // step one: calculate average experience rating
         averageSkillLevel = getSkillLevel(campaign, true);
-        averageExperienceRating = getReputationModifier(averageSkillLevel);
+        averageExperienceRating = getAverageExperienceModifier(averageSkillLevel);
         atbModifier = getAtBModifier(campaign);
 
         // step two: calculate command rating
@@ -181,6 +181,16 @@ public class ReputationController {
         reputationRating += financialRating;
         reputationRating += crimeRating;
         reputationRating += otherModifiers;
+    }
+
+    /**
+     * Retrieves the unit rating modifier as described in Campaign Operations. This value is equal
+     * to the total reputation score divided by ten, rounded down to the nearest whole number.
+     *
+     * @return The unit rating modifier as described in Campaign Operations.
+     */
+    public int getReputationModifier() {
+        return reputationRating / 10;
     }
 
     /**


### PR DESCRIPTION
There was an error when calculating the payment multiplier using the CamOps unit rating method for AtBMonthly contracts, which was caused by incorrectly using the reputation score instead of the reputation modifier for determining this multiplier. This PR does a couple of things:

1. Fixes `getReputationFactor()` to use the camopsUnitRatingMod instead of the reputation score
2. Reverts the change in `AtBMonthlyContractMarket` and uses the `AtBUnitRatingMod` instead
3. Adds a `getCamOpsUnitRatingMod()` method to get the camops unit rating mod and support `getReputationFactor()`
4. Adds docstrings for everything

Closes #4952 