### PR TITLE
[FG3] StratCon will No Longer Display GBV when Using FG3

### DIFF
--- a/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardLanceRenderer.java
+++ b/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardLanceRenderer.java
@@ -56,7 +56,7 @@ public class ScenarioWizardLanceRenderer extends JLabel implements ListCellRende
             roleString = lance.getRole().toString() + ", ";
         }
 
-        setText(String.format("%s (%sBV: %d)", value.getName(), roleString, value.getTotalBV(campaign, false)));
+        setText(String.format("%s (%sBV: %d)", value.getName(), roleString, value.getTotalBV(campaign, true)));
 
         return this;
     }


### PR DESCRIPTION
Changed the `forceStandardBattleValue` parameter from `false` to `true` to ensure accurate BV display in the Scenario Wizard Lance Renderer. This stops the StratCon force allocation windows from displaying GBV.