### PR TITLE
Adjusted Support Points Negotiation Logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3961,6 +3961,7 @@ public class Campaign implements ITechManager {
                 }
 
                 if (negoatiatedSupportPoints >= maximumSupportPointsNegotiated) {
+                    negoatiatedSupportPoints = maximumSupportPointsNegotiated;
                     break;
                 }
             }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3937,7 +3937,7 @@ public class Campaign implements ITechManager {
         // out of Admin/Transport personnel, or we run out of active contracts
         for (AtBContract contract : sortedContracts) {
             int negoatiatedSupportPoints = 0;
-            int tracks = contract.getStratconCampaignState().getTracks().size();
+            int maximumSupportPointsNegotiated = contract.getRequiredLances();
 
             if (adminTransport.isEmpty()) {
                 break;
@@ -3954,9 +3954,13 @@ public class Campaign implements ITechManager {
 
                 if (roll >= targetNumber) {
                     negoatiatedSupportPoints++;
+
+                    int marginOfSuccess = (roll - targetNumber) / 4;
+
+                    negoatiatedSupportPoints += marginOfSuccess;
                 }
 
-                if (negoatiatedSupportPoints >= tracks) {
+                if (negoatiatedSupportPoints >= maximumSupportPointsNegotiated) {
                     break;
                 }
             }
@@ -4537,7 +4541,7 @@ public class Campaign implements ITechManager {
     public int getInitiativeBonus() {
         return initiativeBonus;
     }
-    
+
     public void setInitiativeBonus(int bonus) {
         initiativeBonus = bonus;
     }
@@ -4545,7 +4549,7 @@ public class Campaign implements ITechManager {
     public void applyInitiativeBonus(int bonus) {
         if (bonus > initiativeMaxBonus) {
             initiativeMaxBonus = bonus;
-        } 
+        }
         if ((bonus + initiativeBonus) > initiativeMaxBonus) {
             initiativeBonus = initiativeMaxBonus;
         } else {


### PR DESCRIPTION
Adjusted the logic for calculating negotiated support points.

Each month personnel in the Admin/Transport role use their administration skill to generate Support Points. Previously the number of Support Points that could be generated was capped at the number of Sectors assigned to the contract.

This PR changes this so that the maximum number of Support Points that can be generated, per month, is equal to the number of combat forces required by the contract.

Furthermore, for every 4 points a character exceeds their Admin skill check, that character will generate an extra Support Point. This should allow Elite personnel to carry less skilled characters.