### PR TITLE
More FG3 Scenario Adjustments

### DIFF
--- a/MekHQ/data/scenariotemplates/Frontline Disruption.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Disruption.xml
@@ -63,7 +63,7 @@
                 <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
+                <forceMultiplier>1.5</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
@@ -79,8 +79,8 @@
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>
-                <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>2</minWeightClass>
+                <maxWeightClass>3</maxWeightClass>
+                <minWeightClass>1</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
@@ -107,7 +107,7 @@
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>Infantry</forceName>
                 <generationMethod>2</generationMethod>
                 <generationOrder>5</generationOrder>
@@ -138,7 +138,7 @@
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>Irregulars</forceName>
                 <generationMethod>2</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Irregular Force Suppression.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Suppression.xml
@@ -60,36 +60,6 @@
             </value>
         </entry>
         <entry>
-            <key>OpFor</key>
-            <value>
-                <actualDeploymentZone>-1</actualDeploymentZone>
-                <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
-                <canReinforceLinked>true</canReinforceLinked>
-                <contributesToBV>false</contributesToBV>
-                <contributesToMapSize>true</contributesToMapSize>
-                <contributesToUnitCount>false</contributesToUnitCount>
-                <deployOffboard>false</deployOffboard>
-                <deploymentZones />
-                <destinationZone>5</destinationZone>
-                <fixedUnitCount>-1</fixedUnitCount>
-                <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.0</forceMultiplier>
-                <forceName>OpFor</forceName>
-                <generationMethod>1</generationMethod>
-                <generationOrder>5</generationOrder>
-                <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>0</minWeightClass>
-                <objectiveLinkedForces />
-                <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
-                <useArtillery>false</useArtillery>
-            </value>
-        </entry>
-        <entry>
             <key>Infantry</key>
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
@@ -107,7 +77,7 @@
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>Infantry</forceName>
                 <generationMethod>2</generationMethod>
                 <generationOrder>5</generationOrder>
@@ -138,7 +108,7 @@
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>Irregulars</forceName>
                 <generationMethod>2</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Skirmish Disruption.xml
+++ b/MekHQ/data/scenariotemplates/Skirmish Disruption.xml
@@ -63,7 +63,7 @@
                 <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
+                <forceMultiplier>1.5</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
+++ b/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
@@ -126,7 +126,7 @@
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
+                <forceMultiplier>1.5</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>


### PR DESCRIPTION
Updated force multipliers in several scenario templates to lower values to ensure more balanced gameplay.

Lowered weight of OpFor in `Irregular Force Assault` from 2-4 to 1-3. Removed the generic OpFor from `Irregular Force Suppression` to make these two scenarios feel more distinctive.