### PR TITLE
Stopped Scenarios Pulling Units from the Hangar

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -290,17 +290,11 @@ public class StratconRulesManager {
 
                 // find units in player's campaign (not just forces!)
                 // by default, all units are eligible
-                if (explicitForceID == Force.FORCE_NONE) {
-                    potentialUnits = campaign.getHangar().getUnits();
-                    // if we're using a seed force, then units transporting this force
-                    // are eligible
-                } else {
-                    Force force = campaign.getForce(explicitForceID);
-                    for (UUID unitID : force.getUnits()) {
-                        Unit unit = campaign.getUnit(unitID);
-                        if (unit.getTransportShipAssignment() != null) {
-                            potentialUnits.add(unit.getTransportShipAssignment().getTransportShip());
-                        }
+                Force force = campaign.getForce(explicitForceID);
+                for (UUID unitID : force.getUnits()) {
+                    Unit unit = campaign.getUnit(unitID);
+                    if (unit.getTransportShipAssignment() != null) {
+                        potentialUnits.add(unit.getTransportShipAssignment().getTransportShip());
                     }
                 }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -288,16 +288,26 @@ public class StratconRulesManager {
 
                 Collection<Unit> potentialUnits = new HashSet<>();
 
-                // find units in player's campaign (not just forces!)
-                // by default, all units are eligible
-                Force force = campaign.getForce(explicitForceID);
-                for (UUID unitID : force.getUnits()) {
-                    Unit unit = campaign.getUnit(unitID);
-                    if (unit.getTransportShipAssignment() != null) {
-                        potentialUnits.add(unit.getTransportShipAssignment().getTransportShip());
+                // find units in player's campaign by default, all units in the TO&E are eligible
+                if (explicitForceID == Force.FORCE_NONE) {
+                    for (UUID unitId : campaign.getForces().getUnits()) {
+                        try {
+                            potentialUnits.add(campaign.getUnit(unitId));
+                        } catch (Exception exception) {
+                            logger.error(String.format("Error retrieving unit (%s): %s",
+                                unitId, exception.getMessage()));
+                        }
+                    }
+                // if we're using a seed force, then units transporting this force are eligible
+                } else {
+                    Force force = campaign.getForce(explicitForceID);
+                    for (UUID unitID : force.getUnits()) {
+                        Unit unit = campaign.getUnit(unitID);
+                        if (unit.getTransportShipAssignment() != null) {
+                            potentialUnits.add(unit.getTransportShipAssignment().getTransportShip());
+                        }
                     }
                 }
-
                 for (Unit unit : potentialUnits) {
                     if ((sft.getAllowedUnitType() == 11) && (!campaign.getCampaignOptions().isUseDropShips())) {
                         continue;


### PR DESCRIPTION
Certain scenarios are set up to substitute enemy units with player units. Typically, this is the DropShip scenarios optionally using player DropShips. Previously, this could pull units from the players' hangar. Now it is restricted to units in the TO&E.