### PR TITLE
Halved Duration of Recon Scenarios

### DIFF
--- a/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -114,7 +114,7 @@
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>50</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>

--- a/MekHQ/data/scenariotemplates/Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Recon Evasion.xml
@@ -119,7 +119,7 @@
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>50</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>

--- a/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
@@ -146,7 +146,7 @@
             <objectiveCriterion>Preserve</objectiveCriterion>
             <percentage>50</percentage>
             <timeLimitAtMost>false</timeLimitAtMost>
-            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitScaleFactor>1</timeLimitScaleFactor>
             <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>


### PR DESCRIPTION
Halved the scenario duration in three scenario templates: Heavy Recon Evasion, Reconnaissance Interdiction, and Recon Evasion. This should make these scenarios feel a little less punishing.