### PR TITLE
Corrected DropShip Scenario Modifier Generation Method

### DIFF
--- a/MekHQ/data/scenariomodifiers/EnemyDropship.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyDropship.xml
@@ -18,9 +18,10 @@
 		<forceAlignment>2</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
 		<forceName>DropShip</forceName>
-		<generationMethod>2</generationMethod>
+		<generationMethod>3</generationMethod>
 		<generationOrder>3</generationOrder>
-		<maxWeightClass>4</maxWeightClass>
+        <maxWeightClass>4</maxWeightClass>
+        <minWeightClass>0</minWeightClass>
 		<objectiveLinkedForces>
 			<objectiveLinkedForce>OpFor</objectiveLinkedForce>
 		</objectiveLinkedForces>

--- a/MekHQ/data/scenariomodifiers/GroundedEnemyDropship.xml
+++ b/MekHQ/data/scenariomodifiers/GroundedEnemyDropship.xml
@@ -22,9 +22,10 @@
 		<forceAlignment>2</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
 		<forceName>DropShip</forceName>
-		<generationMethod>2</generationMethod>
+		<generationMethod>3</generationMethod>
 		<generationOrder>3</generationOrder>
-		<maxWeightClass>4</maxWeightClass>
+        <maxWeightClass>4</maxWeightClass>
+        <minWeightClass>0</minWeightClass>
 		<retreatThreshold>50</retreatThreshold>
 		<startingAltitude>0</startingAltitude>
 		<syncDeploymentType>SameEdge</syncDeploymentType>


### PR DESCRIPTION
Changed the generation method from 2 to 3 and added `minWeightClass` with a value of 0 in both `GroundedEnemyDropship.xml` and `EnemyDropship.xml`.

This corrects the 'fleet of DropShips' bug (again).

### Closes #5109