### PR TITLE
Add Check for StratCon Usage in `getAtBBattleChance` Method

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -4465,9 +4465,13 @@ public class CampaignOptions {
 
     /**
      * @param role the {@link AtBLanceRole} to get the battle chance for
-     * @return the chance of having a battle for the specified role
+     * @return the chance of having a battle for the specified role, or {@code 0} if StratCon is enabled
      */
     public int getAtBBattleChance(final AtBLanceRole role) {
+        if (useStratCon) {
+            return 0;
+        }
+
         return role.isUnassigned() ? 0 : atbBattleChance[role.ordinal()];
     }
 


### PR DESCRIPTION
Updated the `getAtBBattleChance` method to return `0` if StratCon is enabled. This removes the need for users to manually set these values to `0` when enabling StratCon.