### PR TITLE
CampaignGUI Tab reordering

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/MHQTabType.java
+++ b/MekHQ/src/mekhq/gui/enums/MHQTabType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2017-2024 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -29,22 +29,24 @@ import java.util.ResourceBundle;
  * Identifies the standard tabs and provides a creation method.
  * The mnemonics used in this are included in the list at {@link CampaignGUI#initMenu()}, and they
  * MUST be unique on that list.
+ * The order in which the tabs appear on onthe CampaignGUI is determined by the order in which they
+ * are declared here.
  * @author Neoancient
  */
 public enum MHQTabType {
     //region Enum Declaration
     COMMAND_CENTER("MHQTabType.COMMAND_CENTER.text", KeyEvent.VK_O),
+    INTERSTELLAR_MAP("MHQTabType.INTERSTELLAR_MAP.text", KeyEvent.VK_S),
     TOE("MHQTabType.TOE.text", KeyEvent.VK_T),
     BRIEFING_ROOM("MHQTabType.BRIEFING_ROOM.text", KeyEvent.VK_B),
-    INTERSTELLAR_MAP("MHQTabType.INTERSTELLAR_MAP.text", KeyEvent.VK_S),
+    STRAT_CON("MHQTabType.STRAT_CON.text", KeyEvent.VK_C),
     PERSONNEL("MHQTabType.PERSONNEL.text", KeyEvent.VK_P),
     HANGAR("MHQTabType.HANGAR.text", KeyEvent.VK_H),
-    WAREHOUSE("MHQTabType.WAREHOUSE.text", KeyEvent.VK_W),
     REPAIR_BAY("MHQTabType.REPAIR_BAY.text", KeyEvent.VK_R),
+    WAREHOUSE("MHQTabType.WAREHOUSE.text", KeyEvent.VK_W),
     INFIRMARY("MHQTabType.INFIRMARY.text", KeyEvent.VK_I),
     FINANCES("MHQTabType.FINANCES.text", KeyEvent.VK_N),
-    MEK_LAB("MHQTabType.MEK_LAB.text", KeyEvent.VK_L),
-    STRAT_CON("MHQTabType.STRAT_CON.text", KeyEvent.VK_C);
+    MEK_LAB("MHQTabType.MEK_LAB.text", KeyEvent.VK_L);
     //endregion Enum Declaration
 
     //region Variable Declarations


### PR DESCRIPTION
<img width="1797" alt="Screenshot 2024-11-01 at 01 11 17" src="https://github.com/user-attachments/assets/503ada61-96e4-4c98-b745-cfa60acaf2f8">

Changes order of the tabs in CampaignGUI, interstellar map is now right beside the command center mostly due to "vibes".

I think a command center should have easy access to a map. Then we have the TO&E, Briefing Room and StratCon, this is the "war room" basically, then we have personnel and hangar. Warehouse moved after the repair bay due to ergonomics, its not so frequent that we "visit" the warehouse, and it has more to do with book keeping most of the time, checking how many tons we have left, if there is anything to sell, etc. Infirmary, Finances, and in the last tab MekLab.
I think that MekLab in the last position is reasonable since it is mostly an empty screen unless you are activelly changing something, and as soo
n as you accept a design it disappears from the mek lab again, so it should be fine staying out of the way when navigating the tabs.

This is, of course, open for comments and suggestions as always.
Lets just try to avoid bikeshed arguments and just come up to "a solution", it does not need to be the best one, but it needs to be one.