### PR TITLE
Updated TO&E to Use "Support" Term instead of "Non-Combat"

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -404,7 +404,7 @@ public class Force {
 
     /**
      * @param combatForcesOnly to only include combat forces or to also include
-     *                         non-combat forces
+     *                         support forces
      * @return all the unit ids in this force and all of its subforces
      */
     public Vector<UUID> getAllUnits(boolean combatForcesOnly) {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1067,19 +1067,20 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             }
 
             if (gui.getCampaign().getCampaignOptions().isUseAtB()) {
-                menuItem = new JMenuItem(force.isCombatForce() ? "Make Support Force" : "Make Combat Force");
+                menuItem = new JMenuItem(force.isCombatForce() ? "Make Support Force" : "Remove Support Designation");
                 menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUS + forceIds);
                 menuItem.addActionListener(this);
                 popup.add(menuItem);
 
                 menuItem = new JMenuItem(force.isCombatForce() ?
-                    "Make All Forces Support Forces" : "Make All Forces Combat Forces");
+                    "Mark All Forces as Support Forces" : "Remove Support Designation from All Forces");
                 menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUSES + forceIds);
                 menuItem.addActionListener(this);
                 popup.add(menuItem);
 
                 if (gui.getCampaign().getCampaignOptions().isUseStratCon()) {
-                    menuItem = new JMenuItem(!force.isConvoyForce() ? "Mark force as a Resupply Convoy" : "Remove Resupply Convoy Designation");
+                    menuItem = new JMenuItem(!force.isConvoyForce() ?
+                        "Mark force as a Resupply Convoy" : "Remove Resupply Convoy Designation");
                     menuItem.setActionCommand(COMMAND_CHANGE_FORCE_CONVOY_STATUS + forceIds);
                     menuItem.addActionListener(this);
                     popup.add(menuItem);

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1067,13 +1067,13 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             }
 
             if (gui.getCampaign().getCampaignOptions().isUseAtB()) {
-                menuItem = new JMenuItem(force.isCombatForce() ? "Make Non-Combat Force" : "Make Combat Force");
+                menuItem = new JMenuItem(force.isCombatForce() ? "Make Support Force" : "Make Combat Force");
                 menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUS + forceIds);
                 menuItem.addActionListener(this);
                 popup.add(menuItem);
 
                 menuItem = new JMenuItem(force.isCombatForce() ?
-                    "Make Force and Subforces Non-Combat Forces" : "Make Force and Subforces Combat Forces");
+                    "Make All Forces Support Forces" : "Make All Forces Combat Forces");
                 menuItem.setActionCommand(COMMAND_CHANGE_FORCE_COMBAT_STATUSES + forceIds);
                 menuItem.addActionListener(this);
                 popup.add(menuItem);

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -200,7 +200,7 @@ public class ForceViewPanel extends JScrollablePanel {
                 if (force.isConvoyForce()) {
                     forceType = "Resupply " + force.getFormationLevel().toString();
                 } else {
-                    forceType = "Non-Combat " + force.getFormationLevel().toString();
+                    forceType = "Support " + force.getFormationLevel().toString();
                 }
             }
 


### PR DESCRIPTION
@Scoppio inadvertently showed how confusingly similar the terms 'Combat Team' and Combat Force were (specifically 'Non-Combat Force'. The confusion arises from the ability to mark a force to never be considered a Combat Team and declaring them a Non-Combat Force is, on the surface, identical - despite having different use-cases.

This PR changes the term 'Non-Combat' to be 'Support'. All player forces previously labeled as 'Non-Combat Forces' will now be labeled as 'Support Forces', instead. With the advent of Combat Teams and our future plans, 'Support Forces' better matches the purpose of that label than 'Non-Combat'.