### PR TITLE
Issue 5333: Show Hired personnel's name change

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -45,6 +45,14 @@ anniversaryRecruitment.text=%s celebrates <b>%s%s%s</b> years with %s!
 #### Personnel Removal
 personnelRemoval.text=Old personnel records have been tidied away.
 
+#### Personnel Recruitment
+personnelRecruitmentFinancesReason.text=Recruitment of %s
+personnelRecruitmentInsufficientFunds.text=<font color='%s'><b>Insufficient funds to recruit %s</b></font>
+personnelRecruitmentFormerSurname.text=(Formerly %s)
+personnelRecruitmentBondsman.text=as a bondsman
+personnelRecruitmentPrisoner.text=as a prisoner
+personnelRecruitmentAddedToRoster.text=%s%s has been added to the personnel roster%s.
+
 #### Turnover and Retention
 turnoverJointDeparture.text=departed with their spouse.
 turnoverJointDepartureChild.text=departed with a parent.

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1676,61 +1676,59 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * @param p              the person being added
+     * @param person              the person being added
      * @param prisonerStatus the person's prisoner status upon recruitment
      * @param gmAdd          false means that they need to pay to hire this person,
      *                       true means it is added without paying
      * @param log            whether or not to write to logs
      * @return true if the person is hired successfully, otherwise false
      */
-    public boolean recruitPerson(Person p, PrisonerStatus prisonerStatus, boolean gmAdd, boolean log) {
-        if (p == null) {
+    public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean gmAdd, boolean log) {
+        if (person == null) {
             return false;
         }
 
         // Only pay if option set, they weren't GM added, and they aren't a dependent, prisoner or bondsman
-        if (getCampaignOptions().isPayForRecruitment() && !p.getPrimaryRole().isDependent()
+        if (getCampaignOptions().isPayForRecruitment() && !person.getPrimaryRole().isDependent()
                 && !gmAdd && prisonerStatus.isFree()) {
             if (!getFinances().debit(TransactionType.RECRUITMENT, getLocalDate(),
-                    p.getSalary(this).multipliedBy(2), "Recruitment of " + p.getFullName())) {
-                addReport("<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor()
-                        + "'><b>Insufficient funds to recruit "
-                        + p.getFullName() + "</b></font>");
+                    person.getSalary(this).multipliedBy(2), String.format(resources.getString("personnelRecruitmentFinancesReason.text"),person.getFullName()))) {
+                addReport(String.format(resources.getString("personnelRecruitmentInsufficientFunds.text"), MekHQ.getMHQOptions().getFontColorNegativeHexColor(), person.getFullName()));
                 return false;
             }
         }
 
-        personnel.put(p.getId(), p);
-        p.setJoinedCampaign(getLocalDate());
+        personnel.put(person.getId(), person);
+        person.setJoinedCampaign(getLocalDate());
 
 
-        String formerSurname = p.getSurname();
+        String formerSurname = person.getSurname();
 
 
-        if (p.getPrimaryRole().isAstech()) {
+        if (person.getPrimaryRole().isAstech()) {
             astechPoolMinutes += Person.PRIMARY_ROLE_SUPPORT_TIME;
             astechPoolOvertime += Person.PRIMARY_ROLE_OVERTIME_SUPPORT_TIME;
-        } else if (p.getSecondaryRole().isAstech()) {
+        } else if (person.getSecondaryRole().isAstech()) {
             astechPoolMinutes += Person.SECONDARY_ROLE_SUPPORT_TIME;
             astechPoolOvertime += Person.SECONDARY_ROLE_OVERTIME_SUPPORT_TIME;
         }
 
-        p.setPrisonerStatus(this, prisonerStatus, log);
+        person.setPrisonerStatus(this, prisonerStatus, log);
 
         if (getCampaignOptions().isUseSimulatedRelationships()) {
-            if ((prisonerStatus.isFree()) && (!p.getOriginFaction().isClan()) && (!p.getPrimaryRole().isDependent())) {
-                simulateRelationshipHistory(p);
+            if ((prisonerStatus.isFree()) && (!person.getOriginFaction().isClan()) && (!person.getPrimaryRole().isDependent())) {
+                simulateRelationshipHistory(person);
             }
         }
 
-        if(log){
-            formerSurname = p.getSurname().equals(formerSurname) ? "" : String.format(" (Formerly %s) ", formerSurname);
-            String add = !prisonerStatus.isFree() ? (prisonerStatus.isBondsman() ? " as a bondsman" : " as a prisoner")
+        if (log) {
+            formerSurname = person.getSurname().equals(formerSurname) ? "" : ' ' + String.format(resources.getString("personnelRecruitmentFormerSurname.text") + ' ', formerSurname);
+            String add = !prisonerStatus.isFree() ? (' ' + resources.getString(prisonerStatus.isBondsman() ? "personnelRecruitmentBondsman.text" : "personnelRecruitmentPrisoner.text"))
                 : "";
-            addReport(String.format("%s%s has been added to the personnel roster%s.", p.getHyperlinkedName(), formerSurname, add));
+            addReport(String.format(resources.getString("personnelRecruitmentAddedToRoster.text"), person.getHyperlinkedName(), formerSurname, add));
         }
 
-        MekHQ.triggerEvent(new PersonNewEvent(p));
+        MekHQ.triggerEvent(new PersonNewEvent(person));
         return true;
     }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1703,11 +1703,9 @@ public class Campaign implements ITechManager {
         personnel.put(p.getId(), p);
         p.setJoinedCampaign(getLocalDate());
 
-        if (log) {
-            String add = !prisonerStatus.isFree() ? (prisonerStatus.isBondsman() ? " as a bondsman" : " as a prisoner")
-                    : "";
-            addReport(String.format("%s has been added to the personnel roster%s.", p.getHyperlinkedName(), add));
-        }
+
+        String formerSurname = p.getSurname();
+
 
         if (p.getPrimaryRole().isAstech()) {
             astechPoolMinutes += Person.PRIMARY_ROLE_SUPPORT_TIME;
@@ -1723,6 +1721,13 @@ public class Campaign implements ITechManager {
             if ((prisonerStatus.isFree()) && (!p.getOriginFaction().isClan()) && (!p.getPrimaryRole().isDependent())) {
                 simulateRelationshipHistory(p);
             }
+        }
+
+        if(log){
+            formerSurname = p.getSurname().equals(formerSurname) ? "" : String.format(" (Formerly %s) ", formerSurname);
+            String add = !prisonerStatus.isFree() ? (prisonerStatus.isBondsman() ? " as a bondsman" : " as a prisoner")
+                : "";
+            addReport(String.format("%s%s has been added to the personnel roster%s.", p.getHyperlinkedName(), formerSurname, add));
         }
 
         MekHQ.triggerEvent(new PersonNewEvent(p));


### PR DESCRIPTION
Fixes #5333 

In order to prevent confusion, when hiring personnel we will simulate their relationship history before showing their name. This lets us show their former surname if their name changed upon getting married. 