### PR TITLE
Updated Convoy Scenarios to Exclude BV and Unit Count Contribution for Convoy Units

### DIFF
--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -88,9 +88,9 @@
                 <allowedUnitType>-2</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>false</canReinforceLinked>
-                <contributesToBV>true</contributesToBV>
+                <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
-                <contributesToUnitCount>true</contributesToUnitCount>
+                <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
                     <deploymentZone>2</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -88,9 +88,9 @@
                 <allowedUnitType>-2</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>false</canReinforceLinked>
-                <contributesToBV>true</contributesToBV>
+                <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
-                <contributesToUnitCount>true</contributesToUnitCount>
+                <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
                     <deploymentZone>2</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -86,9 +86,9 @@
                 <allowedUnitType>1</allowedUnitType>
                 <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>false</canReinforceLinked>
-                <contributesToBV>true</contributesToBV>
+                <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
-                <contributesToUnitCount>true</contributesToUnitCount>
+                <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
                     <deploymentZone>10</deploymentZone>


### PR DESCRIPTION
Changed `contributesToBV` and `contributesToUnitCount` to `false` in `Critical Convoy Escort`, `Convoy Escort`, and `Emergency Convoy Defense` (NPC Convoys Only). This ensures these units do not affect battle value calculations or unit counting during scenarios.

This change was suggested by QA.