### PR TITLE
Added Force BV Multiplier Logging & Adjusted Calculation in `AtBDynamicScenarioFactory`

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -442,15 +442,19 @@ public class AtBDynamicScenarioFactory {
         int forceBV = 0;
         double forceMultiplier = forceTemplate.getForceMultiplier();
 
+        if (forceTemplate.getForceMultiplier() != 1) {
+            logger.info(String.format("Force BV Multiplier: %s (from scenario template)", forceMultiplier));
+        }
+
         int forceBVBudget = (int) (effectiveBV * forceMultiplier);
 
         if (isScenarioModifier) {
-            forceBVBudget = (int) (forceBVBudget * ((double) campaign.getCampaignOptions().getScenarioModBV() / 100)
-                * forceMultiplier);
+            forceBVBudget = (int) (forceBVBudget * ((double) campaign.getCampaignOptions().getScenarioModBV() / 100));
         }
 
         if (forceTemplate.getForceMultiplier() != 1) {
-            logger.info(String.format("Force BV Multiplier: %s (from scenario template)", forceMultiplier));
+            logger.info(String.format("BV Budget was %s, now %s (includes Modifier settings and Multiplier)",
+                effectiveBV, forceBVBudget));
         }
 
         int forceUnitBudget = 0;


### PR DESCRIPTION
Added logging to display the force BV multiplier from the scenario template and the computed BV budget after applying the multiplier and any scenario modifiers. This helps in debugging by providing detailed information about how the BV budget is calculated.