### PR TITLE
Reworked StratCon Sector Sizes & Initialize State

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -193,8 +193,9 @@ public class StratconContractInitializer {
             AtBContractType contractType = contract.getContractType();
 
             // If the contract is a garrison type, we don't want to generate what will appear to be
-            // a full-scale invasion on day one.
-            if (contractType.isGarrisonType()) {
+            // a full-scale invasion on day one. Furthermore, Pirates do not have enough resources
+            // to deploy standing forces in this manner.
+            if (contractType.isGarrisonType() || contractType.isPirateHunting()) {
                 break;
             }
 
@@ -205,7 +206,7 @@ public class StratconContractInitializer {
 
             int multiplier = DEFENSIVE_MULTIPLIER;
 
-            if (contractType.isRaidType() || contractType.isPirateHunting()) {
+            if (contractType.isRaidType() || contractType.isGuerrillaWarfare()) {
                 multiplier = OFFENSIVE_MULTIPLIER;
             } else if (contract.getContractType().isPlanetaryAssault()) {
                 multiplier = OFFENSIVE_MULTIPLIER / 2;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -70,6 +70,7 @@ public class StratconContractInitializer {
 
         int maximumTrackIndex = Math.max(0, contract.getRequiredLances() / NUM_LANCES_PER_TRACK);
         int planetaryTemperature = campaign.getLocation().getPlanet().getTemperature(campaign.getLocalDate());
+        double planetaryDiameter = campaign.getLocation().getPlanet().getDiameter();
 
         for (int x = 0; x < maximumTrackIndex; x++) {
             int scenarioOdds = contractDefinition.getScenarioOdds()
@@ -78,7 +79,7 @@ public class StratconContractInitializer {
                     .get(Compute.randomInt(contractDefinition.getDeploymentTimes().size()));
 
             StratconTrackState track = initializeTrackState(NUM_LANCES_PER_TRACK, scenarioOdds, deploymentTime,
-                    planetaryTemperature);
+                    planetaryTemperature, planetaryDiameter);
             track.setDisplayableName(String.format("Sector %d", x));
             campaignState.addTrack(track);
         }
@@ -94,7 +95,7 @@ public class StratconContractInitializer {
                     .get(Compute.randomInt(contractDefinition.getDeploymentTimes().size()));
 
             StratconTrackState track = initializeTrackState(oddLanceCount, scenarioOdds, deploymentTime,
-                    planetaryTemperature);
+                    planetaryTemperature, planetaryDiameter);
             track.setDisplayableName(String.format("Sector %d", campaignState.getTracks().size()));
             campaignState.addTrack(track);
         }
@@ -193,6 +194,8 @@ public class StratconContractInitializer {
             for (StratconTrackState track : campaignState.getTracks()) {
                 track.getStrategicObjectives().clear();
             }
+        } else {
+            // Initialize non-objective scenarios
         }
 
         // now we're done
@@ -203,20 +206,24 @@ public class StratconContractInitializer {
      * lances.
      */
     public static StratconTrackState initializeTrackState(int numLances, int scenarioOdds,
-            int deploymentTime, int planetaryTemp) {
+                                                          int deploymentTime, int planetaryTemp,
+                                                          double planetaryDiameter) {
         // to initialize a track,
         // 1. we set the # of required lances
-        // 2. set the track size to a total of numlances * 28 hexes, a rectangle that is
+        // 2. set the track size to a total of numlances * 84 hexes, a rectangle that is
         // wider than it is taller
-        // the idea being to create a roughly rectangular playing field that,
-        // if one deploys a scout lance each week to a different spot, can be more or
-        // less fully covered
 
         StratconTrackState retVal = new StratconTrackState();
         retVal.setRequiredLanceCount(numLances);
 
+        // calculate planet surface area
+        double radius = planetaryDiameter / 2;
+        double planetSurfaceArea = 4 * Math.PI * Math.pow(radius, 2);
+        // This gives us a decently sized track, without it feeling too large
+        planetSurfaceArea /= 1000000;
+
         // set width and height
-        int numHexes = numLances * 28;
+        int numHexes = (int) Math.round(planetSurfaceArea);
         int height = (int) Math.floor(Math.sqrt(numHexes));
         int width = numHexes / height;
         retVal.setWidth(width);

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -23,9 +23,9 @@ import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import megamek.common.annotations.Nullable;
-import mekhq.utilities.MHQXMLUtility;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
+import mekhq.utilities.MHQXMLUtility;
 
 import java.time.LocalDate;
 import java.util.*;
@@ -107,6 +107,13 @@ public class StratconTrackState {
         this.height = height;
     }
 
+    /**
+     * @return The size of the track derived by multiplying width and height.
+     */
+    public int getSize() {
+        return width * height;
+    }
+
     @XmlElementWrapper(name = "trackFacilities")
     @XmlElement(name = "facility")
     public Map<StratconCoords, StratconFacility> getFacilities() {
@@ -159,7 +166,7 @@ public class StratconTrackState {
             removeScenario(getBackingScenariosMap().get(campaignScenarioID));
         }
     }
-    
+
     /**
      * Removes a StratconScenario from this track.
      */
@@ -169,7 +176,7 @@ public class StratconTrackState {
         Map<StratconCoords, StratconStrategicObjective> objectives = getObjectivesByCoords();
         if (objectives.containsKey(scenario.getCoords())) {
             StrategicObjectiveType objectiveType = objectives.get(scenario.getCoords()).getObjectiveType();
-            
+
             switch (objectiveType) {
                 case RequiredScenarioVictory:
                 case SpecificScenarioVictory:


### PR DESCRIPTION
This PR does a couple of things.

First it adds more robust checks and balances to the method added in 50.01 that allows easy addition of new scenarios to a StratCon Track (aka sector). It also adds the ability to insert hidden scenarios into a StratCon Track. This is taken from the in-dev Logistics Module.

Previously the size of a StratCon Track was determined by the number of lances required by the contract. Now Tracks are sized according to the surface area of the planet the contract is based on. This substantially increases the size of Tracks by design. This is in preparation for a major 2025 project that we're not ready to discuss at this time. Developers, if you're not aware of what this alludes to, and want to know, ask in the Developer chat. :)

Finally, using the new method that allows us to add non-objective scenarios to the StratCon Track, we now seed enemy forces on Tracks prior to the players' arrival. These are fixed hidden scenarios (i.e. they will always be there until found and resolved). The number of hidden enemy forces is based on the size of the Track and the type of contract:

**Garrison or Pirate Hunting:** None
**Raid or Guerrilla Warfare:** Track Size / 10
**Planetary Assault:** Track Size / 5
**Other:** Track Size / 20

These values are then modified by the scenario spawn chance for the contract.

These pre-seeded fixed forces are also required for the 2025 project.