### PR TITLE
Fixed Combat Team Eligibility Check by Rolling Back Use of `getAllUnits()`

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -348,7 +348,9 @@ public class CombatTeam {
             return overrideState;
         }
 
-        if (force.getAllUnits(true).isEmpty()) {
+        // This should never be getAllUnits() as otherwise parent nodes will be assessed as being
+        // automatically eligible to be Combat Teams preventing child nodes from being Combat Teams
+        if (force.getUnits().isEmpty()) {
             force.setCombatTeamStatus(false);
             return false;
         }


### PR DESCRIPTION
Replaced `getAllUnits() with `getUnits()` to prevent parent nodes from incorrectly being marked as Combat Teams. Added a comment for clarification of the logic.