### PR TITLE
Lowered Capture Percentage Requirement to 25%

### DIFF
--- a/MekHQ/data/scenariomodifiers/FacilityHostileCapture.xml
+++ b/MekHQ/data/scenariomodifiers/FacilityHostileCapture.xml
@@ -29,7 +29,7 @@
 			<description>Leave intact the following force(s) and unit(s) to be able to take control of this facility:</description>
 			<destinationEdge>NONE</destinationEdge>
 			<objectiveCriterion>Preserve</objectiveCriterion>
-			<percentage>75</percentage>
+			<percentage>25</percentage>
 			<timeLimit>0</timeLimit>
 			<timeLimitAtMost>true</timeLimitAtMost>
 			<timeLimitType>None</timeLimitType>

--- a/MekHQ/data/scenariomodifiers/FacilityHostileCaptureNonWin.xml
+++ b/MekHQ/data/scenariomodifiers/FacilityHostileCaptureNonWin.xml
@@ -29,7 +29,7 @@
 			<description>Leave intact at least 75% of the following force(s) and unit(s) in order to be able to take control of this facility:</description>
 			<destinationEdge>NONE</destinationEdge>
 			<objectiveCriterion>Preserve</objectiveCriterion>
-			<percentage>75</percentage>
+			<percentage>25</percentage>
 			<timeLimit>0</timeLimit>
 			<timeLimitAtMost>true</timeLimitAtMost>
 			<timeLimitType>None</timeLimitType>


### PR DESCRIPTION
Reduced the percentage of forces to be preserved for a successful hostile facility capture from 75% to 25%. This brings these modifiers in better alignment with their defense equivalents.

### Closes #5220