### PR TITLE
allows to select a previous engineer or new crew member to activate large vessels

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2447,6 +2447,14 @@ public class Campaign implements ITechManager {
         return getTechs(noZeroMinute, false);
     }
 
+    public List<Person> getTechsExpanded() {
+        return getTechsExpanded(false, false, true);
+    }
+
+    public List<Person> getTechs(final boolean noZeroMinute, final boolean eliteFirst) {
+        return getTechsExpanded(noZeroMinute, eliteFirst, false);
+    }
+
     /**
      * Returns a list of active technicians.
      *
@@ -2454,12 +2462,14 @@ public class Campaign implements ITechManager {
      *                     excluded from the list.
      * @param eliteFirst   If TRUE and sorted also TRUE, then return the list sorted
      *                     from best to worst
+     * @param expanded     If TRUE, then include techs with expanded roles (e.g. Tech/Vessel skill)
      * @return The list of active {@link Person}s who qualify as technicians
-     *         ({@link Person#isTech()}).
+     *         ({@link Person#isTech()}), or who qualify as expanded technicians ({@link Person#isTechExpanded()}).
      */
-    public List<Person> getTechs(final boolean noZeroMinute, final boolean eliteFirst) {
+    public List<Person> getTechsExpanded(final boolean noZeroMinute, final boolean eliteFirst, final boolean expanded) {
         final List<Person> techs = getActivePersonnel().stream()
-                .filter(person -> person.isTech() && (!noZeroMinute || (person.getMinutesLeft() > 0)))
+                .filter(person -> (expanded ? person.isTechExpanded() : person.isTech())
+                    && (!noZeroMinute || (person.getMinutesLeft() > 0)))
                 .collect(Collectors.toList());
 
         // also need to loop through and collect engineers on self-crewed vessels

--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -38,7 +38,7 @@ import mekhq.utilities.MHQXMLUtility;
  * This class is used to store information about a particular unit that is
  * lost when a unit is mothballed, so that it may be restored to as close to
  * its prior state as possible when the unit is reactivated.
- * 
+ *
  * @author NickAragua
  */
 public class MothballInfo {
@@ -62,8 +62,16 @@ public class MothballInfo {
     }
 
     /**
+     * Who was the original tech of this vessel?
+     * @return The original tech
+     */
+    public Person getTech() {
+        return tech;
+    }
+
+    /**
      * Creates a set of mothball info for a given unit
-     * 
+     *
      * @param unit The unit to work with
      */
     public MothballInfo(Unit unit) {
@@ -78,7 +86,7 @@ public class MothballInfo {
 
     /**
      * Restore a unit's pilot, assigned tech and force, to the best of our ability
-     * 
+     *
      * @param unit     The unit to restore
      * @param campaign The campaign in which this is happening
      */
@@ -158,7 +166,7 @@ public class MothballInfo {
 
     /**
      * Deserializer method implemented in standard MekHQ pattern.
-     * 
+     *
      * @return Instance of MothballInfo
      */
     public static MothballInfo generateInstanceFromXML(Node wn, Version version) {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1614,7 +1614,7 @@ public class CampaignGUI extends JPanel {
                 StringBuilder nameBuilder = new StringBuilder(128);
                 nameBuilder.append("<html>")
                     .append(tech.getFullName())
-                    .append(", <b>") 
+                    .append(", <b>")
                     .append(SkillType.getColoredExperienceLevelName(tech.getSkillLevel(getCampaign(), false)))
                     .append("</b> ")
                     .append(tech.getPrimaryRoleDesc())
@@ -1722,7 +1722,7 @@ public class CampaignGUI extends JPanel {
     public @Nullable UUID selectTech(Unit u, String desc, boolean ignoreMaintenance) {
         String name;
         Map<String, Person> techHash = new LinkedHashMap<>();
-        for (Person tech : getCampaign().getTechs()) {
+        for (Person tech : getCampaign().getTechsExpanded()) {
             if (!tech.isMothballing() && tech.canTech(u.getEntity())) {
                 int time = tech.getMinutesLeft();
                 if (!ignoreMaintenance) {

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -205,7 +205,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
             String quality = (String) JOptionPane.showInputDialog(gui.getFrame(), "Choose the new quality level",
                     "Set Quality", JOptionPane.PLAIN_MESSAGE, null, possibilities,
                     PartQuality.QUALITY_D.toName(reverse));
-            
+
             PartQuality q = PartQuality.fromName(quality, reverse);
             for (Unit unit : units) {
                 if (null != unit) {
@@ -526,7 +526,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
 
     private @Nullable Person pickTechForMothballOrActivation(Unit unit, String description) {
         Person tech = null;
-        if (!unit.isSelfCrewed()) {
+        if (!unit.isSelfCrewed() || isSelfCrewedButHasNoTech(unit)) {
             UUID id = gui.selectTech(unit, description, true);
             if (null != id) {
                 tech = gui.getCampaign().getPerson(id);
@@ -542,6 +542,10 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
             }
         }
         return tech;
+    }
+
+    private boolean isSelfCrewedButHasNoTech(Unit unit) {
+        return unit.isSelfCrewed() && unit.engineerResponsible().isEmpty();
     }
 
     @Override

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -133,6 +133,7 @@ public class CampaignTest {
         when(testCampaign.getTechs()).thenCallRealMethod();
         when(testCampaign.getTechs(anyBoolean())).thenCallRealMethod();
         when(testCampaign.getTechs(anyBoolean(), anyBoolean())).thenCallRealMethod();
+        when(testCampaign.getTechsExpanded(anyBoolean(), anyBoolean(), anyBoolean())).thenCallRealMethod();
 
         // Test just getting the list of active techs.
         List<Person> expected = new ArrayList<>(3);


### PR DESCRIPTION
Because we have the concept of "engineer" inside MM to handle the self-healing properties of large vessels, funcitonalities like "mothball" and "activate" are compromised due to them requiring a tech.

This fix does two things:

- fix #4529, it does that by adding the previous "engineer" to the crew of the mothballed vessel.
- Adds `vessel techs` to the selection of techs in the "select a techie" drop down window when you want to activate a unit.

The later was necessary to deal with a rare but possible situation. If the engineer that originally mothballed the large vessel (present in the mothballInfo object) is not active, or were removed/sacked by any reason then they would not be available to activate the ship, this means that the ship would be locked in a situation that could only be circunvented by GM activating.

PS.: I hope the second change does not cause any trouble