### PR TITLE
Added Motive System Exclusion in Resupply Eligibility

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -566,6 +566,7 @@ public class Resupply {
         return checkExclusionList(part)
             || checkMekLocation(part, unit)
             || checkTankLocation(part)
+            || checkMotiveSystem(part)
             || checkTransporter(part);
     }
 
@@ -587,6 +588,16 @@ public class Resupply {
             }
         }
         return false;
+    }
+
+    /**
+     * Checks if the given part is an instance of {@code MotiveSystem}.
+     *
+     * @param part the {@link Part} to be checked.
+     * @return {@code true} if the part is a {@link MotiveSystem}, {@code false} otherwise.
+     */
+    private boolean checkMotiveSystem(Part part) {
+        return part instanceof MotiveSystem;
     }
 
     /**


### PR DESCRIPTION
Implemented a new method to verify if parts are instances of `MotiveSystem` and included it in the resupply check logic. This ensures MotiveSystem components are not considered eligible for resupply.