### PR TITLE
Updated Fatigue Column of Personnel Table to Use Effective Fatigue Value

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -490,11 +490,8 @@ public enum PersonnelTableModelColumn {
             case GENDER:
                 return GenderDescriptors.MALE_FEMALE_OTHER.getDescriptorCapitalized(person.getGender());
             case SKILL_LEVEL:
-                StringBuilder levelName = new StringBuilder(64);
-                levelName.append("<html>")
-                    .append(SkillType.getColoredExperienceLevelName(person.getSkillLevel(campaign, false)))
-                    .append("</html>");
-                return levelName.toString();
+                return "<html>" + SkillType.getColoredExperienceLevelName(
+                    person.getSkillLevel(campaign, false)) + "</html>";
             case PERSONNEL_ROLE:
                 return person.getRoleDesc();
             case UNIT_ASSIGNMENT: {
@@ -673,7 +670,7 @@ public enum PersonnelTableModelColumn {
             case INJURIES:
                 if (campaign.getCampaignOptions().isUseAdvancedMedical()) {
                     return Integer.toString(person.getInjuries().size());
-                } else { 
+                } else {
                     return Integer.toString(person.getHits());
                 }
             case KILLS:
@@ -720,7 +717,7 @@ public enum PersonnelTableModelColumn {
             case TOUGHNESS:
                 return Integer.toString(person.getToughness());
             case FATIGUE:
-                return Integer.toString(person.getFatigue());
+                return Integer.toString(person.getEffectiveFatigue(campaign));
             case EDGE:
                 return Integer.toString(person.getEdge());
             case SPA_COUNT:


### PR DESCRIPTION
Modified the `PersonnelTableModelColumn` to use the effective fatigue value for personnel instead of the raw fatigue.

### Closes #4999