### PR TITLE
Corrected Further XML Availability Formatting Errors

### DIFF
--- a/MekHQ/data/forcegenerator/2823.xml
+++ b/MekHQ/data/forcegenerator/2823.xml
@@ -2401,7 +2401,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>

--- a/MekHQ/data/forcegenerator/3075.xml
+++ b/MekHQ/data/forcegenerator/3075.xml
@@ -5498,7 +5498,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
-			<availability>CC:1,FS:7,MERC:4,CDP:2,Periphery:2,FVC:7LA:2,DC:1</availability>
+			<availability>CC:1,FS:7,MERC:4,CDP:2,Periphery:2,FVC:7,LA:2,DC:1</availability>
 			<model name='ENF-4R'>
 				<availability>FVC:4-,General:2-,FS:4-,TC:4-</availability>
 			</model>
@@ -9557,7 +9557,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,BAN:2,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,BAN:2,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FWL:3,WOB:6</availability>
 			</model>
@@ -10639,7 +10639,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:2FRR:4,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,CS:2-,LA:4,NIOPS:2-</availability>
+			<availability>CC:2,FRR:4,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,CS:2-,LA:4,NIOPS:2-</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>

--- a/MekHQ/data/forcegenerator/3085.xml
+++ b/MekHQ/data/forcegenerator/3085.xml
@@ -4768,7 +4768,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>CC:3,MOC:3,CHH:2-,HL:3,CEI:2,FR:2,MERC:4,CDP:4,RA:2Periphery:4,ROS:6,NIOPS:6,CJF:2-</availability>
+			<availability>CC:3,MOC:3,CHH:2-,HL:3,CEI:2,FR:2,MERC:4,CDP:4,RA:2,Periphery:4,ROS:6,NIOPS:6,CJF:2-</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:4,CEI:4,ROS:5</availability>
@@ -11513,7 +11513,7 @@
 			</model>
 		</chassis>
 		<chassis name='Myrmidon Medium Tank' unitType='Tank'>
-			<availability>MOC:2CC:5,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,Periphery:2,DC:4</availability>
+			<availability>MOC:2,CC:5,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,Periphery:2,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>


### PR DESCRIPTION
Fixed missing commas in the availability data for several unit chassis types across different XML files.

Given the large number of these little buggers I don't doubt there are some still hiding in the recesses of the less popular eras, however with this PR all 'bookmarked' years will now load correctly.