### PR TITLE
ResolveScenarioWizardDialog - Ransom All Button

### DIFF
--- a/MekHQ/resources/mekhq/resources/ResolveScenarioWizardDialog.properties
+++ b/MekHQ/resources/mekhq/resources/ResolveScenarioWizardDialog.properties
@@ -10,6 +10,7 @@ mia=MIA
 kia=KIA
 prisoner=Captured
 prisonerRansomed.text=Ransomed
+prisonerRansomAllButton.text=Ransom All Prisoners
 bondsman=Bondsman
 escaped=Escaped
 dead=Dead

--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -243,8 +243,6 @@ public class ResolveScenarioWizardDialog extends JDialog {
         txtInstructions.setBorder(BorderFactory.createCompoundBorder(
                 BorderFactory.createTitledBorder(resourceMap.getString("txtInstructions.title")),
                 BorderFactory.createEmptyBorder(5,5,5,5)));
-        txtInstructions.setMinimumSize(new Dimension(590,120));
-        txtInstructions.setPreferredSize(new Dimension(590,120));
         getContentPane().add(txtInstructions, BorderLayout.PAGE_START);
 
         /*
@@ -993,7 +991,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
 
         scrMain = new JScrollPaneWithSpeed(pnlMain);
         scrMain.setMinimumSize(new Dimension(600, 500));
-        scrMain.setPreferredSize(new Dimension(600, 500));
+        scrMain.setPreferredSize(new Dimension(900, 500));
         getContentPane().add(scrMain, BorderLayout.CENTER);
 
 
@@ -1169,34 +1167,6 @@ public class ResolveScenarioWizardDialog extends JDialog {
         cardLayout.show(pnlMain, currentPanel);
         switchInstructions();
 
-        switch (name) {
-            case PILOTPANEL:
-                pnlMain.setPreferredSize(pnlPilotStatus.getLayout().preferredLayoutSize(pnlMain));
-                break;
-            case UNITSPANEL:
-                pnlMain.setPreferredSize(pnlUnitStatus.getLayout().preferredLayoutSize(pnlMain));
-                break;
-            case SALVAGEPANEL:
-                pnlMain.setPreferredSize(pnlSalvage.getLayout().preferredLayoutSize(pnlMain));
-                break;
-            case KILLPANEL:
-                pnlMain.setPreferredSize(pnlKills.getLayout().preferredLayoutSize(pnlMain));
-                break;
-            case REWARDPANEL:
-                pnlMain.setPreferredSize(pnlRewards.getLayout().preferredLayoutSize(pnlMain));
-                break;
-            case PREVIEWPANEL:
-                pnlMain.setPreferredSize(pnlPreview.getLayout().preferredLayoutSize(pnlMain));
-                break;
-            case OBJECTIVEPANEL:
-                pnlMain.setPreferredSize(pnlObjectiveStatus.getLayout().preferredLayoutSize(pnlMain));
-                break;
-            case PRISONERPANEL:
-                pnlMain.setPreferredSize(pnlPrisonerStatus.getLayout().preferredLayoutSize(pnlMain));
-                break;
-        }
-
-
         SwingUtilities.invokeLater(() -> scrMain.getVerticalScrollBar().setValue(0));
         pack();
     }
@@ -1237,8 +1207,6 @@ public class ResolveScenarioWizardDialog extends JDialog {
         txtInstructions.setBorder(BorderFactory.createCompoundBorder(
                 BorderFactory.createTitledBorder(resourceMap.getString("txtInstructions.title")),
                 BorderFactory.createEmptyBorder(5, 5, 5, 5)));
-        txtInstructions.setMinimumSize(new Dimension(590, 150));
-        txtInstructions.setPreferredSize(new Dimension(590, 150));
         getContentPane().add(txtInstructions, BorderLayout.PAGE_START);
     }
 
@@ -1769,8 +1737,8 @@ public class ResolveScenarioWizardDialog extends JDialog {
         gridBagConstraints.fill = GridBagConstraints.NONE;
         dialog.getContentPane().add(btn, gridBagConstraints);
 
-        dialog.setMinimumSize(new Dimension(600, 300));
-        dialog.setPreferredSize(new Dimension(600, 300));
+        dialog.setMinimumSize(new Dimension(450, 700));
+        dialog.setPreferredSize(new Dimension(450, 700));
         dialog.validate();
         dialog.setLocationRelativeTo(frame);
         dialog.setVisible(true);

--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -126,6 +126,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
     /*
      * Prisoner status panel components
      */
+    private JButton prisonerRansomAllButton;
     private final List<JCheckBox> prisonerCapturedBtns = new ArrayList<>();
     private final List<JCheckBox> prisonerRansomedBtns = new ArrayList<>();
     private final List<JCheckBox> prisonerKiaBtns = new ArrayList<>();
@@ -417,6 +418,19 @@ public class ResolveScenarioWizardDialog extends JDialog {
         pnlPrisonerStatus.setLayout(new GridBagLayout());
 
         gridx = 1;
+
+        prisonerRansomAllButton = new JButton(resourceMap.getString("prisonerRansomAllButton.text"));
+
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx=2;
+        gridBagConstraints.gridy=0;
+        gridBagConstraints.gridwidth=3;
+        gridBagConstraints.anchor = GridBagConstraints.CENTER;
+        gridBagConstraints.insets = new Insets(5, 5, 0, 0);
+        pnlPrisonerStatus.add(prisonerRansomAllButton, gridBagConstraints);
+
+        prisonerRansomAllButton.addActionListener(evt -> prisonerRansomAll());
+
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = gridx++;
@@ -1051,6 +1065,19 @@ public class ResolveScenarioWizardDialog extends JDialog {
 
         pack();
     }
+
+    private void prisonerRansomAll() {
+        Iterator<JCheckBox> capturedBoxes = prisonerCapturedBtns.iterator();
+        Iterator<JCheckBox> ransomedBoxes = prisonerRansomedBtns.iterator();
+        while (capturedBoxes.hasNext() && ransomedBoxes.hasNext()) {
+            JCheckBox capturedBox = capturedBoxes.next();
+            JCheckBox ransomedBox = ransomedBoxes.next();
+            if (capturedBox.isSelected()) {
+                ransomedBox.setSelected(true);
+            }
+        }
+    }
+
 
     /**
      * Rolls the dice to determine if the opposition personnel is captured.


### PR DESCRIPTION
**Requires #5105**

Adds a very simple button to the Resolve Sceanrio Wizard Dialog. This button checks 'ransom prisoner' for every prisoner who has 'captured' set.

When you have a lot of vehicles and infantry, going through this list and ransoming everyone you don't want can be tiresome. Hence, button.

![2024-10-21_174318](https://github.com/user-attachments/assets/d5da91d9-cba7-4b90-a091-4208237e41e4)
