### PR TITLE
Implements #4946 - Adds Recent Promotion Modifier to Turnover System

### DIFF
--- a/MekHQ/resources/mekhq/resources/RetirementDefectionTracker.properties
+++ b/MekHQ/resources/mekhq/resources/RetirementDefectionTracker.properties
@@ -25,3 +25,4 @@ founder.text=Founder
 shares.text=Shares
 administrativeStrain.text=Admin Strain
 managementSkill.text=Management Skill
+recentpromotion.text=Recently Promoted

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -180,7 +180,7 @@ public class RetirementDefectionTracker {
                 long monthsBetween = ChronoUnit.MONTHS.between(lastPromotionDate, today);
 
                 if (monthsBetween <= 6) {
-                    targetNumber.addModifier(- 1, resources.getString("recentpromotion.text"))
+                    targetNumber.addModifier(- 1, resources.getString("recentpromotion.text"));
                 }
             }
 

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -172,6 +172,18 @@ public class RetirementDefectionTracker {
                         resources.getString("desirability.text"));
             }
 
+            // Recent Promotion Modifier
+            if (campaign.getCampaignOptions().isUseSkillModifiers()) {
+                LocalDate today = campaign.getLocalDate();
+                LocalDate lastPromotionDate = person.getLastRankChangeDate();
+
+                long monthsBetween = ChronoUnit.MONTHS.between(lastPromotionDate, today);
+
+                if (monthsBetween <= 6) {
+                    targetNumber.addModifier(- 1, resources.getString("recentpromotion.text"))
+                }
+            }
+
             // Fatigue modifier
             if ((campaign.getCampaignOptions().isUseFatigue())
                     && (campaign.getCampaignOptions().isUseFatigueModifiers())) {


### PR DESCRIPTION
This PR implements RFE #4946. 

After discussion and code help from @IllianiCBT I've implemented a -1 modifier to the TN, if a person has been promoted in the last 6 months.

In future this should have a campaign option, but that's not done until CO IIC is done.

Tested and observed working in an MHQ test campaign.