### PR TITLE
Renamed Fight, Defense, and Scouting Combat Role Names

### DIFF
--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -30,12 +30,12 @@ AtBContractType.EXTRACTION_RAID.text=Extraction Raid
 AtBContractType.EXTRACTION_RAID.toolTipText=The unit is tasked with raiding an enemy planet to capture a target and return the target to their employer.
 
 # CombatRole Enum
-CombatRole.FIGHTING.text=Fight
-CombatRole.FIGHTING.toolTipText=The force has been tasked with performing offensive actions against the enemy.
-CombatRole.DEFENCE.text=Defend
-CombatRole.DEFENCE.toolTipText=The force has been tasked with performing defensive actions, protecting designated targets and locations from the enemy.
-CombatRole.SCOUTING.text=Scout
-CombatRole.SCOUTING.toolTipText=The force has been tasked with performing reconnaissance actions, scouting the enemy and their positions.
+CombatRole.BATTLELINE.text=Battleline
+CombatRole.BATTLELINE.toolTipText=The force has been tasked with performing offensive actions against the enemy.
+CombatRole.GARRISON.text=Garrison
+CombatRole.GARRISON.toolTipText=The force has been tasked with performing defensive actions, protecting designated targets and locations from the enemy.
+CombatRole.RECON.text=Recon
+CombatRole.RECON.toolTipText=The force has been tasked with performing reconnaissance actions, scouting the enemy and their positions.
 CombatRole.TRAINING.text=Training
 CombatRole.TRAINING.toolTipText=The force has been tasked with trained ultra green and green members of the force under the leadership of a veteran or elite officer.
 CombatRole.AUXILIARY.text=Auxiliary

--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -30,8 +30,8 @@ AtBContractType.EXTRACTION_RAID.text=Extraction Raid
 AtBContractType.EXTRACTION_RAID.toolTipText=The unit is tasked with raiding an enemy planet to capture a target and return the target to their employer.
 
 # CombatRole Enum
-CombatRole.BATTLELINE.text=Battleline
-CombatRole.BATTLELINE.toolTipText=The force has been tasked with performing offensive actions against the enemy.
+CombatRole.FRONTLINE.text=Frontline
+CombatRole.FRONTLINE.toolTipText=The force has been tasked with performing offensive actions against the enemy.
 CombatRole.GARRISON.text=Garrison
 CombatRole.GARRISON.toolTipText=The force has been tasked with performing defensive actions, protecting designated targets and locations from the enemy.
 CombatRole.RECON.text=Recon

--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -40,8 +40,8 @@ CombatRole.TRAINING.text=Training
 CombatRole.TRAINING.toolTipText=The force has been tasked with trained ultra green and green members of the force under the leadership of a veteran or elite officer.
 CombatRole.AUXILIARY.text=Auxiliary
 CombatRole.AUXILIARY.toolTipText=The force has been tasked with supporting other forces.
-CombatRole.IN_RESERVE.text=In Reserve
-CombatRole.IN_RESERVE.toolTipText=The force is not currently assigned to combat duties.
+CombatRole.RESERVE.text=Reserve
+CombatRole.RESERVE.toolTipText=The force is not currently assigned to combat duties.
 
 # AtBMoraleLevel Enum
 AtBMoraleLevel.ROUTED.text=Routed

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3768,7 +3768,7 @@ public class Campaign implements ITechManager {
 
         final CombatRole requiredLanceRole = contract.getContractType().getRequiredLanceRole();
         for (CombatTeam combatTeam : combatTeams.values()) {
-            if (!(combatTeam.getRole().isInReserve() || combatTeam.getRole().isAuxiliary())
+            if (!(combatTeam.getRole().isReserve() || combatTeam.getRole().isAuxiliary())
                 && (combatTeam.getMissionId() == contract.getId())) {
                 total++;
                 if (combatTeam.getRole() == requiredLanceRole) {

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -1209,9 +1209,9 @@ public class CampaignOptions {
         additionalStrategyDeployment = 1;
         adjustPaymentForStrategy = false;
         atbBattleChance = new int[CombatRole.values().length - 1];
-        atbBattleChance[CombatRole.FIGHTING.ordinal()] = 40;
-        atbBattleChance[CombatRole.DEFENCE.ordinal()] = 20;
-        atbBattleChance[CombatRole.SCOUTING.ordinal()] = 60;
+        atbBattleChance[CombatRole.BATTLELINE.ordinal()] = 40;
+        atbBattleChance[CombatRole.GARRISON.ordinal()] = 20;
+        atbBattleChance[CombatRole.RECON.ordinal()] = 60;
         atbBattleChance[CombatRole.TRAINING.ordinal()] = 10;
         generateChases = true;
 
@@ -6353,9 +6353,9 @@ public class CampaignOptions {
                 } else if (wn2.getNodeName().equalsIgnoreCase("intensity")) { // Legacy
                     double intensity = Double.parseDouble(wn2.getTextContent().trim());
 
-                    retVal.atbBattleChance[CombatRole.FIGHTING.ordinal()] = (int) Math.round(((40.0 * intensity) / (40.0 * intensity + 60.0)) * 100.0 + 0.5);
-                    retVal.atbBattleChance[CombatRole.DEFENCE.ordinal()] = (int) Math.round(((20.0 * intensity) / (20.0 * intensity + 80.0)) * 100.0 + 0.5);
-                    retVal.atbBattleChance[CombatRole.SCOUTING.ordinal()] = (int) Math.round(((60.0 * intensity) / (60.0 * intensity + 40.0)) * 100.0 + 0.5);
+                    retVal.atbBattleChance[CombatRole.BATTLELINE.ordinal()] = (int) Math.round(((40.0 * intensity) / (40.0 * intensity + 60.0)) * 100.0 + 0.5);
+                    retVal.atbBattleChance[CombatRole.GARRISON.ordinal()] = (int) Math.round(((20.0 * intensity) / (20.0 * intensity + 80.0)) * 100.0 + 0.5);
+                    retVal.atbBattleChance[CombatRole.RECON.ordinal()] = (int) Math.round(((60.0 * intensity) / (60.0 * intensity + 40.0)) * 100.0 + 0.5);
                     retVal.atbBattleChance[CombatRole.TRAINING.ordinal()] = (int) Math.round(((10.0 * intensity) / (10.0 * intensity + 90.0)) * 100.0 + 0.5);
                 } else if (wn2.getNodeName().equalsIgnoreCase("personnelMarketType")) { // Legacy
                     retVal.personnelMarketName = PersonnelMarket.getTypeName(Integer.parseInt(wn2.getTextContent().trim()));

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -4478,7 +4478,7 @@ public class CampaignOptions {
      * This method calculates the battle chance percentage for the provided combat role based on
      * its ordinal position in the {@code atbBattleChance} array. If StratCon is enabled, the
      * method immediately returns {@code 0}.
-     * Roles marked as {@link CombatRole#IN_RESERVE} or as {@link CombatRole#AUXILIARY} are not
+     * Roles marked as {@link CombatRole#RESERVE} or as {@link CombatRole#AUXILIARY} are not
      * eligible for battles and also return {@code 0}.
      * </p>
      *
@@ -4486,7 +4486,7 @@ public class CampaignOptions {
      * @return the chance of having a battle for the specified role. Returns:
      *         <ul>
      *           <li>{@code 0} if StratCon is enabled.</li>
-     *           <li>{@code 0} if the role is {@link CombatRole#IN_RESERVE} or
+     *           <li>{@code 0} if the role is {@link CombatRole#RESERVE} or
      *           {@link CombatRole#AUXILIARY}.</li>
      *           <li>A non-zero value from the {@code atbBattleChance} array corresponding to the
      *           role otherwise.</li>
@@ -4497,7 +4497,7 @@ public class CampaignOptions {
             return 0;
         }
 
-        if (role.isInReserve() || role.isAuxiliary()) {
+        if (role.isReserve() || role.isAuxiliary()) {
             return 0;
         }
 

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -1209,7 +1209,7 @@ public class CampaignOptions {
         additionalStrategyDeployment = 1;
         adjustPaymentForStrategy = false;
         atbBattleChance = new int[CombatRole.values().length - 1];
-        atbBattleChance[CombatRole.BATTLELINE.ordinal()] = 40;
+        atbBattleChance[CombatRole.FRONTLINE.ordinal()] = 40;
         atbBattleChance[CombatRole.GARRISON.ordinal()] = 20;
         atbBattleChance[CombatRole.RECON.ordinal()] = 60;
         atbBattleChance[CombatRole.TRAINING.ordinal()] = 10;
@@ -6353,7 +6353,7 @@ public class CampaignOptions {
                 } else if (wn2.getNodeName().equalsIgnoreCase("intensity")) { // Legacy
                     double intensity = Double.parseDouble(wn2.getTextContent().trim());
 
-                    retVal.atbBattleChance[CombatRole.BATTLELINE.ordinal()] = (int) Math.round(((40.0 * intensity) / (40.0 * intensity + 60.0)) * 100.0 + 0.5);
+                    retVal.atbBattleChance[CombatRole.FRONTLINE.ordinal()] = (int) Math.round(((40.0 * intensity) / (40.0 * intensity + 60.0)) * 100.0 + 0.5);
                     retVal.atbBattleChance[CombatRole.GARRISON.ordinal()] = (int) Math.round(((20.0 * intensity) / (20.0 * intensity + 80.0)) * 100.0 + 0.5);
                     retVal.atbBattleChance[CombatRole.RECON.ordinal()] = (int) Math.round(((60.0 * intensity) / (60.0 * intensity + 40.0)) * 100.0 + 0.5);
                     retVal.atbBattleChance[CombatRole.TRAINING.ordinal()] = (int) Math.round(((10.0 * intensity) / (10.0 * intensity + 90.0)) * 100.0 + 0.5);

--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -422,7 +422,7 @@ public class CombatTeam {
          */
 
         switch (role) {
-            case FIGHTING: {
+            case BATTLELINE: {
                 roll = Compute.randomInt(40) + battleTypeMod;
                 if (roll < 1) {
                     return AtBScenarioFactory.createScenario(campaign, this,
@@ -460,7 +460,7 @@ public class CombatTeam {
                             getBattleDate(campaign.getLocalDate()));
                 }
             }
-            case SCOUTING: {
+            case RECON: {
                 roll = Compute.randomInt(60) + battleTypeMod;
                 if (roll < 1) {
                     return AtBScenarioFactory.createScenario(campaign, this,
@@ -498,7 +498,7 @@ public class CombatTeam {
                             getBattleDate(campaign.getLocalDate()));
                 }
             }
-            case DEFENCE: {
+            case GARRISON: {
                 roll = Compute.randomInt(20) + battleTypeMod;
                 if (roll < 1) {
                     return AtBScenarioFactory.createScenario(campaign, this,

--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -139,7 +139,7 @@ public class CombatTeam {
 
     public CombatTeam(int forceId, Campaign campaign) {
         this.forceId = forceId;
-        role = CombatRole.IN_RESERVE;
+        role = CombatRole.RESERVE;
         missionId = -1;
         for (AtBContract contract : campaign.getActiveAtBContracts()) {
             missionId = ((contract.getParentContract() == null)

--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -422,7 +422,7 @@ public class CombatTeam {
          */
 
         switch (role) {
-            case BATTLELINE: {
+            case FRONTLINE: {
                 roll = Compute.randomInt(40) + battleTypeMod;
                 if (roll < 1) {
                     return AtBScenarioFactory.createScenario(campaign, this,

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -208,7 +208,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     public AtBScenario() {
         super();
         combatTeamId = -1;
-        combatRole = CombatRole.IN_RESERVE;
+        combatRole = CombatRole.RESERVE;
         alliesPlayer = new ArrayList<>();
         alliesPlayerStub = new ArrayList<>();
         attachedUnitIds = new ArrayList<>();
@@ -237,7 +237,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
         if (null == lance) {
             combatTeamId = -1;
-            combatRole = CombatRole.IN_RESERVE;
+            combatRole = CombatRole.RESERVE;
         } else {
             this.combatTeamId = lance.getForceId();
             combatRole = lance.getRole();

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -229,7 +229,7 @@ public class AtBScenarioFactory {
                     List<CombatTeam> lList = new ArrayList<>();
                     for (CombatTeam combatTeam : combatTeamsTable.values()) {
                         if ((combatTeam.getMissionId() == contract.getId())
-                            && combatTeam.getRole().isDefence() && combatTeam.isEligible(campaign)) {
+                            && combatTeam.getRole().isGarrison() && combatTeam.isEligible(campaign)) {
                             lList.add(combatTeam);
                         }
                     }

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -180,7 +180,7 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
             // Rout for a while
             ObjectiveEffect victoryEffect = new ObjectiveEffect();
             final CombatRole requiredLanceRole = contract.getContractType().getRequiredLanceRole();
-            if (requiredLanceRole.isBattleline() || requiredLanceRole.isScouting()) {
+            if (requiredLanceRole.isFrontline() || requiredLanceRole.isScouting()) {
                 victoryEffect.effectType = ObjectiveEffectType.ContractVictory;
                 destroyHostiles.addDetail(getResourceBundle().getString("battleDetails.baseAttack.attacker.details.winnerFightScout"));
             } else {

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -180,7 +180,7 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
             // Rout for a while
             ObjectiveEffect victoryEffect = new ObjectiveEffect();
             final CombatRole requiredLanceRole = contract.getContractType().getRequiredLanceRole();
-            if (requiredLanceRole.isFighting() || requiredLanceRole.isScouting()) {
+            if (requiredLanceRole.isBattleline() || requiredLanceRole.isScouting()) {
                 victoryEffect.effectType = ObjectiveEffectType.ContractVictory;
                 destroyHostiles.addDetail(getResourceBundle().getString("battleDetails.baseAttack.attacker.details.winnerFightScout"));
             } else {

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
@@ -206,7 +206,7 @@ public enum AtBContractType {
             case PIRATE_HUNTING:
             case PLANETARY_ASSAULT:
             case RELIEF_DUTY:
-                return CombatRole.BATTLELINE;
+                return CombatRole.FRONTLINE;
             case DIVERSIONARY_RAID:
             case EXTRACTION_RAID:
             case OBJECTIVE_RAID:

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
@@ -201,17 +201,17 @@ public enum AtBContractType {
             case GARRISON_DUTY:
             case SECURITY_DUTY:
             case RIOT_DUTY:
-                return CombatRole.DEFENCE;
+                return CombatRole.GARRISON;
             case GUERRILLA_WARFARE:
             case PIRATE_HUNTING:
             case PLANETARY_ASSAULT:
             case RELIEF_DUTY:
-                return CombatRole.FIGHTING;
+                return CombatRole.BATTLELINE;
             case DIVERSIONARY_RAID:
             case EXTRACTION_RAID:
             case OBJECTIVE_RAID:
             case RECON_RAID:
-                return CombatRole.SCOUTING;
+                return CombatRole.RECON;
             default:
                 return CombatRole.IN_RESERVE;
         }

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
@@ -213,7 +213,7 @@ public enum AtBContractType {
             case RECON_RAID:
                 return CombatRole.RECON;
             default:
-                return CombatRole.IN_RESERVE;
+                return CombatRole.RESERVE;
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
@@ -25,7 +25,7 @@ import java.util.ResourceBundle;
 
 public enum CombatRole {
     // region Enum Declarations
-    BATTLELINE("CombatRole.BATTLELINE.text", "CombatRole.BATTLELINE.toolTipText"),
+    FRONTLINE("CombatRole.FRONTLINE.text", "CombatRole.FRONTLINE.toolTipText"),
     GARRISON("CombatRole.GARRISON.text", "CombatRole.GARRISON.toolTipText"),
     RECON("CombatRole.RECON.text", "CombatRole.RECON.toolTipText"),
     TRAINING("CombatRole.TRAINING.text", "CombatRole.TRAINING.toolTipText"),
@@ -54,8 +54,8 @@ public enum CombatRole {
     // endregion Getters
 
     // region Boolean Comparison Methods
-    public boolean isBattleline() {
-        return this == BATTLELINE;
+    public boolean isFrontline() {
+        return this == FRONTLINE;
     }
 
     public boolean isGarrison() {

--- a/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
@@ -25,9 +25,9 @@ import java.util.ResourceBundle;
 
 public enum CombatRole {
     // region Enum Declarations
-    FIGHTING("CombatRole.FIGHTING.text", "CombatRole.FIGHTING.toolTipText"),
-    DEFENCE("CombatRole.DEFENCE.text", "CombatRole.DEFENCE.toolTipText"),
-    SCOUTING("CombatRole.SCOUTING.text", "CombatRole.SCOUTING.toolTipText"),
+    BATTLELINE("CombatRole.BATTLELINE.text", "CombatRole.BATTLELINE.toolTipText"),
+    GARRISON("CombatRole.GARRISON.text", "CombatRole.GARRISON.toolTipText"),
+    RECON("CombatRole.RECON.text", "CombatRole.RECON.toolTipText"),
     TRAINING("CombatRole.TRAINING.text", "CombatRole.TRAINING.toolTipText"),
     AUXILIARY("CombatRole.AUXILIARY.text", "CombatRole.AUXILIARY.toolTipText"),
     IN_RESERVE("CombatRole.IN_RESERVE.text", "CombatRole.IN_RESERVE.toolTipText");
@@ -54,16 +54,16 @@ public enum CombatRole {
     // endregion Getters
 
     // region Boolean Comparison Methods
-    public boolean isFighting() {
-        return this == FIGHTING;
+    public boolean isBattleline() {
+        return this == BATTLELINE;
     }
 
-    public boolean isDefence() {
-        return this == DEFENCE;
+    public boolean isGarrison() {
+        return this == GARRISON;
     }
 
     public boolean isScouting() {
-        return this == SCOUTING;
+        return this == RECON;
     }
 
     public boolean isTraining() {

--- a/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
@@ -30,7 +30,7 @@ public enum CombatRole {
     RECON("CombatRole.RECON.text", "CombatRole.RECON.toolTipText"),
     TRAINING("CombatRole.TRAINING.text", "CombatRole.TRAINING.toolTipText"),
     AUXILIARY("CombatRole.AUXILIARY.text", "CombatRole.AUXILIARY.toolTipText"),
-    IN_RESERVE("CombatRole.IN_RESERVE.text", "CombatRole.IN_RESERVE.toolTipText");
+    RESERVE("CombatRole.RESERVE.text", "CombatRole.RESERVE.toolTipText");
     // endregion Enum Declarations
 
     // region Variable Declarations
@@ -74,8 +74,8 @@ public enum CombatRole {
         return this == AUXILIARY;
     }
 
-    public boolean isInReserve() {
-        return this == IN_RESERVE;
+    public boolean isReserve() {
+        return this == RESERVE;
     }
     // endregion Boolean Comparison Methods
 
@@ -111,7 +111,7 @@ public enum CombatRole {
         MMLogger.create(CombatRole.class)
             .error("Unable to parse " + text + " into an CombatRole. Returning IN_RESERVE.");
 
-        return IN_RESERVE;
+        return RESERVE;
     }
     // endregion File I/O
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -2194,7 +2194,7 @@ public class StratconRulesManager {
             }
 
             if (campaignState.getSupportPoints() > 0) {
-                if (formation.getRole().isBattleline() || formation.getRole().isAuxiliary()) {
+                if (formation.getRole().isFrontline() || formation.getRole().isAuxiliary()) {
                     return AUXILIARY;
                 } else {
                     return ReinforcementEligibilityType.REGULAR;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1534,7 +1534,7 @@ public class StratconRulesManager {
             if (commanderUnit != null) {
                 CombatTeam lance = campaign.getCombatTeamsTable().get(commanderUnit.getForceId());
 
-                return (lance != null) && lance.getRole().isDefence();
+                return (lance != null) && lance.getRole().isGarrison();
             }
         }
 
@@ -2194,7 +2194,7 @@ public class StratconRulesManager {
             }
 
             if (campaignState.getSupportPoints() > 0) {
-                if (formation.getRole().isFighting() || formation.getRole().isAuxiliary()) {
+                if (formation.getRole().isBattleline() || formation.getRole().isAuxiliary()) {
                     return AUXILIARY;
                 } else {
                     return ReinforcementEligibilityType.REGULAR;

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1917,7 +1917,7 @@ public class StratconRulesManager {
             }
 
             // So long as the combat team isn't In Reserve or Auxiliary, they are eligible to be deployed
-            if (!combatTeam.getRole().isInReserve() && !combatTeam.getRole().isAuxiliary()) {
+            if (!combatTeam.getRole().isReserve() && !combatTeam.getRole().isAuxiliary()) {
                 suitableForces.add(combatTeam.getForceId());
             }
         }
@@ -1978,7 +1978,7 @@ public class StratconRulesManager {
                 continue;
             }
 
-            if (formation.getRole().isInReserve()) {
+            if (formation.getRole().isReserve()) {
                 continue;
             }
 

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -3152,13 +3152,13 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         spnAtBBattleChance = new JSpinner[CombatRole.values().length - 1];
 
-        JLabel lblFightChance = new JLabel(CombatRole.BATTLELINE + ":");
+        JLabel lblFightChance = new JLabel(CombatRole.FRONTLINE + ":");
         gridBagConstraints.gridy = 15;
         gridBagConstraints.gridwidth = 1;
         panSubAtBContract.add(lblFightChance, gridBagConstraints);
 
         JSpinner atbBattleChance = new JSpinner(new SpinnerNumberModel(0, 0, 100, 1));
-        spnAtBBattleChance[CombatRole.BATTLELINE.ordinal()] = atbBattleChance;
+        spnAtBBattleChance[CombatRole.FRONTLINE.ordinal()] = atbBattleChance;
         gridBagConstraints.gridx = 1;
         panSubAtBContract.add(atbBattleChance, gridBagConstraints);
 
@@ -8962,8 +8962,8 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnBaseStrategyDeployment.setValue(options.getBaseStrategyDeployment());
         spnAdditionalStrategyDeployment.setValue(options.getAdditionalStrategyDeployment());
         chkAdjustPaymentForStrategy.setSelected(options.isAdjustPaymentForStrategy());
-        spnAtBBattleChance[CombatRole.BATTLELINE.ordinal()]
-                .setValue(options.getAtBBattleChance(CombatRole.BATTLELINE));
+        spnAtBBattleChance[CombatRole.FRONTLINE.ordinal()]
+                .setValue(options.getAtBBattleChance(CombatRole.FRONTLINE));
         spnAtBBattleChance[CombatRole.GARRISON.ordinal()]
                 .setValue(options.getAtBBattleChance(CombatRole.GARRISON));
         spnAtBBattleChance[CombatRole.RECON.ordinal()]
@@ -9977,7 +9977,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private double determineAtBBattleIntensity() {
         double intensity = 0.0;
 
-        int x = (Integer) spnAtBBattleChance[CombatRole.BATTLELINE.ordinal()].getValue();
+        int x = (Integer) spnAtBBattleChance[CombatRole.FRONTLINE.ordinal()].getValue();
         intensity += ((-3.0 / 2.0) * (2.0 * x - 1.0)) / (2.0 * x - 201.0);
 
         x = (Integer) spnAtBBattleChance[CombatRole.GARRISON.ordinal()].getValue();
@@ -10006,7 +10006,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             if (intensity >= AtBContract.MINIMUM_INTENSITY) {
                 int value = (int) Math.min(
                         Math.round(400.0 * intensity / (4.0 * intensity + 6.0) + 0.05), 100);
-                spnAtBBattleChance[CombatRole.BATTLELINE.ordinal()].setValue(value);
+                spnAtBBattleChance[CombatRole.FRONTLINE.ordinal()].setValue(value);
                 value = (int) Math.min(Math.round(200.0 * intensity / (2.0 * intensity + 8.0) + 0.05),
                         100);
                 spnAtBBattleChance[CombatRole.GARRISON.ordinal()].setValue(value);
@@ -10016,7 +10016,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                 value = (int) Math.min(Math.round(100.0 * intensity / (intensity + 9.0) + 0.05), 100);
                 spnAtBBattleChance[CombatRole.TRAINING.ordinal()].setValue(value);
             } else {
-                spnAtBBattleChance[CombatRole.BATTLELINE.ordinal()].setValue(0);
+                spnAtBBattleChance[CombatRole.FRONTLINE.ordinal()].setValue(0);
                 spnAtBBattleChance[CombatRole.GARRISON.ordinal()].setValue(0);
                 spnAtBBattleChance[CombatRole.RECON.ordinal()].setValue(0);
                 spnAtBBattleChance[CombatRole.TRAINING.ordinal()].setValue(0);

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -3152,33 +3152,33 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         spnAtBBattleChance = new JSpinner[CombatRole.values().length - 1];
 
-        JLabel lblFightChance = new JLabel(CombatRole.FIGHTING + ":");
+        JLabel lblFightChance = new JLabel(CombatRole.BATTLELINE + ":");
         gridBagConstraints.gridy = 15;
         gridBagConstraints.gridwidth = 1;
         panSubAtBContract.add(lblFightChance, gridBagConstraints);
 
         JSpinner atbBattleChance = new JSpinner(new SpinnerNumberModel(0, 0, 100, 1));
-        spnAtBBattleChance[CombatRole.FIGHTING.ordinal()] = atbBattleChance;
+        spnAtBBattleChance[CombatRole.BATTLELINE.ordinal()] = atbBattleChance;
         gridBagConstraints.gridx = 1;
         panSubAtBContract.add(atbBattleChance, gridBagConstraints);
 
-        JLabel lblDefendChance = new JLabel(CombatRole.DEFENCE + ":");
+        JLabel lblDefendChance = new JLabel(CombatRole.GARRISON + ":");
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 16;
         panSubAtBContract.add(lblDefendChance, gridBagConstraints);
 
         atbBattleChance = new JSpinner(new SpinnerNumberModel(0, 0, 100, 1));
-        spnAtBBattleChance[CombatRole.DEFENCE.ordinal()] = atbBattleChance;
+        spnAtBBattleChance[CombatRole.GARRISON.ordinal()] = atbBattleChance;
         gridBagConstraints.gridx = 1;
         panSubAtBContract.add(atbBattleChance, gridBagConstraints);
 
-        JLabel lblScoutChance = new JLabel(CombatRole.SCOUTING + ":");
+        JLabel lblScoutChance = new JLabel(CombatRole.RECON + ":");
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 17;
         panSubAtBContract.add(lblScoutChance, gridBagConstraints);
 
         atbBattleChance = new JSpinner(new SpinnerNumberModel(0, 0, 100, 1));
-        spnAtBBattleChance[CombatRole.SCOUTING.ordinal()] = atbBattleChance;
+        spnAtBBattleChance[CombatRole.RECON.ordinal()] = atbBattleChance;
         gridBagConstraints.gridx = 1;
         panSubAtBContract.add(atbBattleChance, gridBagConstraints);
 
@@ -8962,12 +8962,12 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         spnBaseStrategyDeployment.setValue(options.getBaseStrategyDeployment());
         spnAdditionalStrategyDeployment.setValue(options.getAdditionalStrategyDeployment());
         chkAdjustPaymentForStrategy.setSelected(options.isAdjustPaymentForStrategy());
-        spnAtBBattleChance[CombatRole.FIGHTING.ordinal()]
-                .setValue(options.getAtBBattleChance(CombatRole.FIGHTING));
-        spnAtBBattleChance[CombatRole.DEFENCE.ordinal()]
-                .setValue(options.getAtBBattleChance(CombatRole.DEFENCE));
-        spnAtBBattleChance[CombatRole.SCOUTING.ordinal()]
-                .setValue(options.getAtBBattleChance(CombatRole.SCOUTING));
+        spnAtBBattleChance[CombatRole.BATTLELINE.ordinal()]
+                .setValue(options.getAtBBattleChance(CombatRole.BATTLELINE));
+        spnAtBBattleChance[CombatRole.GARRISON.ordinal()]
+                .setValue(options.getAtBBattleChance(CombatRole.GARRISON));
+        spnAtBBattleChance[CombatRole.RECON.ordinal()]
+                .setValue(options.getAtBBattleChance(CombatRole.RECON));
         spnAtBBattleChance[CombatRole.TRAINING.ordinal()]
                 .setValue(options.getAtBBattleChance(CombatRole.TRAINING));
         btnIntensityUpdate.doClick();
@@ -9977,13 +9977,13 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private double determineAtBBattleIntensity() {
         double intensity = 0.0;
 
-        int x = (Integer) spnAtBBattleChance[CombatRole.FIGHTING.ordinal()].getValue();
+        int x = (Integer) spnAtBBattleChance[CombatRole.BATTLELINE.ordinal()].getValue();
         intensity += ((-3.0 / 2.0) * (2.0 * x - 1.0)) / (2.0 * x - 201.0);
 
-        x = (Integer) spnAtBBattleChance[CombatRole.DEFENCE.ordinal()].getValue();
+        x = (Integer) spnAtBBattleChance[CombatRole.GARRISON.ordinal()].getValue();
         intensity += ((-4.0) * (2.0 * x - 1.0)) / (2.0 * x - 201.0);
 
-        x = (Integer) spnAtBBattleChance[CombatRole.SCOUTING.ordinal()].getValue();
+        x = (Integer) spnAtBBattleChance[CombatRole.RECON.ordinal()].getValue();
         intensity += ((-2.0 / 3.0) * (2.0 * x - 1.0)) / (2.0 * x - 201.0);
 
         x = (Integer) spnAtBBattleChance[CombatRole.TRAINING.ordinal()].getValue();
@@ -10006,19 +10006,19 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             if (intensity >= AtBContract.MINIMUM_INTENSITY) {
                 int value = (int) Math.min(
                         Math.round(400.0 * intensity / (4.0 * intensity + 6.0) + 0.05), 100);
-                spnAtBBattleChance[CombatRole.FIGHTING.ordinal()].setValue(value);
+                spnAtBBattleChance[CombatRole.BATTLELINE.ordinal()].setValue(value);
                 value = (int) Math.min(Math.round(200.0 * intensity / (2.0 * intensity + 8.0) + 0.05),
                         100);
-                spnAtBBattleChance[CombatRole.DEFENCE.ordinal()].setValue(value);
+                spnAtBBattleChance[CombatRole.GARRISON.ordinal()].setValue(value);
                 value = (int) Math.min(Math.round(600.0 * intensity / (6.0 * intensity + 4.0) + 0.05),
                         100);
-                spnAtBBattleChance[CombatRole.SCOUTING.ordinal()].setValue(value);
+                spnAtBBattleChance[CombatRole.RECON.ordinal()].setValue(value);
                 value = (int) Math.min(Math.round(100.0 * intensity / (intensity + 9.0) + 0.05), 100);
                 spnAtBBattleChance[CombatRole.TRAINING.ordinal()].setValue(value);
             } else {
-                spnAtBBattleChance[CombatRole.FIGHTING.ordinal()].setValue(0);
-                spnAtBBattleChance[CombatRole.DEFENCE.ordinal()].setValue(0);
-                spnAtBBattleChance[CombatRole.SCOUTING.ordinal()].setValue(0);
+                spnAtBBattleChance[CombatRole.BATTLELINE.ordinal()].setValue(0);
+                spnAtBBattleChance[CombatRole.GARRISON.ordinal()].setValue(0);
+                spnAtBBattleChance[CombatRole.RECON.ordinal()].setValue(0);
                 spnAtBBattleChance[CombatRole.TRAINING.ordinal()].setValue(0);
             }
         }

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -350,7 +350,7 @@ class RequiredLancesTableModel extends DataTableModel {
                 int t = 0;
                 for (CombatTeam combatTeam : campaign.getAllCombatTeams()) {
                     if (data.get(row).equals(combatTeam.getContract(campaign))
-                            && (combatTeam.getRole() != CombatRole.IN_RESERVE)
+                            && (combatTeam.getRole() != CombatRole.RESERVE)
                             && combatTeam.isEligible(campaign)) {
                         t++;
                     }

--- a/MekHQ/unittests/mekhq/campaign/autoresolve/ResolverTest.java
+++ b/MekHQ/unittests/mekhq/campaign/autoresolve/ResolverTest.java
@@ -177,7 +177,7 @@ public class ResolverTest {
         when(scenario.getBlowingSand()).thenReturn(BlowingSand.BLOWING_SAND_NONE);
 
         // Lance setup
-        when(scenario.getCombatRole()).thenReturn(CombatRole.BATTLELINE);
+        when(scenario.getCombatRole()).thenReturn(CombatRole.FRONTLINE);
         when(scenario.getId()).thenReturn(11);
 
         // Bots setup

--- a/MekHQ/unittests/mekhq/campaign/autoresolve/ResolverTest.java
+++ b/MekHQ/unittests/mekhq/campaign/autoresolve/ResolverTest.java
@@ -177,7 +177,7 @@ public class ResolverTest {
         when(scenario.getBlowingSand()).thenReturn(BlowingSand.BLOWING_SAND_NONE);
 
         // Lance setup
-        when(scenario.getCombatRole()).thenReturn(CombatRole.FIGHTING);
+        when(scenario.getCombatRole()).thenReturn(CombatRole.BATTLELINE);
         when(scenario.getId()).thenReturn(11);
 
         // Bots setup


### PR DESCRIPTION
Renamed "Fight", "Defense", and "Scouting" combat roles to ~~"Battleline"~~ "Frontline", "Garrison", and "Recon".

Functionality is unchanged

This change is part of a recent effort to implement more immersive language, where possible.