### PR TITLE
Corrected Scenario Briefings by Removing Explicit Turn Limits.

### DIFF
--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -2,7 +2,7 @@
 <ScenarioTemplate>
     <name>Deep Raid Defense</name>
     <shortBriefing>Defend grounded DropShip from raid.</shortBriefing>
-    <detailedBriefing>An enemy raid deep behind friendly lines is targeting a grounded DropShip. Protect it for 30 turns until liftoff, ensuring it does not become crippled. Defeat at least 50% of the enemy raiders while preserving 50% of your forces during the defense.</detailedBriefing>
+    <detailedBriefing>An enemy raid deep behind friendly lines is targeting a grounded DropShip. Protect it until liftoff, ensuring it does not become crippled. Defeat at least 50% of the enemy raiders while preserving 50% of your forces during the defense.</detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Deep Raid.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid.xml
@@ -2,7 +2,7 @@
 <ScenarioTemplate>
     <name>Deep Raid</name>
     <shortBriefing>Destroy or cripple DropShip.</shortBriefing>
-    <detailedBriefing>A grounded DropShip must be destroyed or crippled within 30 turns before it lifts off. This raid takes place deep behind enemy lines, and the DropShip’s defenders are not important. Preserve 50% of your forces during the operation to ensure mission success.</detailedBriefing>
+    <detailedBriefing>A grounded DropShip must be destroyed or crippled before it lifts off. This raid takes place deep behind enemy lines, and the DropShip’s defenders are not important. Preserve 50% of your forces during the operation to ensure mission success.</detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/DropShip Raid.xml
+++ b/MekHQ/data/scenariotemplates/DropShip Raid.xml
@@ -2,7 +2,7 @@
 <ScenarioTemplate>
     <name>DropShip Raid</name>
     <shortBriefing>Destroy or cripple DropShip.</shortBriefing>
-    <detailedBriefing>A DropShip has been intercepted shortly after landing. You have 30 turns to destroy or cripple it before it can lift off. The defenders are not the priority. Preserve 50% of your forces to ensure mission success.</detailedBriefing>
+    <detailedBriefing>A DropShip has been intercepted shortly after landing. Destroy or cripple it before it can lift off. The defenders are not the priority. Preserve 50% of your forces to ensure mission success.</detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -2,7 +2,7 @@
 <ScenarioTemplate>
     <name>Isolated DropShip Defense</name>
     <shortBriefing>Defend isolated DropShip from interception.</shortBriefing>
-    <detailedBriefing>A DropShip has been intercepted shortly after landing and is isolated behind enemy lines. Defend it for 30 turns until it can lift off, preventing it from being crippled. Defeat at least 50% of the attacking forces while preserving 50% of your own units during the engagement.</detailedBriefing>
+    <detailedBriefing>A DropShip has been intercepted shortly after landing and is isolated behind enemy lines. Defend it until it can lift off, preventing it from being crippled. Defeat at least 50% of the attacking forces while preserving 50% of your own units during the engagement.</detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>


### PR DESCRIPTION
Removed references to "30 turns" in scenario briefings to match the scenario templates, which FG3 changed to have a variable turn limit.

Fixes #5394