### PR TITLE
Fix Track Calculation in `StratconContractInitializer`

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -68,10 +68,10 @@ public class StratconContractInitializer {
         // scenarios
         // when objective is allied/hostile facility, place those facilities
 
-        int numTracks = Math.max(0, contract.getRequiredLances() / NUM_LANCES_PER_TRACK);
+        int maximumTrackIndex = Math.max(0, contract.getRequiredLances() / NUM_LANCES_PER_TRACK);
         int planetaryTemperature = campaign.getLocation().getPlanet().getTemperature(campaign.getLocalDate());
 
-        for (int x = 0; x < numTracks; x++) {
+        for (int x = 0; x < maximumTrackIndex; x++) {
             int scenarioOdds = contractDefinition.getScenarioOdds()
                     .get(Compute.randomInt(contractDefinition.getScenarioOdds().size()));
             int deploymentTime = contractDefinition.getDeploymentTimes()

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -68,7 +68,7 @@ public class StratconContractInitializer {
         // scenarios
         // when objective is allied/hostile facility, place those facilities
 
-        int numTracks = Math.max(1, contract.getRequiredLances() / NUM_LANCES_PER_TRACK);
+        int numTracks = Math.max(0, contract.getRequiredLances() / NUM_LANCES_PER_TRACK);
         int planetaryTemperature = campaign.getLocation().getPlanet().getTemperature(campaign.getLocalDate());
 
         for (int x = 0; x < numTracks; x++) {


### PR DESCRIPTION
Changed minimum number of tracks from 1 to 0 when initializing contracts. This adjustment ensures that the number of tracks properly reflects contracts requiring fewer lances, preventing erroneous excess tracks.

This fixes a misunderstanding in #5091. Seeing a variable called `numTracks` I mistakenly thought it was the number of tracks, instead it's the maximum track index. Mea culpa.