### PR TITLE
FG3 Scenario Improvements

### DIFF
--- a/MekHQ/data/scenariomodifiers/LiaisonGround.xml
+++ b/MekHQ/data/scenariomodifiers/LiaisonGround.xml
@@ -9,7 +9,7 @@
     <forceDefinition>
         <actualDeploymentZone>-1</actualDeploymentZone>
         <allowAeroBombs>false</allowAeroBombs>
-        <allowedUnitType>9</allowedUnitType>
+        <allowedUnitType>0</allowedUnitType>
         <arrivalTurn>0</arrivalTurn>
         <canReinforceLinked>false</canReinforceLinked>
         <contributesToBV>true</contributesToBV>

--- a/MekHQ/data/scenariotemplates/Decoy Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Engagement.xml
@@ -110,7 +110,7 @@
             <objectiveCriterion>Custom</objectiveCriterion>
             <percentage>1</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
         <scenarioObjective>

--- a/MekHQ/data/scenariotemplates/Decoy Interception.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Interception.xml
@@ -110,7 +110,7 @@
             <objectiveCriterion>Custom</objectiveCriterion>
             <percentage>1</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
         <scenarioObjective>

--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -66,8 +66,7 @@
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy, cripple or force to withdraw 50% of the following force(s) and
-                unit(s):</description>
+            <description>Destroy, cripple or force to withdraw 50% of the following force(s) and unit(s):</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
             <percentage>50</percentage>

--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -42,9 +42,9 @@
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>100</percentage>
-            <timeLimit>30</timeLimit>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitType>Fixed</timeLimitType>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
+            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>

--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -43,7 +43,7 @@
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>100</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
+            <timeLimitScaleFactor>2</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
         <scenarioObjective>

--- a/MekHQ/data/scenariotemplates/Deep Raid.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid.xml
@@ -156,7 +156,7 @@
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
             <percentage>100</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>1</timeLimitScaleFactor>
+            <timeLimitScaleFactor>2</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
         <scenarioObjective>

--- a/MekHQ/data/scenariotemplates/Deep Raid.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid.xml
@@ -155,9 +155,9 @@
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
             <percentage>100</percentage>
-            <timeLimit>30</timeLimit>
-            <timeLimitAtMost>true</timeLimitAtMost>
-            <timeLimitType>Fixed</timeLimitType>
+            <timeLimitAtMost>false</timeLimitAtMost>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
+            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>

--- a/MekHQ/data/scenariotemplates/DropShip Raid.xml
+++ b/MekHQ/data/scenariotemplates/DropShip Raid.xml
@@ -155,9 +155,9 @@
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>
             <percentage>100</percentage>
-            <timeLimit>30</timeLimit>
-            <timeLimitAtMost>true</timeLimitAtMost>
-            <timeLimitType>Fixed</timeLimitType>
+            <timeLimitAtMost>false</timeLimitAtMost>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
+            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>

--- a/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -114,7 +114,7 @@
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>50</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>

--- a/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -42,9 +42,9 @@
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>100</percentage>
-            <timeLimit>30</timeLimit>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitType>Fixed</timeLimitType>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
+            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>

--- a/MekHQ/data/scenariotemplates/Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Recon Evasion.xml
@@ -114,7 +114,7 @@
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>50</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>


### PR DESCRIPTION
- Updated the turn limit on a number of scenarios, some have been made harder, others easier.
- Fixed ground forward observers turning up in aerospace fighters. These would spawn on the ground and the observer would spend the entire battle just driving them about - making airplane noises as they did so, I suspect.

### Closes #5118 && #5117