### PR TITLE
Fixed Legacy AtB Battle Chance Spinner Array Indexing Bug

### DIFF
--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -3150,7 +3150,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         gridBagConstraints.gridwidth = 2;
         panSubAtBContract.add(lblBattleFrequency, gridBagConstraints);
 
-        spnAtBBattleChance = new JSpinner[CombatRole.values().length - 1];
+        spnAtBBattleChance = new JSpinner[CombatRole.values().length - 2];
 
         JLabel lblFightChance = new JLabel(CombatRole.FIGHTING + ":");
         gridBagConstraints.gridy = 15;


### PR DESCRIPTION
Adjusted the spinner array size to account for correct CombatRole enumeration length. This resolved an off-by-one error that caused improper initialization.

Fixes #5461