### PR TITLE
Fixed Wrapping of Personality Description

### DIFF
--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -88,7 +88,6 @@ public class PersonViewPanel extends JScrollablePanel {
     }
 
     private void initComponents() {
-
         setLayout(new GridBagLayout());
         getAccessibleContext().setAccessibleName("Details for " + person.getFullName());
 
@@ -204,7 +203,7 @@ public class PersonViewPanel extends JScrollablePanel {
             txtDesc.setName("personalityDescription");
             txtDesc.setEditable(false);
             txtDesc.setContentType("text/html");
-            txtDesc.setText(MarkdownRenderer.getRenderedHtml(wordWrap(person.getPersonalityDescription(), 200)));
+            txtDesc.setText(person.getPersonalityDescription());
             txtDesc.setBorder(BorderFactory.createTitledBorder(resourceMap.getString("pnlPersonality.title")));
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 0;
@@ -222,7 +221,7 @@ public class PersonViewPanel extends JScrollablePanel {
             txtDesc.setName("txtDesc");
             txtDesc.setEditable(false);
             txtDesc.setContentType("text/html");
-            txtDesc.setText(MarkdownRenderer.getRenderedHtml(wordWrap(person.getBiography(), 200)));
+            txtDesc.setText(MarkdownRenderer.getRenderedHtml(person.getBiography()));
             txtDesc.setBorder(BorderFactory.createCompoundBorder(
                     BorderFactory.createTitledBorder(resourceMap.getString("pnlDescription.title")),
                     BorderFactory.createEmptyBorder(0, 2, 2, 2)));


### PR DESCRIPTION
Removed the markdown rendering of the personality description and the word wrapping from the text field. As well as two incorrect uses of `wordWrap`.

### Closes #5003