### PR TITLE
Fix TurretLock Part not saving

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/TurretLock.java
+++ b/MekHQ/src/mekhq/campaign/parts/TurretLock.java
@@ -35,6 +35,11 @@ import mekhq.campaign.Campaign;
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
 public class TurretLock extends Part {
+    public TurretLock() {
+        // Needed for loading from save
+        this(null);
+    }
+
     public TurretLock(Campaign c) {
         super(0, c);
         this.name = "Turret Lock";
@@ -73,14 +78,15 @@ public class TurretLock extends Part {
     }
 
     @Override
-    protected void loadFieldsFromXmlNode(Node wn) {
-        // TODO Auto-generated method stub
-
+    public void writeToXML(final PrintWriter pw, int indent) {
+        // Just use Part's writer
+        indent = writeToXMLBegin(pw, indent);
+        writeToXMLEnd(pw, indent);
     }
 
     @Override
-    public void writeToXML(final PrintWriter pw, int indent) {
-        // TODO Auto-generated method stub
+    protected void loadFieldsFromXmlNode(Node wn) {
+        // Since we're not adding any bits above Part, think this can be empty
     }
 
     @Override


### PR DESCRIPTION
This makes Turret Locks write to and restore from the save file.

Without this, Turret Locks will always "load" from the save file as quality D items rather than the quality they were when saved, and possibly other problems involving saved work scheduling.

Thanks to @atmafox for notcing that her Turret Locks were maintaining up to quality E and somtimes F repeatedly.

---

It's possible that this is the wrong solution for this problem because Turret Locks are meant to be a meta component. If this is the case, they should not be maintenance items and they should not show up in the part quality report.