### PR TITLE
BriefingTab  Fix

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -320,12 +320,11 @@ public final class BriefingTab extends CampaignGuiTab {
                     ? new NewAtBContractDialog(getFrame(), true, getCampaign())
                     : new NewContractDialog(getFrame(), true, getCampaign());
             ncd.setVisible(true);
-            this.setVisible(false);
             comboMission.setSelectedItem(ncd.getContract());
-        } else {
+        }
+         if (mtd.isMission()) {
             CustomizeMissionDialog cmd = new CustomizeMissionDialog(getFrame(), true, null, getCampaign());
             cmd.setVisible(true);
-            this.setVisible(false);
             comboMission.setSelectedItem(cmd.getMission());
         }
     }

--- a/MekHQ/src/mekhq/gui/dialog/MissionTypeDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MissionTypeDialog.java
@@ -39,6 +39,7 @@ public class MissionTypeDialog extends JDialog {
     private static final MMLogger logger = MMLogger.create(MissionTypeDialog.class);
 
     private boolean contract;
+    private boolean mission;
 
     public MissionTypeDialog(final JFrame frame, final boolean modal) {
         super(frame, modal);
@@ -60,7 +61,7 @@ public class MissionTypeDialog extends JDialog {
         btnMission.setToolTipText(resourceMap.getString("btnMission.tooltip"));
         btnMission.setName("btnMission");
         btnMission.addActionListener(evt -> {
-            contract = false;
+            mission = true;
             setVisible(false);
         });
         getContentPane().add(btnMission);
@@ -91,5 +92,9 @@ public class MissionTypeDialog extends JDialog {
 
     public boolean isContract() {
         return contract;
+    }
+    
+    public boolean isMission() {
+        return mission;
     }
 }


### PR DESCRIPTION
Bad behavior on canceling "Add Mission" was due to single boolean check if mission was contract.  If add mission tab was closed it would default to false and CustomizeMissionDialog frame would be generated.
   -- added isMission() check 

Also set briefing tab to remain visible.

Add mission check to AddMission and left BriefTab visible
closes #5060