### PR TITLE
Adjusted Marshaling and Unmarshaling of New AutoLogistics Module

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -105,8 +105,8 @@ import mekhq.campaign.storyarc.StoryArc;
 import mekhq.campaign.stratcon.StratconContractInitializer;
 import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.stratcon.StratconTrackState;
-import mekhq.campaign.unit.*;
 import mekhq.campaign.unit.CrewType;
+import mekhq.campaign.unit.*;
 import mekhq.campaign.universe.*;
 import mekhq.campaign.universe.Planet.PlanetaryEvent;
 import mekhq.campaign.universe.PlanetarySystem.PlanetarySystemEvent;
@@ -178,7 +178,7 @@ public class Campaign implements ITechManager {
     private final TreeMap<Integer, Scenario> scenarios = new TreeMap<>();
     private final Map<UUID, List<Kill>> kills = new HashMap<>();
 
-    // This maps PartInUse ToString() results to doubles, representing a mapping 
+    // This maps PartInUse ToString() results to doubles, representing a mapping
     // of parts in use to their requested stock percentages to make these values persistent
     private Map<String, Double> partsInUseRequestedStockMap = new LinkedHashMap<>();
 
@@ -5876,7 +5876,7 @@ public class Campaign implements ITechManager {
             writeCustoms(pw);
         }
 
-      
+
         // Okay, we're done.
         // Close everything out and be done with it.
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "campaign");
@@ -8806,12 +8806,13 @@ public class Campaign implements ITechManager {
     public void setIgnoreSparesUnderQuality(PartQuality ignoreSparesUnderQuality) {
         this.ignoreSparesUnderQuality = ignoreSparesUnderQuality;
     }
-    
+
 
     public void writePartInUseToXML(final PrintWriter pw, int indent) {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreMothBalled", ignoreMothballed);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "topUpWeekly", topUpWeekly);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreSparesUnderQuality", ignoreSparesUnderQuality.toName(campaignOptions.isReverseQualityNames()));
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "ignoreSparesUnderQuality",
+            ignoreSparesUnderQuality.name());
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "partInUseMap");
         writePartInUseMapToXML(pw, indent);
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "partInUseMap");
@@ -8821,7 +8822,8 @@ public class Campaign implements ITechManager {
         for(String key : partsInUseRequestedStockMap.keySet()) {
             MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "partInUseMapEntry");
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "partInUseMapKey", key);
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "partInUseMapVal", partsInUseRequestedStockMap.get(key));
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "partInUseMapVal",
+                partsInUseRequestedStockMap.get(key));
             MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "partInUseMapEntry");
         }
     }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -1627,7 +1627,7 @@ public class CampaignXmlParser {
             } else if (wn2.getNodeName().equalsIgnoreCase("topUpWeekly")) {
                 retVal.setTopUpWeekly(Boolean.parseBoolean(wn2.getTextContent()));
             } else if (wn2.getNodeName().equalsIgnoreCase("ignoreSparesUnderQuality")) {
-                PartQuality ignoreQuality = PartQuality.fromName(wn2.getTextContent(), retVal.getCampaignOptions().isReverseQualityNames());
+                PartQuality ignoreQuality = PartQuality.valueOf(wn2.getTextContent());
                 retVal.setIgnoreSparesUnderQuality(ignoreQuality);
             } else if (wn2.getNodeName().equalsIgnoreCase("partInUseMap")) {
                 processPartsInUseRequestedStockMap(retVal, wn2);


### PR DESCRIPTION
Adjusted how the new autoLogistics module, added by @Lapras, marshals and unmarshals to/from xml.

Previously, it was converting the PartQuality to string (adjusted based on whether the user had reverse quality names enabled). This is a bit cumbersome and I'm not confident it would properly handle users enabling/disabling that option mid-campaign.

Instead, I've changed it so that it's using the enum value, as this remains consistent no matter what options the user has enabled. QUALITY_A is always QUALITY_A, the only thing that changes is how that's presented to the user.