### PR TITLE
Improved StratCon Force Picker & Renamed `LayeredForceIconOperationalStatus` to `OperationalStatus`

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -33,7 +33,7 @@ import mekhq.campaign.icons.ForcePieceIcon;
 import mekhq.campaign.icons.LayeredForceIcon;
 import mekhq.campaign.icons.StandardForceIcon;
 import mekhq.campaign.icons.enums.LayeredForceIconLayer;
-import mekhq.campaign.icons.enums.LayeredForceIconOperationalStatus;
+import mekhq.campaign.icons.enums.OperationalStatus;
 import mekhq.campaign.log.ServiceLogger;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.personnel.Person;
@@ -652,10 +652,10 @@ public class Force {
      * @return a list of the operational statuses for units in this force and in all
      *         of its subForces.
      */
-    public List<LayeredForceIconOperationalStatus> updateForceIconOperationalStatus(final Campaign campaign) {
+    public List<OperationalStatus> updateForceIconOperationalStatus(final Campaign campaign) {
         // First, update all subForces, collecting their unit statuses into a single
         // list
-        final List<LayeredForceIconOperationalStatus> statuses = getSubForces().stream()
+        final List<OperationalStatus> statuses = getSubForces().stream()
                 .flatMap(subForce -> subForce.updateForceIconOperationalStatus(campaign).stream())
                 .collect(Collectors.toList());
 
@@ -663,7 +663,7 @@ public class Force {
         statuses.addAll(getUnits().stream()
                 .map(campaign::getUnit)
                 .filter(Objects::nonNull)
-                .map(LayeredForceIconOperationalStatus::determineLayeredForceIconOperationalStatus)
+                .map(OperationalStatus::determineLayeredForceIconOperationalStatus)
                 .toList());
 
         // Can only update the icon for LayeredForceIcons, but still need to return the
@@ -682,7 +682,7 @@ public class Force {
             // the ordinal of the force's status. Then assign the operational status to
             // this.
             final int index = (int) round(statuses.stream().mapToInt(Enum::ordinal).sum() / (statuses.size() * 1.0));
-            final LayeredForceIconOperationalStatus status = LayeredForceIconOperationalStatus.values()[index];
+            final OperationalStatus status = OperationalStatus.values()[index];
             ((LayeredForceIcon) getForceIcon()).getPieces().put(LayeredForceIconLayer.SPECIAL_MODIFIER,
                     new ArrayList<>());
             ((LayeredForceIcon) getForceIcon()).getPieces().get(LayeredForceIconLayer.SPECIAL_MODIFIER)

--- a/MekHQ/src/mekhq/campaign/icons/enums/OperationalStatus.java
+++ b/MekHQ/src/mekhq/campaign/icons/enums/OperationalStatus.java
@@ -22,6 +22,8 @@ import megamek.common.Entity;
 import mekhq.MHQConstants;
 import mekhq.campaign.unit.Unit;
 
+import static megamek.codeUtilities.MathUtility.clamp;
+
 /**
  * This is the Operational Status of a force or unit, as part of automatically assigning and
  * updating the force's LayeredForceIcon on a new day. It is also used to determine the Operation
@@ -29,7 +31,7 @@ import mekhq.campaign.unit.Unit;
  *
  * @author Justin "Windchild" Bowen
  */
-public enum LayeredForceIconOperationalStatus {
+public enum OperationalStatus {
     //region Enum Declarations
     FULLY_OPERATIONAL(MHQConstants.LAYERED_FORCE_ICON_OPERATIONAL_STATUS_FULLY_OPERATIONAL_FILENAME),
     SUBSTANTIALLY_OPERATIONAL(MHQConstants.LAYERED_FORCE_ICON_OPERATIONAL_STATUS_SUBSTANTIALLY_OPERATIONAL_FILENAME),
@@ -43,7 +45,7 @@ public enum LayeredForceIconOperationalStatus {
     //endregion Variable Declarations
 
     //region Constructors
-    LayeredForceIconOperationalStatus(final String filename) {
+    OperationalStatus(final String filename) {
         this.filename = filename;
     }
     //endregion Constructors
@@ -82,7 +84,7 @@ public enum LayeredForceIconOperationalStatus {
      * @param unit the specified unit
      * @return the determined operational status
      */
-    public static LayeredForceIconOperationalStatus determineLayeredForceIconOperationalStatus(final Unit unit) {
+    public static OperationalStatus determineLayeredForceIconOperationalStatus(final Unit unit) {
         if (unit.isMothballing() || unit.isMothballed() || !unit.isPresent() || unit.isRefitting()
                 || !unit.isRepairable() || !unit.isFunctional()) {
             return NOT_OPERATIONAL;
@@ -94,5 +96,22 @@ public enum LayeredForceIconOperationalStatus {
             case Entity.DMG_HEAVY, Entity.DMG_CRIPPLED -> MARGINALLY_OPERATIONAL;
             default -> NOT_OPERATIONAL;
         };
+    }
+
+    /**
+     * Retrieves the {@code LayeredForceIconOperationalStatus} corresponding to the given ordinal value.
+     * <p>
+     * If the specified ordinal is out of range, it will be clamped to ensure it lies within the valid range
+     * of the available enumeration values.
+     *
+     * @param ordinal the ordinal value to map to a {@code LayeredForceIconOperationalStatus}.
+     *                If the value is less than 0, it will be clamped to 0. If it exceeds the
+     *                maximum ordinal value, it will be clamped to the last index.
+     * @return the corresponding {@code LayeredForceIconOperationalStatus} enum value for the adjusted ordinal.
+     */
+    public static OperationalStatus fromInt(int ordinal) {
+        ordinal = clamp(ordinal, 0, values().length);
+
+        return values()[ordinal];
     }
 }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -64,7 +64,7 @@ import static megamek.common.Compute.d6;
 import static megamek.common.Compute.randomInt;
 import static megamek.common.Coords.ALL_DIRECTIONS;
 import static mekhq.campaign.force.Force.FORCE_NONE;
-import static mekhq.campaign.icons.enums.LayeredForceIconOperationalStatus.determineLayeredForceIconOperationalStatus;
+import static mekhq.campaign.icons.enums.OperationalStatus.determineLayeredForceIconOperationalStatus;
 import static mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment.Allied;
 import static mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment.Opposing;
 import static mekhq.campaign.mission.ScenarioMapParameters.MapLocation.AllGroundTerrain;

--- a/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardLanceModel.java
+++ b/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardLanceModel.java
@@ -14,16 +14,14 @@
 
 package mekhq.gui.stratcon;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-
-import javax.swing.DefaultListModel;
-
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * List data model for the StratCon scenario wizard.
@@ -41,8 +39,7 @@ public class ScenarioWizardLanceModel extends DefaultListModel<Force> {
         }
 
         // let's sort these guys by alphabetical order
-        Collections.sort(sortedForces,
-                (Comparator<Force>) (Force o1, Force o2) -> o1.getName().compareTo(o2.getName()) );
+        sortedForces.sort(Comparator.comparing(Force::getName));
 
         super.addAll(sortedForces);
     }

--- a/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardUnitRenderer.java
+++ b/MekHQ/src/mekhq/gui/stratcon/ScenarioWizardUnitRenderer.java
@@ -13,12 +13,19 @@
 */
 package mekhq.gui.stratcon;
 
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
+import mekhq.campaign.icons.enums.OperationalStatus;
 import mekhq.campaign.unit.Unit;
 
 import javax.swing.*;
 import java.awt.*;
+
+import static mekhq.campaign.icons.enums.OperationalStatus.NOT_OPERATIONAL;
+import static mekhq.campaign.icons.enums.OperationalStatus.determineLayeredForceIconOperationalStatus;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 /**
  * Handles rendering individual units in lists in the StratCon scenario wizard.
@@ -30,13 +37,29 @@ public class ScenarioWizardUnitRenderer extends JLabel implements ListCellRender
     }
 
     @Override
-    public Component getListCellRendererComponent(JList<? extends Unit> list, Unit value, int index,
+    public Component getListCellRendererComponent(JList<? extends Unit> list, Unit unit, int index,
             boolean isSelected, boolean cellHasFocus) {
-        Campaign campaign = value.getCampaign();
+        Campaign campaign = unit.getCampaign();
 
-        int valueForceId = value.getForceId();
+        int valueForceId = unit.getForceId();
         Force force = campaign.getForce(valueForceId);
 
+        // Determine name color
+        OperationalStatus operationalStatus = determineLayeredForceIconOperationalStatus(unit);
+
+        String statusOpenFormat = switch (operationalStatus) {
+            case NOT_OPERATIONAL -> "<s>";
+            case MARGINALLY_OPERATIONAL -> spanOpeningWithCustomColor(
+                MekHQ.getMHQOptions().getFontColorNegativeHexColor());
+            case SUBSTANTIALLY_OPERATIONAL -> spanOpeningWithCustomColor(
+                MekHQ.getMHQOptions().getFontColorWarningHexColor());
+            case FULLY_OPERATIONAL, FACTORY_FRESH -> spanOpeningWithCustomColor(
+                MekHQ.getMHQOptions().getFontColorPositiveHexColor());
+        };
+
+        String statusCloseFormat = operationalStatus == NOT_OPERATIONAL ? "</s>" : CLOSING_SPAN_TAG;
+
+        // Adjust force name to remove unnecessary information
         String forceName = "";
         if (force != null) {
             forceName = force.getFullName();
@@ -44,9 +67,10 @@ public class ScenarioWizardUnitRenderer extends JLabel implements ListCellRender
             forceName = forceName.replaceAll(originNodeName, "");
         }
 
-        setText(String.format("<html><b>%s (%s/%s)</b> - %s - Base BV: %d<br><i>%s</i></html>",
-            value.getName(), value.getEntity().getCrew().getGunnery(), value.getEntity().getCrew().getPiloting(),
-            value.getCondition(), value.getEntity().calculateBattleValue(true, true),
+        // Format string
+        setText(String.format("<html><b>%s%s%s (%s/%s)</b> - Base BV: %d<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<i>%s</i></html>",
+            statusOpenFormat, unit.getName(), statusCloseFormat, unit.getEntity().getCrew().getGunnery(),
+            unit.getEntity().getCrew().getPiloting(), unit.getEntity().calculateBattleValue(true, true),
             forceName));
 
         if (isSelected) {


### PR DESCRIPTION
Renamed `LayeredForceIconOperationalStatus` to `OperationalStatus` now that enum is no longer only used to determine layered force icons.

Made a number of visual improvements to the StratCon force pickers, so that the user has more upfront information. Previously, users only had access to the force name, combat stance, and BV. I've added operational status and a full force name, so that users with multiple identically named forces can more easily differentiate between them.

Old...
<img width="274" alt="image" src="https://github.com/user-attachments/assets/cd72c79c-f479-4cf9-8f29-13efe9940cd8" />

...New...
<img width="387" alt="image" src="https://github.com/user-attachments/assets/d48303d3-763e-4a22-a455-1f9567ee2ce0" />

These changes were extended to the reinforcement dialog...

<img width="681" alt="image" src="https://github.com/user-attachments/assets/29613e93-cbb8-4ae3-81d6-5d8e15ca9b46" />

Fixes #5344