### PR TITLE
Adjusted Scenario Modifiers BV & Unit Count Contribution

### DIFF
--- a/MekHQ/data/scenariomodifiers/AlliedASFAce01.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedASFAce01.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>-2</allowedUnitType>
 		<arrivalTurn>2</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedAirSupport.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedAirSupport.xml
@@ -8,9 +8,9 @@
 		<allowedUnitType>-3</allowedUnitType>
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedAirSupportBombers.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedAirSupportBombers.xml
@@ -8,9 +8,9 @@
 		<allowedUnitType>-3</allowedUnitType>
 		<arrivalTurn>-3</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedArtyGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedArtyGarrison.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>1</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedArtySupport.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedArtySupport.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>1</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>false</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>true</deployOffboard>
 		<deploymentZones>
 			<deploymentZone>9</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedCavLance.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedCavLance.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>-2</allowedUnitType>
 		<arrivalTurn>3</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedHorseCav.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedHorseCav.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>-2</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedMekAceCRD.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekAceCRD.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>-2</allowedUnitType>
 		<arrivalTurn>2</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedMekAceGLT.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekAceGLT.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>-2</allowedUnitType>
 		<arrivalTurn>2</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedMekAceGOL.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekAceGOL.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>-2</allowedUnitType>
 		<arrivalTurn>2</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedMekAceOTT.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekAceOTT.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>-2</allowedUnitType>
 		<arrivalTurn>2</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedMekAceTBT.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekAceTBT.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>-2</allowedUnitType>
 		<arrivalTurn>2</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedMekGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedMekGarrison.xml
@@ -14,7 +14,7 @@
 		<canReinforceLinked>false</canReinforceLinked>
 		<contributesToBV>true</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>false</contributesToUnitCount>
+		<contributesToUnitCount>true</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/AlliedOfficerMek.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedOfficerMek.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>0</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedTraineesAir.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTraineesAir.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>9</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedTraineesGround.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTraineesGround.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>0</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/AlliedTurrets.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedTurrets.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>7</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>
 			<deploymentZone>10</deploymentZone>
 		</deploymentZones>

--- a/MekHQ/data/scenariomodifiers/FacilityAlliedEvac.xml
+++ b/MekHQ/data/scenariomodifiers/FacilityAlliedEvac.xml
@@ -8,9 +8,9 @@
         <allowedUnitType>-1</allowedUnitType>
         <arrivalTurn>0</arrivalTurn>
         <canReinforceLinked>true</canReinforceLinked>
-        <contributesToBV>true</contributesToBV>
+        <contributesToBV>false</contributesToBV>
         <contributesToMapSize>true</contributesToMapSize>
-        <contributesToUnitCount>true</contributesToUnitCount>
+        <contributesToUnitCount>false</contributesToUnitCount>
         <deployOffboard>false</deployOffboard>
         <deploymentZones>
             <deploymentZone>10</deploymentZone>

--- a/MekHQ/data/scenariomodifiers/LocalGarrisonInfantry.xml
+++ b/MekHQ/data/scenariomodifiers/LocalGarrisonInfantry.xml
@@ -12,7 +12,7 @@
 		<allowedUnitType>3</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
 		<contributesToUnitCount>false</contributesToUnitCount>
 		<deploymentZones>

--- a/MekHQ/data/scenariomodifiers/PrimaryAlliesAir.xml
+++ b/MekHQ/data/scenariomodifiers/PrimaryAlliesAir.xml
@@ -8,9 +8,9 @@
 		<allowedUnitType>-3</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariomodifiers/PrimaryAlliesGround.xml
+++ b/MekHQ/data/scenariomodifiers/PrimaryAlliesGround.xml
@@ -12,9 +12,9 @@
 		<allowedUnitType>-2</allowedUnitType>
 		<arrivalTurn>0</arrivalTurn>
 		<canReinforceLinked>false</canReinforceLinked>
-		<contributesToBV>true</contributesToBV>
+		<contributesToBV>false</contributesToBV>
 		<contributesToMapSize>true</contributesToMapSize>
-		<contributesToUnitCount>true</contributesToUnitCount>
+		<contributesToUnitCount>false</contributesToUnitCount>
 		<deployOffboard>false</deployOffboard>
 		<deploymentZones />
 		<destinationZone>5</destinationZone>


### PR DESCRIPTION
We received some feedback on Discord that highlighted a significant problem with how Scenario Modifiers were being handled:

In short, getting an Allied Force modifier would actually make the scenario harder. As for every allied unit added, the OpFor's size would increase. Conversely, whenever the player got an Enemy Force modifier, it would increase the size of the enemy force, by nature of giving the OpFor more units.

No matter what kind of modifier the player got, it would result in a harder scenario.

This PR addresses this by telling MekHQ to ignore random allied force modifiers, when calculating the OpFor's BV allowance. An exception was made for two types of allied force: those added by scenarios (like Allied DropShips) and those added by Command Rights (like Liaison units). For all others, no BV (or unit count) adjustment is made, meaning getting an Allied Force modifier is now always a good thing.

This has the added benefit of reducing average scenario size.