### PR TITLE
Refined Deploy/Undeploy Menu Behavior for GM Permissions.

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1134,10 +1134,10 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             }
 
             if (StaticChecks.areAllForcesDeployed(forces)) {
-                menuItem = new JMenuItem("Undeploy Force");
+                menuItem = new JMenuItem("Undeploy Force (GM)");
                 menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_FORCE + forceIds);
                 menuItem.addActionListener(this);
-                menuItem.setEnabled(!gui.getCampaign().getCampaignOptions().isUseStratCon());
+                menuItem.setEnabled(gui.getCampaign().isGM() || !gui.getCampaign().getCampaignOptions().isUseStratCon());
                 popup.add(menuItem);
             }
 
@@ -1635,10 +1635,10 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             }
 
             if (StaticChecks.areAllUnitsDeployed(units)) {
-                menuItem = new JMenuItem("Undeploy Unit");
+                menuItem = new JMenuItem("Undeploy Unit (GM)");
                 menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_UNIT + unitIds);
                 menuItem.addActionListener(this);
-                menuItem.setEnabled(!gui.getCampaign().getCampaignOptions().isUseStratCon());
+                menuItem.setEnabled(gui.getCampaign().isGM() || !gui.getCampaign().getCampaignOptions().isUseStratCon());
                 popup.add(menuItem);
             }
 

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -1006,10 +1006,10 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                 }
 
                 if (oneDeployed) {
-                    menuItem = new JMenuItem("Undeploy Unit");
+                    menuItem = new JMenuItem("Undeploy Unit (GM)");
                     menuItem.setActionCommand(COMMAND_UNDEPLOY);
                     menuItem.addActionListener(this);
-                    menuItem.setEnabled(!gui.getCampaign().getCampaignOptions().isUseStratCon());
+                    menuItem.setEnabled(gui.getCampaign().isGM() || !gui.getCampaign().getCampaignOptions().isUseStratCon());
                     menu.add(menuItem);
                 }
 


### PR DESCRIPTION
Updated "Undeploy Force" and "Undeploy Unit" menu items to include "(GM)" labels and adjusted their enabled state to consider GM status.

We don't really want users to be using these options for StratCon play. Previously I disabled them entirely, however QA requested they be re-enabled. A compromise was enabling them for GMs, while disabling for general users.