### PR TITLE
Fix a/an grammar in camops personnel market notification

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -151,8 +151,12 @@ public class PersonnelMarket {
                 stringBuilder.append(':');
                 Person person = personnel.get(0);
                 String expLevel = SkillType.getExperienceLevelName(person.getExperienceLevel(campaign, false));
-                stringBuilder.append("<br>A ")
-                    .append("<b> ")
+                if (expLevel.equals("Elite") || expLevel.equals("Ultra-Green")) {
+                    stringBuilder.append("<br>An ");
+                } else {
+                    stringBuilder.append("<br>A ");
+                }
+                stringBuilder.append("<b> ")
                     .append(expLevel)
                     .append(' ')
                     .append(person.getPrimaryRole().toString())


### PR DESCRIPTION
This fixes the grammar in the CamOps personnel market notification to use "An" for the exp levels starting with a vowel and "A" for the others.