### PR TITLE
Improved Reinforcement Transparency and User Control

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -26,12 +26,12 @@ reinforcementsNoAdmin.text=Attempting to reinforce scenario %s, %s<b>ERROR</b>%s
   \ spent in this attempt.
 reinforcementsAttempt.text=Attempting to reinforce scenario %s, roll <b>%s%s</b> vs. <b>%s</b>:
 reinforcementsCriticalFailure.text=%s<b>Critical Command Failure</b>%s. Reinforcement attempt\
-  \ fails and Support Point is lost.
+  \ fails and Support Points are lost.
 reinforcementsSuccess.text=%s<b>Reinforcement Success</b>%s.
 reinforcementsSuccessRouted.text=%s<b>Reinforcement Success</b>%s. The enemy has routed\
   \ and is unable to intercept your reinforcements.
 reinforcementsCommandFailure.text=%s<b>Command Failure</b>%s. Reinforcement attempt\
-  \ fails and Support Point is lost.
+  \ delayed.
 reinforcementsInterceptionAttempt.text=Due to a %s<b>Command Failure</b>%s your reinforcements are\
   \ out of position. Enemy forces were dispatched in an attempt to capitalize on this tactical error.
 reinforcementsErrorNoCommander.text=%s<b>Error</b>%s. There is no commander assigned to this force.\

--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -16,17 +16,14 @@ selectForceForTemplate.Text=<html><b>Select a force from the list below.</b>\
   <br>If multiple forces are selected, only the first will be deployed.</html>
 selectReinforcementsForTemplate.Text=<html><b>Select reinforcements from the list below.</b>\
   <br>\
-  <br>Each attempt will cost 1 Support Point and may be unsuccessful.</html>
-selectReinforcementsForTemplateNoSupportPoints.Text=<html><b>Unable to assign reinforcements. No Support Points available.</b></html>
+  <br>Each attempt will cost Support Points and may be unsuccessful.</html>
+selectReinforcementsForTemplateNoSupportPoints.Text=<html><b>Unable to assign reinforcements. No\
+  \ Support Points available.</b></html>
 
-reinforcementsNoSupportPoints.text=Attempting to reinforce scenario %s, %s<b>Automatic Failure</b>%s You\
-  \ have no remaining Support Points.
-reinforcementsNoAdmin.text=Attempting to reinforce scenario %s, %s<b>ERROR</b>%s nobody has been\
-  \ assigned to an <i>Admin/Command</i> position. Roll automatically fails. No Support Points were\
+reinforcementsNoAdmin.text=Attempting to reinforce scenario %s, %s<b>ERROR</b>%s either nobody has\
+  \ been assigned to an <i>Admin/Command</i> position, or the most senior character in that\
+  \ position lacks the <i>Administration</i> skill. Roll automatically fails. No Support Points were\
   \ spent in this attempt.
-reinforcementsNoAdminSkill.text=Attempting to reinforce scenario %s, %s<b>ERROR</b>%s %s does not have the\
-  \ <i>Administration</i> skill. Roll automatically fails. No Support Points were spent in this\
-  \ attempt.
 reinforcementsAttempt.text=Attempting to reinforce scenario %s, roll <b>%s%s</b> vs. <b>%s</b>:
 reinforcementsCriticalFailure.text=%s<b>Critical Command Failure</b>%s. Reinforcement attempt\
   \ fails and Support Point is lost.
@@ -63,3 +60,24 @@ btnRemoveCVP.text=Remove CVP (GM)
 requestingResupply.title=Requesting Resupply
 supplyPointExpenditure.text=How many Support Points would you like to spend?
 btnConfirm.text=Confirm
+
+scenarioSetupWizard.title=Scenario Setup Wizard
+unitSelectLabelDefaultValue.text=0 selected
+reinforcementConfirmation.title=Reinforcement Confirmation
+reinforcementConfirmation.description=<html><div style='width: %s; text-align: center;'>%s, we've\
+  \ run the numbers. If we reinforce now, here is our likelihood of success. If we have excess\
+  \ <b>Support Points</b>, we will be able to reduce the target number by 2 for each additional\
+  \ Support Point spent.\
+  <br>\
+  <br>Forces assigned to the 'Fight' or 'Auxiliary' roles perform two checks, keeping the best\
+  \ result.</div></html>
+reinforcementConfirmation.breakdown=<html><div style='width: %s; text-align: center;'><br><b>Breakdown\
+  \ of Target Numbers:</b><br>
+reinforcementConfirmation.breakdown.noTarget=<html><div style='width: %s; text-align: center;'><br>%s<b>ERROR</b>%s\
+  \ nobody has been assigned to an <i>Admin/Command</i> position, or the most senior Admin/Command\
+  \ character lacks the <i>Administration</i> skill. Roll will automatically fail.<br>
+reinforcementConfirmation.spinnerLabel=Support Points
+reinforcementConfirmation.confirmButton=Confirm
+reinforcementConfirmation.cancelButton=Cancel
+unitsSelectedLabel.bv=selected (ignores crew skill)
+unitsSelectedLabel.count=selected

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -3873,12 +3873,14 @@ public class AtBDynamicScenarioFactory {
      */
     public static void setDeploymentTurnsForReinforcements(List<Entity> entityList, int turnModifier,
                                                            boolean isDelayed) {
-        int minimumSpeed = 999;
         int arrivalScale = REINFORCEMENT_ARRIVAL_SCALE;
 
         // First, we organize the reinforcements into pools.
         // This ensures each Force's reinforcements are handled separately.
         Map<Integer, Integer> delayByForce = new HashMap<>();
+
+        int actualArrivalTurn = 0;
+        int delayedArrivalScale = REINFORCEMENT_ARRIVAL_SCALE * (randomInt(2) + 2);
 
         // first, we figure out the slowest "atb speed" of this group.
         for (Entity entity : entityList) {
@@ -3888,7 +3890,6 @@ public class AtBDynamicScenarioFactory {
                 if (delayByForce.containsKey(forceId)) {
                     arrivalScale = delayByForce.get(forceId);
                 } else {
-                    int delayedArrivalScale = REINFORCEMENT_ARRIVAL_SCALE * (randomInt(2) + 2);
                     delayByForce.put(forceId, delayedArrivalScale);
                     arrivalScale = delayedArrivalScale;
                 }
@@ -3899,13 +3900,7 @@ public class AtBDynamicScenarioFactory {
                 continue;
             }
 
-            int speed = calculateAtBSpeed(entity);
-
-            // don't reduce minimum speed to 0, since dividing by zero further down is
-            // problematic
-            if ((speed < minimumSpeed) && (speed > 0)) {
-                minimumSpeed = speed;
-            }
+            int speed = max(1, calculateAtBSpeed(entity));
 
             // the actual arrival turn will be the scale divided by the slowest speed.
             // so, a group of Atlases (3/5) should arrive at turn 7 (20 / 3)
@@ -3913,8 +3908,14 @@ public class AtBDynamicScenarioFactory {
             // a group of Ostscouts (8/12/8) should arrive on turn 2 (20 / 9, rounded down)
             // we then subtract the passed-in turn modifier, which is usually the
             // commander's strategy skill level.
-            int actualArrivalTurn = max(0, (arrivalScale / minimumSpeed) - turnModifier);
+            int rollingArrivalTurn = max(0, (arrivalScale / speed) - turnModifier);
 
+            if (rollingArrivalTurn > actualArrivalTurn) {
+                actualArrivalTurn = rollingArrivalTurn;
+            }
+        }
+
+        for (Entity entity : entityList) {
             entity.setDeployRound(actualArrivalTurn);
         }
     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1407,7 +1407,6 @@ public class StratconRulesManager {
      *     <li><b>Liaison Modifiers:</b> Reductions based on the type of command rights
      *         (e.g., Liaison, House, or Integrated).</li>
      * </ul>
-     * </p>
      *
      * @param campaign          the {@link Campaign} representing the current campaign, which provides global game
      *                          configuration and reputation data.

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1409,25 +1409,27 @@ public class StratconRulesManager {
      * </ul>
      * </p>
      *
-     * @param campaign           the {@link Campaign} representing the current campaign, which provides global game
-     *                           configuration and reputation data.
-     * @param skillTargetNumber  the base target number derived from the skill level of the relevant unit or character.
-     * @param track              the {@link StratconTrackState} representing the current track in the strategic
-     *                           conflict, providing facility details for modifier calculations. Can be {@code null}.
-     * @param contract           the {@link AtBContract} containing the details of the ongoing contract, such as
-     *                           ally and enemy skill levels, and command rights.
+     * @param campaign          the {@link Campaign} representing the current campaign, which provides global game
+     *                          configuration and reputation data.
+     * @param commandLiaison    the {@link Person} performing the reinforcement check.
+     * @param skillTargetNumber the base target number derived from the skill level of the relevant unit or character.
+     * @param track             the {@link StratconTrackState} representing the current track in the strategic
+     *                          conflict, providing facility details for modifier calculations. Can be {@code null}.
+     * @param contract          the {@link AtBContract} containing the details of the ongoing contract, such as
+     *                          ally and enemy skill levels, and command rights.
      * @return a {@link TargetRoll} object containing the calculated target number and all contributing modifiers.
      */
-    public static TargetRoll calculateReinforcementTargetNumber(Campaign campaign, int skillTargetNumber,
-                                                                StratconTrackState track, AtBContract contract,
-                                                                int supportPoints) {
+    public static TargetRoll calculateReinforcementTargetNumber(Campaign campaign,
+                                                                Person commandLiaison,
+                                                                int skillTargetNumber,
+                                                                StratconTrackState track, AtBContract contract) {
         TargetRoll reinforcementTargetNumber = new TargetRoll();
 
         // Base Target Number
-        reinforcementTargetNumber.addModifier(skillTargetNumber, "Base TN");
+        reinforcementTargetNumber.addModifier(skillTargetNumber,
+            "Base TN (" + commandLiaison.getFullName() +')');
 
         // Facilities Modifier
-
         int facilityModifier = 0;
         if (track != null) {
             for (StratconFacility facility : track.getFacilities().values()) {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1219,7 +1219,7 @@ public class StratconRulesManager {
         }
 
         if (reinforcementTargetNumber == 999) {
-            campaign.addReport(String.format(resources.getString("reinforcementsNoAdmin..text"),
+            campaign.addReport(String.format(resources.getString("reinforcementsNoAdmin.text"),
                 scenario.getName(),
                 spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
                 CLOSING_SPAN_TAG));

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1283,7 +1283,7 @@ public class StratconRulesManager {
                 spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
                 CLOSING_SPAN_TAG));
             campaign.addReport(reportStatus.toString());
-            return FAILED;
+            return DELAYED;
         }
 
         // Check failed, but enemy is routed
@@ -1460,11 +1460,9 @@ public class StratconRulesManager {
         int liaisonModifier = 0;
         if (commandRights.isLiaison()) {
             liaisonModifier -= 1;
-        } else if (commandRights.isHouse() || commandRights.isIntegrated()) {
-            liaisonModifier -= 2;
         }
 
-        reinforcementTargetNumber.addModifier(liaisonModifier, "Command Rights");
+        reinforcementTargetNumber.addModifier(liaisonModifier, "Liaison Command Rights");
 
         // Return final value
         return reinforcementTargetNumber;

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -597,7 +597,7 @@ public class StratconScenarioWizard extends JDialog {
 
                 // Recalculate the target number using updated spinner value
                 TargetRoll reinforcementTargetNumber = calculateReinforcementTargetNumber(
-                    campaign, skillTargetNumber, track, currentCampaignState.getContract(), 1);
+                    campaign, commandLiaison, skillTargetNumber, track, currentCampaignState.getContract());
                 targetNumber = reinforcementTargetNumber.getValue();
 
                 breakdownContents.append(String.format(resourceMap.getString("reinforcementConfirmation.breakdown"),


### PR DESCRIPTION
Now, when reinforcing, users will be presented with a dialog detailing a breakdown of the target number, who is performing the check, and providing the option to spend additional Support Points to improve the target number by 2, per additional Support Point spent.

Fixes #5442