### PR TITLE
Temporarily Removed CAM_OPS from Contract Market Method ComboBox

### DIFF
--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -53,7 +53,6 @@ import mekhq.campaign.market.enums.ContractMarketMethod;
 import mekhq.campaign.market.enums.UnitMarketMethod;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.enums.AtBLanceRole;
-import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.enums.PartQuality;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.SkillType;
@@ -99,6 +98,7 @@ import java.util.Map.Entry;
 import java.util.stream.IntStream;
 
 import static megamek.client.ui.WrapLayout.wordWrap;
+import static mekhq.campaign.market.enums.ContractMarketMethod.CAM_OPS;
 
 /**
  * @author Justin 'Windchild' Bowen
@@ -7998,6 +7998,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         comboContractMarketMethod = new MMComboBox<>("comboContractMarketMethod",
                 ContractMarketMethod.values());
+        comboContractMarketMethod.removeItem(CAM_OPS);
         comboContractMarketMethod.setToolTipText(resources.getString("lblContractMarketMethod.toolTipText"));
         comboContractMarketMethod.setRenderer(new DefaultListCellRenderer() {
             @Override


### PR DESCRIPTION
Removed the CAM_OPS item from the `comboContractMarketMethod` comboBox in `CampaignOptionsPane`. This option is not ready for general use and will be re-enabled once 50.01 has shipped.

@Algebro7 I know you had plans to do this yourself, but I also know you're super busy IRL and I had time, so figured I'd do it.