### PR TITLE
Null checks in manual contract generation

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewAtBContractDialog.java
@@ -509,7 +509,24 @@ public class NewAtBContractDialog extends NewContractDialog {
 
     @Override
     protected void btnOKActionPerformed(ActionEvent evt) {
+        
         if (!btnOK.equals(evt.getSource())) {
+            return;
+        }
+
+        if (getCurrentEmployerCode() == null) {
+            JOptionPane.showMessageDialog(rootPane, "Make sure you set Employer!",
+                    "Contract is Missing Field", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        if (getCurrentEnemyCode() == null) {
+            JOptionPane.showMessageDialog(rootPane, "Make sure you set Enemy!",
+                    "Contract is Missing Field", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+        if (cbPlanets.getSelectedItem() == null) {
+            JOptionPane.showMessageDialog(rootPane, "Make sure you set the Planet!",
+                    "Contract is Missing Field", JOptionPane.WARNING_MESSAGE);
             return;
         }
 


### PR DESCRIPTION
closes #5149 

Added null checks for Employer, Enemy, and Planet with matching messages.

![image](https://github.com/user-attachments/assets/34ae85a0-774e-4561-8bf6-523e271acb6c)
![image](https://github.com/user-attachments/assets/6fcca4de-8d4a-4f1a-9627-e6919c710db9)
