### PR TITLE
Fixed Unit Check in Combat Team Status Evaluation

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -348,7 +348,7 @@ public class CombatTeam {
             return overrideState;
         }
 
-        if (force.getUnits().isEmpty()) {
+        if (force.getAllUnits(true).isEmpty()) {
             force.setCombatTeamStatus(false);
             return false;
         }


### PR DESCRIPTION
Replaced `getUnits` with `getAllUnits` to include all units (including those in child forces) during the status check. This ensures proper evaluation of Combat Team suitability.