### PR TITLE
Re-enabled Confirm Preset Option for New Campaign Preset Picker

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -289,7 +289,7 @@ public class DataLoadingDialog extends AbstractMHQDialog implements PropertyChan
 
                 // Campaign Preset
                 final SelectPresetDialog presetSelectionDialog =
-                    new SelectPresetDialog(getFrame(), false, true);
+                    new SelectPresetDialog(getFrame(), true, true);
                 CampaignPreset preset;
                 boolean isSelect = false;
 


### PR DESCRIPTION
This was temporarily disabled, prior to the release of 50.01, as it wasn't ready for public consumption.