### PR TITLE
Corrected Briefing Room Unit Editing Menu Condition

### DIFF
--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -927,11 +927,11 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
     private class TreeMouseAdapter extends MouseInputAdapter implements ActionListener {
         private JTree tree;
-        int index;
+        int forceIndex;
 
-        public TreeMouseAdapter(JTree tree, int index) {
+        public TreeMouseAdapter(JTree tree, int forceIndex) {
             this.tree = tree;
-            this.index = index;
+            this.forceIndex = forceIndex;
         }
 
         @Override
@@ -941,21 +941,20 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
             if (command.equalsIgnoreCase("CONFIG_BOT")) {
                 BotConfigDialog pbd = new BotConfigDialog(frame,
                         null,
-                        scenario.getBotForce(index).getBehaviorSettings(),
+                        scenario.getBotForce(forceIndex).getBehaviorSettings(),
                         null);
-                pbd.setBotName(scenario.getBotForce(index).getName());
+                pbd.setBotName(scenario.getBotForce(forceIndex).getName());
                 pbd.setVisible(true);
                 if (!pbd.getResult().isCancelled()) {
-                    scenario.getBotForce(index).setBehaviorSettings(pbd.getBehaviorSettings());
-                    scenario.getBotForce(index).setName(pbd.getBotName());
+                    scenario.getBotForce(forceIndex).setBehaviorSettings(pbd.getBehaviorSettings());
+                    scenario.getBotForce(forceIndex).setName(pbd.getBotName());
                 }
             } else if (command.equalsIgnoreCase("EDIT_UNIT")) {
                 if ((tree.getSelectionCount() > 0) && (tree.getSelectionRows() != null)) {
-                    // row 0 is root node
-                    int i = tree.getSelectionRows()[0] - 1;
-                    UnitEditorDialog med = new UnitEditorDialog(frame,
-                            scenario.getBotForce(index).getFullEntityList(campaign).get(i));
-                    med.setVisible(true);
+                    int unitIndex = tree.getSelectionRows()[0] - 1;
+                    UnitEditorDialog editorDialog = new UnitEditorDialog(frame,
+                            scenario.getBotForce(this.forceIndex).getFullEntityList(campaign).get(unitIndex));
+                    editorDialog.setVisible(true);
                 }
             }
         }
@@ -979,7 +978,8 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
                 }
 
                 JMenuItem menuItem;
-                if (path.getPathCount() > 1) {
+                if ((path.getPathCount() > 1) && (tree.getSelectionRows() != null)
+                    && (tree.getSelectionRows()[0] != 0)) {
                     menuItem = new JMenuItem("Edit Unit...");
                     menuItem.setActionCommand("EDIT_UNIT");
                     menuItem.addActionListener(this);


### PR DESCRIPTION
Updated `maybeShowPopup` to ensure the "Edit Unit" menu item appears only when a valid unit is selected, preventing out of index errors.

I also updated a couple of variable names for improved clarity.

Closes #5350