### PR TITLE
Removed Contract Breach References in Scenario and Loan Events

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -326,7 +326,7 @@ InsufficientMedicsNagDialog.text=Your Medical Teams require more Astechs. You ne
 
 ### OutstandingScenariosNagDialog Class
 OutstandingScenariosNagDialog.title=Pending Battle
-OutstandingScenariosNagDialog.text=You have a pending battle. Failure to deploy will result in a defeat and a minor contract breach. \nDo you really wish to advance the day?
+OutstandingScenariosNagDialog.text=You have a pending battle. Failure to deploy will result in a defeat. \nDo you really wish to advance the day?
 
 ### ShortDeploymentNagDialog Class
 ShortDeploymentNagDialog.title=Unmet Deployment Requirements

--- a/MekHQ/src/mekhq/gui/adapter/LoanTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/LoanTableMouseAdapter.java
@@ -18,16 +18,6 @@
  */
 package mekhq.gui.adapter;
 
-import java.awt.event.ActionEvent;
-import java.util.Optional;
-import java.util.UUID;
-
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.JPopupMenu;
-import javax.swing.JTable;
-
 import mekhq.MekHQ;
 import mekhq.campaign.event.LoanRemovedEvent;
 import mekhq.campaign.event.PartRemovedEvent;
@@ -36,6 +26,11 @@ import mekhq.campaign.parts.Part;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.PayCollateralDialog;
 import mekhq.gui.model.LoanTableModel;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.util.Optional;
+import java.util.UUID;
 
 public class LoanTableMouseAdapter extends JPopupMenuAdapter {
     private CampaignGUI gui;
@@ -69,7 +64,7 @@ public class LoanTableMouseAdapter extends JPopupMenuAdapter {
             if (0 == JOptionPane
                     .showConfirmDialog(
                             null,
-                            "Defaulting on this loan will affect your unit rating the same as a contract breach.\nDo you wish to proceed?",
+                            "Defaulting on this loan will affect your unit rating.\nDo you wish to proceed?",
                             "Default on " + selectedLoan + "?", JOptionPane.YES_NO_OPTION)) {
                 PayCollateralDialog pcd = new PayCollateralDialog(
                         gui.getFrame(), true, gui.getCampaign(), selectedLoan);


### PR DESCRIPTION
Removed use of the term 'contract breach' in the 'outstanding scenario', and 'defaulting on a loan' nags.

In the latter case this nag was no longer accurate now we only support CamOps Reputation.

In the former case we want users to be empowered to skip scenarios they can't win. Taking a CVP loss is punishment enough. While I do intend to fully implement contract breaches, at this current time we don't track them and adding this messaging is confusing to players.