### PR TITLE
Fixed Passenger Capacity Calculation in CamOps Reputation

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/TransportationRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/TransportationRating.java
@@ -304,6 +304,8 @@ public class TransportationRating {
 
                 passengerCapacity += bay.getPersonnel(entity.isClan());
             }
+
+            passengerCapacity += entity.getNPassenger();
         }
 
         // Map the capacity of each bay type


### PR DESCRIPTION
Fixed the passenger capacity calculation to include the number of passengers from `entity.getNPassenger()`. This was previously omitted due to oversight.

Fixes #5408