### PR TITLE
Fix Spouse Dependency Check in Divorce Logic.

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/divorce/AbstractDivorce.java
+++ b/MekHQ/src/mekhq/campaign/personnel/divorce/AbstractDivorce.java
@@ -266,7 +266,7 @@ public abstract class AbstractDivorce {
         }
 
         if (spouse.getPrimaryRole().isDependent()) {
-            departingPartners.add(origin);
+            departingPartners.add(spouse);
         }
 
         if (!departingPartners.isEmpty()) {


### PR DESCRIPTION
Corrected an error where the departing partner was incorrectly set to the origin partner rather than the spouse. This ensures that the dependent spouse is properly added to the departing partners list.

### Closes #5196