### PR TITLE
Change "Clear All Items" to "Remove Selected Items" on CC Tab List

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -268,8 +268,8 @@ addMinimumComplementGreen.text=Green
 addMinimumComplementUltraGreen.text=Ultra Green
 
 #### ProcurementTableMouseAdapter Class
-miClearItems.text=Clear All Items
-miClearItems.toolTipText=This immediately removes all selected items from the procurement list, as well as any items currently showing as zero left to acquire.
+miClearItems.text=Remove Selected Items
+miClearItems.toolTipText=This immediately removes all selected items from the procurement list.
 miProcureSingleItemImmediately.text=Procure a Single Item Immediately
 miProcureSingleItemImmediately.toolTipText=This immediately attempts to procure an item for each selected row as if an administrator had successfully rolled to acquire the item.
 miAddSingleItemImmediately.text=Add a Single Item Immediately


### PR DESCRIPTION
It took me a long time to realize that this command didn't wipe the entire procurement list. This updates its name to something that reflects that, and drops some (nowadays) untrue information from the tooltip.

![2024-10-18_221346](https://github.com/user-attachments/assets/2e6afb0e-d1be-46bd-8a40-f4cf6fbd1ec1)
