### PR TITLE
Parts - minor refactoring and better information

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3507,7 +3507,7 @@ public class Campaign implements ITechManager {
             if (getCampaignOptions().isPayForRepairs()
                     && action.equals(" fix ")
                     && !(partWork instanceof Armor)) {
-                Money cost = partWork.getActualValue().multipliedBy(0.2);
+                Money cost = partWork.getUndamagedValue().multipliedBy(0.2);
                 report += "<br>Repairs cost " +
                         cost.toAmountAndSymbolString() +
                         " worth of parts.";

--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -429,7 +429,7 @@ public class PartsStore {
         parts.add(new VeeStabilizer(0, -1, c));
         for (int ton = 5; ton <= 100; ton = ton + 5) {
             parts.add(new Rotor(ton, c));
-            parts.add(new Turret(ton, -1, c));
+            parts.add(new Turret(ton, ton, c));
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -88,8 +88,6 @@ public class PartsStore {
         stockProtomekComponents(c);
         stockBattleArmorSuits(c);
 
-        Pattern cleanUp1 = Pattern.compile("\\d+\\shit\\(s\\),\\s");
-        Pattern cleanUp2 = Pattern.compile("\\d+\\shit\\(s\\)");
         StringBuilder sb = new StringBuilder();
         for (Part p : parts) {
             p.setBrandNew(true);
@@ -97,7 +95,6 @@ public class PartsStore {
             sb.append(p.getName());
             if (!(p instanceof Armor)) { // ProtoMekArmor and BaArmor are derived from Armor
                 String details = p.getDetails();
-                details = cleanUp2.matcher(cleanUp1.matcher(details).replaceFirst("")).replaceFirst("");
                 if (!details.isEmpty()) {
                     sb.append(" (").append(details).append(")");
                 }

--- a/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
@@ -51,6 +51,7 @@ public class AeroSensor extends Part {
         super(tonnage, c);
         this.name = "Aerospace Sensors";
         this.largeCraft = lc;
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -234,19 +235,7 @@ public class AeroSensor extends Part {
 
     @Override
     public String getDetails(boolean includeRepairDetails) {
-        String dropper = "";
-        if (largeCraft) {
-            dropper = " (spacecraft)";
-        }
-
-        String details = super.getDetails(includeRepairDetails);
-        if (!details.isEmpty()) {
-            details += ", ";
-        }
-
-        details += getUnitTonnage() + " tons" + dropper;
-
-        return details;
+        return super.getDetails(includeRepairDetails) + (largeCraft ? " (spacecraft)" : "");
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -160,35 +160,58 @@ public class Armor extends Part implements IAcquisitionWork {
 
     @Override
     public String getDetails(boolean includeRepairDetails) {
+        StringBuilder toReturn = new StringBuilder();
         if (null != unit) {
-            String rearMount = "";
-            if (rear) {
-                rearMount = " (R)";
-            }
-            if (!isSalvaging()) {
-                String availability;
+            if (isSalvaging()) {
+                toReturn.append(unit.getEntity().getLocationName(location))
+                .append(rear ? " (Rear)" : "")
+                .append(", ")
+                .append(amount)
+                .append(amount == 1 ? " point" : " points");
+            } else {
+                toReturn.append(unit.getEntity().getLocationName(location))
+                    .append(rear ? " (Rear)" : "")
+                    .append(", ")
+                    .append(amountNeeded)
+                    .append(amountNeeded == 1 ? " point" : " points")
+                    .append("<br/>");
+
                 int amountAvailable = getAmountAvailable();
-                PartInventory inventories = campaign.getPartInventory(getNewPart());
-
-                String orderTransitString = inventories.getTransitOrderedDetails();
-
-                if (amountAvailable == 0) {
-                    availability = "<br><font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor()
-                            + "'>No armor (" + orderTransitString + ")</font>";
+                if(amountAvailable == 0) {
+                    toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
+                        MekHQ.getMHQOptions().getFontColorNegativeHexColor(), "None in stock"));
                 } else if (amountAvailable < amountNeeded) {
-                    availability = "<br><font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor()
-                            + "'>Only " + amountAvailable + " available (" + orderTransitString + ")</font>";
+                    toReturn.append(ReportingUtilities.spanOpeningWithCustomColor(
+                            MekHQ.getMHQOptions().getFontColorNegativeHexColor()))
+                        .append("Only ")
+                        .append(amountAvailable)
+                        .append(" in stock")
+                        .append(ReportingUtilities.CLOSING_SPAN_TAG);
                 } else {
-                    availability = "<br><font color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'>"
-                            + amountAvailable + " available (" + orderTransitString + ")</font>";
+                    toReturn.append(ReportingUtilities.spanOpeningWithCustomColor(
+                            MekHQ.getMHQOptions().getFontColorPositiveHexColor()))
+                        .append(amountAvailable)
+                        .append(" in stock")
+                        .append(ReportingUtilities.CLOSING_SPAN_TAG);
                 }
-
-                return unit.getEntity().getLocationName(location) + rearMount + ", " + amountNeeded + " points"
-                        + availability;
+    
+                PartInventory inventories = campaign.getPartInventory(getNewPart());
+                String orderTransitString = inventories.getTransitOrderedDetails();
+                if (!orderTransitString.isEmpty()) {
+                    toReturn.append(ReportingUtilities.spanOpeningWithCustomColor(
+                            MekHQ.getMHQOptions().getFontColorWarningHexColor()))
+                        .append(" (")
+                        .append(orderTransitString)
+                        .append(")")
+                        .append(ReportingUtilities.CLOSING_SPAN_TAG);
+                }
             }
-            return unit.getEntity().getLocationName(location) + rearMount + ", " + amount + " points";
+        
+        } else {
+            toReturn.append(amount)
+                .append(" points");
         }
-        return amount + " points";
+        return toReturn.toString();
     }
 
     public int getType() {

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -170,17 +170,17 @@ public class Armor extends Part implements IAcquisitionWork {
                 int amountAvailable = getAmountAvailable();
                 PartInventory inventories = campaign.getPartInventory(getNewPart());
 
-                String orderTransitString = getOrderTransitStringForDetails(inventories);
+                String orderTransitString = inventories.getTransitOrderedDetails();
 
                 if (amountAvailable == 0) {
                     availability = "<br><font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor()
-                            + "'>No armor " + orderTransitString + "</font>";
+                            + "'>No armor (" + orderTransitString + ")</font>";
                 } else if (amountAvailable < amountNeeded) {
                     availability = "<br><font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor()
-                            + "'>Only " + amountAvailable + " available " + orderTransitString + "</font>";
+                            + "'>Only " + amountAvailable + " available (" + orderTransitString + ")</font>";
                 } else {
                     availability = "<br><font color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'>"
-                            + amountAvailable + " available " + orderTransitString + "</font>";
+                            + amountAvailable + " available (" + orderTransitString + ")</font>";
                 }
 
                 return unit.getEntity().getLocationName(location) + rearMount + ", " + amountNeeded + " points"

--- a/MekHQ/src/mekhq/campaign/parts/EnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/EnginePart.java
@@ -54,6 +54,7 @@ public class EnginePart extends Part {
         this.engine = e;
         this.forHover = hover;
         this.name = engine.getEngineName() + " Engine";
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -408,19 +409,8 @@ public class EnginePart extends Part {
     @Override
     public String getDetails(boolean includeRepairDetails) {
         String details = super.getDetails(includeRepairDetails);
-        if (null != unit) {
-            return details;
-        }
-
-        if (!details.isEmpty()) {
-            details += ", ";
-        }
-
-        String hvrString = "";
-        if (forHover) {
-            hvrString = " (hover)";
-        }
-        return details + getUnitTonnage() + " tons" + hvrString;
+        
+        return details + (forHover ? " (hover)" : "");
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/KFChargingSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFChargingSystem.java
@@ -72,6 +72,7 @@ public class KFChargingSystem extends Part {
         this.coreType = coreType;
         this.docks = docks;
         this.name = "K-F Charging System";
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -255,8 +256,7 @@ public class KFChargingSystem extends Part {
         if (!details.isEmpty()) {
             joiner.add(details);
         }
-        joiner.add(getUnitTonnage() + " tons")
-                .add(getDocks() + " collars");
+        joiner.add(getDocks() + " collars");
         return joiner.toString();
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/KFDriveCoil.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFDriveCoil.java
@@ -72,6 +72,7 @@ public class KFDriveCoil extends Part {
         this.coreType = coreType;
         this.docks = docks;
         this.name = "K-F Drive Coil";
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -254,8 +255,7 @@ public class KFDriveCoil extends Part {
         if (!details.isEmpty()) {
             joiner.add(details);
         }
-        joiner.add(getUnitTonnage() + " tons")
-                .add(getDocks() + " collars");
+        joiner.add(getDocks() + " collars");
         return joiner.toString();
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/KFDriveController.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFDriveController.java
@@ -72,6 +72,7 @@ public class KFDriveController extends Part {
         this.coreType = coreType;
         this.docks = docks;
         this.name = "K-F Drive Controller";
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -255,7 +256,7 @@ public class KFDriveController extends Part {
         if (!details.isEmpty()) {
             joiner.add(details);
         }
-        joiner.add(getUnitTonnage() + " tons").add(getDocks() + " collars");
+        joiner.add(getDocks() + " collars");
         return joiner.toString();
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/KFFieldInitiator.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFFieldInitiator.java
@@ -72,6 +72,7 @@ public class KFFieldInitiator extends Part {
         this.coreType = coreType;
         this.docks = docks;
         this.name = "K-F Field Initiator";
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -257,8 +258,7 @@ public class KFFieldInitiator extends Part {
         if (!details.isEmpty()) {
             joiner.add(details);
         }
-        joiner.add(getUnitTonnage() + " tons")
-                .add(getDocks() + " collars");
+        joiner.add(getDocks() + " collars");
         return joiner.toString();
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/KFHeliumTank.java
+++ b/MekHQ/src/mekhq/campaign/parts/KFHeliumTank.java
@@ -72,6 +72,7 @@ public class KFHeliumTank extends Part {
         this.coreType = coreType;
         this.docks = docks;
         this.name = "K-F Helium Tank";
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -259,8 +260,7 @@ public class KFHeliumTank extends Part {
         if (!details.isEmpty()) {
             joiner.add(details);
         }
-        joiner.add(getUnitTonnage() + " tons")
-                .add(getDocks() + " collars");
+        joiner.add(getDocks() + " collars");
         return joiner.toString();
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/MekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekActuator.java
@@ -27,12 +27,10 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.personnel.SkillType;
-import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.io.PrintWriter;
-import java.util.StringJoiner;
 
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
@@ -77,6 +75,7 @@ public class MekActuator extends Part {
         Mek m = new BipedMek();
         this.name = m.getSystemName(type) + " Actuator";
         this.location = loc;
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -228,21 +227,6 @@ public class MekActuator extends Part {
     @Override
     public String getDetails() {
         return getDetails(true);
-    }
-
-    @Override
-    public String getDetails(boolean includeRepairDetails) {
-        if (null != unit) {
-            StringJoiner sj = new StringJoiner(", ");
-            if (!StringUtils.isEmpty(getLocationName())) {
-                sj.add(getLocationName());
-            }
-            if (includeRepairDetails && campaign.getCampaignOptions().isPayForRepairs()) {
-                sj.add(getActualValue().multipliedBy(0.2).toAmountAndSymbolString() + " to repair");
-            }
-            return sj.toString();
-        }
-        return getUnitTonnage() + " tons";
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -570,18 +570,22 @@ public class MekLocation extends Part {
     public String getDetails(boolean includeRepairDetails) {
         StringBuilder toReturn = new StringBuilder();
 
-        toReturn.append(super.getDetails(includeRepairDetails));
+        if (null != getUnit()) {
+            toReturn.append(Objects.requireNonNull(getUnit()).getEntity().getLocationName(loc))
+                .append(", ");
+        }
 
+        toReturn.append(getUnitTonnage())
+            .append(" tons");
+            
         if (loc == Mek.LOC_HEAD) {
             StringJoiner components = new StringJoiner(", ");
             if (hasSensors()) {
                 components.add("Sensors");
             }
-
             if (hasLifeSupport()) {
                 components.add("Life Support");
             }
-
             if (components.length() > 0) {
                 toReturn.append(" [")
                     .append(components)
@@ -589,31 +593,21 @@ public class MekLocation extends Part {
             }
         }
 
-        if (getUnit() != null) {
-            return getDetailsOnUnit(includeRepairDetails);
-        }
-
-        if (includeRepairDetails && getPercent() < 1.0) {
-            toReturn.append(" (")
+        if (includeRepairDetails) {
+            if (isBlownOff()) {
+                toReturn.append(" (Blown Off)");
+            } else if (isBreached()) {
+                toReturn.append(" (Breached)");
+            } else if (onBadHipOrShoulder()) {
+                toReturn.append(" (Bad Hip/Shoulder)");
+            } else if (getPercent() < 1.0) {
+                toReturn.append(" (")
                     .append(Math.round(100 * getPercent()))
                     .append("%)");
+            }
         }
 
         return toReturn.toString();
-    }
-
-    private String getDetailsOnUnit(boolean includeRepairDetails) {
-        String toReturn = Objects.requireNonNull(getUnit()).getEntity().getLocationName(loc);
-        if (includeRepairDetails) {
-            if (isBlownOff()) {
-                toReturn += " (Blown Off)";
-            } else if (isBreached()) {
-                toReturn += " (Breached)";
-            } else if (onBadHipOrShoulder()) {
-                toReturn += " (Bad Hip/Shoulder)";
-            }
-        }
-        return toReturn;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -872,9 +872,9 @@ public class MekLocation extends Part {
         toReturn.append("<html><b>")
             .append(isBlownOff() ? "Re-attach " : "Seal ")
             .append(getName())
-            .append(", ")
-            .append(getTonnage())
-            .append("ton - ")
+            .append(" (")
+            .append(getUnitTonnage())
+            .append(" ton) - ")
             .append(ReportingUtilities.messageSurroundedBySpanWithColor(
                 SkillType.getExperienceLevelColor(getSkillMin()),
                 SkillType.getExperienceLevelName(getSkillMin()) + "+"))

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -68,6 +68,7 @@ public class MekLocation extends Part {
 
     public MekLocation() {
         this(0, 0, 0, false, false, false, false, false, null);
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -109,6 +110,7 @@ public class MekLocation extends Part {
         this.sensors = sensors;
         this.lifeSupport = lifeSupport;
         this.breached = false;
+        this.unitTonnageMatters = true;
         // TODO : need to account for internal structure and myomer types
         // crap, no static report for location names?
         this.name = "Mek Location";
@@ -566,14 +568,9 @@ public class MekLocation extends Part {
 
     @Override
     public String getDetails(boolean includeRepairDetails) {
-        if (getUnit() != null) {
-            return getDetailsOnUnit(includeRepairDetails);
-        }
+        StringBuilder toReturn = new StringBuilder();
 
-        String toReturn = getUnitTonnage() + " tons";
-        if (includeRepairDetails) {
-            toReturn += " (" + Math.round(100 * getPercent()) + "%)";
-        }
+        toReturn.append(super.getDetails(includeRepairDetails));
 
         if (loc == Mek.LOC_HEAD) {
             StringJoiner components = new StringJoiner(", ");
@@ -586,11 +583,23 @@ public class MekLocation extends Part {
             }
 
             if (components.length() > 0) {
-                toReturn += " [" + components + ']';
+                toReturn.append(" [")
+                    .append(components)
+                    .append(']');
             }
         }
 
-        return toReturn;
+        if (getUnit() != null) {
+            return getDetailsOnUnit(includeRepairDetails);
+        }
+
+        if (includeRepairDetails && getPercent() < 1.0) {
+            toReturn.append(" (")
+                    .append(Math.round(100 * getPercent()))
+                    .append("%)");
+        }
+
+        return toReturn.toString();
     }
 
     private String getDetailsOnUnit(boolean includeRepairDetails) {
@@ -602,11 +611,8 @@ public class MekLocation extends Part {
                 toReturn += " (Breached)";
             } else if (onBadHipOrShoulder()) {
                 toReturn += " (Bad Hip/Shoulder)";
-            } else {
-                toReturn += " (" + Math.round(100 * getPercent()) + "%)";
             }
         }
-
         return toReturn;
     }
 
@@ -861,14 +867,16 @@ public class MekLocation extends Part {
 
     @Override
     public String getDesc() {
-        if ((!isBreached() && !isBlownOff()) || isSalvaging()) {
+        if ((!isBreached() && !isBlownOff())) {
             return super.getDesc();
         }
         StringBuilder toReturn = new StringBuilder();
         toReturn.append("<html><b>")
             .append(isBlownOff() ? "Re-attach " : "Seal ")
             .append(getName())
-            .append(" - ")
+            .append(", ")
+            .append(getTonnage())
+            .append("ton - ")
             .append(ReportingUtilities.messageSurroundedBySpanWithColor(
                 SkillType.getExperienceLevelColor(getSkillMin()),
                 SkillType.getExperienceLevelName(getSkillMin()) + "+"))

--- a/MekHQ/src/mekhq/campaign/parts/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekLocation.java
@@ -604,6 +604,10 @@ public class MekLocation extends Part {
                 toReturn.append(" (")
                     .append(Math.round(100 * getPercent()))
                     .append("%)");
+                if (campaign.getCampaignOptions().isPayForRepairs()) {
+                    toReturn.append(", ")
+                        .append(getUndamagedValue().multipliedBy(0.2).toAmountAndSymbolString() + " to repair");
+                }
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/parts/MekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MekSensor.java
@@ -47,6 +47,7 @@ public class MekSensor extends Part {
     public MekSensor(int tonnage, Campaign c) {
         super(tonnage, c);
         this.name = "Mek Sensors";
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -219,20 +220,6 @@ public class MekSensor extends Part {
             }
         }
         return false;
-    }
-
-    @Override
-    public String getDetails() {
-        return getDetails(true);
-    }
-
-    @Override
-    public String getDetails(boolean includeRepairDetails) {
-        String details = super.getDetails(includeRepairDetails);
-        if (!details.isEmpty()) {
-            details += ", ";
-        }
-        return  details + getUnitTonnage() + " tons";
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -259,12 +259,13 @@ public class MissingBattleArmorSuit extends MissingPart {
 
     @Override
     public String getDetails(boolean includeRepairDetails) {
-        if (null == unit) {
-            return super.getDetails(includeRepairDetails);
-
+        StringBuilder toReturn = new StringBuilder();
+        if (null != unit) {
+            toReturn.append(unit.getEntity().getLocationName(trooper))
+                .append("<br>");
         }
-        String toReturn = unit.getEntity().getLocationName(trooper) + "<br>";
-        return toReturn + super.getDetails(includeRepairDetails);
+        toReturn.append(super.getDetails(includeRepairDetails));
+        return toReturn.toString();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingKFChargingSystem.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingKFChargingSystem.java
@@ -57,6 +57,7 @@ public class MissingKFChargingSystem extends MissingPart {
         this.coreType = coreType;
         this.docks = docks;
         this.name = "K-F Charging System";
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingKFDriveCoil.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingKFDriveCoil.java
@@ -57,6 +57,7 @@ public class MissingKFDriveCoil extends MissingPart {
         this.coreType = coreType;
         this.docks = docks;
         this.name = "K-F Drive Coil";
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingKFDriveController.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingKFDriveController.java
@@ -57,6 +57,7 @@ public class MissingKFDriveController extends MissingPart {
         this.coreType = coreType;
         this.docks = docks;
         this.name = "K-F Drive Controller";
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingKFFieldInitiator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingKFFieldInitiator.java
@@ -59,6 +59,7 @@ public class MissingKFFieldInitiator extends MissingPart {
         this.coreType = coreType;
         this.docks = docks;
         this.name = "K-F Field Initiator";
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingKFHeliumTank.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingKFHeliumTank.java
@@ -58,6 +58,7 @@ public class MissingKFHeliumTank extends MissingPart {
         this.coreType = coreType;
         this.docks = docks;
         this.name = "K-F Helium Tank";
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekActuator.java
@@ -62,6 +62,7 @@ public class MissingMekActuator extends MissingPart {
         Mek m = new BipedMek();
         this.name = m.getSystemName(type) + " Actuator";
         this.location = loc;
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekLocation.java
@@ -80,6 +80,7 @@ public class MissingMekLocation extends MissingPart {
         this.tsm = hasTSM;
         this.percent = 1.0;
         this.forQuad = quad;
+        this.unitTonnageMatters = true;
         // TODO: need to account for internal structure and myomer types
         // crap, no static report for location names?
         this.name = "Mek Location";

--- a/MekHQ/src/mekhq/campaign/parts/MissingMekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingMekSensor.java
@@ -41,6 +41,7 @@ public class MissingMekSensor extends MissingPart {
     public MissingMekSensor(int tonnage, Campaign c) {
         super(tonnage, c);
         this.name = resources.getString("MissingMekSensor.title");
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingOmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingOmniPod.java
@@ -76,6 +76,18 @@ public class MissingOmniPod extends MissingPart {
     public Part getPartType() {
         return partType;
     }
+    
+    /**
+     * @return The tech base of the part the omnipod is meant to contain.
+     */
+    @Override
+    public int getTechBase() {
+        if (null != partType) {
+            return partType.getTechBase();
+        } else {
+            return TechAdvancement.TECH_BASE_ALL;
+        }
+    }
 
     /**
      * Exports class data to xml

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -84,9 +84,14 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
     @Override
     public String getDesc() {
         StringBuilder toReturn = new StringBuilder();
-        toReturn.append("<html><b>Replace ")
-            .append(getName())
-            .append(" - ")
+            toReturn.append("<html><b>Replace ")
+                .append(getName());
+            if(isUnitTonnageMatters()) {
+                toReturn.append(" (")
+                    .append(getUnitTonnage())
+                    .append(" ton)");
+            }
+            toReturn.append(" - ")
             .append(ReportingUtilities.messageSurroundedBySpanWithColor(
                 SkillType.getExperienceLevelColor(getSkillMin()),
                 SkillType.getExperienceLevelName(getSkillMin()) + "+"))

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -84,7 +84,7 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
     @Override
     public String getDesc() {
         StringBuilder toReturn = new StringBuilder();
-            toReturn.append("<html><b>Replace ")
+        toReturn.append("<html><b>Replace ")
                 .append(getName());
             if(isUnitTonnageMatters()) {
                 toReturn.append(" (")
@@ -119,7 +119,9 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
     @Override
     public String succeed() {
         fix();
-        return " <font color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'><b> replaced.</b></font>";
+        return ReportingUtilities.messageSurroundedBySpanWithColor(
+                MekHQ.getMHQOptions().getFontColorPositiveHexColor(),
+                " <b>replaced</b>.");
     }
 
     @Override
@@ -178,7 +180,7 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
                         return part;
                     } else if (bestPart.needsFixing() && !part.needsFixing()) {
                         return part;
-                    } else if (bestPart.getQuality() < part.getQuality()) {
+                    } else if (bestPart.getQuality().toNumeric() < part.getQuality().toNumeric()) {
                         return part;
                     }
                 }
@@ -206,13 +208,30 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
 
     @Override
     public String getDetails(boolean includeRepairDetails) {
+        PartInventory inventories = campaign.getPartInventory(getNewPart());
+        StringBuilder toReturn = new StringBuilder();
+
         if (isReplacementAvailable()) {
-            return "Replacement part available";
+            toReturn.append(inventories.getSupply())
+                .append(" in stock");
         } else {
-            PartInventory inventories = campaign.getPartInventory(getNewPart());
-            return "<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>No replacement (" + inventories.getTransitOrderedDetails() + ")</font>";
+            toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
+                MekHQ.getMHQOptions().getFontColorNegativeHexColor(), "None in stock"));
         }
-    }
+
+        String incoming = inventories.getTransitOrderedDetails();
+        if (!incoming.isEmpty()) {
+            StringBuilder incomingSB = new StringBuilder();
+
+            incomingSB.append(" (")
+                .append(ReportingUtilities.messageSurroundedBySpanWithColor(
+                    MekHQ.getMHQOptions().getFontColorWarningHexColor(), incoming))
+                .append(")");
+
+            toReturn.append(incomingSB.toString());
+        }
+        return toReturn.toString();
+    } 
 
     @Override
     public boolean needsFixing() {

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -26,6 +26,7 @@ import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.equipment.MissingAmmoBin;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.work.IAcquisitionWork;
@@ -210,25 +211,34 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
     public String getDetails(boolean includeRepairDetails) {
         PartInventory inventories = campaign.getPartInventory(getNewPart());
         StringBuilder toReturn = new StringBuilder();
+        
+        String superDetails = super.getDetails(includeRepairDetails);
+        toReturn.append(superDetails);
 
-        if (isReplacementAvailable()) {
-            toReturn.append(inventories.getSupply())
-                .append(" in stock");
-        } else {
-            toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
-                MekHQ.getMHQOptions().getFontColorNegativeHexColor(), "None in stock"));
-        }
+        if (!(this instanceof MissingAmmoBin)) {
+            // Ammo bins don't require/have stock replacements.
+            if(!superDetails.isEmpty()) {
+                toReturn.append(", ");
+            }
+            if (isReplacementAvailable()) {
+                toReturn.append(inventories.getSupply())
+                    .append(" in stock");
+            } else {
+                toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
+                    MekHQ.getMHQOptions().getFontColorNegativeHexColor(), "None in stock"));
+            }
 
-        String incoming = inventories.getTransitOrderedDetails();
-        if (!incoming.isEmpty()) {
-            StringBuilder incomingSB = new StringBuilder();
+            String incoming = inventories.getTransitOrderedDetails();
+            if (!incoming.isEmpty()) {
+                StringBuilder incomingSB = new StringBuilder();
 
-            incomingSB.append(" (")
-                .append(incoming)
-                .append(")");
+                incomingSB.append(" (")
+                    .append(incoming)
+                    .append(")");
 
-            toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
-                MekHQ.getMHQOptions().getFontColorWarningHexColor(), incomingSB.toString()));
+                toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
+                    MekHQ.getMHQOptions().getFontColorWarningHexColor(), incomingSB.toString()));
+            }
         }
         return toReturn.toString();
     } 

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -412,9 +412,17 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
 
     @Override
     public String getAcquisitionName() {
+        // TODO: Unify shopping system to use these everywhere instead of only some places?
+        StringBuilder toReturn = new StringBuilder();
+        toReturn.append(getPartName());
+
         String details = getNewPart().getDetails();
-        details = details.replaceFirst("\\d+\\shit\\(s\\)", "");
-        return getPartName() + ' ' + details;
+        if (!details.isEmpty()) {
+            toReturn.append(" (")
+                .append(details)
+                .append(')');
+        }
+        return toReturn.toString();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -224,11 +224,11 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
             StringBuilder incomingSB = new StringBuilder();
 
             incomingSB.append(" (")
-                .append(ReportingUtilities.messageSurroundedBySpanWithColor(
-                    MekHQ.getMHQOptions().getFontColorWarningHexColor(), incoming))
+                .append(incoming)
                 .append(")");
 
-            toReturn.append(incomingSB.toString());
+            toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
+                MekHQ.getMHQOptions().getFontColorWarningHexColor(), incomingSB.toString()));
         }
         return toReturn.toString();
     } 
@@ -264,9 +264,13 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
                 part.decrementQuantity();
                 skillMin = SkillType.EXP_GREEN;
             }
-            return " <font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'><b> failed and part destroyed.</b></font>";
+            return ReportingUtilities.messageSurroundedBySpanWithColor(
+                    MekHQ.getMHQOptions().getFontColorNegativeHexColor(),
+                    "<b> failed and part destroyed</b>") + ".";
         } else {
-            return " <font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'><b> failed.</b></font>";
+            return ReportingUtilities.messageSurroundedBySpanWithColor(
+                    MekHQ.getMHQOptions().getFontColorNegativeHexColor(),
+                    "<b> failed</b>") + ".";
         }
     }
 
@@ -345,14 +349,24 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
 
     @Override
     public String find(int transitDays) {
+        // TODO: Move me to live with procurment functions?
+        // Which shopping method is this used for?
         Part newPart = getNewPart();
         newPart.setBrandNew(true);
         newPart.setDaysToArrival(transitDays);
+        StringBuilder toReturn = new StringBuilder();
         if (campaign.getQuartermaster().buyPart(newPart, transitDays)) {
-            return "<font color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'><b> part found</b>.</font> It will be delivered in " + transitDays + " days.";
+            toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
+                MekHQ.getMHQOptions().getFontColorPositiveHexColor(), "<b> part found</b>"))
+                .append(". It will be delivered in ")
+                .append(transitDays)
+                .append(" days.");
         } else {
-            return "<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'><b> You cannot afford this part. Transaction cancelled</b>.</font>";
+            toReturn.append(ReportingUtilities.messageSurroundedBySpanWithColor(
+                MekHQ.getMHQOptions().getFontColorNegativeHexColor(),
+                "<b> You cannot afford this part. Transaction cancelled</b>"));
         }
+        return toReturn.toString();
     }
 
     @Override
@@ -364,7 +378,9 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
 
     @Override
     public String failToFind() {
-        return "<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'><b> part not found</b>.</font>";
+        // TODO: Move me to live with procurment functions?
+        return ReportingUtilities.messageSurroundedBySpanWithColor(
+            MekHQ.getMHQOptions().getFontColorNegativeHexColor(), "<b> part not found</b>") + ".";
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/OmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/OmniPod.java
@@ -69,6 +69,15 @@ public class OmniPod extends Part {
     }
 
     @Override
+    public int getTechBase() {
+        if (null != partType) {
+            return partType.getTechBase();
+        } else {
+            return TechAdvancement.TECH_BASE_ALL;
+        }
+    }
+
+    @Override
     public void setCampaign(Campaign c) {
         super.setCampaign(c);
         partType.setCampaign(c);

--- a/MekHQ/src/mekhq/campaign/parts/OmniPod.java
+++ b/MekHQ/src/mekhq/campaign/parts/OmniPod.java
@@ -68,6 +68,9 @@ public class OmniPod extends Part {
         name = "OmniPod";
     }
 
+    /**
+     * @return The tech base of the part the omnipod is meant to contain.
+     */
     @Override
     public int getTechBase() {
         if (null != partType) {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1048,7 +1048,7 @@ public abstract class Part implements IPartWork, ITechnology {
         timeSpent = 0;
         shorthandedMod = 0;
         return ReportingUtilities.messageSurroundedBySpanWithColor(
-                MekHQ.getMHQOptions().getFontColorNegativeHexColor(), "'<b> failed</b>") + ".";
+                MekHQ.getMHQOptions().getFontColorNegativeHexColor(), "<b> failed</b>") + ".";
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1096,25 +1096,6 @@ public abstract class Part implements IPartWork, ITechnology {
         return sj.toString();
     }
 
-    /**
-     * Converts the array of strings normally returned by a call to
-     * campaign.getInventory()
-     * to a string that reads like "(x in transit, y on order)"
-     *
-     * @param inventories The inventory array, see campaign.getInventory() for
-     *                    details.
-     * @return Human readable string.
-     */
-    public String getOrderTransitStringForDetails(PartInventory inventories) {
-        String inTransitString = (inventories.getTransit() == 0) ? "" : inventories.transitAsString() + " in transit";
-        String onOrderString = (inventories.getOrdered() == 0) ? "" : inventories.orderedAsString() + " on order";
-        String transitOrderSeparator = !inTransitString.isBlank() && !onOrderString.isBlank() ? ", " : "";
-
-        return (!inTransitString.isBlank() || !onOrderString.isBlank())
-                ? String.format("(%s%s%s)", inTransitString, transitOrderSeparator, onOrderString)
-                : "";
-    }
-
     @Override
     public boolean isSalvaging() {
         if (null != unit) {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -239,17 +239,33 @@ public abstract class Part implements IPartWork, ITechnology {
     }
 
     @Override
+    public Money getUndamagedValue() {
+        return adjustCostsForCampaignOptions(getStickerPrice(), true);
+    }
+
+    @Override
     public boolean isPriceAdjustedForAmount() {
         return false;
     }
 
     /**
-     * Adjusts the cost of a part based on one's campaign options
+     * Adjusts the cost of a part based on campaign options and the part's condition
      *
      * @param cost the part's base cost
      * @return the part's cost adjusted for campaign options
      */
     public Money adjustCostsForCampaignOptions(@Nullable Money cost) {
+        return adjustCostsForCampaignOptions(cost, false);
+    } 
+
+    /**
+     * Adjusts the cost of a part based on campaign options
+     *
+     * @param cost the part's base cost
+     * @param ignoreDamage do we ignore damaged condition
+     * @return the part's cost adjusted for campaign options
+     */
+    public Money adjustCostsForCampaignOptions(@Nullable Money cost, boolean ignoreDamage) {
         // if the part doesn't cost anything, no amount of multiplication will change it
         if ((cost == null) || cost.isZero()) {
             return Money.zero();
@@ -276,7 +292,7 @@ public abstract class Part implements IPartWork, ITechnology {
                     .getUsedPartPriceMultipliers()[getQuality().toNumeric()]);
         }
 
-        if (needsFixing() && !isPriceAdjustedForAmount()) {
+        if (!ignoreDamage && needsFixing() && !isPriceAdjustedForAmount()) {
             cost = cost.multipliedBy((getSkillMin() > SkillType.EXP_ELITE)
                     ? campaign.getCampaignOptions().getUnrepairablePartsValueMultiplier()
                     : campaign.getCampaignOptions().getDamagedPartsValueMultiplier());

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1031,18 +1031,20 @@ public abstract class Part implements IPartWork, ITechnology {
         skillMin = ++rating;
         timeSpent = 0;
         shorthandedMod = 0;
-        return " <font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'><b> failed.</b></font>";
+        return ReportingUtilities.messageSurroundedBySpanWithColor(
+                MekHQ.getMHQOptions().getFontColorNegativeHexColor(), "'<b> failed</b>") + ".";
     }
 
     @Override
     public String succeed() {
         if (isSalvaging()) {
             remove(true);
-            return " <font color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor()
-                    + "'><b> salvaged.</b></font>";
+            return ReportingUtilities.messageSurroundedBySpanWithColor(
+                MekHQ.getMHQOptions().getFontColorPositiveHexColor(), "<b> salvaged</b>") + ".";
         } else {
             fix();
-            return " <font color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'><b> fixed.</b></font>";
+            return ReportingUtilities.messageSurroundedBySpanWithColor(
+                MekHQ.getMHQOptions().getFontColorPositiveHexColor(), "<b> fixed</b>") + ".";
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -98,10 +98,16 @@ public abstract class Part implements IPartWork, ITechnology {
     protected String name;
     protected int id;
 
-    // this is the unitTonnage which needs to be tracked for some parts
-    // even when off the unit. actual tonnage is returned via the
-    // getTonnage() method
+    /** 
+     * This is the unitTonnage which needs to be tracked for some parts
+     * even when off the unit. Actual tonnage is returned via the
+     * getTonnage() method
+     */
     protected int unitTonnage;
+    /**
+     * Is this part's unitTonnage something that differentiates it from other parts
+     */
+    protected boolean unitTonnageMatters;
 
     protected boolean omniPodded;
 
@@ -185,6 +191,7 @@ public abstract class Part implements IPartWork, ITechnology {
     public Part(int tonnage, boolean omniPodded, Campaign c) {
         this.name = "Unknown";
         this.unitTonnage = tonnage;
+        this.unitTonnageMatters = false;
         this.omniPodded = omniPodded;
         this.hits = 0;
         this.skillMin = SkillType.EXP_GREEN;
@@ -354,6 +361,13 @@ public abstract class Part implements IPartWork, ITechnology {
     public int getUnitTonnage() {
         return unitTonnage;
     }
+    
+    /** 
+     * @return Is this an item that exists in multiple forms for units of different tonnages?
+     */
+    public boolean isUnitTonnageMatters() {
+        return unitTonnageMatters;
+    }
 
     public abstract double getTonnage();
 
@@ -427,6 +441,11 @@ public abstract class Part implements IPartWork, ITechnology {
         toReturn.append("<html><b>")
             .append(isSalvaging() ? "Salvage  " : "Repair ")
             .append(getName());
+            if(isUnitTonnageMatters()) {
+                toReturn.append(" (")
+                    .append(getUnitTonnage())
+                    .append(" ton)");
+            }
         if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
             toReturn.append(" - ")
             .append(ReportingUtilities.messageSurroundedBySpanWithColor(
@@ -1123,9 +1142,14 @@ public abstract class Part implements IPartWork, ITechnology {
             sj.add("OmniPod");
         }
 
-        if (includeRepairDetails) {
-            sj.add(hits + " hit(s)");
-            if (campaign.getCampaignOptions().isPayForRepairs() && (hits > 0)) {
+        if (isUnitTonnageMatters())
+        {
+            sj.add(getUnitTonnage() + " tons");
+        }
+
+        if (includeRepairDetails && hits > 0) {            
+            sj.add(hits + (hits == 1 ? " hit" : " hits"));
+            if (campaign.getCampaignOptions().isPayForRepairs()) {
                 sj.add(getActualValue().multipliedBy(0.2).toAmountAndSymbolString() + " to repair");
             }
         }

--- a/MekHQ/src/mekhq/campaign/parts/PartInventory.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInventory.java
@@ -140,6 +140,18 @@ public class PartInventory {
      * @see #orderedAsString()
      */
     public String getTransitOrderedDetails() {
-        return transitAsString() + " in transit, " + orderedAsString() + " on order";
+        StringBuilder toReturn = new StringBuilder();
+        if(transit > 0) {
+            toReturn.append(transitAsString())
+                .append(" in transit");
+        }
+        if(ordered > 0) {
+            if (transit > 0) {
+                toReturn.append(", ");
+            }
+            toReturn.append(orderedAsString())
+                .append(" on order");
+        }
+        return toReturn.toString();
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/PartInventory.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInventory.java
@@ -133,9 +133,8 @@ public class PartInventory {
     /**
      * Gets the transit and ordered counts formatted as a String.
      *
-     * @return A String like, <code>&quot;XXX in transit, YYY on order&quot;</code>,
-     *         describing
-     *         the transit and ordered counts.
+     * @return A String like, <code>&quot;X in transit, Y on order&quot;</code>,
+     *         describing the transit and ordered counts.
      * @see #transitAsString()
      * @see #orderedAsString()
      */

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -78,7 +78,7 @@ public class PodSpace implements IPartWork {
     }
 
     public List<Part> getPartList() {
-        return childPartIds.stream().map(id -> campaign.getPart(id))
+        return childPartIds.stream().map(id -> campaign.getWarehouse().getPart(id))
                 .filter(Objects::nonNull).collect(Collectors.toList());
     }
 
@@ -102,7 +102,7 @@ public class PodSpace implements IPartWork {
         shorthandedMod = 0;
         //Iterate through all pod-mounted equipment in space and remove them.
         for (int pid : childPartIds) {
-            final Part part = campaign.getPart(pid);
+            final Part part = campaign.getWarehouse().getPart(pid);
             if (part != null) {
                 part.remove(salvage);
                 MekHQ.triggerEvent(new PartChangedEvent(part));
@@ -115,7 +115,7 @@ public class PodSpace implements IPartWork {
     public void fix() {
         shorthandedMod = 0;
         for (int pid : childPartIds) {
-            final Part part = campaign.getPart(pid);
+            final Part part = campaign.getWarehouse().getPart(pid);
             if (part != null && !(part instanceof MissingPart)
                     && !(part instanceof AmmoBin)
                     && part.needsFixing()
@@ -126,7 +126,7 @@ public class PodSpace implements IPartWork {
         }
         updateConditionFromEntity(false);
         for (int pid : childPartIds) {
-            final Part part = campaign.getPart(pid);
+            final Part part = campaign.getWarehouse().getPart(pid);
             if (part instanceof MissingPart) {
                 part.fix();
                 MekHQ.triggerEvent(new PartChangedEvent(part));
@@ -156,7 +156,7 @@ public class PodSpace implements IPartWork {
             }
             if (repairInPlace) {
                 for (int id : childPartIds) {
-                    final Part p = unit.getCampaign().getPart(id);
+                    final Part p = unit.getCampaign().getWarehouse().getPart(id);
                     if (p instanceof MissingPart) {
                         return null;
                     }
@@ -164,7 +164,7 @@ public class PodSpace implements IPartWork {
                 return unit.getEntity().getLocationName(location) + " is not missing any pod-mounted equipment.";
             } else {
                 for (int id : childPartIds) {
-                    final Part p = unit.getCampaign().getPart(id);
+                    final Part p = unit.getCampaign().getWarehouse().getPart(id);
                     if (p == null || !p.needsFixing()) {
                         continue;
                     }
@@ -188,7 +188,7 @@ public class PodSpace implements IPartWork {
     @Override
     public boolean needsFixing() {
         return childPartIds.stream()
-                .map(id -> campaign.getPart(id)).filter(Objects::nonNull)
+                .map(id -> campaign.getWarehouse().getPart(id)).filter(Objects::nonNull)
                 .anyMatch(p -> !(p instanceof AmmoBin) && p.needsFixing());
     }
 
@@ -247,7 +247,7 @@ public class PodSpace implements IPartWork {
         shorthandedMod = 0;
         boolean replacing = false;
         for (int id : childPartIds) {
-            final Part part = campaign.getPart(id);
+            final Part part = campaign.getWarehouse().getPart(id);
             if (part != null && (isSalvaging() ||
                     (!(part instanceof AmmoBin) && part.needsFixing()))) {
                 part.fail(rating);
@@ -280,7 +280,7 @@ public class PodSpace implements IPartWork {
     public int getSkillMin() {
         int minSkill = SkillType.EXP_GREEN;
         for (int id : childPartIds) {
-            final Part part = campaign.getPart(id);
+            final Part part = campaign.getWarehouse().getPart(id);
             if (part != null) {
                 if ((isSalvaging() && !(part instanceof MissingPart))
                         || (!isSalvaging() && (part instanceof MissingPart)
@@ -402,7 +402,7 @@ public class PodSpace implements IPartWork {
         int inTransit = 0;
         int onOrder = 0;
         for (int id : childPartIds) {
-            Part part = campaign.getPart(id);
+            Part part = campaign.getWarehouse().getPart(id);
             if (part != null) {
                 if (!isSalvaging() && !(part instanceof AmmoBin) && part.needsFixing()) {
                     allParts++;
@@ -461,7 +461,7 @@ public class PodSpace implements IPartWork {
 
     public boolean hasSalvageableParts() {
         for (int id : childPartIds) {
-            final Part p = campaign.getPart(id);
+            final Part p = campaign.getWarehouse().getPart(id);
             if (p != null && p.isSalvaging()) {
                 return true;
             }
@@ -471,13 +471,13 @@ public class PodSpace implements IPartWork {
 
     @Override
     public void reservePart() {
-        childPartIds.stream().map(id -> campaign.getPart(id))
+        childPartIds.stream().map(id -> campaign.getWarehouse().getPart(id))
             .filter(Objects::nonNull).forEach(Part::reservePart);
     }
 
     @Override
     public void cancelReservation() {
-        childPartIds.stream().map(id -> campaign.getPart(id))
+        childPartIds.stream().map(id -> campaign.getWarehouse().getPart(id))
             .filter(Objects::nonNull).forEach(Part::cancelReservation);
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -516,6 +516,17 @@ public class PodSpace implements IPartWork {
         return Money.of(0.0);
     }
 
+    /**
+     * This is the value of the part that may be affected by characteristics and campaign options
+     * but which ignores damage
+     * (Note: Pod Space, an abstraction, does not have value or price.
+     * @return the part's actual value
+     */
+    @Override
+    public Money getUndamagedValue() {
+        return Money.of(0.0);
+    }
+
     @Override
     public boolean isPriceAdjustedForAmount(){
         return false;

--- a/MekHQ/src/mekhq/campaign/parts/PodSpace.java
+++ b/MekHQ/src/mekhq/campaign/parts/PodSpace.java
@@ -234,10 +234,12 @@ public class PodSpace implements IPartWork {
     public String succeed() {
         if (isSalvaging()) {
             remove(true);
-            return " <font color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'><b> removed.</b></font>";
+            return ReportingUtilities.messageSurroundedBySpanWithColor(
+                    MekHQ.getMHQOptions().getFontColorPositiveHexColor(), "<b> removed</b>") + ".";
         } else {
             fix();
-            return " <font color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'><b> fixed.</b></font>";
+            return ReportingUtilities.messageSurroundedBySpanWithColor(
+                    MekHQ.getMHQOptions().getFontColorPositiveHexColor(), "<b> fixed</b>") + ".";
         }
     }
 
@@ -255,9 +257,12 @@ public class PodSpace implements IPartWork {
             }
         }
         if (rating >= SkillType.EXP_ELITE && replacing) {
-                return " <font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'><b> failed and part(s) destroyed.</b></font>";
+                return ReportingUtilities.messageSurroundedBySpanWithColor(
+                        MekHQ.getMHQOptions().getFontColorNegativeHexColor(),
+                        "<b> failed and part(s) destroyed</b>") + ".";
         } else {
-            return " <font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'><b> failed.</b></font>";
+            return ReportingUtilities.messageSurroundedBySpanWithColor(
+                    MekHQ.getMHQOptions().getFontColorNegativeHexColor(),"<b> failed</b>") + ".";
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/ProtoMekArmActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtoMekArmActuator.java
@@ -65,6 +65,7 @@ public class ProtoMekArmActuator extends Part {
         super(tonnage, c);
         this.name = "ProtoMek Arm Actuator";
         this.location = loc;
+        this.unitTonnageMatters = true;
     }
 
     public void setLocation(int loc) {

--- a/MekHQ/src/mekhq/campaign/parts/ProtoMekJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtoMekJumpJet.java
@@ -60,6 +60,7 @@ public class ProtoMekJumpJet extends Part {
     public ProtoMekJumpJet(int tonnage, Campaign c) {
         super(tonnage, c);
         this.name = "ProtoMek Jump Jet";
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/ProtoMekLegActuator.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtoMekLegActuator.java
@@ -54,6 +54,7 @@ public class ProtoMekLegActuator extends Part {
     public ProtoMekLegActuator(int tonnage, Campaign c) {
         super(tonnage, c);
         this.name = "ProtoMek Leg Actuator";
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/ProtoMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtoMekLocation.java
@@ -77,6 +77,7 @@ public class ProtoMekLocation extends Part {
         this.percent = 1.0;
         this.forQuad = quad;
         this.breached = false;
+        this.unitTonnageMatters = true;
         this.name = "ProtoMek Location";
         switch (loc) {
             case ProtoMek.LOC_HEAD:
@@ -584,6 +585,11 @@ public class ProtoMekLocation extends Part {
         toReturn.append("<html><b>")
             .append(isBlownOff() ? "Re-attach " : "Seal ")
             .append(getName());
+        if(isUnitTonnageMatters()) {
+            toReturn.append(" (")
+                .append(getUnitTonnage())
+                .append(" ton)");
+        }
         if (!getCampaign().getCampaignOptions().isDestroyByMargin()) {
             toReturn.append(" - ")
             .append(ReportingUtilities.messageSurroundedBySpanWithColor(

--- a/MekHQ/src/mekhq/campaign/parts/ProtoMekSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/ProtoMekSensor.java
@@ -53,6 +53,7 @@ public class ProtoMekSensor extends Part {
     public ProtoMekSensor(int tonnage, Campaign c) {
         super(tonnage, c);
         this.name = "ProtoMek Sensors";
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -57,6 +57,7 @@ import mekhq.campaign.parts.equipment.HeatSink;
 import mekhq.campaign.parts.equipment.LargeCraftAmmoBin;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.cleanup.EquipmentUnscrambler;
@@ -1768,8 +1769,8 @@ public class Refit extends Part implements IAcquisitionWork {
             mods.addModifier(2, "custom job");
         }
 
-        if ((null != tech) && tech.getOptions().booleanOption("tech_engineer")) {
-            mods.addModifier(-2, "engineer");
+        if ((null != tech) && tech.getOptions().booleanOption(PersonnelOptions.TECH_ENGINEER)) {
+            mods.addModifier(-2, "Engineer");
         }
         return mods;
     }

--- a/MekHQ/src/mekhq/campaign/parts/Rotor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Rotor.java
@@ -46,6 +46,7 @@ public class Rotor extends TankLocation {
         super(VTOL.LOC_ROTOR, tonnage, c);
         this.name = "Rotor";
         this.damage = 0;
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/TankLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/TankLocation.java
@@ -242,15 +242,22 @@ public class TankLocation extends Part {
 
     @Override
     public String getDetails(boolean includeRepairDetails) {
+        StringBuilder toReturn = new StringBuilder();
+
+        toReturn.append(super.getDetails(includeRepairDetails));
+
         if (includeRepairDetails) {
             if (isBreached()) {
-                return "Breached";
-            } else {
-                return damage + " point(s) of damage";
+                toReturn.append(", Breached");
+            } else if (damage > 0) {
+                toReturn.append(", ")
+                    .append(damage)
+                    .append(damage == 1 ? " point" : " points")
+                    .append(" of damage");
             }
-        } else {
-            return super.getDetails(false);
         }
+
+        return toReturn.toString();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/Turret.java
+++ b/MekHQ/src/mekhq/campaign/parts/Turret.java
@@ -53,6 +53,7 @@ public class Turret extends TankLocation {
         super(loc, tonnage, c);
         weight = 0;
         this.name = "Turret";
+        this.unitTonnageMatters = true;
     }
 
     @Override
@@ -225,15 +226,6 @@ public class Turret extends TankLocation {
     @Override
     public String getDetails() {
         return getDetails(true);
-    }
-
-    @Override
-    public String getDetails(boolean includeRepairDetails) {
-        String details = weight + " tons";
-        if (includeRepairDetails) {
-            details += ", " + damage + " point(s) of damage";
-        }
-        return details;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -517,17 +517,17 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
             int shotsAvailable = getAmountAvailable();
             PartInventory inventories = campaign.getPartInventory(getNewPart());
 
-            String orderTransitString = getOrderTransitStringForDetails(inventories);
+            String orderTransitString = inventories.getTransitOrderedDetails();
 
             if (shotsAvailable == 0) {
-                availability = "<br><font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>No ammo "
-                        + orderTransitString + "</font>";
+                availability = "<br><font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>No ammo ("
+                        + orderTransitString + ")</font>";
             } else if (shotsAvailable < getShotsNeeded()) {
                 availability = "<br><font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>Only "
-                        + shotsAvailable + " available" + orderTransitString + "</font>";
+                        + shotsAvailable + " available (" + orderTransitString + ")</font>";
             } else {
                 availability = "<br><font color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'>"
-                        + shotsAvailable + " available " + orderTransitString + "</font>";
+                        + shotsAvailable + " available (" + orderTransitString + ")</font>";
             }
 
             return getType().getDesc() + ", " + getShotsNeeded() + " shots needed" + availability;

--- a/MekHQ/src/mekhq/campaign/parts/equipment/JumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/JumpJet.java
@@ -36,6 +36,7 @@ public class JumpJet extends EquipmentPart {
         // TODO : on which it would have a different price (only tonnage is taken into
         // TODO : account for compatibility)
         super(tonnage, et, equipNum, 1.0, omniPodded, c);
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
@@ -81,7 +81,7 @@ public class MASC extends EquipmentPart {
     @Override
     public Money getStickerPrice() {
         if (isSupercharger()) {
-            return Money.of(engineRating * (isOmniPodded() ? 1250 : 10000));
+            return Money.of(engineRating * (isOmniPodded() ? 12500 : 10000));
         } else {
             return Money.of(engineRating * getTonnage() * 1000);
         }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
@@ -157,15 +157,19 @@ public class MASC extends EquipmentPart {
 
     @Override
     public String getDetails(boolean includeRepairDetails) {
-        String details = super.getDetails(includeRepairDetails);
+        StringBuilder details = new StringBuilder();
+        details.append(super.getDetails(includeRepairDetails));
         if (!details.isEmpty()) {
-            details += ", ";
+            details.append(", ");
         }
         if (isSupercharger()) {
             // Causes extra information but needed so omnipods show all data
-            details += equipTonnage + " tons, ";
+            details.append(equipTonnage)
+                .append(" tons, ");
         }
-        return details + getEngineRating() + " rating";
+        details.append(getEngineRating())
+            .append(" rating");
+        return details.toString();
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MASC.java
@@ -146,6 +146,11 @@ public class MASC extends EquipmentPart {
     }
 
     @Override
+    public boolean isUnitTonnageMatters() {
+        return !isSupercharger();
+    }
+
+    @Override
     public String getDetails() {
         return getDetails(true);
     }
@@ -153,16 +158,14 @@ public class MASC extends EquipmentPart {
     @Override
     public String getDetails(boolean includeRepairDetails) {
         String details = super.getDetails(includeRepairDetails);
-        if (null != unit) {
-            return details;
-        }
         if (!details.isEmpty()) {
             details += ", ";
         }
         if (isSupercharger()) {
-            return details + ", " + getEngineRating() + " rating";
+            // Causes extra information but needed so omnipods show all data
+            details += equipTonnage + " tons, ";
         }
-        return details + ", " + getUnitTonnage() + " tons, " + getEngineRating() + " rating";
+        return details + getEngineRating() + " rating";
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -64,7 +64,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
      * pod space, so we're going to stick them in LOC_NONE where the heat sinks are */
     @Override
     public String getLocationName() {
-        if (unit.getEntity() instanceof Aero
+        if ((null != unit) && (unit.getEntity() instanceof Aero)
                 && !((unit.getEntity() instanceof SmallCraft) || (unit.getEntity() instanceof Jumpship))) {
             return "Fuselage";
         }
@@ -73,7 +73,7 @@ public class MissingAmmoBin extends MissingEquipmentPart {
 
     @Override
     public int getLocation() {
-        if (unit.getEntity() instanceof Aero
+        if ((null != unit) && (unit.getEntity() instanceof Aero)
                 && !((unit.getEntity() instanceof SmallCraft) || (unit.getEntity() instanceof Jumpship))) {
             return Aero.LOC_NONE;
         }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingJumpJet.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingJumpJet.java
@@ -36,6 +36,7 @@ public class MissingJumpJet extends MissingEquipmentPart {
 
     public MissingJumpJet(int tonnage, EquipmentType et, int equipNum, boolean omniPodded, Campaign c) {
         super(tonnage, et, equipNum, c, 1, 1.0, omniPodded);
+        this.unitTonnageMatters = true;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingMASC.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingMASC.java
@@ -120,6 +120,11 @@ public class MissingMASC extends MissingEquipmentPart {
     }
 
     @Override
+    public boolean isUnitTonnageMatters() {
+        return !isSupercharger();
+    }
+
+    @Override
     public MASC getNewPart() {
         MASC epart = new MASC(getUnitTonnage(), type, -1, campaign, engineRating, omniPodded);
         epart.setEquipTonnage(equipTonnage);

--- a/MekHQ/src/mekhq/campaign/work/IPartWork.java
+++ b/MekHQ/src/mekhq/campaign/work/IPartWork.java
@@ -138,5 +138,13 @@ public interface IPartWork extends IWork {
      */
     public abstract Money getActualValue();
 
+    /**
+     * This is the value of the part that may be affected by characteristics and campaign options
+     * but not affected by part damage
+     * @return the part's actual value if it wasn't damaged
+     */
+    public abstract Money getUndamagedValue();
+
+
     public abstract boolean isPriceAdjustedForAmount();
 }

--- a/MekHQ/src/mekhq/gui/model/TechTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TechTableModel.java
@@ -139,6 +139,26 @@ public class TechTableModel extends DataTableModel {
         if (overtimeAllowed) {
             toReturn.append(String.format(" + (%d overtime)", tech.getOvertimeLeft()));
         }
+
+        if (tech.getOptions().booleanOption(PersonnelOptions.TECH_ENGINEER)) {
+            toReturn.append(", <i>Engineer</i>");
+        }
+        if (tech.getOptions().booleanOption(PersonnelOptions.TECH_MAINTAINER)) {
+            toReturn.append(", <i>Maintainer</i>");
+        }
+        if (tech.getOptions().booleanOption(PersonnelOptions.TECH_FIXER)) {
+            toReturn.append(", <i>Mr/Ms Fix-it</i>");
+        }
+        if (tech.getOptions().booleanOption(PersonnelOptions.TECH_ARMOR_SPECIALIST)) {
+            toReturn.append(", <i>Armor Specialist</i>");
+        }
+        if (tech.getOptions().booleanOption(PersonnelOptions.TECH_INTERNAL_SPECIALIST)) {
+            toReturn.append(", <i>Internal Specialist</i>");
+        }
+        if (tech.getOptions().booleanOption(PersonnelOptions.TECH_WEAPON_SPECIALIST)) {
+            toReturn.append(", <i>Weapon Specialist</i>");
+        }
+
         toReturn.append("</font></html>");
         return toReturn.toString();
     }

--- a/MekHQ/unittests/mekhq/campaign/parts/MekLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MekLocationTest.java
@@ -2017,7 +2017,9 @@ class MekLocationTest {
     @Test
     void getDetailsSpareTest() {
         Campaign mockCampaign = mock(Campaign.class);
-
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+        
         MekLocation mekLocation = new MekLocation(Mek.LOC_CT, 25, 0, false, false, false, false, false, mockCampaign);
 
         assertNotNull(mekLocation.getDetails());
@@ -2062,6 +2064,8 @@ class MekLocationTest {
     @Test
     void getDetailsOnUnitTest() {
         Campaign mockCampaign = mock(Campaign.class);
+        CampaignOptions mockCampaignOptions = mock(CampaignOptions.class);
+        when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
         Unit unit = mock(Unit.class);
         Mek entity = mock(Mek.class);
         when(unit.getEntity()).thenReturn(entity);

--- a/MekHQ/unittests/mekhq/campaign/parts/MekLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MekLocationTest.java
@@ -2022,7 +2022,6 @@ class MekLocationTest {
 
         assertNotNull(mekLocation.getDetails());
         assertTrue(mekLocation.getDetails().startsWith("25 tons"));
-        assertTrue(mekLocation.getDetails().contains("(100%)"));
         assertNotNull(mekLocation.getDetails(false));
         assertEquals("25 tons", mekLocation.getDetails(false));
 
@@ -2037,7 +2036,7 @@ class MekLocationTest {
 
         assertNotNull(mekLocation.getDetails());
         assertTrue(mekLocation.getDetails().startsWith("25 tons"));
-        assertTrue(mekLocation.getDetails().contains("(100%)"));
+        //assertTrue(mekLocation.getDetails().contains("(100%)"));
         assertNotNull(mekLocation.getDetails(false));
         assertEquals("25 tons", mekLocation.getDetails(false));
 
@@ -2045,7 +2044,7 @@ class MekLocationTest {
 
         assertNotNull(mekLocation.getDetails());
         assertTrue(mekLocation.getDetails().startsWith("25 tons"));
-        assertTrue(mekLocation.getDetails().contains("(100%)"));
+        //assertTrue(mekLocation.getDetails().contains("(100%)"));
         assertTrue(mekLocation.getDetails().contains("[Sensors]"));
         assertNotNull(mekLocation.getDetails(false));
         assertEquals("25 tons [Sensors]", mekLocation.getDetails(false));
@@ -2054,7 +2053,7 @@ class MekLocationTest {
 
         assertNotNull(mekLocation.getDetails());
         assertTrue(mekLocation.getDetails().startsWith("25 tons"));
-        assertTrue(mekLocation.getDetails().contains("(100%)"));
+        //assertTrue(mekLocation.getDetails().contains("(100%)"));
         assertTrue(mekLocation.getDetails().contains("[Sensors, Life Support]"));
         assertNotNull(mekLocation.getDetails(false));
         assertEquals("25 tons [Sensors, Life Support]", mekLocation.getDetails(false));
@@ -2075,39 +2074,39 @@ class MekLocationTest {
         mekLocation.setUnit(unit);
 
         assertNotNull(mekLocation.getDetails());
-        assertEquals("Right Arm (100%)", mekLocation.getDetails());
+        assertEquals("Right Arm, 30 tons", mekLocation.getDetails());
         assertNotNull(mekLocation.getDetails(false));
-        assertEquals("Right Arm", mekLocation.getDetails(false));
+        assertEquals("Right Arm, 30 tons", mekLocation.getDetails(false));
 
         mekLocation.setPercent(0.1);
 
         assertNotNull(mekLocation.getDetails());
-        assertEquals("Right Arm (10%)", mekLocation.getDetails());
+        assertEquals("Right Arm, 30 tons (10%)", mekLocation.getDetails());
         assertNotNull(mekLocation.getDetails(false));
-        assertEquals("Right Arm", mekLocation.getDetails(false));
+        assertEquals("Right Arm, 30 tons", mekLocation.getDetails(false));
 
         mekLocation.setBlownOff(true);
 
         assertNotNull(mekLocation.getDetails());
-        assertEquals("Right Arm (Blown Off)", mekLocation.getDetails());
+        assertEquals("Right Arm, 30 tons (Blown Off)", mekLocation.getDetails());
         assertNotNull(mekLocation.getDetails(false));
-        assertEquals("Right Arm", mekLocation.getDetails(false));
+        assertEquals("Right Arm, 30 tons", mekLocation.getDetails(false));
 
         mekLocation.setBlownOff(false);
         mekLocation.setBreached(true);
 
         assertNotNull(mekLocation.getDetails());
-        assertEquals("Right Arm (Breached)", mekLocation.getDetails());
+        assertEquals("Right Arm, 30 tons (Breached)", mekLocation.getDetails());
         assertNotNull(mekLocation.getDetails(false));
-        assertEquals("Right Arm", mekLocation.getDetails(false));
+        assertEquals("Right Arm, 30 tons", mekLocation.getDetails(false));
 
         mekLocation.setBreached(false);
         doReturn(true).when(unit).hasBadHipOrShoulder((mekLocation.getLoc()));
 
         assertNotNull(mekLocation.getDetails());
-        assertEquals("Right Arm (Bad Hip/Shoulder)", mekLocation.getDetails());
+        assertEquals("Right Arm, 30 tons (Bad Hip/Shoulder)", mekLocation.getDetails());
         assertNotNull(mekLocation.getDetails(false));
-        assertEquals("Right Arm", mekLocation.getDetails(false));
+        assertEquals("Right Arm, 30 tons", mekLocation.getDetails(false));
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/parts/MekLocationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/MekLocationTest.java
@@ -2038,7 +2038,6 @@ class MekLocationTest {
 
         assertNotNull(mekLocation.getDetails());
         assertTrue(mekLocation.getDetails().startsWith("25 tons"));
-        //assertTrue(mekLocation.getDetails().contains("(100%)"));
         assertNotNull(mekLocation.getDetails(false));
         assertEquals("25 tons", mekLocation.getDetails(false));
 
@@ -2046,7 +2045,6 @@ class MekLocationTest {
 
         assertNotNull(mekLocation.getDetails());
         assertTrue(mekLocation.getDetails().startsWith("25 tons"));
-        //assertTrue(mekLocation.getDetails().contains("(100%)"));
         assertTrue(mekLocation.getDetails().contains("[Sensors]"));
         assertNotNull(mekLocation.getDetails(false));
         assertEquals("25 tons [Sensors]", mekLocation.getDetails(false));
@@ -2055,7 +2053,6 @@ class MekLocationTest {
 
         assertNotNull(mekLocation.getDetails());
         assertTrue(mekLocation.getDetails().startsWith("25 tons"));
-        //assertTrue(mekLocation.getDetails().contains("(100%)"));
         assertTrue(mekLocation.getDetails().contains("[Sensors, Life Support]"));
         assertNotNull(mekLocation.getDetails(false));
         assertEquals("25 tons [Sensors, Life Support]", mekLocation.getDetails(false));


### PR DESCRIPTION
This is a fairly hefty scrub and tuning of campaign/parts/\*.java, particularly the string and UI-related bits. It fixes a number of minor bugs and nuisances as it goes.

Original Goal:

- Display unit tonnage of parts that it matters for (locations, sensors, jump jets, MASC, etc) prominently in the repair bay and generally enhance the repair experience.
- Display available stores on replacement items so you know if you're using the last one on a repair and such.
- Get any other useful information in front of the user.

Major points:

- Parts now rely more on their parent (usually Part) for getDetails information, some of them losing their own implementation completely.
- More robust generic getDetails in major classes, particularly Part
- This ends up fixing or improving the shop descriptions of numerous items as well
- General code cleanup of campaign/parts/\*.java, especially regrading string handling functions.

Along the way:

- Only show damage on parts that are actually damaged
- Turrets and Rotors now show the tonnage they're for
- Turrets now get said tonnage applied properly in the parts store
- Superchargers now show all their relevant stats in empty omnipods.
- Superchargers in omnipods are now the correct price instead of way cheaper (missing zero in math).
- Empty omnipods now show the tech base of the part they're made for.
- Make missing parts display how many you have in stock and make the display of transit parts nicer there.
- Updated deprecated campaign.getPart()s in PodSpace
- Update lots of things to use ReportingTools and StringBuilders
- Drop Part.getOrderTransitStringForDetails because this is also done by a function in PartInventory, changed the places it was used to the other one.
- Some pluralization tweaks and other minor grammar stuff.
- Show parentheses around item details on Command Center tab.
- Mek locations show cost now too; minor cost function refactoring.
- Show Tech SPAs on the Tech Panel. Probably should have been a separate PR but got mixed in here and I don't know how to separate it.

There isn't a whole lot to see but here are a few examples of stuff that you can:

![2024-10-18_182625](https://github.com/user-attachments/assets/8d01df3c-634a-4211-8aff-629626e5086a)
![2024-10-18_182704](https://github.com/user-attachments/assets/23655947-af3d-43e8-9895-f19e9d8a1672)
![2024-10-18_190011](https://github.com/user-attachments/assets/2c7e43ea-9dee-4e83-bef1-1c206b5b31bf)
![2024-10-18_190025](https://github.com/user-attachments/assets/2d72f5c1-a57a-46b0-9d8a-414386445229)
![2024-10-18_190045](https://github.com/user-attachments/assets/9b43a9e6-a3c2-4ae3-8771-8fdce9d29f72)
![2024-10-19_134742](https://github.com/user-attachments/assets/cb474ee5-18f2-4778-a0d7-74496b8ed8e6)
![2024-10-19_134725](https://github.com/user-attachments/assets/b4632c22-e64a-435d-916f-46b4598a7291)
![2024-10-20_160336](https://github.com/user-attachments/assets/1afe4410-dc74-4d0d-a829-3d7012318bd2)
![2024-10-18_183125](https://github.com/user-attachments/assets/ce682b80-6ebd-4e70-8896-d1c7c97e304c)
