### PR TITLE
Added Turning Points Dialog to `DateChooser`

### DIFF
--- a/MekHQ/resources/mekhq/resources/DateChooser.properties
+++ b/MekHQ/resources/mekhq/resources/DateChooser.properties
@@ -30,72 +30,84 @@ friday.text=Fri
 saturday.text=Sat
 sunday.text=Sun
 dayPicker.tooltip=Click on a day to choose it
-dateField.text=Click on the date field to edit it
+dateField.text=Click on the date to edit it
 confirmDate.text=Confirm Date
 
 # createEraButtons
-eraAgeOfWar.text=<b>Age of War</b><br>(2475)
+eraAgeOfWar.text=<b>Age of War</b><br>
+eraAgeOfWar.year=(2005-2570)
 eraAgeOfWar.tooltip=Humanity's expansion into space sparks political turmoil and the creation of vast\
   \ interstellar empires. These powers inevitably engage in wars over resources and territory, with\
-  \ the introduction of the powerful BattleMech revolutionizing warfare.
-eraStarLeague.text=<b>Star League</b><br>(2571)
+  \ the introduction of the powerful BattleMek revolutionizing warfare.
+eraStarLeague.text=<b>Star League</b><br>
+eraStarLeague.year=(2571-2780)
 eraStarLeague.tooltip=The League prospers for two centuries under the leadership of the First Lords,\
   \ with rapid technological advancements and widespread peace. However, unrest brews as the Periphery\
   \ nations rebel, stemming from the consequences of Ian Cameron's initial actions.
-eraEarlySuccessionWar.text=<b>Early Succession War</b><br>(2781)
+eraEarlySuccessionWar.text=<b>Early Succession War</b><br>
+eraEarlySuccessionWar.year=(2781-2900)
 eraEarlySuccessionWar.tooltip=Minoru Kurita of the Draconis Combine claims the title of First Lord of\
   \ the Star League, triggering the First Succession War and involving all Great Houses in the conflict.\
   \ The widespread use of weapons of mass destruction results in significant loss of life and technological\
   \ regression. Although the war ends with a fragile truce, the Second Succession War erupts within\
   \ a decade, causing even more devastation.
-eraLateSuccessionWarLosTech.text=<b>Late Succession War</b><br>(LostTech - 2901)
+eraLateSuccessionWarLosTech.text=<b>Late Succession War</b><br>
+eraLateSuccessionWarLosTech.year=(2901-3019)
 eraLateSuccessionWarLosTech.tooltip=By the onset of the Third Succession War, the prolonged conflicts\
   \ of the Second War and early stages of the Third have rendered much of the Star League's advanced\
   \ technology as "lostech." The Third War begins with a Draconis Combine assault on the Lyran\
   \ Commonwealth, but it soon devolves into two centuries of continuous, low-level warfare, with the\
   \ Great Houses facing the consequences of their destructive actions.
-eraLateSuccessionWarRenaissance.text=<b>Late Succession War</b><br>(Renaissance - 3020)
+eraLateSuccessionWarRenaissance.text=<b>Late Succession War</b><br>
+eraLateSuccessionWarRenaissance.year=(3020-3049)
 eraLateSuccessionWarRenaissance.tooltip=In the early 31st century, the Grey Death Legion uncovers the\
   \ Helm memory core, sparking the revival of many lost technologies. Secretly, Hanse Davion and Katrina\
   \ Steiner form the FedCom Accords, planning to unite the Federated Suns and Lyran Commonwealth. Using\
   \ his marriage to Melissa Steiner as a cover, Davion initiates the Fourth Succession War with a\
   \ large-scale invasion. The war ends with Davion capturing half of the Capellan Confederation and\
   \ establishing a crucial link to the Commonwealth, though he fails to conquer the Draconis Combine.
-eraClanInvasion.text=<b>Clan Invasion</b><br>(3050)
+eraClanInvasion.text=<b>Clan Invasion</b><br>
+eraClanInvasion.year=(3050-3061)
 eraClanInvasion.tooltip=A mysterious force known as the Clans invades the coreward region of the Inner\
   \ Sphere. The Clans, descendants of Kerensky's SLDF troops, have evolved into a society focused on\
   \ becoming the ultimate fighting force. With advanced technology and elite warriors, they swiftly\
   \ conquer numerous worlds. This external threat eventually leads to the formation of a new Star League,\
   \ an achievement that centuries of warfare could not attain. Additionally, the Clans' presence\
   \ sparks a technological renaissance.
-eraCivilWar.text=<b>Civil War</b><br>(3062)
+eraCivilWar.text=<b>Civil War</b><br>
+eraCivilWar.year=(3062-3067)
 eraCivilWar.tooltip=The Clan threat diminishes after the complete destruction of one Clan. With the\
   \ external danger seemingly neutralized, internal conflicts erupt across the Inner Sphere. House\
   \ Liao reclaims the St. Ives Compact, sparking internal unrest. A rebellion within House Kurita's\
   \ military triggers a war with Clan Ghost Bear, while the once-mighty Federated Commonwealth of\
   \ House Steiner and House Davion disintegrates into a five-year civil war.
-eraJihad.text=<b>Jihad</b><br>(3068)
+eraJihad.text=<b>Jihad</b><br>
+eraJihad.year=(3068-3080)
 eraJihad.tooltip=After the Federated Commonwealth Civil War, the leaders of the Great Houses disband\
   \ the new Star League, dismissing it as illegitimate. In response, the Word of Blake, a fanatical\
   \ splinter group from ComStar, initiates the Jihad - a devastating interstellar war. This conflict\
   \ draws every faction into battle, even against their own, as weapons of mass destruction are used\
   \ for the first time in centuries, alongside the emergence of terrifying new technologies.
-eraEarlyRepublic.text=<b>Early Republic</b><br>(3081)
+eraEarlyRepublic.text=<b>Early Republic</b><br>
+eraEarlyRepublic.year=(3081-3100)
 eraEarlyRepublic.tooltip=After the Jihad, Stone's Republic ushers in an era of peace and prosperity.\
   \ While minor conflicts persist, the large-scale wars that once plagued the Inner Sphere become a\
   \ thing of the past.
-eraLateRepublic.text=<b>Late Republic</b><br>(3101)
+eraLateRepublic.text=<b>Late Republic</b><br>
+eraLateRepublic.year=(3101-3130)
 eraLateRepublic.tooltip=The peace established by Stone's Republic unravels as war escalates. Sun-Tzu\
   \ Liao and his son, Daoshen, launch a campaign to reclaim territories taken by the Republic, sparking\
   \ widespread violence. Conflicts erupt across the Inner Sphere and Periphery, including the Second\
   \ Combine-Dominion War, the Victoria War, territorial disputes in the former Free Worlds League,\
   \ rebellion in the Marian Hegemony, and the ongoing threat of Clan expansion. These events shatter\
   \ the era of peace, leaving the Inner Sphere in turmoil once again.
-eraDarkAge.text=<b>Dark Age</b><br>(3131)
+eraDarkAge.text=<b>Dark Age</b><br>
+eraDarkAge.year=(3131-3150)
 eraDarkAge.tooltip=Two years after Stone's disappearance, the communications network collapses,\
   \ plunging the Inner Sphere into chaos. Seizing the opportunity, the Great Houses begin reclaiming\
   \ the worlds they had ceded to the Republic, reigniting old rivalries and long-standing animosities.
-eraIlClan.text=<b>ilClan</b><br>(3151)
+eraIlClan.text=<b>ilClan</b><br>
+eraIlClan.year=(3151-Present)
 eraIlClan.tooltip=With Clan Wolf's conquest of Terra, a pivotal moment unfolds in the Inner Sphere.\
   \ This victory is likely to trigger major shifts in power, as other Clans and Great Houses react\
   \ to this bold move. Clan Wolf's control over Terra, the symbolic heart of the Inner Sphere, could\
@@ -103,3 +115,216 @@ eraIlClan.tooltip=With Clan Wolf's conquest of Terra, a pivotal moment unfolds i
   \ rival factions seeking to challenge their dominance. Alternatively, the conquest may inspire a\
   \ fragile unity among the Great Houses and other Clans to resist Clan Wolf's growing influence. The\
   \ balance of power hangs in the balance, with the future of the Inner Sphere uncertain.
+
+# turningPointsDialog
+turningPoints.title=Select a Turning Point
+
+TerranHegemonyFounded.text=Founding of the Hegemony
+TerranHegemonyFounded.tooltip=The Terran Hegemony was born in 2315, ignited by Admiral James McKenna's\
+  \ military coup, overthrowing a faltering Terran Alliance. This marked the dawn of humanity's most\
+  \ powerful realm, blending unmatched technological advancement and military might, setting the stage\
+  \ for the rise of the Star League and reshaping interstellar politics.
+RiseOfTheBattleMek.text=Rise of the BattleMek
+RiseOfTheBattleMek.tooltip=In 2439, the BattleMek revolution began with the successful combat trial\
+  \ of the Mackie. Developed by the Terran Hegemony, these massive humanoid war machines dominated\
+  \ the battlefield with superior mobility, firepower, and durability. The proliferation of BattleMeks\
+  \ changed warfare across the Inner Sphere, escalating conflicts and leading to an arms race among\
+  \ the Great Houses.
+ReunificationWar.text=Reunification War
+ReunificationWar.tooltip=The Reunification War was the Star League's first major conflict, aimed at\
+  \ forcibly integrating the independent Periphery states into the League. It involved massive campaigns\
+  \ by the Star League Defense Force and Inner Sphere powers against the Outworlds Alliance, Taurian\
+  \ Concordat, Magistracy of Canopus, and the Rim Worlds Republic, reshaping interstellar politics.
+FirstHiddenWar.text=First Hidden War
+FirstHiddenWar.tooltip=The First Hidden War was a secretive conflict between the Federated Suns and\
+  \ Capellan Confederation, fought largely through espionage, sabotage, and covert operations. This\
+  \ war saw both sides using subterfuge and proxy forces, rather than direct military confrontation,\
+  \ to influence disputed border regions. Though not a full-scale war, the tension and clandestine\
+  \ tactics involved led to ongoing friction between the two powers.
+SecondHiddenWar.text=Second Hidden War
+SecondHiddenWar.tooltip=The Second Hidden War, also known as the War of Davion Succession, was an\
+  \ intense period of covert conflict between the Federated Suns and Draconis Combine. It involved\
+  \ espionage, raids, and proxy battles, with each side attempting to weaken the other without a\
+  \ full-scale war. This shadowy struggle revolved around control of strategic worlds and resources,\
+  \ leading to significant military and political maneuvering that reshaped relations between these\
+  \ powerful factions, while avoiding open conflict until later, larger wars erupted.
+ThirdHiddenWar.text=Third Hidden War
+ThirdHiddenWar.tooltip=The Third Hidden War was a shadowy conflict between the Federated Suns, Draconis\
+  \ Combine, and Lyran Commonwealth over control and influence in the Rimward Periphery. Rather than\
+  \ open warfare, the struggle played out through espionage, sabotage, and proxy battles. Each faction\
+  \ sought to expand its reach without triggering a full-scale war, making it a tense but indirect\
+  \ conflict that shifted political balances in the region.
+AmarisCivilWar.text=Amaris Civil War
+AmarisCivilWar.tooltip=The Amaris Civil War was a devastating conflict triggered by Stefan Amaris'\
+  \ coup against the Star League. After seizing Terra and assassinating First Lord Richard Cameron,\
+  \ Amaris ruled the Hegemony. General Aleksandr Kerensky led the Star League Defense Force in a bloody\
+  \ campaign to reclaim Terra, ultimately toppling Amaris and ending the Star League.
+OperationExodus.text=Operation Exodus
+OperationExodus.tooltip=Operation Exodus was General Aleksandr Kerensky's daring decision to lead the\
+  \ Star League Defense Force into deep space after the collapse of the Star League. Refusing to let\
+  \ the Great Houses exploit his troops, Kerensky and his followers sought refuge beyond the Inner\
+  \ Sphere, ultimately forming the foundation of the future Clans.
+OperationKlondike.text=Operation Klondike
+OperationKlondike.tooltip=Operation Klondike was the Clans' campaign to recapture the Pentagon Worlds,\
+  \ which had fallen into chaos after Aleksandr Kerensky's death. Led by Nicholas Kerensky, the newly\
+  \ formed Clans launched fierce attacks, retaking the planets from rebel factions. This operation\
+  \ solidified the Clans' dominance and established their military traditions.
+SecondSuccessionWar.text=Second Succession War
+SecondSuccessionWar.tooltip=The Second Succession War was a devastating conflict among the Great Houses\
+  \ of the Inner Sphere, marked by widespread destruction and technological regression. Despite brutal\
+  \ fighting, no house gained a decisive advantage. The war accelerated the loss of advanced technology,\
+  \ pushing the Inner Sphere into a dark age and setting the stage for the next Succession War.
+ThirdSuccessionWar.text=Third Succession War
+ThirdSuccessionWar.tooltip=The Third Succession War was marked by prolonged, low-intensity conflict\
+  \ between the Great Houses of the Inner Sphere. Raids replaced large-scale battles as resources and\
+  \ technology dwindled, pushing humanity further into decline. Despite constant skirmishes, no house\
+  \ gained a decisive advantage, and the war ended without a formal peace, merely giving way to the\
+  \ next conflict.
+OperationFreedom.text=Operation Freedom
+OperationFreedom.tooltip=Operation FREEDOM was a sprawling and hard-fought campaign launched by the\
+  \ Lyran Commonwealth to reclaim critical industrial worlds from the Draconis Combine. With bold\
+  \ offensives targeting key planets like Freedom and Skondia, the operation stretched across decades.\
+  \ Though initial victories sparked hope, the conflict devolved into grueling attrition, testing the\
+  \ Lyran military's resolve and reshaping their future military strategy.
+ThirdSuccessionWarEnds.text=Third Succession War Ends
+ThirdSuccessionWarEnds.tooltip=The Third Succession War ended in 3025 without a decisive military outcome,\
+  \ as years of low-intensity skirmishes between the Great Houses gave way to exhaustion. Archon Katrina\
+  \ Steiner's peace efforts formed the Federated Commonwealth Alliance with Hanse Davion, while the\
+  \ other states created the Concord of Kapteyn. Around the same time, the Arano Restoration in the\
+  \ Aurigan Reach highlighted smaller-scale conflicts, with Kamea Arano reclaiming her throne. These\
+  \ events paved the way for the Fourth Succession War.
+ForthSuccessionWar.text=Forth Succession War
+ForthSuccessionWar.tooltip=The Fourth Succession War was a dramatic conflict driven by Hanse Davion's\
+  \ surprise alliance with the Lyran Commonwealth against the Capellan Confederation and their allies.\
+  \ With cunning strategies and bold offensives, Davion forces gained significant territory, especially\
+  \ from the Capellans. The war reshaped the political landscape of the Inner Sphere, as powerful nations\
+  \ rose, alliances were tested, and long-standing rivalries intensified, ultimately leading to the\
+  \ formation of the Federated Commonwealth and setting the stage for future conflicts.
+FRRFounded.text=Free Rasalhague Republic Founded
+FRRFounded.tooltip=The Free Rasalhague Republic was born from the ashes centuries-long resistance\
+  \ against the Draconis Combine. In a landmark decision, the Combine granted independence to the\
+  \ Rasalhague region, allowing the proud people of Rasalhague to finally govern themselves. This bold\
+  \ move marked the creation of a sovereign state, fueled by a fierce desire for freedom and cultural\
+  \ preservation, standing as a testament to the perseverance of its people.
+WarOf3039.text=War of 3039
+WarOf3039.tooltip=The War of 3039 was an ambitious attempt by Hanse Davion to crush the Draconis\
+  \ Combine after the successes of the Fourth Succession War. However, the Combine, led by Theodore\
+  \ Kurita, mounted a fierce defense with unexpected resilience. What started as a bold campaign\
+  \ devolved into a war of attrition, with minimal territorial gains and the eventual cessation of\
+  \ hostilities. Although the Federated Commonwealth won several battles, the Combine's tenacity\
+  \ prevented a decisive victory, leaving both sides bloodied but largely unchanged.
+FirstContact.text=First Contact
+FirstContact.tooltip=The Clan Invasion's first contact with the Inner Sphere was swift and devastating.\
+  \ Emerging from the Periphery, the Clans overwhelmed unprepared defenders with their advanced\
+  \ technology and martial prowess. Entire worlds fell before most even realized the magnitude of the\
+  \ threat. The invaders' relentless, honor-driven tactics and their superior war machines sent shockwaves\
+  \ through the Inner Sphere, marking the dawn of a new era of warfare as rumors spread that these\
+  \ fearsome conquerors might even be aliens.
+YearOfPeace.text=Year of Peace
+YearOfPeace.tooltip=During the "Year of Peace," both the Clans and Inner Sphere regrouped and rearmed\
+  \ after the initial Clan Invasion waves. The Clans, bolstered by fresh reinforcements, prepared to\
+  \ renew their assault. Meanwhile, the Inner Sphere's Great Houses, unprecedentedly united, worked\
+  \ together to upgrade their forces, producing new technologies and 'Meks to counter the invaders.\
+  \ Though tensions remained high, this brief lull set the stage for the fierce battles that would\
+  \ follow, as both sides braced for the next chapter in their conflict.
+Tukayyid.text=Tukayyid
+Tukayyid.tooltip=The Battle of Tukayyid was a defining moment in the Clan Invasion, where ComStar's\
+  \ Com Guards faced off against seven Clan armies in a desperate struggle for Terra. Against all odds,\
+  \ the Com Guards outmaneuvered the technologically superior Clans, turning the planet into a battleground\
+  \ of ambushes and attrition. The victory forced the Clans into a fifteen-year truce, halting their\
+  \ advance toward Terra and giving the Inner Sphere a much-needed respite from the invaders' relentless\
+  \ march.
+RefusalWar.text=Refusal War
+RefusalWar.tooltip=The Refusal War was a brutal internal Clan conflict between Clan Wolf and Clan Jade\
+  \ Falcon. Sparked by accusations of treason against ilKhan Ulric Kerensky, it became a massive Trial\
+  \ of Refusal. Ulric fought to protect his Clan's honor, splitting Clan Wolf into two factions:\
+  \ Crusader-aligned Clan Jade Wolf and Warden-aligned Clan Wolf-in-Exile. The war saw the deaths of\
+  \ many key leaders, including Ulric and Natasha Kerensky, and reshaped Clan politics, delaying further\
+  \ Clan aggression toward the Inner Sphere.
+OperationBulldog.text=Operation Bulldog
+OperationBulldog.tooltip=Operation Bulldog was a bold campaign launched by the Second Star League to\
+  \ annihilate Clan Smoke Jaguar's presence in the Inner Sphere. Led by Anastasius Focht and Victor\
+  \ Steiner-Davion, the assault was a massive success, exploiting the Jaguars' lack of support from\
+  \ other Clans. With strategic brilliance and the aid of defector Nova Cat warriors, the operation\
+  \ reclaimed numerous planets, ultimately ejecting Smoke Jaguar from the Inner Sphere and signaling\
+  \ the Star League's resurgence against the Clans.
+FCCWStarts.text=FedCom Civil War
+FCCWStarts.tooltip=The FedCom Civil War erupted between Victor Steiner-Davion and his sister, Katherine,\
+  \ over control of the Federated Commonwealth. Katherine's ruthless manipulation and power grab led\
+  \ to a full-scale civil war, dividing loyalties and shattering the once-powerful nation. Battles\
+  \ raged across numerous worlds, with both sides suffering heavy losses. Victor ultimately emerged\
+  \ victorious, ousting Katherine from power, but the war left the Federated Commonwealth in ruins,\
+  \ deeply altering the balance of power in the Inner Sphere.
+JadeFalconOffensive.text=Jade Falcon Offensive
+JadeFalconOffensive.tooltip=The Jade Falcon Offensive of 3064 saw Clan Jade Falcon launch a fierce\
+  \ incursion into the Lyran Alliance, striking with overwhelming force across key worlds. Initially,\
+  \ they captured several planets, but the campaign met stiff resistance from Lyran forces and their\
+  \ allies. The offensive stalled, turning into a series of brutal engagements, where both sides\
+  \ suffered heavy losses. Despite early successes, the Jade Falcons were forced to pull back,\
+  \ demonstrating the ferocity of Clan warfare and the resilience of the Lyran defenders.
+FirstBattleOfHarlech.text=First Battle of Harlech
+FirstBattleOfHarlech.tooltip=The First Battle of Harlech marked the explosive start of the Word of Blake\
+  \ Jihad. Mercenary forces, led by the Waco Rangers and backed by the Word of Blake, launched a\
+  \ surprise attack on Wolf's Dragoons' stronghold on Outreach. The fierce battle devastated the city\
+  \ of Harlech, leading to massive civilian and military casualties. Despite the ferocity of the attack,\
+  \ the Dragoons fought back with a relentless counterassault, ultimately crushing the Waco Rangers.\
+  \ This bloody conflict ignited the galaxy-wide Word of Blake Jihad.
+WarsOfReaving.text=Wars of Reaving
+WarsOfReaving.tooltip=The Wars of Reaving were a savage period of civil war within the Clan Homeworlds,\
+  \ initiated by ilKhan Brett Andrews' purges of Clans tainted by Inner Sphere contact. Fierce internal\
+  \ battles led to the annihilation of several Clans, like Ice Hellion and Fire Mandrill, and resulted\
+  \ in the isolation of the Home Clans from those in the Inner Sphere. This conflict left the Clans\
+  \ fractured and politically unstable, altering their future forever.
+OperationScour.text=Operation Scour
+OperationScour.tooltip=Operation Scour was the climactic campaign to eradicate the Word of Blake during\
+  \ the Jihad. Led by Devlin Stone, a coalition of Inner Sphere forces launched coordinated assaults\
+  \ across multiple fronts, culminating in the liberation of Terra. Despite fierce resistance, the\
+  \ Word of Blake was ultimately crushed, marking the end of their reign of terror and bringing a\
+  \ fragile peace to the Inner Sphere. This operation paved the way for a new era under Stone's leadership.
+RepublicFounded.text=Republic Founded
+RepublicFounded.tooltip=The Republic of the Sphere was founded by Devlin Stone from the remnants of\
+  \ the Word of Blake Protectorate. Created as a buffer state between the major Inner Sphere powers,\
+  \ it embodied Stone's vision of peace and unity, with Terra as its capital. The Republic disarmed\
+  \ much of the Inner Sphere and redistributed populations, promoting stability and security. Over\
+  \ time, it faced internal strife, invasions, and eventual dissolution, but it marked a significant\
+  \ era of relative peace after centuries of war.
+OperationGoldenDawn.text=Operation Golden Dawn
+OperationGoldenDawn.tooltip=Operation Golden Dawn was a swift military campaign launched by the\
+  \ Republic of the Sphere against former Free Worlds League states in 3081. Led by Paladin Alys\
+  \ Rousset-Marik, the operation aimed to secure Republic borders and legitimacy. Through multiple\
+  \ waves of assaults, the Republic reclaimed key worlds, including New Hope, forcing several states\
+  \ into peace agreements and solidifying control over ex-League territories.
+SecondCombineDominionWar.text=Second Combine-Dominion War
+SecondCombineDominionWar.tooltip=The Second Combine-Dominion War was sparked by escalating tensions\
+  \ between Clan Ghost Bear and the Draconis Combine, worsened by raids and the Black Dragon Society's\
+  \ interference. Both sides engaged in brutal battles over border worlds, resulting in heavy casualties.\
+  \ The war ended in a stalemate, with neither side achieving a decisive victory, and a fragile\
+  \ ceasefire was established.
+VictoriaWar.text=Victoria War
+VictoriaWar.tooltip=The Victoria War was a brief but intense conflict launched by Duchess Amanda Hasek\
+  \ of the Federated Suns against the Capellan Confederation. Targeting the vital industrial world of\
+  \ Victoria, the Federated Suns gained initial success but lost other strategic worlds in the process.\
+  \ The war demonstrated the fragile balance of power between the two realms and the high cost of\
+  \ territorial ambition.
+CapellanCrusades.text=Capellan Crusades
+CapellanCrusades.tooltip=The Capellan Crusades were a series of aggressive campaigns launched by the\
+  \ Capellan Confederation under Chancellor Sun-Tzu Liao. Aimed at reclaiming lost territories and\
+  \ restoring Capellan pride, the Crusades targeted House Davion and other enemies. These conflicts\
+  \ showcased the Confederation's revitalized military strength, driven by Sun-Tzu's political\
+  \ machinations and strategic brilliance, but also led to heavy losses and fierce resistance from\
+  \ neighboring powers. The campaigns were a critical period for Capellan ambitions and influence\
+  \ in the Inner Sphere.
+GreyMonday.text=Grey Monday
+GreyMonday.tooltip=Grey Monday, also known as the Blackout, was a catastrophic event in which interstellar\
+  \ communications, reliant on HPG (Hyperpulse Generators), mysteriously collapsed across the Inner\
+  \ Sphere. The blackout disrupted economies, militaries, and daily life, plunging regions into chaos\
+  \ and uncertainty. The cause of the event remains unclear, but it gave rise to conspiracy theories,\
+  \ power struggles, and opportunistic invasions as factions vied for control in the resulting\
+  \ communication vacuum. This marked a turning point in Inner Sphere politics, sparking further\
+  \ conflicts and instability.
+BattleOfTerra.text=Battle of Terra
+BattleOfTerra.tooltip=The Battle of Terra was a decisive and brutal conflict between Clan Wolf and\
+  \ Clan Jade Falcon, fighting for control of Terra and the right to become ilClan, the supreme Clan\
+  \ leader. After fierce combat across the planet, Clan Wolf emerged victorious, securing Terra and\
+  \ significantly altering the balance of power in the Inner Sphere. This victory marked the end of\
+  \ the ilClan Trial and positioned Clan Wolf as the dominant force in the Clans.

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -137,9 +137,6 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         this.date = date;
         workingDate = this.date;
 
-        // Ensure the dialog isn't hidden
-        setAlwaysOnTop(true);
-
         Container contentPane = getContentPane();
         contentPane.setLayout(new BorderLayout());
 
@@ -271,7 +268,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         // setResizable(false);
         ready = false;
         pack();
-        setMinimumSize(new Dimension(700, 300));
+        setMinimumSize(new Dimension(750, 550));
 
         // center this dialog over the owner
         setLocationRelativeTo(owner);
@@ -600,99 +597,211 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
      * @return The created JButton object representing the specified era.
      */
     private JButton createEraButton(int era) {
-        final List<Integer> eraYears = List.of(2475, 2571, 2781,  2901, 3020, 3050, 3062,
-            3068, 3081, 3101, 3131, 3151);
+          String reference = switch (era) {
+            case 0 -> "eraAgeOfWar";
+            case 1 -> "eraStarLeague";
+            case 2 -> "eraEarlySuccessionWar";
+            case 3 -> "eraLateSuccessionWarLosTech";
+            case 4 -> "eraLateSuccessionWarRenaissance";
+            case 5 -> "eraClanInvasion";
+            case 6 -> "eraCivilWar";
+            case 7 -> "eraJihad";
+            case 8 -> "eraEarlyRepublic";
+            case 9 -> "eraLateRepublic";
+            case 10 -> "eraDarkAge";
+            case 11 -> "eraIlClan";
+              default -> throw new IllegalStateException("Unexpected value mekhq/gui/dialog/DateChooser.java/createEraButton: "
+                  + era);
+          };
 
-        final String ERA_AGE_OF_WAR_LABEL = resources.getString("eraAgeOfWar.text");
-        final String ERA_AGE_OF_WAR_TOOLTIP = resources.getString("eraAgeOfWar.tooltip");
-        final String ERA_STAR_LEAGUE_LABEL = resources.getString("eraStarLeague.text");
-        final String ERA_STAR_LEAGUE_TOOLTIP = resources.getString("eraStarLeague.tooltip");
-        final String ERA_EARLY_SUCCESSION_WAR_LABEL = resources.getString("eraEarlySuccessionWar.text");
-        final String ERA_EARLY_SUCCESSION_WAR_TOOLTIP = resources.getString("eraEarlySuccessionWar.tooltip");
-        final String ERA_LATE_SUCCESSION_WAR_LOSTECH_LABEL = resources.getString("eraLateSuccessionWarLosTech.text");
-        final String ERA_LATE_SUCCESSION_WAR_LOSTECH_TOOLTIP = resources.getString("eraLateSuccessionWarLosTech.tooltip");
-        final String ERA_LATE_SUCCESSION_WAR_RENAISSANCE_LABEL = resources.getString("eraLateSuccessionWarRenaissance.text");
-        final String ERA_LATE_SUCCESSION_WAR_RENAISSANCE_TOOLTIP = resources.getString("eraLateSuccessionWarRenaissance.tooltip");
-        final String ERA_CLAN_INVASION_LABEL = resources.getString("eraClanInvasion.text");
-        final String ERA_CLAN_INVASION_TOOLTIP = resources.getString("eraClanInvasion.tooltip");
-        final String ERA_CIVIL_WAR_LABEL = resources.getString("eraCivilWar.text");
-        final String ERA_CIVIL_WAR_TOOLTIP = resources.getString("eraCivilWar.tooltip");
-        final String ERA_JIHAD_LABEL = resources.getString("eraJihad.text");
-        final String ERA_JIHAD_TOOLTIP = resources.getString("eraJihad.tooltip");
-        final String ERA_EARLY_REPUBLIC_LABEL = resources.getString("eraEarlyRepublic.text");
-        final String ERA_EARLY_REPUBLIC_TOOLTIP = resources.getString("eraEarlyRepublic.tooltip");
-        final String ERA_LATE_REPUBLIC_LABEL = resources.getString("eraLateRepublic.text");
-        final String ERA_LATE_REPUBLIC_TOOLTIP = resources.getString("eraLateRepublic.tooltip");
-        final String ERA_DARK_AGE_LABEL = resources.getString("eraDarkAge.text");
-        final String ERA_DARK_AGE_TOOLTIP = resources.getString("eraDarkAge.tooltip");
-        final String ERA_ILCLAN_LABEL = resources.getString("eraIlClan.text");
-        final String ERA_ILCLAN_TOOLTIP = resources.getString("eraIlClan.tooltip");
-
-          String eraLabel;
-          String eraTooltip;
-          switch (era) {
-            case 0 -> {
-                eraLabel = ERA_AGE_OF_WAR_LABEL;
-                eraTooltip = ERA_AGE_OF_WAR_TOOLTIP;
-            }
-            case 1 -> {
-                eraLabel = ERA_STAR_LEAGUE_LABEL;
-                eraTooltip = ERA_STAR_LEAGUE_TOOLTIP;
-            }
-            case 2 -> {
-                eraLabel = ERA_EARLY_SUCCESSION_WAR_LABEL;
-                eraTooltip = ERA_EARLY_SUCCESSION_WAR_TOOLTIP;
-            }
-            case 3 -> {
-                eraLabel = ERA_LATE_SUCCESSION_WAR_LOSTECH_LABEL;
-                eraTooltip = ERA_LATE_SUCCESSION_WAR_LOSTECH_TOOLTIP;
-            }
-            case 4 -> {
-                eraLabel = ERA_LATE_SUCCESSION_WAR_RENAISSANCE_LABEL;
-                eraTooltip = ERA_LATE_SUCCESSION_WAR_RENAISSANCE_TOOLTIP;
-            }
-            case 5 -> {
-                eraLabel = ERA_CLAN_INVASION_LABEL;
-                eraTooltip = ERA_CLAN_INVASION_TOOLTIP;
-            }
-            case 6 -> {
-                eraLabel = ERA_CIVIL_WAR_LABEL;
-                eraTooltip = ERA_CIVIL_WAR_TOOLTIP;
-            }
-            case 7 -> {
-                eraLabel = ERA_JIHAD_LABEL;
-                eraTooltip = ERA_JIHAD_TOOLTIP;
-            }
-            case 8 -> {
-                eraLabel = ERA_EARLY_REPUBLIC_LABEL;
-                eraTooltip = ERA_EARLY_REPUBLIC_TOOLTIP;
-            }
-            case 9 -> {
-                eraLabel = ERA_LATE_REPUBLIC_LABEL;
-                eraTooltip = ERA_LATE_REPUBLIC_TOOLTIP;
-            }
-            case 10 -> {
-                eraLabel = ERA_DARK_AGE_LABEL;
-                eraTooltip = ERA_DARK_AGE_TOOLTIP;
-            }
-            case 11 -> {
-                eraLabel = ERA_ILCLAN_LABEL;
-                eraTooltip = ERA_ILCLAN_TOOLTIP;
-            }
-            default -> {
-                eraLabel = "ERROR";
-                eraTooltip = "ERROR";
-            }
-          }
-
-        String label = String.format("<html><center>%s</center></html>", eraLabel);
+        String label = String.format("<html><center>%s%s</center></html>",
+            resources.getString(reference + ".text"),
+            resources.getString(reference + ".year"));
 
         JButton button = new JButton(label);
-        button.setToolTipText(wordWrap(eraTooltip));
+        button.setToolTipText(wordWrap(resources.getString(reference + ".tooltip")));
         button.setHorizontalAlignment(SwingConstants.CENTER);
-        button.addActionListener(e -> setDate(LocalDate.of(eraYears.get(era), 1, 1)));
+        button.addActionListener(e -> turningPointsDialog(era, reference));
 
-        // Return the button
         return button;
     }
+
+    /**
+     * Displays a dialog window with buttons representing turning points in history based on the era provided.
+     *
+     * @param era an integer value specifying the era of turning points to display
+     */
+    private void turningPointsDialog(int era, String reference) {
+        TurningPoints turningPointData = getTurningPoints(era);
+
+        JPanel panelDescriptionContainer = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        JLabel panelDescription = new JLabel(String.format(
+            "<html><div style='width:500px;'><center><font size='6'>%s</font></center><justify>%s</justify></div></html>",
+            resources.getString(reference + ".text"),
+            resources.getString(reference + ".tooltip")));
+        panelDescriptionContainer.add(panelDescription);
+
+        JDialog turningPointsDialog = new JDialog();
+        turningPointsDialog.setTitle(resources.getString("turningPoints.title"));
+        turningPointsDialog.setModalityType(ModalityType.APPLICATION_MODAL);
+
+        JPanel buttonPanel = new JPanel();
+        final List<LocalDate> finalTurningPointDates = turningPointData.turningPointDates();
+
+        for (int index = 1; index <= turningPointData.turningPoints().size(); index++) {
+            JButton eraButtonN = new JButton(String.format("<html><center><b>" + resources.getString(turningPointData.turningPoints().get(index - 1) + ".text")
+                + "</b><br>(" + finalTurningPointDates.get(index - 1).toString() + ")</center></html>"));
+            eraButtonN.setToolTipText(String.format(resources.getString(turningPointData.turningPoints().get(index - 1) + ".tooltip")));
+
+            final int finalIndex = index - 1;
+            eraButtonN.addActionListener(e -> {
+                setDate(finalTurningPointDates.get(finalIndex));
+                turningPointsDialog.dispose();
+            });
+
+            buttonPanel.add(eraButtonN);
+        }
+
+        JLabel eraLogoLabel = new JLabel();
+        eraLogoLabel.setIcon(turningPointData.eraLogo());
+        eraLogoLabel.setHorizontalAlignment(JLabel.CENTER);
+
+        // Create a JPanel to hold the description and buttons, then add to the center of the dialog
+        JPanel descriptionAndButtonsPanel = new JPanel(new BorderLayout());
+        descriptionAndButtonsPanel.add(panelDescriptionContainer, BorderLayout.NORTH);
+        descriptionAndButtonsPanel.add(buttonPanel, BorderLayout.CENTER);
+
+        turningPointsDialog.getContentPane().add(eraLogoLabel, BorderLayout.PAGE_START);
+        turningPointsDialog.getContentPane().add(descriptionAndButtonsPanel, BorderLayout.CENTER);
+
+        // set turningPointsDialog size and location, and make it visible
+        setResizable(false);
+        turningPointsDialog.pack();
+        turningPointsDialog.setMinimumSize(turningPointsDialog.getSize());
+        turningPointsDialog.setLocationRelativeTo(null);
+        turningPointsDialog.setVisible(true);
+    }
+
+    /**
+     * Retrieves turning points based on the given era.
+     *
+     * @param era the era for which turning points are requested
+     * @return {@link TurningPoints} object containing the turning points, their dates, and era logo
+     */
+    private static TurningPoints getTurningPoints(int era) {
+        final String LOGO_DIRECTORY = "data/images/universe/";
+        final String LOGO_FILE_TYPE = ".png";
+
+        List<String> turningPoints;
+        List<LocalDate> turningPointDates;
+        ImageIcon eraLogo;
+
+        switch (era) {
+            case 0 -> {
+                turningPoints = List.of("TerranHegemonyFounded", "RiseOfTheBattleMek");
+                turningPointDates = List.of(
+                    LocalDate.of(2315, 6, 2),
+                    LocalDate.of(2475, 1, 1));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_starleague" + LOGO_FILE_TYPE);
+            }
+            case 1 -> {
+                turningPoints = List.of("ReunificationWar", "FirstHiddenWar", "SecondHiddenWar",
+                    "ThirdHiddenWar", "AmarisCivilWar");
+                turningPointDates = List.of(
+                    LocalDate.of(2571, 1, 1),
+                    LocalDate.of(2681, 1, 1),
+                    LocalDate.of(2725, 1, 1),
+                    LocalDate.of(2741, 1, 1),
+                    LocalDate.of(2766, 11, 26));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_starleague" + LOGO_FILE_TYPE);
+            }
+            case 2 -> {
+                turningPoints = List.of("OperationExodus", "OperationKlondike", "SecondSuccessionWar",
+                    "ThirdSuccessionWar");
+                turningPointDates = List.of(
+                    LocalDate.of(2784, 2, 14),
+                    LocalDate.of(2821, 7, 2),
+                    LocalDate.of(2830, 1, 1),
+                    LocalDate.of(2866, 1, 1));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_sw" + LOGO_FILE_TYPE);
+            }
+            case 3 -> {
+                turningPoints = List.of("OperationFreedom");
+                turningPointDates = List.of(LocalDate.of(2866, 1, 1));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_sw" + LOGO_FILE_TYPE);
+            }
+            case 4 -> {
+                turningPoints = List.of("ThirdSuccessionWarEnds", "ForthSuccessionWar", "FRRFounded",
+                    "WarOf3039");
+                turningPointDates = List.of(
+                    LocalDate.of(3025, 1, 1),
+                    LocalDate.of(3028, 8, 20),
+                    LocalDate.of(3034, 3, 13),
+                    LocalDate.of(3039, 4, 16));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_sw" + LOGO_FILE_TYPE);
+            }
+            case 5 -> {
+                turningPoints = List.of("FirstContact", "YearOfPeace", "Tukayyid", "RefusalWar",
+                    "OperationBulldog");
+                turningPointDates = List.of(
+                    LocalDate.of(3049, 1, 1),
+                    LocalDate.of(3050, 10, 31),
+                    LocalDate.of(3052, 5, 1),
+                    LocalDate.of(3057, 9, 1),
+                    LocalDate.of(3059, 5, 1));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_claninvasion" + LOGO_FILE_TYPE);
+            }
+            case 6 -> {
+                turningPoints = List.of("FCCWStarts", "JadeFalconOffensive");
+                turningPointDates = List.of(
+                    LocalDate.of(3062, 11, 16),
+                    LocalDate.of(3064, 5, 10));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_civilwar" + LOGO_FILE_TYPE);
+            }
+            case 7 -> {
+                turningPoints = List.of("FirstBattleOfHarlech", "WarsOfReaving", "OperationScour");
+                turningPointDates = List.of(
+                    LocalDate.of(3067, 10, 15),
+                    LocalDate.of(3071, 12, 1),
+                    LocalDate.of(3077, 1, 10));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_jihad" + LOGO_FILE_TYPE);
+            }
+            case 8 -> {
+                turningPoints = List.of("RepublicFounded", "OperationGoldenDawn");
+                turningPointDates = List.of(
+                    LocalDate.of(3081, 3, 7),
+                    LocalDate.of(3081, 4, 3));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_darkage" + LOGO_FILE_TYPE);
+            }
+            case 9 -> {
+                turningPoints = List.of("SecondCombineDominionWar", "VictoriaWar", "CapellanCrusades");
+                turningPointDates = List.of(
+                    LocalDate.of(3098, 9, 14),
+                    LocalDate.of(3103, 9, 7),
+                    LocalDate.of(3111, 10, 11));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_darkage" + LOGO_FILE_TYPE);
+            }
+            case 10 -> {
+                turningPoints = List.of("GreyMonday");
+                turningPointDates = List.of(LocalDate.of(3132, 8, 7));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_darkage" + LOGO_FILE_TYPE);
+            }
+            case 11 -> {
+                turningPoints = List.of("BattleOfTerra");
+                turningPointDates = List.of(LocalDate.of(3151, 1, 1));
+                eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_ilclan" + LOGO_FILE_TYPE);
+            }
+            default -> throw new IllegalStateException(
+                "Unexpected value mekhq/gui/turningPointsDialog/DateChooser.java/turningPointsDialog: "
+                + era);
+        }
+
+        return new TurningPoints(turningPoints, turningPointDates, eraLogo);
+    }
+
+    /**
+     * Represents a record for storing turning points in history.
+     * Contains lists of turning point names, their corresponding dates, and an {@link ImageIcon} of the era logo.
+     */
+    private record TurningPoints(List<String> turningPoints, List<LocalDate> turningPointDates, ImageIcon eraLogo) {}
 }

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -651,7 +651,8 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         for (int index = 1; index <= turningPointData.turningPoints().size(); index++) {
             JButton eraButtonN = new JButton(String.format("<html><center><b>" + resources.getString(turningPointData.turningPoints().get(index - 1) + ".text")
                 + "</b><br>(" + finalTurningPointDates.get(index - 1).toString() + ")</center></html>"));
-            eraButtonN.setToolTipText(String.format(resources.getString(turningPointData.turningPoints().get(index - 1) + ".tooltip")));
+            eraButtonN.setToolTipText(wordWrap(String.format(
+                resources.getString(turningPointData.turningPoints().get(index - 1) + ".tooltip"))));
 
             final int finalIndex = index - 1;
             eraButtonN.addActionListener(e -> {


### PR DESCRIPTION
Introduced a turning points dialog with comprehensive descriptions and selectable dates. This was a feature suggested by user feedback.

While this PR doesn't rely on [6053](https://github.com/MegaMek/megamek/pull/6053), the tooltips are unusable without it.