### PR TITLE
Refactored Strategic Formations

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -472,6 +472,13 @@ public class Campaign implements ITechManager {
         for (StrategicFormation strategicFormation : strategicFormations.values()) {
             if (!strategicFormation.isEligible(this)) {
                 formationsToSanitize.add(strategicFormation.getForceId());
+                try {
+                    Force force = getForce(strategicFormation.getForceId());
+                    force.setStrategicFormation(false);
+                } catch (Exception ex) {
+                    // We're not too worried if we can't find the associated Force,
+                    // as this just means it has been deleted at some point and not removed correctly.
+                }
             }
         }
 
@@ -4333,6 +4340,7 @@ public class Campaign implements ITechManager {
     private void processNewDayForces() {
         // update formation levels
         Force.populateFormationLevelsFromOrigin(this);
+        recalculateStrategicFormations(this);
 
         // Update the force icons based on the end-of-day unit status if desired
         if (MekHQ.getMHQOptions().getNewDayForceIconOperationalStatus()) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -459,8 +459,8 @@ public class Campaign implements ITechManager {
         strategicFormations.put(strategicFormation.getForceId(), strategicFormation);
     }
 
-    public void setStrategicFormations(final Hashtable<Integer, StrategicFormation> strategicFormations) {
-        this.strategicFormations = strategicFormations;
+    public void removeStrategicFormation(final int forceId) {
+        this.strategicFormations.remove(forceId);
     }
 
     public Hashtable<Integer, StrategicFormation> getStrategicFormations() {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -455,15 +455,35 @@ public class Campaign implements ITechManager {
         return new ArrayList<>(forceIds.values());
     }
 
-    public void importStrategicFormation(StrategicFormation strategicFormation) {
+    /**
+     * Adds a {@link StrategicFormation} to the {@code strategicFormations} {@link Hashtable} using
+     * {@code forceId} as the key.
+     *
+     * @param strategicFormation the {@link StrategicFormation} to be added to the {@link Hashtable}
+     */
+    public void addStrategicFormation(StrategicFormation strategicFormation) {
         strategicFormations.put(strategicFormation.getForceId(), strategicFormation);
     }
 
+    /**
+     * Removes a {@link StrategicFormation} from the {@code strategicFormations} {@link Hashtable}
+     * using {@code forceId} as they key.
+     *
+     * @param forceId the key of the {@link StrategicFormation} to be removed from the {@link Hashtable}
+     */
     public void removeStrategicFormation(final int forceId) {
         this.strategicFormations.remove(forceId);
     }
 
-    public Hashtable<Integer, StrategicFormation> getStrategicFormations() {
+    /**
+     * Returns the {@link Hashtable} containing all the {@link StrategicFormation} objects after
+     * removing the ineligible ones. Although sanitization might not be necessary, it ensures that
+     * there is no need for {@code isEligible()} checks when fetching the {@link Hashtable}.
+     *
+     * @return the sanitized {@link Hashtable} of {@link StrategicFormation} objects stored in the
+     * current campaign.
+     */
+    public Hashtable<Integer, StrategicFormation> getStrategicFormationsTable() {
         // Here we sanitize the list, ensuring ineligible formations have been removed before
         // returning the hashtable. In theory, this shouldn't be necessary, however, having this
         // sanitizing step should remove the need for isEligible() checks whenever we fetch the
@@ -489,10 +509,19 @@ public class Campaign implements ITechManager {
         return strategicFormations;
     }
 
-    public ArrayList<StrategicFormation> getStrategicFormationList() {
-        // This call allows us to utilize the self-sanitizing feature of getStrategicFormations(),
+    /**
+     * Returns an {@link ArrayList} of all {@link StrategicFormation} objects in the
+     * {@code strategicFormations} {@link Hashtable}.
+     * Calls the {@code getStrategicFormationsTable()} method to sanitize the {@link Hashtable}
+     * before conversion to {@link ArrayList}.
+     *
+     * @return an {@link ArrayList} of all the {@link StrategicFormation} objects in the
+     * {@code strategicFormations} {@link Hashtable}
+     */
+    public ArrayList<StrategicFormation> getAllStrategicFormations() {
+        // This call allows us to utilize the self-sanitizing feature of getStrategicFormationsTable(),
         // without needing to directly include the code here, too.
-        strategicFormations = getStrategicFormations();
+        strategicFormations = getStrategicFormationsTable();
 
         return strategicFormations.values().stream()
                 .filter(l -> forceIds.containsKey(l.getForceId()))
@@ -3814,7 +3843,7 @@ public class Campaign implements ITechManager {
             processShipSearch();
 
             // Training Experience - Award to eligible training Strategic Formations on active contracts
-            getStrategicFormations().values().stream()
+            getStrategicFormationsTable().values().stream()
                     .filter(strategicFormation -> strategicFormation.getRole().isTraining()
                             && (strategicFormation.getContract(this) != null) && strategicFormation.isEligible(this)
                             && strategicFormation.getContract(this).isActiveOn(getLocalDate(), true))

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -397,9 +397,7 @@ public class Force {
         }
 
         for (Force force : subForces) {
-            if (force.getOverrideStrategicFormation() != STRATEGIC_FORMATION_OVERRIDE_FALSE) {
-                allUnits.addAll(force.getAllUnits(combatForcesOnly));
-            }
+            allUnits.addAll(force.getAllUnits(combatForcesOnly));
         }
 
         return allUnits;

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -389,15 +389,19 @@ public class Force {
      */
     public Vector<UUID> getAllUnits(boolean combatForcesOnly) {
         Vector<UUID> allUnits;
+
         if (combatForcesOnly && !isCombatForce()) {
             allUnits = new Vector<>();
         } else {
             allUnits = new Vector<>(units);
         }
 
-        for (Force f : subForces) {
-            allUnits.addAll(f.getAllUnits(combatForcesOnly));
+        for (Force force : subForces) {
+            if (force.getOverrideStrategicFormation() != STRATEGIC_FORMATION_OVERRIDE_FALSE) {
+                allUnits.addAll(force.getAllUnits(combatForcesOnly));
+            }
         }
+
         return allUnits;
     }
 
@@ -841,11 +845,7 @@ public class Force {
     public int getTotalBV(Campaign campaign, boolean forceStandardBattleValue) {
         int bvTotal = 0;
 
-        for (Force subforce : getSubForces()) {
-            bvTotal += subforce.getTotalBV(campaign, forceStandardBattleValue);
-        }
-
-        for (UUID unitId : getUnits()) {
+        for (UUID unitId : getAllUnits(false)) {
             // no idea how this would happen, but sometimes a unit in a forces unit ID list
             // has an invalid ID?
             if (campaign.getUnit(unitId) == null) {
@@ -904,16 +904,16 @@ public class Force {
      * Calculates the unit type most represented in this force
      * and all subforces.
      *
-     * @param c Working campaign
+     * @param campaign Working campaign
      * @return Majority unit type.
      */
-    public int getPrimaryUnitType(Campaign c) {
+    public int getPrimaryUnitType(Campaign campaign) {
         Map<Integer, Integer> unitTypeBuckets = new TreeMap<>();
         int biggestBucketID = -1;
         int biggestBucketCount = 0;
 
-        for (UUID id : getUnits()) {
-            int unitType = c.getUnit(id).getEntity().getUnitType();
+        for (UUID id : getAllUnits(false)) {
+            int unitType = campaign.getUnit(id).getEntity().getUnitType();
 
             unitTypeBuckets.merge(unitType, 1, Integer::sum);
 

--- a/MekHQ/src/mekhq/campaign/force/StrategicFormation.java
+++ b/MekHQ/src/mekhq/campaign/force/StrategicFormation.java
@@ -621,7 +621,7 @@ public class StrategicFormation {
      * @param campaign the current campaign.
      */
     public static void recalculateStrategicFormations(Campaign campaign) {
-        Hashtable<Integer, StrategicFormation> strategicFormations = campaign.getStrategicFormations();
+        Hashtable<Integer, StrategicFormation> strategicFormations = campaign.getStrategicFormationsTable();
         StrategicFormation strategicFormation = strategicFormations.get(0); // This is the origin node
         Force force = campaign.getForce(0);
 
@@ -640,7 +640,7 @@ public class StrategicFormation {
             boolean isEligible = strategicFormation.isEligible(campaign);
 
             if (isEligible) {
-                campaign.importStrategicFormation(strategicFormation);
+                campaign.addStrategicFormation(strategicFormation);
             }
 
             force.setStrategicFormation(isEligible);
@@ -648,7 +648,7 @@ public class StrategicFormation {
 
         // Update the TO&E and then begin recursively walking it
         MekHQ.triggerEvent(new OrganizationChangedEvent(force));
-        recalculateSubForceStrategicStatus(campaign, campaign.getStrategicFormations(), force);
+        recalculateSubForceStrategicStatus(campaign, campaign.getStrategicFormationsTable(), force);
     }
 
     /**
@@ -686,7 +686,7 @@ public class StrategicFormation {
                 boolean isEligible = strategicFormation.isEligible(campaign);
 
                 if (isEligible) {
-                    campaign.importStrategicFormation(strategicFormation);
+                    campaign.addStrategicFormation(strategicFormation);
                 }
 
                 force.setStrategicFormation(isEligible);
@@ -694,7 +694,7 @@ public class StrategicFormation {
 
             // Update the TO&E and then continue recursively walking it
             MekHQ.triggerEvent(new OrganizationChangedEvent(force));
-            recalculateSubForceStrategicStatus(campaign, campaign.getStrategicFormations(), force);
+            recalculateSubForceStrategicStatus(campaign, campaign.getStrategicFormationsTable(), force);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -78,6 +78,7 @@ import java.time.LocalDate;
 import java.util.*;
 import java.util.Map.Entry;
 
+import static mekhq.campaign.force.StrategicFormation.recalculateStrategicFormations;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 
@@ -854,6 +855,7 @@ public class CampaignXmlParser {
             }
         }
 
+        recalculateStrategicFormations(retVal);
         logger.info("Load of Force Organization complete!");
     }
 

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -793,7 +793,7 @@ public class CampaignXmlParser {
             StrategicFormation strategicFormation = StrategicFormation.generateInstanceFromXML(wn2);
 
             if (strategicFormation != null) {
-                campaign.importLance(strategicFormation);
+                campaign.importStrategicFormation(strategicFormation);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -355,7 +355,7 @@ public class CampaignXmlParser {
 
         // determine if we've missed any lances and add those back into the campaign
         if (options.isUseAtB()) {
-            Hashtable<Integer, StrategicFormation> lances = retVal.getStrategicFormations();
+            Hashtable<Integer, StrategicFormation> lances = retVal.getStrategicFormationsTable();
             for (Force f : retVal.getAllForces()) {
                 if (!f.getUnits().isEmpty() && (null == lances.get(f.getId()))) {
                     lances.put(f.getId(), new StrategicFormation(f.getId(), retVal));
@@ -794,7 +794,7 @@ public class CampaignXmlParser {
             StrategicFormation strategicFormation = StrategicFormation.generateInstanceFromXML(wn2);
 
             if (strategicFormation != null) {
-                campaign.importStrategicFormation(strategicFormation);
+                campaign.addStrategicFormation(strategicFormation);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -371,7 +371,7 @@ public class AtBDynamicScenario extends AtBScenario {
             return null; // if we don't have forces, just a bunch of units, then get the highest-ranked?
         }
 
-        StrategicFormation strategicFormation = campaign.getStrategicFormations().get(getForceIDs().get(0));
+        StrategicFormation strategicFormation = campaign.getStrategicFormationsTable().get(getForceIDs().get(0));
 
         if (strategicFormation != null) {
             strategicFormation.refreshCommander(campaign);

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -445,6 +445,10 @@ public class AtBDynamicScenarioFactory {
         int forceBV = 0;
         double forceMultiplier = forceTemplate.getForceMultiplier();
 
+        if (forceMultiplier == 0) {
+            forceMultiplier = 1;
+        }
+
         if (forceMultiplier != 1) {
             logger.info(String.format("Force BV Multiplier: %s (from scenario template)", forceMultiplier));
         }

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -192,7 +192,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     // key-value pairs linking transports and the units loaded onto them.
     private Map<String, List<String>> transportLinkages;
 
-    private Map<Integer, Integer> numPlayerMinefields;
+    private final Map<Integer, Integer> numPlayerMinefields;
 
     private String terrainType;
 
@@ -1971,7 +1971,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     }
 
     public StrategicFormation getStrategicFormation(Campaign campaign) {
-        return campaign.getStrategicFormations().get(strategicFormationId);
+        return campaign.getStrategicFormationsTable().get(strategicFormationId);
     }
 
     public void setLance(StrategicFormation strategicFormation) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -32,7 +32,7 @@ import java.util.*;
 public class AtBScenarioFactory {
     private static final MMLogger logger = MMLogger.create(AtBScenarioFactory.class);
 
-    private static Map<Integer, List<Class<IAtBScenario>>> scenarioMap = new HashMap<>();
+    private static final Map<Integer, List<Class<IAtBScenario>>> scenarioMap = new HashMap<>();
 
     static {
         registerScenario(new AceDuelBuiltInScenario());
@@ -126,7 +126,7 @@ public class AtBScenarioFactory {
         }
 
         // If we have an active contract, then we can progress with generation
-        Hashtable<Integer, StrategicFormation> strategicFormations = campaign.getStrategicFormations();
+        Hashtable<Integer, StrategicFormation> strategicFormations = campaign.getStrategicFormationsTable();
 
         List<AtBScenario> sList;
         List<Integer> assignedLances = new ArrayList<>();

--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/MiscAwards.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/MiscAwards.java
@@ -279,7 +279,7 @@ public class MiscAwards {
      */
     private static boolean drillInstructor(Campaign campaign, Award award, UUID person) {
         if (award.canBeAwarded(campaign.getPerson(person))) {
-            return campaign.getStrategicFormationList().stream()
+            return campaign.getAllStrategicFormations().stream()
                     .anyMatch(lance -> (lance.getRole().isTraining()) && (lance.getCommanderId().equals(person)));
         }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1438,7 +1438,7 @@ public class StratconRulesManager {
         // assemble a set of all force IDs that are currently assigned to tracks that are not this one
         Set<Integer> forcesInTracks = campaign.getActiveAtBContracts().stream()
                 .flatMap(contract -> contract.getStratconCampaignState().getTracks().stream())
-                .filter(track -> (track != currentTrack) || !reinforcements)
+                .filter(track -> (!Objects.equals(track, currentTrack)) || !reinforcements)
                 .flatMap(track -> track.getAssignedForceCoords().keySet().stream())
                 .collect(Collectors.toSet());
 
@@ -1449,10 +1449,6 @@ public class StratconRulesManager {
         }
 
         for (StrategicFormation formation : campaign.getStrategicFormations().values()) {
-            if (!formation.isEligible(campaign)) {
-                continue;
-            }
-
             Force force = campaign.getForce(formation.getForceId());
 
             if (force == null) {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -833,7 +833,7 @@ public class StratconRulesManager {
             MekHQ.triggerEvent(new ScenarioChangedEvent(scenario.getBackingScenario()));
         }
 
-        if (campaign.getStrategicFormations().get(forceID).getRole().isScouting()) {
+        if (campaign.getStrategicFormationsTable().get(forceID).getRole().isScouting()) {
             for (int direction = 0; direction < 6; direction++) {
                 StratconCoords checkCoords = coords.translate(direction);
 
@@ -1043,7 +1043,7 @@ public class StratconRulesManager {
         if (lanceCommander != null){
             Unit commanderUnit = lanceCommander.getUnit();
             if (commanderUnit != null) {
-                StrategicFormation lance = campaign.getStrategicFormations().get(commanderUnit.getForceId());
+                StrategicFormation lance = campaign.getStrategicFormationsTable().get(commanderUnit.getForceId());
 
                 return (lance != null) && lance.getRole().isDefence();
             }
@@ -1415,7 +1415,7 @@ public class StratconRulesManager {
         // that are
         // deployed to a scenario and not in a track already
 
-        return campaign.getStrategicFormations().keySet().stream()
+        return campaign.getStrategicFormationsTable().keySet().stream()
                 .mapToInt(key -> key)
                 .mapToObj(campaign::getForce).filter(force -> (force != null)
                         && !force.isDeployed()
@@ -1448,7 +1448,7 @@ public class StratconRulesManager {
             forcesInTracks.addAll(currentScenario.getFailedReinforcements());
         }
 
-        for (StrategicFormation formation : campaign.getStrategicFormations().values()) {
+        for (StrategicFormation formation : campaign.getStrategicFormationsTable().values()) {
             Force force = campaign.getForce(formation.getForceId());
 
             if (force == null) {
@@ -1671,8 +1671,8 @@ public class StratconRulesManager {
 
         // if the force is in 'fight' stance, it'll be able to deploy using 'fight
         // lance' rules
-        if (campaign.getStrategicFormations().containsKey(forceID)
-                && (campaign.getStrategicFormations().get(forceID).getRole().isFighting())) {
+        if (campaign.getStrategicFormationsTable().containsKey(forceID)
+                && (campaign.getStrategicFormationsTable().get(forceID).getRole().isFighting())) {
             return ReinforcementEligibilityType.FightLance;
         }
 

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -452,6 +452,14 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             singleForce.setStrategicFormation(!formationState);
             singleForce.setOverrideStrategicFormation(formationState ? STRATEGIC_FORMATION_OVERRIDE_FALSE : STRATEGIC_FORMATION_OVERRIDE_TRUE);
 
+            for (Force childForce : singleForce.getAllSubForces()) {
+                childForce.setOverrideStrategicFormation(STRATEGIC_FORMATION_OVERRIDE_NONE);
+            }
+
+            for (Force parentForce : singleForce.getAllParents()) {
+                parentForce.setOverrideStrategicFormation(STRATEGIC_FORMATION_OVERRIDE_NONE);
+            }
+
             recalculateStrategicFormations(gui.getCampaign());
         } else if (command.contains(REMOVE_STRATEGIC_FORCE_OVERRIDE)) {
             if (singleForce == null) {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -58,6 +58,7 @@ import java.util.*;
 import static mekhq.campaign.force.Force.STRATEGIC_FORMATION_OVERRIDE_FALSE;
 import static mekhq.campaign.force.Force.STRATEGIC_FORMATION_OVERRIDE_NONE;
 import static mekhq.campaign.force.Force.STRATEGIC_FORMATION_OVERRIDE_TRUE;
+import static mekhq.campaign.force.StrategicFormation.recalculateStrategicFormations;
 
 public class TOEMouseAdapter extends JPopupMenuAdapter {
     private static final MMLogger logger = MMLogger.create(TOEMouseAdapter.class);
@@ -449,21 +450,16 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
 
             boolean formationState = singleForce.isStrategicFormation();
             singleForce.setStrategicFormation(!formationState);
-            singleForce.setOverrideStrategicFormation(!formationState ? STRATEGIC_FORMATION_OVERRIDE_TRUE : STRATEGIC_FORMATION_OVERRIDE_FALSE);
+            singleForce.setOverrideStrategicFormation(formationState ? STRATEGIC_FORMATION_OVERRIDE_FALSE : STRATEGIC_FORMATION_OVERRIDE_TRUE);
 
-            for (Force formation : gui.getCampaign().getAllForces()) {
-                MekHQ.triggerEvent(new OrganizationChangedEvent(formation));
-            }
+            recalculateStrategicFormations(gui.getCampaign());
         } else if (command.contains(REMOVE_STRATEGIC_FORCE_OVERRIDE)) {
             if (singleForce == null) {
                 return;
             }
 
             singleForce.setOverrideStrategicFormation(STRATEGIC_FORMATION_OVERRIDE_NONE);
-
-            for (Force formation : gui.getCampaign().getAllForces()) {
-                MekHQ.triggerEvent(new OrganizationChangedEvent(formation));
-            }
+            recalculateStrategicFormations(gui.getCampaign());
         } else if (command.contains(TOEMouseAdapter.REMOVE_FORCE)) {
             for (Force force : forces) {
                 if (null != force && null != force.getParentForce()) {
@@ -1041,28 +1037,30 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 popup.add(menuItem);
             }
 
-            menuItem = new JMenuItem(force.isCombatForce() ? "Make Non-Combat Force" : "Make Combat Force");
-            menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUS + forceIds);
-            menuItem.addActionListener(this);
-            popup.add(menuItem);
+            if (gui.getCampaign().getCampaignOptions().isUseAtB()) {
+                menuItem = new JMenuItem(force.isCombatForce() ? "Make Non-Combat Force" : "Make Combat Force");
+                menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUS + forceIds);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
 
-            menuItem = new JMenuItem(force.isCombatForce() ? "Make Force and Subforces Non-Combat Forces"
-                    : "Make Force and Subforces Combat Forces");
-            menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUSES + forceIds);
-            menuItem.addActionListener(this);
-            popup.add(menuItem);
+                menuItem = new JMenuItem(force.isCombatForce() ?
+                    "Make Force and Subforces Non-Combat Forces" : "Make Force and Subforces Combat Forces");
+                menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUSES + forceIds);
+                menuItem.addActionListener(this);
+                popup.add(menuItem);
 
-            JMenuItem optionStrategicForceOverride = new JMenuItem((force.isStrategicFormation() ?
-                "Never" : "Always") + " Consider Force a Strategic Formation");
-            optionStrategicForceOverride.setActionCommand(COMMAND_CHANGE_STRATEGIC_FORCE_OVERRIDE + forceIds);
-            optionStrategicForceOverride.addActionListener(this);
-            popup.add(optionStrategicForceOverride);
+                JMenuItem optionStrategicForceOverride = new JMenuItem((force.isStrategicFormation() ?
+                    "Never" : "Always") + " Consider Force a Strategic Formation");
+                optionStrategicForceOverride.setActionCommand(COMMAND_CHANGE_STRATEGIC_FORCE_OVERRIDE + forceIds);
+                optionStrategicForceOverride.addActionListener(this);
+                popup.add(optionStrategicForceOverride);
 
-            JMenuItem optionRemoveStrategicForceOverride = new JMenuItem("Remove Strategic Force Override");
-            optionRemoveStrategicForceOverride.setActionCommand(COMMAND_REMOVE_STRATEGIC_FORCE_OVERRIDE + forceIds);
-            optionRemoveStrategicForceOverride.addActionListener(this);
-            optionRemoveStrategicForceOverride.setVisible(force.getOverrideStrategicFormation() != STRATEGIC_FORMATION_OVERRIDE_NONE);
-            popup.add(optionRemoveStrategicForceOverride);
+                JMenuItem optionRemoveStrategicForceOverride = new JMenuItem("Remove Strategic Force Override");
+                optionRemoveStrategicForceOverride.setActionCommand(COMMAND_REMOVE_STRATEGIC_FORCE_OVERRIDE + forceIds);
+                optionRemoveStrategicForceOverride.addActionListener(this);
+                optionRemoveStrategicForceOverride.setVisible(force.getOverrideStrategicFormation() != STRATEGIC_FORMATION_OVERRIDE_NONE);
+                popup.add(optionRemoveStrategicForceOverride);
+            }
 
             if (StaticChecks.areAllForcesUndeployed(gui.getCampaign(), forces)
                     && StaticChecks.areAllCombatForces(forces)) {

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -98,6 +98,7 @@ import java.util.Map.Entry;
 import java.util.stream.IntStream;
 
 import static megamek.client.ui.WrapLayout.wordWrap;
+import static mekhq.campaign.force.StrategicFormation.recalculateStrategicFormations;
 
 /**
  * @author Justin 'Windchild' Bowen
@@ -9569,6 +9570,8 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             // endregion Against the Bot
 
             campaign.setCampaignOptions(options);
+
+            recalculateStrategicFormations(campaign);
 
             MekHQ.triggerEvent(new OptionsChangedEvent(campaign, options));
         } catch (Exception ex) {

--- a/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardLanceRenderer.java
+++ b/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardLanceRenderer.java
@@ -50,7 +50,7 @@ public class ScenarioWizardLanceRenderer extends JLabel implements ListCellRende
         setForeground(foreground);
         setBackground(background);
 
-        StrategicFormation lance = campaign.getStrategicFormations().get(value.getId());
+        StrategicFormation lance = campaign.getStrategicFormationsTable().get(value.getId());
         String roleString = "";
         if (lance != null) {
             roleString = lance.getRole().toString() + ", ";

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -223,14 +223,14 @@ public class LanceAssignmentView extends JPanel {
             cbContract.addItem(contract);
         }
         AtBContract defaultContract = activeContracts.isEmpty() ? null : activeContracts.get(0);
-        for (StrategicFormation strategicFormation : campaign.getStrategicFormations().values()) {
+        for (StrategicFormation strategicFormation : campaign.getStrategicFormationsTable().values()) {
             if ((strategicFormation.getContract(campaign) == null)
                     || !strategicFormation.getContract(campaign).isActiveOn(campaign.getLocalDate(), true)) {
                 strategicFormation.setContract(defaultContract);
             }
         }
         ((DataTableModel) tblRequiredLances.getModel()).setData(activeContracts);
-        ((DataTableModel) tblAssignments.getModel()).setData(campaign.getStrategicFormationList());
+        ((DataTableModel) tblAssignments.getModel()).setData(campaign.getAllStrategicFormations());
         panRequiredLances.setVisible(tblRequiredLances.getRowCount() > 0);
     }
 
@@ -285,7 +285,7 @@ class RequiredLancesTableModel extends DataTableModel {
     public static final int COL_TRAINING = 5;
     public static final int COL_NUM = 6;
 
-    private Campaign campaign;
+    private final Campaign campaign;
 
     public RequiredLancesTableModel(final Campaign campaign) {
         this.campaign = campaign;
@@ -344,7 +344,7 @@ class RequiredLancesTableModel extends DataTableModel {
         if (data.get(row) instanceof AtBContract contract) {
             if (column == COL_TOTAL) {
                 int t = 0;
-                for (StrategicFormation strategicFormation : campaign.getStrategicFormationList()) {
+                for (StrategicFormation strategicFormation : campaign.getAllStrategicFormations()) {
                     if (data.get(row).equals(strategicFormation.getContract(campaign))
                             && (strategicFormation.getRole() != AtBLanceRole.UNASSIGNED)
                             && strategicFormation.isEligible(campaign)) {
@@ -357,7 +357,7 @@ class RequiredLancesTableModel extends DataTableModel {
                 return Integer.toString(contract.getRequiredLances());
             } else if (contract.getContractType().getRequiredLanceRole().ordinal() == column - 2) {
                 int t = 0;
-                for (StrategicFormation strategicFormation : campaign.getStrategicFormationList()) {
+                for (StrategicFormation strategicFormation : campaign.getAllStrategicFormations()) {
                     if (data.get(row).equals(strategicFormation.getContract(campaign))
                             && (strategicFormation.getRole() == strategicFormation.getContract(campaign).getContractType().getRequiredLanceRole())
                             && strategicFormation.isEligible(campaign)) {
@@ -382,7 +382,7 @@ class LanceAssignmentTableModel extends DataTableModel {
     public static final int COL_ROLE = 3;
     public static final int COL_NUM = 4;
 
-    private Campaign campaign;
+    private final Campaign campaign;
 
     public LanceAssignmentTableModel(Campaign campaign) {
         this.campaign = campaign;


### PR DESCRIPTION
This PR does a bunch of refactoring for the new Strategic Formations system. It bolsters existing methods with a few extra calls and integrates better across MHQ. This includes self-sanitizing methods and a centralized way to review the TO&E to ensure it's always up-to-date. A number of bugs have been resolved and the general user experience has been improved.