### PR TITLE
Fixed SPA Tooltip HTML Wrapping in `PersonViewPanel`

### DIFF
--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1449,9 +1449,8 @@ public class PersonViewPanel extends JScrollablePanel {
                 IOption option = i.nextElement();
                 if (option.booleanValue()) {
                     JLabel lblAbility2 = new JLabel(Utilities.getOptionDisplayName(option));
-                    lblAbility2.setToolTipText(wordWrap("<html>"
-                        + option.getDescription().replaceAll("\\n", "<br>")
-                        + "</html>"));
+                    lblAbility2.setToolTipText(wordWrap(
+                        option.getDescription().replaceAll("\\n", "<br>")));
                     lblAbility2.setName("lblAbility2");
                     lblAbility2.getAccessibleContext().getAccessibleRelationSet().add(
                             new AccessibleRelation(AccessibleRelation.LABELED_BY, lblAbility1));
@@ -1482,9 +1481,8 @@ public class PersonViewPanel extends JScrollablePanel {
 
                 if (option.booleanValue()) {
                     JLabel lblImplants2 = new JLabel(Utilities.getOptionDisplayName(option));
-                    lblImplants2.setToolTipText(wordWrap("<html>"
-                        + option.getDescription().replaceAll("\\n", "<br>")
-                        + "</html>"));
+                    lblImplants2.setToolTipText(wordWrap(
+                        option.getDescription().replaceAll("\\n", "<br>")));
                     lblImplants2.setName("lblImplants2");
                     lblImplants2.getAccessibleContext().getAccessibleRelationSet().add(
                             new AccessibleRelation(AccessibleRelation.LABELED_BY, lblImplants1));


### PR DESCRIPTION
Removed the unnecessary `<html>` tags from tooltip descriptions in `PersonViewPanel`.

### Closes #4995 && #5020