### PR TITLE
Generate required lances for manual AtB contracts for StratCon init

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -375,6 +375,16 @@ public class AtBContract extends Contract {
         setLength(getContractType().calculateLength(variable, this));
     }
 
+    /**
+     * Calculates the number of lances required for this contract, based on [campaign].
+     *
+     * @param campaign The campaign to reference.
+     * @return The number of lances required.
+     */
+    public static int calculateRequiredLances(Campaign campaign) {
+        return Math.max(getEffectiveNumUnits(campaign) / 6, 1);
+    }
+
     public static int getEffectiveNumUnits(Campaign campaign) {
         double numUnits = 0;
         for (UUID uuid : campaign.getForces().getAllUnits(true)) {
@@ -1477,7 +1487,7 @@ public class AtBContract extends Contract {
             enemyCode = "REB";
         }
 
-        requiredLances = Math.max(getEffectiveNumUnits(campaign) / 6, 1);
+        requiredLances = calculateRequiredLances(campaign);
 
         setPartsAvailabilityLevel(getContractType().calculatePartsAvailabilityLevel());
 

--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -527,6 +527,8 @@ public class NewAtBContractDialog extends NewContractDialog {
         contract.setDesc(txtDesc.getText());
         contract.setCommandRights(choiceCommand.getSelectedItem());
 
+        contract.setRequiredLances(AtBContract.calculateRequiredLances(campaign));
+
         contract.setEnemyCode(getCurrentEnemyCode());
         contract.setAllySkill(comboAllySkill.getSelectedItem());
         contract.setAllyQuality(cbAllyQuality.getSelectedIndex());


### PR DESCRIPTION
StratCon initialization requires a nonzero requiredLances to generate a nonzero number of tracks, and zero tracks causes a division by zero further along in initialization.

Solves issue #5181.