### PR TITLE
Fixed Marshalling and Unmarshalling of `stratConScenarioType`

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -878,7 +878,7 @@ public class Scenario implements IPlayerSettings {
     protected int writeToXMLBegin(final PrintWriter pw, int indent) {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "scenario", "id", id, "type", getClass());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "name", getName());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "stratConScenarioType", stratConScenarioType.ordinal());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "stratConScenarioType", stratConScenarioType.name());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "desc", desc);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "report", report);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingPos", startingPos);
@@ -1013,8 +1013,8 @@ public class Scenario implements IPlayerSettings {
 
                 if (wn2.getNodeName().equalsIgnoreCase("name")) {
                     retVal.setName(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("scenarioType")) {
-                    retVal.setStratConScenarioType(ScenarioType.fromOrdinal(Integer.parseInt(wn2.getTextContent())));
+                } else if (wn2.getNodeName().equalsIgnoreCase("stratConScenarioType")) {
+                    retVal.setStratConScenarioType(ScenarioType.valueOf(wn2.getTextContent().trim().toUpperCase()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("status")) {
                     retVal.setStatus(ScenarioStatus.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("id")) {

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
@@ -34,6 +34,8 @@ import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
 import mekhq.campaign.mission.ScenarioMapParameters.MapLocation;
 import mekhq.campaign.mission.enums.ScenarioType;
 import mekhq.utilities.MHQXMLUtility;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Node;
 
 import javax.xml.namespace.QName;
@@ -59,6 +61,7 @@ public class ScenarioTemplate implements Cloneable {
 
     public static final String ROOT_XML_ELEMENT_NAME = "ScenarioTemplate";
     public static final String PRIMARY_PLAYER_FORCE_ID = "Player";
+    private static final Logger log = LogManager.getLogger(ScenarioTemplate.class);
 
     public String name;
     @XmlElement(name = "stratConScenarioType")
@@ -111,7 +114,7 @@ public class ScenarioTemplate implements Cloneable {
 
     public void setStratConScenarioType(String scenarioType) {
         try {
-            this.stratConScenarioType = ScenarioType.valueOf(scenarioType.trim());
+            this.stratConScenarioType = ScenarioType.valueOf(scenarioType.trim().toUpperCase());
         } catch (IllegalArgumentException e) {
             logger.error("Invalid ScenarioType: " + scenarioType, e);
             this.stratConScenarioType = ScenarioType.NONE;
@@ -306,8 +309,8 @@ public class ScenarioTemplate implements Cloneable {
 
         try {
             JAXBContext context = JAXBContext.newInstance(ScenarioTemplate.class);
-            Unmarshaller um = context.createUnmarshaller();
-            JAXBElement<ScenarioTemplate> templateElement = um.unmarshal(xmlNode, ScenarioTemplate.class);
+            Unmarshaller unmarshaller = context.createUnmarshaller();
+            JAXBElement<ScenarioTemplate> templateElement = unmarshaller.unmarshal(xmlNode, ScenarioTemplate.class);
             resultingTemplate = templateElement.getValue();
         } catch (Exception e) {
             logger.error("Error Deserializing Scenario Template", e);
@@ -320,19 +323,17 @@ public class ScenarioTemplate implements Cloneable {
         @Override
         public ScenarioType unmarshal(String value) {
             try {
-                // Match XML string to Enum
-                return ScenarioType.valueOf(value.trim()); // Ensure no extra spaces
-            } catch (IllegalArgumentException | NullPointerException e) {
-                // Log a warning for invalid input and return default
-                MMLogger.create(ScenarioTypeAdapter.class).warn("Invalid ScenarioType in XML: " + value);
-                return ScenarioType.NONE;
+                return ScenarioType.valueOf(value.trim().toUpperCase());
+            } catch (IllegalArgumentException iae) {
+                MMLogger.create(ScenarioTypeAdapter.class).error("Error Invalid ScenarioType in XML: " + value);
+                return ScenarioType.NONE; // Default for invalid values
             }
         }
 
         @Override
         public String marshal(ScenarioType scenarioType) {
             // Converts Enum back to String for XML
-            return scenarioType.name();
+            return String.valueOf(scenarioType);
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/mission/enums/ScenarioType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/ScenarioType.java
@@ -18,8 +18,6 @@
  */
 package mekhq.campaign.mission.enums;
 
-import megamek.logging.MMLogger;
-
 public enum ScenarioType {
     NONE,
     SPECIAL_LOSTECH,
@@ -37,17 +35,5 @@ public enum ScenarioType {
      */
     public boolean isResupply() {
         return this == SPECIAL_RESUPPLY;
-    }
-
-    public static ScenarioType fromOrdinal(int ordinal) {
-        final MMLogger logger = MMLogger.create(ScenarioType.class);
-
-        try {
-            return ScenarioType.values()[ordinal];
-        }  catch (IndexOutOfBoundsException e) {
-            logger.warn("Unknown scenario type {}, valid scenario types are {}",
-                ordinal, ScenarioType.values());
-            return ScenarioType.NONE;
-        }
     }
 }


### PR DESCRIPTION
This PR addresses an issue where MekHQ would 'forget' the value of `stratConScenarioType` on load, as well as failing to parse this value from the scenario template.

This was caused by multiple failure points, which this PR corrects.