### PR TITLE
Update Rank Systems to Version 0.50.2-SNAPSHOT

### DIFF
--- a/MekHQ/userdata/data/universe/ranks.xml
+++ b/MekHQ/userdata/data/universe/ranks.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rankSystems version="0.50.2-SNAPSHOT">
+<rankSystems version="0.50.02-SNAPSHOT">
 </rankSystems>

--- a/MekHQ/userdata/data/universe/ranks.xml
+++ b/MekHQ/userdata/data/universe/ranks.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rankSystems version="0.50.1-SNAPSHOT">
+<rankSystems version="0.50.2-SNAPSHOT">
 </rankSystems>


### PR DESCRIPTION
Incremented the rank systems version in ranks.xml from 0.50.1-SNAPSHOT to 0.50.2-SNAPSHOT. This stops IDEA from pestering us to update it any time we make a change in mhq.