### PR TITLE
Fix NPE when searching for primary force in Stratcon scenario generation

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -3649,7 +3649,13 @@ public class AtBDynamicScenarioFactory {
 
             for (StratconTrackState track : campaignState.getTracks()) {
                 StratconScenario stratconScenario = track.getBackingScenariosMap().get(scenario.getId());
-                primaryForceIDs = stratconScenario.getPrimaryForceIDs();
+                if (stratconScenario != null) {
+                    primaryForceIDs = stratconScenario.getPrimaryForceIDs();
+                }
+            }
+
+            if (primaryForceIDs.isEmpty()) {
+                logger.warn(String.format("Unable to find primary force for scenario %s (%d)", scenario.getName(), scenario.getId()));
             }
         }
 


### PR DESCRIPTION
In its original form, the modified loop causes the following exception when the scenario is on any track but the first:

```
java.lang.NullPointerException: Cannot invoke "mekhq.campaign.stratcon.StratconScenario.getPrimaryForceIDs()" because "stratconScenario" is null
    at mekhq.campaign.mission.AtBDynamicScenarioFactory.setPlayerDeploymentTurns(AtBDynamicScenarioFactory.java:3652)
    at mekhq.gui.BriefingTab.startScenario(BriefingTab.java:908)
```

I'm not sure if warning is the correct action if a primary force isn't found, or if it needs to be an exception.