### PR TITLE
 Fix Perm. Injury showing as Injury on Personnel tabel

### DIFF
--- a/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PersonnelTableModel.java
@@ -166,7 +166,7 @@ public class PersonnelTableModel extends DataTableModel {
             // Colouring
             boolean personIsDamaged = false;
             if (campaign.getCampaignOptions().isUseAdvancedMedical()) {
-                personIsDamaged = person.hasInjuries(false);
+                personIsDamaged = person.hasInjuries(true);
             } else {
                 personIsDamaged = person.getHits() > 0;
             }


### PR DESCRIPTION
When I was last in these parts apparently I didn't set the filter argument to a function correctly and permanent injuries displayed as if they were regular injuries in the list. This fixes that.