### PR TITLE
Prevent StratCon from Pulling in Player DropShips, when Option is Disabled

### DIFF
--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -201,7 +201,7 @@
                 <forceAlignment>1</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
                 <forceName>DropShip</forceName>
-                <generationMethod>3</generationMethod>
+                <generationMethod>4</generationMethod>
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>

--- a/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -201,7 +201,7 @@
                 <forceAlignment>1</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
                 <forceName>DropShip</forceName>
-                <generationMethod>3</generationMethod>
+                <generationMethod>4</generationMethod>
                 <generationOrder>3</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
@@ -188,7 +188,7 @@
                 <forceAlignment>1</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
                 <forceName>DropShip</forceName>
-                <generationMethod>3</generationMethod>
+                <generationMethod>4</generationMethod>
                 <generationOrder>4</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>

--- a/MekHQ/data/scenariotemplates/Space Blockade Run.xml
+++ b/MekHQ/data/scenariotemplates/Space Blockade Run.xml
@@ -158,7 +158,7 @@
                 <forceAlignment>1</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
                 <forceName>DropShip</forceName>
-                <generationMethod>3</generationMethod>
+                <generationMethod>4</generationMethod>
                 <generationOrder>4</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -305,6 +305,10 @@ public class StratconRulesManager {
                 }
 
                 for (Unit unit : potentialUnits) {
+                    if ((sft.getAllowedUnitType() == 11) && (!campaign.getCampaignOptions().isUseDropShips())) {
+                        continue;
+                    }
+
                     // if it's the right type of unit and is around
                     if (forceCompositionMatchesDeclaredUnitType(unit.getEntity().getUnitType(),
                             sft.getAllowedUnitType(), false) &&


### PR DESCRIPTION
- Added a condition to check whether Use DropShips is enabled in AtB Options, before substituting NPC DropShips with Player DropShips.
- Fixed player DropShip substitution in FG3