### PR TITLE
Corrected Date of Resupply Interception Scenarios & Added Clarity to Scenario Names

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
@@ -601,17 +601,19 @@ public class PerformResupply {
         // scenario, or a facility. If the player is really lucky, the scenario will spawn on top
         // of a force already deployed to the Strategic Map.
         StratconScenario scenario = generateExternalScenario(campaign, contract, track,
-            null, template, false);
+            null, template, false, 0);
 
         // If we successfully generated a scenario, we need to make a couple of final
         // adjustments, including assigning the Resupply contents as loot and
         // assigning a player convoy (if appropriate)
         if (scenario != null) {
             AtBDynamicScenario backingScenario = scenario.getBackingScenario();
-            backingScenario.setDate(campaign.getLocalDate());
 
             if (targetConvoy != null) {
-                backingScenario.addForce(targetConvoy.getId(), "Player");
+                String currentName = backingScenario.getName();
+                backingScenario.setName(currentName + " - " + targetConvoy.getName());
+
+                backingScenario.addForce(targetConvoy.getId(), ScenarioTemplate.PRIMARY_PLAYER_FORCE_ID);
                 targetConvoy.setScenarioId(backingScenario.getId(), campaign);
                 scenario.commitPrimaryForces();
             }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -366,8 +366,31 @@ public class StratconContractInitializer {
     }
 
     /**
-     * Worker function that takes a trackstate and plops down the given number of
-     * facilities owned by the given faction
+     * Initializes and populates a StratCon track with a specified number of objective scenarios.
+     * This method selects scenario templates, places them on the track in unoccupied coordinates,
+     * and optionally assigns facilities and objectives based on predefined rules.
+     *
+     * <p>The key steps of this method include:
+     * <ul>
+     *   <li>Selecting scenario templates from the provided list of objective scenarios.</li>
+     *   <li>Identifying unoccupied coordinates on the track to place each scenario.</li>
+     *   <li>Adding facilities if the scenario template requires them (hostile or allied).</li>
+     *   <li>Generating and configuring scenarios with relevant attributes and modifiers:</li>
+     *   <ul>
+     *     <li>Clearing scenario dates to maintain persistence.</li>
+     *     <li>Marking scenarios as strategic objectives.</li>
+     *     <li>Adding optional modifiers to provide additional effects or conditions.</li>
+     *   </ul>
+     *   <li>Tracking newly added scenarios as strategic objectives for gameplay purposes.</li>
+     * </ul>
+     *
+     * @param campaign            the {@link Campaign} managing the state of the overall gameplay
+     * @param contract            the {@link AtBContract} related to the current StratCon campaign
+     * @param trackState          the {@link StratconTrackState} representing the track where objectives are placed
+     * @param numScenarios        the number of objective scenarios to generate
+     * @param objectiveScenarios  a list of {@link String} identifiers for potential scenarios that can be generated
+     * @param objectiveModifiers  a list of optional {@link String} modifiers to apply to the generated scenarios;
+     *                             can be {@code null} if no modifiers are required
      */
     private static void initializeObjectiveScenarios(Campaign campaign, AtBContract contract,
             StratconTrackState trackState,
@@ -409,7 +432,7 @@ public class StratconContractInitializer {
 
             // create scenario - don't assign a force yet
             StratconScenario scenario = StratconRulesManager.generateScenario(campaign, contract, trackState,
-                    Force.FORCE_NONE, coords, template);
+                    Force.FORCE_NONE, coords, template, null);
 
             // clear dates, because we don't want the scenario disappearing on us
             scenario.setDeploymentDate(null);

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -347,7 +347,7 @@ public class StratconRulesManager {
      */
     public static @Nullable StratconScenario generateExternalScenario(Campaign campaign, AtBContract contract) {
         return generateExternalScenario(campaign, contract, null, null,
-            null, false);
+            null, false, null);
     }
 
     /**
@@ -366,11 +366,16 @@ public class StratconRulesManager {
      *                 or {@code null} to select scenario template randomly.
      * @param allowPlayerFacilities Whether the scenario is allowed to spawn on top of
      *                             player-allied facilities.
+     * @param daysTilDeployment How many days beyond current date until the scenario, or {@code null}
+     *                         to pick a random date within the next 7 days.
      * @return A newly generated {@link StratconScenario}, or {@code null} if scenario creation fails.
      */
      public static @Nullable StratconScenario generateExternalScenario(Campaign campaign, AtBContract contract,
-                                    @Nullable StratconTrackState track, @Nullable StratconCoords scenarioCoords,
-                                    @Nullable ScenarioTemplate template, boolean allowPlayerFacilities) {
+                                                                       @Nullable StratconTrackState track,
+                                                                       @Nullable StratconCoords scenarioCoords,
+                                                                       @Nullable ScenarioTemplate template,
+                                                                       boolean allowPlayerFacilities,
+                                                                       @Nullable Integer daysTilDeployment) {
          // If we're not generating for a specific track, randomly pick one.
          if (track == null) {
              track = getRandomTrack(contract);
@@ -404,7 +409,7 @@ public class StratconRulesManager {
          if (track.getAssignedCoordForces().containsKey(scenarioCoords)) {
              scenario = generateScenarioForExistingForces(scenarioCoords,
                  track.getAssignedCoordForces().get(scenarioCoords), contract, campaign, track,
-                 template);
+                 template, daysTilDeployment);
          }
 
          // Otherwise, pick a random force from those available
@@ -439,7 +444,8 @@ public class StratconRulesManager {
                  randomForceID = availableForceIDs.get(randomForceIndex);
              }
 
-             scenario = setupScenario(scenarioCoords, randomForceID, campaign, contract, track, template, false);
+             scenario = setupScenario(scenarioCoords, randomForceID, campaign, contract, track,
+                 template, false, daysTilDeployment);
          }
 
          if (scenario == null) {
@@ -472,7 +478,7 @@ public class StratconRulesManager {
          StratconCoords scenarioCoords = getUnoccupiedCoords(track, false);
 
          StratconScenario scenario = setupScenario(scenarioCoords, interceptedForce.getId(), campaign,
-             contract, track, template, true);
+             contract, track, template, true, 0);
 
          if (scenario == null) {
              logger.error("Failed to generate a random interception scenario, aborting scenario generation.");
@@ -497,15 +503,19 @@ public class StratconRulesManager {
      *                  If {@code null}, the default template is used.
      * @param allowPlayerFacilities Whether the scenario is allowed to spawn on top of
      *                             player-allied facilities.
+     * @param daysTilDeployment How many days until the scenario takes place, or {@code null} to
+     *                         pick a random day within the next 7 days.
      *
      * @return The created {@link StratconScenario} or @code null},
      * if no {@link ScenarioTemplate} is found or if all coordinates in the provided
      * {@link StratconTrackState} are occupied (and therefore, scenario placement is not possible).
      */
-    public static @Nullable StratconScenario addHiddenExternalScenario(Campaign campaign, AtBContract contract,
-                                                      @Nullable StratconTrackState trackState,
-                                                      @Nullable ScenarioTemplate template,
-                                                      boolean allowPlayerFacilities) {
+    public static @Nullable StratconScenario addHiddenExternalScenario(Campaign campaign,
+                                                                       AtBContract contract,
+                                                                       @Nullable StratconTrackState trackState,
+                                                                       @Nullable ScenarioTemplate template,
+                                                                       boolean allowPlayerFacilities,
+                                                                       @Nullable Integer daysTilDeployment) {
         // If we're not generating for a specific track, randomly pick one.
         if (trackState == null) {
             trackState = getRandomTrack(contract);
@@ -527,7 +537,7 @@ public class StratconRulesManager {
 
         // create scenario - don't assign a force yet
         StratconScenario scenario = StratconRulesManager.generateScenario(campaign, contract,
-            trackState, FORCE_NONE, coords, template);
+            trackState, FORCE_NONE, coords, template, daysTilDeployment);
 
         if (scenario == null) {
             return null;
@@ -749,7 +759,7 @@ public class StratconRulesManager {
                                     Set<Integer> forceIDs, AtBContract contract, Campaign campaign,
                                     StratconTrackState track) {
         return generateScenarioForExistingForces(scenarioCoords, forceIDs, contract, campaign,
-            track, null);
+            track, null, null);
     }
 
     /**
@@ -764,17 +774,24 @@ public class StratconRulesManager {
      * @param track             The relevant StratCon track.
      * @param template          A specific {@link ScenarioTemplate} to use, or {@code null} to
      *                          select a random template.
+     * @param daysTilDeployment How many days until the scenario takes place, or {@code null} to
+     *                         pick a random day within the next 7 days.
      * @return The newly generated {@link StratconScenario}.
      */
     public static @Nullable StratconScenario generateScenarioForExistingForces(StratconCoords scenarioCoords,
-                                    Set<Integer> forceIDs, AtBContract contract, Campaign campaign,
-                                    StratconTrackState track, @Nullable ScenarioTemplate template) {
+                                                                               Set<Integer> forceIDs,
+                                                                               AtBContract contract,
+                                                                               Campaign campaign,
+                                                                               StratconTrackState track,
+                                                                               @Nullable ScenarioTemplate template,
+                                                                               @Nullable Integer daysTilDeployment) {
         boolean firstForce = true;
         StratconScenario scenario = null;
 
         for (int forceID : forceIDs) {
             if (firstForce) {
-                scenario = setupScenario(scenarioCoords, forceID, campaign, contract, track, template, false);
+                scenario = setupScenario(scenarioCoords, forceID, campaign, contract, track,
+                    template, false, daysTilDeployment);
                 firstForce = false;
 
                 if (scenario == null) {
@@ -981,7 +998,7 @@ public class StratconRulesManager {
      */
     private static @Nullable StratconScenario setupScenario(StratconCoords coords, int forceID, Campaign campaign,
                                                   AtBContract contract, StratconTrackState track) {
-        return setupScenario(coords, forceID, campaign, contract, track, null, false);
+        return setupScenario(coords, forceID, campaign, contract, track, null, false, null);
     }
 
     /**
@@ -1001,22 +1018,27 @@ public class StratconRulesManager {
      * @param template  A specific {@link ScenarioTemplate} to use for scenario setup, or
      *                  {@code null} to select the scenario template randomly.
      * @param ignoreFacilities  Whether we should ignore any facilities at the selected location
+     * @param daysTilDeployment How many days until the scenario takes place, or {@code null} to
+     *                         pick a random day within the next 7 days.
      * @return The newly set up {@link StratconScenario}.
      */
-    private static @Nullable StratconScenario setupScenario(StratconCoords coords, int forceID, Campaign campaign,
-                                                  AtBContract contract, StratconTrackState track,
-                                                  @Nullable ScenarioTemplate template, boolean ignoreFacilities) {
+    private static @Nullable StratconScenario setupScenario(StratconCoords coords, int forceID,
+                                                            Campaign campaign, AtBContract contract,
+                                                            StratconTrackState track,
+                                                            @Nullable ScenarioTemplate template,
+                                                            boolean ignoreFacilities,
+                                                            @Nullable Integer daysTilDeployment) {
         StratconScenario scenario;
 
         if (track.getFacilities().containsKey(coords) && !ignoreFacilities) {
             StratconFacility facility = track.getFacility(coords);
             boolean alliedFacility = facility.getOwner() == Allied;
             template = StratconScenarioFactory.getFacilityScenario(alliedFacility);
-            scenario = generateScenario(campaign, contract, track, forceID, coords, template);
+            scenario = generateScenario(campaign, contract, track, forceID, coords, template, daysTilDeployment);
             setupFacilityScenario(scenario, facility);
         } else {
             if (template != null) {
-                scenario = generateScenario(campaign, contract, track, forceID, coords, template);
+                scenario = generateScenario(campaign, contract, track, forceID, coords, template, daysTilDeployment);
             } else {
                 scenario = generateScenario(campaign, contract, track, forceID, coords);
             }
@@ -1584,25 +1606,52 @@ public class StratconRulesManager {
      * given force, on the
      * given track. Also registers it with the track and campaign.
      */
-    private static @Nullable StratconScenario generateScenario(Campaign campaign, AtBContract contract, StratconTrackState track,
-            int forceID, StratconCoords coords) {
+    private static @Nullable StratconScenario generateScenario(Campaign campaign, AtBContract contract,
+                                                               StratconTrackState track, int forceID,
+                                                               StratconCoords coords) {
         int unitType = campaign.getForce(forceID).getPrimaryUnitType(campaign);
         ScenarioTemplate template = StratconScenarioFactory.getRandomScenario(unitType);
         // useful for debugging specific scenario types
         // template = StratconScenarioFactory.getSpecificScenario("Defend Grounded
         // Dropship.xml");
 
-        return generateScenario(campaign, contract, track, forceID, coords, template);
+        return generateScenario(campaign, contract, track, forceID, coords, template, -1);
     }
 
     /**
-     * Worker function that generates stratcon scenario at the given coords, for the
-     * given force, on the
-     * given track, using the given template. Also registers it with the campaign.
+     * Generates a StratCon scenario at the specified coordinates for the given force on the specified track,
+     * using the provided scenario template. The scenario is customized and registered with the campaign.
+     *
+     * <p>The generated scenario is configured as follows:
+     * <ul>
+     *     <li>If no template is provided, a random template is chosen based on the unit type of the given force.</li>
+     *     <li>If provided, deployment dates are explicitly set. Otherwise, dates are determined dynamically.</li>
+     *     <li>Global modifiers, facility modifiers, attached unit modifiers, and allied force modifiers
+     *         are applied as appropriate.</li>
+     *     <li>The scenario is marked as unresolved and is registered with the campaign and track.</li>
+     * </ul>
+     * This method also handles special conditions:
+     * <ul>
+     *     <li>Forces with specific command rights (House or Integrated) will mark the scenario as required.</li>
+     *     <li>If no force is provided, the scenario is treated as part of contract initialization (e.g., allied forces).</li>
+     * </ul>
+     *
+     * @param campaign           the {@link Campaign} managing the gameplay state
+     * @param contract           the {@link AtBContract} governing the StratCon campaign
+     * @param track              the {@link StratconTrackState} to which the scenario belongs
+     * @param forceID            the ID of the force for which the scenario is generated, or
+     * {@link Force#FORCE_NONE} if none
+     * @param coords             the {@link StratconCoords} specifying where the scenario will be placed
+     * @param template           the {@link ScenarioTemplate} to use for scenario generation; if
+     * {@code null}, a random one is selected
+     * @param daysTilDeployment  the number of days until the scenario is deployed; if {@code null},
+     *                          dates will be dynamically set
+     * @return the generated {@link StratconScenario}, or {@code null} if scenario generation failed
      */
     static @Nullable StratconScenario generateScenario(Campaign campaign, AtBContract contract,
                                                        StratconTrackState track, int forceID,
-                                                       StratconCoords coords, ScenarioTemplate template) {
+                                                       StratconCoords coords, ScenarioTemplate template,
+                                                       @Nullable Integer daysTilDeployment) {
         StratconScenario scenario = new StratconScenario();
 
         if (template == null) {
@@ -1641,9 +1690,15 @@ public class StratconRulesManager {
             scenario.setRequiredScenario(true);
         }
 
-        AtBDynamicScenarioFactory.setScenarioModifiers(campaign.getCampaignOptions(), scenario.getBackingScenario());
+        AtBDynamicScenarioFactory.setScenarioModifiers(campaign.getCampaignOptions(),
+            scenario.getBackingScenario());
         scenario.setCurrentState(ScenarioState.UNRESOLVED);
-        setScenarioDates(track, campaign, scenario);
+
+        if (daysTilDeployment == null) {
+            setScenarioDates(track, campaign, scenario);
+        } else {
+            setScenarioDates(daysTilDeployment, track, campaign, scenario);
+        }
 
         // the backing scenario ID must be updated after registering the backing
         // scenario
@@ -1813,8 +1868,7 @@ public class StratconRulesManager {
 
     /**
      * Worker function that sets scenario deploy/battle/return dates based on the
-     * track's properties and
-     * current campaign date
+     * track's properties and current campaign date
      */
     private static void setScenarioDates(StratconTrackState track, Campaign campaign, StratconScenario scenario) {
         int deploymentDay = track.getDeploymentTime() < 7 ? randomInt(7 - track.getDeploymentTime()) : 0;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1040,7 +1040,7 @@ public class StratconRulesManager {
             if (template != null) {
                 scenario = generateScenario(campaign, contract, track, forceID, coords, template, daysTilDeployment);
             } else {
-                scenario = generateScenario(campaign, contract, track, forceID, coords);
+                scenario = generateScenario(campaign, contract, track, forceID, coords, daysTilDeployment);
             }
 
             if (scenario == null) {
@@ -1602,20 +1602,34 @@ public class StratconRulesManager {
     }
 
     /**
-     * Worker function that generates stratcon scenario at the given coords, for the
-     * given force, on the
-     * given track. Also registers it with the track and campaign.
+     * Generates a StratCon scenario at the specified coordinates for the given force on the specified track.
+     * The scenario is determined based on a random template suitable for the unit type of the specified force,
+     * and it is optionally configured with a deployment delay.
+     *
+     * <p>This method selects a random scenario template based on the primary unit type of the force,
+     * then delegates the scenario creation and configuration to another overloaded {@code generateScenario} method
+     * which handles specific template-based scenario generation.</p>
+     *
+     * @param campaign           the {@link Campaign} managing the overall gameplay state
+     * @param contract           the {@link AtBContract} governing the StratCon campaign
+     * @param track              the {@link StratconTrackState} where the scenario is placed
+     * @param forceID            the ID of the force for which the scenario is generated
+     * @param coords             the {@link StratconCoords} specifying where the scenario will be generated
+     * @param daysTilDeployment  the number of days until the scenario is deployed; if {@code null},
+     *                          deployment dates are determined dynamically
+     * @return the generated {@link StratconScenario}, or {@code null} if scenario generation fails
      */
     private static @Nullable StratconScenario generateScenario(Campaign campaign, AtBContract contract,
                                                                StratconTrackState track, int forceID,
-                                                               StratconCoords coords) {
+                                                               StratconCoords coords,
+                                                               @Nullable Integer daysTilDeployment) {
         int unitType = campaign.getForce(forceID).getPrimaryUnitType(campaign);
         ScenarioTemplate template = StratconScenarioFactory.getRandomScenario(unitType);
         // useful for debugging specific scenario types
         // template = StratconScenarioFactory.getSpecificScenario("Defend Grounded
         // Dropship.xml");
 
-        return generateScenario(campaign, contract, track, forceID, coords, template, -1);
+        return generateScenario(campaign, contract, track, forceID, coords, template, daysTilDeployment);
     }
 
     /**


### PR DESCRIPTION
Modified multiple methods to include an optional `daysTilDeployment` parameter for specifying scenario deployment timelines. This enhances flexibility by allowing dynamic or fixed deployment dates based on gameplay needs. It also ensures the date resupply interceptions announce in the command log will also match the date in which they take place.

Also updated scenario names for convoy interception scenarios. If a player convoy is intercepted, the convoy's name will appear in the scenario name.

Fixes #5465