### PR TITLE
Refactored Required Lances Calculation Logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
@@ -213,12 +213,12 @@ public abstract class AbstractContractMarket {
         // Otherwise, we roll to determine the amount we divide availableForces by
         int roll = d6(2);
         double varianceFactor = switch (roll) {
-            case 2 -> 6;
-            case 3 -> 5;
-            case 4 -> 4;
-            case 10 -> 2;
-            case 11 -> 1;
-            case 12 -> 0;
+            case 2 -> 4.5;
+            case 3 -> 4;
+            case 4 -> 3.5;
+            case 10 -> 2.5;
+            case 11 -> 2;
+            case 12 -> 1.5;
             default -> 3;
         };
 

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
@@ -21,10 +21,12 @@ import org.w3c.dom.NodeList;
 import java.io.PrintWriter;
 import java.util.*;
 
+import static java.lang.Math.abs;
 import static java.lang.Math.floor;
 import static java.lang.Math.max;
 import static java.lang.Math.round;
 import static megamek.common.Compute.d6;
+import static megamek.common.Compute.randomInt;
 import static mekhq.campaign.force.StrategicFormation.getStandardForceSize;
 import static mekhq.campaign.mission.AtBContract.getEffectiveNumUnits;
 
@@ -182,42 +184,66 @@ public abstract class AbstractContractMarket {
      * Determines the number of required lances to be deployed for a contract. For Mercenary subcontracts
      * this defaults to 1; otherwise, the number is based on the number of combat units in the
      * campaign. Modified by a 2d6 roll if {@code bypassVariance} is {@code false}.
+     *
      * @param campaign the current campaign
      * @param contract the relevant contract
      * @param bypassVariance if {@code true} requirements will not be semi-randomized.
      * @return The number of lances required to be deployed.
      */
     public int calculateRequiredLances(Campaign campaign, AtBContract contract, boolean bypassVariance) {
-        int maxDeployedLances = max(calculateMaxDeployedLances(campaign), 1);
         if (contract.isSubcontract()) {
             return 1;
-        } else {
-            int formationSize = getStandardForceSize(campaign.getFaction());
-            int availableForces = max(getEffectiveNumUnits(campaign) / formationSize, 1);
+        }
 
-            // We allow for one reserve force per 3 depth 0 forces (lances, etc)
-            availableForces -= max((int) floor((double) availableForces / 3), 1);
+        int maxDeployedLances = max(calculateMaxDeployedLances(campaign), 1);
+        int formationSize = getStandardForceSize(campaign.getFaction());
+        int availableForces = max(getEffectiveNumUnits(campaign) / formationSize, 1);
 
-            if (!bypassVariance) {
-                int roll = d6(2);
+        // Base required forces
+        availableForces -= max((int) floor((double) availableForces / 3), 1);
 
-                if (roll == 2) {
-                    availableForces = (int) round((double) availableForces * 0.25);
-                } else if (roll == 3) {
-                    availableForces = (int) round((double) availableForces * 0.5);
-                } else if (roll < 5) {
-                    availableForces = (int) round((double) availableForces * 0.75);
-                } else if (roll == 12) {
-                    availableForces = (int) round((double) availableForces * 1.75);
-                } else if (roll == 11) {
-                    availableForces = (int) round((double) availableForces * 1.5);
-                } else if (roll > 9) {
-                    availableForces = (int) round((double) availableForces * 1.25);
-                }
-            }
-
+        // If we're bypassing variance, we can early exit here
+        if (bypassVariance) {
             return MathUtility.clamp(availableForces, 1, maxDeployedLances);
         }
+
+        // We use a 2d6 roll here, instead of a pure randomInt call, as this gives us more control
+        // over the results; ensuring that in most cases required lances will equal the value of
+        // availableForces (calculated above)
+        int roll = d6(2);
+        double varianceFactor = switch (roll) {
+            case 2 -> -0.75;
+            case 3 -> -0.5;
+            case 4 -> -0.25;
+            case 10 -> 0.25;
+            case 11 -> 0.5;
+            case 12 -> 0.75;
+            default -> 0;
+        };
+
+        int variance = getRequiredLanceVariance(availableForces, varianceFactor);
+
+        if (variance > 0) {
+            availableForces += randomInt(variance);
+        }
+
+        if (variance < 0) {
+            // The value in randomInt must be positive
+            availableForces -= randomInt(abs(variance));
+        }
+
+        return MathUtility.clamp(availableForces, 1, maxDeployedLances);
+    }
+
+    /**
+     * Calculates the required lance variance for a new contract
+     *
+     * @param  availableForces  The number of available forces to be adjusted.
+     * @param  factor           The factor by which the available forces should be adjusted.
+     * @return An integer representing the calculated variance.
+     */
+    private int getRequiredLanceVariance(int availableForces, double factor) {
+        return (int) round((double) availableForces * factor);
     }
 
     /**


### PR DESCRIPTION
Earlier in this dev cycle we added 'required lance variance'. Essentially, the number of required lances could vary from 25% to 175% of the available lances (capped at 1, or available lances). However, the likelihood that a player would have 75% spare forces just lying about is effectively zero in most cases; causing required lances to hit their force cap more often than intended.

We now calculate Required Lances thus:
1. Calculate the number of lances (or regional equivalent) the player can muster, based on combat units in their TO&E and campaign faction. This is referred to as 'available forces' in this PR write-up.
2. Calculate the maximum number of forces the player can field, based on campaign commander strategy (if this option is enabled in campaign options).
3. Roll 2d6 and consult the following table:
```
Roll / Divider
  2 = 4.5
  3 = 4
  4 = 3.5
5-9 = 3
 10 = 2.5
 11 = 2
 12 = 1.5
```
4. Subtract that value from available forces the result of available forces divided by the divider rolled.
5. Required Lances is equal to available forces, with a minimum of 1.

**Bug Fix**
Finally, previously we did not check whether 'use commander strategy' was enabled in Campaign Options when determining maximum lance count. This means that campaigns with that option disabled were still affected by its' settings. This PR corrects that.

**A note on purpose**
Recently there has been a general push towards harder contracts, with increased scenario count and players being increasingly forced to make difficult decisions. Furthermore, we're starting to encourage players to have more comprehensive TO&E. These two factors combined mean we don't want to be in a situation where the only way a player has to pick less intense contracts is to either hope they get a low Skull contract; or by removing units from their TO&E.

The changes in this PR mean contracts will offer a variety of intensities with not every contract requiring the player dedicate their entire TO&E to the effort. This, combined with FG3's Skulls rating system, means players are in a far better position to cherry pick contracts based on the needs of their campaign at that time.