### PR TITLE
Added Name for Resupply Loot

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
@@ -617,6 +617,7 @@ public class PerformResupply {
             }
 
             Loot loot = new Loot();
+            loot.setName("Resupply");
 
             if (convoyContents != null) {
                 for (Part part : convoyContents) {


### PR DESCRIPTION
Added a default name "Resupply" for the Loot object in the `PerformResupply` class to improve clarity. This ensures loot from resupply missions is properly labeled, rather than inheriting the default loot name of "None'