### PR TITLE
Reassigned StratCon Force Assignment Picker as Modal

### DIFF
--- a/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
+++ b/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
@@ -72,12 +72,10 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
 
         JScrollPane forceListContainer = new JScrollPaneWithSpeed();
 
-        ScenarioWizardLanceModel lanceModel;
-
         // if we're waiting to assign primary forces, we can only do so from the current track
-        lanceModel = new ScenarioWizardLanceModel(campaign,
-                StratconRulesManager.getAvailableForceIDs(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX,
-                        campaign, ownerPanel.getCurrentTrack(), false, null, currentCampaignState));
+        ScenarioWizardLanceModel lanceModel = new ScenarioWizardLanceModel(campaign,
+            StratconRulesManager.getAvailableForceIDs(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX,
+                campaign, ownerPanel.getCurrentTrack(), false, null, currentCampaignState));
 
         availableForceList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         availableForceList.setModel(lanceModel);
@@ -94,6 +92,7 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
 
         pack();
         repaint();
+        setModal(true);
     }
 
     /**
@@ -111,22 +110,17 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
      */
     @Override
     public void actionPerformed(ActionEvent e) {
-        switch (e.getActionCommand()) {
-            case CMD_CONFIRM:
-                // sometimes the scenario templates take a little while to load, we don't want the user
-                // clicking the button fifty times and getting a bunch of scenarios.
-                btnConfirm.setEnabled(false);
-                for (Force force : availableForceList.getSelectedValuesList()) {
-                    StratconRulesManager.deployForceToCoords(
-                            ownerPanel.getSelectedCoords(),
-                            force.getId(),
-                            campaign, currentCampaignState.getContract(),
-                            ownerPanel.getCurrentTrack(), false);
-                }
-                setVisible(false);
-                ownerPanel.repaint();
-                btnConfirm.setEnabled(true);
-                break;
+        if (e.getActionCommand().equals(CMD_CONFIRM)) {
+            // sometimes the scenario templates take a little while to load, we don't want the user
+            // clicking the button fifty times and getting a bunch of scenarios.
+            btnConfirm.setEnabled(false);
+            for (Force force : availableForceList.getSelectedValuesList()) {
+                StratconRulesManager.deployForceToCoords(ownerPanel.getSelectedCoords(),
+                    force.getId(), campaign, currentCampaignState.getContract(), ownerPanel.getCurrentTrack(), false);
+            }
+            setVisible(false);
+            ownerPanel.repaint();
+            btnConfirm.setEnabled(true);
         }
     }
 }


### PR DESCRIPTION
Added setModal(true) to enforce modal behavior for the Manage Force Assignment dialog.

Simplified variable declarations and refactored the `actionPerformed` method by replacing the switch statement with an if condition.

Closes #5345