### PR TITLE
Campaign now uses pickRandomCamouflage when initialized

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -149,7 +149,7 @@ import static mekhq.campaign.personnel.education.EducationController.getAcademy;
 import static mekhq.campaign.personnel.turnoverAndRetention.RetirementDefectionTracker.Payout.isBreakingContract;
 import static mekhq.campaign.unit.Unit.SITE_FACILITY_BASIC;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
-
+import static mekhq.campaign.mission.AtBContract.pickRandomCamouflage;
 /**
  * The main campaign class, keeps track of teams and units
  *
@@ -224,7 +224,7 @@ public class Campaign implements ITechManager {
     private boolean gmMode;
     private transient boolean overviewLoadingValue = true;
 
-    private Camouflage camouflage = new Camouflage(Camouflage.COLOUR_CAMOUFLAGE, PlayerColour.BLUE.name());
+    private Camouflage camouflage = pickRandomCamouflage(3025, "Root");
     private PlayerColour colour = PlayerColour.BLUE;
     private StandardForceIcon unitIcon = new UnitIcon(null, null);
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -267,15 +267,10 @@ public class AtBContract extends Contract {
         List<Path> allPaths = null;
 
         try {
-            // if(factionCode == "Root"){
-            //     allPaths = Files.find(Paths.get(ROOT_DIRECTORY + camouflageDirectory), Integer.MAX_VALUE,
-            //             (path, bfa) -> bfa.isRegularFile())
-            //             .toList();
-            // }else {
             allPaths = Files.find(Paths.get(ROOT_DIRECTORY + camouflageDirectory + '/'), Integer.MAX_VALUE,
                     (path, bfa) -> bfa.isRegularFile())
                 .toList();
-            // }
+
         } catch (IOException e) {
             logger.error("Error getting list of camouflages", e);
         }

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -267,9 +267,15 @@ public class AtBContract extends Contract {
         List<Path> allPaths = null;
 
         try {
+            // if(factionCode == "Root"){
+            //     allPaths = Files.find(Paths.get(ROOT_DIRECTORY + camouflageDirectory), Integer.MAX_VALUE,
+            //             (path, bfa) -> bfa.isRegularFile())
+            //             .toList();
+            // }else {
             allPaths = Files.find(Paths.get(ROOT_DIRECTORY + camouflageDirectory + '/'), Integer.MAX_VALUE,
                     (path, bfa) -> bfa.isRegularFile())
                 .toList();
+            // }
         } catch (IOException e) {
             logger.error("Error getting list of camouflages", e);
         }
@@ -326,6 +332,7 @@ public class AtBContract extends Contract {
             case "SL" -> "Star League Defense Force";
             case "TC" -> "Taurian Concordat";
             case "WOB" -> "Word of Blake";
+            case "Root" -> "";
             default -> {
                 Faction faction = Factions.getInstance().getFaction(factionCode);
 


### PR DESCRIPTION


Modified pickRandomCamo to have "Root" faction that selects from all faction icons and implemented it in Campaign.

closes #5114