### PR TITLE
Issue 4085: MegaMek fails to load Dropship sent from MekHQ

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -259,7 +259,7 @@ public class AtBGameThread extends GameThread {
                     }
                     // If this unit is a spacecraft, set the crew size and marine size values
                     if (entity.isLargeCraft() || (entity.getUnitType() == UnitType.SMALL_CRAFT)) {
-                        entity.setNCrew(unit.getActiveCrew().size());
+                        entity.setNCrew(unit.getActiveCrew().size() + entity.getBayPersonnel()); //We don't track bay personnel currently.
                         // TODO : Change this when marines are fully implemented
                         entity.setNMarines(unit.getMarineCount());
                     }


### PR DESCRIPTION
Fixes #4085 

We don't actually track bay personnel. You can assign units to a dropship, but it doesn't change the nCrew for the ship, which MegaMek assumes will include bay personnel, so when loading a spaceship from MekHQ to MegaMek, it will calculate the current crew by taking nCrew and removing the assumed bay personnel - this is what prevents Spaceships from being moved form MHQ to MM, they will never have enough crew.

When spaceships are loaded from data, the crew includes the bay personnel, so the calculation passes.