### PR TITLE
Added Notification for Users Attempting to Manually Deploy on Integrated Commands

### DIFF
--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -158,6 +158,12 @@ public class StratconPanel extends JPanel implements ActionListener {
 
         StratconScenario scenario = getSelectedScenario();
 
+        if (campaignState.getContract().getCommandRights().isIntegrated()) {
+            menuItemManageForceAssignments = new JMenuItem();
+            menuItemManageForceAssignments.setText("Unable to Deploy: Integrated Command");
+            rightClickMenu.add(menuItemManageForceAssignments);
+        }
+
         // display "Manage Force Assignment" if there is not a force already on the hex
         // except if there is already a non-cloaked scenario here.
         if (StratconRulesManager.canManuallyDeployAnyForce(coords, currentTrack, campaignState.getContract())) {


### PR DESCRIPTION
Previously, no visual feedback was provided for deployment restrictions under integrated command rights. This update adds a menu item to inform users when deployment is unavailable due to integrated command settings. This should make things a little easier on new players.