### PR TITLE
Handled StratCon Scenario Placement Failure when All Coordinates Occupied

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -289,6 +289,13 @@ public class StratconContractInitializer {
 
             StratconCoords coords = getUnoccupiedCoords(trackState);
 
+            if (coords == null) {
+                logger.warn(String.format("Unable to place facility on track %s," +
+                        " as all coords were occupied. Aborting.",
+                    trackState.getDisplayableName()));
+                return;
+            }
+
             trackState.addFacility(coords, sf);
 
             if (strategicObjective) {
@@ -336,6 +343,13 @@ public class StratconContractInitializer {
 
             StratconCoords coords = getUnoccupiedCoords(trackState);
 
+            if (coords == null) {
+                logger.error(String.format("Unable to place objective scenario on track %s," +
+                        " as all coords were occupied. Aborting.",
+                    trackState.getDisplayableName()));
+                return;
+            }
+
             // facility
             if (template.isFacilityScenario()) {
                 StratconFacility facility = template.isHostileFacility()
@@ -376,18 +390,24 @@ public class StratconContractInitializer {
      * Utility function that, given a track state, picks a random set of unoccupied
      * coordinates.
      */
-    private static StratconCoords getUnoccupiedCoords(StratconTrackState trackState) {
-        // plonk
+    public static StratconCoords getUnoccupiedCoords(StratconTrackState trackState) {
+        // Maximum number of attempts
+        int maxAttempts = trackState.getWidth() * trackState.getHeight();
+        int attempts = 0;
+
         int x = Compute.randomInt(trackState.getWidth());
         int y = Compute.randomInt(trackState.getHeight());
         StratconCoords coords = new StratconCoords(x, y);
 
-        // make sure we don't put the facility down on top of anything else
-        while ((trackState.getFacility(coords) != null) ||
-                (trackState.getScenario(coords) != null)) {
+        while ((trackState.getFacility(coords) != null || trackState.getScenario(coords) != null) && attempts < maxAttempts) {
             x = Compute.randomInt(trackState.getWidth());
             y = Compute.randomInt(trackState.getHeight());
             coords = new StratconCoords(x, y);
+            attempts++;
+        }
+
+        if (attempts == maxAttempts) {
+            return null;
         }
 
         return coords;


### PR DESCRIPTION
Added checks to handle scenarios where facilities or objectives could not be placed because all coordinates in a StratCon track were occupied. Issued warnings and errors, and updated the `getUnoccupiedCoords` method to return null when placement is not possible.

It's worth noting that this is not a scenario that is likely to ever come up, because what are the chances we try to place a new scenario down on a track where _every_ hex is occupied? In vanilla StratCon that scenario will never occur because `getUnoccupiedCoords` is only called at the beginning of a contract when a track is effectively empty.

I'm currently working on a secret project that will require me to place events on the StratCon map. I'm planning to use `getUnoccupiedCoords`, as I don't want stacked events, but that raises the chance of this exception occurring from 'none' to 'very low'. Prior to this PR, if that scenario _did_ occur the client would end in an infinite loop.