### PR TITLE
PartsStore - Fix EquipmentParts and OmniPods - Fixes Hatchets and Maces at least

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -232,6 +232,8 @@ public class PartsStore {
                             epart = new EquipmentPart(0, et, -1, 1.0, true, c);
                             epart.setEquipTonnage(ton);
                             parts.add(epart);
+                            epart = new EquipmentPart(0, et, -1, 1.0, true, c);
+                            epart.setEquipTonnage(ton);
                             parts.add(new OmniPod(epart, c));
                         }
                         // TODO: still need to deal with talons (unit tonnage) and masc (engine rating)
@@ -241,7 +243,7 @@ public class PartsStore {
                     parts.add(p);
                     if (poddable) {
                         parts.add(new EquipmentPart(0, et, -1, 1.0, true, c));
-                        parts.add(new OmniPod(p, c));
+                        parts.add(new OmniPod(new EquipmentPart(0, et, -1, 1.0, false, c), c));
                     }
                 }
             }


### PR DESCRIPTION
PartsStore's generator for miscellaneous EquipmentParts was not using new instances of the part everywhere it needed to. In particular this was causing this to happen:

1. New Hatchet A is generated with Omnipod turned off.
2. Hatchet A is placed in parts list.
3. New Hatchet B is generated with OmniPod turned on.
4. Hatchet B is placed in parts list.
5. Hatchet B is used to generate an empty OmniPod.
6. Empty OmniPod constructor turns off OmniPoddedness on Hatchet B, which propagates back to the one in the parts list.

Which results in two copies of each non-OmniPodded hatchet in the parts store, effectively:

![2024-10-21_080558](https://github.com/user-attachments/assets/cacd4784-a539-45c2-b2f1-6fa8e628b7bc)

My change adds a Hatchet C used to create the OmniPod, which fixes this:

![2024-10-21_080430](https://github.com/user-attachments/assets/5437c093-49c9-4f6d-85ae-f1ac01dd0b13)

The same is true for at least Maces if not other misc-type EquipmentParts