### PR TITLE
Fixed StratCon Reinforcement Deployment Check

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1527,8 +1527,7 @@ public class StratconRulesManager {
         }
 
         // otherwise, the force requires support points / vps to deploy
-        if ((campaignState.getSupportPoints() > 0) ||
-                (campaignState.getVictoryPoints() > 0)) {
+        if (campaignState.getSupportPoints() > 0) {
             return ReinforcementEligibilityType.SupportPoint;
         }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1526,7 +1526,7 @@ public class StratconRulesManager {
             return ReinforcementEligibilityType.FightLance;
         }
 
-        // otherwise, the force requires support points / vps to deploy
+        // otherwise, the force requires support points to deploy
         if (campaignState.getSupportPoints() > 0) {
             return ReinforcementEligibilityType.SupportPoint;
         }


### PR DESCRIPTION
Removed redundant check for victory points in deployment eligibility. Previously we removed the automatic exchange of CVP to SP when reinforcing a non-Fight Stance'd force. However, this check was missed so would display non-Fight forces even if the player has no SP. Now, those forces will only be visible if the player has SP adding visible value to the Fight stance.