### PR TITLE
Added Further Edge Case Handling for Turn Limit Scenario Objectives

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1379,6 +1379,7 @@ public class AtBDynamicScenarioFactory {
      * units that have associated force templates that "contribute to the unit count".
      */
     private static void scaleObjectiveTimeLimits(AtBDynamicScenario scenario, Campaign campaign) {
+        final int DEFAULT_TIME_LIMIT = 6;
         int primaryUnitCount = 0;
 
         for (int forceID : scenario.getPlayerForceTemplates().keySet()) {
@@ -1398,9 +1399,13 @@ public class AtBDynamicScenarioFactory {
         // We want a minimum value here, to avoid situations where we spawn scenarios with only a
         // single turn requirement.
         // This effectively treats any player-aligned forces less than 6 as 6.
-        primaryUnitCount = max(primaryUnitCount, 6);
+        primaryUnitCount = max(DEFAULT_TIME_LIMIT, 6);
 
         for (ScenarioObjective objective : scenario.getScenarioObjectives()) {
+            // We set a default time to protect against instances where setting time limit fails
+            // for some reason.
+            objective.setTimeLimit(DEFAULT_TIME_LIMIT);
+
             if (objective.getTimeLimitType() == TimeLimitType.ScaledToPrimaryUnitCount) {
                 Integer scaleFactor = objective.getTimeLimitScaleFactor();
 


### PR DESCRIPTION
Introduced a default time limit constant to ensure objectives always have a minimum time limit. This prevents edge cases where objectives could lack a proper time constraint and improves overall scenario reliability. Adjusted related logic to use the constant for consistency.

If we _still_ get null turn limits it means the objective is failing to parse in its' entirety, which will be a thornier problem to resolve, so I'm hoping it's not necessary.