### PR TITLE
Renamed 'Lances' to 'Strategic Formations', Expanded Functionality

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -18,46 +18,32 @@
  */
 package mekhq;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-
-import javax.swing.JOptionPane;
-
 import io.sentry.Sentry;
 import megamek.client.AbstractClient;
 import megamek.client.Client;
 import megamek.client.bot.BotClient;
+import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.Princess;
+import megamek.client.bot.princess.PrincessException;
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.ui.swing.ClientGUI;
-import megamek.common.Entity;
-import megamek.common.IAero;
-import megamek.common.Infantry;
-import megamek.common.MapSettings;
-import megamek.common.Minefield;
-import megamek.common.UnitType;
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
 import megamek.common.planetaryconditions.PlanetaryConditions;
 import megamek.logging.MMLogger;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.force.Lance;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.force.StrategicFormation;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
+
+import javax.swing.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Enhanced version of GameThread which imports settings and non-player units
@@ -621,7 +607,7 @@ public class AtBGameThread extends GameThread {
             lanceSize = StrategicFormation.getStdLanceSize(contract.getEmployerFaction());
         }
 
-        Comparator<Entity> comp = Comparator.comparing(((Entity entity) -> entity.getEntityMajorTypeName(e.getEntityType())));
+        Comparator<Entity> comp = Comparator.comparing(((Entity e) -> Entity.getEntityMajorTypeName(e.getEntityType())));
         comp = comp.thenComparing(((Entity e) -> e.getRunMP()), Comparator.reverseOrder());
         comp = comp.thenComparing(((Entity e) -> e.getRole().toString()));
         entitiesSorted.sort(comp);
@@ -632,13 +618,13 @@ public class AtBGameThread extends GameThread {
             }
 
             if ((i != 0)
-                    && !lastType.equals(entity.getEntityMajorTypeName(entity.getEntityType()))) {
+                    && !lastType.equals(Entity.getEntityMajorTypeName(entity.getEntityType()))) {
                 forceIdLance++;
                 lanceName = RCG.generate();
                 i = forceIdLance * lanceSize;
             }
 
-            lastType = entity.getEntityMajorTypeName(entity.getEntityType());
+            lastType = Entity.getEntityMajorTypeName(entity.getEntityType());
             entity.setOwner(botClient.getLocalPlayer());
             String fName = String.format(forceName, lanceName, forceIdLance);
             entity.setForceString(fName);

--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -18,22 +18,6 @@
  */
 package mekhq;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-
-import javax.swing.JOptionPane;
-
 import io.sentry.Sentry;
 import megamek.client.AbstractClient;
 import megamek.client.Client;
@@ -41,23 +25,21 @@ import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.Princess;
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.ui.swing.ClientGUI;
-import megamek.common.Entity;
-import megamek.common.IAero;
-import megamek.common.Infantry;
-import megamek.common.MapSettings;
-import megamek.common.Minefield;
-import megamek.common.UnitType;
+import megamek.common.*;
 import megamek.common.planetaryconditions.PlanetaryConditions;
 import megamek.logging.MMLogger;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.force.Lance;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.force.StrategicFormation;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
+
+import javax.swing.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.*;
 
 /**
  * Enhanced version of GameThread which imports settings and non-player units
@@ -277,8 +259,8 @@ public class AtBGameThread extends GameThread {
                         // Set scenario type-specific delay
                         deploymentRound = Math.max(entity.getDeployRound(), scenario.getDeploymentDelay() - speed);
                         // Lances deployed in scout roles always deploy units in 6-walking speed turns
-                        if (scenario.getLanceRole().isScouting() && (scenario.getLance(campaign) != null)
-                                && (scenario.getLance(campaign).getForceId() == scenario.getLanceForceId())
+                        if (scenario.getLanceRole().isScouting() && (scenario.getStrategicFormation(campaign) != null)
+                                && (scenario.getStrategicFormation(campaign).getForceId() == scenario.getStrategicFormationId())
                                 && !useDropship) {
                             deploymentRound = Math.max(deploymentRound, 6 - speed);
                         }
@@ -346,7 +328,7 @@ public class AtBGameThread extends GameThread {
                         }
                         deploymentRound = Math.max(entity.getDeployRound(), scenario.getDeploymentDelay() - speed);
                         if (!useDropship && scenario.getLanceRole().isScouting()
-                                && (scenario.getLance(campaign).getForceId() == scenario.getLanceForceId())) {
+                                && (scenario.getStrategicFormation(campaign).getForceId() == scenario.getStrategicFormationId())) {
                             deploymentRound = Math.max(deploymentRound, 6 - speed);
                         }
                     }
@@ -537,12 +519,12 @@ public class AtBGameThread extends GameThread {
         int lanceSize;
 
         if (botForce.getTeam() == 2) {
-            lanceSize = Lance.getStdLanceSize(contract.getEnemy());
+            lanceSize = StrategicFormation.getStdLanceSize(contract.getEnemy());
         } else {
-            lanceSize = Lance.getStdLanceSize(contract.getEmployerFaction());
+            lanceSize = StrategicFormation.getStdLanceSize(contract.getEmployerFaction());
         }
 
-        Comparator<Entity> comp = Comparator.comparing(((Entity e) -> e.getEntityMajorTypeName(e.getEntityType())));
+        Comparator<Entity> comp = Comparator.comparing(((Entity e) -> Entity.getEntityMajorTypeName(e.getEntityType())));
         comp = comp.thenComparing(((Entity e) -> e.getRunMP()), Comparator.reverseOrder());
         comp = comp.thenComparing(((Entity e) -> e.getRole().toString()));
         entitiesSorted.sort(comp);
@@ -553,13 +535,13 @@ public class AtBGameThread extends GameThread {
             }
 
             if ((i != 0)
-                    && !lastType.equals(entity.getEntityMajorTypeName(entity.getEntityType()))) {
+                    && !lastType.equals(Entity.getEntityMajorTypeName(entity.getEntityType()))) {
                 forceIdLance++;
                 lanceName = RCG.generate();
                 i = forceIdLance * lanceSize;
             }
 
-            lastType = entity.getEntityMajorTypeName(entity.getEntityType());
+            lastType = Entity.getEntityMajorTypeName(entity.getEntityType());
             entity.setOwner(botClient.getLocalPlayer());
             String fName = String.format(forceName, lanceName, forceIdLance);
             entity.setForceString(fName);

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -68,11 +68,17 @@ public class Force {
     // pathway to force icon
     public static final int FORCE_NONE = -1;
 
+    public static final int STRATEGIC_FORMATION_OVERRIDE_NONE = -1;
+    public static final int STRATEGIC_FORMATION_OVERRIDE_FALSE = 0;
+    public static final int STRATEGIC_FORMATION_OVERRIDE_TRUE = 1;
+
     private String name;
     private StandardForceIcon forceIcon;
     private Camouflage camouflage;
     private String desc;
     private boolean combatForce;
+    private boolean isStrategicFormation;
+    private int overrideStrategicFormation;
     private FormationLevel formationLevel;
     private FormationLevel overrideFormationLevel;
     private Force parentForce;
@@ -94,6 +100,8 @@ public class Force {
         setCamouflage(new Camouflage());
         setDescription("");
         this.combatForce = true;
+        this.isStrategicFormation = false;
+        this.overrideStrategicFormation = STRATEGIC_FORMATION_OVERRIDE_NONE;
         this.formationLevel = FormationLevel.NONE;
         this.overrideFormationLevel = FormationLevel.NONE;
         this.parentForce = null;
@@ -161,6 +169,22 @@ public class Force {
                 force.setCombatForce(combatForce, true);
             }
         }
+    }
+
+    public boolean isStrategicFormation() {
+        return isStrategicFormation;
+    }
+
+    public void setStrategicFormation(final boolean isStrategicFormation) {
+        this.isStrategicFormation = isStrategicFormation;
+    }
+
+    public int getOverrideStrategicFormation() {
+        return overrideStrategicFormation;
+    }
+
+    public void setOverrideStrategicFormation(final int overrideStrategicFormation) {
+        this.overrideStrategicFormation = overrideStrategicFormation;
     }
 
     public FormationLevel getFormationLevel() {
@@ -232,12 +256,18 @@ public class Force {
     public List<Force> getAllParents() {
         List<Force> parentForces = new ArrayList<>();
 
-        Force parentForce = getParentForce();
+        Force parentFormation = parentForce;
 
-        while (parentForce.getParentForce() != null) {
-            parentForces.add(parentForce.getParentForce());
+        if (parentForce != null) {
+            parentForces.add(parentForce);
+        }
 
-            parentForce = parentForce.getParentForce();
+        while (parentFormation != null) {
+            parentFormation = parentFormation.getParentForce();
+
+            if (parentFormation != null) {
+                parentForces.add(parentFormation);
+            }
         }
 
         return parentForces;
@@ -653,6 +683,7 @@ public class Force {
             MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "desc", desc);
         }
         MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "combatForce", combatForce);
+        MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "overrideStrategicFormation", overrideStrategicFormation);
         MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "formationLevel", formationLevel.toString());
         MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "populateOriginNode", overrideFormationLevel.toString());
         MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "scenarioId", scenarioId);
@@ -700,6 +731,8 @@ public class Force {
                     retVal.setDescription(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("combatForce")) {
                     retVal.setCombatForce(Boolean.parseBoolean(wn2.getTextContent().trim()), false);
+                } else if (wn2.getNodeName().equalsIgnoreCase("overrideStrategicFormation")) {
+                    retVal.setOverrideStrategicFormation(Integer.parseInt(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("formationLevel")) {
                     retVal.setFormationLevel(FormationLevel.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("populateOriginNode")) {

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -221,12 +221,57 @@ public class Force {
         return parentForce;
     }
 
+    /**
+     * This method generates a list of all parent forces for the current force object in the
+     * hierarchy. It repeatedly fetches the parent force of the current force and adds it to a list
+     * until no more parent forces can be found (i.e., until the top of the force hierarchy is reached).
+     *
+     * @return A list of {@link Force} objects representing all the parent forces of the current
+     * force object in the hierarchy. The list will be empty if there are no parent forces.
+     */
+    public List<Force> getAllParents() {
+        List<Force> parentForces = new ArrayList<>();
+
+        Force parentForce = getParentForce();
+
+        while (parentForce.getParentForce() != null) {
+            parentForces.add(parentForce.getParentForce());
+
+            parentForce = parentForce.getParentForce();
+        }
+
+        return parentForces;
+    }
+
     public void setParentForce(final @Nullable Force parent) {
         this.parentForce = parent;
     }
 
     public Vector<Force> getSubForces() {
         return subForces;
+    }
+
+    /**
+     * Returns a list of all of this forces' descendant forces.
+     * This includes direct child forces and their descendents recursively.
+     * <p>
+     * This method works by first adding all direct child forces to the list, and
+     * then recursively adding their descendants by calling this method on each child
+     * force.
+     *
+     * @return A list of {@link Force} objects representing all descendant forces.
+     *         If there are no descendant forces, this method will return an empty list.
+     */
+    public List<Force> getAllSubForces() {
+        List<Force> allSubForces = new ArrayList<>();
+
+        for (Force subForce : subForces) {
+            allSubForces.add(subForce);
+
+            allSubForces.addAll(subForce.getAllSubForces());
+        }
+
+        return allSubForces;
     }
 
     public boolean isAncestorOf(Force otherForce) {

--- a/MekHQ/src/mekhq/campaign/force/StrategicFormation.java
+++ b/MekHQ/src/mekhq/campaign/force/StrategicFormation.java
@@ -315,17 +315,6 @@ public class StrategicFormation {
         }
 
         if (hasGround) {
-            // Parent Forces
-            List<Force> parentForces = force.getAllParents();
-
-            for (Force parentForce : parentForces) {
-                if (parentForce.isStrategicFormation()) {
-                    force.setStrategicFormation(false);
-                    return false;
-                }
-            }
-
-            // Child Forces
             List<Force> childForces = force.getAllSubForces();
 
             for (Force childForce : childForces) {

--- a/MekHQ/src/mekhq/campaign/force/StrategicFormation.java
+++ b/MekHQ/src/mekhq/campaign/force/StrategicFormation.java
@@ -47,7 +47,7 @@ import static mekhq.campaign.force.Force.STRATEGIC_FORMATION_OVERRIDE_NONE;
 import static mekhq.campaign.force.Force.STRATEGIC_FORMATION_OVERRIDE_TRUE;
 
 /**
- * Used by Against the Bot & StratCon to track additional information about each force
+ * Used by Against the Bot &amp; StratCon to track additional information about each force
  * on the TO&amp;E that has at least one unit assigned. Extra info includes whether
  * the force counts as a Strategic Formation eligible for assignment to a scenario role
  * and what the assignment is on which contract.
@@ -576,7 +576,7 @@ public class StrategicFormation {
     /**
      * Worker function that calculates the total weight of a force with the given ID
      *
-     * @param c       Campaign in which the force resides
+     * @param campaign       Campaign in which the force resides
      * @param forceId Force for which to calculate weight
      * @return Total force weight
      */

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -279,8 +279,8 @@ public class CampaignXmlParser {
                     retVal.setUnitMarket(retVal.getCampaignOptions().getUnitMarketMethod().getUnitMarket());
                     retVal.getUnitMarket().fillFromXML(wn, retVal, version);
                     foundUnitMarket = true;
-                } else if (xn.equalsIgnoreCase("lances")) {
-                    processLanceNodes(retVal, wn);
+                } else if (xn.equalsIgnoreCase("lances") || xn.equalsIgnoreCase("strategicFormations")) {
+                    processStrategicFormationNodes(retVal, wn);
                 } else if (xn.equalsIgnoreCase("retirementDefectionTracker")) {
                     retVal.setRetirementDefectionTracker(
                             RetirementDefectionTracker.generateInstanceFromXML(wn, retVal));
@@ -759,29 +759,30 @@ public class CampaignXmlParser {
         retVal.setNewReports(newReports);
     }
 
-    private static void processLanceNodes(Campaign retVal, Node wn) {
-        NodeList wList = wn.getChildNodes();
+    private static void processStrategicFormationNodes(Campaign campaign, Node workingNode) {
+        NodeList workingNodes = workingNode.getChildNodes();
 
-        // Okay, lets iterate through the children, eh?
-        for (int x = 0; x < wList.getLength(); x++) {
-            Node wn2 = wList.item(x);
+        // Okay, let's iterate through the children, eh?
+        for (int x = 0; x < workingNodes.getLength(); x++) {
+            Node wn2 = workingNodes.item(x);
 
             // If it's not an element node, we ignore it.
             if (wn2.getNodeType() != Node.ELEMENT_NODE) {
                 continue;
             }
 
-            if (!wn2.getNodeName().equalsIgnoreCase("lance")) {
+            if (!wn2.getNodeName().equalsIgnoreCase("lance")
+                && !wn2.getNodeName().equalsIgnoreCase("strategicFormations")) {
                 // Error condition of sorts!
                 // Errr, what should we do here?
-                logger.error("Unknown node type not loaded in Lance nodes: " + wn2.getNodeName());
+                logger.error("Unknown node type not loaded in strategicFormations nodes: " + wn2.getNodeName());
                 continue;
             }
 
-            StrategicFormation l = StrategicFormation.generateInstanceFromXML(wn2);
+            StrategicFormation strategicFormation = StrategicFormation.generateInstanceFromXML(wn2);
 
-            if (l != null) {
-                retVal.importLance(l);
+            if (strategicFormation != null) {
+                campaign.importLance(strategicFormation);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -35,7 +35,7 @@ import mekhq.campaign.*;
 import mekhq.campaign.againstTheBot.AtBConfiguration;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.force.Lance;
+import mekhq.campaign.force.StrategicFormation;
 import mekhq.campaign.icons.UnitIcon;
 import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.market.ShoppingList;
@@ -345,10 +345,10 @@ public class CampaignXmlParser {
 
         // determine if we've missed any lances and add those back into the campaign
         if (options.isUseAtB()) {
-            Hashtable<Integer, Lance> lances = retVal.getLances();
+            Hashtable<Integer, StrategicFormation> lances = retVal.getStrategicFormations();
             for (Force f : retVal.getAllForces()) {
                 if (!f.getUnits().isEmpty() && (null == lances.get(f.getId()))) {
-                    lances.put(f.getId(), new Lance(f.getId(), retVal));
+                    lances.put(f.getId(), new StrategicFormation(f.getId(), retVal));
                     logger.warn(String.format("Added missing Lance %s to AtB list", f.getName()));
                 }
             }
@@ -778,7 +778,7 @@ public class CampaignXmlParser {
                 continue;
             }
 
-            Lance l = Lance.generateInstanceFromXML(wn2);
+            StrategicFormation l = StrategicFormation.generateInstanceFromXML(wn2);
 
             if (l != null) {
                 retVal.importLance(l);

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -23,7 +23,7 @@ import megamek.common.Entity;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.SkillLevel;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.force.Lance;
+import mekhq.campaign.force.StrategicFormation;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
 import mekhq.campaign.mission.atb.AtBScenarioModifier;
 import mekhq.campaign.personnel.Person;
@@ -371,11 +371,11 @@ public class AtBDynamicScenario extends AtBScenario {
             return null; // if we don't have forces, just a bunch of units, then get the highest-ranked?
         }
 
-        Lance lance = campaign.getLances().get(getForceIDs().get(0));
+        StrategicFormation strategicFormation = campaign.getStrategicFormations().get(getForceIDs().get(0));
 
-        if (lance != null) {
-            lance.refreshCommander(campaign);
-            return lance.getCommander(campaign);
+        if (strategicFormation != null) {
+            strategicFormation.refreshCommander(campaign);
+            return strategicFormation.getCommander(campaign);
         } else {
             return null;
         }

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -21,34 +21,19 @@
  */
 package mekhq.campaign.mission;
 
-import java.io.PrintWriter;
-import java.text.ParseException;
-import java.time.LocalDate;
-import java.util.*;
-
-import megamek.common.*;
-import megamek.common.util.fileUtils.MegaMekFile;
-import megamek.utilities.BoardClassifier;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.Version;
 import megamek.client.generator.TeamLoadOutGenerator;
 import megamek.codeUtilities.ObjectUtility;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.SkillLevel;
 import megamek.common.icons.Camouflage;
 import megamek.common.options.OptionsConstants;
 import megamek.common.planetaryconditions.Atmosphere;
-import megamek.common.planetaryconditions.BlowingSand;
-import megamek.common.planetaryconditions.EMI;
-import megamek.common.planetaryconditions.Fog;
-import megamek.common.planetaryconditions.Light;
-import megamek.common.planetaryconditions.PlanetaryConditions;
-import megamek.common.planetaryconditions.Weather;
-import megamek.common.planetaryconditions.Wind;
+import megamek.common.planetaryconditions.*;
+import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.logging.MMLogger;
+import megamek.utilities.BoardClassifier;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.Utilities;
@@ -56,7 +41,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.againstTheBot.AtBConfiguration;
 import mekhq.campaign.againstTheBot.AtBStaticWeightGenerator;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.force.Lance;
+import mekhq.campaign.force.StrategicFormation;
 import mekhq.campaign.mission.ObjectiveEffect.ObjectiveEffectType;
 import mekhq.campaign.mission.ScenarioObjective.ObjectiveCriterion;
 import mekhq.campaign.mission.atb.IAtBScenario;
@@ -66,12 +51,16 @@ import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.stratcon.StratconBiomeManifest;
 import mekhq.campaign.stratcon.StratconBiomeManifest.MapTypeList;
 import mekhq.campaign.unit.Unit;
-import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.Factions;
-import mekhq.campaign.universe.Planet;
-import mekhq.campaign.universe.PlanetarySystem;
-import mekhq.campaign.universe.Systems;
+import mekhq.campaign.universe.*;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.util.*;
 
 /**
  * @author Neoancient
@@ -154,7 +143,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     public static final int NO_LANCE = -1;
 
     private boolean attacker;
-    private int lanceForceId; // -1 if scenario is not generated for a specific lance (special scenario, big
+    private int strategicFormationId; // -1 if scenario is not generated for a specific lance (special scenario, big
                               // battle)
     private AtBLanceRole lanceRole; /*
                                      * set when scenario is created in case it is changed for the next week before
@@ -218,7 +207,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
     public AtBScenario() {
         super();
-        lanceForceId = -1;
+        strategicFormationId = -1;
         lanceRole = AtBLanceRole.UNASSIGNED;
         alliesPlayer = new ArrayList<>();
         alliesPlayerStub = new ArrayList<>();
@@ -235,7 +224,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         SB = StratconBiomeManifest.getInstance();
     }
 
-    public void initialize(Campaign c, Lance lance, boolean attacker, LocalDate date) {
+    public void initialize(Campaign c, StrategicFormation lance, boolean attacker, LocalDate date) {
         setAttacker(attacker);
 
         alliesPlayer = new ArrayList<>();
@@ -247,10 +236,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         entityIds = new HashMap<>();
 
         if (null == lance) {
-            lanceForceId = -1;
+            strategicFormationId = -1;
             lanceRole = AtBLanceRole.UNASSIGNED;
         } else {
-            this.lanceForceId = lance.getForceId();
+            this.strategicFormationId = lance.getForceId();
             lanceRole = lance.getRole();
             setMissionId(lance.getMissionId());
 
@@ -337,10 +326,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             lanceCount = 2;
         }
 
-        if (null != getLance(campaign)) {
-            getLance(campaign).refreshCommander(campaign);
-            if (null != getLance(campaign).getCommander(campaign).getSkill(SkillType.S_TACTICS)) {
-                rerollsRemaining = getLance(campaign).getCommander(campaign).getSkill(SkillType.S_TACTICS).getLevel();
+        if (null != getStrategicFormation(campaign)) {
+            getStrategicFormation(campaign).refreshCommander(campaign);
+            if (null != getStrategicFormation(campaign).getCommander(campaign).getSkill(SkillType.S_TACTICS)) {
+                rerollsRemaining = getStrategicFormation(campaign).getCommander(campaign).getSkill(SkillType.S_TACTICS).getLevel();
             }
         }
     }
@@ -899,7 +888,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
-        addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);
+        addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign), campaign);
         addBotForce(getEnemyBotForce(getContract(campaign), enemyHome, enemyHome, enemyEntities), campaign);
     }
 
@@ -1651,7 +1640,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     @Override
     protected void writeToXMLEnd(final PrintWriter pw, int indent) {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "attacker", isAttacker());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "lanceForceId", lanceForceId);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "lanceForceId", strategicFormationId);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "lanceRole", lanceRole.name());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "deploymentDelay", deploymentDelay);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "lanceCount", lanceCount);
@@ -1745,7 +1734,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 if (wn2.getNodeName().equalsIgnoreCase("attacker")) {
                     setAttacker(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("lanceForceId")) {
-                    lanceForceId = Integer.parseInt(wn2.getTextContent());
+                    strategicFormationId = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("lanceRole")) {
                     lanceRole = AtBLanceRole.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("deploymentDelay")) {
@@ -1973,20 +1962,20 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         return retVal;
     }
 
-    public int getLanceForceId() {
-        return lanceForceId;
+    public int getStrategicFormationId() {
+        return strategicFormationId;
     }
 
     public AtBLanceRole getLanceRole() {
         return lanceRole;
     }
 
-    public Lance getLance(Campaign c) {
-        return c.getLances().get(lanceForceId);
+    public StrategicFormation getStrategicFormation(Campaign campaign) {
+        return campaign.getStrategicFormations().get(strategicFormationId);
     }
 
-    public void setLance(Lance l) {
-        lanceForceId = l.getForceId();
+    public void setLance(StrategicFormation strategicFormation) {
+        strategicFormationId = strategicFormation.getForceId();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/CommonObjectiveFactory.java
@@ -37,7 +37,7 @@ import java.util.UUID;
  *
  */
 public class CommonObjectiveFactory {
-    private static final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AtBScenarioBuiltIn",
+    private static final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AtBScenarioBuiltIn",
             MekHQ.getMHQOptions().getLocale());
 
     /**
@@ -77,7 +77,7 @@ public class CommonObjectiveFactory {
             keepFriendliesAlive.setDescription(String.format(resourceMap.getString("commonObjectives.preserveFriendlyUnits.text"), number, ""));
             keepFriendliesAlive.setFixedAmount(number);
         } else {
-            keepFriendliesAlive.setDescription(String.format(resourceMap.getString("commonObjectives.preserveFriendlyUnits.text"), number, "%"));
+            keepFriendliesAlive.setDescription(String.format(resourceMap.getString("commonObjectives.preserveFriendlyUnits.text"), number, '%'));
             keepFriendliesAlive.setPercentage(number);
         }
         keepFriendliesAlive.setObjectiveCriterion(ObjectiveCriterion.Preserve);
@@ -108,7 +108,7 @@ public class CommonObjectiveFactory {
             keepFriendliesAlive.setDescription(String.format(resourceMap.getString("commonObjectives.preserveFriendlyUnits.text"), number, ""));
             keepFriendliesAlive.setFixedAmount(number);
         } else {
-            keepFriendliesAlive.setDescription(String.format(resourceMap.getString("commonObjectives.preserveFriendlyUnits.text"), number, "%"));
+            keepFriendliesAlive.setDescription(String.format(resourceMap.getString("commonObjectives.preserveFriendlyUnits.text"), number, '%'));
             keepFriendliesAlive.setPercentage(number);
         }
 
@@ -228,8 +228,8 @@ public class CommonObjectiveFactory {
 
         // some scenarios have a lance assigned
         // some scenarios have individual units assigned
-        if (scenario.getLanceForceId() != AtBScenario.NO_LANCE) {
-            objective.addForce(campaign.getForce(scenario.getLanceForceId()).getName());
+        if (scenario.getStrategicFormationId() != AtBScenario.NO_LANCE) {
+            objective.addForce(campaign.getForce(scenario.getStrategicFormationId()).getName());
         } else {
             int unitCount = 0;
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -21,7 +21,7 @@ package mekhq.campaign.mission.atb;
 import megamek.codeUtilities.ObjectUtility;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.force.Lance;
+import mekhq.campaign.force.StrategicFormation;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.atb.scenario.*;
@@ -67,7 +67,7 @@ public class AtBScenarioFactory {
         return scenarioMap.get(type);
     }
 
-    public static AtBScenario createScenario(Campaign c, Lance lance, int type, boolean attacker, LocalDate date) {
+    public static AtBScenario createScenario(Campaign c, StrategicFormation lance, int type, boolean attacker, LocalDate date) {
         List<Class<IAtBScenario>> classList = getScenarios(type);
         Class<IAtBScenario> selectedClass;
 
@@ -117,16 +117,16 @@ public class AtBScenarioFactory {
      *
      * Note that this handles having multiple active contracts at the same time
      *
-     * @param c the campaign for which to generate scenarios
+     * @param campaign the campaign for which to generate scenarios
      */
-    public static void createScenariosForNewWeek(Campaign c) {
+    public static void createScenariosForNewWeek(Campaign campaign) {
         // First, we only want to generate if we have an active contract
-        if (!c.hasActiveContract()) {
+        if (!campaign.hasActiveContract()) {
             return;
         }
 
         // If we have an active contract, then we can progress with generation
-        Hashtable<Integer, Lance> lances = c.getLances();
+        Hashtable<Integer, StrategicFormation> strategicFormations = campaign.getStrategicFormations();
 
         List<AtBScenario> sList;
         List<Integer> assignedLances = new ArrayList<>();
@@ -135,7 +135,7 @@ public class AtBScenarioFactory {
         boolean hasBaseAttackAttacker;
 
         // We only need to process active AtB contracts that haven't hit their end date
-        for (final AtBContract contract : c.getActiveAtBContracts()) {
+        for (final AtBContract contract : campaign.getActiveAtBContracts()) {
             // region Value Initialization
             sList = new ArrayList<>();
             dontGenerateForces = new ArrayList<>();
@@ -151,8 +151,8 @@ public class AtBScenarioFactory {
             // the generation rules are followed for all active scenarios not just new
             // scenarios
             for (final AtBScenario scenario : contract.getCurrentAtBScenarios()) {
-                // Add any currently assigned lances to the assignedLances
-                assignedLances.add(scenario.getLanceForceId());
+                // Add any currently assigned strategicFormations to the assignedLances
+                assignedLances.add(scenario.getStrategicFormationId());
 
                 // Remove any active scenarios from the contract, and add them to the current
                 // scenarios list instead
@@ -174,14 +174,14 @@ public class AtBScenarioFactory {
             // endregion Current Scenarios
 
             // region Generate Scenarios
-            // Generate scenarios for lances based on their current situation
+            // Generate scenarios for strategicFormations based on their current situation
             if (!hasBaseAttackAttacker) {
-                for (Lance lance : lances.values()) {
-                    // Don't generate scenarios for any lances already assigned, those assigned to a
-                    // different contract, those not assigned to a contract, or for illegible lances
-                    if (assignedLances.contains(lance.getForceId()) || (lance.getContract(c) == null)
-                            || !lance.isEligible(c) || (lance.getMissionId() != contract.getId())
-                            || !lance.getContract(c).isActiveOn(c.getLocalDate(), true)) {
+                for (StrategicFormation strategicFormation : strategicFormations.values()) {
+                    // Don't generate scenarios for any strategicFormations already assigned, those assigned to a
+                    // different contract, those not assigned to a contract, or for illegible strategicFormations
+                    if (assignedLances.contains(strategicFormation.getForceId()) || (strategicFormation.getContract(campaign) == null)
+                            || !strategicFormation.isEligible(campaign) || (strategicFormation.getMissionId() != contract.getId())
+                            || !strategicFormation.getContract(campaign).isActiveOn(campaign.getLocalDate(), true)) {
                         continue;
                     }
 
@@ -191,13 +191,13 @@ public class AtBScenarioFactory {
                         continue;
                     }
 
-                    // Attempt to generate a scenario for the lance
-                    AtBScenario scenario = lance.checkForBattle(c);
+                    // Attempt to generate a scenario for the strategicFormation
+                    AtBScenario scenario = strategicFormation.checkForBattle(campaign);
 
                     // If one is generated, then add it to the scenario list
                     if (scenario != null) {
                         sList.add(scenario);
-                        assignedLances.add(lance.getForceId());
+                        assignedLances.add(strategicFormation.getForceId());
 
                         // We care if the scenario is a Base Attack, as one must be generated if the
                         // current contract's morale is Unbreakable
@@ -219,45 +219,46 @@ public class AtBScenarioFactory {
 
             // region Overwhelming Morale Missions
             // Make sure Overwhelming morale missions have a base attack scenario generated
-            if (!c.getCampaignOptions().isUseStratCon()) {
+            if (!campaign.getCampaignOptions().isUseStratCon()) {
                 if (!hasBaseAttack && contract.getMoraleLevel().isOverwhelming()) {
                     /*
                      * find a lance to act as defender, giving preference
                      * first to those assigned to the same contract,
                      * then to those assigned to defense roles
                      */
-                    List<Lance> lList = new ArrayList<>();
-                    for (Lance l : lances.values()) {
-                        if ((l.getMissionId() == contract.getId()) && l.getRole().isDefence() && l.isEligible(c)) {
-                            lList.add(l);
+                    List<StrategicFormation> lList = new ArrayList<>();
+                    for (StrategicFormation strategicFormation : strategicFormations.values()) {
+                        if ((strategicFormation.getMissionId() == contract.getId())
+                            && strategicFormation.getRole().isDefence() && strategicFormation.isEligible(campaign)) {
+                            lList.add(strategicFormation);
                         }
                     }
 
                     if (lList.isEmpty()) {
-                        for (Lance l : lances.values()) {
-                            if ((l.getMissionId() == contract.getId()) && l.isEligible(c)) {
-                                lList.add(l);
+                        for (StrategicFormation strategicFormation : strategicFormations.values()) {
+                            if ((strategicFormation.getMissionId() == contract.getId()) && strategicFormation.isEligible(campaign)) {
+                                lList.add(strategicFormation);
                             }
                         }
                     }
 
                     if (lList.isEmpty()) {
-                        for (Lance l : lances.values()) {
-                            if (l.isEligible(c)) {
-                                lList.add(l);
+                        for (StrategicFormation strategicFormation : strategicFormations.values()) {
+                            if (strategicFormation.isEligible(campaign)) {
+                                lList.add(strategicFormation);
                             }
                         }
                     }
 
                     if (!lList.isEmpty()) {
-                        Lance lance = ObjectUtility.getRandomItem(lList);
-                        AtBScenario atbScenario = AtBScenarioFactory.createScenario(c, lance,
-                                AtBScenario.BASEATTACK, false, Lance.getBattleDate(c.getLocalDate()));
+                        StrategicFormation strategicFormation = ObjectUtility.getRandomItem(lList);
+                        AtBScenario atbScenario = AtBScenarioFactory.createScenario(campaign, strategicFormation,
+                                AtBScenario.BASEATTACK, false, StrategicFormation.getBattleDate(campaign.getLocalDate()));
                         if (atbScenario != null) {
-                            if ((lance.getMissionId() == atbScenario.getMissionId())
-                                    || (lance.getMissionId() == Lance.NO_MISSION)) {
+                            if ((strategicFormation.getMissionId() == atbScenario.getMissionId())
+                                    || (strategicFormation.getMissionId() == StrategicFormation.NO_MISSION)) {
                                 for (int i = 0; i < sList.size(); i++) {
-                                    if (sList.get(i).getLanceForceId() == lance.getForceId()) {
+                                    if (sList.get(i).getStrategicFormationId() == strategicFormation.getForceId()) {
                                         if (dontGenerateForces.contains(atbScenario.getId())) {
                                             dontGenerateForces.remove(atbScenario.getId());
                                         }
@@ -266,23 +267,23 @@ public class AtBScenarioFactory {
                                     }
                                 }
                             } else {
-                                // edge case: lance assigned to another mission gets assigned the scenario,
+                                // edge case: strategicFormation assigned to another mission gets assigned the scenario,
                                 // we need to remove any scenario they are assigned to already
-                                c.getMission(lance.getMissionId()).getScenarios()
+                                campaign.getMission(strategicFormation.getMissionId()).getScenarios()
                                         .removeIf(scenario -> (scenario instanceof AtBScenario)
-                                                && (((AtBScenario) scenario).getLanceForceId() == lance.getForceId()));
+                                                && (((AtBScenario) scenario).getStrategicFormationId() == strategicFormation.getForceId()));
                             }
                             if (!sList.contains(atbScenario)) {
                                 sList.add(atbScenario);
                             }
-                            if (!assignedLances.contains(lance.getForceId())) {
-                                assignedLances.add(lance.getForceId());
+                            if (!assignedLances.contains(strategicFormation.getForceId())) {
+                                assignedLances.add(strategicFormation.getForceId());
                             }
                         } else {
                             logger.error("Unable to generate Base Attack scenario.");
                         }
                     } else {
-                        logger.warn("No lances assigned to mission " + contract.getName()
+                        logger.warn("No strategicFormations assigned to mission " + contract.getName()
                                 + ". Can't generate an Unbreakable Morale base defense mission for this force.");
                     }
                 }
@@ -305,9 +306,9 @@ public class AtBScenarioFactory {
             // for the scenario if required
             sList.sort((s1, s2) -> ObjectUtility.compareNullable(s1.getDate(), s2.getDate(), LocalDate::compareTo));
             for (AtBScenario atbScenario : sList) {
-                c.addScenario(atbScenario, contract);
+                campaign.addScenario(atbScenario, contract);
                 if (!dontGenerateForces.contains(atbScenario.getId())) {
-                    atbScenario.setForces(c);
+                    atbScenario.setForces(campaign);
                 }
             }
             // endregion Add to Campaign

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -18,23 +18,18 @@
  */
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.common.Board;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.enums.AtBLanceRole;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ObjectiveEffect;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.ObjectiveEffect.ObjectiveEffectType;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+import mekhq.campaign.mission.enums.AtBLanceRole;
+
+import java.util.ArrayList;
 
 @AtBScenarioEnabled
 public class BaseAttackBuiltInScenario extends AtBScenario {
@@ -103,7 +98,7 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
          * Ally deploys 2 lances of a lighter weight class than the player,
          * minimum light
          */
-        int allyForceWeight = Math.max(getLance(campaign).getWeightClass(campaign) - 1, EntityWeightClass.WEIGHT_LIGHT);
+        int allyForceWeight = Math.max(getStrategicFormation(campaign).getWeightClass(campaign) - 1, EntityWeightClass.WEIGHT_LIGHT);
         addLance(allyEntities, getContract(campaign).getEmployerCode(), getContract(campaign).getAllySkill(),
                 getContract(campaign).getAllyQuality(), allyForceWeight, campaign);
         addLance(allyEntities, getContract(campaign).getEmployerCode(), getContract(campaign).getAllySkill(),
@@ -143,14 +138,14 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
         addBotForce(new BotForce(BASE_TURRET_FORCE_ID, isAttacker() ? 2 : 1, defenderStart, defenderHome, turretForce), campaign);
 
         /* Roll 2x on bot lances roll */
-        addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);
+        addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign), campaign);
         addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);
 
         // the "second" enemy force will either flee in the same direction as
         // the first enemy force in case of the player being the attacker
         // or where it came from in case of player being defender
         ArrayList<Entity> secondBotEntities = new ArrayList<>();
-        addEnemyForce(secondBotEntities, getLance(campaign).getWeightClass(campaign), campaign);
+        addEnemyForce(secondBotEntities, getStrategicFormation(campaign).getWeightClass(campaign), campaign);
         BotForce secondBotForce = getEnemyBotForce(getContract(campaign),
                 isAttacker() ? enemyStart : secondAttackerForceStart,
                 isAttacker() ? getEnemyHome() : secondAttackerForceStart, secondBotEntities);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BreakthroughBuiltInScenario.java
@@ -18,8 +18,6 @@
  */
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.common.Board;
 import megamek.common.Compute;
@@ -27,13 +25,10 @@ import megamek.common.Entity;
 import megamek.common.OffBoardDirection;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+
+import java.util.ArrayList;
 
 @AtBScenarioEnabled
 public class BreakthroughBuiltInScenario extends AtBScenario {
@@ -97,7 +92,7 @@ public class BreakthroughBuiltInScenario extends AtBScenario {
             addBotForce(allyEntitiesForce, campaign);
         }
 
-        addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);
+        addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign), campaign);
         BotForce botForce = getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities);
 
         try {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ChaseBuiltInScenario.java
@@ -18,24 +18,15 @@
  */
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.bot.princess.PrincessException;
-import megamek.common.Board;
-import megamek.common.Compute;
-import megamek.common.Entity;
-import megamek.common.EntityWeightClass;
-import megamek.common.OffBoardDirection;
+import megamek.common.*;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ScenarioObjective;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+
+import java.util.ArrayList;
 
 @AtBScenarioEnabled
 public class ChaseBuiltInScenario extends AtBScenario {
@@ -89,9 +80,9 @@ public class ChaseBuiltInScenario extends AtBScenario {
             addBotForce(allyEntitiesForce, campaign);
         }
 
-        addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_ASSAULT, 0,
+        addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_ASSAULT, 0,
                 -1, campaign);
-        addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_ASSAULT, 0,
+        addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_ASSAULT, 0,
                 -1, campaign);
 
         BotForce botForce = getEnemyBotForce(getContract(campaign), startEdge, getEnemyHome(), enemyEntities);
@@ -121,7 +112,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
             int speed = en.getWalkMP();
 
             if (en.getJumpMP() > 0) {
-                if (en instanceof megamek.common.Infantry) {
+                if (en instanceof Infantry) {
                     speed = en.getJumpMP();
                 } else {
                     speed++;
@@ -135,7 +126,7 @@ public class ChaseBuiltInScenario extends AtBScenario {
             int speed = en.getWalkMP();
 
             if (en.getJumpMP() > 0) {
-                if (en instanceof megamek.common.Infantry) {
+                if (en instanceof Infantry) {
                     speed = en.getJumpMP();
                 } else {
                     speed++;

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ExtractionBuiltInScenario.java
@@ -18,9 +18,6 @@
  */
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-import java.util.UUID;
-
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.bot.princess.PrincessException;
 import megamek.common.Board;
@@ -28,16 +25,14 @@ import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ObjectiveEffect;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.ObjectiveEffect.EffectScalingType;
 import mekhq.campaign.mission.ObjectiveEffect.ObjectiveEffectType;
-import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.campaign.mission.ScenarioObjective.TimeLimitType;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+
+import java.util.ArrayList;
+import java.util.UUID;
 
 @AtBScenarioEnabled
 public class ExtractionBuiltInScenario extends AtBScenario {
@@ -103,7 +98,7 @@ public class ExtractionBuiltInScenario extends AtBScenario {
             addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
-        addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);
+        addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign), campaign);
         addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);
 
         ArrayList<Entity> otherForce = new ArrayList<>();

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/HideAndSeekBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/HideAndSeekBuiltInScenario.java
@@ -29,6 +29,7 @@ import mekhq.campaign.mission.CommonObjectiveFactory;
 import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
 import mekhq.campaign.stratcon.StratconBiomeManifest;
+import mekhq.campaign.stratcon.StratconBiomeManifest.MapTypeList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +55,7 @@ public class HideAndSeekBuiltInScenario extends AtBScenario {
 
     @Override
     public void setTerrain() {
-        Map<String, StratconBiomeManifest.MapTypeList> mapTypes = StratconBiomeManifest.getInstance().getBiomeMapTypes();
+        Map<String, MapTypeList> mapTypes = StratconBiomeManifest.getInstance().getBiomeMapTypes();
         List<String> keys = mapTypes.keySet().stream().sorted().collect(Collectors.toList());
         do {
             setTerrainType(keys.get(Compute.randomInt(keys.size())));
@@ -107,10 +108,10 @@ public class HideAndSeekBuiltInScenario extends AtBScenario {
         }
 
         if (isAttacker()) {
-            addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign),
+            addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign),
                     EntityWeightClass.WEIGHT_ASSAULT, 2, 0, campaign);
         } else {
-            addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign),
+            addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign),
                     EntityWeightClass.WEIGHT_HEAVY, 0, 0, campaign);
         }
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/HoldTheLineBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/HoldTheLineBuiltInScenario.java
@@ -18,8 +18,6 @@
  */
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-
 import megamek.common.Board;
 import megamek.common.Compute;
 import megamek.common.Entity;
@@ -30,6 +28,8 @@ import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.CommonObjectiveFactory;
 import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+
+import java.util.ArrayList;
 
 @AtBScenarioEnabled
 public class HoldTheLineBuiltInScenario extends AtBScenario {
@@ -79,7 +79,7 @@ public class HoldTheLineBuiltInScenario extends AtBScenario {
             addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
-        addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_ASSAULT,
+        addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_ASSAULT,
                 isAttacker() ? 0 : 4, 0, campaign);
 
         addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ProbeBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ProbeBuiltInScenario.java
@@ -18,11 +18,6 @@
  */
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
@@ -33,6 +28,12 @@ import mekhq.campaign.mission.CommonObjectiveFactory;
 import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
 import mekhq.campaign.stratcon.StratconBiomeManifest;
+import mekhq.campaign.stratcon.StratconBiomeManifest.MapTypeList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @AtBScenarioEnabled
 public class ProbeBuiltInScenario extends AtBScenario {
@@ -53,7 +54,7 @@ public class ProbeBuiltInScenario extends AtBScenario {
 
     @Override
     public void setTerrain() {
-        Map<String, StratconBiomeManifest.MapTypeList> mapTypes = StratconBiomeManifest.getInstance().getBiomeMapTypes();
+        Map<String, MapTypeList> mapTypes = StratconBiomeManifest.getInstance().getBiomeMapTypes();
         List<String> keys = mapTypes.keySet().stream().sorted().collect(Collectors.toList());
         do {
             setTerrainType(keys.get(Compute.randomInt(keys.size())));
@@ -78,7 +79,7 @@ public class ProbeBuiltInScenario extends AtBScenario {
             addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
-        addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_MEDIUM, 0, 0,
+        addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign), EntityWeightClass.WEIGHT_MEDIUM, 0, 0,
                 campaign);
 
         addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/ReconRaidBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/ReconRaidBuiltInScenario.java
@@ -18,24 +18,15 @@
  */
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-
-import megamek.common.Board;
-import megamek.common.Compute;
-import megamek.common.Entity;
-import megamek.common.EntityWeightClass;
-import megamek.common.OffBoardDirection;
+import megamek.common.*;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
-import mekhq.campaign.mission.AtBScenario;
-import mekhq.campaign.mission.CommonObjectiveFactory;
-import mekhq.campaign.mission.ObjectiveEffect;
+import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.ObjectiveEffect.ObjectiveEffectType;
-import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.campaign.mission.ScenarioObjective.ObjectiveCriterion;
 import mekhq.campaign.mission.ScenarioObjective.TimeLimitType;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+
+import java.util.ArrayList;
 
 @AtBScenarioEnabled
 public class ReconRaidBuiltInScenario extends AtBScenario {
@@ -85,7 +76,7 @@ public class ReconRaidBuiltInScenario extends AtBScenario {
             addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
-        addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign),
+        addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign),
                 isAttacker() ? EntityWeightClass.WEIGHT_ASSAULT : EntityWeightClass.WEIGHT_MEDIUM, 0, 0, campaign);
 
         addBotForce(getEnemyBotForce(getContract(campaign), enemyStart, getEnemyHome(), enemyEntities), campaign);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/StandUpBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/StandUpBuiltInScenario.java
@@ -18,8 +18,6 @@
  */
 package mekhq.campaign.mission.atb.scenario;
 
-import java.util.ArrayList;
-
 import megamek.common.Compute;
 import megamek.common.Entity;
 import mekhq.campaign.Campaign;
@@ -28,6 +26,8 @@ import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.CommonObjectiveFactory;
 import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.campaign.mission.atb.AtBScenarioEnabled;
+
+import java.util.ArrayList;
 
 @AtBScenarioEnabled
 public class StandUpBuiltInScenario extends AtBScenario {
@@ -64,7 +64,7 @@ public class StandUpBuiltInScenario extends AtBScenario {
             addBotForce(getAllyBotForce(getContract(campaign), getStartingPos(), playerHome, allyEntities), campaign);
         }
 
-        addEnemyForce(enemyEntities, getLance(campaign).getWeightClass(campaign), campaign);
+        addEnemyForce(enemyEntities, getStrategicFormation(campaign).getWeightClass(campaign), campaign);
         addBotForce(getEnemyBotForce(getContract(campaign), getEnemyHome(), getEnemyHome(), enemyEntities), campaign);
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/MiscAwards.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/MiscAwards.java
@@ -279,7 +279,7 @@ public class MiscAwards {
      */
     private static boolean drillInstructor(Campaign campaign, Award award, UUID person) {
         if (award.canBeAwarded(campaign.getPerson(person))) {
-            return campaign.getLanceList().stream()
+            return campaign.getStrategicFormationList().stream()
                     .anyMatch(lance -> (lance.getRole().isTraining()) && (lance.getCommanderId().equals(person)));
         }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1459,20 +1459,19 @@ public class StratconRulesManager {
                 continue;
             }
 
-            logger.info(force.getName());
-
             int primaryUnitType = force.getPrimaryUnitType(campaign);
-            boolean noReinforcementRestriction = !reinforcements || (reinforcements
-                    && (getReinforcementType(force.getId(), currentTrack, campaign,
-                            campaignState) != ReinforcementEligibilityType.None));
-            if ((force.getScenarioId() <= 0) && !force.getAllUnits(true).isEmpty()
-                    && !forcesInTracks.contains(force.getId())
-                    && forceCompositionMatchesDeclaredUnitType(primaryUnitType, unitType, reinforcements)
-                    && noReinforcementRestriction
-                    && !subElementsOrSelfDeployed(force, campaign)) {
+            boolean noReinforcementRestriction = !reinforcements ||
+                (getReinforcementType(force.getId(), currentTrack, campaign, campaignState) != ReinforcementEligibilityType.None);
+
+            if ((force.getScenarioId() <= 0)
+                && !force.getAllUnits(true).isEmpty()
+                && !forcesInTracks.contains(force.getId())
+                && forceCompositionMatchesDeclaredUnitType(primaryUnitType, unitType, reinforcements)
+                && noReinforcementRestriction
+                && !subElementsOrSelfDeployed(force, campaign)) {
+
                 retVal.add(force.getId());
             }
-            retVal.add(force.getId());
         }
 
         return retVal;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -33,7 +33,7 @@ import mekhq.campaign.event.NewDayEvent;
 import mekhq.campaign.event.ScenarioChangedEvent;
 import mekhq.campaign.event.StratconDeploymentEvent;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.force.Lance;
+import mekhq.campaign.force.StrategicFormation;
 import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
@@ -833,7 +833,7 @@ public class StratconRulesManager {
             MekHQ.triggerEvent(new ScenarioChangedEvent(scenario.getBackingScenario()));
         }
 
-        if (campaign.getLances().get(forceID).getRole().isScouting()) {
+        if (campaign.getStrategicFormations().get(forceID).getRole().isScouting()) {
             for (int direction = 0; direction < 6; direction++) {
                 StratconCoords checkCoords = coords.translate(direction);
 
@@ -1043,7 +1043,7 @@ public class StratconRulesManager {
         if (lanceCommander != null){
             Unit commanderUnit = lanceCommander.getUnit();
             if (commanderUnit != null) {
-                Lance lance = campaign.getLances().get(commanderUnit.getForceId());
+                StrategicFormation lance = campaign.getStrategicFormations().get(commanderUnit.getForceId());
 
                 return (lance != null) && lance.getRole().isDefence();
             }
@@ -1415,7 +1415,7 @@ public class StratconRulesManager {
         // that are
         // deployed to a scenario and not in a track already
 
-        return campaign.getLances().keySet().stream()
+        return campaign.getStrategicFormations().keySet().stream()
                 .mapToInt(key -> key)
                 .mapToObj(campaign::getForce).filter(force -> (force != null)
                         && !force.isDeployed()
@@ -1451,7 +1451,7 @@ public class StratconRulesManager {
             forcesInTracks.addAll(currentScenario.getFailedReinforcements());
         }
 
-        for (int key : campaign.getLances().keySet()) {
+        for (int key : campaign.getStrategicFormations().keySet()) {
             Force force = campaign.getForce(key);
 
             if (force == null) {
@@ -1672,8 +1672,8 @@ public class StratconRulesManager {
 
         // if the force is in 'fight' stance, it'll be able to deploy using 'fight
         // lance' rules
-        if (campaign.getLances().containsKey(forceID)
-                && (campaign.getLances().get(forceID).getRole().isFighting())) {
+        if (campaign.getStrategicFormations().containsKey(forceID)
+                && (campaign.getStrategicFormations().get(forceID).getRole().isFighting())) {
             return ReinforcementEligibilityType.FightLance;
         }
 

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -38,7 +38,7 @@ import mekhq.campaign.ResolveScenarioTracker.PersonStatus;
 import mekhq.campaign.event.*;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
-import mekhq.campaign.force.Lance;
+import mekhq.campaign.force.StrategicFormation;
 import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
 import mekhq.campaign.mission.enums.MissionStatus;
@@ -893,11 +893,11 @@ public final class BriefingTab extends CampaignGuiTab {
 
         // code to support deployment of reinforcements for legacy ATB scenarios.
         if ((scenario instanceof AtBScenario) && !(scenario instanceof AtBDynamicScenario)) {
-            Lance assignedLance = ((AtBScenario) scenario).getLance(getCampaign());
+            StrategicFormation assignedLance = ((AtBScenario) scenario).getStrategicFormation(getCampaign());
             if (assignedLance != null) {
                 int assignedForceId = assignedLance.getForceId();
                 int cmdrStrategy = 0;
-                Person commander = getCampaign().getPerson(Lance.findCommander(assignedForceId, getCampaign()));
+                Person commander = getCampaign().getPerson(StrategicFormation.findCommander(assignedForceId, getCampaign()));
                 if ((null != commander) && (null != commander.getSkill(SkillType.S_STRATEGY))) {
                     cmdrStrategy = commander.getSkill(SkillType.S_STRATEGY).getLevel();
                 }

--- a/MekHQ/src/mekhq/gui/ForceRenderer.java
+++ b/MekHQ/src/mekhq/gui/ForceRenderer.java
@@ -32,6 +32,8 @@ import javax.swing.*;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import java.awt.*;
 
+import static mekhq.campaign.force.Force.STRATEGIC_FORMATION_OVERRIDE_NONE;
+
 public class ForceRenderer extends DefaultTreeCellRenderer {
     private static final MMLogger logger = MMLogger.create(ForceRenderer.class);
 
@@ -147,9 +149,16 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
                 setOpaque(true);
             }
 
+            String format;
             if (force.isStrategicFormation()) {
-                setText("<html><u>" + force.getName() + "</u></html>");
+                format = (force.getOverrideStrategicFormation() != STRATEGIC_FORMATION_OVERRIDE_NONE) ?
+                    "<html><b><u>%s</u></b></html>" : "<html><b>%s</b></html>";
+            } else {
+                format = (force.getOverrideStrategicFormation() != STRATEGIC_FORMATION_OVERRIDE_NONE) ?
+                    "<html><u>%s</u></html>" : "%s";
             }
+
+            setText(String.format(format, force.getName()));
         } else {
             logger.error("Attempted to render node with unknown node class of "
                     + ((value != null) ? value.getClass() : "null"));

--- a/MekHQ/src/mekhq/gui/ForceRenderer.java
+++ b/MekHQ/src/mekhq/gui/ForceRenderer.java
@@ -18,13 +18,6 @@
  */
 package mekhq.gui;
 
-import java.awt.Component;
-
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JTree;
-import javax.swing.tree.DefaultTreeCellRenderer;
-
 import megamek.client.ui.Messages;
 import megamek.common.Entity;
 import megamek.common.GunEmplacement;
@@ -34,6 +27,10 @@ import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.utilities.ReportingUtilities;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import java.awt.*;
 
 public class ForceRenderer extends DefaultTreeCellRenderer {
     private static final MMLogger logger = MMLogger.create(ForceRenderer.class);
@@ -51,7 +48,7 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
         super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
         setOpaque(false);
 
-        if (value instanceof Unit) {
+        if (value instanceof Unit unit) {
             String name = ReportingUtilities.messageSurroundedBySpanWithColor(
                     MekHQ.getMHQOptions().getFontColorNegativeHexColor(), "No Crew");
             if (((Unit) value).getEntity() instanceof GunEmplacement) {
@@ -59,7 +56,6 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
             }
             String c3network = "";
             StringBuilder transport = new StringBuilder();
-            Unit unit = (Unit) value;
             Person person = unit.getCommander();
             if (person != null) {
                 name = person.getFullTitle();
@@ -142,14 +138,17 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
                 setBackground(MekHQ.getMHQOptions().getDeployedBackground());
                 setOpaque(true);
             }
-        } else if (value instanceof Force) {
-            Force force = (Force) value;
+        } else if (value instanceof Force force) {
             getAccessibleContext().setAccessibleName((
                     force.isDeployed() ? "Deployed Force: " : "Force: ") + force.getFullName());
             if (!sel && force.isDeployed()) {
                 setForeground(MekHQ.getMHQOptions().getDeployedForeground());
                 setBackground(MekHQ.getMHQOptions().getDeployedBackground());
                 setOpaque(true);
+            }
+
+            if (force.isStrategicFormation()) {
+                setText("<html><u>" + force.getName() + "</u></html>");
             }
         } else {
             logger.error("Attempted to render node with unknown node class of "

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -18,24 +18,6 @@
  */
 package mekhq.gui.adapter;
 
-import java.awt.event.ActionEvent;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.StringJoiner;
-import java.util.StringTokenizer;
-import java.util.UUID;
-import java.util.Vector;
-
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.JPopupMenu;
-import javax.swing.JTree;
-import javax.swing.tree.TreePath;
-
 import megamek.client.ui.dialogs.CamoChooserDialog;
 import megamek.common.EntityWeightClass;
 import megamek.common.GunEmplacement;
@@ -67,6 +49,15 @@ import mekhq.gui.dialog.iconDialogs.LayeredForceIconDialog;
 import mekhq.gui.menus.ExportUnitSpriteMenu;
 import mekhq.gui.utilities.JMenuHelpers;
 import mekhq.gui.utilities.StaticChecks;
+
+import javax.swing.*;
+import javax.swing.tree.TreePath;
+import java.awt.event.ActionEvent;
+import java.util.*;
+
+import static mekhq.campaign.force.Force.STRATEGIC_FORMATION_OVERRIDE_FALSE;
+import static mekhq.campaign.force.Force.STRATEGIC_FORMATION_OVERRIDE_NONE;
+import static mekhq.campaign.force.Force.STRATEGIC_FORMATION_OVERRIDE_TRUE;
 
 public class TOEMouseAdapter extends JPopupMenuAdapter {
     private static final MMLogger logger = MMLogger.create(TOEMouseAdapter.class);
@@ -136,6 +127,8 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
     private static final String CHANGE_NAME = "CHANGE_NAME";
     private static final String CHANGE_COMBAT_STATUS = "CHANGE_COMBAT_STATUS";
     private static final String CHANGE_COMBAT_STATUSES = "CHANGE_COMBAT_STATUSES";
+    private static final String CHANGE_STRATEGIC_FORCE_OVERRIDE = "CHANGE_STRATEGIC_FORCE_OVERRIDE";
+    private static final String REMOVE_STRATEGIC_FORCE_OVERRIDE = "REMOVE_STRATEGIC_FORCE_OVERRIDE";
 
     private static final String COMMAND_CHANGE_FORCE_CAMO = "CHANGE_CAMO|FORCE|empty|";
     private static final String COMMAND_CHANGE_FORCE_DESC = "CHANGE_DESC|FORCE|empty|";
@@ -146,6 +139,8 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
     private static final String COMMAND_CHANGE_FORCE_NAME = "CHANGE_NAME|FORCE|empty|";
     private static final String COMMAND_CHANGE_FORCE_COMBAT_STATUS = "CHANGE_COMBAT_STATUS|FORCE|empty|";
     private static final String COMMAND_CHANGE_FORCE_COMBAT_STATUSES = "CHANGE_COMBAT_STATUSES|FORCE|empty|";
+    private static final String COMMAND_CHANGE_STRATEGIC_FORCE_OVERRIDE = "CHANGE_STRATEGIC_FORCE_OVERRIDE|FORCE|empty|";
+    private static final String COMMAND_REMOVE_STRATEGIC_FORCE_OVERRIDE = "REMOVE_STRATEGIC_FORCE_OVERRIDE|FORCE|empty|";
 
     private static final String COMMAND_OVERRIDE_FORCE_FORMATION_LEVEL = "OVERRIDE_FORMATION_LEVEL|FORCE|FORMATION_LEVEL|";
 
@@ -443,6 +438,28 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             }
             gui.undeployForces(forces);
             gui.getTOETab().refreshForceView();
+        } else if (command.contains(CHANGE_STRATEGIC_FORCE_OVERRIDE)) {
+            if (singleForce == null) {
+                return;
+            }
+
+            boolean overrideState = singleForce.getOverrideStrategicFormation() == STRATEGIC_FORMATION_OVERRIDE_TRUE;
+            singleForce.setStrategicFormation(!overrideState);
+            singleForce.setOverrideStrategicFormation(!overrideState ? STRATEGIC_FORMATION_OVERRIDE_TRUE : STRATEGIC_FORMATION_OVERRIDE_FALSE);
+
+            for (Force formation : gui.getCampaign().getAllForces()) {
+                MekHQ.triggerEvent(new OrganizationChangedEvent(formation));
+            }
+        } else if (command.contains(REMOVE_STRATEGIC_FORCE_OVERRIDE)) {
+            if (singleForce == null) {
+                return;
+            }
+
+            singleForce.setOverrideStrategicFormation(STRATEGIC_FORMATION_OVERRIDE_NONE);
+
+            for (Force formation : gui.getCampaign().getAllForces()) {
+                MekHQ.triggerEvent(new OrganizationChangedEvent(formation));
+            }
         } else if (command.contains(TOEMouseAdapter.REMOVE_FORCE)) {
             for (Force force : forces) {
                 if (null != force && null != force.getParentForce()) {
@@ -1030,6 +1047,18 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUSES + forceIds);
             menuItem.addActionListener(this);
             popup.add(menuItem);
+
+            JMenuItem optionStrategicForceOverride = new JMenuItem(force.isStrategicFormation() ?
+                "Remove Strategic Formation Assignment" : "Assign as Strategic Formation");
+            optionStrategicForceOverride.setActionCommand(COMMAND_CHANGE_STRATEGIC_FORCE_OVERRIDE + forceIds);
+            optionStrategicForceOverride.addActionListener(this);
+            popup.add(optionStrategicForceOverride);
+
+            JMenuItem optionRemoveStrategicForceOverride = new JMenuItem("Remove Strategic Force Override");
+            optionRemoveStrategicForceOverride.setActionCommand(COMMAND_REMOVE_STRATEGIC_FORCE_OVERRIDE + forceIds);
+            optionRemoveStrategicForceOverride.addActionListener(this);
+            optionRemoveStrategicForceOverride.setVisible(force.getOverrideStrategicFormation() != STRATEGIC_FORMATION_OVERRIDE_NONE);
+            popup.add(optionRemoveStrategicForceOverride);
 
             if (StaticChecks.areAllForcesUndeployed(gui.getCampaign(), forces)
                     && StaticChecks.areAllCombatForces(forces)) {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -438,14 +438,18 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             }
             gui.undeployForces(forces);
             gui.getTOETab().refreshForceView();
+
+            for (Force formation : gui.getCampaign().getAllForces()) {
+                MekHQ.triggerEvent(new OrganizationChangedEvent(formation));
+            }
         } else if (command.contains(CHANGE_STRATEGIC_FORCE_OVERRIDE)) {
             if (singleForce == null) {
                 return;
             }
 
-            boolean overrideState = singleForce.getOverrideStrategicFormation() == STRATEGIC_FORMATION_OVERRIDE_TRUE;
-            singleForce.setStrategicFormation(!overrideState);
-            singleForce.setOverrideStrategicFormation(!overrideState ? STRATEGIC_FORMATION_OVERRIDE_TRUE : STRATEGIC_FORMATION_OVERRIDE_FALSE);
+            boolean formationState = singleForce.isStrategicFormation();
+            singleForce.setStrategicFormation(!formationState);
+            singleForce.setOverrideStrategicFormation(!formationState ? STRATEGIC_FORMATION_OVERRIDE_TRUE : STRATEGIC_FORMATION_OVERRIDE_FALSE);
 
             for (Force formation : gui.getCampaign().getAllForces()) {
                 MekHQ.triggerEvent(new OrganizationChangedEvent(formation));
@@ -1048,8 +1052,8 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             menuItem.addActionListener(this);
             popup.add(menuItem);
 
-            JMenuItem optionStrategicForceOverride = new JMenuItem(force.isStrategicFormation() ?
-                "Remove Strategic Formation Assignment" : "Assign as Strategic Formation");
+            JMenuItem optionStrategicForceOverride = new JMenuItem((force.isStrategicFormation() ?
+                "Never" : "Always") + " Consider Force a Strategic Formation");
             optionStrategicForceOverride.setActionCommand(COMMAND_CHANGE_STRATEGIC_FORCE_OVERRIDE + forceIds);
             optionStrategicForceOverride.addActionListener(this);
             popup.add(optionStrategicForceOverride);

--- a/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardLanceRenderer.java
+++ b/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardLanceRenderer.java
@@ -20,7 +20,7 @@ package mekhq.gui.stratcon;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.force.Lance;
+import mekhq.campaign.force.StrategicFormation;
 
 import javax.swing.*;
 import java.awt.*;
@@ -50,7 +50,7 @@ public class ScenarioWizardLanceRenderer extends JLabel implements ListCellRende
         setForeground(foreground);
         setBackground(background);
 
-        Lance lance = campaign.getLances().get(value.getId());
+        StrategicFormation lance = campaign.getStrategicFormations().get(value.getId());
         String roleString = "";
         if (lance != null) {
             roleString = lance.getRole().toString() + ", ";

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -292,8 +292,8 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
             gridBagConstraints.gridwidth = 1;
             panStats.add(lblForce, gridBagConstraints);
 
-            if (null != scenario.getLance(campaign)) {
-                lblForceDesc.setText(campaign.getForce(scenario.getLanceForceId()).getFullName());
+            if (null != scenario.getStrategicFormation(campaign)) {
+                lblForceDesc.setText(campaign.getForce(scenario.getStrategicFormationId()).getFullName());
             } else if (scenario instanceof AtBDynamicScenario) {
                 StringBuilder forceBuilder = new StringBuilder();
                 forceBuilder.append("<html>");
@@ -376,12 +376,12 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
         for (ScenarioObjective objective : scenario.getScenarioObjectives()) {
             objectiveBuilder.append(objective.getDescription());
-            objectiveBuilder.append("\n");
+            objectiveBuilder.append('\n');
 
             for (String forceName : objective.getAssociatedForceNames()) {
-                objectiveBuilder.append("\t");
+                objectiveBuilder.append('\t');
                 objectiveBuilder.append(forceName);
-                objectiveBuilder.append("\n");
+                objectiveBuilder.append('\n');
             }
 
             for (String associatedUnitID : objective.getAssociatedUnitIDs()) {
@@ -399,22 +399,22 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
                 if (associatedUnitName.isBlank()) {
                     continue;
                 }
-                objectiveBuilder.append("\t");
+                objectiveBuilder.append('\t');
                 objectiveBuilder.append(associatedUnitName);
-                objectiveBuilder.append("\n");
+                objectiveBuilder.append('\n');
             }
 
-            objectiveBuilder.append("\t");
+            objectiveBuilder.append('\t');
             objectiveBuilder.append(objective.getTimeLimitString());
-            objectiveBuilder.append("\n");
+            objectiveBuilder.append('\n');
 
             for (String detail : objective.getDetails()) {
-                objectiveBuilder.append("\t");
+                objectiveBuilder.append('\t');
                 objectiveBuilder.append(detail);
-                objectiveBuilder.append("\n");
+                objectiveBuilder.append('\n');
             }
 
-            objectiveBuilder.append("\n");
+            objectiveBuilder.append('\n');
         }
 
         objectiveBuilder.append(scenario.getBattlefieldControlDescription());

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -387,7 +387,7 @@ class LanceAssignmentTableModel extends DataTableModel {
     public LanceAssignmentTableModel(Campaign campaign) {
         this.campaign = campaign;
         data = new ArrayList<>();
-        columnNames = new String[]{"Force", "Wt", "Mission", "Role"};
+        columnNames = new String[]{"Force", "Weight Class", "Mission", "Role"};
     }
 
     @Override
@@ -429,7 +429,7 @@ class LanceAssignmentTableModel extends DataTableModel {
 
     @Override
     public Object getValueAt(int row, int column) {
-        final String[] WEIGHT_CODES = {"UL", "L", "M", "H", "A", "SH"};
+        final String[] WEIGHT_CODES = {"Ultra-Light", "Light", "Medium", "Heavy", "Assault", "Super Heavy"};
 
         if (row >= getRowCount()) {
             return "";


### PR DESCRIPTION
**Key Note:** `Lances` are what MHQ called any combat `Force`, i.e. any combat node in your TO&E that contains at least one ground `Unit`. When reading the below any instance of 'lance' is referring to the internal class and _not_ the IS Formation.

To reduce confusion `Lance.java` has been renamed to `StrategicFormation.java`. The relevant methods and classes have also been renamed.

A StratFor is considered to be any combat force in the TO&E that contains at least one ground unit and has no ancestor or descendant nodes which are also StratFors. Players can manually define individual forces to always be considered StratFors, or never considered StratFors. These overrides can be easily removed. Assigning or removing an override is accessed via the TO&E right-click menu.

StratFors are easily recognized by their bold nameplate. StratFors that have had their state overridden are also underlined.

A force that has had its StratFor status set to `true` will consider all units in that force, and all descendant forces, to be a part of that StratFor. This allows for deployment of entire companies at will (or greater).

The Briefing Room has been updated to consider units in descendant forces, when determining force weight. Weight is derived from a mean of all individual forces in the StratFor, ignoring empty forces.

StratCon and AtB will consider any StratFor fair game when picking seed forces, so players should be advised to try and keep their forces roughly equal, where possible.

StratCon will no longer consider non-combat forces as fair game for assignment to a track (manual or via integrated command rights), or scenario seeding.