### PR TITLE
fix: change how damage is applied on ACAR

### DIFF
--- a/MekHQ/resources/mekhq/resources/acs-report-messages.properties
+++ b/MekHQ/resources/mekhq/resources/acs-report-messages.properties
@@ -86,14 +86,14 @@
 3335={0} has has succumbed from his wounds ☠
 3336={0} is still alive ({1} hits) ⛑
 
-3337={0} has been devastated, {1}
-3338={0} was left behind after the pilot ejected, {1}
-3339={0} was destroyed after being pushed off the battlefield, {1}
-3340={0} was captured by enemy forces, {1}
-3341={0} is in full retreat, {1}
-3342={0} was lost in the way, it never joined the battle, {1}
-3343={0} is salvageable, {1}
-3344={0} was destoryed by surprise, it is salvageable, {1}
+3337={0} has been devastated, there is nothing left of it.
+3338={0} was destroyed by the pilot ejection.
+3339={0} was destroyed after being pushed off the combat envelope.
+3340={0} was captured by enemy forces.
+3341={0} has left the battlefield in full retreat.
+3342={0} never joined the battle.
+3343={0} was destroyed, it is salvageable.
+3344={0} was destroyed by surprise, it is salvageable.
 
 4500={0} attempts a morale check. Need {1} to succeed.
 4501={0} rolled {1}.

--- a/MekHQ/src/mekhq/campaign/autoresolve/acar/SimulationContext.java
+++ b/MekHQ/src/mekhq/campaign/autoresolve/acar/SimulationContext.java
@@ -439,11 +439,12 @@ public class SimulationContext implements IGame {
     }
 
     public void addUnitToGraveyard(Entity entity) {
-        var entityInGame = getEntity(entity.getId());
-        if (entityInGame.isPresent()) {
-            removeEntity(entity);
-            graveyard.add(entity);
+        if (!inGameObjects.containsKey(entity.getId())) {
+            logger.error("Tried to add entity {} to graveyard, but it's not in the game!", entity);
+            return;
         }
+        removeEntity(entity);
+        graveyard.add(entity);
     }
 
     public void setPlayerSkillLevel(int playerId, SkillLevel averageSkillLevel) {

--- a/MekHQ/src/mekhq/campaign/autoresolve/acar/phase/EndPhase.java
+++ b/MekHQ/src/mekhq/campaign/autoresolve/acar/phase/EndPhase.java
@@ -116,13 +116,11 @@ public class EndPhase extends PhaseHandler {
                 var entityOpt = getContext().getEntity(element.getId());
                 if (entityOpt.isPresent()) {
                     var entity = entityOpt.get();
-                    var roll = Compute.rollD6(2);
-                    switch (roll.getIntValue()) {
+                    switch (Compute.rollD6(2).getIntValue()) {
                         case 3, 4, 10, 11 -> entity.setRemovalCondition(IEntityRemovalConditions.REMOVE_EJECTED);
                         case 2, 12 -> entity.setRemovalCondition(IEntityRemovalConditions.REMOVE_DEVASTATED);
                         default -> entity.setRemovalCondition(IEntityRemovalConditions.REMOVE_SALVAGEABLE);
                     }
-                    DamageApplierChooser.damageRemovedEntity(entity, entity.getRemovalCondition());
                     reporter.reportUnitDestroyed(entity);
                     getContext().addUnitToGraveyard(entity);
                 }

--- a/MekHQ/src/mekhq/campaign/autoresolve/acar/phase/VictoryPhase.java
+++ b/MekHQ/src/mekhq/campaign/autoresolve/acar/phase/VictoryPhase.java
@@ -19,10 +19,15 @@
 
 package mekhq.campaign.autoresolve.acar.phase;
 
+import megamek.common.Entity;
 import megamek.common.enums.GamePhase;
+import megamek.common.strategicBattleSystems.SBFUnit;
+import mekhq.campaign.autoresolve.acar.SimulationContext;
 import mekhq.campaign.autoresolve.acar.SimulationManager;
 import mekhq.campaign.autoresolve.acar.report.VictoryPhaseReporter;
+import mekhq.campaign.autoresolve.component.Formation;
 import mekhq.campaign.unit.damage.DamageApplierChooser;
+import mekhq.campaign.unit.damage.EntityFinalState;
 
 public class VictoryPhase extends PhaseHandler {
 
@@ -35,30 +40,48 @@ public class VictoryPhase extends PhaseHandler {
 
     @Override
     protected void executePhase() {
-        applyDamageToRemainingUnits(getSimulationManager());
+        applyDamageToRemainingUnits(getContext());
         victoryPhaseReporter.victoryHeader();
         victoryPhaseReporter.victoryResult(getSimulationManager());
     }
 
-    private static void applyDamageToRemainingUnits(SimulationManager gameManager) {
-        for (var formation : gameManager.getGame().getActiveFormations()) {
-            for ( var unit : formation.getUnits()) {
-                if (unit.getCurrentArmor() < unit.getArmor()) {
-                    for (var element : unit.getElements()) {
-                        var entityOpt = gameManager.getGame().getEntity(element.getId());
-                        if (entityOpt.isPresent()) {
-                            var entity = entityOpt.get();
-                            var percent = (double) unit.getCurrentArmor() / unit.getArmor();
-                            var crits = Math.min(9, unit.getTargetingCrits() + unit.getMpCrits() + unit.getDamageCrits());
-                            percent -= percent * (crits / 11.0);
-                            percent = Math.min(0.95, percent);
-                            var totalDamage = (int) ((entity.getTotalArmor() + entity.getTotalInternal()) * (1 - percent));
-                            DamageApplierChooser.choose(entity, DamageApplierChooser.EntityFinalState.CREW_AND_ENTITY_MUST_SURVIVE)
-                                .applyDamageInClusters(totalDamage, 5);
-                        }
-                    }
-                }
+    private static void applyDamageToRemainingUnits(SimulationContext context) {
+        for (var formation : context.getActiveFormations()) {
+            applyDamageToEntitiesFromFormation(context, formation);
+        }
+
+        for (var inGameObject : context.getGraveyard()) {
+            if (inGameObject instanceof Entity entity) {
+                DamageApplierChooser.damageRemovedEntity(entity, entity.getRemovalCondition());
             }
         }
+    }
+
+    private static void applyDamageToEntitiesFromFormation(SimulationContext context, Formation formation) {
+        for ( var unit : formation.getUnits()) {
+            if (unit.getCurrentArmor() < unit.getArmor()) {
+                applyDamageToEntitiesFromUnit(context, unit);
+            }
+        }
+    }
+
+    private static void applyDamageToEntitiesFromUnit(SimulationContext context, SBFUnit unit) {
+        for (var element : unit.getElements()) {
+            var entityOpt = context.getEntity(element.getId());
+            if (entityOpt.isPresent()) {
+                var entity = entityOpt.get();
+                applyDamageToEntityFromUnit(unit, entity);
+            }
+        }
+    }
+
+    private static void applyDamageToEntityFromUnit(SBFUnit unit, Entity entity) {
+        var percent = (double) unit.getCurrentArmor() / unit.getArmor();
+        var crits = Math.min(9, unit.getTargetingCrits() + unit.getMpCrits() + unit.getDamageCrits());
+        percent -= percent * (crits / 11.0);
+        percent = Math.min(0.95, percent);
+        var totalDamage = (int) ((entity.getTotalArmor() + entity.getTotalInternal()) * (1 - percent));
+        DamageApplierChooser.choose(entity, EntityFinalState.CREW_AND_ENTITY_MUST_SURVIVE)
+            .applyDamageInClusters(totalDamage, 5);
     }
 }

--- a/MekHQ/src/mekhq/campaign/autoresolve/acar/report/EndPhaseReporter.java
+++ b/MekHQ/src/mekhq/campaign/autoresolve/acar/report/EndPhaseReporter.java
@@ -50,21 +50,12 @@ public class EndPhaseReporter {
     }
 
     public void reportUnitDestroyed(Entity entity) {
-        var crewMessageId = entity.getCrew().isDead() ? 3335 : 3336;
         var removalCondition = entity.getRemovalCondition();
         var reportId = reportIdForEachRemovalCondition.getOrDefault(removalCondition, MSG_ID_UNIT_DESTROYED_UNKNOWINGLY);
 
         var r = new PublicReportEntry(reportId)
-            .add(new EntityNameReportEntry(entity).reportText())
-            .add(new PublicReportEntry(crewMessageId)
-                .add(entity.getCrew().getName())
-                .add(entity.getCrew().getHits())
-                .reportText());
-        reportConsumer.accept(new PublicReportEntry(5005)
-                .add(r.reportText())
-                .add(String.format("%.2f%%", (entity).getArmorRemainingPercent() * 100))
-                .add(String.format("%.2f%%", (entity).getInternalRemainingPercent() * 100))
-                .indent(2));
+            .add(new EntityNameReportEntry(entity).reportText());
+        reportConsumer.accept(r);
     }
 
     public void destroyedUnitsHeader() {

--- a/MekHQ/src/mekhq/campaign/autoresolve/acar/report/VictoryPhaseReporter.java
+++ b/MekHQ/src/mekhq/campaign/autoresolve/acar/report/VictoryPhaseReporter.java
@@ -69,35 +69,39 @@ public class VictoryPhaseReporter {
     private void playerFinalReport(Player player) {
         var playerEntities = game.getInGameObjects().stream()
             .filter(e -> e.getOwnerId() == player.getId())
-            .filter(Entity.class::isInstance).toList();
+            .filter(Entity.class::isInstance)
+            .map(Entity.class::cast)
+            .toList();
 
         reportConsumer.accept(new PublicReportEntry(5003).add(new PlayerNameReportEntry(player).reportText())
             .add(playerEntities.size()).indent());
 
         for (var entity : playerEntities) {
             reportConsumer.accept(new PublicReportEntry(5004)
-                .add(new EntityNameReportEntry((Entity) entity).reportText())
-                .add(String.format("%.2f%%", ((Entity) entity).getArmorRemainingPercent() * 100))
-                .add(String.format("%.2f%%", ((Entity) entity).getInternalRemainingPercent() * 100))
-                .add(((Entity) entity).getCrew().getName())
-                .add(((Entity) entity).getCrew().getHits())
+                .add(new EntityNameReportEntry(entity).reportText())
+                .add(String.format("%.2f%%", (entity).getArmorRemainingPercent() * 100))
+                .add(String.format("%.2f%%", (entity).getInternalRemainingPercent() * 100))
+                .add(entity.getCrew().getName())
+                .add(entity.getCrew().getHits())
                 .indent(2));
         }
 
         var deadEntities = game.getGraveyard().stream()
             .filter(e -> e.getOwnerId() == player.getId())
-            .filter(Entity.class::isInstance).toList();
+            .filter(Entity.class::isInstance)
+            .map(Entity.class::cast)
+            .toList();
 
         reportConsumer.accept(new PublicReportEntry(5006).add(new PlayerNameReportEntry(player).reportText())
             .add(deadEntities.size()).indent());
 
         for (var entity : deadEntities) {
             reportConsumer.accept(new PublicReportEntry(5004)
-                .add(new EntityNameReportEntry((Entity) entity).reportText())
-                .add(String.format("%.2f%%", ((Entity) entity).getArmorRemainingPercent() * 100))
-                .add(String.format("%.2f%%", ((Entity) entity).getInternalRemainingPercent() * 100))
-                .add(((Entity) entity).getCrew().getName())
-                .add(((Entity) entity).getCrew().getHits())
+                .add(new EntityNameReportEntry(entity).reportText())
+                .add(String.format("%.2f%%", entity.getArmorRemainingPercent() * 100))
+                .add(String.format("%.2f%%", entity.getInternalRemainingPercent() * 100))
+                .add(entity.getCrew().getName())
+                .add(entity.getCrew().getHits())
                 .indent(2));
         }
     }

--- a/MekHQ/src/mekhq/campaign/unit/damage/DamageApplier.java
+++ b/MekHQ/src/mekhq/campaign/unit/damage/DamageApplier.java
@@ -55,7 +55,7 @@ public interface DamageApplier<E extends Entity> {
         int damageApplied = 0;
         while (totalDamage > 0) {
             if (entity().isCrippled() && entity().getRemovalCondition() == IEntityRemovalConditions.REMOVE_DEVASTATED) {
-                // devastated units don't need to take any damage
+                // devastated units don't need to take any damage anymore
                 break;
             }
             var clusterDamage = Math.min(totalDamage, clusterSize);

--- a/MekHQ/src/mekhq/campaign/unit/damage/DamageApplierChooser.java
+++ b/MekHQ/src/mekhq/campaign/unit/damage/DamageApplierChooser.java
@@ -26,20 +26,6 @@ import megamek.common.*;
  */
 public class DamageApplierChooser {
 
-    public enum EntityFinalState {
-        ANY(false, false),
-        CREW_MUST_SURVIVE(true, false),
-        ENTITY_MUST_SURVIVE(false, true),
-        CREW_AND_ENTITY_MUST_SURVIVE(true, true);
-
-        final boolean crewMustSurvive;
-        final boolean entityMustSurvive;
-
-        EntityFinalState(boolean crewMustSurvive, boolean entityMustSurvive) {
-            this.crewMustSurvive = crewMustSurvive;
-            this.entityMustSurvive = entityMustSurvive;
-        }
-    }
 
     /**
      * Choose the correct DamageHandler for the given entity.

--- a/MekHQ/src/mekhq/campaign/unit/damage/EntityFinalState.java
+++ b/MekHQ/src/mekhq/campaign/unit/damage/EntityFinalState.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ *  This file is part of MekHQ.
+ *
+ *  MekHQ is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  MekHQ is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.unit.damage;
+
+
+public enum EntityFinalState {
+    ANY(false, false),
+    CREW_MUST_SURVIVE(true, false),
+    ENTITY_MUST_SURVIVE(false, true),
+    CREW_AND_ENTITY_MUST_SURVIVE(true, true);
+
+    final boolean crewMustSurvive;
+    final boolean entityMustSurvive;
+
+    EntityFinalState(boolean crewMustSurvive, boolean entityMustSurvive) {
+        this.crewMustSurvive = crewMustSurvive;
+        this.entityMustSurvive = entityMustSurvive;
+    }
+}


### PR DESCRIPTION
This makes a couple of changes in ACAR and how it applies damage to entities, it will now only "consolidate" the damage on the entities after the game has ended, instead of doing it whenever they are destroyed and again after the game ends. Now its just a single step.

Also changed one of the reports so it makes more sense.