### PR TITLE
Hacky Fix: Makes StratCon Scenario Generation Respect Non-Combat Flag in TO&E

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1087,6 +1087,7 @@ public class StratconRulesManager {
                 .mapToInt(key -> key)
                 .mapToObj(campaign::getForce).filter(force -> (force != null)
                         && !force.isDeployed()
+                        && force.isCombatForce()
                         && !forcesInTracks.contains(force.getId()))
                 .map(Force::getId)
                 .collect(Collectors.toList());
@@ -1122,16 +1123,6 @@ public class StratconRulesManager {
             Force force = campaign.getForce(key);
 
             if (force == null) {
-                continue;
-            }
-
-            //checks if force is flagged as combat in TOE
-            if (!force.isCombatForce()) {
-                continue;
-            }
-
-            //checks if force is not top level (suggested by Illiani)
-            if (force.getFormationLevel().getDepth() != 0) {
                 continue;
             }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1125,6 +1125,10 @@ public class StratconRulesManager {
                 continue;
             }
 
+            if (!force.isCombatForce()) {
+                continue;
+            }
+
             int primaryUnitType = force.getPrimaryUnitType(campaign);
             boolean noReinforcementRestriction = !reinforcements || (reinforcements
                     && (getReinforcementType(force.getId(), currentTrack, campaign,

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1125,7 +1125,13 @@ public class StratconRulesManager {
                 continue;
             }
 
+            //checks if force is flagged as combat in TOE
             if (!force.isCombatForce()) {
+                continue;
+            }
+
+            //checks if force is not top level (suggested by Illiani)
+            if (force.getFormationLevel().getDepth() != 0) {
                 continue;
             }
 


### PR DESCRIPTION
This is a very simple hacky fix to StratconRulesManager.java's scenario generation.

Please be aware I don't know how to write or add unit tests, so haven't done any of that here.

I've added a line that, when trying to generate a new scenario on a Monday, as well as Nick's original checks of whether a unit is already deployed and is assigned to a track, also checks if the force is flagged as combat.

I've seen it step over a force that was flagged as non-combat in a very simple test campaign using the debugger so I think this works, but this needs careful testing to make sure.

I've attached a save file to this PR that people can use to test by generating some contracts and then seeing if you ever get 'lance-truck' picked as the seed lance.

 It has one combat force and one non-combat force - lance-mek (combat) and lance-truck (non-combat).

[NonCombatTestUnit-Base.cpnx.gz](https://github.com/user-attachments/files/17298574/NonCombatTestUnit-Base.cpnx.gz)
