### PR TITLE
Add Persistent Initiative Bonus to campaign

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -132,6 +132,7 @@ public class AtBGameThread extends GameThread {
 
                 client.getLocalPlayer().setCamouflage(app.getCampaign().getCamouflage().clone());
                 client.getLocalPlayer().setColour(app.getCampaign().getColour());
+                client.getLocalPlayer().setConstantInitBonus(campaign.getInitiativeBonus());
 
                 if (started) {
                     client.getGame().getOptions().loadOptions();

--- a/MekHQ/src/mekhq/GameThread.java
+++ b/MekHQ/src/mekhq/GameThread.java
@@ -204,6 +204,7 @@ class GameThread extends Thread implements CloseClientListener {
                 client.getLocalPlayer().setStartingAnyNWy(scenario.getStartingAnyNWy());
                 client.getLocalPlayer().setStartingAnySEx(scenario.getStartingAnySEx());
                 client.getLocalPlayer().setStartingAnySEy(scenario.getStartingAnySEy());
+                client.getLocalPlayer().setConstantInitBonus(campaign.getInitiativeBonus());
 
                 client.getLocalPlayer().setTeam(1);
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -307,7 +307,7 @@ public class Campaign implements ITechManager {
         crimeRating = 0;
         crimePirateModifier = 0;
         dateOfLastCrime = null;
-        initiativeBonus = 10;
+        initiativeBonus = 0;
         setRankSystemDirect(Ranks.getRankSystemFromCode(Ranks.DEFAULT_SYSTEM_CODE));
         forces = new Force(name);
         forceIds.put(0, forces);
@@ -4468,7 +4468,6 @@ public class Campaign implements ITechManager {
     }
 
     public int getInitiativeBonus(){
-        System.out.println("reached here"+ initiativeBonus);
         return initiativeBonus;
     }
      public void setInitiativeBonus(int bonus){
@@ -5507,7 +5506,7 @@ public class Campaign implements ITechManager {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "lastMissionId", lastMissionId);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "lastScenarioId", lastScenarioId);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "calendar", getLocalDate());
-
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "InitiativeBonus", initiativeBonus);
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "nameGen");
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "faction", RandomNameGenerator.getInstance().getChosenFaction());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "percentFemale", RandomGenderGenerator.getPercentFemale());

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -265,6 +265,7 @@ public class Campaign implements ITechManager {
     private int crimeRating;
     private int crimePirateModifier;
     private LocalDate dateOfLastCrime;
+    private int initiativeBonus;
     private final CampaignSummary campaignSummary;
     private final Quartermaster quartermaster;
     private StoryArc storyArc;
@@ -306,6 +307,7 @@ public class Campaign implements ITechManager {
         crimeRating = 0;
         crimePirateModifier = 0;
         dateOfLastCrime = null;
+        initiativeBonus = 10;
         setRankSystemDirect(Ranks.getRankSystemFromCode(Ranks.DEFAULT_SYSTEM_CODE));
         forces = new Force(name);
         forceIds.put(0, forces);
@@ -4462,6 +4464,22 @@ public class Campaign implements ITechManager {
 
         if (currentDay.getDayOfWeek().equals(DayOfWeek.MONDAY)) {
             reputation.initializeReputation(this);
+        }
+    }
+
+    public int getInitiativeBonus(){
+        System.out.println("reached here"+ initiativeBonus);
+        return initiativeBonus;
+    }
+     public void setInitiativeBonus(int bonus){
+        initiativeBonus = bonus;
+    }
+
+    public void initiativeBonusIncrement(boolean change){
+        if(change){
+            setInitiativeBonus(++initiativeBonus);
+        }else{
+             setInitiativeBonus(--initiativeBonus);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -688,6 +688,8 @@ public class CampaignXmlParser {
                     retVal.setRetainerStartDate(LocalDate.parse(wn.getTextContent()));
                 } else if (xn.equalsIgnoreCase("crimeRating")) {
                     retVal.setCrimeRating(Integer.parseInt(wn.getTextContent()));
+                } else if (xn.equalsIgnoreCase("initiativeBonus")) {
+                    retVal.setInitiativeBonus(Integer.parseInt(wn.getTextContent()));
                 } else if (xn.equalsIgnoreCase("crimePirateModifier")) {
                     retVal.setCrimePirateModifier(Integer.parseInt(wn.getTextContent()));
                 } else if (xn.equalsIgnoreCase("dateOfLastCrime")) {


### PR DESCRIPTION
Added initiative bonus to campaign and passes it to megaMek's constantInitBonus.

Currently doesn't have bonus/negative ceiling, but can implement something along those lines if needed.  
The initiativeBonusIncrement function takes a boolean-->  true increases by 1, false decrease by one.


closes #4600


In future could tie bonus to fatigue/morale module