### PR TITLE
Updated Interstellar Map View Defaults & Optimized 'ISW' view

### DIFF
--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -404,6 +404,8 @@ public class InterstellarMapPanel extends JPanel {
                 final Stroke thin = new BasicStroke(1.2f);
                 final Stroke dashed = new BasicStroke(1.5f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0,
                         new float[] { 3 }, 0);
+                final Stroke dashedThick = new BasicStroke(3.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0,
+                        new float[] { 3 }, 0);
                 final Stroke dotted = new BasicStroke(1.5f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0,
                         new float[] { 2, 5 }, 0);
                 final Color darkCyan = new Color(0, 100, 50);
@@ -424,11 +426,12 @@ public class InterstellarMapPanel extends JPanel {
                     if (!campaign.getCampaignOptions().getContractMarketMethod().isNone()
                             && MekHQ.getMHQOptions().getInterstellarMapShowContractSearchRadius()) {
                         final double z = map2scrX(selectedSystem.getX()
-                                + campaign.getCampaignOptions().getContractSearchRadius());
+                            + campaign.getCampaignOptions().getContractSearchRadius());
                         final double contractSearchRadius = z - x;
                         g2.setPaint(MekHQ.getMHQOptions().getInterstellarMapContractSearchRadiusColour());
+                        g2.setStroke(dashedThick);
                         arc.setArcByCenter(x, y, contractSearchRadius, 0, 360, Arc2D.OPEN);
-                        g2.fill(arc);
+                        g2.draw(arc);
                     }
 
                     // Acquisition Search Radius Aura
@@ -439,10 +442,11 @@ public class InterstellarMapPanel extends JPanel {
                         final double z = map2scrX(selectedSystem.getX()
                                 + (MHQConstants.MAX_JUMP_RADIUS
                                         * campaign.getCampaignOptions().getMaxJumpsPlanetaryAcquisition()));
-                        final double contractSearchRadius = z - x;
+                        final double acquisitionRadius = z - x;
                         g2.setPaint(MekHQ.getMHQOptions().getInterstellarMapPlanetaryAcquisitionRadiusColour());
-                        arc.setArcByCenter(x, y, contractSearchRadius, 0, 360, Arc2D.OPEN);
-                        g2.fill(arc);
+                        g2.setStroke(dashedThick);
+                        arc.setArcByCenter(x, y, acquisitionRadius, 0, 360, Arc2D.OPEN);
+                        g2.draw(arc);
                     }
 
                     // Jump Radius Aura
@@ -451,8 +455,9 @@ public class InterstellarMapPanel extends JPanel {
                         final double z = map2scrX(selectedSystem.getX() + MHQConstants.MAX_JUMP_RADIUS);
                         final double jumpRadius = z - x;
                         g2.setPaint(MekHQ.getMHQOptions().getInterstellarMapJumpRadiusColour());
+                        g2.setStroke(dashedThick);
                         arc.setArcByCenter(x, y, jumpRadius, 0, 360, Arc2D.OPEN);
-                        g2.fill(arc);
+                        g2.draw(arc);
                     }
 
                     // Don't override HPG Network drawing

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -478,7 +478,7 @@ public class InterstellarMapPanel extends JPanel {
                     int minY = (int) Math.floor(scr2mapY(getHeight()) / HEX_SIZE);
                     int maxY = (int) Math.ceil(scr2mapY(0.0) / HEX_SIZE);
 
-                    Faction independentFaction = Factions.getInstance().getFaction("IND");
+                    Faction indFaction = Factions.getInstance().getFaction("IND");
 
                     for (int x = minX; x <= maxX; ++x) {
                         for (int y = minY; y <= maxY; ++y) {
@@ -495,7 +495,7 @@ public class InterstellarMapPanel extends JPanel {
                             for (PlanetarySystem system : nearbySystems) {
                                 if (!isSystemEmpty(system) && path.contains(system.getX(), system.getY())) {
                                     Set<Faction> factions = system.getFactionSet(now);
-                                    factions.remove(independentFaction);
+                                    factions.remove(indFaction);
                                     hexFactions.addAll(factions);
                                 }
                             }
@@ -510,7 +510,7 @@ public class InterstellarMapPanel extends JPanel {
                             }
 
                             if (hexFactions.size() > 1) {
-                                hexFactions.remove(independentFaction);
+                                hexFactions.remove(indFaction);
                             }
 
                             path.transform(transform);

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -747,8 +747,8 @@ public class InterstellarMapPanel extends JPanel {
                                     ++i;
                                 }
                             } else {
-                                // Just a black circle then
-                                g2.setPaint(new Color(0.0f, 0.0f, 0.0f, 0.5f));
+                                // Just a dark grey circle then
+                                g2.setPaint(Color.DARK_GRAY);
                                 arc.setArcByCenter(x, y, size, 0, 360.0, Arc2D.PIE);
                                 g2.fill(arc);
                             }

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -18,37 +18,6 @@
  */
 package mekhq.gui;
 
-import java.awt.*;
-import java.awt.MultipleGradientPaint.CycleMethod;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseWheelEvent;
-import java.awt.geom.AffineTransform;
-import java.awt.geom.Arc2D;
-import java.awt.geom.GeneralPath;
-import java.awt.geom.Line2D;
-import java.awt.geom.Point2D;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import javax.imageio.ImageIO;
-import javax.swing.*;
-import javax.vecmath.Vector2d;
-
 import megamek.codeUtilities.MathUtility;
 import megamek.codeUtilities.ObjectUtility;
 import megamek.common.EquipmentType;
@@ -58,13 +27,25 @@ import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.JumpPath;
-import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.*;
 import mekhq.campaign.universe.Faction.Tag;
-import mekhq.campaign.universe.Factions;
-import mekhq.campaign.universe.PlanetarySystem;
-import mekhq.campaign.universe.SocioIndustrialData;
-import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.Systems.HPGLink;
+import mekhq.campaign.universe.enums.HiringHallLevel;
+
+import javax.imageio.ImageIO;
+import javax.swing.Timer;
+import javax.swing.*;
+import javax.vecmath.Vector2d;
+import java.awt.*;
+import java.awt.MultipleGradientPaint.CycleMethod;
+import java.awt.event.*;
+import java.awt.geom.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * This is not functional yet. Just testing things out.
@@ -726,18 +707,28 @@ public class InterstellarMapPanel extends JPanel {
                                 int i = 0;
                                 for (Faction faction : factions) {
                                     if (capitals.get(faction).equals(system.getId())) {
-                                        g2.setPaint(new Color(255, 228, 181));
+                                        g2.setPaint(faction.getColor());
+                                        arc.setArcByCenter(x, y, size + 5, 0,
+                                            360.0 * (1 - ((double) i) / factions.size()), Arc2D.OPEN);
+                                        g2.fill(arc);
+                                        g2.setPaint(new Color(0.0f, 0.0f, 0.0f, 0.5f));
                                         arc.setArcByCenter(x, y, size + 3, 0,
-                                                360.0 * (1 - ((double) i) / factions.size()), Arc2D.PIE);
+                                            360.0 * (1 - ((double) i) / factions.size()), Arc2D.OPEN);
                                         g2.fill(arc);
+                                    } else {
+                                        if (campaign.getCampaignOptions().isUseAtB()
+                                            && (system.getHiringHallLevel(campaign.getLocalDate()) == HiringHallLevel.GREAT)) {
+                                            g2.setPaint(new Color(176, 196, 222));
+                                            arc.setArcByCenter(x, y, size + 5, 0,
+                                                360.0 * (1 - ((double) i) / factions.size()), Arc2D.OPEN);
+                                            g2.fill(arc);
+                                            g2.setPaint(new Color(0.0f, 0.0f, 0.0f, 0.5f));
+                                            arc.setArcByCenter(x, y, size + 3, 0,
+                                                360.0 * (1 - ((double) i) / factions.size()), Arc2D.OPEN);
+                                            g2.fill(arc);
+                                        }
                                     }
-                                    if (campaign.getCampaignOptions().isUseAtB()
-                                            && system.isHiringHall(campaign.getLocalDate())) {
-                                        g2.setPaint(new Color(176, 196, 222));
-                                        arc.setArcByCenter(x, y, size + 4, 0,
-                                                360.0 * (1 - ((double) i) / factions.size()), Arc2D.PIE);
-                                        g2.fill(arc);
-                                    }
+
                                     g2.setPaint(faction.getColor());
                                     arc.setArcByCenter(x, y, size, 0, 360.0 * (1 - ((double) i) / factions.size()),
                                             Arc2D.PIE);


### PR DESCRIPTION
This PR updates the interstellar map to make the old ISW the default. It makes some substantial optimizations under the hood to ISW to make it less of a resource hog. As well as some general visual changes to that view and renamed it to 'Territory'.

This has a few added benefits. In addition to looking closer to CGL's official maps, the territory won't disappear when the user changes map filters. So you avoid situations like the image below:
![image](https://github.com/user-attachments/assets/1325588f-9adb-4a51-9922-d22ff7046d22)

Instead you get...
![image](https://github.com/user-attachments/assets/93963a02-eb97-47df-b422-33b94fd5e5be)