### PR TITLE
Remove Origin Node Name from Lance Assignment Table

### DIFF
--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -140,7 +140,10 @@ public class LanceAssignmentView extends JPanel {
                     switch (column) {
                         case LanceAssignmentTableModel.COL_FORCE:
                             if (null != value) {
-                                setText((((Force) value)).getFullName());
+                                String forceName = (((Force) value)).getFullName();
+                                String originNodeName = ", " + campaign.getForce(0).getName();
+                                forceName = forceName.replaceAll(originNodeName, "");
+                                setText(forceName);
                             }
                             break;
                         case LanceAssignmentTableModel.COL_CONTRACT:


### PR DESCRIPTION
Updated the force display logic to exclude the origin node name in the Lance Assignment View. This ensures that the force name is displayed without unnecessary origin information.