### PR TITLE
Adjusted Command Rights Scenario Modifiers

### DIFF
--- a/MekHQ/data/scenariomodifiers/HouseOfficerAir.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerAir.xml
@@ -1,10 +1,10 @@
 <AtBScenarioModifier>
-    <additionalBriefingText>Your employer is dispatching a force to assist with this objective.</additionalBriefingText>
+    <additionalBriefingText>Your force will be deployed under the command of an allied commander.</additionalBriefingText>
     <benefitsPlayer>true</benefitsPlayer>
     <eventTiming>PreForceGeneration</eventTiming>
     <forceDefinition>
         <actualDeploymentZone>-1</actualDeploymentZone>
-        <allowAeroBombs>true</allowAeroBombs>
+        <allowAeroBombs>false</allowAeroBombs>
         <allowedUnitType>9</allowedUnitType>
         <arrivalTurn>0</arrivalTurn>
         <canReinforceLinked>false</canReinforceLinked>
@@ -14,14 +14,14 @@
         <deployOffboard>false</deployOffboard>
         <deploymentZones />
         <destinationZone>5</destinationZone>
-        <fixedUnitCount>0</fixedUnitCount>
-        <forceAlignment>1</forceAlignment>
+        <fixedUnitCount>1</fixedUnitCount>
+        <forceAlignment>0</forceAlignment>
         <forceMultiplier>1.0</forceMultiplier>
-        <forceName>Joint Force</forceName>
-        <generationMethod>2</generationMethod>
+        <forceName>Commander</forceName>
+        <generationMethod>3</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
-        <minWeightClass>2</minWeightClass>
+        <minWeightClass>3</minWeightClass>
         <retreatThreshold>0</retreatThreshold>
         <startingAltitude>5</startingAltitude>
         <objectiveLinkedForces>

--- a/MekHQ/data/scenariomodifiers/HouseOfficerAir.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerAir.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-    <additionalBriefingText>Your force will be deployed under the command of an allied commander.</additionalBriefingText>
+    <additionalBriefingText>Your employer is dispatching a force to assist with this objective.</additionalBriefingText>
     <benefitsPlayer>true</benefitsPlayer>
     <eventTiming>PreForceGeneration</eventTiming>
     <forceDefinition>
@@ -14,14 +14,14 @@
         <deployOffboard>false</deployOffboard>
         <deploymentZones />
         <destinationZone>5</destinationZone>
-        <fixedUnitCount>1</fixedUnitCount>
-        <forceAlignment>0</forceAlignment>
-        <forceMultiplier>1.0</forceMultiplier>
-        <forceName>Commander</forceName>
-        <generationMethod>3</generationMethod>
+        <fixedUnitCount>0</fixedUnitCount>
+        <forceAlignment>1</forceAlignment>
+        <forceMultiplier>0.25</forceMultiplier>
+        <forceName>Joint Force</forceName>
+        <generationMethod>2</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
-        <minWeightClass>3</minWeightClass>
+        <minWeightClass>2</minWeightClass>
         <retreatThreshold>0</retreatThreshold>
         <startingAltitude>5</startingAltitude>
         <objectiveLinkedForces>

--- a/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-    <additionalBriefingText>Your force will be deployed under the command of an allied commander.</additionalBriefingText>
+    <additionalBriefingText>Your employer is dispatching a force to assist with this objective.</additionalBriefingText>
     <allowedMapLocations>
         <allowedMapLocation>AllGroundTerrain</allowedMapLocation>
         <allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
@@ -18,14 +18,14 @@
         <deployOffboard>false</deployOffboard>
         <deploymentZones />
         <destinationZone>5</destinationZone>
-        <fixedUnitCount>1</fixedUnitCount>
-        <forceAlignment>0</forceAlignment>
-        <forceMultiplier>1.0</forceMultiplier>
-        <forceName>Allied Commander</forceName>
-        <generationMethod>3</generationMethod>
+        <fixedUnitCount>0</fixedUnitCount>
+        <forceAlignment>1</forceAlignment>
+        <forceMultiplier>0.25</forceMultiplier>
+        <forceName>Joint Force</forceName>
+        <generationMethod>2</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
-        <minWeightClass>3</minWeightClass>
+        <minWeightClass>2</minWeightClass>
         <retreatThreshold>0</retreatThreshold>
         <startingAltitude>0</startingAltitude>
         <objectiveLinkedForces>

--- a/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-    <additionalBriefingText>Your employer is dispatching a force to assist with this objective.</additionalBriefingText>
+    <additionalBriefingText>Your force will be deployed under the command of an allied commander.</additionalBriefingText>
     <allowedMapLocations>
         <allowedMapLocation>AllGroundTerrain</allowedMapLocation>
         <allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
@@ -8,7 +8,7 @@
     <eventTiming>PreForceGeneration</eventTiming>
     <forceDefinition>
         <actualDeploymentZone>-1</actualDeploymentZone>
-        <allowAeroBombs>true</allowAeroBombs>
+        <allowAeroBombs>false</allowAeroBombs>
         <allowedUnitType>0</allowedUnitType>
         <arrivalTurn>0</arrivalTurn>
         <canReinforceLinked>false</canReinforceLinked>
@@ -18,14 +18,14 @@
         <deployOffboard>false</deployOffboard>
         <deploymentZones />
         <destinationZone>5</destinationZone>
-        <fixedUnitCount>0</fixedUnitCount>
-        <forceAlignment>1</forceAlignment>
+        <fixedUnitCount>1</fixedUnitCount>
+        <forceAlignment>0</forceAlignment>
         <forceMultiplier>1.0</forceMultiplier>
-        <forceName>Joint Force</forceName>
-        <generationMethod>2</generationMethod>
+        <forceName>Allied Commander</forceName>
+        <generationMethod>3</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
-        <minWeightClass>2</minWeightClass>
+        <minWeightClass>3</minWeightClass>
         <retreatThreshold>0</retreatThreshold>
         <startingAltitude>0</startingAltitude>
         <objectiveLinkedForces>

--- a/MekHQ/data/scenariomodifiers/IntegratedAlliesAir.xml
+++ b/MekHQ/data/scenariomodifiers/IntegratedAlliesAir.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-    <additionalBriefingText>Your force will be deployed as part of an integrated unit.</additionalBriefingText>
+    <additionalBriefingText>Your employer has deployed you alongside an integrated force.</additionalBriefingText>
     <benefitsPlayer>true</benefitsPlayer>
     <eventTiming>PreForceGeneration</eventTiming>
     <forceDefinition>
@@ -14,11 +14,11 @@
         <deployOffboard>false</deployOffboard>
         <deploymentZones />
         <destinationZone>5</destinationZone>
-        <fixedUnitCount>2</fixedUnitCount>
+        <fixedUnitCount>0</fixedUnitCount>
         <forceAlignment>1</forceAlignment>
-        <forceMultiplier>1.0</forceMultiplier>
+        <forceMultiplier>0.5</forceMultiplier>
         <forceName>Integrated Allies</forceName>
-        <generationMethod>3</generationMethod>
+        <generationMethod>2</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
         <minWeightClass>1</minWeightClass>

--- a/MekHQ/data/scenariomodifiers/IntegratedAlliesAir.xml
+++ b/MekHQ/data/scenariomodifiers/IntegratedAlliesAir.xml
@@ -1,10 +1,10 @@
 <AtBScenarioModifier>
-    <additionalBriefingText>Your employer has deployed you alongside an integrated force.</additionalBriefingText>
+    <additionalBriefingText>Your force will be deployed as part of an integrated unit.</additionalBriefingText>
     <benefitsPlayer>true</benefitsPlayer>
     <eventTiming>PreForceGeneration</eventTiming>
     <forceDefinition>
         <actualDeploymentZone>-1</actualDeploymentZone>
-        <allowAeroBombs>true</allowAeroBombs>
+        <allowAeroBombs>false</allowAeroBombs>
         <allowedUnitType>9</allowedUnitType>
         <arrivalTurn>0</arrivalTurn>
         <canReinforceLinked>false</canReinforceLinked>
@@ -14,11 +14,11 @@
         <deployOffboard>false</deployOffboard>
         <deploymentZones />
         <destinationZone>5</destinationZone>
-        <fixedUnitCount>0</fixedUnitCount>
+        <fixedUnitCount>2</fixedUnitCount>
         <forceAlignment>1</forceAlignment>
-        <forceMultiplier>2.0</forceMultiplier>
+        <forceMultiplier>1.0</forceMultiplier>
         <forceName>Integrated Allies</forceName>
-        <generationMethod>2</generationMethod>
+        <generationMethod>3</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
         <minWeightClass>1</minWeightClass>

--- a/MekHQ/data/scenariomodifiers/IntegratedAlliesGround.xml
+++ b/MekHQ/data/scenariomodifiers/IntegratedAlliesGround.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-    <additionalBriefingText>Your employer has deployed you alongside an integrated force.</additionalBriefingText>
+    <additionalBriefingText>Your force will be deployed as part of an integrated unit.</additionalBriefingText>
     <allowedMapLocations>
         <allowedMapLocation>AllGroundTerrain</allowedMapLocation>
         <allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
@@ -8,7 +8,7 @@
     <eventTiming>PreForceGeneration</eventTiming>
     <forceDefinition>
         <actualDeploymentZone>-1</actualDeploymentZone>
-        <allowAeroBombs>true</allowAeroBombs>
+        <allowAeroBombs>false</allowAeroBombs>
         <allowedUnitType>0</allowedUnitType>
         <arrivalTurn>0</arrivalTurn>
         <canReinforceLinked>false</canReinforceLinked>
@@ -18,11 +18,11 @@
         <deployOffboard>false</deployOffboard>
         <deploymentZones />
         <destinationZone>5</destinationZone>
-        <fixedUnitCount>0</fixedUnitCount>
+        <fixedUnitCount>2</fixedUnitCount>
         <forceAlignment>1</forceAlignment>
-        <forceMultiplier>2.0</forceMultiplier>
+        <forceMultiplier>1.0</forceMultiplier>
         <forceName>Integrated Allies</forceName>
-        <generationMethod>2</generationMethod>
+        <generationMethod>3</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
         <minWeightClass>1</minWeightClass>

--- a/MekHQ/data/scenariomodifiers/IntegratedAlliesGround.xml
+++ b/MekHQ/data/scenariomodifiers/IntegratedAlliesGround.xml
@@ -1,5 +1,5 @@
 <AtBScenarioModifier>
-    <additionalBriefingText>Your force will be deployed as part of an integrated unit.</additionalBriefingText>
+    <additionalBriefingText>Your employer has deployed you alongside an integrated force.</additionalBriefingText>
     <allowedMapLocations>
         <allowedMapLocation>AllGroundTerrain</allowedMapLocation>
         <allowedMapLocation>SpecificGroundTerrain</allowedMapLocation>
@@ -18,11 +18,11 @@
         <deployOffboard>false</deployOffboard>
         <deploymentZones />
         <destinationZone>5</destinationZone>
-        <fixedUnitCount>2</fixedUnitCount>
+        <fixedUnitCount>0</fixedUnitCount>
         <forceAlignment>1</forceAlignment>
-        <forceMultiplier>1.0</forceMultiplier>
+        <forceMultiplier>0.5</forceMultiplier>
         <forceName>Integrated Allies</forceName>
-        <generationMethod>3</generationMethod>
+        <generationMethod>2</generationMethod>
         <generationOrder>1</generationOrder>
         <maxWeightClass>4</maxWeightClass>
         <minWeightClass>1</minWeightClass>

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1793,8 +1793,8 @@ public class AtBContract extends Contract {
         double allyRatio = switch (getCommandRights()) {
             case INDEPENDENT    -> 0; // no allies
             case LIAISON        -> 0.4; // single allied heavy/assault mek, pure guess for now
-            case HOUSE          -> 0.25; // allies with same (G)BV budget
-            case INTEGRATED     -> 0.5; // allies with twice the player's (G)BV budget
+            case HOUSE          -> 0.25; // allies with 25% the player's (G)BV budget
+            case INTEGRATED     -> 0.5; // allies with 50% the player's (G)BV budget
         };
 
         if (allyRatio > 0) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1793,8 +1793,8 @@ public class AtBContract extends Contract {
         double allyRatio = switch (getCommandRights()) {
             case INDEPENDENT    -> 0; // no allies
             case LIAISON        -> 0.4; // single allied heavy/assault mek, pure guess for now
-            case HOUSE          -> 1; // allies with same (G)BV budget
-            case INTEGRATED     -> 2; // allies with twice the player's (G)BV budget
+            case HOUSE          -> 0.25; // allies with 25% of the player's (G)BV budget
+            case INTEGRATED     -> 0.5; // allies with half the player's (G)BV budget
         };
 
         if (allyRatio > 0) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1793,8 +1793,8 @@ public class AtBContract extends Contract {
         double allyRatio = switch (getCommandRights()) {
             case INDEPENDENT    -> 0; // no allies
             case LIAISON        -> 0.4; // single allied heavy/assault mek, pure guess for now
-            case HOUSE          -> 0.25; // allies with 25% of the player's (G)BV budget
-            case INTEGRATED     -> 0.5; // allies with half the player's (G)BV budget
+            case HOUSE          -> 0.25; // allies with same (G)BV budget
+            case INTEGRATED     -> 0.5; // allies with twice the player's (G)BV budget
         };
 
         if (allyRatio > 0) {


### PR DESCRIPTION
Adjusted the command rights modifiers based on player feedback.

Originally the intent was to roll these modifiers back to their 50.0 values, however that presented a couple of issues. As those modifiers use fixed unit counts we end up in a situation where we have to use magic numbers to guesstimate the power of those units when preparing the contract difficulty estimate. It also fails to scale with the player force, leading to an undesirable scenario where the player might have a tiny force (say, a couple of Warrior VTOL) and the allied princess drops two 100t assault 'meks.

Instead, I've opted to keep things scaled by BV, but adjusted the BV multiplier to reduce the overall size of engagements and to reduce the players' reliance on the performance of their allied Princess (the two chief causes of concern).

Independent: No Allies -> _no change_
Liaison: 1x Heavy or Assault 'Mek -> _no change_
Integrated: 200% Allies -> 50% Allies
House: 100% Allies -> 25% Allies

This means a 7,500 GBV player force can expect 3,750 GBV of allies on Integrated contracts, or 1,875 of allies on House contracts. This should amount to a couple of extra units, similar to the fixed values found in <50.01. Note that with the current set up it is possible for the allied force to exceed this target value by around 25%. We have a solution in the works, but it's a really big project so will come later.