### PR TITLE
Re-enabled CamOps Contract Market Method

### DIFF
--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -98,7 +98,6 @@ import java.util.Map.Entry;
 import java.util.stream.IntStream;
 
 import static megamek.client.ui.WrapLayout.wordWrap;
-import static mekhq.campaign.market.enums.ContractMarketMethod.CAM_OPS;
 
 /**
  * @author Justin 'Windchild' Bowen
@@ -7998,7 +7997,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         comboContractMarketMethod = new MMComboBox<>("comboContractMarketMethod",
                 ContractMarketMethod.values());
-        comboContractMarketMethod.removeItem(CAM_OPS);
         comboContractMarketMethod.setToolTipText(resources.getString("lblContractMarketMethod.toolTipText"));
         comboContractMarketMethod.setRenderer(new DefaultListCellRenderer() {
             @Override


### PR DESCRIPTION
This was temporarily disabled, prior to the release of 50.01, as it wasn't ready for public consumption.