### PR TITLE
Fixed Theatre of War Faction Checks

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/TheatreOfWarAwards.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/TheatreOfWarAwards.java
@@ -52,7 +52,13 @@ public class TheatreOfWarAwards {
         boolean isEligible;
         List<Award> eligibleAwards = new ArrayList<>();
 
-        String employer = ((Contract) mission).getEmployer();
+        // if the mission isn't an instance of 'AtBContract' we won't have the information we need,
+        // so abort processing.
+        if (!(mission instanceof AtBContract)) {
+            return AutoAwardsController.prepareAwardData(person, eligibleAwards);
+        }
+
+        String employer = ((AtBContract) mission).getEmployerCode();
 
         int contractStartYear = ((Contract) mission).getStartDate().getYear();
         int currentYear = campaign.getGameYear();
@@ -103,10 +109,10 @@ public class TheatreOfWarAwards {
                 }
 
                 if (belligerents.size() == 1) {
-                    if (!processFaction(belligerents.get(0), employer)) {
+                    if (!processFaction(employer, belligerents.get(0))) {
                         continue;
                     }
-                } else if ((campaign.getCampaignOptions().isUseAtB()) && (mission instanceof AtBContract)) {
+                } else if (campaign.getCampaignOptions().isUseAtB()) {
                     String enemy = ((AtBContract) mission).getEnemyCode();
 
                     if (hasLoyalty(employer, attackers)) {

--- a/MekHQ/src/mekhq/gui/dialog/AutoAwardsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AutoAwardsDialog.java
@@ -145,7 +145,7 @@ public class AutoAwardsDialog extends JDialog {
         AutoAwardsTableModel model = new AutoAwardsTableModel(campaign);
         // This is where we insert the external data
         logger.info("Trying to pass data to AutoAwardsTableModel.java");
-        logger.info("Data being passed: {}", data);
+        logger.debug("Data being passed: {}", data);
         model.setData(data);
         logger.info("Attempt successful");
         personnelTable = new AutoAwardsTable(model);

--- a/MekHQ/src/mekhq/gui/model/AutoAwardsTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/AutoAwardsTableModel.java
@@ -61,11 +61,11 @@ public class AutoAwardsTableModel extends AbstractTableModel {
         if (map.isEmpty()) {
             logger.error("AutoAwardsDialog failed to pass 'data' into AutoAwardsTableModel");
         } else {
-            logger.info("AutoAwardsDialog passed 'data' into AutoAwardsTableModel: {}", map);
+            logger.debug("AutoAwardsDialog passed 'data' into AutoAwardsTableModel: {}", map);
         }
 
         data = map;
-        logger.info("Translated data: {}", data);
+        logger.debug("Translated data: {}", data);
     }
 
     @Override


### PR DESCRIPTION
Reordered parameters in the `processFaction` method call to ensure proper functionality. Fixed call fetching employer faction, to correctly call faction code. Changed log message levels to debug - these were missed when I lowered the logging level of the majority of the internal autoAwards logger messages.

### Fixes #5301