### PR TITLE
Fixed Force Deployment Order Bug

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -2041,7 +2041,8 @@ public class StratconRulesManager {
      *
      * @return List of unit IDs.
      */
-    public static List<Unit> getEligibleLeadershipUnits(Campaign campaign, Set<Integer> forceIDs, int leadershipSkill) {
+    public static List<Unit> getEligibleLeadershipUnits(Campaign campaign, ArrayList<Integer> forceIDs,
+                                                        int leadershipSkill) {
         List<Unit> eligibleUnits = new ArrayList<>();
 
         // If there is no leadership skill, we shouldn't continue
@@ -2107,7 +2108,7 @@ public class StratconRulesManager {
     /**
      * Calculates the majority unit type for the forces given the IDs.
      */
-    private static int getPrimaryUnitType(Campaign campaign, Set<Integer> forceIDs) {
+    private static int getPrimaryUnitType(Campaign campaign, ArrayList<Integer> forceIDs) {
         Map<Integer, Integer> unitTypeBuckets = new TreeMap<>();
         int biggestBucketID = -1;
         int biggestBucketCount = 0;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -13,6 +13,8 @@
 */
 package mekhq.campaign.stratcon;
 
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import megamek.common.annotations.Nullable;
@@ -78,7 +80,7 @@ public class StratconScenario implements IStratconDisplayable {
     private boolean ignoreForceAutoAssignment;
     private int leadershipPointsUsed;
     private Set<Integer> failedReinforcements = new HashSet<>();
-    private Set<Integer> primaryForceIDs = new HashSet<>();
+    private ArrayList<Integer> primaryForceIDs = new ArrayList<>();
 
     /**
      * Add a force to the backing scenario. Do our best to add the force as a "primary" force, as defined in the scenario template.
@@ -136,11 +138,13 @@ public class StratconScenario implements IStratconDisplayable {
      * These are all the "primary" force IDs, meaning forces that have been used
      * by the scenario to drive the generation of the OpFor.
      */
-    public Set<Integer> getPrimaryForceIDs() {
+    @XmlElementWrapper(name = "primaryForceIDs")
+    @XmlElement(name = "primaryForceID")
+    public ArrayList<Integer> getPrimaryForceIDs() {
         return primaryForceIDs;
     }
 
-    public void setPrimaryForceIDs(Set<Integer> primaryForceIDs) {
+    public void setPrimaryForceIDs(ArrayList<Integer> primaryForceIDs) {
         this.primaryForceIDs = primaryForceIDs;
     }
 

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -253,7 +253,7 @@ public class StratconScenarioWizard extends JDialog {
             localGbc.gridy = 1;
             JLabel selectedForceInfo = new JLabel();
             JList<Force> availableForceList = addAvailableForceList(forcePanel, localGbc, forceTemplate);
-
+            availableForceList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
             // Add a listener to handle changes to the selected force
             availableForceList
                     .addListSelectionListener(e -> {
@@ -515,8 +515,13 @@ public class StratconScenarioWizard extends JDialog {
         // go through all the force lists and add the selected forces to the scenario
         for (String templateID : availableForceLists.keySet()) {
             for (Force force : availableForceLists.get(templateID).getSelectedValuesList()) {
-                // if we are assigning reinforcements, pay the price if appropriate
-                if (currentScenario.getCurrentState() == ScenarioState.PRIMARY_FORCES_COMMITTED) {
+                if (templateID.equals(ScenarioForceTemplate.PRIMARY_FORCE_TEMPLATE_ID)) {
+                    logger.info("Committing primary force: " + force.getFullName());
+                    if (currentScenario.getCurrentState() == ScenarioState.UNRESOLVED) {
+                        currentScenario.addForce(force, templateID, campaign);
+                    }
+                } else if (currentScenario.getCurrentState() == ScenarioState.PRIMARY_FORCES_COMMITTED) {
+                    logger.info("Committing reinforcement force: " + force.getFullName());
                     if (currentCampaignState.getSupportPoints() <= 0) {
                         campaign.addReport(String.format(resourceMap.getString("reinforcementsNoSupportPoints.text"),
                             currentScenario.getName(),
@@ -526,8 +531,8 @@ public class StratconScenarioWizard extends JDialog {
                     }
 
                     ReinforcementEligibilityType reinforcementType = StratconRulesManager.getReinforcementType(
-                            force.getId(), currentTrackState,
-                            campaign, currentCampaignState);
+                        force.getId(), currentTrackState,
+                        campaign, currentCampaignState);
 
                     // if we failed to deploy as reinforcements, move on to the next force
                     ReinforcementResultsType reinforcementResults = processReinforcementDeployment(
@@ -551,11 +556,6 @@ public class StratconScenarioWizard extends JDialog {
                             }
                         }
                     }
-                } else {
-                    // In the event the player has selected multiple forces to act as the primary
-                    // force, only commit the first force
-                    currentScenario.addForce(force, templateID, campaign);
-                    break;
                 }
             }
         }


### PR DESCRIPTION
The bug this aims to fix is primary and reinforcement forces swapping about when reloading MekHQ. So forces previously sent to a scenario would end up as the primary force, while the primary force got shunted to reinforcements.

In the first place we had an issue where primary force wasn't being serialized or deserialized. So mhq would, essentially, 'forget' that information when reloading the client.

However, fixing that did not resolve the problem, which lead us to the second issue: when reloading mhq also 'forgets' what Template player forces are assigned to. I did a couple hours' digging and I've concluded that we simply do not save this information. `StratconScenario` inherits from `AtBScenario` which inherits from `Scenario` and it's in `Scenario` that we store what forces have been assigned to the scenario. Fixing this issue there would likely cause a lot of problems for non-StratCon players.

The 'fix' is to cross-reference the ID of forces assigned to the scenario, with the list of Primary Forces. If we confirm that the force is a primary force we tell mhq to ignore that and assign them to the Primary Force template, instead. If the force has been assigned to the Primary Force template, but is _not_ included in our list of Primary Forces, we tell mhq to assign it to the Reinforcements template, instead. This check only occurs if the player is using StratCon.

This is an ugly solution, but if anyone else can come up with a better option I would love to hear it, because I'm at a loss.

Fixes #2800