### PR TITLE
Added New StratCon Scenario Generation Utility Method

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -376,7 +376,7 @@ public class StratconContractInitializer {
      * Utility function that, given a track state, picks a random set of unoccupied
      * coordinates.
      */
-    private static StratconCoords getUnoccupiedCoords(StratconTrackState trackState) {
+    public static StratconCoords getUnoccupiedCoords(StratconTrackState trackState) {
         // plonk
         int x = Compute.randomInt(trackState.getWidth());
         int y = Compute.randomInt(trackState.getHeight());

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -210,10 +210,11 @@ public class StratconRulesManager {
              List<StratconTrackState> tracks = contract.getStratconCampaignState().getTracks();
              Random rand = new Random();
 
-             if (tracks.size() > 0) {
+             if (!tracks.isEmpty()) {
                  track = tracks.get(rand.nextInt(tracks.size()));
              } else {
                  logger.error("No tracks available. Aborting scenario generation.");
+                 return;
              }
          }
 

--- a/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
@@ -19,6 +19,7 @@
 package mekhq.gui.dialog;
 
 import megamek.client.ui.Messages;
+import megamek.client.ui.advancedsearch.MekSearchFilter;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.dialog.AbstractUnitSelectorDialog;
 import megamek.common.*;


### PR DESCRIPTION
Added a new helper method to `StratconRulesManager` that allows Classes outside of StratCon to spawn StratCon scenarios. These scenarios can be spawned either on a random or specific Track. Likewise, the scenario template can be either specific or random.

I also extracted some repeated logic into helper methods and consolidated map location imports, seeing that they're being used in a whole bunch of places in this class.

Finally, I adjusted `generateScenariosForTrack` (which my new method is based on) to only place scenarios in unoccupied locations. This should help avoid scenarios being lost under facilities (or visa versa) and is meant to work alongside the changes made in #5141.