### PR TITLE
Updated Primary Allies Scenario Modifiers

### DIFF
--- a/MekHQ/data/scenariomodifiers/PrimaryAlliesAir.xml
+++ b/MekHQ/data/scenariomodifiers/PrimaryAlliesAir.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>To compensate for the presence of a large opposing force, allied units will be working alongside us on this operation.</additionalBriefingText>
+	<additionalBriefingText>Additional allied units will be working alongside us on this operation.</additionalBriefingText>
 	<benefitsPlayer>true</benefitsPlayer>
 	<eventTiming>PreForceGeneration</eventTiming>
 	<forceDefinition>
@@ -8,16 +8,16 @@
 		<allowedUnitType>-3</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>false</contributesToBV>
+		<contributesToBV>true</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>false</contributesToUnitCount>
+		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>1</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
-		<forceName>Allied Force</forceName>
+		<forceName>Additional Force</forceName>
 		<generationMethod>3</generationMethod>
 		<generationOrder>1</generationOrder>
 		<maxWeightClass>4</maxWeightClass>

--- a/MekHQ/data/scenariomodifiers/PrimaryAlliesGround.xml
+++ b/MekHQ/data/scenariomodifiers/PrimaryAlliesGround.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>To compensate for the presence of a large opposing force, allied units will be working alongside us on this operation.</additionalBriefingText>
+	<additionalBriefingText>Additional allied units will be working alongside us on this operation.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
@@ -12,16 +12,16 @@
 		<allowedUnitType>-2</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>false</contributesToBV>
+		<contributesToBV>true</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>false</contributesToUnitCount>
+		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>1</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
-		<forceName>Allied Force</forceName>
+		<forceName>Additional Force</forceName>
 		<generationMethod>3</generationMethod>
 		<generationOrder>1</generationOrder>
 		<maxWeightClass>4</maxWeightClass>


### PR DESCRIPTION
The two primary allies modifiers are a special case that is randomly added to a scenario, based on the contract command level (or contract type)...
<img width="521" alt="image" src="https://github.com/user-attachments/assets/d451a88f-1236-4dba-977a-4b7cce8e35c7">
...this runs contrary to the modifiers' description which made it seem like mhq was reacting to the size of enemy forces. 

Instead, this modifier would increase the size of the OpFor (by increasing the size of the player-allied force), resulting in the 'overwhelming enemy forces' problem it was claiming to 'solve'.

This PR restores the ability for these modifiers to contribute to BV (that had been accidentally dropped some time around 50.0) and updates the modifier description. While the original description was well intentioned, and technically accurate, it contributed to a lot of confusion over the months whenever Force Generation and balancing were being discussed.

### Closes #5008
