### PR TITLE
Camops Paid Recrutiment Removal

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -555,6 +555,9 @@ public class PersonnelMarketDialog extends JDialog {
     @Override
     public void setVisible(boolean visible) {
         filterPersonnel();
+        if (tablePersonnel.getRowCount() != 0) {
+            tablePersonnel.setRowSelectionInterval(0,0);
+        }
         super.setVisible(visible);
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -183,7 +183,10 @@ public class PersonnelMarketDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         panelFilterBtns.add(comboPersonType, gridBagConstraints);
 
-        if (campaign.getCampaignOptions().isUseAtB() && !campaign.hasActiveContract()) {
+        boolean ATBoutofContract = campaign.getCampaignOptions().isUseAtB() && !campaign.hasActiveContract();
+        boolean usingCamOpsMarkets = campaign.getCampaignOptions().getPersonnelMarketName().equals("Campaign Ops");
+        if (ATBoutofContract && !usingCamOpsMarkets) {
+            // Paid recruitment is available
             radioNormalRoll.setText("Make normal roll next week");
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = 1;
@@ -229,6 +232,10 @@ public class PersonnelMarketDialog extends JDialog {
             } else {
                 radioNormalRoll.setSelected(true);
             }
+        } else {
+            // Turn off paid recruitment if it's not available
+            radioNormalRoll.setSelected(true);
+            personnelMarket.setPaidRecruitment(false);
         }
 
         scrollTablePersonnel.setMinimumSize(new Dimension(500, 400));

--- a/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PersonnelMarketDialog.java
@@ -183,9 +183,9 @@ public class PersonnelMarketDialog extends JDialog {
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         panelFilterBtns.add(comboPersonType, gridBagConstraints);
 
-        boolean ATBoutofContract = campaign.getCampaignOptions().isUseAtB() && !campaign.hasActiveContract();
+        boolean atbOutofContract = campaign.getCampaignOptions().isUseAtB() && !campaign.hasActiveContract();
         boolean usingCamOpsMarkets = campaign.getCampaignOptions().getPersonnelMarketName().equals("Campaign Ops");
-        if (ATBoutofContract && !usingCamOpsMarkets) {
+        if (atbOutofContract && !usingCamOpsMarkets) {
             // Paid recruitment is available
             radioNormalRoll.setText("Make normal roll next week");
             gridBagConstraints.gridx = 0;

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -9478,6 +9478,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             // region Markets Tab
             // Personnel Market
             options.setPersonnelMarketName(comboPersonnelMarketType.getSelectedItem());
+            if (comboPersonnelMarketType.getSelectedItem().equals("Campaign Ops")) {
+                campaign.getPersonnelMarket().setPaidRecruitment(false);
+            }
             options.setPersonnelMarketReportRefresh(chkPersonnelMarketReportRefresh.isSelected());
             for (final Entry<SkillLevel, JSpinner> entry : spnPersonnelMarketRandomRemovalTargets
                     .entrySet()) {


### PR DESCRIPTION
This fixes the real issue behind #4986: that paid recruitment is even available when camops markets are selected.

It adds camops markets as a reason not to show the paid recruitment controls. It also makes sure paid recruitment is turned if the controls are turned off, though this won't come into effect until the window is opened. 

Added bonus QoL: Since camops markets only have one person at a time, select the first person in the list automatically when opened. One less click and it doesn't really hurt other market types either.