### PR TITLE
MHQ part of Fix 6240: era-illegal asf bombs

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -726,10 +726,10 @@ public class AtBDynamicScenarioFactory {
                         break;
                 }
 
+                Game cGame = campaign.getGame();
+                TeamLoadOutGenerator tlg = new TeamLoadOutGenerator(cGame);
                 if (campaign.getCampaignOptions().isAutoConfigMunitions()) {
                     // Configure *all* generated units with appropriate munitions (for BV calcs)
-                    Game cGame = campaign.getGame();
-                    TeamLoadOutGenerator tlg = new TeamLoadOutGenerator(cGame);
                     ArrayList<Entity> arrayGeneratedLance = new ArrayList<>(generatedLance);
                     // bin fill ratio will be adjusted by the load out generator based on piracy and
                     // quality
@@ -743,7 +743,14 @@ public class AtBDynamicScenarioFactory {
                     tlg.reconfigureEntities(arrayGeneratedLance, factionCode, mt, rp);
                 } else {
                     // Load the fighters with bombs
-                    TeamLoadOutGenerator.populateAeroBombs(generatedLance, campaign.getGameYear(), onGround, ownerBaseQuality, isPirate);
+                    tlg.populateAeroBombs(
+                        generatedLance,
+                        campaign.getGameYear(),
+                        onGround,
+                        ownerBaseQuality,
+                        isPirate,
+                        faction.getShortName()
+                    );
                 }
             }
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -1453,12 +1453,15 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
             // TODO: replace with TeamLoadoutGenerator call once 0.50.1 errata go in
             boolean isAeroMap = getBoardType() == T_SPACE || getBoardType() == T_ATMOSPHERE;
-
-            TeamLoadOutGenerator.populateAeroBombs(aircraft,
-                    campaign.getGameYear(),
-                    !isAeroMap,
-                    contract.getEnemyQuality(),
-                    contract.getEnemy().isPirate());
+            TeamLoadOutGenerator tlg = new TeamLoadOutGenerator(campaign.getGame());
+            tlg.populateAeroBombs(
+                aircraft,
+                campaign.getGameYear(),
+                !isAeroMap,
+                contract.getEnemyQuality(),
+                contract.getEnemy().isPirate(),
+                contract.getEnemy().getShortName()
+            );
 
             BotForce bf = getEnemyBotForce(getContract(campaign), enemyHome, enemyHome, aircraft);
             bf.setName(bf.getName() + " (Air Support)");


### PR DESCRIPTION
Fix to align MHQ calls of TeamLoadOutGenerator functions with their updated argument lists.

Testing:
- Ran all 3 suites' unit tests
- Ran mission vs pirate ASFs
- Manually confirmed Rocket Launcher (Prototype) 10 bomb /RL-P 10 bomb ammo is purchasable in MHQ

NOTE: should be pulled immediately after https://github.com/MegaMek/megamek/pull/6254
