### PR TITLE
Prevent Reserved Formations from Being Deployed to StratCon

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1914,6 +1914,10 @@ public class StratconRulesManager {
                 continue;
             }
 
+            if (formation.getRole().isInReserve()) {
+                continue;
+            }
+
             int primaryUnitType = force.getPrimaryUnitType(campaign);
             boolean noReinforcementRestriction = !reinforcements ||
                 (getReinforcementType(force.getId(), currentTrack, campaign, campaignState) != ReinforcementEligibilityType.NONE);


### PR DESCRIPTION
Added a check to skip formations with a reserve role in the `StratconRulesManager`. This ensures that combat teams in reserve cannot be deployed to StratCon hexes. This is beneficial in a few ways: it ensures users are using the role system - which benefits them - and it also reinforces the idea that having a force 'in reserve' exempts it from being processed by StratCon (this is particularly important for Integrated commands).