### PR TITLE
Added 'No Eligible Personnel' Dialog to Turnover & Retention Checks

### DIFF
--- a/MekHQ/resources/mekhq/resources/RetirementDefectionDialog.properties
+++ b/MekHQ/resources/mekhq/resources/RetirementDefectionDialog.properties
@@ -20,3 +20,6 @@ txtInstructions.Overview.text=The turnover check involves rolling 2d6 and compar
 txtInstructions.Results.text=Combat personnel who brought their units with them should be given a unit upon departure. If no unit of the appropriate weight class and technology is available, the retiree is compensated in C-bills.\
   \n\
   \nAny pilots with a final payout value of zero have either been compensated with a unit that meets or exceeds the payout amount, or are breaking their employment contract.
+
+nobodyEligibleDialog.title=Turnover & Retention
+nobodyEligibleDialog.text=Nobody wants to leave the unit at this time.

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -515,8 +515,6 @@ public class MekHQ implements GameListener {
             if (!getCampaign().getRetirementDefectionTracker().getRetirees().isEmpty()) {
                 RetirementDefectionDialog rdd = new RetirementDefectionDialog(campaignGUI,
                         campaignGUI.getCampaign().getMission(currentScenario.getMissionId()), false);
-                rdd.setLocation(rdd.getLocation().x, 0);
-                rdd.setVisible(true);
 
                 if (!rdd.wasAborted()) {
                     getCampaign().applyRetirement(rdd.totalPayout(), rdd.getUnitAssignments());

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -440,8 +440,6 @@ public final class BriefingTab extends CampaignGuiTab {
                 && (getCampaign().getCampaignOptions().isUseContractCompletionRandomRetirement())) {
             RetirementDefectionDialog rdd = new RetirementDefectionDialog(getCampaignGui(), mission, true);
 
-
-
             if (rdd.wasAborted()) {
                 /*
                  * Once the retirement rolls have been made, the outstanding payouts can be

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -439,8 +439,8 @@ public final class BriefingTab extends CampaignGuiTab {
         if ((getCampaign().getCampaignOptions().isUseRandomRetirement())
                 && (getCampaign().getCampaignOptions().isUseContractCompletionRandomRetirement())) {
             RetirementDefectionDialog rdd = new RetirementDefectionDialog(getCampaignGui(), mission, true);
-            rdd.setLocation(rdd.getLocation().x, 0);
-            rdd.setVisible(true);
+
+
 
             if (rdd.wasAborted()) {
                 /*
@@ -727,8 +727,8 @@ public final class BriefingTab extends CampaignGuiTab {
         if (!getCampaign().getRetirementDefectionTracker().getRetirees().isEmpty()) {
             RetirementDefectionDialog rdd = new RetirementDefectionDialog(getCampaignGui(),
                     getCampaign().getMission(scenario.getMissionId()), false);
-            rdd.setLocation(rdd.getLocation().x, 0);
-            rdd.setVisible(true);
+
+
 
             if (!rdd.wasAborted()) {
                 getCampaign().applyRetirement(rdd.totalPayout(), rdd.getUnitAssignments());

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -723,13 +723,11 @@ public final class BriefingTab extends CampaignGuiTab {
         resolveDialog.setVisible(true);
 
         if (!getCampaign().getRetirementDefectionTracker().getRetirees().isEmpty()) {
-            RetirementDefectionDialog rdd = new RetirementDefectionDialog(getCampaignGui(),
+            RetirementDefectionDialog dialog = new RetirementDefectionDialog(getCampaignGui(),
                     getCampaign().getMission(scenario.getMissionId()), false);
 
-
-
-            if (!rdd.wasAborted()) {
-                getCampaign().applyRetirement(rdd.totalPayout(), rdd.getUnitAssignments());
+            if (!dialog.wasAborted()) {
+                getCampaign().applyRetirement(dialog.totalPayout(), dialog.getUnitAssignments());
             }
         }
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1220,10 +1220,8 @@ public class CampaignGUI extends JPanel {
          * present the retirement view to give the player a chance to follow a
          * custom schedule
          */
-        RetirementDefectionDialog rdd = new RetirementDefectionDialog(this, null,
-                getCampaign().getRetirementDefectionTracker().getRetirees().isEmpty());
-
-
+        boolean doRetirement = getCampaign().getRetirementDefectionTracker().getRetirees().isEmpty();
+        RetirementDefectionDialog rdd = new RetirementDefectionDialog(this, null, doRetirement);
 
         if (!rdd.wasAborted()) {
             getCampaign().applyRetirement(rdd.totalPayout(), rdd.getUnitAssignments());

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1221,10 +1221,10 @@ public class CampaignGUI extends JPanel {
          * custom schedule
          */
         boolean doRetirement = getCampaign().getRetirementDefectionTracker().getRetirees().isEmpty();
-        RetirementDefectionDialog rdd = new RetirementDefectionDialog(this, null, doRetirement);
+        RetirementDefectionDialog dialog = new RetirementDefectionDialog(this, null, doRetirement);
 
-        if (!rdd.wasAborted()) {
-            getCampaign().applyRetirement(rdd.totalPayout(), rdd.getUnitAssignments());
+        if (!dialog.wasAborted()) {
+            getCampaign().applyRetirement(dialog.totalPayout(), dialog.getUnitAssignments());
             return true;
         } else {
             return false;

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1222,8 +1222,8 @@ public class CampaignGUI extends JPanel {
          */
         RetirementDefectionDialog rdd = new RetirementDefectionDialog(this, null,
                 getCampaign().getRetirementDefectionTracker().getRetirees().isEmpty());
-        rdd.setLocation(rdd.getLocation().x, 0);
-        rdd.setVisible(true);
+
+
 
         if (!rdd.wasAborted()) {
             getCampaign().applyRetirement(rdd.totalPayout(), rdd.getUnitAssignments());

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -824,7 +824,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 if (showDialog) {
                     RetirementDefectionDialog rdd = new RetirementDefectionDialog(
                             gui, null, false);
-                    rdd.setVisible(true);
+
                     if (rdd.wasAborted()
                             || !gui.getCampaign().applyRetirement(rdd.totalPayout(),
                                     rdd.getUnitAssignments())) {

--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -23,6 +23,7 @@ import megamek.client.ui.preferences.JComboBoxPreference;
 import megamek.client.ui.preferences.JIntNumberSpinnerPreference;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
 import megamek.common.TargetRoll;
 import megamek.common.TechConstants;
@@ -122,7 +123,7 @@ public class RetirementDefectionDialog extends JDialog {
             targetRolls = rdTracker.getTargetNumbers(mission, hqView.getCampaign());
         }
         currentPanel = doRetirement ? PAN_OVERVIEW : PAN_RESULTS;
-        setSize(new Dimension(800, 600));
+        setSize(UIUtil.scaleForGUI(800, 600));
         initComponents(doRetirement);
         if (!doRetirement) {
             initResults();

--- a/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/RetirementDefectionDialog.java
@@ -18,31 +18,6 @@
  */
 package mekhq.gui.dialog;
 
-import static mekhq.campaign.personnel.turnoverAndRetention.RetirementDefectionTracker.Payout.isBreakingContract;
-
-import java.awt.BorderLayout;
-import java.awt.CardLayout;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.Toolkit;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.UUID;
-
-import javax.swing.*;
-import javax.swing.JSpinner.DefaultEditor;
-import javax.swing.RowSorter.SortKey;
-import javax.swing.table.TableCellEditor;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-
 import megamek.client.ui.models.XTableColumnModel;
 import megamek.client.ui.preferences.JComboBoxPreference;
 import megamek.client.ui.preferences.JIntNumberSpinnerPreference;
@@ -67,6 +42,21 @@ import mekhq.gui.model.UnitAssignmentTableModel;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.PersonRankStringSorter;
 import mekhq.gui.sorter.WeightClassSorter;
+
+import javax.swing.*;
+import javax.swing.JSpinner.DefaultEditor;
+import javax.swing.RowSorter.SortKey;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.*;
+
+import static mekhq.campaign.personnel.turnoverAndRetention.RetirementDefectionTracker.Payout.isBreakingContract;
 
 /**
  * @author Neoancient
@@ -141,6 +131,8 @@ public class RetirementDefectionDialog extends JDialog {
 
         setLocationRelativeTo(gui.getFrame());
         setUserPreferences(doRetirement);
+        setAlwaysOnTop(true);
+        setVisible(true);
     }
 
     private void initComponents(boolean doRetirement) {


### PR DESCRIPTION
Currently, when users are prompted to make a turnover check the turnover table will only show characters with a TN greater than 2. This means that often the table will appear empty, creating confusion among users. This is especially true for early campaigns, when all personnel are benefiting from employment contract bonuses.

Now, if nobody is eligible for turnover, a dialog will replace the turnover table informing users of this. It is not possible to skip the turnover dialog entirely, as the prompt does not know that the table is empty when it is triggered.

The image shown in the dialog will change to match the campaign faction, where possible.

### Closes #5059

<img width="406" alt="image" src="https://github.com/user-attachments/assets/ad1fd8fb-6dd6-4eb6-a065-00e27194ba4c">