### PR TITLE
Fixed Line Breaks in StratCon Facility Descriptions

### DIFF
--- a/MekHQ/data/stratconfacilities/AlliedAirBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedAirBase.xml
@@ -5,7 +5,6 @@
     <localModifiers>AlliedAirGarrison.xml</localModifiers>
     <owner>Allied</owner>
     <sharedModifiers>AlliedAirSupport.xml</sharedModifiers>
-    <userDescription>Allied aircraft will participate in scenarios on this track and defend this
-        facility.</userDescription>
+    <userDescription>Allied aircraft will participate in scenarios on this track and defend this facility.</userDescription>
     <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedArtilleryBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedArtilleryBase.xml
@@ -5,7 +5,6 @@
     <localModifiers>AlliedArtyGarrison.xml</localModifiers>
     <owner>Allied</owner>
     <sharedModifiers>AlliedArtySupport.xml</sharedModifiers>
-    <userDescription>A force of allied artillery will participate in scenarios on this track and
-        defend this facility.</userDescription>
+    <userDescription>A force of allied artillery will participate in scenarios on this track and defend this facility.</userDescription>
     <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedBaseOfOperations.xml
+++ b/MekHQ/data/stratconfacilities/AlliedBaseOfOperations.xml
@@ -8,8 +8,8 @@
 	<localModifiers>AlliedTurrets.xml</localModifiers>
 	<localModifiers>AlliedOfficerMek.xml</localModifiers>
 	<sharedModifiers>AlliedOfficerMek.xml</sharedModifiers>
-	<userDescription>This base is defended by well-equipped veteran troops, turrets and a commander in
-		a Mek. &lt;br&gt;
-		The commander will participate in scenarios on this track.</userDescription>
+	<userDescription>This base is defended by well-equipped veteran troops, turrets and a commander in a Mek.
+
+        The commander will participate in scenarios on this track.</userDescription>
 	<visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedCommsCenter.xml
+++ b/MekHQ/data/stratconfacilities/AlliedCommsCenter.xml
@@ -4,7 +4,6 @@
 	<facilityType>CommandCenter</facilityType>
 	<owner>Allied</owner>
 	<sharedModifiers>GoodEvent.xml</sharedModifiers>
-	<userDescription>This facility will coordinate additional allied reinforcements to scenarios on
-		this track.</userDescription>
+	<userDescription>This facility will coordinate additional allied reinforcements to scenarios on this track.</userDescription>
 	<visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedMekBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedMekBase.xml
@@ -5,7 +5,6 @@
     <localModifiers>AlliedMekGarrison.xml</localModifiers>
     <owner>Allied</owner>
     <sharedModifiers>AlliedMekReinforcements.xml</sharedModifiers>
-    <userDescription>Allied Meks will participate in scenarios on this track and defend this
-        facility.</userDescription>
+    <userDescription>Allied Meks will participate in scenarios on this track and defend this facility.</userDescription>
     <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedTankBase.xml
+++ b/MekHQ/data/stratconfacilities/AlliedTankBase.xml
@@ -5,7 +5,6 @@
     <localModifiers>AlliedTankGarrison.xml</localModifiers>
     <owner>Allied</owner>
     <sharedModifiers>AlliedTankReinforcements.xml</sharedModifiers>
-    <userDescription>Allied vehicles will participate in scenarios on this track and defend this
-        facility.</userDescription>
+    <userDescription>Allied vehicles will participate in scenarios on this track and defend this facility.</userDescription>
     <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileAirBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileAirBase.xml
@@ -5,7 +5,6 @@
     <localModifiers>EnemyAirGarrison.xml</localModifiers>
     <owner>Opposing</owner>
     <sharedModifiers>EnemyAirSupport.xml</sharedModifiers>
-    <userDescription>Hostile aircraft will participate in scenarios on this track and defend this
-        facility.</userDescription>
+    <userDescription>Hostile aircraft will participate in scenarios on this track and defend this facility.</userDescription>
     <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileArtilleryBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileArtilleryBase.xml
@@ -5,7 +5,6 @@
     <localModifiers>EnemyArtyGarrison.xml</localModifiers>
     <owner>Opposing</owner>
     <sharedModifiers>EnemyArty.xml</sharedModifiers>
-    <userDescription>Hostile artillery will participate in scenarios on this track and defend this
-        facility.</userDescription>
+    <userDescription>Hostile artillery will participate in scenarios on this track and defend this facility.</userDescription>
     <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileBaseOfOperations.xml
+++ b/MekHQ/data/stratconfacilities/HostileBaseOfOperations.xml
@@ -7,7 +7,6 @@
     <localModifiers>GoodEquipment.xml</localModifiers>
     <localModifiers>EnemyTurrets.xml</localModifiers>
     <sharedModifiers>EnemyCommanderMek.xml</sharedModifiers>
-    <userDescription>This base is defended by well-equipped veteran troops, turrets and a commander
-        in a Mek.</userDescription>
+    <userDescription>This base is defended by well-equipped veteran troops, turrets and a commander in a Mek.</userDescription>
     <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileDataCenter.xml
+++ b/MekHQ/data/stratconfacilities/HostileDataCenter.xml
@@ -5,7 +5,6 @@
     <facilityType>DataCenter</facilityType>
     <owner>Opposing</owner>
     <sharedModifiers>EnemyMekPatrol.xml</sharedModifiers>
-    <userDescription>An additional hostile Mek patrol will sweep through scenarios on this
-        track.</userDescription>
+    <userDescription>An additional hostile Mek patrol will sweep through scenarios on this track.</userDescription>
     <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileIndustrialFacility.xml
+++ b/MekHQ/data/stratconfacilities/HostileIndustrialFacility.xml
@@ -4,7 +4,6 @@
     <facilityType>IndustrialFacility</facilityType>
     <owner>Opposing</owner>
     <sharedModifiers>ArmednArmored.xml</sharedModifiers>
-    <userDescription>Hostile forces on this track are larger and better equipped with factory-fresh
-        units.</userDescription>
+    <userDescription>Hostile forces on this track are larger and better equipped with factory-fresh units.</userDescription>
     <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileMekBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileMekBase.xml
@@ -5,8 +5,7 @@
     <localModifiers>EnemyMekGarrison.xml</localModifiers>
     <owner>Opposing</owner>
     <sharedModifiers>EnemyMekReinforcements.xml</sharedModifiers>
-    <userDescription>Hostile Meks will participate in scenarios on this track and defend this
-        facility.</userDescription>
+    <userDescription>Hostile Meks will participate in scenarios on this track and defend this facility.</userDescription>
     <visible>false</visible>
     <biomes>
         <biomeCategory>TerranFacility</biomeCategory>

--- a/MekHQ/data/stratconfacilities/HostileOrbitalDefense.xml
+++ b/MekHQ/data/stratconfacilities/HostileOrbitalDefense.xml
@@ -5,7 +5,6 @@
     <owner>Opposing</owner>
     <preventAerospace>true</preventAerospace>
     <sharedModifiers>EnemyOfficerMek.xml</sharedModifiers>
-    <userDescription>Prevents allied aerospace unit operation on this track and supplies an
-        additional hostile Mek to ground scenarios.</userDescription>
+    <userDescription>Prevents allied aerospace unit operation on this track and supplies an additional hostile Mek to ground scenarios.</userDescription>
     <visible>false</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/HostileTankBase.xml
+++ b/MekHQ/data/stratconfacilities/HostileTankBase.xml
@@ -5,7 +5,6 @@
     <localModifiers>EnemyTankGarrison.xml</localModifiers>
     <owner>Opposing</owner>
     <sharedModifiers>EnemyTankReinforcements.xml</sharedModifiers>
-    <userDescription>Hostile vehicles will participate in scenarios on this track and defend
-        this facility.</userDescription>
+    <userDescription>Hostile vehicles will participate in scenarios on this track and defend this facility.</userDescription>
     <visible>false</visible>
 </StratconFacility>


### PR DESCRIPTION
Removed unnecessary line breaks in `userDescription` tags.