### PR TITLE
Issue 4849: Replaced Cubicles Persist after Saving & Loading

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
@@ -92,10 +92,11 @@ public class MissingCubicle extends MissingPart {
             unit.addPart(actualReplacement);
             campaign.getQuartermaster().addPart(actualReplacement, 0);
             replacement.decrementQuantity();
+            Part parentReference = parentPart;
             remove(false);
-            if (null != parentPart) {
-                parentPart.addChildPart(actualReplacement);
-                parentPart.updateConditionFromPart();
+            if (null != parentReference) {
+                parentReference.addChildPart(actualReplacement);
+                parentReference.updateConditionFromPart();
             }
         }
     }


### PR DESCRIPTION
Fixes #4849 

Same fix was used on the MissingBayDoor class.