### PR TITLE
Fix #5028 and allow random camo to go into deeper directories

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -260,7 +260,8 @@ public class AtBContract extends Contract {
             Path randomPath = allPaths.get(new Random().nextInt(allPaths.size()));
 
             String fileName = randomPath.getFileName().toString();
-            String fileCategory = randomPath.getParent().toString(); // randomFile.getParent().replaceAll("\\\\", "/");
+            String fileCategory = randomPath.getParent().toString()
+                .replaceAll("\\\\", "/"); // Is this necessary on windows machines?
             fileCategory = fileCategory.replaceAll(ROOT_DIRECTORY, "");
 
             return new Camouflage(fileCategory, fileName);


### PR DESCRIPTION
The random camouflage picker was sometimes picking directories instead of files to use as camo for a group in a generated contract. It also wasn't going into all of the subdirectories, only the first level under the faction, so some files were getting left out. This fixes both of those problems. 

It seems like Camoflauge or AbstractIcon should have some verification that the files you pass them exist, but...