### PR TITLE
Label OmniUnits as Omni in the MekHQ UI

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -274,6 +274,25 @@ public class Unit implements ITechnology {
         }
     }
 
+    /**
+     * Like UnitType.getTypeDisplayableName but prepends "Omni" to omni units
+     * @return String displayable name with possible "Omni"
+     */
+    public String getTypeDisplayableNameWithOmni() {
+        Entity ourEntity = getEntity();
+        int type = ourEntity.getUnitType();
+        if (!ourEntity.isOmni()) {
+            return UnitType.getTypeDisplayableName(type);
+        }
+        StringBuilder toReturn = new StringBuilder();
+        toReturn.append("Omni");
+        if (!(type == UnitType.TANK || type == UnitType.MEK)) {
+            toReturn.append(" ");
+        }
+        toReturn.append(UnitType.getTypeDisplayableName(type));
+        return toReturn.toString();
+    }
+
     public void reCalc() {
         // Do Nothing
     }

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -227,37 +227,37 @@ public class UnitTableModel extends DataTableModel {
             return "";
         }
 
-        Unit u = getUnit(row);
-        Entity e = u.getEntity();
-        if (e == null) {
+        Unit unit = getUnit(row);
+        Entity entity = unit.getEntity();
+        if (entity == null) {
             return "?";
         }
 
         return switch (col) {
-            case COL_NAME -> u.getName();
-            case COL_TYPE -> UnitType.getTypeDisplayableName(e.getUnitType());
-            case COL_WCLASS -> e.getWeightClassName();
-            case COL_TECH -> TechConstants.getLevelDisplayableName(e.getTechLevel());
-            case COL_WEIGHT -> e.getWeight();
-            case COL_COST -> u.getSellValue().toAmountAndSymbolString();
-            case COL_STATUS -> u.getStatus();
-            case COL_CONDITION -> u.getCondition();
-            case COL_CREW_STATE -> u.getCrewState();
-            case COL_QUALITY -> u.getQualityName();
-            case COL_PILOT -> (u.getCommander() != null) ? u.getCommander().getHTMLTitle() : "-";
+            case COL_NAME -> unit.getName();
+            case COL_TYPE -> unit.getTypeDisplayableNameWithOmni();
+            case COL_WCLASS -> entity.getWeightClassName();
+            case COL_TECH -> TechConstants.getLevelDisplayableName(entity.getTechLevel());
+            case COL_WEIGHT -> entity.getWeight();
+            case COL_COST -> unit.getSellValue().toAmountAndSymbolString();
+            case COL_STATUS -> unit.getStatus();
+            case COL_CONDITION -> unit.getCondition();
+            case COL_CREW_STATE -> unit.getCrewState();
+            case COL_QUALITY -> unit.getQualityName();
+            case COL_PILOT -> (unit.getCommander() != null) ? unit.getCommander().getHTMLTitle() : "-";
             case COL_FORCE -> {
-                Force force = u.getCampaign().getForce(u.getForceId());
+                Force force = unit.getCampaign().getForce(unit.getForceId());
                 yield (force != null) ? force.getFullName() : "-";
             }
-            case COL_CREW -> u.getActiveCrew().size() + "/" + u.getFullCrewSize();
-            case COL_TECH_CRW -> (u.getTech() != null) ? u.getTech().getHTMLTitle() : "-";
-            case COL_MAINTAIN -> u.getMaintenanceCost().toAmountAndSymbolString();
-            case COL_BV -> e.calculateBattleValue(true, u.getEntity().getCrew() == null);
-            case COL_REPAIR -> u.getPartsNeedingFixing().size();
-            case COL_PARTS -> u.getPartsNeeded().size();
-            case COL_SITE -> Unit.getSiteName(u.getSite());
-            case COL_QUIRKS -> e.countQuirks();
-            case COL_RSTATUS -> u.isSalvage() ? "Strip" : "Repair";
+            case COL_CREW -> unit.getActiveCrew().size() + "/" + unit.getFullCrewSize();
+            case COL_TECH_CRW -> (unit.getTech() != null) ? unit.getTech().getHTMLTitle() : "-";
+            case COL_MAINTAIN -> unit.getMaintenanceCost().toAmountAndSymbolString();
+            case COL_BV -> entity.calculateBattleValue(true, unit.getEntity().getCrew() == null);
+            case COL_REPAIR -> unit.getPartsNeedingFixing().size();
+            case COL_PARTS -> unit.getPartsNeeded().size();
+            case COL_SITE -> Unit.getSiteName(unit.getSite());
+            case COL_QUIRKS -> entity.countQuirks();
+            case COL_RSTATUS -> unit.isSalvage() ? "Strip" : "Repair";
             default -> "?";
         };
     }

--- a/MekHQ/src/mekhq/gui/sorter/UnitTypeSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/UnitTypeSorter.java
@@ -29,18 +29,47 @@ import megamek.common.UnitType;
  */
 public class UnitTypeSorter implements Comparator<String> {
     @Override
-    public int compare(String s0, String s1) {
+    public int compare(String compare0, String compare1) {
         // lets find the weight class integer for each name
-        int l0 = 0;
-        int l1 = 0;
+        int sort0 = 0;
+        int sort1 = 0;
+
+        // We ONLY get the strings so sorting Omni units (in this case to be after the same
+        // unit type but otherwise in the same order as this) is going to be a little silly
+
+        boolean omni0 = false;
+        boolean omni1 = false;
+
+        if (compare0.startsWith("Omni ")) {
+            omni0 = true;
+            compare0 = compare0.substring(5);
+        } else if (compare0.startsWith("Omni")) {
+            omni0 = true;
+            compare0 = compare0.substring(4);
+        }
+
+        if (compare1.startsWith("Omni ")) {
+            omni1 = true;
+            compare1 = compare1.substring(5);
+        } else if (compare1.startsWith("Omni")) {
+            omni1 = true;
+            compare1 = compare1.substring(4);
+        }
+
         for (int i = 0; i <= UnitType.SPACE_STATION; i++) {
-            if (UnitType.getTypeDisplayableName(i).equals(s0)) {
-                l0 = i;
+            if (UnitType.getTypeDisplayableName(i).equals(compare0)) {
+                sort0 = i * 2;
+                if (omni0) {
+                    sort0++;
+                }
             }
-            if (UnitType.getTypeDisplayableName(i).equals(s1)) {
-                l1 = i;
+            if (UnitType.getTypeDisplayableName(i).equals(compare1)) {
+                sort1 = i * 2;
+                if (omni1) {
+                    sort1++;
+                }
             }
         }
-        return ((Comparable<Integer>) l1).compareTo(l0);
+        return ((Comparable<Integer>) sort1).compareTo(sort0);
     }
 }

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -22,7 +22,6 @@ import megamek.client.ui.swing.util.FluffImageHelper;
 import megamek.common.Entity;
 import megamek.common.MekView;
 import megamek.common.TechConstants;
-import megamek.common.UnitType;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
@@ -184,7 +183,7 @@ public class UnitViewPanel extends JScrollablePanel {
         pnlStats.setLayout(new GridBagLayout());
 
         lblType.setName("lblType");
-        lblType.setText("<html><i>" + UnitType.getTypeDisplayableName(entity.getUnitType()) + "</i></html>");
+        lblType.setText("<html><i>" + unit.getTypeDisplayableNameWithOmni() + "</i></html>");
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -25,7 +25,6 @@ import megamek.common.TechConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
-import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.utilities.ImgLabel;
 import mekhq.gui.utilities.MarkdownRenderer;
 
@@ -37,7 +36,7 @@ import java.util.ResourceBundle;
  * A custom panel that gets filled in with goodies from a unit record
  * @author  Jay Lawson (jaylawson39 at yahoo.com)
  */
-public class UnitViewPanel extends JScrollablePanel {
+public class UnitViewPanel extends JPanel {
     private Unit unit;
     private Entity entity;
     private Campaign campaign;


### PR DESCRIPTION
Omni units have different rules in regards to refits and such that matter in MekHQ more than in MegaMek, so I thought it would be nice to distinguish them a little more clearly.

Omni units sort after non-omni units of the same type.

Unit list filters don't change, e.g. OmniMeks and Meks are both listed under the Mek filter.

![2024-10-23_094534](https://github.com/user-attachments/assets/c8d8c772-e138-4632-af7e-6218a8d8a5c2)
![2024-10-23_094608](https://github.com/user-attachments/assets/2fc259a1-0c6b-466a-8a14-7eaf7d204d4a)
![2024-10-23_094649](https://github.com/user-attachments/assets/1f05f2ed-0f73-44b8-8ac2-f2063dca945f)

Also kills a couple deprecaiton warnings along the way.