### PR TITLE
Fixed Position of `NewDayEvent` Trigger in `processNewDay`

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4241,8 +4241,6 @@ public class Campaign implements ITechManager {
         newReports.clear();
         beginReport("<b>" + MekHQ.getMHQOptions().getLongDisplayFormattedDate(getLocalDate()) + "</b>");
 
-        MekHQ.triggerEvent(new NewDayEvent(this));
-
         // New Year Changes
         if (getLocalDate().getDayOfYear() == 1) {
             // News is reloaded
@@ -4320,6 +4318,8 @@ public class Campaign implements ITechManager {
             }
         }
 
+        // This must be the last step before returning true
+        MekHQ.triggerEvent(new NewDayEvent(this));
         return true;
     }
 


### PR DESCRIPTION
Moved `MekHQ.triggerEvent(new NewDayEvent(this))` to the end of `processNewDay` method. This refactor ensures the event trigger occurs after all day-start logic has been processed.

### Closes #5119 && #5108 && #4297 (for real this time)