### PR TITLE
Refined Turnover Prompt Dialog Text

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -50,9 +50,9 @@ turnoverJointDeparture.text=departed with their spouse.
 turnoverJointDepartureChild.text=departed with a parent.
 orphaned.text=has been orphaned.
 
-turnoverEmployeeTurnoverDialog.text=Employee Turnover
-turnoverAdvanceRegardless=Advance Day Regardless
-turnoverCancel.text=Cancel Advance Day
+turnoverEmployeeTurnoverDialog.text=Continue
+turnoverAdvanceRegardless=Ignore Check
+turnoverCancel.text=Cancel
 
 turnoverRollRequired.text=Employee Turnover Check Required
 turnoverDialogDescription.text=<html>It is time for an Employee Turnover Check.\


### PR DESCRIPTION
Updated text for the Employee Turnover dialog to provide clearer instructions.

Changed "Employee Turnover" to "Continue", "Advance Day Regardless" to "Ignore Check", and "Cancel Advance Day" as "Cancel".

These changes should help remove any possible confusion as to what button should be clicked.