### PR TITLE
Improved Unit Substitution

### DIFF
--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -81,7 +81,7 @@
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>1</allowedUnitType>
+                <allowedUnitType>-2</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>false</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>

--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -81,7 +81,7 @@
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
+                <allowedUnitType>1</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>false</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
@@ -110,8 +110,8 @@
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>CIVILIAN</forceRole>
-                    <forceRole>CARGO</forceRole>
                     <forceRole>SUPPORT</forceRole>
+                    <forceRole>CARGO</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -111,7 +111,11 @@
                 <roleChoices>
                     <forceRole>CIVILIAN</forceRole>
                     <forceRole>SUPPORT</forceRole>
+                    <forceRole>SUPPORT</forceRole>
                     <forceRole>CARGO</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>APC</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
@@ -107,7 +107,11 @@
                 <roleChoices>
                     <forceRole>CIVILIAN</forceRole>
                     <forceRole>SUPPORT</forceRole>
+                    <forceRole>SUPPORT</forceRole>
                     <forceRole>CARGO</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>APC</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
@@ -77,7 +77,7 @@
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
+                <allowedUnitType>1</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
@@ -106,8 +106,8 @@
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>CIVILIAN</forceRole>
-                    <forceRole>CARGO</forceRole>
                     <forceRole>SUPPORT</forceRole>
+                    <forceRole>CARGO</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
@@ -77,7 +77,7 @@
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>1</allowedUnitType>
+                <allowedUnitType>-2</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>

--- a/MekHQ/data/scenariotemplates/Convoy Raid.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Raid.xml
@@ -77,7 +77,7 @@
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
+                <allowedUnitType>1</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
@@ -107,7 +107,6 @@
                 <roleChoices>
                     <forceRole>CIVILIAN</forceRole>
                     <forceRole>CARGO</forceRole>
-                    <forceRole>SUPPORT</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -81,7 +81,7 @@
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>1</allowedUnitType>
+                <allowedUnitType>-2</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>false</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -81,7 +81,7 @@
             <value>
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
+                <allowedUnitType>1</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>false</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
@@ -110,8 +110,8 @@
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>CIVILIAN</forceRole>
-                    <forceRole>CARGO</forceRole>
                     <forceRole>SUPPORT</forceRole>
+                    <forceRole>CARGO</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -111,7 +111,11 @@
                 <roleChoices>
                     <forceRole>CIVILIAN</forceRole>
                     <forceRole>SUPPORT</forceRole>
+                    <forceRole>SUPPORT</forceRole>
                     <forceRole>CARGO</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>CARGO</forceRole>
+                    <forceRole>APC</forceRole>
                     <forceRole>APC</forceRole>
                 </roleChoices>
             </value>

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -3260,7 +3260,7 @@ public class AtBDynamicScenarioFactory {
         }
 
         int weight;
-        if (weights.length() == 1) {
+        if (weights.length() == 1 || (weights.charAt(0) == 'U' && weights.length() == 2)) {
             weight = AtBConfiguration.decodeWeightStr(weights, 0);
         } else {
             weight = AtBConfiguration.decodeWeightStr(weights, unitIndex);

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -3119,6 +3119,14 @@ public class AtBDynamicScenarioFactory {
                 continue;
             }
 
+            entity = substituteEntity(faction, skill, quality, weights, rolesByType,
+                campaign, unitTypes, unitIndex, unitTypes);
+
+            if (entity != null) {
+                generatedEntities.add(entity);
+                continue;
+            }
+
             String role = null;
             Integer type = unitTypes.get(unitIndex);
             if (type != null) {
@@ -3147,10 +3155,16 @@ public class AtBDynamicScenarioFactory {
                     if (unitTypes.get(unitIndex) != TANK) {
                         logger.info("Switching unit type to Tank");
                         fallbackUnitType = List.of(TANK);
+
+                        entity = substituteEntity(faction, skill, quality, weights, rolesByType,
+                            campaign, unitTypes, unitIndex, fallbackUnitType);
                     }
 
-                    entity = substituteEntity(faction, skill, quality, weights, rolesByType,
-                        campaign, unitTypes, unitIndex, fallbackUnitType);
+                    // Abandon attempts to generate
+                    if (entity == null) {
+                        entity = substituteEntity(faction, skill, quality, weights, null,
+                            campaign, unitTypes, unitIndex, fallbackUnitType);
+                    }
                 } else {
                     logger.info("Unable to generate Tank due to scenario limitations. Aborting" +
                         " attempt.");
@@ -3160,10 +3174,16 @@ public class AtBDynamicScenarioFactory {
                 if (unitTypes.get(unitIndex) != AEROSPACEFIGHTER) {
                     logger.info("Switching unit type to Aerospace Fighter");
                     fallbackUnitType = List.of(AEROSPACEFIGHTER);
+
+                    entity = substituteEntity(faction, skill, quality, weights, rolesByType,
+                        campaign, unitTypes, unitIndex, fallbackUnitType);
                 }
 
-                entity = substituteEntity(faction, skill, quality, weights, rolesByType,
-                    campaign, unitTypes, unitIndex, fallbackUnitType);
+                // Abandon attempts to generate
+                if (entity == null) {
+                    entity = substituteEntity(faction, skill, quality, weights, null,
+                        campaign, unitTypes, unitIndex, fallbackUnitType);
+                }
             }
 
             if (entity != null) {

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -3176,7 +3176,24 @@ public class AtBDynamicScenarioFactory {
         return generatedEntities;
     }
 
-    private static Entity substituteEntity(String faction, SkillLevel skill, int quality,
+    /**
+     * Attempts to substitute an entity with a fallback unit type in a series of steps.
+     * When the initial entity generation fails, this method makes various changes to the unit type
+     * and weight and tries again until it either successfully generates a new entity
+     * or exhausts all alternatives.
+     *
+     * @param faction      The faction for the new Entity being generated
+     * @param skill        The skill level for the new Entity being generated
+     * @param quality      The quality for the new Entity being generated
+     * @param weights      The weights for the unit types being considered
+     * @param rolesByType  The roles available for each unit type
+     * @param campaign     The campaign to which this Entity will be added
+     * @param unitTypes    The unit types available for substitution
+     * @param unitIndex    The index of the unit being replaced in the unitTypes list
+     * @param fallbackUnitType The fallback unit type to be used if normal generation steps fail
+     * @return The new generated Entity or null if substitution unsuccessful
+     */
+    private static @Nullable Entity substituteEntity(String faction, SkillLevel skill, int quality,
                                            String weights, Map<Integer, Collection<MissionRole>> rolesByType,
                                            Campaign campaign, List<Integer> unitTypes, int unitIndex,
                                            List<Integer> fallbackUnitType) {
@@ -3220,6 +3237,22 @@ public class AtBDynamicScenarioFactory {
         return null;
     }
 
+    /**
+     * Attempts to generate an Entity by substituting weight classes in a specific order.
+     * Starting from the lightest (`UL`) to the heaviest (`A`), each weight class is attempted
+     * until a valid Entity can be generated, or all weight classes have been tried. If a valid
+     * Entity is generated, that Entity is returned; otherwise, the method returns null.
+     *
+     * @param faction      The faction for the new Entity being generated.
+     * @param skill        The SkillLevel for the new Entity being generated.
+     * @param quality      The quality for the new Entity being generated.
+     * @param weights      A String representing the weights for the unit types being considered.
+     * @param rolesByType  The roles available for each unit type. This may be null.
+     * @param campaign     The campaign to which this Entity will be added.
+     * @param individualType The unit types available for substitution.
+     * @param unitIndex    The index of the unit type being replaced in the unitTypes list.
+     * @return             The new Entity generated or null if substitution is unsuccessful.
+     */
     private static @Nullable Entity attemptSubstitutionViaWeight(String faction, SkillLevel skill,
                                                                  int quality, String weights,
                                                                  @Nullable Map<Integer, Collection<MissionRole>> rolesByType,


### PR DESCRIPTION
As a part of our FG3 push, we included a 'unit substitution' system to try and resolve the old issue of 0 entity forces. This system goes through multiple layers of failure, attempting to substitute failed entities, step-by-step loosening generation restrictions until we find _something_, even if that something isn't quite what we wanted.

At some point prior I included a much simpler system that did the same thing, but worse. That older system simply tried to generate a unit and if it failed it tried again, this time without any role requirements.

Because both of these systems existed at the same time what would happen is we'd try and generate a unit, fail for whatever reason, then abandon all attempts to match role requirements. Essentially bypassing unit substitution entirely. This meant that convoy scenarios would constantly fail to generate entities - because of the very narrow pool of non-combat units for many factions - and then just give up on roles entirely and just generate a combat unit.

While I was addressing the above (by removing the errant code) I also took the opportunity to improve unit substitution. Now we only drop roles after all other options have been explored.

It should be noted that military units _can_ still appear in convoy forces. This is particularly likely with Clan factions who have no civilian units (insofar as I can tell). I have mitigated this by decreasing the likelihood that a convoy formation will use the CIVILIAN role from 1in4 to 1in8.

Closes #5302