### PR TITLE
Added Contract Automation

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -83,3 +83,4 @@ bonusPartLog.text=Bonus part used to acquire 1x
 newAtBScenario.format=New scenario "{0}" will occur on {1}.
 atbScenarioToday.format=Scenario "{0}" is today, deploy a force from your TOE!
 atbScenarioTodayWithForce.format=Scenario "{0}" is today, {1} has been deployed!
+generalFallbackAddress.text=Commander

--- a/MekHQ/resources/mekhq/resources/ContractAutomation.properties
+++ b/MekHQ/resources/mekhq/resources/ContractAutomation.properties
@@ -1,0 +1,36 @@
+# General
+generalTitle.text=++ INCOMING TRANSMISSION ++
+generalSpeakerNameFallback.text=%s Actual
+generalFallbackAddress.text=Commander
+generalConfirm.text=Accept
+generalDecline.text=Decline
+generalEmployerFallback=mercenary
+
+# Messages
+mothballDescription.text=%s, our employer has offered to assist our personnel in getting our\
+  \ equipment ready for transport.\
+  <br>\
+  <br>Prior to loading, all equipment in our TO&E will be mothballed. This will prevent us needing\
+  \ to maintain it while in transit. Equipment outside our TO&E will be unaffected.\
+  <br>\
+  <br>Will we be accepting their offer?\
+  <br>\
+  <br>If we decline, you will still be able to manually order mothballing of equipment, but this\
+  \ will need to be arranged by right-clicking the unit in the Hangar panel of your command console,\
+  \ and selecting 'mothball.' Our techs will then take care of it as time becomes available.
+
+chartCourseDescription.text=Our target system is %s. Our %s contact has already calculated the best\
+  \ route for us.\
+  <br>\
+  <br>This journey will take us %s days and cost %s. Would you like to accept this route?\
+  <br>\
+  <br>If we decline, you will need to manually order route calculation from the Interstellar Map\
+  \ panel of your command console. Select the target system, and then 'Calculate Jump Path.'\
+  \ Alternatively, if you click on the hyper-linked system name in your Briefing Room, that will\
+  \ automatically select the appropriate system in the Interstellar Map panel.
+
+beginTransitDescription.text=%s, everything is good to go. Should I order our forces to mount up and\
+  \ pass word to the DropShips to begin transit?\
+  <br>\
+  <br>If you decline, you will need to manually make this order by selecting 'Begin Transit' in the\
+  \ Interstellar Map.

--- a/MekHQ/resources/mekhq/resources/ContractAutomation.properties
+++ b/MekHQ/resources/mekhq/resources/ContractAutomation.properties
@@ -19,18 +19,12 @@ mothballDescription.text=%s, our employer has offered to assist our personnel in
   \ will need to be arranged by right-clicking the unit in the Hangar panel of your command console,\
   \ and selecting 'mothball.' Our techs will then take care of it as time becomes available.
 
-chartCourseDescription.text=Our target system is %s. Our %s contact has already calculated the best\
+transitDescription.text=Our target system is %s. Our %s contact has already calculated the best\
   \ route for us.\
   <br>\
-  <br>This journey will take us %s days and cost %s. Would you like to accept this route?\
+  <br>This journey will take us %s days and cost %s. Would you like to accept this route and begin\
+  \ transit?\
   <br>\
-  <br>If we decline, you will need to manually order route calculation from the Interstellar Map\
-  \ panel of your command console. Select the target system, and then 'Calculate Jump Path.'\
-  \ Alternatively, if you click on the hyper-linked system name in your Briefing Room, that will\
-  \ automatically select the appropriate system in the Interstellar Map panel.
-
-beginTransitDescription.text=%s, everything is good to go. Should I order our forces to mount up and\
-  \ pass word to the DropShips to begin transit?\
-  <br>\
-  <br>If you decline, you will need to manually make this order by selecting 'Begin Transit' in the\
-  \ Interstellar Map.
+  <br>If we decline, you will need to manually order route calculation from the Interstellar Map.\
+  \ This can be done by selecting the target system in your Briefing Room, followed by 'Calculate\
+  \ Jump Path' and 'Begin Transit.'

--- a/MekHQ/resources/mekhq/resources/ContractAutomation.properties
+++ b/MekHQ/resources/mekhq/resources/ContractAutomation.properties
@@ -1,6 +1,5 @@
 # General
 generalTitle.text=++ INCOMING TRANSMISSION ++
-generalFallbackAddress.text=Commander
 generalConfirm.text=Accept
 generalDecline.text=Decline
 generalNonClan.text=The %s
@@ -22,9 +21,14 @@ mothballDescription.text=%s, our employer has offered to assist our personnel in
 transitDescription.text=Our target system is <b>%s</b>. %s has already calculated the best route\
   \ for us.\
   <br>\
-  <br>This journey will take us <b>%s</b> days and cost <b>%s</b>. Would you like to accept this\
-  \ route and begin transit?\
+  <br>This journey will take us approximately <b>%s</b> days and cost <b>%s</b>. Would you like to\
+  \ accept this route and begin transit?\
   <br>\
   <br>If we decline, you will need to manually order route calculation from the Interstellar Map.\
   \ This can be done by selecting the target system in your Briefing Room, followed by 'Calculate\
   \ Jump Path' and 'Begin Transit.'
+
+# Reports
+mothballingFailed.text=%s was not eligible to be automatically mothballed. Units cannot be\
+  \ destroyed, refitting, undergoing repairs, mid-mothball, or already mothballed.
+activationFailed.text=%s could not be automatically un-mothballed.

--- a/MekHQ/resources/mekhq/resources/ContractAutomation.properties
+++ b/MekHQ/resources/mekhq/resources/ContractAutomation.properties
@@ -1,17 +1,17 @@
 # General
 generalTitle.text=++ INCOMING TRANSMISSION ++
-generalSpeakerNameFallback.text=%s Actual
 generalFallbackAddress.text=Commander
 generalConfirm.text=Accept
 generalDecline.text=Decline
-generalEmployerFallback=mercenary
+generalNonClan.text=The %s
 
 # Messages
 mothballDescription.text=%s, our employer has offered to assist our personnel in getting our\
   \ equipment ready for transport.\
   <br>\
-  <br>Prior to loading, all equipment in our TO&E will be mothballed. This will prevent us needing\
-  \ to maintain it while in transit. Equipment outside our TO&E will be unaffected.\
+  <br>Prior to loading, all equipment in our TO&E will be <b>mothballed</b>. This will prevent us\
+  \ needing to maintain it while in transit and the units will be <b>unmothballed</b> prior to\
+  \ arrival. Equipment outside our TO&E will be unaffected.\
   <br>\
   <br>Will we be accepting their offer?\
   <br>\
@@ -19,11 +19,11 @@ mothballDescription.text=%s, our employer has offered to assist our personnel in
   \ will need to be arranged by right-clicking the unit in the Hangar panel of your command console,\
   \ and selecting 'mothball.' Our techs will then take care of it as time becomes available.
 
-transitDescription.text=Our target system is %s. Our %s contact has already calculated the best\
-  \ route for us.\
+transitDescription.text=Our target system is <b>%s</b>. %s has already calculated the best route\
+  \ for us.\
   <br>\
-  <br>This journey will take us %s days and cost %s. Would you like to accept this route and begin\
-  \ transit?\
+  <br>This journey will take us <b>%s</b> days and cost <b>%s</b>. Would you like to accept this\
+  \ route and begin transit?\
   <br>\
   <br>If we decline, you will need to manually order route calculation from the Interstellar Map.\
   \ This can be done by selecting the target system in your Briefing Room, followed by 'Calculate\

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -268,6 +268,7 @@ public class Campaign implements ITechManager {
     private final Quartermaster quartermaster;
     private StoryArc storyArc;
     private FameAndInfamyController fameAndInfamy;
+    private List<Unit> automatedMothballUnits;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Campaign",
             MekHQ.getMHQOptions().getLocale());
@@ -335,6 +336,7 @@ public class Campaign implements ITechManager {
         quartermaster = new Quartermaster(this);
         fieldKitchenWithinCapacity = false;
         fameAndInfamy = new FameAndInfamyController();
+        automatedMothballUnits = new ArrayList<>();
     }
 
     /**
@@ -5311,6 +5313,14 @@ public class Campaign implements ITechManager {
 
     public FameAndInfamyController getFameAndInfamy() {
         return fameAndInfamy;
+    }
+
+    public List<Unit> getAutomatedMothballUnits() {
+        return automatedMothballUnits;
+    }
+
+    public void setAutomatedMothballUnits(List<Unit> automatedMothballUnits) {
+        this.automatedMothballUnits = automatedMothballUnits;
     }
 
     public void writeToXML(final PrintWriter pw) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8400,4 +8400,27 @@ public class Campaign implements ITechManager {
     public boolean showExtinct() {
         return !campaignOptions.isDisallowExtinctStuff();
     }
+
+    /**
+     * Gets a string to use for addressing the commander.
+     * If no commander is flagged, returns a default address.
+     *
+     * @return The title of the commander, or a default string if no commander.
+     */
+    public String getCommanderAddress() {
+        Person commander = getFlaggedCommander();
+
+        if (commander == null) {
+            return resources.getString("generalFallbackAddress.text");
+        }
+
+        String commanderRank = commander.getRankName();
+
+        if (commanderRank.equalsIgnoreCase("None") || commanderRank.isBlank()) {
+            return commander.getFullName();
+        }
+
+        return commanderRank;
+    }
+
 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -140,6 +140,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import static mekhq.campaign.market.contractMarket.ContractAutomation.performAutomatedActivation;
 import static mekhq.campaign.personnel.backgrounds.BackgroundsController.randomMercenaryCompanyNameGenerator;
 import static mekhq.campaign.personnel.education.EducationController.getAcademy;
 import static mekhq.campaign.personnel.turnoverAndRetention.RetirementDefectionTracker.Payout.isBreakingContract;
@@ -3660,6 +3661,12 @@ public class Campaign implements ITechManager {
                     contract.addPlayerMinorBreaches(deficit);
                     addReport("Failure to meet " + contract.getName() + " requirements resulted in " + deficit
                             + ((deficit == 1) ? " minor contract breach" : " minor contract breaches"));
+                }
+            }
+
+            if (Objects.equals(location.getCurrentSystem(), contract.getSystem())) {
+                if (!automatedMothballUnits.isEmpty()) {
+                    performAutomatedActivation(this);
                 }
             }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5512,6 +5512,12 @@ public class Campaign implements ITechManager {
 
         retirementDefectionTracker.writeToXML(pw, indent);
 
+        MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "automatedMothballUnits");
+        for (Unit unit : automatedMothballUnits) {
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mothballedUnit", unit.getId());
+        }
+        MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "automatedMothballUnits");
+
         // Customised planetary events
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "customPlanetaryEvents");
         for (PlanetarySystem psystem : Systems.getInstance().getSystems().values()) {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -942,7 +942,6 @@ public class CampaignXmlParser {
     private static List<Unit> processAutomatedMothballNodes(Node workingNode, Campaign campaign) {
         logger.info("Loading Automated Mothball Nodes from XML...");
 
-        // TODO: make SpecialAbility a Campaign instance
         List<Unit> mothballedUnits = new ArrayList<>();
 
         NodeList workingList = workingNode.getChildNodes();
@@ -955,8 +954,6 @@ public class CampaignXmlParser {
             }
 
             if (!childNode.getNodeName().equalsIgnoreCase("mothballedUnit")) {
-                // Error condition of sorts!
-                // Errr, what should we do here?
                 logger.error("Unknown node type not loaded in Automated Mothball nodes: "
                     + childNode.getNodeName());
                 continue;

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
@@ -1,0 +1,209 @@
+package mekhq.campaign.market.contractMarket;
+
+import megamek.common.annotations.Nullable;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.JumpPath;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.force.Force;
+import mekhq.campaign.mission.Contract;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.Factions;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+import java.util.*;
+
+import static megamek.common.icons.AbstractIcon.DEFAULT_ICON_FILENAME;
+
+public class ContractAutomation {
+    private final static ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.ContractAutomation");
+    // Ask the user if they want to mothball their stuff.
+    //     Store the units mothballed in this manner, so we can activate them.
+    // Ask the user if they want to chart a course to their destination.
+    //     Make sure the user knows how much the journey will cost.
+    //     Make sure the user knows how to set the journey if they refuse.
+    // Ask the user if they want to start their journey.
+    //     Make sure the user knows how long the journey will take cost.
+    //     Make sure the user knows how to begin the journey if they refuse.
+
+    // When the user enters the target system automatically active the previously mothballed units.
+
+    public static void contractStartPrompt(Campaign campaign, Contract contract) {
+        // If we're already in the right system there is no need to automate these actions
+        if (Objects.equals(campaign.getLocation().getCurrentSystem(), contract.getSystem())) {
+            return;
+        }
+
+        // Initial setup
+        final Person speaker = getSpeaker(campaign);
+        final String speakerName = getSpeakerName(campaign, speaker);
+        final ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
+
+        final String commanderAddress = getCommanderAddress(campaign);
+
+        // Mothballing
+        String message = String.format(resources.getString("mothballDescription.text"), commanderAddress);
+
+        if (createDialog(speakerName, speakerIcon, message)) {
+            campaign.setAutomatedMothballUnits(performAutomatedMothballing(campaign));
+        }
+
+        // Chart Course;
+        String targetSystem = contract.getSystemName(campaign.getLocalDate());
+
+        Faction employerFaction = Factions.getInstance().getFaction(contract.getEmployer());
+        String employerName = resources.getString("generalEmployerFallback");
+        if (employerFaction != null) {
+            employerName = employerFaction.getFullName(campaign.getGameYear());
+        }
+
+        JumpPath jumpPath = contract.getJumpPath(campaign);
+        int travelDays = contract.getTravelDays(campaign);
+
+        Money costPerJump = campaign.calculateCostPerJump(true,
+                campaign.getCampaignOptions().isEquipmentContractBase());
+        String totalCost = costPerJump.multipliedBy(jumpPath.getJumps()).toAmountAndSymbolString();
+
+        message = String.format(resources.getString("chartCourseDescription.text"),
+            targetSystem, employerName, travelDays, totalCost);
+        boolean calculateJumpPath = createDialog(speakerName, speakerIcon, message);
+
+        if (calculateJumpPath) {
+            campaign.getLocation().setJumpPath(jumpPath);
+        } else {
+            return;
+        }
+
+        // Begin Transit
+        message = String.format(resources.getString("beginTransitDescription.text"),
+            commanderAddress);
+        if (createDialog(speakerName, speakerIcon, message)) {
+            campaign.getLocation().setJumpPath(jumpPath);
+            campaign.getUnits().forEach(unit -> unit.setSite(Unit.SITE_FACILITY_BASIC));
+        }
+    }
+
+    private static @Nullable Person getSpeaker(Campaign campaign) {
+        List<Person> admins = campaign.getAdmins();
+
+        if (admins.isEmpty()) {
+            return null;
+        }
+
+        List<Person> transportAdmins = new ArrayList<>();
+
+        for (Person admin : admins) {
+            if (admin.getPrimaryRole().isAdministratorTransport()
+                || admin.getSecondaryRole().isAdministratorTransport()) {
+                transportAdmins.add(admin);
+            }
+        }
+
+        if (transportAdmins.isEmpty()) {
+            return null;
+        }
+
+        Person speaker = transportAdmins.get(0);
+
+        for (Person admin : transportAdmins) {
+            if (admin.outRanksUsingSkillTiebreaker(campaign, speaker)) {
+                speaker = admin;
+            }
+        }
+
+        return speaker;
+    }
+
+    private static String getSpeakerName(Campaign campaign, @Nullable Person speaker) {
+        if (speaker == null) {
+            return String.format(resources.getString("generalSpeakerNameFallback.text"),
+                campaign.getName());
+        } else {
+            return speaker.getFullTitle();
+        }
+    }
+
+    private static ImageIcon getSpeakerIcon(Campaign campaign, @Nullable Person speaker) {
+        ImageIcon icon;
+
+        if (speaker == null) {
+            String fallbackIconFilename = campaign.getUnitIcon().getFilename();
+
+            if (fallbackIconFilename == null || fallbackIconFilename.equals(DEFAULT_ICON_FILENAME)) {
+                icon = Factions.getFactionLogo(campaign, campaign.getFaction().getShortName(), true);
+            } else {
+                icon = new ImageIcon(fallbackIconFilename);
+            }
+        } else {
+            icon = speaker.getPortrait().getImageIcon();
+        }
+
+        Image originalImage = icon.getImage();
+        Image scaledImage = originalImage.getScaledInstance(100, -1, Image.SCALE_SMOOTH);
+        return new ImageIcon(scaledImage);
+    }
+
+    private static String getCommanderAddress(Campaign campaign) {
+        Person commander = campaign.getFlaggedCommander();
+
+        if (commander == null) {
+            return resources.getString("generalFallbackAddress.text");
+        }
+
+        String commanderRank = commander.getRankName();
+
+        if (commanderRank.equalsIgnoreCase("None")) {
+            return commander.getFullName();
+        }
+
+        return commanderRank;
+    }
+
+    private static boolean createDialog(String speakerName, ImageIcon speakerIcon, String message) {
+        // Custom button text
+        Object[] options = {
+            resources.getString("generalConfirm.text"),
+            resources.getString("generalDecline.text")
+        };
+
+        // Create a custom message with a border
+        JPanel descriptionPanel = new JPanel();
+        descriptionPanel.setLayout(new BoxLayout(descriptionPanel, BoxLayout.PAGE_AXIS));
+        JLabel description = new JLabel(message);
+        description.setBorder(BorderFactory.createTitledBorder(speakerName));
+        descriptionPanel.add(description);
+
+        int response = JOptionPane.showOptionDialog(null,
+            descriptionPanel,  // Description
+            resources.getString("generalTitle.text"),  // Title
+            JOptionPane.YES_NO_OPTION,  // Option type
+            JOptionPane.QUESTION_MESSAGE,  // Message type
+            speakerIcon,  // Icon
+            options,  // Array of options
+            options[0]);  // Default button title
+
+        return (response == JOptionPane.YES_OPTION);
+    }
+
+    private static List<Unit> performAutomatedMothballing(Campaign campaign) {
+        List<Unit> mothballedUnits = new ArrayList<>();
+
+        for (Force force : campaign.getAllForces()) {
+            for (UUID unitId : force.getUnits()) {
+                Unit unit = campaign.getUnit(unitId);
+
+                if (unit != null) {
+                    if (!unit.isMothballed()) {
+                        unit.completeMothball();
+                        mothballedUnits.add(unit);
+                    }
+                }
+            }
+        }
+
+        return mothballedUnits;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
@@ -293,7 +293,7 @@ public class ContractAutomation {
                 Unit unit = campaign.getUnit(unitId);
 
                 if (unit != null) {
-                    if (!unit.isMothballed()) {
+                    if (unit.isAvailable(false) && !unit.isUnderRepair()) {
                         mothballTargets.add(unit);
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -2,6 +2,7 @@
  * Contract.java
  *
  * Copyright (c) 2011 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
+ * Copyright (c) 2024 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -20,14 +20,6 @@
  */
 package mekhq.campaign.mission;
 
-import java.io.PrintWriter;
-import java.text.ParseException;
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
@@ -38,6 +30,13 @@ import mekhq.campaign.mission.enums.ContractCommandRights;
 import mekhq.campaign.rating.UnitRatingMethod;
 import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Contracts - we need to track static amounts here because changes in the
@@ -163,7 +162,7 @@ public class Contract extends Mission {
      * This sets the Start Date and End Date of the Contract based on the length of
      * the contract and
      * the starting date provided
-     * 
+     *
      * @param startDate the date the contract starts at
      */
     public void setStartAndEndDate(LocalDate startDate) {
@@ -442,7 +441,7 @@ public class Contract extends Mission {
                 .minus(getTotalEstimatedPayrollExpenses(c));
     }
 
-    private int getTravelDays(Campaign c) {
+    public int getTravelDays(Campaign c) {
         if (null != this.getSystem()) {
             JumpPath jumpPath = getJumpPath(c);
             double days = Math.round(jumpPath.getTotalTime(c.getLocalDate(), c.getLocation().getTransitTime()) * 100.0)
@@ -567,7 +566,7 @@ public class Contract extends Mission {
      * Only do this at the time the contract is set up, otherwise amounts may change
      * after
      * the ink is signed, which is a no-no.
-     * 
+     *
      * @param c current campaign
      */
     public void calculateContract(Campaign c) {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -1,8 +1,8 @@
 /*
  * Unit.java
  *
- * Copyright (C) 2016-2024 - The MegaMek Team. All Rights Reserved.
  * Copyright (c) 2009 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
+ * Copyright (c) 2016-2024 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -289,7 +289,7 @@ public class Unit implements ITechnology {
         StringBuilder toReturn = new StringBuilder();
         toReturn.append("Omni");
         if (!(type == UnitType.TANK || type == UnitType.MEK)) {
-            toReturn.append(" ");
+            toReturn.append(' ');
         }
         toReturn.append(UnitType.getTypeDisplayableName(type));
         return toReturn.toString();
@@ -4817,7 +4817,7 @@ public class Unit implements ITechnology {
             getCampaign().mothball(this);
         } else {
             completeMothball();
-            getCampaign().addReport(getHyperlinkedName() + " has been mothballed (GM)");
+            getCampaign().addReport(getHyperlinkedName() + " has been mothballed");
         }
     }
 
@@ -4866,7 +4866,7 @@ public class Unit implements ITechnology {
             getCampaign().activate(this);
         } else {
             completeActivation();
-            getCampaign().addReport(getHyperlinkedName() + " has been activated (GM)");
+            getCampaign().addReport(getHyperlinkedName() + " has been activated");
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -48,6 +48,7 @@ import java.awt.event.WindowEvent;
 import java.util.List;
 import java.util.*;
 
+import static mekhq.campaign.market.contractMarket.ContractAutomation.contractStartPrompt;
 import static mekhq.campaign.universe.Factions.getFactionLogo;
 
 /**
@@ -479,6 +480,8 @@ public class ContractMarketDialog extends JDialog {
                     return;
                 }
             }
+
+            contractStartPrompt(campaign, selectedContract);
 
             selectedContract.setName(contractView.getContractName());
             campaign.getFinances().credit(TransactionType.CONTRACT_PAYMENT, campaign.getLocalDate(),

--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -2,6 +2,7 @@
  * ContractMarketDialog.java
  *
  * Copyright (c) 2014-2024 Carl Spain. All rights reserved.
+ * Copyright (c) 2024 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *


### PR DESCRIPTION
Currently accepting a contract is a bit of a process: you need to accept the contract, navigate to the Briefing Room, click on the system, click on Calculate Jump Path, click on Begin Transit. Then, by the time you arrive half of your forces are falling apart from failed maintenance checks.

To resolve that last problem, I'm aware that many of our players advise mothballing forces before transit. Seeing just how crippling RAW maintenance rules can be, I'm inclined to agree.

From a New Player Experience perspective, both of these issues present a couple of problems:
- Having beginning a contract such a process creates multiple 'quit moments' for the player, multiple stumbling blocks where if they can't figure out what they want to do they're potentially just going to close the program.
- Players don't expect to arrive with half of their 'Meks falling apart. From what I've seen, this usually results in the player just GM fixing the units, or turning off maintenance entirely.
- Mothballing units means the player has to remember to unmothball them when they arrive. If they forget, they're likely to just GM Active.

This PR attempts to resolve these options in a couple of steps:
- When the contract is accepted the player is presented with a dialog asking whether they would like to mothball their TO&E for transport. This mothballing is automatic, to avoid any issues with Tech assignment. We're essentially GM Mothballing, and this can be justified as the employer hiring techs or as techs to ensure their contracted unit is able to get en route as quickly as possible.
- A second dialog is then triggered, asking the player whether they would like to begin transit to the contract system. If they accept a route is immediately laid out and transit begins.
- When the contract date arrives all of the players units, previously mothballed by this system, are automatically un-mothballed.