### PR TITLE
TechTabelModel - Show Daily Available Time for Techs

### DIFF
--- a/MekHQ/src/mekhq/gui/model/TechTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TechTableModel.java
@@ -136,7 +136,9 @@ public class TechTableModel extends DataTableModel {
         }
         toReturn.append("<br/>");
 
-        toReturn.append(String.format("%d minutes left", tech.getMinutesLeft()));
+        toReturn.append(String.format("%d/%d minutes left", tech.getMinutesLeft(),
+                tech.getDailyAvailableTechTime()));
+                
         if (overtimeAllowed) {
             toReturn.append(String.format(" + (%d overtime)", tech.getOvertimeLeft()));
         }


### PR DESCRIPTION
When you're eyeballs deep in multiple days of repair, tasks stretched over days, not sure who's time you've spent  today or yesterday, it's easy to lose track of how much time people are going to have tomorrow after maintenance; this would help with that. 

It's also how we already display tech time on the refit tech selector.

I think this might just be the last change to the tech list for a good while. Probably. :>

![2024-10-22_133018](https://github.com/user-attachments/assets/616f8971-5636-4c33-b9b1-bee2d95a6086)
