### PR TITLE
Remove hiring halls from clan worlds

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
+++ b/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
@@ -758,6 +758,9 @@ public class PlanetarySystem {
             if (faction.isPirate() || faction.isChaos()) {
                 return HiringHallLevel.QUESTIONABLE;
             }
+            if (faction.isClan()) {
+                return HiringHallLevel.NONE;
+            }
         }
         score += getHiringHallHpgBonus(date);
         score += getHiringHallTechBonus(date);


### PR DESCRIPTION
This PR updates the dynamic hiring hall formula to remove hiring halls for systems owned by the clans. This was due to a discussion in Discord where the consensus was that having hiring halls was inconsistent with clan lore.