### PR TITLE
Removed Legacy AtB Guaranteed SPAs

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultSpecialAbilityGenerator.java
@@ -21,7 +21,6 @@ package mekhq.campaign.personnel.generator;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.SkillType;
 
 public class DefaultSpecialAbilityGenerator extends AbstractSpecialAbilityGenerator {
     @Override
@@ -39,45 +38,6 @@ public class DefaultSpecialAbilityGenerator extends AbstractSpecialAbilityGenera
             while ((numAbilities > 0)
                     && singleSpecialAbilityGenerator.generateSpecialAbilities(campaign, person, expLvl)) {
                 numAbilities--;
-            }
-
-            // Based on the AtB rules, veteran recruits gain one and elite recruits gain two
-            // additional special abilities. Further, these are converted to edge if they
-            // cannot be
-            // generated.
-            if (campaign.getCampaignOptions().isUseAtB() && (expLvl >= SkillType.EXP_VETERAN)) {
-                // If we have more than 0 remaining abilities we can skip trying to generate
-                // after
-                // deciding on the number of further rolls and just convert it into edge
-                final boolean instantEdgeConversion = numAbilities != 0;
-
-                // then we set the number of abilities to generate at 1 for veteran and 2 for
-                // elite
-                switch (expLvl) {
-                    case SkillType.EXP_VETERAN:
-                        numAbilities = 1;
-                        break;
-                    case SkillType.EXP_ELITE:
-                        numAbilities = 2;
-                        break;
-                }
-
-                // If we aren't going to immediately convert into edge, we attempt to generate
-                // special
-                // abilities for the person
-                if (!instantEdgeConversion) {
-                    while ((numAbilities > 0)
-                            && singleSpecialAbilityGenerator.generateSpecialAbilities(campaign, person, expLvl)) {
-                        numAbilities--;
-                    }
-                }
-
-                // If edge is enabled and there are any leftover abilities that cannot be
-                // generated
-                // we assign edge
-                if (campaign.getCampaignOptions().isUseEdge() && (instantEdgeConversion || (numAbilities > 0))) {
-                    person.changeEdge(numAbilities);
-                }
             }
 
             return true;

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -49,7 +49,6 @@ import mekhq.campaign.personnel.education.EducationController;
 import mekhq.campaign.personnel.enums.*;
 import mekhq.campaign.personnel.enums.education.EducationLevel;
 import mekhq.campaign.personnel.enums.education.EducationStage;
-import mekhq.campaign.personnel.generator.SingleSpecialAbilityGenerator;
 import mekhq.campaign.personnel.randomEvents.PersonalityController;
 import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.campaign.personnel.ranks.RankSystem;
@@ -480,30 +479,6 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 gui.getCampaign().addReport(String.format(resources.getString("improved.format"),
                         selectedPerson.getHyperlinkedName(), type));
 
-                if (gui.getCampaign().getCampaignOptions().isUseAtB()
-                        && gui.getCampaign().getCampaignOptions().isUseAbilities()) {
-                    if (selectedPerson.getPrimaryRole().isCombat()
-                            && (selectedPerson.getExperienceLevel(gui.getCampaign(), false) > oldExpLevel)
-                            && (oldExpLevel >= SkillType.EXP_REGULAR)) {
-                        SingleSpecialAbilityGenerator spaGenerator = new SingleSpecialAbilityGenerator();
-                        String spa = spaGenerator.rollSPA(gui.getCampaign(), selectedPerson);
-                        if (spa == null) {
-                            if (gui.getCampaign().getCampaignOptions().isUseEdge()) {
-                                selectedPerson.changeEdge(1);
-                                selectedPerson.changeCurrentEdge(1);
-                                PersonalLogger.gainedEdge(gui.getCampaign(), selectedPerson,
-                                        gui.getCampaign().getLocalDate());
-                                gui.getCampaign().addReport(String.format(resources.getString("gainedEdge.format"),
-                                        selectedPerson.getHyperlinkedName()));
-                            }
-                        } else {
-                            PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                                    gui.getCampaign().getLocalDate(), spa);
-                            gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                                    selectedPerson.getHyperlinkedName(), spa));
-                        }
-                    }
-                }
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
             }

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -18,26 +18,8 @@
  */
 package mekhq.gui.dialog;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.GridLayout;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.ResourceBundle;
-
-import javax.swing.*;
-import javax.swing.RowSorter.SortKey;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-
 import megamek.client.ui.models.XTableColumnModel;
-import megamek.client.ui.preferences.JComboBoxPreference;
-import megamek.client.ui.preferences.JIntNumberSpinnerPreference;
-import megamek.client.ui.preferences.JToggleButtonPreference;
-import megamek.client.ui.preferences.JWindowPreference;
-import megamek.client.ui.preferences.PreferencesNode;
+import megamek.client.ui.preferences.*;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
@@ -49,12 +31,21 @@ import mekhq.campaign.personnel.Skill;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.Skills;
 import mekhq.campaign.personnel.enums.PersonnelRole;
-import mekhq.campaign.personnel.generator.SingleSpecialAbilityGenerator;
 import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.gui.enums.PersonnelTableModelColumn;
 import mekhq.gui.model.PersonnelTableModel;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
+
+import javax.swing.*;
+import javax.swing.RowSorter.SortKey;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.ResourceBundle;
 
 public final class BatchXPDialog extends JDialog {
     private static final MMLogger logger = MMLogger.create(BatchXPDialog.class);
@@ -403,26 +394,6 @@ public final class BatchXPDialog extends JDialog {
                 p.spendXP(cost);
                 PersonalLogger.improvedSkill(campaign, p, campaign.getLocalDate(),
                         p.getSkill(skillName).getType().getName(), p.getSkill(skillName).toString());
-
-                // The next part isn't ideal and doesn't belong here, but as long as we hardcode
-                // AtB ...
-                if (campaign.getCampaignOptions().isUseAtB()) {
-                    if (p.getPrimaryRole().isCombat() && !p.getPrimaryRole().isVesselCrew()
-                            && (p.getExperienceLevel(campaign, false) > startingExperienceLevel)
-                            && (startingExperienceLevel >= SkillType.EXP_REGULAR)) {
-                        final SingleSpecialAbilityGenerator spaGenerator = new SingleSpecialAbilityGenerator();
-                        final String spa = spaGenerator.rollSPA(campaign, p);
-                        if (spa == null) {
-                            if (campaign.getCampaignOptions().isUseEdge()) {
-                                p.changeEdge(1);
-                                p.changeCurrentEdge(1);
-                                PersonalLogger.gainedEdge(campaign, p, campaign.getLocalDate());
-                            }
-                        } else {
-                            PersonalLogger.gainedSPA(campaign, p, campaign.getLocalDate(), spa);
-                        }
-                    }
-                }
                 campaign.personUpdated(p);
             }
 


### PR DESCRIPTION
Removed hard-coded logic for SPA gain when improving personnel from Regular -> Veteran and Veteran -> Elite.

Legacy AtB has personnel automatically gain SPA when reaching Veteran and Elite ratings. Personnel acquired off the market have a random chance of 0-2 SPAs, plus those guaranteed SPAs.

SPAs cost around 50 xp each. Hitting Elite will cost 170-340 xp (depending on whether it's a one or two skill profession). That means buying an Elite character from the personnel market is the equivalent of getting 320-540+ xp for effectively free.

Furthermore, these hardcoded SPA improvements cause problems for anyone wanting to play using CamOps, as they need to manually remove the hardcoded SPAs prior to adding their own picks.

While the second issue could be resolved by adding a campaign option to disable fixed SPAs, I would prefer that we remove hardcoded SPA gains entirely. The benefit of being able to grab an Elite character from the market with 2-4 SPAs already acquired is simply too powerful. Being able to hire Elites is already a no-brainer, they don't need to also arrive with a few hundred xp of SPAs too.

**Note:** characters can still spawn with 0-2 random SPAs, with higher rated characters more likely to appear with a random SPA. This PR only removes the guaranteed SPAs gained from hitting Veteran and Elite (or spawning at Veteran or Elite).