### PR TITLE
Updated Sector Display & Expanded Scenario Information

### DIFF
--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -64,7 +64,7 @@ ContractCommandRights.INTEGRATED.toolTipText=<html><body style="width: 300px;">-
   <br>- No map scouting (StratCon).\
   <br>\
   <br><i>Integrated command rights, standard for government forces, streamline command and control, particularly in large-scale operations involving multiple forces, ensuring effective collaboration without inter-service rivalry or confusion over command authority.</i></body></html>
-ContractCommandRights.INTEGRATED.stratConText=The employer will make Lance assignments. Complete required scenarios to fulfill contract conditions.
+ContractCommandRights.INTEGRATED.stratConText=The employer will make Lance assignments.<br>Complete required scenarios to fulfill contract conditions.
 
 ContractCommandRights.HOUSE.text=House
 ContractCommandRights.HOUSE.toolTipText=<html><body style="width: 300px;">- Keep your Campaign Victory Points (CVP) positive. Winning a non-initiated scenario: +1 CVP. Losing a non-initiated scenario: -1 CVP.\

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -22,13 +22,17 @@ import megamek.Version;
 import megamek.common.Entity;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.SkillLevel;
+import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.force.Force;
 import mekhq.campaign.force.StrategicFormation;
+import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
 import mekhq.campaign.mission.atb.AtBScenarioModifier;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.rating.IUnitRating;
+import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
@@ -38,6 +42,11 @@ import org.w3c.dom.NodeList;
 import java.io.PrintWriter;
 import java.text.ParseException;
 import java.util.*;
+
+import static mekhq.campaign.mission.AtBDynamicScenarioFactory.getPlanetOwnerAlignment;
+import static mekhq.campaign.mission.AtBDynamicScenarioFactory.getPlanetOwnerFaction;
+import static mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment.Allied;
+import static mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment.PlanetOwner;
 
 /**
  * Data structure intended to hold data relevant to AtB Dynamic Scenarios (AtB 3.0)
@@ -84,6 +93,9 @@ public class AtBDynamicScenario extends AtBScenario {
     private transient Map<Integer, ScenarioForceTemplate> playerForceTemplates;
     private transient Map<UUID, ScenarioForceTemplate> playerUnitTemplates;
     private transient List<AtBScenarioModifier> scenarioModifiers;
+
+    private static final MMLogger logger = MMLogger.create(AtBDynamicScenario.class);
+
 
     public AtBDynamicScenario() {
         super();
@@ -577,5 +589,65 @@ public class AtBDynamicScenario extends AtBScenario {
     @Override
     public String getBattlefieldControlDescription() {
         return "";
+    }
+
+    /**
+     * Returns the total battle value (BV) either for allied forces or opposing forces in
+     * a given contract campaign, as per the parameter {@code isAllied}.
+     * <p>
+     * If {@code isAllied} is {@code true}, the method calculates the total BV for the allied
+     * forces inclusive of player forces. If {@code isAllied} is {@code false}, the total BV for
+     * opposing forces is calculated.
+     * <p>
+     * The calculation is done based on Bot forces attributed to each side. In the case of
+     * PlanetOwner, the alignment of the owner faction is considered to determine the ownership of
+     * Bot forces.
+     *
+     * @param campaign  The campaign in which the forces are participating.
+     * @param isAllied  A boolean value indicating whether to calculate the total BV for
+     *                  allied forces (if true) or opposing forces (if false).
+     * @return          The total battle value (BV) either for the allied forces or
+     *                  opposing forces, as specified by the parameter isAllied.
+     */
+    public int getTeamTotalBattleValue(Campaign campaign, boolean isAllied) {
+        AtBContract contract = getContract(campaign);
+        int totalBattleValue = 0;
+
+        for (BotForce botForce : getBotForces()) {
+            int battleValue = botForce.getTotalBV(campaign);
+
+            int team = botForce.getTeam();
+
+            if (team == PlanetOwner.ordinal()) {
+                String planetOwnerFaction = getPlanetOwnerFaction(contract, campaign.getLocalDate());
+                ForceAlignment forceAlignment = getPlanetOwnerAlignment(contract, planetOwnerFaction, campaign.getLocalDate());
+                team = forceAlignment.ordinal();
+            }
+
+            if (team <= Allied.ordinal()) {
+                if (isAllied) {
+                    totalBattleValue += battleValue;
+                }
+            } else if (!isAllied) {
+                totalBattleValue += battleValue;
+            }
+        }
+
+        if (isAllied) {
+            Force playerForces = this.getForces(campaign);
+
+            for (UUID unitID : playerForces.getAllUnits(false)) {
+                try {
+                    Unit unit = campaign.getUnit(unitID);
+                    Entity entity = unit.getEntity();
+
+                    totalBattleValue += entity.calculateBattleValue();
+                } catch (Exception ex) {
+                    logger.warn(ex.getMessage(), ex);
+                }
+            }
+        }
+
+        return totalBattleValue;
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -3877,7 +3877,7 @@ public class AtBDynamicScenarioFactory {
      * @param currentDate Current date.
      * @return Faction code.
      */
-    private static String getPlanetOwnerFaction(AtBContract contract, LocalDate currentDate) {
+    static String getPlanetOwnerFaction(AtBContract contract, LocalDate currentDate) {
         String factionCode = "MERC";
 
         // planet owner is the first of the factions that owns the current planet.
@@ -3903,8 +3903,7 @@ public class AtBDynamicScenarioFactory {
      * @param currentDate Current date.
      * @return ForceAlignment.
      */
-    private static ForceAlignment getPlanetOwnerAlignment(AtBContract contract, String factionCode,
-            LocalDate currentDate) {
+    static ForceAlignment getPlanetOwnerAlignment(AtBContract contract, String factionCode, LocalDate currentDate) {
         // if the faction is one of the planet owners, see if it's either the employer
         // or opfor. If it's not, third-party.
         if (contract.getSystem().getFactions(currentDate).contains(factionCode)) {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -15,6 +15,7 @@ package mekhq.campaign.stratcon;
 
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.adapter.DateAdapter;
 import mekhq.campaign.Campaign;
@@ -165,10 +166,10 @@ public class StratconScenario implements IStratconDisplayable {
 
     @Override
     public String getInfo() {
-        return getInfo(true);
+        return getInfo(null, true);
     }
 
-    public String getInfo(boolean html) {
+    public String getInfo(@Nullable Campaign campaign, boolean html) {
         StringBuilder stateBuilder = new StringBuilder();
 
         if (isStrategicObjective()) {
@@ -201,20 +202,31 @@ public class StratconScenario implements IStratconDisplayable {
 
         if (deploymentDate != null) {
             stateBuilder.append("Deployment Date: ")
-                .append(deploymentDate.toString())
+                .append(deploymentDate)
                 .append("<br/>");
         }
 
         if (actionDate != null) {
             stateBuilder.append("Battle Date: ")
-                .append(actionDate.toString())
+                .append(actionDate)
                 .append("<br/>");
         }
 
         if (returnDate != null) {
             stateBuilder.append("Return Date: ")
-                .append(returnDate.toString())
+                .append(returnDate)
                 .append("<br/>");
+        }
+
+        if (campaign != null) {
+            AtBDynamicScenario backingScenario = getBackingScenario();
+
+            if (backingScenario != null) {
+                stateBuilder.append(String.format("Hostile BV: %d<br>",
+                    backingScenario.getTeamTotalBattleValue(campaign, false)));
+                stateBuilder.append(String.format("Allied BV: %d",
+                    backingScenario.getTeamTotalBattleValue(campaign, true)));
+            }
         }
 
         stateBuilder.append("</html>");

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -13,7 +13,9 @@
 */
 package mekhq.gui;
 
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.event.Subscribe;
+import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.event.MissionCompletedEvent;
 import mekhq.campaign.event.MissionRemovedEvent;
@@ -48,7 +50,8 @@ public class StratconTab extends CampaignGuiTab {
 
     private StratconPanel stratconPanel;
     private JPanel infoPanel;
-    private JComboBox<TrackDropdownItem> cboCurrentTrack;
+    private DefaultListModel<TrackDropdownItem> listModel = new DefaultListModel<>();
+    private JList<TrackDropdownItem> listCurrentTrack;
     private JLabel infoPanelText;
     private JLabel campaignStatusText;
     private JLabel objectiveStatusText;
@@ -87,7 +90,7 @@ public class StratconTab extends CampaignGuiTab {
         objectiveStatusText.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent me) {
-                TrackDropdownItem currentTDI = (TrackDropdownItem) cboCurrentTrack.getSelectedItem();
+                TrackDropdownItem currentTDI = listCurrentTrack.getSelectedValue();
                 StratconCampaignState campaignState = currentTDI.contract.getStratconCampaignState();
                 objectivesCollapsed = !objectivesCollapsed;
                 objectiveStatusText.setText(getStrategicObjectiveText(campaignState));
@@ -116,47 +119,54 @@ public class StratconTab extends CampaignGuiTab {
      * Worker function that sets up the layout of the right-side info panel.
      */
     private void initializeInfoPanel() {
-        infoPanel = new JPanel();
-        infoPanel.setLayout(new BoxLayout(infoPanel, BoxLayout.PAGE_AXIS));
+        int gridY = 0;
+        infoPanel = new JPanel(new GridBagLayout());
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.anchor = GridBagConstraints.NORTHWEST;
+        constraints.gridx = gridY++;
 
-        infoPanel.add(new JLabel("Current Campaign Status:"));
-        infoPanel.add(campaignStatusText);
+        infoPanel.add(new JLabel("Current Campaign Status:"), constraints);
+
+        constraints.gridy = gridY++;
+        infoPanel.add(campaignStatusText, constraints);
 
         JButton btnManageCampaignState = new JButton("Manage SP/CVP");
-        btnManageCampaignState.setHorizontalAlignment(SwingConstants.LEFT);
-        btnManageCampaignState.setVerticalAlignment(SwingConstants.TOP);
         btnManageCampaignState.addActionListener(this::showCampaignStateManagement);
-        infoPanel.add(btnManageCampaignState);
+        constraints.gridy = gridY++;
+        infoPanel.add(btnManageCampaignState, constraints);
 
         expandedObjectivePanel = new JScrollPaneWithSpeed(objectiveStatusText);
-        expandedObjectivePanel.setMaximumSize(new Dimension(400, 300));
-        expandedObjectivePanel.setAlignmentX(LEFT_ALIGNMENT);
-        infoPanel.add(expandedObjectivePanel);
+        expandedObjectivePanel.setPreferredSize(new Dimension(400, 300));
+        constraints.gridy = gridY++;
+        infoPanel.add(expandedObjectivePanel, constraints);
 
-        JLabel lblCurrentTrack = new JLabel("Current Sector:");
-        infoPanel.add(lblCurrentTrack);
+        JLabel lblCurrentTrack = new JLabel("Assigned Sectors:");
+        constraints.gridy = gridY++;
+        infoPanel.add(lblCurrentTrack, constraints);
 
-        cboCurrentTrack = new JComboBox<>();
-        cboCurrentTrack.setAlignmentX(LEFT_ALIGNMENT);
-        cboCurrentTrack.setMaximumSize(new Dimension(320, 20));
+        listModel = new DefaultListModel<>();
+        listCurrentTrack = new JList<>(listModel);
+        listCurrentTrack.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        listCurrentTrack.setFixedCellHeight(UIUtil.scaleForGUI(20));
         repopulateTrackList();
-        cboCurrentTrack.addItemListener(evt -> trackSelectionHandler());
+        listCurrentTrack.addListSelectionListener(evt -> trackSelectionHandler());
 
-        infoPanel.add(cboCurrentTrack);
+        JScrollPane scrollPane = new JScrollPane(listCurrentTrack);
+        scrollPane.setPreferredSize(new Dimension(UIUtil.scaleForGUI(400),
+            listCurrentTrack.getFixedCellHeight() * 10));
+        constraints.gridy = gridY++;
 
-        // have a default selected
-        if (cboCurrentTrack.getItemCount() > 0) {
-            trackSelectionHandler();
-        }
-
-        infoPanel.add(infoPanelText);
+        infoPanel.add(scrollPane, constraints);
+        constraints.gridx = 2;
+        constraints.gridheight = 2;
+        infoPanel.add(infoPanelText, constraints);
     }
 
     /**
      * Worker that handles track selection.
      */
     private void trackSelectionHandler() {
-        TrackDropdownItem tdi = (TrackDropdownItem) cboCurrentTrack.getSelectedItem();
+        TrackDropdownItem tdi = listCurrentTrack.getSelectedValue();
         if (tdi != null) {
             stratconPanel.selectTrack(tdi.contract.getStratconCampaignState(), tdi.track);
             updateCampaignState();
@@ -185,7 +195,7 @@ public class StratconTab extends CampaignGuiTab {
      * with such info as current objective status, VP/SP totals, etc.
      */
     public void updateCampaignState() {
-        if ((cboCurrentTrack == null) || (campaignStatusText == null)) {
+        if ((listCurrentTrack == null) || (campaignStatusText == null)) {
             return;
         }
 
@@ -193,7 +203,7 @@ public class StratconTab extends CampaignGuiTab {
         // list of remaining objectives, percentage remaining
         // current VP
         // current support points
-        TrackDropdownItem currentTDI = (TrackDropdownItem) cboCurrentTrack.getSelectedItem();
+        TrackDropdownItem currentTDI = listCurrentTrack.getSelectedValue();
         if (currentTDI == null) {
             campaignStatusText.setText("No active contract selected, or contract has not started.");
             expandedObjectivePanel.setVisible(false);
@@ -387,40 +397,43 @@ public class StratconTab extends CampaignGuiTab {
      * Refreshes the list of tracks
      */
     private void repopulateTrackList() {
-        TrackDropdownItem currentTDI = (TrackDropdownItem) cboCurrentTrack.getSelectedItem();
-        cboCurrentTrack.removeAllItems();
+        final MMLogger logger = MMLogger.create(StratconTab.class);
+        int currentTrackIndex = listCurrentTrack.getSelectedIndex();
+        listModel.clear();
 
-        // track dropdown is populated with all tracks across all active contracts
         for (AtBContract contract : getCampaignGui().getCampaign().getActiveAtBContracts(true)) {
-            if (contract.getStratconCampaignState() != null) {
-                for (StratconTrackState track : contract.getStratconCampaignState().getTracks()) {
-                    TrackDropdownItem tdi = new TrackDropdownItem(contract, track);
-                    cboCurrentTrack.addItem(tdi);
-
-                    if ((currentTDI != null) && currentTDI.equals(tdi)) {
-                        currentTDI = tdi;
-                        cboCurrentTrack.setSelectedItem(tdi);
-                    } else if (currentTDI == null) {
-                        currentTDI = tdi;
-                        cboCurrentTrack.setSelectedItem(tdi);
-                    }
+            StratconCampaignState campaignState = contract.getStratconCampaignState();
+            if (campaignState != null) {
+                for (StratconTrackState track : campaignState.getTracks()) {
+                    TrackDropdownItem trackItem = new TrackDropdownItem(contract, track);
+                    logger.info(trackItem);
+                    listModel.addElement(trackItem);
+                    logger.info(listModel.toString());
                 }
             }
         }
 
-        if ((cboCurrentTrack.getItemCount() > 0) && (currentTDI != null) && (currentTDI.contract != null)) {
-            TrackDropdownItem selectedTrack = (TrackDropdownItem) cboCurrentTrack.getSelectedItem();
+        listCurrentTrack.setModel(listModel);
+        listCurrentTrack.setSelectedIndex(currentTrackIndex);
 
-            stratconPanel.selectTrack(selectedTrack.contract.getStratconCampaignState(), currentTDI.track);
+        if (listCurrentTrack.getSelectedValue() == null) {
+            listCurrentTrack.setSelectedIndex(0);
+        }
+
+        logger.info(listCurrentTrack.getSelectedValue());
+
+        if (listCurrentTrack.getSelectedValue() != null) {
+            TrackDropdownItem selectedTrack = listCurrentTrack.getSelectedValue();
+            stratconPanel.selectTrack(selectedTrack.contract.getStratconCampaignState(), selectedTrack.track);
             stratconPanel.setVisible(true);
         } else {
-            infoPanelText.setText("No active sectors");
+            infoPanelText.setText("");
             stratconPanel.setVisible(false);
         }
     }
 
     private void showCampaignStateManagement(ActionEvent e) {
-        TrackDropdownItem selectedTrack = (TrackDropdownItem) cboCurrentTrack.getSelectedItem();
+        TrackDropdownItem selectedTrack = listCurrentTrack.getSelectedValue();
         if (selectedTrack == null) {
             return;
         }

--- a/MekHQ/src/mekhq/gui/StratconTab.java
+++ b/MekHQ/src/mekhq/gui/StratconTab.java
@@ -15,7 +15,6 @@ package mekhq.gui;
 
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.event.Subscribe;
-import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.event.MissionCompletedEvent;
 import mekhq.campaign.event.MissionRemovedEvent;
@@ -397,7 +396,6 @@ public class StratconTab extends CampaignGuiTab {
      * Refreshes the list of tracks
      */
     private void repopulateTrackList() {
-        final MMLogger logger = MMLogger.create(StratconTab.class);
         int currentTrackIndex = listCurrentTrack.getSelectedIndex();
         listModel.clear();
 
@@ -406,9 +404,7 @@ public class StratconTab extends CampaignGuiTab {
             if (campaignState != null) {
                 for (StratconTrackState track : campaignState.getTracks()) {
                     TrackDropdownItem trackItem = new TrackDropdownItem(contract, track);
-                    logger.info(trackItem);
                     listModel.addElement(trackItem);
-                    logger.info(listModel.toString());
                 }
             }
         }
@@ -419,8 +415,6 @@ public class StratconTab extends CampaignGuiTab {
         if (listCurrentTrack.getSelectedValue() == null) {
             listCurrentTrack.setSelectedIndex(0);
         }
-
-        logger.info(listCurrentTrack.getSelectedValue());
 
         if (listCurrentTrack.getSelectedValue() != null) {
             TrackDropdownItem selectedTrack = listCurrentTrack.getSelectedValue();

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -54,8 +54,8 @@ public class StratconScenarioWizard extends JDialog {
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.AtBStratCon",
             MekHQ.getMHQOptions().getLocale());
 
-    private Map<String, JList<Force>> availableForceLists = new HashMap<>();
-    private Map<String, JList<Unit>> availableUnitLists = new HashMap<>();
+    private final Map<String, JList<Force>> availableForceLists = new HashMap<>();
+    private final Map<String, JList<Unit>> availableUnitLists = new HashMap<>();
 
     private JList<Unit> availableInfantryUnits = new JList<>();
     private JList<Unit> availableLeadershipUnits = new JList<>();
@@ -145,16 +145,13 @@ public class StratconScenarioWizard extends JDialog {
         if (currentTrackState.isGmRevealed()
                 || currentTrackState.getRevealedCoords().contains(currentScenario.getCoords()) ||
                 (currentScenario.getDeploymentDate() != null)) {
-            labelBuilder.append(currentScenario.getInfo());
+            labelBuilder.append(currentScenario.getInfo(campaign, true));
         }
 
-        switch (currentScenario.getCurrentState()) {
-            case UNRESOLVED:
-                labelBuilder.append("primaryForceAssignmentInstructions.text");
-                break;
-            default:
-                labelBuilder.append("reinforcementsAndSupportInstructions.text");
-                break;
+        if (Objects.requireNonNull(currentScenario.getCurrentState()) == ScenarioState.UNRESOLVED) {
+            labelBuilder.append("primaryForceAssignmentInstructions.text");
+        } else {
+            labelBuilder.append("reinforcementsAndSupportInstructions.text");
         }
 
         labelBuilder.append("<br/>");


### PR DESCRIPTION
This PR updates the StratCon sector display to display a list of sectors, rather than using a drop-down. This makes it easier for users to spot how many sectors they are assigned to, for any given contract.

I also went ahead and expanded the scenario information to include ally (including player) and hostile (including 3rd parties) BV. This should make it easier for users to determine what forces to assign to what scenario without needing to bounce between the AO and Briefing tabs quite as much.

Players currently on Integrated contracts, when updating, will notice a minor visual bug where things don't use the best alignment. It's very minor and doesn't break anything. This bug will not exist for campaigns that pick Integrated contracts _after_ updating.