### PR TITLE
Cleanup related to new naming scheme and refactoring, fixes refits to blank model names.

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -1331,23 +1331,21 @@ public class Utilities {
      * @throws EntityLoadingException
      */
     public static MekSummary retrieveOriginalUnit(Entity newE) throws EntityLoadingException {
-        MekSummaryCache cacheInstance = MekSummaryCache.getInstance();
-        cacheInstance.loadMekData();
-
+        // this might be better with refreshUnitData() and/or elsewhere
+        MekSummaryCache.getInstance().loadMekData();
+        
         // I need to change the new entity to the one from the mtf file now, so that
         // equipment numbers will match
-        MekSummary summary = cacheInstance.getMek(newE.getFullChassis() + ' ' + newE.getModel());
-
-        if (null == summary) {
-            // Attempt to deal with new naming convention directly
-            summary = cacheInstance.getMek(
-                    newE.getChassis() + " (" + newE.getClanChassisName() + ") " + newE.getModel());
-        }
+        return retrieveUnit(newE.getShortNameRaw());
+    }
+    
+    public static MekSummary retrieveUnit(String shortNameRaw) throws EntityLoadingException {
+        MekSummary summary = MekSummaryCache.getInstance().getMek(shortNameRaw);
 
         // If we got this far with no summary loaded, give up
         if (null == summary) {
-            throw new EntityLoadingException(String.format("Could not load %s %s from the mek cache",
-                    newE.getChassis(), newE.getModel()));
+            throw new EntityLoadingException(String.format("Could not load %s from the mek cache",
+                    shortNameRaw));
         }
 
         return summary;

--- a/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ChooseRefitDialog.java
@@ -40,6 +40,7 @@ import javax.swing.table.TableRowSorter;
 
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
+import megamek.codeUtilities.StringUtility;
 import megamek.common.Entity;
 import megamek.common.MekFileParser;
 import megamek.common.MekSummary;
@@ -287,17 +288,11 @@ public class ChooseRefitDialog extends JDialog {
     private void populateRefits() {
         List<Refit> refits = new ArrayList<>();
         Entity e = unit.getEntity();
+        String chassis = e.getFullChassis();
         for (String model : Utilities.getAllVariants(e, campaign)) {
-            MekSummary summary = MekSummaryCache.getInstance().getMek(e.getFullChassis() + " " + model);
-            if (null == summary) {
-                // Attempt to deal with new naming scheme directly
-                summary = MekSummaryCache.getInstance()
-                        .getMek(e.getChassis() + " (" + e.getClanChassisName() + ") " + model);
-                if (null == summary) {
-                    continue;
-                }
-            }
+            model = StringUtility.isNullOrBlank(model) ? "" : " " + model;
             try {
+                MekSummary summary = Utilities.retrieveUnit(chassis + model);
                 Entity refitEn = new MekFileParser(summary.getSourceFile(), summary.getEntryName()).getEntity();
                 if (null != refitEn) {
                     Refit r = new Refit(unit, refitEn, false, false, false);


### PR DESCRIPTION
Removed old kludges obsoleted by getFullChassis()
Refactoring of retrieveOriginalUnit() to enable
refactoring of populateRefits() that properly throws exceptions.

This fixes the bug that ever since `(Standard)` was purged from model names, those models with now blank names stopped showing up as targets for refits in the GUI.
And if something similar happens again we will get an EntityLoadingException now.

Screenshots from 49.7 (last milestone before the bug) vs 50.0 vs this commit for illustration purposes.
![MekHQ refit bug3](https://github.com/user-attachments/assets/41fb331e-1ae5-477c-b421-69baf2c7667f)
![MekHQ refit bug1](https://github.com/user-attachments/assets/cd2e2c34-2599-4c9b-9001-eb851f2e949c)
![MekHQ refit bug5](https://github.com/user-attachments/assets/1697c5bd-f210-4b58-899a-b4fb1888c158)