### PR TITLE
Handled Exception when Fetching Force by ID in `StratconPanel`

### DIFF
--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -655,6 +655,17 @@ public class StratconPanel extends JPanel implements ActionListener {
 
                 if (currentTrack.getAssignedCoordForces().containsKey(currentCoords)) {
                     for (int forceID : currentTrack.getAssignedCoordForces().get(currentCoords)) {
+                        String forceName = "";
+                        try {
+                            Force force = campaign.getForce(forceID);
+                            forceName = force.getName();
+                        } catch (Exception e) {
+                            // If we can't successfully fetch the Force, there is no point trying
+                            // to draw it on the map.
+                            logger.error(String.format("Failed to fetch force from ID %s", forceID));
+                            continue;
+                        }
+
                         g2D.setColor(Color.GREEN);
 
                         BufferedImage forceImage = getImage(StratconBiomeManifest.FORCE_FRIENDLY,
@@ -670,7 +681,7 @@ public class StratconPanel extends JPanel implements ActionListener {
                                 TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD));
                         g2D.setFont(newFont);
 
-                        drawTextEffect(g2D, forceMarker, campaign.getForce(forceID).getName(), currentCoords);
+                        drawTextEffect(g2D, forceMarker, forceName, currentCoords);
 
                         g2D.setFont(currentFont);
                     }


### PR DESCRIPTION
Added a try-catch block to handle errors when fetching a force by its ID in `StratconPanel.java`. This prevents the application from attempting to draw a force on the map if it fails to fetch the force data and logs an error message accordingly.

### Closes #5203