### PR TITLE
Removed VIP Capture Scenarios, Added Role Templates, Fixed Objectives

### DIFF
--- a/MekHQ/data/scenariomodifiers/AlliedAirSupportBombers.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedAirSupportBombers.xml
@@ -26,5 +26,8 @@
 		<syncDeploymentType>SameEdge</syncDeploymentType>
 		<syncedForceName>Player</syncedForceName>
 		<useArtillery>false</useArtillery>
+        <roleChoices>
+            <forceRole>BOMBER</forceRole>
+        </roleChoices>
 	</forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/AlliedOfficerMek.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedOfficerMek.xml
@@ -33,5 +33,8 @@
 		<syncDeploymentType>SameEdge</syncDeploymentType>
 		<syncedForceName>Player</syncedForceName>
 		<useArtillery>false</useArtillery>
+        <roleChoices>
+            <forceRole>COMMAND</forceRole>
+        </roleChoices>
 	</forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/EnemyAirSupportBombers.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyAirSupportBombers.xml
@@ -37,5 +37,8 @@
 		<startingAltitude>5</startingAltitude>
 		<syncDeploymentType>None</syncDeploymentType>
 		<syncedForceName />
+        <roleChoices>
+            <forceRole>BOMBER</forceRole>
+        </roleChoices>
 	</forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/EnemyCommanderMek.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyCommanderMek.xml
@@ -33,5 +33,8 @@
 		<syncDeploymentType>SameEdge</syncDeploymentType>
 		<syncedForceName>OpFor</syncedForceName>
 		<useArtillery>false</useArtillery>
+        <roleChoices>
+            <forceRole>COMMAND</forceRole>
+        </roleChoices>
 	</forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/EnemyOfficerMek.xml
+++ b/MekHQ/data/scenariomodifiers/EnemyOfficerMek.xml
@@ -33,5 +33,8 @@
 		<syncDeploymentType>SameEdge</syncDeploymentType>
 		<syncedForceName>OpFor</syncedForceName>
 		<useArtillery>false</useArtillery>
+        <roleChoices>
+            <forceRole>COMMAND</forceRole>
+        </roleChoices>
 	</forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/HouseOfficerAir.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerAir.xml
@@ -30,5 +30,8 @@
         <syncDeploymentType>SameEdge</syncDeploymentType>
         <syncedForceName>Player</syncedForceName>
         <useArtillery>false</useArtillery>
+        <roleChoices>
+            <forceRole>INTERCEPTOR</forceRole>
+        </roleChoices>
     </forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
+++ b/MekHQ/data/scenariomodifiers/HouseOfficerGround.xml
@@ -34,5 +34,8 @@
         <syncDeploymentType>SameEdge</syncDeploymentType>
         <syncedForceName>Player</syncedForceName>
         <useArtillery>false</useArtillery>
+        <roleChoices>
+            <forceRole>COMMAND</forceRole>
+        </roleChoices>
     </forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/LiaisonAir.xml
+++ b/MekHQ/data/scenariomodifiers/LiaisonAir.xml
@@ -30,5 +30,8 @@
         <syncDeploymentType>SameEdge</syncDeploymentType>
         <syncedForceName>Player</syncedForceName>
         <useArtillery>false</useArtillery>
+        <roleChoices>
+            <forceRole>INTERCEPTOR</forceRole>
+        </roleChoices>
     </forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariomodifiers/LiaisonGround.xml
+++ b/MekHQ/data/scenariomodifiers/LiaisonGround.xml
@@ -34,5 +34,8 @@
         <syncDeploymentType>SameEdge</syncDeploymentType>
         <syncedForceName>Player</syncedForceName>
         <useArtillery>false</useArtillery>
+        <roleChoices>
+            <forceRole>COMMAND</forceRole>
+        </roleChoices>
     </forceDefinition>
 </AtBScenarioModifier>

--- a/MekHQ/data/scenariotemplates/Assassination.xml
+++ b/MekHQ/data/scenariotemplates/Assassination.xml
@@ -111,6 +111,10 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>COMMAND</forceRole>
+                    <forceRole>APC</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/MekHQ/data/scenariotemplates/Close Air Support.xml
+++ b/MekHQ/data/scenariotemplates/Close Air Support.xml
@@ -2,7 +2,7 @@
 <ScenarioTemplate>
     <name>Close Air Support</name>
     <shortBriefing>Provide air support, minimize losses.</shortBriefing>
-    <detailedBriefing>Provide air support to allied ground forces under heavy attack. Prioritize minimizing casualties while neutralizing enemy units. Expect anti-air defenses. Success depends on keeping at least 50% of allies alive and destroying half of the enemy force.</detailedBriefing>
+    <detailedBriefing>Provide air support to allied ground forces under heavy attack. Prioritize minimizing casualties while neutralizing enemy units. Success depends on keeping at least 50% of allies alive and destroying half of the enemy force.</detailedBriefing>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -74,6 +74,10 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Convoy</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -74,6 +74,10 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Convoy</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -178,6 +178,13 @@
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>ARTILLERY</forceRole>
+                    <forceRole>MISSILE_ARTILLERY</forceRole>
+                    <forceRole>MIXED_ARTILLERY</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/MekHQ/data/scenariotemplates/Frontline VIP Capture.xml
+++ b/MekHQ/data/scenariotemplates/Frontline VIP Capture.xml
@@ -111,6 +111,10 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>COMMAND</forceRole>
+                    <forceRole>APC</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>
@@ -142,59 +146,59 @@
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>OpFor</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Destroy or rout 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Player</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Preserve 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
     </scenarioObjectives>
-    <scenarioObjective>
-        <associatedForceNames>
-            <associatedForceName>OpFor</associatedForceName>
-        </associatedForceNames>
-        <associatedUnitIDs />
-        <successEffects>
-            <successEffect>
-                <effectType>ScenarioVictory</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </successEffect>
-        </successEffects>
-        <failureEffects>
-            <failureEffect>
-                <effectType>ScenarioDefeat</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </failureEffect>
-        </failureEffects>
-        <additionalDetails />
-        <description>Destroy or rout 50% of the following force(s) and unit(s):</description>
-        <destinationEdge>NONE</destinationEdge>
-        <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-        <percentage>50</percentage>
-        <timeLimitAtMost>true</timeLimitAtMost>
-        <timeLimitType>None</timeLimitType>
-    </scenarioObjective>
-    <scenarioObjective>
-        <associatedForceNames>
-            <associatedForceName>Player</associatedForceName>
-        </associatedForceNames>
-        <associatedUnitIDs />
-        <successEffects>
-            <successEffect>
-                <effectType>ScenarioVictory</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </successEffect>
-        </successEffects>
-        <failureEffects>
-            <failureEffect>
-                <effectType>ScenarioDefeat</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </failureEffect>
-        </failureEffects>
-        <additionalDetails />
-        <description>Preserve 50% of the following force(s) and unit(s):</description>
-        <destinationEdge>NONE</destinationEdge>
-        <objectiveCriterion>Preserve</objectiveCriterion>
-        <percentage>50</percentage>
-        <timeLimitAtMost>true</timeLimitAtMost>
-        <timeLimitType>None</timeLimitType>
-    </scenarioObjective>
 </ScenarioTemplate>

--- a/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -2,7 +2,7 @@
 <ScenarioTemplate>
     <name>Heavy Recon Evasion</name>
     <shortBriefing>Evade patrols while scanning enemy heavies.</shortBriefing>
-    <detailedBriefing>Enemy patrols are active, and your mission is to scan the enemy’s heavy units. Survive for the duration of the scan without being detected. Preserve at least 50% of your forces until the turn limit is reached to ensure mission success.</detailedBriefing>
+    <detailedBriefing>Enemy patrols are active, and your mission is to scan the enemy’s heavy units. Survive for the duration of the scan. Preserve at least 50% of your forces until the turn limit is reached to ensure mission success.</detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Intercept Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Intercept Engagement.xml
@@ -74,6 +74,10 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/MekHQ/data/scenariotemplates/Interception Defense.xml
+++ b/MekHQ/data/scenariotemplates/Interception Defense.xml
@@ -130,9 +130,7 @@
                 </failureEffect>
             </failureEffects>
             <additionalDetails />
-            <description>Destroy 50% of the following force(s) and unit(s) before they can reach the
-                destination
-                edge:</description>
+            <description>Destroy 50% of the following force(s) and unit(s) before they can reach the destination edge:</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Destroy</objectiveCriterion>
             <percentage>50</percentage>

--- a/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
@@ -153,6 +153,10 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>INF_SUPPORT</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -179,6 +179,13 @@
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>ARTILLERY</forceRole>
+                    <forceRole>MISSILE_ARTILLERY</forceRole>
+                    <forceRole>MIXED_ARTILLERY</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Assault.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Assault.xml
@@ -147,32 +147,32 @@
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Player</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Preserve 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
     </scenarioObjectives>
-    <scenarioObjective>
-        <associatedForceNames>
-            <associatedForceName>Player</associatedForceName>
-        </associatedForceNames>
-        <associatedUnitIDs />
-        <successEffects>
-            <successEffect>
-                <effectType>ScenarioVictory</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </successEffect>
-        </successEffects>
-        <failureEffects>
-            <failureEffect>
-                <effectType>ScenarioDefeat</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </failureEffect>
-        </failureEffects>
-        <additionalDetails />
-        <description>Preserve 50% of the following force(s) and unit(s):</description>
-        <destinationEdge>NONE</destinationEdge>
-        <objectiveCriterion>Preserve</objectiveCriterion>
-        <percentage>50</percentage>
-        <timeLimitAtMost>true</timeLimitAtMost>
-        <timeLimitType>None</timeLimitType>
-    </scenarioObjective>
 </ScenarioTemplate>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
@@ -168,6 +168,9 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>INTERCEPTOR</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
@@ -81,6 +81,9 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>INTERCEPTOR</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
@@ -74,6 +74,10 @@
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/MekHQ/data/scenariotemplates/Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Recon Evasion.xml
@@ -2,7 +2,7 @@
 <ScenarioTemplate>
     <name>Recon Evasion</name>
     <shortBriefing>Evade patrols until scan is complete.</shortBriefing>
-    <detailedBriefing>Enemy patrols are sweeping the area, and your forces need to evade detection until scans of the enemy are complete. Survive for the turn limit while preserving at least 50% of your forces to ensure success.</detailedBriefing>
+    <detailedBriefing>Enemy patrols are sweeping the area, and your forces need to evade until scans of the enemy are complete. Survive for the turn limit while preserving at least 50% of your forces to ensure success.</detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
@@ -85,6 +85,11 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
@@ -85,6 +85,11 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
@@ -81,6 +81,11 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>RECON</forceRole>
+                    <forceRole>RAIDER</forceRole>
+                    <forceRole>CAVALRY</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/MekHQ/data/scenariotemplates/Remote VIP Capture.xml
+++ b/MekHQ/data/scenariotemplates/Remote VIP Capture.xml
@@ -111,6 +111,10 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>COMMAND</forceRole>
+                    <forceRole>APC</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>
@@ -142,59 +146,59 @@
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>OpFor</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Destroy or rout 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Player</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Preserve 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>Preserve</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
     </scenarioObjectives>
-    <scenarioObjective>
-        <associatedForceNames>
-            <associatedForceName>OpFor</associatedForceName>
-        </associatedForceNames>
-        <associatedUnitIDs />
-        <successEffects>
-            <successEffect>
-                <effectType>ScenarioVictory</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </successEffect>
-        </successEffects>
-        <failureEffects>
-            <failureEffect>
-                <effectType>ScenarioDefeat</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </failureEffect>
-        </failureEffects>
-        <additionalDetails />
-        <description>Destroy or rout 50% of the following force(s) and unit(s):</description>
-        <destinationEdge>NONE</destinationEdge>
-        <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-        <percentage>50</percentage>
-        <timeLimitAtMost>true</timeLimitAtMost>
-        <timeLimitType>None</timeLimitType>
-    </scenarioObjective>
-    <scenarioObjective>
-        <associatedForceNames>
-            <associatedForceName>Player</associatedForceName>
-        </associatedForceNames>
-        <associatedUnitIDs />
-        <successEffects>
-            <successEffect>
-                <effectType>ScenarioVictory</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </successEffect>
-        </successEffects>
-        <failureEffects>
-            <failureEffect>
-                <effectType>ScenarioDefeat</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </failureEffect>
-        </failureEffects>
-        <additionalDetails />
-        <description>Preserve 50% of the following force(s) and unit(s):</description>
-        <destinationEdge>NONE</destinationEdge>
-        <objectiveCriterion>Preserve</objectiveCriterion>
-        <percentage>50</percentage>
-        <timeLimitAtMost>true</timeLimitAtMost>
-        <timeLimitType>None</timeLimitType>
-    </scenarioObjective>
 </ScenarioTemplate>

--- a/MekHQ/data/scenariotemplates/ScenarioManifest.xml
+++ b/MekHQ/data/scenariotemplates/ScenarioManifest.xml
@@ -1,5 +1,5 @@
 <scenarioManifest>
-	<scenarioFileNames>
+    <scenarioFileNames>
         <entry>
             <key>0</key>
             <value>Annihilation.xml</value>
@@ -82,106 +82,98 @@
         </entry>
         <entry>
             <key>20</key>
-            <value>Frontline VIP Capture.xml</value>
-        </entry>
-        <entry>
-            <key>21</key>
             <value>Heavy Recon Evasion.xml</value>
         </entry>
         <entry>
-            <key>22</key>
+            <key>21</key>
             <value>Hostile Facility.xml</value>
         </entry>
         <entry>
-            <key>23</key>
+            <key>22</key>
             <value>Intercept Engagement.xml</value>
         </entry>
         <entry>
-            <key>24</key>
+            <key>23</key>
             <value>Interception Defense.xml</value>
         </entry>
         <entry>
-            <key>25</key>
+            <key>24</key>
             <value>Irregular Force Assault.xml</value>
         </entry>
         <entry>
-            <key>26</key>
+            <key>25</key>
             <value>Irregular Force Suppression.xml</value>
         </entry>
         <entry>
-            <key>27</key>
+            <key>26</key>
             <value>Isolated DropShip Defense.xml</value>
         </entry>
         <entry>
-            <key>28</key>
+            <key>27</key>
             <value>Low-Atmosphere Air Intercept.xml</value>
         </entry>
         <entry>
-            <key>29</key>
+            <key>28</key>
             <value>Low-Atmosphere DropShip Assault.xml</value>
         </entry>
         <entry>
-            <key>30</key>
+            <key>29</key>
             <value>Low-Atmosphere DropShip Escort.xml</value>
         </entry>
         <entry>
-            <key>31</key>
+            <key>30</key>
             <value>Minor Engagement.xml</value>
         </entry>
         <entry>
-            <key>32</key>
+            <key>31</key>
             <value>Picket Line Breakthrough.xml</value>
         </entry>
         <entry>
-            <key>33</key>
+            <key>32</key>
             <value>Pivotal Battle.xml</value>
         </entry>
         <entry>
-            <key>34</key>
+            <key>33</key>
             <value>Recon Evasion.xml</value>
         </entry>
         <entry>
-            <key>35</key>
+            <key>34</key>
             <value>Reconnaissance Interdiction.xml</value>
         </entry>
         <entry>
-            <key>36</key>
-            <value>Remote VIP Capture.xml</value>
-        </entry>
-        <entry>
-            <key>37</key>
+            <key>35</key>
             <value>Skirmish.xml</value>
         </entry>
         <entry>
-            <key>38</key>
+            <key>36</key>
             <value>Skirmish Disruption.xml</value>
         </entry>
         <entry>
-            <key>39</key>
+            <key>37</key>
             <value>Space Aerospace Intercept.xml</value>
         </entry>
         <entry>
-            <key>40</key>
+            <key>38</key>
             <value>Space Blockade Run.xml</value>
         </entry>
         <entry>
-            <key>41</key>
+            <key>39</key>
             <value>Space DropShip Intercept.xml</value>
         </entry>
         <entry>
-            <key>42</key>
+            <key>40</key>
             <value>Tactical Withdrawal.xml</value>
         </entry>
         <entry>
-            <key>43</key>
-            <value>VIP Capture.xml</value>
+            <key>41</key>
+            <value>VIP Ambush.xml</value>
         </entry>
         <entry>
-            <key>44</key>
+            <key>42</key>
             <value>VIP Defense.xml</value>
         </entry>
         <entry>
-            <key>45</key>
+            <key>43</key>
             <value>Engagement.xml</value>
         </entry>
     </scenarioFileNames>

--- a/MekHQ/data/scenariotemplates/Space Blockade Run.xml
+++ b/MekHQ/data/scenariotemplates/Space Blockade Run.xml
@@ -207,6 +207,9 @@
                 <syncDeploymentType>SameEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>INTERCEPTOR</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
@@ -161,6 +161,9 @@
                 <syncDeploymentType>SameEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>ESCORT</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
@@ -85,6 +85,9 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>INTERCEPTOR</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>

--- a/MekHQ/data/scenariotemplates/VIP Ambush.xml
+++ b/MekHQ/data/scenariotemplates/VIP Ambush.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ScenarioTemplate>
-    <name>VIP Capture</name>
-    <shortBriefing>Capture VIP, disable or force ejection.</shortBriefing>
-    <detailedBriefing>The objective is to capture a high-value target by disabling their unit or forcing an ejection, then securing the ejected individual. The target must remain alive and cannot escape the battlefield. Preserve 50% of your forces, and destroy at least 50% of the VIP’s bodyguards.</detailedBriefing>
+    <name>VIP Ambush</name>
+    <shortBriefing>Ambush &amp; eliminate VIP, evade reinforcements.</shortBriefing>
+    <detailedBriefing>Eliminate a high-value VIP target. Neutralize the target quickly and avoid getting caught by incoming enemy reinforcements. Precision and speed are critical for mission success.</detailedBriefing>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>
@@ -60,7 +60,7 @@
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>-3</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -111,6 +111,10 @@
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>COMMAND</forceRole>
+                    <forceRole>APC</forceRole>
+                </roleChoices>
             </value>
         </entry>
     </scenarioForces>
@@ -142,59 +146,63 @@
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
         </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>OpFor</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails />
+            <description>Destroy or rout 50% of the following force(s) and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>ForceWithdraw</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
+        <scenarioObjective>
+            <associatedForceNames>
+                <associatedForceName>Player</associatedForceName>
+            </associatedForceNames>
+            <associatedUnitIDs />
+            <successEffects>
+                <successEffect>
+                    <effectType>ScenarioVictory</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </successEffect>
+            </successEffects>
+            <failureEffects>
+                <failureEffect>
+                    <effectType>ScenarioDefeat</effectType>
+                    <effectScaling>Fixed</effectScaling>
+                    <howMuch>1</howMuch>
+                </failureEffect>
+            </failureEffects>
+            <additionalDetails>
+                <additionalDetail>Crippled units do not count towards this objective.</additionalDetail>
+            </additionalDetails>
+            <description>Reach the far edge of the map with at least 50% of the following force(s)
+                and unit(s):</description>
+            <destinationEdge>NONE</destinationEdge>
+            <objectiveCriterion>ReachMapEdge</objectiveCriterion>
+            <percentage>50</percentage>
+            <timeLimit>0</timeLimit>
+            <timeLimitAtMost>true</timeLimitAtMost>
+            <timeLimitType>None</timeLimitType>
+        </scenarioObjective>
     </scenarioObjectives>
-    <scenarioObjective>
-        <associatedForceNames>
-            <associatedForceName>OpFor</associatedForceName>
-        </associatedForceNames>
-        <associatedUnitIDs />
-        <successEffects>
-            <successEffect>
-                <effectType>ScenarioVictory</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </successEffect>
-        </successEffects>
-        <failureEffects>
-            <failureEffect>
-                <effectType>ScenarioDefeat</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </failureEffect>
-        </failureEffects>
-        <additionalDetails />
-        <description>Destroy or rout 50% of the following force(s) and unit(s):</description>
-        <destinationEdge>NONE</destinationEdge>
-        <objectiveCriterion>ForceWithdraw</objectiveCriterion>
-        <percentage>50</percentage>
-        <timeLimitAtMost>true</timeLimitAtMost>
-        <timeLimitType>None</timeLimitType>
-    </scenarioObjective>
-    <scenarioObjective>
-        <associatedForceNames>
-            <associatedForceName>Player</associatedForceName>
-        </associatedForceNames>
-        <associatedUnitIDs />
-        <successEffects>
-            <successEffect>
-                <effectType>ScenarioVictory</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </successEffect>
-        </successEffects>
-        <failureEffects>
-            <failureEffect>
-                <effectType>ScenarioDefeat</effectType>
-                <effectScaling>Fixed</effectScaling>
-                <howMuch>1</howMuch>
-            </failureEffect>
-        </failureEffects>
-        <additionalDetails />
-        <description>Preserve 50% of the following force(s) and unit(s):</description>
-        <destinationEdge>NONE</destinationEdge>
-        <objectiveCriterion>Preserve</objectiveCriterion>
-        <percentage>50</percentage>
-        <timeLimitAtMost>true</timeLimitAtMost>
-        <timeLimitType>None</timeLimitType>
-    </scenarioObjective>
 </ScenarioTemplate>

--- a/MekHQ/data/scenariotemplates/VIP Defense.xml
+++ b/MekHQ/data/scenariotemplates/VIP Defense.xml
@@ -82,6 +82,10 @@
                 <syncDeploymentType>SameEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>COMMAND</forceRole>
+                    <forceRole>APC</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>
@@ -115,7 +119,7 @@
         </entry>
     </scenarioForces>
     <scenarioObjectives>
-        <objective>
+        <scenarioObjective>
             <associatedForceNames>
                 <associatedForceName>VIP</associatedForceName>
             </associatedForceNames>
@@ -141,7 +145,7 @@
             <timeLimit>0</timeLimit>
             <timeLimitAtMost>true</timeLimitAtMost>
             <timeLimitType>None</timeLimitType>
-        </objective>
+        </scenarioObjective>
         <scenarioObjective>
             <associatedForceNames>
                 <associatedForceName>OpFor</associatedForceName>


### PR DESCRIPTION
Renamed "VIP Capture" to "VIP Ambush" with updated objectives and description. Removed other flavors of 'VIP Capture'. These other flavors of VIP Capture scenarios were removed from the manifest, but not deleted, so can still be accessed manually. I opted to remove these scenario types as they required a significant degree of player manipulation to succeed and generally created an abrasive experience. 

Added "roleChoices" to various scenario forces, and refined a couple of briefings for clarity.

A number of scenario templates had malformed objectives, meaning a number of objectives would not appear in the scenario description. This has been corrected, closing #5323