### PR TITLE
[FG3] Updated Infantry Generation Method and Trainee Settings

### DIFF
--- a/MekHQ/data/scenariomodifiers/AlliedTraineesAir.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTraineesAir.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>Three trainees will deploy alongside your force. Keep them alive.</additionalBriefingText>
+	<additionalBriefingText>A force of trainees will deploy alongside your force. Keep them alive.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>Space</allowedMapLocation>
 		<allowedMapLocation>LowAtmosphere</allowedMapLocation>
@@ -18,47 +18,20 @@
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>
-		<fixedUnitCount>3</fixedUnitCount>
+		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>0</forceAlignment>
-		<forceMultiplier>1.0</forceMultiplier>
-		<forceName>Allied Trainees</forceName>
+		<forceMultiplier>0.25</forceMultiplier>
+		<forceName>Trainees</forceName>
 		<generationMethod>3</generationMethod>
 		<generationOrder>1</generationOrder>
 		<maxWeightClass>1</maxWeightClass>
 		<retreatThreshold>0</retreatThreshold>
 		<startingAltitude>5</startingAltitude>
+        <objectiveLinkedForces>
+            <objectiveLinkedForce>Player</objectiveLinkedForce>
+        </objectiveLinkedForces>
 		<syncDeploymentType>SameEdge</syncDeploymentType>
 		<syncedForceName>Player</syncedForceName>
 		<useArtillery>false</useArtillery>
 	</forceDefinition>
-
-	<objectives>
-		<objective>
-			<associatedForceNames>
-				<associatedForceName>Allied Trainees</associatedForceName>
-			</associatedForceNames>
-			<associatedUnitIDs />
-			<successEffects>
-				<successEffect>
-					<effectType>ScenarioVictory</effectType>
-					<effectScaling>Fixed</effectScaling>
-					<howMuch>1</howMuch>
-				</successEffect>
-			</successEffects>
-			<failureEffects>
-				<failureEffect>
-					<effectType>ScenarioDefeat</effectType>
-					<effectScaling>Fixed</effectScaling>
-					<howMuch>1</howMuch>
-				</failureEffect>
-			</failureEffects>
-			<description>Preserve 100% of the following force(s) and unit(s):</description>
-			<destinationEdge>NONE</destinationEdge>
-			<objectiveCriterion>Preserve</objectiveCriterion>
-			<percentage>100</percentage>
-			<timeLimit>0</timeLimit>
-			<timeLimitAtMost>true</timeLimitAtMost>
-			<timeLimitType>None</timeLimitType>
-		</objective>
-	</objectives>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/AlliedTraineesGround.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTraineesGround.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>Three trainees will deploy alongside your lance. Keep them alive.</additionalBriefingText>
+	<additionalBriefingText>A force of trainees will deploy alongside your lance. Keep them alive.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
@@ -18,47 +18,20 @@
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>
-		<fixedUnitCount>3</fixedUnitCount>
+		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>0</forceAlignment>
 		<forceMultiplier>1.0</forceMultiplier>
-		<forceName>Allied Trainees</forceName>
+		<forceName>Trainees</forceName>
 		<generationMethod>3</generationMethod>
 		<generationOrder>1</generationOrder>
 		<maxWeightClass>1</maxWeightClass>
 		<retreatThreshold>0</retreatThreshold>
 		<startingAltitude>0</startingAltitude>
+        <objectiveLinkedForces>
+            <objectiveLinkedForce>Player</objectiveLinkedForce>
+        </objectiveLinkedForces>
 		<syncDeploymentType>SameEdge</syncDeploymentType>
 		<syncedForceName>Player</syncedForceName>
 		<useArtillery>false</useArtillery>
 	</forceDefinition>
-
-	<objectives>
-		<objective>
-			<associatedForceNames>
-				<associatedForceName>Allied Trainees</associatedForceName>
-			</associatedForceNames>
-			<associatedUnitIDs />
-			<successEffects>
-				<successEffect>
-					<effectType>ScenarioVictory</effectType>
-					<effectScaling>Fixed</effectScaling>
-					<howMuch>1</howMuch>
-				</successEffect>
-			</successEffects>
-			<failureEffects>
-				<failureEffect>
-					<effectType>ScenarioDefeat</effectType>
-					<effectScaling>Fixed</effectScaling>
-					<howMuch>1</howMuch>
-				</failureEffect>
-			</failureEffects>
-			<description>Preserve 100% of the following force(s) and unit(s):</description>
-			<destinationEdge>NONE</destinationEdge>
-			<objectiveCriterion>Preserve</objectiveCriterion>
-			<percentage>100</percentage>
-			<timeLimit>0</timeLimit>
-			<timeLimitAtMost>true</timeLimitAtMost>
-			<timeLimitType>None</timeLimitType>
-		</objective>
-	</objectives>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/LocalGarrisonInfantry.xml
+++ b/MekHQ/data/scenariomodifiers/LocalGarrisonInfantry.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-	<additionalBriefingText>Planetary garrison infantry have been reported in the area.</additionalBriefingText>
+	<additionalBriefingText>Planetary garrison infantry are reported in the area.</additionalBriefingText>
 	<allowedMapLocations>
 		<allowedMapLocation>AllGroundTerrain</allowedMapLocation>
 		<allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>

--- a/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
@@ -109,7 +109,7 @@
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
                 <forceName>Infantry</forceName>
-                <generationMethod>1</generationMethod>
+                <generationMethod>2</generationMethod>
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>

--- a/MekHQ/data/scenariotemplates/Irregular Force Suppression.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Suppression.xml
@@ -79,7 +79,7 @@
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
                 <forceName>Infantry</forceName>
-                <generationMethod>1</generationMethod>
+                <generationMethod>2</generationMethod>
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>


### PR DESCRIPTION
Changed infantry generation method in two scenario templates to reduce infantry spam.

Updated text and settings in trainee forces. They are now tied to the same victory conditions as the player force and will now spawn as a full lance/star/level II instead of an arbitrary 3 unit count.
### Closes #5160 && #5162