### PR TITLE
Added Empty Jump Path Check `UnableToAffordJumpNagDialog`

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
@@ -21,10 +21,13 @@ package mekhq.gui.dialog.nagDialogs;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CurrentLocation;
+import mekhq.campaign.JumpPath;
 import mekhq.campaign.finances.Money;
 import mekhq.gui.baseComponents.AbstractMHQNagDialog;
 
 import javax.swing.*;
+import java.util.Objects;
 
 /**
  * This class represents a nag dialog displayed when the campaign can't afford its next jump
@@ -45,7 +48,11 @@ public class UnableToAffordJumpNagDialog extends AbstractMHQNagDialog {
         Money currentFunds = campaign.getFunds();
         Money nextJumpCost = getNextJumpCost(campaign);
 
-        return currentFunds.isLessThan(nextJumpCost);
+        if (nextJumpCost.isZero()) {
+            return false;
+        } else {
+            return currentFunds.isLessThan(nextJumpCost);
+        }
     }
 
     /**
@@ -59,7 +66,14 @@ public class UnableToAffordJumpNagDialog extends AbstractMHQNagDialog {
      * @return the cost of the next jump for the campaign
      */
     static Money getNextJumpCost(Campaign campaign) {
-        if (campaign.getLocation().getJumpPath() == null) {
+        CurrentLocation location = campaign.getLocation();
+        JumpPath jumpPath = location.getJumpPath();
+
+        if (jumpPath == null) {
+            return Money.zero();
+        }
+
+        if (Objects.equals(jumpPath.getLastSystem(), location.getCurrentSystem())) {
             return Money.zero();
         }
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
@@ -59,6 +59,10 @@ public class UnableToAffordJumpNagDialog extends AbstractMHQNagDialog {
      * @return the cost of the next jump for the campaign
      */
     static Money getNextJumpCost(Campaign campaign) {
+        if (campaign.getLocation().getJumpPath() == null) {
+            return Money.zero();
+        }
+
         boolean isContractPayBasedOnToeUnitsValue = campaign.getCampaignOptions().isEquipmentContractBase();
 
         return campaign.calculateCostPerJump(true, isContractPayBasedOnToeUnitsValue);

--- a/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialogTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialogTest.java
@@ -23,6 +23,7 @@ import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.JumpPath;
 import mekhq.campaign.finances.Money;
+import mekhq.campaign.universe.PlanetarySystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -57,8 +58,12 @@ class UnableToAffordJumpNagDialogTest {
         // Stubs
         when(campaign.getCampaignOptions()).thenReturn(options);
 
-        jumpPath.addSystem(campaign.getSystemById("Terra"));
+        PlanetarySystem originSystem = mock(PlanetarySystem.class);
+        PlanetarySystem destinationSystem = mock(PlanetarySystem.class);
+
+        jumpPath.addSystem(destinationSystem);
         when(campaign.getLocation()).thenReturn(location);
+        when(location.getCurrentSystem()).thenReturn(originSystem);
         when(location.getJumpPath()).thenReturn(jumpPath);
     }
 

--- a/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialogTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialogTest.java
@@ -20,6 +20,8 @@ package mekhq.gui.dialog.nagDialogs;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.CurrentLocation;
+import mekhq.campaign.JumpPath;
 import mekhq.campaign.finances.Money;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +40,6 @@ import static org.mockito.Mockito.when;
 class UnableToAffordJumpNagDialogTest {
     // Mock objects for the tests
     private Campaign campaign;
-    private CampaignOptions options;
 
     /**
      * Test setup for each test, runs before each test.
@@ -48,10 +49,17 @@ class UnableToAffordJumpNagDialogTest {
     void init() {
         // Initialize the mock objects
         campaign = mock(Campaign.class);
-        options = mock(CampaignOptions.class);
+        CampaignOptions options = mock(CampaignOptions.class);
+        CurrentLocation location = mock(CurrentLocation.class);
+        JumpPath jumpPath = mock(JumpPath.class);
+
 
         // Stubs
         when(campaign.getCampaignOptions()).thenReturn(options);
+
+        jumpPath.addSystem(campaign.getSystemById("Terra"));
+        when(campaign.getLocation()).thenReturn(location);
+        when(location.getJumpPath()).thenReturn(jumpPath);
     }
 
     // In the following tests the canAffordNextJump() method is called, and its response is checked


### PR DESCRIPTION
Prevented the 'UnableToAffordJumpNagDialog' nag from appearing if jump path is empty, or the campaign is in transit to the final planet in the Jump Path.

### Closes #4988