### PR TITLE
fix: adds null check before accessing skill property

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -2169,7 +2169,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         if (specialistMenu.getMenuComponentCount() > 0) {
                             abMenu.add(specialistMenu);
                         }
-                    } else if ((person.getOptions().getOption(spa.getName()).getType() == IOption.CHOICE)
+                    } else if (Optional.ofNullable((person.getOptions().getOption(spa.getName()))).isPresent()
+                            && (person.getOptions().getOption(spa.getName()).getType() == IOption.CHOICE)
                             && !(person.getOptions().getOption(spa.getName()).booleanValue())) {
                         JMenu specialistMenu = new JMenu(spa.getDisplayName());
                         List<String> choices = spa.getChoiceValues();


### PR DESCRIPTION
I dont know of any bug in particular that called for this, however when checking the save from the issue #4529 I encountered this error, where it was looking for a specific skill that the person didnt had loaded, so when trying to open the person contextual menu it threw a null pointer exception.