### PR TITLE
Fixed `isMilitary` and `isPrepSchool` flags; Corrected Typo.

### DIFF
--- a/MekHQ/data/universe/academies/Prestigious Academies.xml
+++ b/MekHQ/data/universe/academies/Prestigious Academies.xml
@@ -438,10 +438,10 @@
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Allison MekWarrior Institute</name>
+        <name>Allison MechWarrior Institute</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Allison MekWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold loyalty.</description>
+        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold loyalty.</description>
         <locationSystem>New Olympia</locationSystem>
         <constructionYear>2465</constructionYear>
         <tuition>5250</tuition>
@@ -456,10 +456,10 @@
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
     <academy>
-        <name>Allison MekWarrior Institute (Officer)</name>
+        <name>Allison MechWarrior Institute (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Allison MekWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold loyalty.</description>
+        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold loyalty.</description>
         <locationSystem>New Olympia</locationSystem>
         <constructionYear>2465</constructionYear>
         <tuition>13125</tuition>

--- a/MekHQ/data/universe/academies/Unit Education.xml
+++ b/MekHQ/data/universe/academies/Unit Education.xml
@@ -89,8 +89,7 @@
     </academy>
     <academy>
         <name>Adult Apprenticeship</name>
-        <isMilitary>true</isMilitary>
-        <isPrepSchool>true</isPrepSchool>
+        <isMilitary>false</isMilitary>
         <description>An adult apprenticeship is a hands-on training program where older recruits are integrated into a military or mercenary unit. The apprenticeship focuses heavily on learning in the field, with recruits shadowing seasoned veterans.</description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>


### PR DESCRIPTION
Changed `isMilitary` and `isPrepSchool` flags to false for Adult Apprenticeship in `Unit Education.xml`. Corrected spelling of "MechWarrior" in `Prestigious Academies.xml`. 
### Closes #5058 && #4973