### PR TITLE
Show refitting techs and fix refit countdown

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3777,7 +3777,9 @@ public class Person {
     }
 
     public int getMaintenanceTimeUsing() {
-        return getTechUnits().stream().mapToInt(Unit::getMaintenanceTime).sum();
+        return getTechUnits().stream()
+            .filter(unit -> !(unit.isRefitting() && unit.getRefit().getTech() == this))
+            .mapToInt(Unit::getMaintenanceTime).sum();
     }
 
     public boolean isMothballing() {

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -38,6 +38,7 @@ import mekhq.campaign.personnel.randomEvents.enums.personalities.*;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
 import mekhq.gui.sorter.*;
+import mekhq.utilities.ReportingUtilities;
 
 import javax.swing.*;
 import java.util.Comparator;
@@ -526,13 +527,21 @@ public enum PersonnelTableModelColumn {
 
                     // Check for tech units
                     if (!person.getTechUnits().isEmpty()) {
+                        Unit refitUnit = person.getTechUnits().stream()
+                            .filter(u -> u.isRefitting() && u.getRefit().getTech() == person)
+                            .findFirst().orElse(null);
+                        String refitString = null != refitUnit ? 
+                                "<b>Refitting</b> " + refitUnit.getName() : "";
                         if (person.getTechUnits().size() == 1) {
                             unit = person.getTechUnits().get(0);
                             if (unit != null) {
-                                return unit.getName() + " (" + person.getMaintenanceTimeUsing() + "m)";
+                                return "<html>" + ReportingUtilities.separateIf(refitString, ", ", 
+                                        unit.getName() + " (" + person.getMaintenanceTimeUsing() + "m)") + "</html>";
                             }
                         } else {
-                            return person.getTechUnits().size() + " units (" + person.getMaintenanceTimeUsing() + "m)";
+                            return "<html>" + ReportingUtilities.separateIf(refitString, ", ", 
+                                    person.getTechUnits().size() + " units (" + person.getMaintenanceTimeUsing() + "m)")
+                                    + "</html>";
                         }
                     }
                 }


### PR DESCRIPTION
Fixes an error in calcluating the number of days left on a refit caused by not discounting time spent by a tech assigned to both do the refit and maintain the mech being refit.

Also marks techs that are doing refits in the personnel column.

![2024-11-07_183959](https://github.com/user-attachments/assets/6d09e6d3-2d74-43a4-a370-d258fe93f895)
