### PR TITLE
Corrected Scenario Modifiers for `HouseOfficer` units

### DIFF
--- a/MekHQ/data/scenariomodifiers/HouseOfficerAir.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerAir.xml
@@ -8,9 +8,9 @@
         <allowedUnitType>9</allowedUnitType>
         <arrivalTurn>0</arrivalTurn>
         <canReinforceLinked>false</canReinforceLinked>
-        <contributesToBV>false</contributesToBV>
+        <contributesToBV>true</contributesToBV>
         <contributesToMapSize>true</contributesToMapSize>
-        <contributesToUnitCount>false</contributesToUnitCount>
+        <contributesToUnitCount>true</contributesToUnitCount>
         <deployOffboard>false</deployOffboard>
         <deploymentZones />
         <destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
@@ -12,9 +12,9 @@
         <allowedUnitType>0</allowedUnitType>
         <arrivalTurn>0</arrivalTurn>
         <canReinforceLinked>false</canReinforceLinked>
-        <contributesToBV>false</contributesToBV>
+        <contributesToBV>true</contributesToBV>
         <contributesToMapSize>true</contributesToMapSize>
-        <contributesToUnitCount>false</contributesToUnitCount>
+        <contributesToUnitCount>true</contributesToUnitCount>
         <deployOffboard>false</deployOffboard>
         <deploymentZones />
         <destinationZone>5</destinationZone>


### PR DESCRIPTION
Changed `HouseOfficerAir` and `HouseOfficerGround` XML files to ensure both now correctly contribute to BV and unit count.