### PR TITLE
Implemented Advanced StratCon Reinforcements

### DIFF
--- a/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ScenarioTemplate>
+    <name>Low-Atmosphere Reinforcements Intercepted</name>
+    <shortBriefing>Destroy hostile air forces.</shortBriefing>
+    <detailedBriefing>Hostile air units have intercepted your reinforcements. Destroy at least 50% of the enemy force while preserving 50% of your own units.</detailedBriefing>
+    <mapParameters>
+        <allowedTerrainTypes />
+        <allowRotation>false</allowRotation>
+        <baseHeight>50</baseHeight>
+        <baseWidth>50</baseWidth>
+        <heightScalingIncrement>5</heightScalingIncrement>
+        <mapLocation>LowAtmosphere</mapLocation>
+        <useStandardAtBSizing>true</useStandardAtBSizing>
+        <widthScalingIncrement>5</widthScalingIncrement>
+    </mapParameters>
+    <scenarioForces>
+        <entry>
+            <key>Player</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-3</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>true</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>true</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>0</deploymentZone>
+                    <deploymentZone>1</deploymentZone>
+                    <deploymentZone>2</deploymentZone>
+                    <deploymentZone>3</deploymentZone>
+                    <deploymentZone>4</deploymentZone>
+                    <deploymentZone>5</deploymentZone>
+                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>7</deploymentZone>
+                    <deploymentZone>8</deploymentZone>
+                    <deploymentZone>9</deploymentZone>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>0</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>Player</forceName>
+                <generationMethod>0</generationMethod>
+                <generationOrder>1</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>OpFor</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-3</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones />
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>OpFor</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>5</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>5</startingAltitude>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>Player</syncedForceName>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+    </scenarioForces>
+    <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>OpFor</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Destroy or rout 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Player</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Preserve 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+    </scenarioObjectives>
+</ScenarioTemplate>

--- a/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ScenarioTemplate>
+    <name>Reinforcements Intercepted</name>
+    <shortBriefing>Destroy hostile forces.</shortBriefing>
+    <detailedBriefing>Hostile units have intercepted your reinforcements. Destroy at least 50% of the enemy force while preserving 50% of your own units.</detailedBriefing>
+    <mapParameters>
+        <allowedTerrainTypes />
+        <allowRotation>false</allowRotation>
+        <baseHeight>0</baseHeight>
+        <baseWidth>0</baseWidth>
+        <heightScalingIncrement>5</heightScalingIncrement>
+        <mapLocation>AllGroundTerrain</mapLocation>
+        <useStandardAtBSizing>true</useStandardAtBSizing>
+        <widthScalingIncrement>5</widthScalingIncrement>
+    </mapParameters>
+    <scenarioForces>
+        <entry>
+            <key>Player</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>true</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>true</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>0</deploymentZone>
+                    <deploymentZone>1</deploymentZone>
+                    <deploymentZone>2</deploymentZone>
+                    <deploymentZone>3</deploymentZone>
+                    <deploymentZone>4</deploymentZone>
+                    <deploymentZone>5</deploymentZone>
+                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>7</deploymentZone>
+                    <deploymentZone>8</deploymentZone>
+                    <deploymentZone>9</deploymentZone>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>0</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>Player</forceName>
+                <generationMethod>0</generationMethod>
+                <generationOrder>1</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>OpFor</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-2</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones />
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>OpFor</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>5</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>Player</syncedForceName>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+    </scenarioForces>
+    <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>OpFor</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Destroy or rout 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Player</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Preserve 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+    </scenarioObjectives>
+</ScenarioTemplate>

--- a/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ScenarioTemplate>
+    <name>Space Reinforcements Intercepted</name>
+    <shortBriefing>Destroy hostile air forces.</shortBriefing>
+    <detailedBriefing>Hostile air units have intercepted your reinforcements. Destroy at least 50% of the enemy force while preserving 50% of your own units.</detailedBriefing>
+    <isHostileFacility>false</isHostileFacility>
+    <isAlliedFacility>false</isAlliedFacility>
+    <mapParameters>
+        <allowedTerrainTypes />
+        <allowRotation>false</allowRotation>
+        <baseHeight>50</baseHeight>
+        <baseWidth>50</baseWidth>
+        <heightScalingIncrement>5</heightScalingIncrement>
+        <mapLocation>Space</mapLocation>
+        <useStandardAtBSizing>true</useStandardAtBSizing>
+        <widthScalingIncrement>5</widthScalingIncrement>
+    </mapParameters>
+    <scenarioForces>
+        <entry>
+            <key>Player</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>9</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>true</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>true</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones>
+                    <deploymentZone>0</deploymentZone>
+                    <deploymentZone>1</deploymentZone>
+                    <deploymentZone>2</deploymentZone>
+                    <deploymentZone>3</deploymentZone>
+                    <deploymentZone>4</deploymentZone>
+                    <deploymentZone>5</deploymentZone>
+                    <deploymentZone>6</deploymentZone>
+                    <deploymentZone>7</deploymentZone>
+                    <deploymentZone>8</deploymentZone>
+                    <deploymentZone>9</deploymentZone>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>0</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>Player</forceName>
+                <generationMethod>0</generationMethod>
+                <generationOrder>1</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>0</startingAltitude>
+                <syncDeploymentType>None</syncDeploymentType>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+        <entry>
+            <key>OpFor</key>
+            <value>
+                <actualDeploymentZone>-1</actualDeploymentZone>
+                <allowAeroBombs>false</allowAeroBombs>
+                <allowedUnitType>-3</allowedUnitType>
+                <arrivalTurn>0</arrivalTurn>
+                <canReinforceLinked>true</canReinforceLinked>
+                <contributesToBV>false</contributesToBV>
+                <contributesToMapSize>true</contributesToMapSize>
+                <contributesToUnitCount>false</contributesToUnitCount>
+                <deployOffboard>false</deployOffboard>
+                <deploymentZones />
+                <destinationZone>5</destinationZone>
+                <fixedUnitCount>0</fixedUnitCount>
+                <forceAlignment>2</forceAlignment>
+                <forceMultiplier>1.0</forceMultiplier>
+                <forceName>OpFor</forceName>
+                <generationMethod>1</generationMethod>
+                <generationOrder>5</generationOrder>
+                <maxWeightClass>4</maxWeightClass>
+                <minWeightClass>0</minWeightClass>
+                <objectiveLinkedForces />
+                <retreatThreshold>50</retreatThreshold>
+                <startingAltitude>5</startingAltitude>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>Player</syncedForceName>
+                <useArtillery>false</useArtillery>
+            </value>
+        </entry>
+    </scenarioForces>
+    <scenarioObjectives>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>OpFor</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Destroy or rout 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Player</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Preserve 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+    </scenarioObjectives>
+</ScenarioTemplate>

--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -30,24 +30,28 @@ reinforcementsNoAdminSkill.text=Attempting to reinforce scenario %s, %s<b>ERROR<
   \ <i>Administration</i> skill. Roll automatically fails. No Support Points were spent in this\
   \ attempt.
 reinforcementsAttempt.text=Attempting to reinforce scenario %s, roll <b>%s%s</b> vs. <b>%s</b>:
-reinforcementsCriticalFailure.text=%s<b>Critical Logistics Failure</b>%s. Reinforcement attempt\
+reinforcementsCriticalFailure.text=%s<b>Critical Command Failure</b>%s. Reinforcement attempt\
   \ fails and Support Point is lost.
-reinforcementsSuccessNoInterception.text= %s<b>Reinforcement Success</b>%s. The enemy failed to\
-  \ intercept your reinforcements.
-reinforcementsInterceptionAttempt.text= Enemy forces attempted to %s<b>Intercept</b>%s your reinforcements.
-reinforcementsErrorNoCommander.text= %s<b>Error</b>%s. There is no commander assigned to this force.\
-  \ Reinforcement attempt fails and Support Point is lost.
+reinforcementsSuccess.text=%s<b>Reinforcement Success</b>%s.
+reinforcementsSuccessRouted.text=%s<b>Reinforcement Success</b>%s. The enemy has routed\
+  \ and is unable to intercept your reinforcements.
+reinforcementsCommandFailure.text=%s<b>Command Failure</b>%s. Reinforcement attempt\
+  \ fails and Support Point is lost.
+reinforcementsInterceptionAttempt.text=Due to a %s<b>Command Failure</b>%s your reinforcements are\
+  \ out of position. Enemy forces were dispatched in an attempt to capitalize on this tactical error.
+reinforcementsErrorNoCommander.text=%s<b>Error</b>%s. There is no commander assigned to this force.\
+  \ Reinforcement attempt fails and Support Point is lost. You should report this bug.
 reinforcementsErrorUnableToFetchCommander.text= %s<b>Error</b>%s. We were unable to fetch the\
-  \ commander using the commander ID logged for this force. You should report this. Reinforcement\
-  \ attempt fails and Support Point is lost.
-reinforcementCommanderNoSkill.text=" %s<b>Automatic Evasion Failure</b>%s. The commander of the\
-  \ reinforcements does not possess the <i>Tactics</i> skill. They are unable to evade the enemy\
+  \ commander using the commander ID logged for this force. You should report this bug.\
+  \ Reinforcement attempt fails and Support Point is lost.
+reinforcementCommanderNoSkill.text=%s<b>Automatic Evasion Failure</b>%s. The commander of the\
+  \ reinforcements does not possess the <i>Tactics</i> skill. They were unable to evade enemy\
   \ forces. An interception scenario has occurred. The reinforcing force has already been assigned\
-  \ to this new scenario."
-reinforcementEvasionSuccessful.text= %s<b>Evasion Success</b>%s (%s vs. %s). The commander of the\
-  \ reinforcements was able to use their <i>Tactics</i> skill to evade the enemy interception.\
-  \ Reinforcements were delayed, but successful.
-reinforcementEvasionUnsuccessful.text= %s<b>Evasion Unsuccessful</b>%s (%s vs. %s). The commander\
+  \ to this new scenario.
+reinforcementEvasionSuccessful.text=%s<b>Evasion Success</b>%s (%s vs. %s). The commander of the\
+  \ reinforcements was able to use their <i>Tactics</i> skill to evade the enemy long enough to\
+  \ reach safety. Reinforcements were delayed, but successful.
+reinforcementEvasionUnsuccessful.text=%s<b>Evasion Unsuccessful</b>%s (%s vs. %s). The commander\
   \ of the reinforcements attempted to use their <i>Tactics</i> skill to evade the enemy\
   \ interception, but was unsuccessful. An interception scenario has occurred. The reinforcing\
   \ force has already been assigned to this new scenario.

--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -32,7 +32,6 @@ reinforcementsNoAdminSkill.text=Attempting to reinforce scenario %s, %s<b>ERROR<
 reinforcementsAttempt.text=Attempting to reinforce scenario %s, roll <b>%s%s</b> vs. <b>%s</b>:
 reinforcementsCriticalFailure.text=%s<b>Critical Logistics Failure</b>%s. Reinforcement attempt\
   \ fails and Support Point is lost.
-reinforcementsSuccess.text= %s<b>Reinforcement Success</b>%s
 reinforcementsSuccessNoInterception.text= %s<b>Reinforcement Success</b>%s. The enemy failed to\
   \ intercept your reinforcements.
 reinforcementsInterceptionAttempt.text= Enemy forces attempted to %s<b>Intercept</b>%s your reinforcements.

--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -1,17 +1,54 @@
-supportPoint.text=Support Point
-supportPointConvert.text=Will convert VP from SP
-reinforcementRoll.Text=Reinforcement Roll
+regular.text=Regular Reinforcement Roll
+lanceInFightRole.text=Improved Reinforcement Roll
 fromChainedScenario.text=Lance already deployed
-lanceInFightRole.text=Fight-Role Reinforcement Roll
 
 lblDefensiveMinefieldCount.text=Defensive Minefield Count: %d
 lblSelectIndividualUnits.text=Select individual units (%d max)
 
-lblDefensivePostureInstructions.Text=This lance is on a defensive deployment and you may deploy additional infantry, battle armor, or minefields.
-lblLeadershipInstructions.Text=The force commander's leadership allows the deployment of additional auxiliary units - choose from the list below.
+lblDefensivePostureInstructions.Text=<html>This lance is on a defensive deployment.\
+  <br>You may deploy additional infantry, battle armor, or minefields.</html>
+lblLeadershipInstructions.Text=<html>The force commander's <i>Leadership</i> allows the deployment of additional\
+  \ auxiliary units - choose from the list below.</html>
 lblFCLeadershipAvailable.Text=<html>Force commander's leadership: %d%s%s</html>
 lblLeaderUnitsUsed.Text=<br/>%d units already assigned
 lblLeadershipReinforcementsUnavailable.Text=<br/>Leadership reinforcements unavailable
 
-selectForceForTemplate.Text=Select at least %d forces from the list below
-selectReinforcementsForTemplate.Text=Select reinforcements from the list below
+selectForceForTemplate.Text=<html><b>Select a force from the list below.</b>\
+  <br>\
+  <br>If multiple forces are selected, only the first will be deployed.</html>
+selectReinforcementsForTemplate.Text=<html><b>Select reinforcements from the list below.</b>\
+  <br>\
+  <br>Each attempt will cost 1 Support Point and may be unsuccessful.</html>
+selectReinforcementsForTemplateNoSupportPoints.Text=<html><b>Unable to assign reinforcements. No Support Points available.</b></html>
+
+reinforcementsNoSupportPoints.text=Attempting to reinforce scenario %s, %s<b>Automatic Failure</b>%s You\
+  \ have no remaining Support Points.
+reinforcementsNoAdmin.text=Attempting to reinforce scenario %s, %s<b>ERROR</b>%s nobody has been\
+  \ assigned to an <i>Admin/Command</i> position. Roll automatically fails. No Support Points were\
+  \ spent in this attempt.
+reinforcementsNoAdminSkill.text=Attempting to reinforce scenario %s, %s<b>ERROR</b>%s %s does not have the\
+  \ <i>Administration</i> skill. Roll automatically fails. No Support Points were spent in this\
+  \ attempt.
+reinforcementsAttempt.text=Attempting to reinforce scenario %s, roll <b>%s%s</b> vs. <b>%s</b>:
+reinforcementsCriticalFailure.text=%s<b>Critical Logistics Failure</b>%s. Reinforcement attempt\
+  \ fails and Support Point is lost.
+reinforcementsSuccess.text= %s<b>Reinforcement Success</b>%s
+reinforcementsSuccessNoInterception.text= %s<b>Reinforcement Success</b>%s. The enemy failed to\
+  \ intercept your reinforcements.
+reinforcementsInterceptionAttempt.text= Enemy forces attempted to %s<b>Intercept</b>%s your reinforcements.
+reinforcementsErrorNoCommander.text= %s<b>Error</b>%s. There is no commander assigned to this force.\
+  \ Reinforcement attempt fails and Support Point is lost.
+reinforcementsErrorUnableToFetchCommander.text= %s<b>Error</b>%s. We were unable to fetch the\
+  \ commander using the commander ID logged for this force. You should report this. Reinforcement\
+  \ attempt fails and Support Point is lost.
+reinforcementCommanderNoSkill.text=" %s<b>Automatic Evasion Failure</b>%s. The commander of the\
+  \ reinforcements does not possess the <i>Tactics</i> skill. They are unable to evade the enemy\
+  \ forces. An interception scenario has occurred. The reinforcing force has already been assigned\
+  \ to this new scenario."
+reinforcementEvasionSuccessful.text= %s<b>Evasion Success</b>%s (%s vs. %s). The commander of the\
+  \ reinforcements was able to use their <i>Tactics</i> skill to evade the enemy interception.\
+  \ Reinforcements were delayed, but successful.
+reinforcementEvasionUnsuccessful.text= %s<b>Evasion Unsuccessful</b>%s (%s vs. %s). The commander\
+  \ of the reinforcements attempted to use their <i>Tactics</i> skill to evade the enemy\
+  \ interception, but was unsuccessful. An interception scenario has occurred. The reinforcing\
+  \ force has already been assigned to this new scenario.

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3932,7 +3932,7 @@ public class Campaign implements ITechManager {
      * Admin/Transport personnel skill levels and contract start dates are considered during negotiations.
      * Side effects include state changes and report generation.
      */
-    private void negotiateAdditionalSupportPoints() {
+    public void negotiateAdditionalSupportPoints() {
         // Fetch a list of all Admin/Transport personnel
         List<Person> adminTransport = new ArrayList<>();
 
@@ -4565,7 +4565,7 @@ public class Campaign implements ITechManager {
     public int getInitiativeBonus() {
         return initiativeBonus;
     }
-    
+
     public void setInitiativeBonus(int bonus) {
         initiativeBonus = bonus;
     }
@@ -4573,7 +4573,7 @@ public class Campaign implements ITechManager {
     public void applyInitiativeBonus(int bonus) {
         if (bonus > initiativeMaxBonus) {
             initiativeMaxBonus = bonus;
-        } 
+        }
         if ((bonus + initiativeBonus) > initiativeMaxBonus) {
             initiativeBonus = initiativeMaxBonus;
         } else {

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -67,6 +67,7 @@ public class AtBDynamicScenario extends AtBScenario {
     private double effectivePlayerBVMultiplier; // Additive multiplier
 
     private int friendlyReinforcementDelayReduction;
+    private List<UUID> friendlyDelayedReinforcements;
     private int hostileReinforcementDelayReduction;
 
     // derived fields used for various calculations
@@ -92,6 +93,7 @@ public class AtBDynamicScenario extends AtBScenario {
         setEffectivePlayerUnitCountMultiplier(0.0);
         setEffectivePlayerBVMultiplier(0.0);
         setFriendlyReinforcementDelayReduction(0);
+        setFriendlyDelayedReinforcements(new ArrayList<>());
         setHostileReinforcementDelayReduction(0);
         setEffectiveOpforSkill(SkillLevel.REGULAR);
         setEffectiveOpforQuality(IUnitRating.DRAGOON_C);
@@ -312,6 +314,14 @@ public class AtBDynamicScenario extends AtBScenario {
         effectiveOpforQuality = qualityLevel;
     }
 
+    public List<UUID> getFriendlyDelayedReinforcements() {
+        return friendlyDelayedReinforcements;
+    }
+
+    public void setFriendlyDelayedReinforcements(final List<UUID> friendlyDelayedReinforcements) {
+        this.friendlyDelayedReinforcements = friendlyDelayedReinforcements;
+    }
+
     public int getFriendlyReinforcementDelayReduction() {
         return friendlyReinforcementDelayReduction;
     }
@@ -482,6 +492,7 @@ public class AtBDynamicScenario extends AtBScenario {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "effectivePlayerUnitCountMultiplier", getEffectivePlayerUnitCountMultiplier());
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "effectivePlayerBVMultiplier", getEffectivePlayerBVMultiplier());
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "friendlyReinforcementDelayReduction", getFriendlyReinforcementDelayReduction());
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "friendlyDelayedReinforcements", getFriendlyDelayedReinforcements());
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "hostileReinforcementDelayReduction", getHostileReinforcementDelayReduction());
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "effectiveOpforSkill", getEffectiveOpforSkill().name());
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "effectiveOpforQuality", getEffectiveOpforQuality());
@@ -525,6 +536,11 @@ public class AtBDynamicScenario extends AtBScenario {
                 setEffectivePlayerBVMultiplier(Double.parseDouble(wn2.getTextContent().trim()));
             } else if (wn2.getNodeName().equalsIgnoreCase("friendlyReinforcementDelayReduction")) {
                 setFriendlyReinforcementDelayReduction(Integer.parseInt(wn2.getTextContent().trim()));
+            } else if (wn2.getNodeName().equalsIgnoreCase("friendlyDelayedReinforcements")) {
+                String[] values = wn2.getTextContent().split(",");
+                for (String value : values) {
+                    getFriendlyDelayedReinforcements().add(UUID.fromString(value));
+                }
             } else if (wn2.getNodeName().equalsIgnoreCase("hostileReinforcementDelayReduction")) {
                 setHostileReinforcementDelayReduction(Integer.parseInt(wn2.getTextContent().trim()));
             } else if (wn2.getNodeName().equalsIgnoreCase("effectiveOpforSkill")) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -102,7 +102,7 @@ public class AtBDynamicScenarioFactory {
     private static final double OPPORTUNISTIC = 1.0;
     private static final double LIBERAL = 1.25;
 
-    private static final int REINFORCEMENT_ARRIVAL_SCALE = 30;
+    private static final int REINFORCEMENT_ARRIVAL_SCALE = 15;
 
     private static final ResourceBundle resources = ResourceBundle.getBundle(
             "mekhq.resources.AtBDynamicScenarioFactory",
@@ -3696,17 +3696,15 @@ public class AtBDynamicScenarioFactory {
             if ((speed < minimumSpeed) && (speed > 0)) {
                 minimumSpeed = speed;
             }
-        }
 
-        // the actual arrival turn will be the scale divided by the slowest speed.
-        // so, a group of Atlases (3/5) should arrive on turn 10 (30 / 3)
-        // a group of jump-capable Griffins (5/8/5) should arrive on turn 5 (30 / 6)
-        // a group of Ostscouts (8/12/8) should arrive on turn 3 (30 / 9, rounded down)
-        // we then subtract the passed-in turn modifier, which is usually the
-        // commander's strategy skill level.
-        int actualArrivalTurn = Math.max(0, (arrivalScale / minimumSpeed) - turnModifier);
+            // the actual arrival turn will be the scale divided by the slowest speed.
+            // so, a group of Atlases (3/5) should arrive at turn 7 (20 / 3)
+            // a group of jump-capable Griffins (5/8/5) should arrive on turn 3 (20 / 6, rounded down)
+            // a group of Ostscouts (8/12/8) should arrive on turn 2 (20 / 9, rounded down)
+            // we then subtract the passed-in turn modifier, which is usually the
+            // commander's strategy skill level.
+            int actualArrivalTurn = Math.max(0, (arrivalScale / minimumSpeed) - turnModifier);
 
-        for (Entity entity : entityList) {
             entity.setDeployRound(actualArrivalTurn);
         }
     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -221,6 +221,9 @@ public class StratconContractInitializer {
             }
         }
 
+        // Determine starting Support Points
+        campaign.negotiateAdditionalSupportPoints();
+
         // now we're done
     }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -373,7 +373,7 @@ public class StratconRulesManager {
      * scenario is set as the current date.
      *
      * @param campaign the current campaign
-     * @param contract the {@link AtBContract for which the scenario is created
+     * @param contract the {@link AtBContract} for which the scenario is created
      * @param track the {@link StratconTrackState} where the scenario is located, or {@code null}
      * if not located on a track
      * @param template the {@link ScenarioTemplate} used to create the scenario
@@ -1160,7 +1160,6 @@ public class StratconRulesManager {
                 CLOSING_SPAN_TAG));
             campaign.addReport(reportStatus.toString());
 
-            StratconCoords scenarioCoords = scenario.getCoords();
             MapLocation mapLocation = scenario.getScenarioTemplate().mapParameters.getMapLocation();
 
             String templateString = "data/scenariotemplates/%sReinforcements Intercepted.xml";
@@ -1200,7 +1199,6 @@ public class StratconRulesManager {
             CLOSING_SPAN_TAG, roll, targetNumber));
         campaign.addReport(reportStatus.toString());
 
-        StratconCoords scenarioCoords = scenario.getCoords();
         MapLocation mapLocation = scenario.getScenarioTemplate().mapParameters.getMapLocation();
 
         String templateString = "data/scenariotemplates/%sReinforcements Intercepted.xml";

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -19,6 +19,7 @@
 package mekhq.gui.stratcon;
 
 import megamek.common.Minefield;
+import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
@@ -28,6 +29,7 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.stratcon.StratconRulesManager.ReinforcementEligibilityType;
+import mekhq.campaign.stratcon.StratconRulesManager.ReinforcementResultsType;
 import mekhq.campaign.stratcon.StratconScenario;
 import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
 import mekhq.campaign.stratcon.StratconTrackState;
@@ -41,7 +43,11 @@ import java.awt.event.ActionEvent;
 import java.util.List;
 import java.util.*;
 
-import static mekhq.utilities.ReportingUtilities.messageSurroundedBySpanWithColor;
+import static mekhq.campaign.stratcon.StratconRulesManager.ReinforcementResultsType.DELAYED;
+import static mekhq.campaign.stratcon.StratconRulesManager.ReinforcementResultsType.FAILED;
+import static mekhq.campaign.stratcon.StratconRulesManager.processReinforcementDeployment;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 /**
  * UI for managing force/unit assignments for individual StratCon scenarios.
@@ -54,13 +60,15 @@ public class StratconScenarioWizard extends JDialog {
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AtBStratCon",
             MekHQ.getMHQOptions().getLocale());
 
-    private Map<String, JList<Force>> availableForceLists = new HashMap<>();
-    private Map<String, JList<Unit>> availableUnitLists = new HashMap<>();
+    private final Map<String, JList<Force>> availableForceLists = new HashMap<>();
+    private final Map<String, JList<Unit>> availableUnitLists = new HashMap<>();
 
     private JList<Unit> availableInfantryUnits = new JList<>();
     private JList<Unit> availableLeadershipUnits = new JList<>();
 
     private JButton btnCommit;
+
+    private static final MMLogger logger = MMLogger.create(StratconScenarioWizard.class);
 
     public StratconScenarioWizard(Campaign campaign) {
         this.campaign = campaign;
@@ -96,39 +104,36 @@ public class StratconScenarioWizard extends JDialog {
         gbc.anchor = GridBagConstraints.WEST;
         setInstructions(gbc);
 
-        switch (currentScenario.getCurrentState()) {
-            case UNRESOLVED:
+        if (Objects.requireNonNull(currentScenario.getCurrentState()) == ScenarioState.UNRESOLVED) {
+            gbc.gridy++;
+            setAssignForcesUI(gbc, false);
+        } else {
+            gbc.gridy++;
+            setAssignForcesUI(gbc, true);
+            gbc.gridy++;
+
+            List<Unit> eligibleLeadershipUnits = StratconRulesManager.getEligibleLeadershipUnits(campaign,
+                currentScenario.getPrimaryForceIDs());
+
+            eligibleLeadershipUnits.sort(Comparator.comparing(Unit::getName));
+
+            int leadershipSkill = currentScenario.getBackingScenario().getLanceCommanderSkill(SkillType.S_LEADER, campaign);
+
+            if (!eligibleLeadershipUnits.isEmpty() && (leadershipSkill > 0)) {
+                setLeadershipUI(gbc, eligibleLeadershipUnits, leadershipSkill);
                 gbc.gridy++;
-                setAssignForcesUI(gbc, false);
-                break;
-            default:
+            }
+
+            if (currentScenario.getNumDefensivePoints() > 0) {
+                setDefensiveUI(gbc);
                 gbc.gridy++;
-                setAssignForcesUI(gbc, true);
-                gbc.gridy++;
-
-                List<Unit> eligibleLeadershipUnits = StratconRulesManager.getEligibleLeadershipUnits(campaign,
-                        currentScenario.getPrimaryForceIDs());
-
-                eligibleLeadershipUnits.sort(Comparator.comparing(Unit::getName));
-
-                int leadershipSkill = currentScenario.getBackingScenario().getLanceCommanderSkill(SkillType.S_LEADER,
-                        campaign);
-
-                if (!eligibleLeadershipUnits.isEmpty() && (leadershipSkill > 0)) {
-                    setLeadershipUI(gbc, eligibleLeadershipUnits, leadershipSkill);
-                    gbc.gridy++;
-                }
-
-                if (currentScenario.getNumDefensivePoints() > 0) {
-                    setDefensiveUI(gbc);
-                    gbc.gridy++;
-                }
-                break;
+            }
         }
 
         gbc.gridx = 0;
         gbc.gridy++;
         setNavigationButtons(gbc);
+
         pack();
         validate();
     }
@@ -148,13 +153,10 @@ public class StratconScenarioWizard extends JDialog {
             labelBuilder.append(currentScenario.getInfo());
         }
 
-        switch (currentScenario.getCurrentState()) {
-            case UNRESOLVED:
-                labelBuilder.append("primaryForceAssignmentInstructions.text");
-                break;
-            default:
-                labelBuilder.append("reinforcementsAndSupportInstructions.text");
-                break;
+        if (Objects.requireNonNull(currentScenario.getCurrentState()) == ScenarioState.UNRESOLVED) {
+            labelBuilder.append("primaryForceAssignmentInstructions.text");
+        } else {
+            labelBuilder.append("reinforcementsAndSupportInstructions.text");
         }
 
         labelBuilder.append("<br/>");
@@ -182,9 +184,12 @@ public class StratconScenarioWizard extends JDialog {
             localGbc.gridx = 0;
             localGbc.gridy = 0;
 
-            String labelText = reinforcements ? resourceMap.getString("selectReinforcementsForTemplate.Text")
-                    : String.format(resourceMap.getString("selectForceForTemplate.Text"),
-                            currentScenario.getRequiredPlayerLances());
+            String reinforcementMessage = currentCampaignState.getSupportPoints() > 0 ?
+                resourceMap.getString("selectReinforcementsForTemplate.Text") :
+                resourceMap.getString("selectReinforcementsForTemplateNoSupportPoints.Text");
+
+            String labelText = reinforcements ? reinforcementMessage
+                : resourceMap.getString("selectForceForTemplate.Text");
 
             JLabel assignForceListInstructions = new JLabel(labelText);
             forcePanel.add(assignForceListInstructions, localGbc);
@@ -273,13 +278,10 @@ public class StratconScenarioWizard extends JDialog {
             ScenarioForceTemplate forceTemplate) {
         JScrollPane forceListContainer = new JScrollPaneWithSpeed();
 
-        ScenarioWizardLanceModel lanceModel;
-
-        lanceModel = new ScenarioWizardLanceModel(campaign,
-                StratconRulesManager.getAvailableForceIDs(forceTemplate.getAllowedUnitType(),
-                        campaign, currentTrackState,
-                        (forceTemplate.getArrivalTurn() == ScenarioForceTemplate.ARRIVAL_TURN_AS_REINFORCEMENTS),
-                        currentScenario, currentCampaignState));
+        ScenarioWizardLanceModel lanceModel = new ScenarioWizardLanceModel(campaign,
+            StratconRulesManager.getAvailableForceIDs(forceTemplate.getAllowedUnitType(), campaign, currentTrackState,
+                (forceTemplate.getArrivalTurn() == ScenarioForceTemplate.ARRIVAL_TURN_AS_REINFORCEMENTS),
+                currentScenario, currentCampaignState));
 
         JList<Force> availableForceList = new JList<>();
         availableForceList.setModel(lanceModel);
@@ -405,21 +407,13 @@ public class StratconScenarioWizard extends JDialog {
         costBuilder.append('(');
 
         switch (StratconRulesManager.getReinforcementType(forceID, currentTrackState, campaign, currentCampaignState)) {
-            case SupportPoint:
-                costBuilder.append(resourceMap.getString("supportPoint.text"));
-
-                if (currentCampaignState.getSupportPoints() <= 0) {
-                    costBuilder.append(", ");
-
-                    costBuilder.append(messageSurroundedBySpanWithColor(
-                            MekHQ.getMHQOptions().getFontColorNegativeHexColor(),
-                            resourceMap.getString("reinforcementRoll.Text")));
-                }
+            case REGULAR:
+                costBuilder.append(resourceMap.getString("regular.text"));
                 break;
-            case ChainedScenario:
+            case CHAINED_SCENARIO:
                 costBuilder.append(resourceMap.getString("fromChainedScenario.text"));
                 break;
-            case FightLance:
+            case FIGHT_LANCE:
                 costBuilder.append(resourceMap.getString("lanceInFightRole.text"));
                 break;
             default:
@@ -459,19 +453,46 @@ public class StratconScenarioWizard extends JDialog {
             for (Force force : availableForceLists.get(templateID).getSelectedValuesList()) {
                 // if we are assigning reinforcements, pay the price if appropriate
                 if (currentScenario.getCurrentState() == ScenarioState.PRIMARY_FORCES_COMMITTED) {
+                    if (currentCampaignState.getSupportPoints() <= 0) {
+                        campaign.addReport(String.format(resourceMap.getString("reinforcementsNoSupportPoints.text"),
+                            currentScenario.getName(),
+                            spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
+                            CLOSING_SPAN_TAG));
+                        continue;
+                    }
+
                     ReinforcementEligibilityType reinforcementType = StratconRulesManager.getReinforcementType(
                             force.getId(), currentTrackState,
                             campaign, currentCampaignState);
 
                     // if we failed to deploy as reinforcements, move on to the next force
-                    if (!StratconRulesManager.processReinforcementDeployment(reinforcementType, currentCampaignState,
-                            currentScenario, campaign)) {
+                    ReinforcementResultsType reinforcementResults = processReinforcementDeployment(
+                        force, reinforcementType, currentCampaignState, currentScenario, campaign);
+
+                    if (reinforcementResults.ordinal() >= FAILED.ordinal()) {
                         currentScenario.addFailedReinforcements(force.getId());
                         continue;
                     }
-                }
 
-                currentScenario.addForce(force, templateID, campaign);
+                    currentScenario.addForce(force, templateID, campaign);
+
+                    if (reinforcementResults == DELAYED) {
+                        List<UUID> delayedReinforcements = currentScenario.getBackingScenario().getFriendlyDelayedReinforcements();
+
+                        for (UUID unitId : force.getAllUnits(true)) {
+                            try {
+                                delayedReinforcements.add(unitId);
+                            } catch (Exception ex) {
+                                logger.error(ex.getMessage(), ex);
+                            }
+                        }
+                    }
+                } else {
+                    // In the event the player has selected multiple forces to act as the primary
+                    // force, only commit the first force
+                    currentScenario.addForce(force, templateID, campaign);
+                    break;
+                }
             }
         }
 
@@ -496,10 +517,8 @@ public class StratconScenarioWizard extends JDialog {
         }
 
         // scenarios that haven't had primary forces committed yet get those committed
-        // now
-        // and the scenario gets published to the campaign and may be played immediately
-        // from the briefing room
-        // that being said, give the player a chance to commit reinforcements too
+        // now and the scenario gets published to the campaign and may be played immediately
+        // from the briefing room that being said, give the player a chance to commit reinforcements too
         if (currentScenario.getCurrentState() == ScenarioState.UNRESOLVED) {
             // if we've already generated forces and applied modifiers, no need to do it
             // twice


### PR DESCRIPTION
### Introduction
The previous reinforcement implementation created some balancing concerns. The gameplay loop would be this: scenario spawns, player deploys a lance, the player then reinforces that scenario using Forces in Fight Stance. This is easily done by converting CVP to SP, if necessary. The player will usually out-BV Princess at this point, allowing for a much easier victory. This generates a CVP, making future scenarios easier. So long as the player can maintain CVP above 1 they can infinitely reinforce. The only limitation is the number of Forces available to them. As they are taking less casualties they end up in a victory spiral where past victories ensure future victories. There is a bit more to it than that, but that's the general gist.

Following a handful of discussions on Discord it was determined that a more advanced implementation was desirable.

### Overview
- All reinforcement attempts cost 1 SP, no matter what role the force is in.
- All reinforcements require a reinforcement check, no matter what role the force is in. Forces in the Fight role re-roll this check using the best result.

### Reinforcement Checks
1. We start by identifying the most senior character in the Admin/Command role. This character is handling communication between the Primary Force, the would-be reinforcements, and any local allied forces. Their Administration skill is used to determine the base Target Number for the reinforcement role.
- If the campaign has no personnel in the Admin/Command role, the check is automatically failed with no Support Points spent.
- If the most senior character in the Admin/Command role does not have the Administration skill (somehow), the check is automatically failed however a Support Point is still spent.

2. Next we identify any _Facility Modifier_. Currently a -1 is applied to the Target Number for each allied facility in the relevant Sector, while a +1 malus is applied for each enemy facility.
3. Then we identify the _Skill Modifier_. This is equal to the skill level of your enemies, minus the skill level of your employer. If using CamOps Reputation and on an Independent contract, your Experience Rating is used instead of your employer's skill.
4. If the contract's command rights are _Liaison_ the Target Number is reduced by 1. If the contract's command rights are _House_ or _Integrated_ the Target number is reduced by 2.
5. Finally, a 2d6 roll is made. If this equals or beats the Target Number the reinforcement check has been passed.
- Forces in the Fight role make two attempts, picking the best result.
- If the 2d6 roll is less than the Target Number or a natural, unmodified 2, then the check has been failed. The Support Point is lost and no reinforcement occurs. Otherwise the check is successful, however we now need to determine whether the enemy has intercepted the reinforcements.

### Interception Check
- Interception checks only occur if the reinforcement was successful.

1. First we roll a d100 and compare the result to the scenario chance for the relevant track. If the roll beats the scenario chance no interception occurs.
- Scenario chance is directly linked to enemy Morale, so the players will need to judge for themselves whether they can risk interception when reinforcing.

2. If an interception occurs, we need to determine whether the leader of the reinforcements was able to evade the interception. The evasion target number is equal to 9 - the force leader's _Tactics_ skill (including Skill Bonus, if present).
- 'Force Leader' is the character marked as the leader of the reinforcing force in your TO&E
- If the force leader does not have the _Tactics_ skill evasion is automatically failed.

3. If an interception occurs, but is evaded, then the reinforcements will arrive but will have been delayed. This means their arrival time is doubled or tripled (based on a d2+1 die roll).
- Evading an interception counts as a scenario, for the purposes of Fatigue.
4. If an interception occurs, and evasion is failed, then the reinforcements have been intercepted. A special interception scenario is spawned with the reinforcements automatically assigned to that scenario.
- Players can choose to reinforce interception scenarios, as normal.
- The date of the interception scenario is equal to the current date, so depending on the date of the original scenario it may be possible for the interception force to return and then assist with the original scenario.
- The scenario can occur in any unoccupied hex in the track. Currently StratCon doesn't handle having multiple scenarios in the same hex very well, so players will just have to use their imagination.

### Fixed Exploits
- It is no longer possible to bypass reinforcement rolls by assigning multiple units as the primary force.
- It is no longer possible to bypass the Support Point cost of reinforcement rolls by picking multiple reinforcement forces at the same time.

### Other
- It should be noted that a campaign's Admin/Transport personnel generate Support Points on a monthly basis. This was added by a prior PR, but is being mentioned here for those users unaware of that change.
- StratCon contracts will now initialize with Support Points based on the skill of the campaign's Admin/Transport personnel.

### Closes #4733