### PR TITLE
Fixed Typo in 'Fourth Succession War' Naming

### DIFF
--- a/MekHQ/resources/mekhq/resources/DateChooser.properties
+++ b/MekHQ/resources/mekhq/resources/DateChooser.properties
@@ -193,7 +193,7 @@ ThirdSuccessionWarEnds.tooltip=The Third Succession War ended in 3025 without a 
   \ other states created the Concord of Kapteyn. Around the same time, the Arano Restoration in the\
   \ Aurigan Reach highlighted smaller-scale conflicts, with Kamea Arano reclaiming her throne. These\
   \ events paved the way for the Fourth Succession War.
-ForthSuccessionWar.text=Forth Succession War
+ForthSuccessionWar.text=Fourth Succession War
 ForthSuccessionWar.tooltip=The Fourth Succession War was a dramatic conflict driven by Hanse Davion's\
   \ surprise alliance with the Lyran Commonwealth against the Capellan Confederation and their allies.\
   \ With cunning strategies and bold offensives, Davion forces gained significant territory, especially\

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -68,7 +68,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
 
     public static final int OK_OPTION = 1;
     public static final int CANCEL_OPTION = 2;
-    private static String RESOURCE_PACKAGE = "mekhq/resources/DateChooser";
+    private static final String RESOURCE_PACKAGE = "mekhq/resources/DateChooser";
     private static final ResourceBundle resources = ResourceBundle.getBundle(RESOURCE_PACKAGE,
         MekHQ.getMHQOptions().getLocale());
 
@@ -732,7 +732,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
                 eraLogo = new ImageIcon(LOGO_DIRECTORY + "era_sw" + LOGO_FILE_TYPE);
             }
             case 4 -> {
-                turningPoints = List.of("ThirdSuccessionWarEnds", "ForthSuccessionWar", "FRRFounded",
+                turningPoints = List.of("ThirdSuccessionWarEnds", "FourthSuccessionWar", "FRRFounded",
                     "WarOf3039");
                 turningPointDates = List.of(
                     LocalDate.of(3025, 1, 1),


### PR DESCRIPTION
Corrected the spelling of "Fourth", from "Forth", in variable lists and properties to ensure accuracy in references to the Fourth Succession War. This change affects both the code's internal logic and user-facing text elements.