### PR TITLE
Fixed Monthly Facility Support Point Gains & Added Functionality to Allied Industrial Facilities

### DIFF
--- a/MekHQ/data/stratconfacilities/AlliedIndustrialFacility.xml
+++ b/MekHQ/data/stratconfacilities/AlliedIndustrialFacility.xml
@@ -3,5 +3,7 @@
     <displayableName>Industrial Center</displayableName>
     <facilityType>IndustrialFacility</facilityType>
     <owner>Allied</owner>
+    <monthlySPModifier>1</monthlySPModifier>
+    <userDescription>Provides 1 SP/month of allied logistical support.</userDescription>
     <visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedSupplyDepot.xml
+++ b/MekHQ/data/stratconfacilities/AlliedSupplyDepot.xml
@@ -3,7 +3,7 @@
 	<displayableName>Supply Depot</displayableName>
 	<facilityType>SupplyDepot</facilityType>
 	<owner>Allied</owner>
-	<weeklySPModifier>1</weeklySPModifier>
+	<monthlySPModifier>1</monthlySPModifier>
 	<userDescription>Provides 1 SP/month of allied logistical support.</userDescription>
 	<visible>true</visible>
 </StratconFacility>

--- a/MekHQ/data/stratconfacilities/AlliedSupplyDepot.xml
+++ b/MekHQ/data/stratconfacilities/AlliedSupplyDepot.xml
@@ -3,7 +3,7 @@
 	<displayableName>Supply Depot</displayableName>
 	<facilityType>SupplyDepot</facilityType>
 	<owner>Allied</owner>
-	<monthlySPModifier>1</monthlySPModifier>
+	<weeklySPModifier>1</weeklySPModifier>
 	<userDescription>Provides 1 SP/month of allied logistical support.</userDescription>
 	<visible>true</visible>
 </StratconFacility>


### PR DESCRIPTION
`AlliedSupplyDepot` was incorrectly using `weeklySPModifier` instead of `monthlySPModifier` preventing monthly SP gain. (this is now addressed as part of #5472)

I also went ahead and added this benefit to `AlliedIndustrialFacility`, as these previously had no functionality.

Fixes #3639
Fixes #4036