### PR TITLE
Fix StratCon vs Normal deployment status of units

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -896,7 +896,7 @@ public class Campaign implements ITechManager {
         int id = lastForceId + 1;
         force.setId(id);
         superForce.addSubForce(force, true);
-        force.setScenarioId(superForce.getScenarioId());
+        force.setScenarioId(superForce.getScenarioId(), this);
         forceIds.put(id, force);
         lastForceId = id;
 
@@ -917,15 +917,7 @@ public class Campaign implements ITechManager {
         }
 
         superForce.addSubForce(force, true);
-        force.setScenarioId(superForce.getScenarioId());
-
-        for (Object o : force.getAllChildren(this)) {
-            if (o instanceof Unit) {
-                ((Unit) o).setScenarioId(superForce.getScenarioId());
-            } else if (o instanceof Force) {
-                ((Force) o).setScenarioId(superForce.getScenarioId());
-            }
-        }
+        force.setScenarioId(superForce.getScenarioId(), this);
 
         // repopulate formation levels across the TO&E
         Force.populateFormationLevelsFromOrigin(this);
@@ -3697,14 +3689,8 @@ public class Campaign implements ITechManager {
                         }
 
                         if (!forceUnderRepair) {
-                            forceIds.get(forceId).setScenarioId(s.getId());
+                            forceIds.get(forceId).setScenarioId(s.getId(), this);
                             s.addForces(forceId);
-                            for (UUID uid : forceIds.get(forceId).getAllUnits(true)) {
-                                Unit u = getHangar().getUnit(uid);
-                                if (u != null) {
-                                    u.setScenarioId(s.getId());
-                                }
-                            }
 
                             addReport(MessageFormat.format(
                                     resources.getString("atbScenarioTodayWithForce.format"),

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -183,6 +183,11 @@ public class Force {
         return scenarioId;
     }
 
+    /**
+     * Set scenario ID (e.g. deploy to scenario) for a force and all of its subforces and units
+     * @param scenarioId scenario to deploy to
+     * @param campaign campaign - required to update units
+     */
     public void setScenarioId(int scenarioId, Campaign campaign) {
         this.scenarioId = scenarioId;
         for (Force sub : getSubForces()) {

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -183,10 +183,16 @@ public class Force {
         return scenarioId;
     }
 
-    public void setScenarioId(int i) {
-        this.scenarioId = i;
+    public void setScenarioId(int scenarioId, Campaign campaign) {
+        this.scenarioId = scenarioId;
         for (Force sub : getSubForces()) {
-            sub.setScenarioId(i);
+            sub.setScenarioId(scenarioId, campaign);
+        }
+        for (UUID uid : getUnits()) {
+            Unit unit = campaign.getUnit(uid);
+            if (null != unit) {
+                unit.setScenarioId(scenarioId);
+            }
         }
     }
 
@@ -410,7 +416,7 @@ public class Force {
                 c.getScenario(getScenarioId()).addUnit(uid);
             }
         }
-        setScenarioId(-1);
+        setScenarioId(-1,c);
     }
 
     public int getId() {

--- a/MekHQ/src/mekhq/campaign/storyarc/storypoint/ScenarioStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyarc/storypoint/ScenarioStoryPoint.java
@@ -95,13 +95,7 @@ public class ScenarioStoryPoint extends StoryPoint {
                 Force force = getCampaign().getForce(deployedForceId);
                 if (null != force) {
                     scenario.addForces(force.getId());
-                    force.setScenarioId(scenario.getId());
-                    for (UUID uid : force.getAllUnits(true)) {
-                        Unit u = getCampaign().getUnit(uid);
-                        if (null != u) {
-                            u.setScenarioId(scenario.getId());
-                        }
-                    }
+                    force.setScenarioId(scenario.getId(), getCampaign());
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -723,7 +723,7 @@ public class StratconRulesManager {
         for (int forceID : scenario.getPlayerTemplateForceIDs()) {
             Force force = campaign.getForce(forceID);
             force.clearScenarioIds(campaign, true);
-            force.setScenarioId(scenario.getBackingScenarioID());
+            force.setScenarioId(scenario.getBackingScenarioID(), campaign);
         }
 
         scenario.commitPrimaryForces();

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -17,6 +17,7 @@ import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import mekhq.MekHQ;
 import mekhq.adapter.DateAdapter;
+import mekhq.campaign.Campaign;
 import mekhq.campaign.event.DeploymentChangedEvent;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBDynamicScenario;
@@ -91,10 +92,10 @@ public class StratconScenario implements IStratconDisplayable {
      * Add a force to the backing scenario, trying to associate it with the given template.
      * Does some scenario and force house-keeping, fires a deployment changed event.
      */
-    public void addForce(Force force, String templateID) {
+    public void addForce(Force force, String templateID, Campaign campaign) {
         if (!getBackingScenario().getForceIDs().contains(force.getId())) {
             backingScenario.addForce(force.getId(), templateID);
-            force.setScenarioId(getBackingScenarioID());
+            force.setScenarioId(getBackingScenarioID(), campaign);
             MekHQ.triggerEvent(new DeploymentChangedEvent(force, getBackingScenario()));
         }
     }

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2419,7 +2419,7 @@ public class CampaignGUI extends JPanel {
                         continue;
                     }
                     scenario.addForces(sub.getId());
-                    sub.setScenarioId(scenario.getId());
+                    sub.setScenarioId(scenario.getId(), getCampaign());
                 }
                 prevId = parent.getId();
             }

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -361,13 +361,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     force.clearScenarioIds(gui.getCampaign(), true);
                     if (null != scenario) {
                         scenario.addForces(force.getId());
-                        force.setScenarioId(scenario.getId());
-                        for (UUID uid : force.getAllUnits(true)) {
-                            Unit u = gui.getCampaign().getUnit(uid);
-                            if (null != u) {
-                                u.setScenarioId(scenario.getId());
-                            }
-                        }
+                        force.setScenarioId(scenario.getId(), gui.getCampaign());
                     }
                     MekHQ.triggerEvent(new DeploymentChangedEvent(force, scenario));
                 }

--- a/MekHQ/src/mekhq/gui/dialog/ForceTemplateAssignmentDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ForceTemplateAssignmentDialog.java
@@ -208,7 +208,7 @@ public class ForceTemplateAssignmentDialog extends JDialog {
         // all this stuff apparently needs to happen when assigning a force to a scenario
         campaignGUI.undeployForce(force);
         force.clearScenarioIds(campaignGUI.getCampaign(), true);
-        force.setScenarioId(currentScenario.getId());
+        force.setScenarioId(currentScenario.getId(),campaignGUI.getCampaign());
         currentScenario.addForce(forceID, templateList.getSelectedValue().getForceName());
         for (UUID uid : force.getAllUnits(true)) {
             Unit u = campaignGUI.getCampaign().getUnit(uid);

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -470,7 +470,7 @@ public class StratconScenarioWizard extends JDialog {
                     }
                 }
 
-                currentScenario.addForce(force, templateID);
+                currentScenario.addForce(force, templateID, campaign);
             }
         }
 


### PR DESCRIPTION
Right now, there's this problem:
![2024-10-20_110103](https://github.com/user-attachments/assets/39d3631b-3fc3-40f3-87e1-2d9a32802f14)
Fire Support I was deployed via the right click menu in TO&E and Scout I was deployed via the StratCon Map.

Of note is that if you save and load the game, the units would get the deployment flag then anyway.

I consolodated the code for updating unit deployments into Force.SetScenarioID.

Note that this does not add or remove issues regarding TO&E drag and drop that I will document in another issue. (#5084)