### PR TITLE
Reduced Force Multiplier for Pirate Scenarios

### DIFF
--- a/MekHQ/data/scenariomodifiers/PiratesIncomingAir.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesIncomingAir.xml
@@ -25,7 +25,7 @@
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>3</forceAlignment>
-		<forceMultiplier>1.0</forceMultiplier>
+		<forceMultiplier>0.5</forceMultiplier>
 		<forceName>Unidentified Hostiles</forceName>
 		<generationMethod>2</generationMethod>
 		<generationOrder>3</generationOrder>

--- a/MekHQ/data/scenariomodifiers/PiratesIncomingGround.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesIncomingGround.xml
@@ -29,7 +29,7 @@
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>3</forceAlignment>
-		<forceMultiplier>1.0</forceMultiplier>
+		<forceMultiplier>0.5</forceMultiplier>
 		<forceName>Unidentified Hostiles</forceName>
 		<generationMethod>2</generationMethod>
 		<generationOrder>3</generationOrder>

--- a/MekHQ/data/scenariomodifiers/PiratesPresentAir.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesPresentAir.xml
@@ -25,7 +25,7 @@
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>3</forceAlignment>
-		<forceMultiplier>1.0</forceMultiplier>
+		<forceMultiplier>0.5</forceMultiplier>
 		<forceName>Unidentified Hostiles</forceName>
 		<generationMethod>2</generationMethod>
 		<generationOrder>3</generationOrder>

--- a/MekHQ/data/scenariomodifiers/PiratesPresentGround.xml
+++ b/MekHQ/data/scenariomodifiers/PiratesPresentGround.xml
@@ -29,7 +29,7 @@
 		<destinationZone>5</destinationZone>
 		<fixedUnitCount>-1</fixedUnitCount>
 		<forceAlignment>3</forceAlignment>
-		<forceMultiplier>1.0</forceMultiplier>
+		<forceMultiplier>0.5</forceMultiplier>
 		<forceName>Unidentified Hostiles</forceName>
 		<generationMethod>2</generationMethod>
 		<generationOrder>3</generationOrder>


### PR DESCRIPTION
Lowered the force multiplier from 1.0 to 0.5 for all pirate-related scenario modifiers. This change affects both ground and air scenarios involving pirates to adjust the difficulty balance.

### Closes #5197