### PR TITLE
Refactored CVP Conversion to Removal of CVP.

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconCampaignState.java
@@ -18,14 +18,6 @@
  */
 package mekhq.campaign.stratcon;
 
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.namespace.QName;
-
-import org.w3c.dom.Node;
-
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.Marshaller;
@@ -36,6 +28,12 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import megamek.logging.MMLogger;
 import mekhq.campaign.mission.AtBContract;
+import org.w3c.dom.Node;
+
+import javax.xml.namespace.QName;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Contract-level state object for a StratCon campaign.
@@ -63,7 +61,7 @@ public class StratconCampaignState {
 
     @XmlElementWrapper(name = "campaignTracks")
     @XmlElement(name = "campaignTrack")
-    private List<StratconTrackState> tracks;
+    private final List<StratconTrackState> tracks;
 
     @XmlTransient
     public AtBContract getContract() {
@@ -154,11 +152,6 @@ public class StratconCampaignState {
 
     public void useSupportPoint() {
         supportPoints--;
-    }
-
-    public void convertVictoryToSupportPoint() {
-        victoryPoints--;
-        supportPoints++;
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/stratcon/CampaignManagementDialog.java
+++ b/MekHQ/src/mekhq/gui/stratcon/CampaignManagementDialog.java
@@ -34,8 +34,8 @@ import java.awt.event.ActionEvent;
  */
 public class CampaignManagementDialog extends JDialog {
     private StratconCampaignState currentCampaignState;
-    private StratconTab parent;
-    private JButton btnConvertVPToSP;
+    private final StratconTab parent;
+    private JButton btnRemoveCVP;
     private JButton btnConvertSPtoBonusPart;
     private JButton btnGMAddVP;
     private JButton btnGMAddSP;
@@ -53,7 +53,7 @@ public class CampaignManagementDialog extends JDialog {
     public void display(StratconCampaignState campaignState, StratconTrackState currentTrack, boolean gmMode) {
         currentCampaignState = campaignState;
 
-        btnConvertVPToSP.setEnabled(currentCampaignState.getVictoryPoints() > 0);
+        btnRemoveCVP.setEnabled(currentCampaignState.getVictoryPoints() > 0);
         btnConvertSPtoBonusPart.setEnabled(currentCampaignState.getSupportPoints() > 0);
         btnGMAddVP.setEnabled(gmMode);
         btnGMAddSP.setEnabled(gmMode);
@@ -78,10 +78,10 @@ public class CampaignManagementDialog extends JDialog {
         getContentPane().removeAll();
         getContentPane().setLayout(layout);
 
-        btnConvertVPToSP = new JButton();
-        btnConvertVPToSP.setText("Convert CVP to SP");
-        btnConvertVPToSP.addActionListener(this::convertVPtoSPHandler);
-        getContentPane().add(btnConvertVPToSP);
+        btnRemoveCVP = new JButton();
+        btnRemoveCVP.setText("Remove CVP (GM)");
+        btnRemoveCVP.addActionListener(this::removeCVP);
+        getContentPane().add(btnRemoveCVP);
 
         btnConvertSPtoBonusPart = new JButton();
         btnConvertSPtoBonusPart.setText("Convert SP to bonus part");
@@ -104,10 +104,9 @@ public class CampaignManagementDialog extends JDialog {
         pack();
     }
 
-    private void convertVPtoSPHandler(ActionEvent e) {
-        currentCampaignState.convertVictoryToSupportPoint();
-        btnConvertVPToSP.setEnabled(currentCampaignState.getVictoryPoints() > 0);
-        btnConvertSPtoBonusPart.setEnabled(currentCampaignState.getSupportPoints() > 0);
+    private void removeCVP(ActionEvent e) {
+        currentCampaignState.updateVictoryPoints(-1);
+
         parent.updateCampaignState();
     }
 
@@ -120,7 +119,7 @@ public class CampaignManagementDialog extends JDialog {
 
     private void gmAddVPHandler(ActionEvent e) {
         currentCampaignState.updateVictoryPoints(1);
-        btnConvertVPToSP.setEnabled(currentCampaignState.getVictoryPoints() > 0);
+        btnRemoveCVP.setEnabled(currentCampaignState.getVictoryPoints() > 0);
         parent.updateCampaignState();
     }
 


### PR DESCRIPTION
Removed the conversion of victory points to support points and replaced it with a GM function to remove victory points.

At will SP is very powerful, and while recent changes have reduced the effectiveness of SP, it was decided that we should remove at will SP sources.

Players are awarded with extra XP if they get over a certain number of CVP, meaning excess CVP are not wasted.

The primary source of SP is Admin/Transport personnel who generate monthly SP.