### PR TITLE
Refactored `JScrollPaneWithSpeed` Constructor

### DIFF
--- a/MekHQ/src/mekhq/gui/utilities/JScrollPaneWithSpeed.java
+++ b/MekHQ/src/mekhq/gui/utilities/JScrollPaneWithSpeed.java
@@ -18,11 +18,10 @@
  */
 package mekhq.gui.utilities;
 
-import java.awt.*;
+import megamek.client.ui.swing.GUIPreferences;
 
 import javax.swing.*;
-
-import megamek.client.ui.swing.GUIPreferences;
+import java.awt.*;
 
 /**
  * It's a JScrollPane that manages its scrollspeed based on the UI scale
@@ -34,7 +33,7 @@ public class JScrollPaneWithSpeed extends JScrollPane {
      * @see JPanel#JPanel()
      */
     public JScrollPaneWithSpeed() {
-        super();
+        super(null);
         setScaleIncrement();
     }
 


### PR DESCRIPTION
Changed the `JScrollPaneWithSpeed` constructor to take a null argument for the viewport. This was done to ensure proper initialization of the scrolling pane.

This might be negated by some refactoring @WeaverThree is doing, but I had to make the change locally so I figured it was worth pushing.