### PR TITLE
Fixed Hire Minimum Compliment Commands

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -127,7 +127,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
     public static final String COMMAND_GM_MOTHBALL = COMMAND_MOTHBALL + COMMAND_GM;
     public static final String COMMAND_GM_ACTIVATE = COMMAND_ACTIVATE + COMMAND_GM;
     public static final String COMMAND_UNDEPLOY = "UNDEPLOY";
-    public static final String COMMAND_HIRE_FULL_GM_RANDOM = COMMAND_HIRE_FULL + COMMAND_GM;
+    public static final String COMMAND_HIRE_FULL_GM = COMMAND_HIRE_FULL + COMMAND_GM;
     public static final String COMMAND_HIRE_FULL_GM_ELITE = COMMAND_HIRE_FULL + COMMAND_GM + "ELITE";
     public static final String COMMAND_HIRE_FULL_GM_VETERAN = COMMAND_HIRE_FULL + COMMAND_GM + "VETERAN";
     public static final String COMMAND_HIRE_FULL_GM_REGULAR = COMMAND_HIRE_FULL + COMMAND_GM + "REGULAR";
@@ -332,29 +332,40 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
             }
         } else if (command.contains(COMMAND_HIRE_FULL)) {
             boolean isGM = command.contains("GM");
+
             HirePersonnelUnitAction hireAction = new HirePersonnelUnitAction(isGM);
+
             for (Unit unit : units) {
+                List<Person> preExistingCrew = unit.getCrew();
+
                 hireAction.execute(gui.getCampaign(), unit);
 
-                if (command.contains("RANDOM")) {
-                    continue;
-                }
+                boolean fixSkillLevels = false;
 
                 SkillLevel skillLevel = SkillLevel.REGULAR;
                 if (command.contains("ELITE")) {
                     skillLevel = SkillLevel.ELITE;
+                    fixSkillLevels = true;
                 } else if (command.contains("VETERAN")) {
                     skillLevel = SkillLevel.VETERAN;
-                } else if (command.contains("GREEN")) {
-                    skillLevel = SkillLevel.GREEN;
+                    fixSkillLevels = true;
                 } else if (command.contains("ULTRA_GREEN")) {
                     skillLevel = SkillLevel.ULTRA_GREEN;
+                    fixSkillLevels = true;
+                } else if (command.contains("GREEN")) {
+                    skillLevel = SkillLevel.GREEN;
+                    fixSkillLevels = true;
                 }
 
-                for (Person person : unit.getCrew()) {
-                    overrideSkills(gui.getCampaign(), person, person.getPrimaryRole(), skillLevel.ordinal());
-                }
+                if (fixSkillLevels) {
+                    for (Person person : unit.getCrew()) {
+                        if (preExistingCrew.contains(person)) {
+                            continue;
+                        }
 
+                        overrideSkills(gui.getCampaign(), person, person.getPrimaryRole(), skillLevel.ordinal());
+                    }
+                }
             }
         } else if (command.equals(COMMAND_CUSTOMIZE)) { // Single Unit only
             ((MekLabTab) gui.getTab(MHQTabType.MEK_LAB)).loadUnit(selectedUnit);
@@ -1008,7 +1019,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                     JMenu menuMinimumComplement = new JMenu(resources.getString("addMinimumComplement.text"));
 
                     menuItem = new JMenuItem(resources.getString("addMinimumComplementRandom.text"));
-                    menuItem.setActionCommand(COMMAND_HIRE_FULL_GM_RANDOM);
+                    menuItem.setActionCommand(COMMAND_HIRE_FULL_GM);
                     menuItem.addActionListener(this);
                     menuMinimumComplement.add(menuItem);
 
@@ -1096,10 +1107,10 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
             Entity entity = unit.getEntity();
             String unitName = entity.getShortNameRaw();
             String fileExtension = entity instanceof Mek ? ".mtf" : ".blk";
-            String fileOutName = MHQConstants.CUSTOM_MEKFILES_DIRECTORY_PATH + File.separator 
+            String fileOutName = MHQConstants.CUSTOM_MEKFILES_DIRECTORY_PATH + File.separator
                     + unitName + fileExtension;
             String fileNameCampaign = sCustomsDirCampaign + File.separator + unitName + fileExtension;
-            
+
             // if this file already exists then don't overwrite it or we will end up with a bunch of copies
             if ((new File(fileOutName)).exists() || (new File(fileNameCampaign)).exists()) {
                 JOptionPane.showMessageDialog(null,
@@ -1107,7 +1118,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                         "File Already Exists", JOptionPane.ERROR_MESSAGE);
                 return;
             }
-            
+
             if (entity instanceof Mek) {
                 try (OutputStream os = new FileOutputStream(fileNameCampaign);
                         PrintStream p = new PrintStream(os)) {


### PR DESCRIPTION
Standardized the GM hire command naming for consistency and fixed the skill level override logic to skip pre-existing crew members. This prevents unintended skill level changes and ensures correct hiring and configuration of personnel.

### Closes #5037