### PR TITLE
Temporarily Disabled Preset Confirm in New Campaign Dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -289,7 +289,7 @@ public class DataLoadingDialog extends AbstractMHQDialog implements PropertyChan
 
                 // Campaign Preset
                 final SelectPresetDialog presetSelectionDialog =
-                    new SelectPresetDialog(getFrame(), true, true);
+                    new SelectPresetDialog(getFrame(), false, true);
                 CampaignPreset preset;
                 boolean isSelect = false;
 


### PR DESCRIPTION
As per title. Customize preset is still available. This functionality was set up to enable easy testing of new features and is feature incomplete without the rest of Campaign Options IIC. Once 50.01 has shipped this option will be re-enabled.