### PR TITLE
Clarify map dimensions in scenario displays

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -847,7 +847,7 @@ public class CustomizeScenarioDialog extends JDialog {
         rightGbc.gridy++;
         panMap.add(new JLabel(resourceMap.getString("lblMapSize.text")), leftGbc);
         sb = new StringBuilder();
-        sb.append(mapSizeX).append(" x ").append(mapSizeY);
+        sb.append(mapSizeX).append(" W x ").append(mapSizeY).append(" H");
         lblMapSize = new JLabel(sb.toString());
         panMap.add(lblMapSize, rightGbc);
     }
@@ -862,7 +862,7 @@ public class CustomizeScenarioDialog extends JDialog {
         }
         lblMap.setText(sb.toString());
         sb = new StringBuilder();
-        sb.append(mapSizeX).append(" x ").append(mapSizeY);
+        sb.append(mapSizeX).append(" W x ").append(mapSizeY).append(" H");
         lblMapSize.setText(sb.toString());
     }
 

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -539,7 +539,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
             chkReroll[REROLL_MAPSIZE].addItemListener(checkBoxListener);
         }
 
-        lblMapSizeDesc.setText(scenario.getMapX() + "x" + scenario.getMapY());
+        lblMapSizeDesc.setText(scenario.getMapX() + " W x " + scenario.getMapY() + " H");
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = y++;
         panStats.add(lblMapSizeDesc, gridBagConstraints);
@@ -721,7 +721,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
             chkReroll[REROLL_MAPSIZE].addItemListener(checkBoxListener);
         }
 
-        lblMapSizeDesc.setText(scenario.getMapSizeX() + "x" + scenario.getMapSizeY());
+        lblMapSizeDesc.setText(scenario.getMapSizeX() + " W x " + scenario.getMapSizeY() + " H");
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = y++;
         panStats.add(lblMapSizeDesc, gridBagConstraints);
@@ -764,7 +764,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
             chkReroll[REROLL_MAPSIZE].addItemListener(checkBoxListener);
         }
 
-        lblMapSizeDesc.setText(scenario.getMapSizeX() + "x" + scenario.getMapSizeY());
+        lblMapSizeDesc.setText(scenario.getMapSizeX() + " W x " + scenario.getMapSizeY() + " H");
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = y++;
         panStats.add(lblMapSizeDesc, gridBagConstraints);

--- a/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
@@ -412,7 +412,7 @@ public class ScenarioViewPanel extends JScrollablePanel {
         leftGbc.gridy++;
         pnlMap.add(lblMapSize, leftGbc);
 
-        JLabel lblMapSizeDesc = new JLabel(scenario.getMapSizeX() + "x" + scenario.getMapSizeY());
+        JLabel lblMapSizeDesc = new JLabel(scenario.getMapSizeX() + " W x " + scenario.getMapSizeY() + " H");
         rightGbc.gridy++;
         pnlMap.add(lblMapSizeDesc, rightGbc);
 


### PR DESCRIPTION
Minor tweak to show which is width and which is height, because we always get confused here and it matters for cross-the-map objectives.

![2024-10-12_160445](https://github.com/user-attachments/assets/8c787ba3-564c-4495-bbc2-3bd4e448c1ce)
