### PR TITLE
Multiple FG3 Improvements

### DIFF
--- a/MekHQ/data/scenariomodifiers/AlliedASFAce01.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedASFAce01.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>One of your employer's ASF Aces is close and is moving to support. Watch
-		and learn.</additionalBriefingText>
+	<additionalBriefingText>One of your employer's ASF Aces is close and is moving to support. Watch and learn.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/AlliedAirSupport.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedAirSupport.xml
@@ -8,9 +8,9 @@
 		<allowedUnitType>-3</allowedUnitType>
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>false</contributesToBV>
+		<contributesToBV>true</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>false</contributesToUnitCount>
+		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedAirSupportBombers.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedAirSupportBombers.xml
@@ -8,9 +8,9 @@
 		<allowedUnitType>-3</allowedUnitType>
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>false</contributesToBV>
+		<contributesToBV>true</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>false</contributesToUnitCount>
+		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedArtyGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedArtyGarrison.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>This facility is defended by an additional force of allied artillery who
-		have been unable to clear the area.</additionalBriefingText>
+	<additionalBriefingText>This facility is defended by an additional force of allied artillery who have been unable to clear the area.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/AlliedArtySupport.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedArtySupport.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>1</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>false</contributesToBV>
+		<contributesToBV>true</contributesToBV>
 		<contributesToMapSize>false</contributesToMapSize>
-		<contributesToUnitCount>false</contributesToUnitCount>
+		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>true</deployOffboard>
 		<deploymentZones>
 			<deploymentZone>9</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedGroundSupport.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedGroundSupport.xml
@@ -14,7 +14,7 @@
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>
 			<deploymentZone>2</deploymentZone>
@@ -30,7 +30,7 @@
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>1</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
-		<forceName>Allied Ground Reinforcements</forceName>
+		<forceName>Ground Reinforcements</forceName>
 		<generationMethod>3</generationMethod>
 		<generationOrder>3</generationOrder>
 		<maxWeightClass>4</maxWeightClass>

--- a/MekHQ/data/scenariomodifiers/AlliedHorseCav.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedHorseCav.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>From half a league onward a Mercenary Light Brigade of Horse Cavalry rides
-		into the valley of death to assist.</additionalBriefingText>
+	<additionalBriefingText>From half a league onward a Mercenary Light Brigade of Horse Cavalry rides into the valley of death to assist.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/AlliedMekAceCRD.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekAceCRD.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>One of your employer's Aces is close and is moving to support. Watch and
-		learn.</additionalBriefingText>
+	<additionalBriefingText>One of your employer's Aces is close and is moving to support. Watch and learn.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/AlliedMekAceGLT.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekAceGLT.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>One of your employer's Aces is close and is moving to support. Watch and
-		learn.</additionalBriefingText>
+	<additionalBriefingText>One of your employer's Aces is close and is moving to support. Watch and learn.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/AlliedMekAceGOL.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekAceGOL.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>One of your employer's Aces is close and is moving to support. Watch and
-		learn.</additionalBriefingText>
+	<additionalBriefingText>One of your employer's Aces is close and is moving to support. Watch and learn.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/AlliedMekAceOTT.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekAceOTT.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>One of your employer's Aces is close and is moving to support. Watch and
-		learn.</additionalBriefingText>
+	<additionalBriefingText>One of your employer's Aces is close and is moving to support. Watch and learn.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/AlliedMekAceTBT.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekAceTBT.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>One of your employer's Aces is close and is moving to support. Watch and
-		learn.</additionalBriefingText>
+	<additionalBriefingText>One of your employer's Aces is close and is moving to support. Watch and learn.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/AlliedMekGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekGarrison.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>This facility is guarded by a lance of allied meks who will fight
-		alongside us in its defense.</additionalBriefingText>
+	<additionalBriefingText>This facility is guarded by a lance of allied meks who will fight alongside us in its defense.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/AlliedReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedReinforcements.xml
@@ -14,7 +14,7 @@
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>
 			<deploymentZone>2</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedTankGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTankGarrison.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>This facility has a garrison of tanks, which will fight alongside your
-		force in the facility's defense.</additionalBriefingText>
+	<additionalBriefingText>This facility has a garrison of tanks, which will fight alongside your force in the facility's defense.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
@@ -15,7 +14,7 @@
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>true</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>false</contributesToUnitCount>
+		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedTankReinforcements.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTankReinforcements.xml
@@ -14,7 +14,7 @@
 		<canReinforceLinked>true</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>1</deploymentZone>
 			<deploymentZone>2</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedTraineesAir.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTraineesAir.xml
@@ -12,7 +12,7 @@
 		<allowedUnitType>9</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>false</contributesToBV>
+		<contributesToBV>true</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>

--- a/MekHQ/data/scenariomodifiers/AlliedTraineesGround.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTraineesGround.xml
@@ -12,7 +12,7 @@
 		<allowedUnitType>0</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>false</contributesToBV>
+		<contributesToBV>true</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>

--- a/MekHQ/data/scenariomodifiers/AlliedTurrets.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTurrets.xml
@@ -14,7 +14,7 @@
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>true</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>false</contributesToUnitCount>
+		<contributesToUnitCount>true</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>
 		</deploymentZones>

--- a/MekHQ/data/scenariomodifiers/BadIntelAir.xml
+++ b/MekHQ/data/scenariomodifiers/BadIntelAir.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>Recon underestimated enemy strength, and additional enemy units are
-		present.</additionalBriefingText>
+	<additionalBriefingText>Recon underestimated enemy strength, and additional enemy units are present.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/BadIntelGround.xml
+++ b/MekHQ/data/scenariomodifiers/BadIntelGround.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>Recon underestimated enemy strength, and additional enemy units are
-		present.</additionalBriefingText>
+	<additionalBriefingText>Recon underestimated enemy strength, and additional enemy units are present.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
@@ -31,7 +30,7 @@
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>2</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
-		<forceName>Additional Ground Units</forceName>
+		<forceName>Additional OpFor</forceName>
 		<generationMethod>3</generationMethod>
 		<generationOrder>3</generationOrder>
 		<maxWeightClass>4</maxWeightClass>

--- a/MekHQ/data/scenariomodifiers/EnemyAirCav.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyAirCav.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>A force of enemy VTOLs coming in low over the horizon. Don't let this be
-		the apocalypse.</additionalBriefingText>
+	<additionalBriefingText>A force of enemy VTOLs coming in low over the horizon. Don't let this be the apocalypse.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/EnemyAirSupportBombers.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyAirSupportBombers.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>Enemy aircraft detected on approach and will arrive shortly after the
-		start of the battle.</additionalBriefingText>
+	<additionalBriefingText>Enemy aircraft detected on approach and will arrive shortly after the start of the battle.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<forceDefinition>

--- a/MekHQ/data/scenariomodifiers/EnemyArtyGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyArtyGarrison.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>This facility is defended by an additional force of enemy artillery who
-		have been unable to clear the area.</additionalBriefingText>
+	<additionalBriefingText>This facility is defended by an additional force of enemy artillery who have been unable to clear the area.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/EnemyHotDrop.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyHotDrop.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>Enemy DropShip has been detected in the area. Telemetry indicates it's at
-		least partially loaded. Expect additional hostile units to be deployed via airdrop.</additionalBriefingText>
+	<additionalBriefingText>Enemy DropShip has been detected in the area. Telemetry indicates it's at least partially loaded. Expect additional hostile units to be deployed via airdrop.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/EnemyMercBrawl.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyMercBrawl.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>The Enemy has hired a Mercenary Brawler Lance with veteran markings.
-		Beware.</additionalBriefingText>
+	<additionalBriefingText>The Enemy has hired a Mercenary Brawler Lance with veteran markings. Beware.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/EnemyMercFireSupport.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyMercFireSupport.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>The Enemy has hired a Mercenary Fire Support Lance with veteran markings.
-		Keep your head down.</additionalBriefingText>
+	<additionalBriefingText>The Enemy has hired a Mercenary Fire Support Lance with veteran markings. Keep your head down.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/EnemyMercHopInfantry.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyMercHopInfantry.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>A horn heralds the arrival of an Enemy unit of Coventry Kangaroo Cavalry.
-		Beware.</additionalBriefingText>
+	<additionalBriefingText>A horn heralds the arrival of an Enemy unit of Coventry Kangaroo Cavalry. Beware.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/EnemyMercSkirmish.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyMercSkirmish.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>OpFor Mercenary Skirmishers with veteran markings are in the area. Don't
-		get flanked.</additionalBriefingText>
+	<additionalBriefingText>OpFor Mercenary Skirmishers with veteran markings are in the area. Don't get flanked.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/EnemyMercSkyInfantry.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyMercSkyInfantry.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>The flap of leathery wings announces the arrival of an Enemy unit of
-		Branth Sky Infantry. Beware.</additionalBriefingText>
+	<additionalBriefingText>The flap of leathery wings announces the arrival of an Enemy unit of Branth Sky Infantry. Beware.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/FacilityAlliedEvac.xml
+++ b/MekHQ/data/scenariomodifiers/FacilityAlliedEvac.xml
@@ -10,7 +10,7 @@
         <canReinforceLinked>true</canReinforceLinked>
         <contributesToBV>true</contributesToBV>
         <contributesToMapSize>true</contributesToMapSize>
-        <contributesToUnitCount>false</contributesToUnitCount>
+        <contributesToUnitCount>true</contributesToUnitCount>
         <deployOffboard>false</deployOffboard>
         <deploymentZones>
             <deploymentZone>10</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/FacilityHostileCapture.xml
+++ b/MekHQ/data/scenariomodifiers/FacilityHostileCapture.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>This facility must be captured: 75% of the designated buildings must
-		remain intact.</additionalBriefingText>
+	<additionalBriefingText>This facility must be captured: 75% of the designated buildings must remain intact.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<modifierName>Capture</modifierName>
@@ -27,8 +26,7 @@
 			<additionalDetails>
 				<additionalDetail>Crippled turrets are considered intact for the purposes of this objective.</additionalDetail>
 			</additionalDetails>
-			<description>Leave intact the following force(s) and unit(s) to be able to take control of
-				this facility:</description>
+			<description>Leave intact the following force(s) and unit(s) to be able to take control of this facility:</description>
 			<destinationEdge>NONE</destinationEdge>
 			<objectiveCriterion>Preserve</objectiveCriterion>
 			<percentage>75</percentage>

--- a/MekHQ/data/scenariomodifiers/FacilityHostileCaptureNonWin.xml
+++ b/MekHQ/data/scenariomodifiers/FacilityHostileCaptureNonWin.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>This facility can be captured if 75% of the designated buildings remain
-		intact with 75% of the hostile forces destroyed, crippled or forced to withdraw.</additionalBriefingText>
+	<additionalBriefingText>This facility can be captured if 75% of the designated buildings remain intact with 75% of the hostile forces destroyed, crippled or forced to withdraw.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<modifierName>Capture</modifierName>
@@ -27,8 +26,7 @@
 			<additionalDetails>
 				<additionalDetail>Crippled turrets are considered intact for the purposes of this objective.</additionalDetail>
 			</additionalDetails>
-			<description>Leave intact at least 75% of the following force(s) and unit(s) in order to be
-				able to take control of this facility:</description>
+			<description>Leave intact at least 75% of the following force(s) and unit(s) in order to be able to take control of this facility:</description>
 			<destinationEdge>NONE</destinationEdge>
 			<objectiveCriterion>Preserve</objectiveCriterion>
 			<percentage>75</percentage>
@@ -56,8 +54,7 @@
 				</failureEffect>
 			</failureEffects>
 			<additionalDetails />
-			<description>Destroy, cripple or force the withdrawal of 75% of the following force(s) and
-				unit(s) to take control of the facility:</description>
+			<description>Destroy, cripple or force the withdrawal of 75% of the following force(s) and unit(s) to take control of the facility:</description>
 			<destinationEdge>NONE</destinationEdge>
 			<objectiveCriterion>ForceWithdraw</objectiveCriterion>
 			<percentage>75</percentage>

--- a/MekHQ/data/scenariomodifiers/GoodIntel.xml
+++ b/MekHQ/data/scenariomodifiers/GoodIntel.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>Recon over-estimated enemy strength. A group of enemy units are not
-		present.</additionalBriefingText>
+	<additionalBriefingText>Recon over-estimated enemy strength. A group of enemy units are not present.</additionalBriefingText>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<eventRecipient>Opposing</eventRecipient>

--- a/MekHQ/data/scenariomodifiers/GroundedEnemyDropship.xml
+++ b/MekHQ/data/scenariomodifiers/GroundedEnemyDropship.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>An enemy DropShip has been grounded in this area, but its weapons are
-		still active so pay attention.</additionalBriefingText>
+	<additionalBriefingText>An enemy DropShip has been grounded in this area, but its weapons are still active so pay attention.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariomodifiers/HostileBVBudgetIncrease.xml
+++ b/MekHQ/data/scenariomodifiers/HostileBVBudgetIncrease.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>Local coordination has allowed the opposition to deploy a larger force to
-		respond to your presence.</additionalBriefingText>
+	<additionalBriefingText>Local coordination has allowed the opposition to deploy a larger force to respond to your presence.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<eventRecipient>Opposing</eventRecipient>

--- a/MekHQ/data/scenariomodifiers/PreBattleDamageAllies.xml
+++ b/MekHQ/data/scenariomodifiers/PreBattleDamageAllies.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>The allied units have not been fully repaired from their previous
-		engagement.</additionalBriefingText>
+	<additionalBriefingText>The allied units have not been fully repaired from their previous engagement.</additionalBriefingText>
 	<benefitsPlayer>false</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<eventRecipient>Allied</eventRecipient>

--- a/MekHQ/data/scenariomodifiers/PreBattleDamageHostiles.xml
+++ b/MekHQ/data/scenariomodifiers/PreBattleDamageHostiles.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>The hostile force appears to have suffered some minor battle damage in a
-		previous engagement.</additionalBriefingText>
+	<additionalBriefingText>The hostile force appears to have suffered some minor battle damage in a previous engagement.</additionalBriefingText>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PostForceGeneration</eventTiming>
 	<eventRecipient>Opposing</eventRecipient>

--- a/MekHQ/data/scenariomodifiers/PrimaryAlliesAir.xml
+++ b/MekHQ/data/scenariomodifiers/PrimaryAlliesAir.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>To compensate for the presence of a large opposing force, allied units
-		will be working alongside us on this operation.</additionalBriefingText>
+	<additionalBriefingText>To compensate for the presence of a large opposing force, allied units will be working alongside us on this operation.</additionalBriefingText>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>
@@ -11,7 +10,7 @@
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/PrimaryAlliesGround.xml
+++ b/MekHQ/data/scenariomodifiers/PrimaryAlliesGround.xml
@@ -1,6 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>To compensate for the presence of a large opposing force, allied units
-		will be working alongside us on this operation.</additionalBriefingText>
+	<additionalBriefingText>To compensate for the presence of a large opposing force, allied units will be working alongside us on this operation.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
@@ -15,7 +14,7 @@
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/airBattleModifiers.xml
+++ b/MekHQ/data/scenariomodifiers/airBattleModifiers.xml
@@ -74,7 +74,7 @@
 		<modifier>
 			EnemyAirPatrol.xml
 		</modifier>
-		<modifier>
+		<!--modifier>
 			AlliedASFAce01.xml
 		</modifier>
 		<modifier>
@@ -82,6 +82,6 @@
 		</modifier>
 		<modifier>
 			EnemyASFAce02.xml
-		</modifier>
+		</modifier-->
 	</modifiers>
 </scenarioModifierManifest>

--- a/MekHQ/data/scenariomodifiers/groundBattleModifiers.xml
+++ b/MekHQ/data/scenariomodifiers/groundBattleModifiers.xml
@@ -159,7 +159,7 @@
 		<modifier>
 			EnemyMekPatrol.xml
 		</modifier>
-		<modifier>
+		<!--modifier>
 			EnemyAceMekARC2R.xml
 		</modifier>
 		<modifier>
@@ -179,17 +179,17 @@
 		</modifier>
 		<modifier>
 			EnemyAceMekPXH1D.xml
-		</modifier>
+		</modifier-->
 		<modifier>
 			EnemyAirCav.xml
 		</modifier>
 		<modifier>
 			EnemyAirMobileInf.xml
 		</modifier>
-		<modifier>
+		<!--modifier>
 			EnemyMercFireSupport.xml
 		</modifier>
-		<modifier>
+		<-modifier>
 			EnemyMercBrawl.xml
 		</modifier>
 		<modifier>
@@ -215,7 +215,7 @@
 		</modifier>
 		<modifier>
 			AlliedMekAceTBT.xml
-		</modifier>
+		</modifier-->
 		<modifier>
 			AlliedOfficerMek.xml
 		</modifier>
@@ -228,20 +228,20 @@
 		<modifier>
 			AlliedHorseCav.xml
 		</modifier>
-		<modifier>
+		<!--modifier>
 			AlliedASFAce01.xml
-		</modifier>
+		</modifier-->
 		<modifier>
 			EnemyFieldArtyCrack.xml
 		</modifier>
 		<modifier>
 			EnemyFieldArtyOffboard.xml
 		</modifier>
-		<modifier>
+		<!--modifier>
 			EnemyASFAce01.xml
 		</modifier>
 		<modifier>
 			EnemyASFAce02.xml
-		</modifier>
+		</modifier-->
 	</modifiers>
 </scenarioModifierManifest>

--- a/MekHQ/data/scenariotemplates/DropShip Raid.xml
+++ b/MekHQ/data/scenariotemplates/DropShip Raid.xml
@@ -106,7 +106,7 @@
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
                 <forceName>DropShip</forceName>
-                <generationMethod>2</generationMethod>
+                <generationMethod>3</generationMethod>
                 <generationOrder>3</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>

--- a/MekHQ/data/scenariotemplates/Frontline Disruption.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Disruption.xml
@@ -129,9 +129,7 @@
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 50% of the following force(s) and unit(s) before they can reach the
-                destination
-                edge:</description>
+            <description>Destroy 50% of the following force(s) and unit(s) before they can reach the destination edge:</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Destroy</objectiveCriterion>
             <percentage>50</percentage>

--- a/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -91,67 +91,6 @@
     <scenarioObjectives>
         <scenarioObjective>
             <associatedForceNames>
-                <associatedForceName>OpFor</associatedForceName>
-            </associatedForceNames>
-            <associatedUnitIDs />
-            <successEffects>
-                <successEffect>
-                    <effectType>ScenarioVictory</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </successEffect>
-            </successEffects>
-            <failureEffects>
-                <failureEffect>
-                    <effectType>ScenarioDefeat</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </failureEffect>
-            </failureEffects>
-            <additionalDetails>
-                <additionalDetail>Scans may be conducted by moving a unit within three hexes of the
-                    target and foregoing all attacks.</additionalDetail>
-                <additionalDetail>Any kind of probe, improved sensors quirk or sensor geek SPA
-                    extends the range to five hexes, and the unit may attack as normal.</additionalDetail>
-                <additionalDetail>Note: This objective should be tracked manually outside of
-                    MegaMek.</additionalDetail>
-            </additionalDetails>
-            <description>Scan the following enemy unit(s) and force(s):</description>
-            <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>Custom</objectiveCriterion>
-            <percentage>100</percentage>
-            <timeLimitAtMost>true</timeLimitAtMost>
-            <timeLimitType>None</timeLimitType>
-        </scenarioObjective>
-        <scenarioObjective>
-            <associatedForceNames>
-                <associatedForceName>OpFor</associatedForceName>
-            </associatedForceNames>
-            <associatedUnitIDs />
-            <successEffects>
-                <successEffect>
-                    <effectType>ScenarioVictory</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </successEffect>
-            </successEffects>
-            <failureEffects>
-                <failureEffect>
-                    <effectType>ScenarioDefeat</effectType>
-                    <effectScaling>Fixed</effectScaling>
-                    <howMuch>1</howMuch>
-                </failureEffect>
-            </failureEffects>
-            <additionalDetails />
-            <description>Destroy or rout 50% of the following force(s) and unit(s):</description>
-            <destinationEdge>NONE</destinationEdge>
-            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-            <percentage>50</percentage>
-            <timeLimitAtMost>true</timeLimitAtMost>
-            <timeLimitType>None</timeLimitType>
-        </scenarioObjective>
-        <scenarioObjective>
-            <associatedForceNames>
                 <associatedForceName>Player</associatedForceName>
             </associatedForceNames>
             <associatedUnitIDs />
@@ -174,8 +113,9 @@
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>50</percentage>
-            <timeLimitAtMost>true</timeLimitAtMost>
-            <timeLimitType>None</timeLimitType>
+            <timeLimitAtMost>false</timeLimitAtMost>
+            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/MekHQ/resources/mekhq/resources/AtBDynamicScenarioFactory.properties
+++ b/MekHQ/resources/mekhq/resources/AtBDynamicScenarioFactory.properties
@@ -1,9 +1,7 @@
 # reportResultsOfBidding
-bidAwayForcesVerbose.text=%s (<b>%s/%s</b>) has bid away the following forces:<br><br>%s<br>
-bidAwayForcesLogger.text=%s (%s/%s) has bid away the following forces:
-bidAwayForces.text=%s (<b>%s/%s</b>) has bid away %s unit%s.
-nothingBidAway.text=%s (%s/%s) has not bid away any forces.<br>
-addedBattleArmorNewReport.text=%s (<b>%s/%s</b>) has supplemented their force with %s additional unit%s of Battle Armor.
+bidAwayForcesVerbose.text=%s has bid away the following forces:<br>%s
+bidAwayForcesLogger.text=%s has bid away the following forces:
+bidAwayForces.text=%s has bid away %s unit%s.
+nothingBidAway.text=%s has not bid away any forces.
+addedBattleArmorNewReport.text=%s supplemented their force with %s additional unit%s of Battle Armor.
 addedBattleArmorContinueReport.text=<br>They also supplemented their force with %s additional unit%s of Battle Armor.
-batchallConcludedVersion1.text=<br><br>"Bargained Well and Done."<br>
-batchallConcludedVersion2.text=<br><br>"Well-Bargained and Done."<br>

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3746,9 +3746,11 @@ public class Campaign implements ITechManager {
             }
         }
 
+        processNewDayATBScenarios();
+
         for (AtBContract contract : getActiveAtBContracts()) {
             if (campaignOptions.isUseGenericBattleValue()) {
-                if (contract.getStartDate().equals(getLocalDate()) && getLocation().isOnPlanet()) {
+                if (contract.getStartDate().equals(getLocalDate())) {
                     if (getCampaignOptions().isUseGenericBattleValue()
                         && BatchallFactions.usesBatchalls(contract.getEnemyCode())) {
                         contract.setBatchallAccepted(contract.initiateBatchall(this));
@@ -3756,8 +3758,6 @@ public class Campaign implements ITechManager {
                 }
             }
         }
-
-        processNewDayATBScenarios();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
@@ -25,7 +25,6 @@ import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
-import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.Person;
@@ -33,6 +32,7 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.universe.Faction;
+import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -189,21 +189,13 @@ public class AtBConfiguration {
     }
 
     public int weightClassIndex(String wc) {
-        switch (wc) {
-            case "L":
-            case "UL":
-                return 0;
-            case "M":
-                return 1;
-            case "H":
-                return 2;
-            case "A":
-            case "C":
-            case "SH":
-                return 3;
-            default:
-                throw new IllegalArgumentException("Could not parse weight class " + wc);
-        }
+        return switch (wc) {
+            case "L", "UL" -> 0;
+            case "M" -> 1;
+            case "H" -> 2;
+            case "A", "C", "SH" -> 3;
+            default -> throw new IllegalArgumentException("Could not parse weight class " + wc);
+        };
     }
 
     public @Nullable String selectBotLances(String org, int weightClass) {
@@ -273,22 +265,15 @@ public class AtBConfiguration {
      *         weight class
      */
     public static int decodeWeightStr(String s, int i) {
-        switch (s.charAt(i)) {
-            case WEIGHT_ULTRA_LIGHT:
-                return EntityWeightClass.WEIGHT_ULTRA_LIGHT;
-            case WEIGHT_LIGHT:
-                return EntityWeightClass.WEIGHT_LIGHT;
-            case WEIGHT_MEDIUM:
-                return EntityWeightClass.WEIGHT_MEDIUM;
-            case WEIGHT_HEAVY:
-                return EntityWeightClass.WEIGHT_HEAVY;
-            case WEIGHT_ASSAULT:
-                return EntityWeightClass.WEIGHT_ASSAULT;
-            case WEIGHT_SUPER_HEAVY:
-                return EntityWeightClass.WEIGHT_SUPER_HEAVY;
-            default:
-                return 0;
-        }
+        return switch (s.charAt(i)) {
+            case WEIGHT_ULTRA_LIGHT -> EntityWeightClass.WEIGHT_ULTRA_LIGHT;
+            case WEIGHT_LIGHT -> EntityWeightClass.WEIGHT_LIGHT;
+            case WEIGHT_MEDIUM -> EntityWeightClass.WEIGHT_MEDIUM;
+            case WEIGHT_HEAVY -> EntityWeightClass.WEIGHT_HEAVY;
+            case WEIGHT_ASSAULT -> EntityWeightClass.WEIGHT_ASSAULT;
+            case WEIGHT_SUPER_HEAVY -> EntityWeightClass.WEIGHT_SUPER_HEAVY;
+            default -> 0;
+        };
     }
 
     public static String getParentFactionType(final Faction faction) {
@@ -318,16 +303,12 @@ public class AtBConfiguration {
     }
 
     public @Nullable Integer shipSearchTargetBase(int unitType) {
-        switch (unitType) {
-            case UnitType.DROPSHIP:
-                return dropshipSearchTarget;
-            case UnitType.JUMPSHIP:
-                return jumpshipSearchTarget;
-            case UnitType.WARSHIP:
-                return warshipSearchTarget;
-            default:
-                return null;
-        }
+        return switch (unitType) {
+            case UnitType.DROPSHIP -> dropshipSearchTarget;
+            case UnitType.JUMPSHIP -> jumpshipSearchTarget;
+            case UnitType.WARSHIP -> warshipSearchTarget;
+            default -> null;
+        };
     }
 
     public TargetRoll shipSearchTargetRoll(int unitType, Campaign campaign) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -32,9 +32,7 @@ import megamek.common.enums.Gender;
 import megamek.common.enums.SkillLevel;
 import megamek.common.icons.Camouflage;
 import megamek.common.planetaryconditions.Atmosphere;
-import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.logging.MMLogger;
-import megamek.utilities.BoardClassifier;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -244,6 +242,7 @@ public class AtBDynamicScenarioFactory {
      * @return How many "lances" or other individual units were generated?
      */
     private static int generateForces(AtBDynamicScenario scenario, AtBContract contract, Campaign campaign) {
+        logger.info(String.format("GENERATING FORCES FOR: %s", scenario.getName().toUpperCase()));
         int generatedLanceCount = 0;
         List<ScenarioForceTemplate> forceTemplates = scenario.getTemplate().getAllScenarioForces();
 
@@ -269,6 +268,11 @@ public class AtBDynamicScenarioFactory {
         // generate all forces in a specific order level taking into account previously
         // generated but not current order levels.
         // recalculate effective BV and unit count each time we change levels
+
+        // how close to the allowances do we want to get?
+        int targetPercentage = 100 + ((Compute.randomInt(8) - 3) * 5);
+        logger.info(String.format("Target Percentage: %s", targetPercentage));
+
         for (int generationOrder : generationOrders) {
             List<ScenarioForceTemplate> currentForceTemplates = orderedForceTemplates.get(generationOrder);
             effectiveBV = calculateEffectiveBV(scenario, campaign, false);
@@ -279,6 +283,11 @@ public class AtBDynamicScenarioFactory {
                     generatedLanceCount += generateFixedForce(scenario, contract, campaign, forceTemplate);
                 } else {
                     int weightClass = randomForceWeight();
+
+                    if (forceTemplate.isEnemyBotForce()) {
+                        int adjustedBV = effectiveBV * (targetPercentage / 100);
+                        int adjustedUnitCount = effectiveUnitCount * (targetPercentage / 100);
+                    }
 
                     generatedLanceCount += generateForce(scenario, contract, campaign,
                             effectiveBV, effectiveUnitCount, weightClass, forceTemplate, false);
@@ -434,14 +443,16 @@ public class AtBDynamicScenarioFactory {
         int forceBVBudget = (int) (effectiveBV * forceTemplate.getForceMultiplier());
 
         if (isScenarioModifier) {
-            forceBVBudget = (int) (forceBVBudget * ((double) campaign.getCampaignOptions().getScenarioModBV() / 100) * forceTemplate.getForceMultiplier());
+            forceBVBudget = (int) (forceBVBudget * ((double) campaign.getCampaignOptions().getScenarioModBV() / 100)
+                * forceTemplate.getForceMultiplier());
         }
 
         int forceUnitBudget = 0;
 
         if (forceTemplate.getGenerationMethod() == ForceGenerationMethod.UnitCountScaled.ordinal()) {
             forceUnitBudget = (int) (effectiveUnitCount * forceTemplate.getForceMultiplier());
-        } else if ((forceTemplate.getGenerationMethod() == ForceGenerationMethod.FixedUnitCount.ordinal()) || (forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerOrFixedUnitCount.ordinal())) {
+        } else if ((forceTemplate.getGenerationMethod() == ForceGenerationMethod.FixedUnitCount.ordinal())
+            || (forceTemplate.getGenerationMethod() == ForceGenerationMethod.PlayerOrFixedUnitCount.ordinal())) {
             forceUnitBudget = forceTemplate.getFixedUnitCount() == ScenarioForceTemplate.FIXED_UNIT_SIZE_LANCE ? lanceSize : forceTemplate.getFixedUnitCount();
         }
 
@@ -450,35 +461,46 @@ public class AtBDynamicScenarioFactory {
         boolean isLowPressure = false;
         boolean isTainted = false;
         boolean allowsConvInfantry = true;
+        boolean allowsBattleArmor = true;
         boolean allowsTanks = true;
-        if (scenario.getAtmosphere().isLighterThan(Atmosphere.THIN)) {
-            isLowPressure = true;
-            allowsTanks = false;
-        } else {
-            mekhq.campaign.universe.Atmosphere specific_atmosphere = contract.getSystem().getPrimaryPlanet().getAtmosphere(currentDate);
-            switch (specific_atmosphere) {
-                case TOXICPOISON:
-                case TOXICCAUSTIC:
-                    allowsConvInfantry = false;
-                    allowsTanks = false;
-                    break;
-                case TAINTEDPOISON:
-                case TAINTEDCAUSTIC:
-                    isTainted = true;
-                    break;
-                default:
-                    break;
-            }
-        }
-        if (scenario.getWind().isTornadoF1ToF3() || scenario.getWind().isTornadoF4()) {
-            allowsConvInfantry = false;
-            if (scenario.getWind().isTornadoF4()) {
+
+        if (campaign.getCampaignOptions().isUsePlanetaryModifiers()) {
+            if (scenario.getAtmosphere().isLighterThan(Atmosphere.THIN)) {
+                isLowPressure = true;
                 allowsTanks = false;
+            } else {
+                mekhq.campaign.universe.Atmosphere specific_atmosphere =
+                    contract.getSystem().getPrimaryPlanet().getAtmosphere(currentDate);
+
+                switch (specific_atmosphere) {
+                    case TOXICPOISON:
+                    case TOXICCAUSTIC:
+                        allowsConvInfantry = false;
+                        allowsTanks = false;
+                        break;
+                    case TAINTEDPOISON:
+                    case TAINTEDCAUSTIC:
+                        isTainted = true;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            if (scenario.getGravity() <= 0.2) {
+                allowsTanks = false;
+                isLowGravity = true;
             }
         }
-        if (scenario.getGravity() <= 0.2) {
-            allowsTanks = false;
-            isLowGravity = true;
+
+        if (campaign.getCampaignOptions().isUseWeatherConditions()) {
+            if (scenario.getWind().isTornadoF1ToF3() || scenario.getWind().isTornadoF4()) {
+                allowsConvInfantry = false;
+                if (scenario.getWind().isTornadoF4()) {
+                    allowsTanks = false;
+                    allowsBattleArmor = false;
+                }
+            }
         }
 
         // Required roles for units in this force. Because these can vary by unit type,
@@ -551,9 +573,6 @@ public class AtBDynamicScenarioFactory {
         boolean stopGenerating = false;
         String currentLanceWeightString = "";
 
-        // how close to the BV allowance do we want to get?
-        int targetPercentage = 100 + ((Compute.randomInt(8) - 3) * 5);
-
         // Generate a tactical formation (lance/star/etc.) until the BV or unit count
         // limits are exceeded
         while (!stopGenerating) {
@@ -584,56 +603,72 @@ public class AtBDynamicScenarioFactory {
             }
 
             // If there are no weight classes available, something went wrong so don't
-            // bother trying
-            // to generate units
+            // bother trying to generate units
             if (currentLanceWeightString == null) {
                 generatedLance = new ArrayList<>();
+            } else {
                 // Hazardous conditions may prohibit deploying infantry or vehicles
-            } else if ((actualUnitType == UnitType.INFANTRY && !allowsConvInfantry) || (actualUnitType == UnitType.TANK && !allowsTanks)) {
-                generatedLance = new ArrayList<>();
-                logger.warn(String.format("Skipping generation of unit type %s due to hostile conditions.", UnitType.getTypeName(actualUnitType)));
+                if ((actualUnitType == UnitType.INFANTRY && !allowsConvInfantry)
+                    || (actualUnitType == UnitType.BATTLE_ARMOR && !allowsBattleArmor)) {
+                    logger.warn("Unable to generate Infantry due to hostile conditions." +
+                        " Switching to Tank.");
+                    actualUnitType = UnitType.TANK;
+                }
+
+                if (actualUnitType == UnitType.TANK && !allowsTanks) {
+                    logger.warn("Unable to generate Tank due to hostile conditions." +
+                        " Switching to Mek.");
+                    actualUnitType = UnitType.MEK;
+                }
 
                 // Gun emplacements use fixed tables instead of the force generator system
-            } else if (actualUnitType == UnitType.GUN_EMPLACEMENT) {
-                generatedLance = generateTurrets(4, skill, quality, campaign, faction);
+                if (actualUnitType == UnitType.GUN_EMPLACEMENT) {
+                    generatedLance = generateTurrets(4, skill, quality, campaign, faction);
 
                 // All other unit types use the force generator system to randomly select units
-            } else {
-                // Determine unit types for each unit of the formation. Normally this is all one
-                // type, but SPECIAL_UNIT_TYPE_ATB_MIX may generate all Meks, all vehicles, or
-                // a Mek/vehicle mixed formation.
-                List<Integer> unitTypes = generateUnitTypes(actualUnitType, lanceSize, quality, factionCode, allowsTanks, campaign);
-
-                // Formations composed entirely of Meks, aerospace fighters (but not conventional),
-                // and ground vehicles use weight categories as do SPECIAL_UNIT_TYPE_ATB_MIX.
-                // Formations of other types, plus artillery formations do not use weight classes.
-                if ((actualUnitType == SPECIAL_UNIT_TYPE_ATB_MIX
-                    || actualUnitType == SPECIAL_UNIT_TYPE_ATB_CIVILIANS
-                    || IUnitGenerator.unitTypeSupportsWeightClass(actualUnitType))
-                    && !forceTemplate.getUseArtillery()) {
-
-                    // Generate a specific weight class for each unit based on the formation weight
-                    // class and lower/upper bounds
-                    final String unitWeights = generateUnitWeights(unitTypes, factionCode,
-                        AtBConfiguration.decodeWeightStr(currentLanceWeightString, 0),
-                        forceTemplate.getMaxWeightClass(), forceTemplate.getMinWeightClass(),
-                        requiredRoles, campaign);
-
-                    if (unitWeights != null) {
-                        generatedLance = generateLance(factionCode, skill, quality, unitTypes, unitWeights,
-                            requiredRoles, campaign, scenario);
-                    } else {
-                        generatedLance = new ArrayList<>();
-                    }
                 } else {
-                    generatedLance = generateLance(factionCode, skill, quality, unitTypes, requiredRoles,
-                        campaign, scenario);
+                    // Determine unit types for each unit of the formation. Normally this is all one
+                    // type, but SPECIAL_UNIT_TYPE_ATB_MIX may generate all Meks, all vehicles, or
+                    // a Mek/vehicle mixed formation.
+                    List<Integer> unitTypes = generateUnitTypes(actualUnitType, lanceSize, quality,
+                        factionCode, allowsTanks, campaign);
 
-                    // If extreme temperatures are present and XCT infantry is not being generated,
-                    // swap out standard armor for snowsuits or heat suits as appropriate
-                    if (actualUnitType == UnitType.INFANTRY) {
-                        for (Entity curPlatoon : generatedLance) {
-                            changeInfantryKit((Infantry) curPlatoon, isLowPressure, isTainted, scenario.getTemperature());
+                    // Formations composed entirely of Meks, aerospace fighters (but not conventional),
+                    // and ground vehicles use weight categories as do SPECIAL_UNIT_TYPE_ATB_MIX.
+                    // Formations of other types, plus artillery formations do not use weight classes.
+                    if ((actualUnitType == SPECIAL_UNIT_TYPE_ATB_MIX
+                        || actualUnitType == SPECIAL_UNIT_TYPE_ATB_CIVILIANS
+                        || IUnitGenerator.unitTypeSupportsWeightClass(actualUnitType))
+                        && !forceTemplate.getUseArtillery()) {
+
+                        // Generate a specific weight class for each unit based on the formation weight
+                        // class and lower/upper bounds
+                        final String unitWeights = generateUnitWeights(unitTypes, factionCode,
+                            AtBConfiguration.decodeWeightStr(currentLanceWeightString, 0),
+                            forceTemplate.getMaxWeightClass(), forceTemplate.getMinWeightClass(),
+                            requiredRoles, campaign);
+
+                        if (unitWeights != null) {
+                            generatedLance = generateLance(factionCode, skill, quality, unitTypes, unitWeights,
+                                requiredRoles, campaign, scenario);
+                        } else {
+                            generatedLance = new ArrayList<>();
+                        }
+
+                        if (!generatedLance.isEmpty() && forceTemplate.isEnemyBotForce()) {
+                            logger.info(String.format("Force Weights: %s (%s)",
+                                currentLanceWeightString, unitWeights));
+                        }
+                    } else {
+                        generatedLance = generateLance(factionCode, skill, quality, unitTypes, requiredRoles,
+                            campaign, scenario);
+
+                        // If extreme temperatures are present and XCT infantry is not being generated,
+                        // swap out standard armor for snowsuits or heat suits as appropriate
+                        if (actualUnitType == UnitType.INFANTRY) {
+                            for (Entity curPlatoon : generatedLance) {
+                                changeInfantryKit((Infantry) curPlatoon, isLowPressure, isTainted, scenario.getTemperature());
+                            }
                         }
                     }
                 }
@@ -643,7 +678,8 @@ public class AtBDynamicScenarioFactory {
             // work with what is already generated
             if (generatedLance.isEmpty()) {
                 stopGenerating = true;
-                logger.warn(String.format("Unable to generate units from RAT: %s, type %d, max weight %d", factionCode, forceTemplate.getAllowedUnitType(), weightClass));
+                logger.warn(String.format("Unable to generate units from RAT: %s, type %d, max weight %d",
+                    factionCode, forceTemplate.getAllowedUnitType(), weightClass));
                 continue;
             }
 
@@ -679,7 +715,9 @@ public class AtBDynamicScenarioFactory {
                     ArrayList<Entity> arrayGeneratedLance = new ArrayList<>(generatedLance);
                     // bin fill ratio will be adjusted by the load out generator based on piracy and
                     // quality
-                    ReconfigurationParameters rp = TeamLoadOutGenerator.generateParameters(cGame, cGame.getOptions(), arrayGeneratedLance, factionCode, new ArrayList<>(), new ArrayList<>(), ownerBaseQuality, ((isPirate) ? TeamLoadOutGenerator.UNSET_FILL_RATIO : 1.0f));
+                    ReconfigurationParameters rp = TeamLoadOutGenerator.generateParameters(cGame,
+                        cGame.getOptions(), arrayGeneratedLance, factionCode, new ArrayList<>(),
+                        new ArrayList<>(), ownerBaseQuality, ((isPirate) ? TeamLoadOutGenerator.UNSET_FILL_RATIO : 1.0f));
                     rp.isPirate = isPirate;
                     rp.groundMap = onGround;
                     rp.spaceEnvironment = (mapLocation == MapLocation.Space);
@@ -726,7 +764,7 @@ public class AtBDynamicScenarioFactory {
                 // the percentage chosen based on unit rating
                 double currentPercentage = ((double) forceBV / forceBVBudget) * 100;
 
-                stopGenerating = currentPercentage > targetPercentage;
+                stopGenerating = currentPercentage > 100;
             } else {
                 // For generation methods other than scaled BV, compare to the overall budget
                 stopGenerating = generatedEntities.size() >= forceUnitBudget;
@@ -746,10 +784,10 @@ public class AtBDynamicScenarioFactory {
             if (campaign.getCampaignOptions().isUseGenericBattleValue()) {
                 balancingType = " Generic";
             }
-            logger.info(String.format("Generated a force with %s / %s %s BV",
-                    forceBV, forceBVBudget, balancingType));
+            logger.info(String.format("%s generated a force with %s / %s %s BV",
+                forceTemplate.getForceName(), forceBV, forceBVBudget, balancingType));
 
-            int adjustedBvBudget = (int) (forceBVBudget * 1.25);
+            int adjustedBvBudget = (int) (forceBVBudget * 1.1);
 
             while ((forceBV > adjustedBvBudget) && (generatedEntities.size() > 1)) {
                 int targetUnit = Compute.randomInt(generatedEntities.size());
@@ -769,7 +807,7 @@ public class AtBDynamicScenarioFactory {
                 generatedEntities.remove(targetUnit);
             }
 
-            logger.info(String.format("Final force %s / %s %s BV",
+            logger.info(String.format("Final force %s / %s %s BV (adjusted for bounds)",
                     forceBV, adjustedBvBudget, balancingType));
         }
 
@@ -1519,12 +1557,20 @@ public class AtBDynamicScenarioFactory {
             unitData = campaign.getUnitGenerator().generate(params);
         }
 
+
         if (unitData == null) {
             if (!params.getMissionRoles().isEmpty()) {
-                logger.warn(String.format("Unable to randomly generate %s %s with roles: %s",
+                Entity secondChanceEntity = getEntity(faction, skill, quality, unitType, weightClass, campaign);
+
+                if (secondChanceEntity == null) {
+                    logger.warn(String.format("Unable to randomly generate %s %s with roles: %s." +
+                            " Second chance generation also failed.",
                         EntityWeightClass.getClassName(params.getWeightClass()),
                         UnitType.getTypeName(unitType),
                         params.getMissionRoles().stream().map(Enum::name).collect(Collectors.joining(","))));
+                } else {
+                    return secondChanceEntity;
+                }
             }
             return null;
         }
@@ -2656,6 +2702,9 @@ public class AtBDynamicScenarioFactory {
         int bvBudget = 0;
         double difficultyMultiplier = getDifficultyMultiplier(campaign);
 
+        String generationMethod = campaign.getCampaignOptions().isUseGenericBattleValue() ?
+            "Generic BV" : "BV2";
+
         // deployed player forces:
         for (int forceID : scenario.getForceIDs()) {
             ScenarioForceTemplate forceTemplate = scenario.getPlayerForceTemplates().get(forceID);
@@ -2684,16 +2733,22 @@ public class AtBDynamicScenarioFactory {
             bvBudget = (int) round(bvBudget * difficultyMultiplier);
         }
 
+        logger.info(String.format("Total Player %s: %s (adjusted for campaign difficulty)", generationMethod, bvBudget));
+
         // allied bot forces that contribute to BV do not get multiplied by the
-        // difficulty
-        // even if the player is super good, the AI doesn't get any better
+        // difficulty even if the player is perfect, the AI doesn't get any better
         for (int index = 0; index < scenario.getNumBots(); index++) {
             BotForce botForce = scenario.getBotForce(index);
             ScenarioForceTemplate forceTemplate = scenario.getBotForceTemplates().get(botForce);
             if (forceTemplate != null && forceTemplate.getContributesToBV()) {
                 bvBudget += botForce.getTotalBV(campaign);
+
+                logger.info(String.format("%s %s: %s",
+                    botForce.getName(), generationMethod, botForce.getTotalBV(campaign)));
             }
         }
+
+        logger.info(String.format("Total Base %s Budget: %s", generationMethod, bvBudget));
 
         return bvBudget;
     }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -284,11 +284,6 @@ public class AtBDynamicScenarioFactory {
                 } else {
                     int weightClass = randomForceWeight();
 
-                    if (forceTemplate.isEnemyBotForce()) {
-                        int adjustedBV = effectiveBV * (targetPercentage / 100);
-                        int adjustedUnitCount = effectiveUnitCount * (targetPercentage / 100);
-                    }
-
                     generatedLanceCount += generateForce(scenario, contract, campaign,
                             effectiveBV, effectiveUnitCount, weightClass, forceTemplate, false);
                 }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1008,8 +1008,7 @@ public class AtBDynamicScenarioFactory {
             for (String unitName : bidAwayForces) {
                 if (report.isEmpty()) {
                     report.append(String.format(resources.getString("bidAwayForcesVerbose.text"),
-                            generatedForce.getName(), scenario.getName(), scenario.getContract(campaign),
-                            unitName));
+                            generatedForce.getName(), unitName));
                 } else {
                     report.append(unitName).append("<br>");
                 }
@@ -1017,14 +1016,13 @@ public class AtBDynamicScenarioFactory {
         } else {
             if (!bidAwayForces.isEmpty()) {
                 report.append(String.format(resources.getString("bidAwayForces.text"),
-                        generatedForce.getName(), scenario.getName(), scenario.getContract(campaign),
-                        bidAwayForces.size(), bidAwayForces.size() > 1 ? "s" : ""));
+                        generatedForce.getName(), bidAwayForces.size(), bidAwayForces.size() > 1 ? "s" : ""));
 
                 boolean isUseLoggerHeader = true;
                 for (String unitName : bidAwayForces) {
                     if (isUseLoggerHeader) {
                         logger.info(String.format(resources.getString("bidAwayForcesLogger.text"),
-                            generatedForce.getName(), scenario.getName(), scenario.getContract(campaign)));
+                            generatedForce.getName()));
                         isUseLoggerHeader = false;
                     }
                     logger.info(unitName);
@@ -1035,8 +1033,7 @@ public class AtBDynamicScenarioFactory {
         if (supplementedForces > 0) {
             if (report.isEmpty()) {
                 report.append(String.format(resources.getString("addedBattleArmorNewReport.text"),
-                        generatedForce.getName(), scenario.getName(), scenario.getContract(campaign),
-                        supplementedForces, supplementedForces > 1 ? "s" : ""));
+                        generatedForce.getName(), supplementedForces, supplementedForces > 1 ? "s" : ""));
             } else {
                 report.append(String.format(
                         resources.getString("addedBattleArmorContinueReport.text"),
@@ -1044,17 +1041,9 @@ public class AtBDynamicScenarioFactory {
             }
         }
 
-        if (supplementedForces > 0 || !bidAwayForces.isEmpty()) {
-            if (Compute.randomInt(8) == 0) {
-                report.append(resources.getString("batchallConcludedVersion2.text"));
-            } else {
-                report.append(resources.getString("batchallConcludedVersion1.text"));
-            }
-        }
-
         if (supplementedForces == 0 && bidAwayForces.isEmpty()) {
-            logger.info(String.format(resources.getString("nothingBidAway.text"),
-                generatedForce.getName(), scenario.getName(), scenario.getContract(campaign)));
+            report.append(String.format(resources.getString("nothingBidAway.text"),
+                generatedForce.getName()));
         }
 
         campaign.addReport(report.toString());


### PR DESCRIPTION
- Added better logging to assist in narrowing down FG3 oddities and to make it easier to verify everything is working as intended.
- Added checks to ensure planetary and weather conditions are enabled before we declare certain unit types as unsuited for the scenario.
- Added fallback generation, so that if we request a unit type that cannot survive in the environment it uses a fallback unit type instead. This is Infantry (Conventional or BA) -> Tank -> Mek. In this way if we try to generate infantry in an environment they cannot survive, we will attempt to spawn a tank instead, if that also can't survive we spawn a Mek. Tanks skip the infantry stage. While this may result in some unusual spawning (for example, reinforcements from a tank base might turn up as meks if the scenario is in a tornado), it will better avoid 0-unit forces. This has been written to work with the 'infantry use survival gear' changes that were made a while ago.
- Corrected a number of scenarios so that they correctly contribute to BV and to fix formatting errors.
- Corrected Heavy Recon Evasion's objectives
- Fixed the 'fleet of DropShips' bug
- Simplified bidding reporting, so that it's less cluttered
- Fixed the Batchall dialog to trigger correctly. Now, while it may trigger while the campaign is still in transit, it will more consistently trigger. There were edge cases that could cause the dialog to never trigger.

### Closes #5041 && #5005 && #5009 && #5027