### PR TITLE
Adjusted TO&E Menu Option Availability

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1455,7 +1455,6 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                         if (scenario.getHasTrack()) {
                             continue;
                         }
-
                         menuItem = new JMenuItem(scenario.getName());
                         menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DEPLOY_UNIT
                                 + scenario.getId() + '|' + unitIds);
@@ -1471,7 +1470,6 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 boolean allUnitsSameType = false;
                 double unitWeight = 0;
                 int singleUnitType = -1;
-                boolean areAnyUnitsDeployed = StaticChecks.areAnyUnitsDeployed(units);
 
                 // Add submenus for different types of transports
                 JMenu m_trn = new JMenu(TOEMouseAdapter.MEK_CARRIERS);
@@ -1505,10 +1503,6 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     menu = new JMenu("Assign Unit to Transport Ship");
                     for (Unit ship : gui.getCampaign().getTransportShips()) {
                         if (ship.isSalvage() || (ship.getCommander() == null)) {
-                            continue;
-                        }
-
-                        if (areAnyUnitsDeployed) {
                             continue;
                         }
 

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1082,6 +1082,11 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                                 || !scenario.canDeployForces(forces, gui.getCampaign())) {
                             continue;
                         }
+
+                        if (scenario.getHasTrack()) {
+                            continue;
+                        }
+
                         menuItem = new JMenuItem(scenario.getName());
                         menuItem.setActionCommand(
                                 TOEMouseAdapter.COMMAND_DEPLOY_FORCE + scenario.getId() + '|' + forceIds);
@@ -1097,10 +1102,12 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 menuItem = new JMenuItem("Undeploy Force");
                 menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_FORCE + forceIds);
                 menuItem.addActionListener(this);
+                menuItem.setEnabled(!gui.getCampaign().getCampaignOptions().isUseStratCon());
                 popup.add(menuItem);
             }
 
             menuItem = new JMenuItem("Remove Force");
+
             menuItem.setActionCommand(TOEMouseAdapter.COMMAND_REMOVE_FORCE + forceIds);
             menuItem.addActionListener(this);
             menuItem.setEnabled(
@@ -1444,6 +1451,11 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                                 !scenario.canDeployUnits(units, gui.getCampaign())) {
                             continue;
                         }
+
+                        if (scenario.getHasTrack()) {
+                            continue;
+                        }
+
                         menuItem = new JMenuItem(scenario.getName());
                         menuItem.setActionCommand(TOEMouseAdapter.COMMAND_DEPLOY_UNIT
                                 + scenario.getId() + '|' + unitIds);
@@ -1593,11 +1605,11 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 menuItem = new JMenuItem("Undeploy Unit");
                 menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_UNIT + unitIds);
                 menuItem.addActionListener(this);
-                menuItem.setEnabled(true);
+                menuItem.setEnabled(!gui.getCampaign().getCampaignOptions().isUseStratCon());
                 popup.add(menuItem);
             }
 
-            if (StaticChecks.areAllUnitsTransported(units)) {
+            if (StaticChecks.areAllUnitsTransported(units) && !StaticChecks.areAnyUnitsDeployed(units)) {
                 menuItem = new JMenuItem("Unassign Unit from Transport Ship");
                 menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNASSIGN_FROM_SHIP + unitIds);
                 menuItem.addActionListener(this);

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1471,6 +1471,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 boolean allUnitsSameType = false;
                 double unitWeight = 0;
                 int singleUnitType = -1;
+                boolean areAnyUnitsDeployed = StaticChecks.areAnyUnitsDeployed(units);
 
                 // Add submenus for different types of transports
                 JMenu m_trn = new JMenu(TOEMouseAdapter.MEK_CARRIERS);
@@ -1504,6 +1505,10 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                     menu = new JMenu("Assign Unit to Transport Ship");
                     for (Unit ship : gui.getCampaign().getTransportShips()) {
                         if (ship.isSalvage() || (ship.getCommander() == null)) {
+                            continue;
+                        }
+
+                        if (areAnyUnitsDeployed) {
                             continue;
                         }
 

--- a/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
+++ b/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
@@ -18,6 +18,15 @@
  */
 package mekhq.gui.handler;
 
+import megamek.logging.MMLogger;
+import mekhq.MekHQ;
+import mekhq.campaign.event.OrganizationChangedEvent;
+import mekhq.campaign.force.Force;
+import mekhq.campaign.unit.Unit;
+import mekhq.gui.CampaignGUI;
+
+import javax.swing.*;
+import javax.swing.tree.TreePath;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
@@ -26,22 +35,10 @@ import java.io.IOException;
 import java.util.StringTokenizer;
 import java.util.UUID;
 
-import javax.swing.JComponent;
-import javax.swing.JTree;
-import javax.swing.TransferHandler;
-import javax.swing.tree.TreePath;
-
-import megamek.logging.MMLogger;
-import mekhq.MekHQ;
-import mekhq.campaign.event.OrganizationChangedEvent;
-import mekhq.campaign.force.Force;
-import mekhq.campaign.unit.Unit;
-import mekhq.gui.CampaignGUI;
-
 public class TOETransferHandler extends TransferHandler {
     private static final MMLogger logger = MMLogger.create(TOETransferHandler.class);
 
-    private CampaignGUI gui;
+    private final CampaignGUI gui;
 
     public TOETransferHandler(CampaignGUI gui) {
         super();
@@ -145,7 +142,7 @@ public class TOETransferHandler extends TransferHandler {
     }
 
     @Override
-    public boolean importData(TransferHandler.TransferSupport support) {
+    public boolean importData(TransferSupport support) {
         if (!canImport(support)) {
             return false;
         }
@@ -159,9 +156,15 @@ public class TOETransferHandler extends TransferHandler {
             String id = st.nextToken();
             if (type.equals("UNIT")) {
                 unit = gui.getCampaign().getUnit(UUID.fromString(id));
+                if (unit == null || unit.isDeployed()) {
+                    return false;
+                }
             }
             if (type.equals("FORCE")) {
                 force = gui.getCampaign().getForce(Integer.parseInt(id));
+                if (force == null || force.isDeployed()) {
+                    return false;
+                }
             }
         } catch (UnsupportedFlavorException ufe) {
             logger.error("UnsupportedFlavor: " + ufe.getMessage());


### PR DESCRIPTION
Removed the ability for users to deploy/undeploy forces to/from StratCon scenarios. Both of these are known to cause issues with StratCon. There are quite a few steps for users to take prior to accidentally deploying the wrong force, so in my mind the benefit outweighs the occasional inconvenience.

Removed the ability to unassigned deployed units from transports.

Removed the ability to move units/forces that are currently deployed.

### Closes #5122 && #5084