### PR TITLE
Update contract scenarios to replace VIP Capture objectives

### DIFF
--- a/MekHQ/data/stratconcontractdefinitions/ExtractionRaid.xml
+++ b/MekHQ/data/stratconcontractdefinitions/ExtractionRaid.xml
@@ -31,9 +31,7 @@
 			<objectiveType>SpecificScenarioVictory</objectiveType>
 			<objectiveCount>-0.5</objectiveCount>
 			<objectiveScenarios>
-				<objectiveScenario>VIP Capture.xml</objectiveScenario>
-				<objectiveScenario>Remote VIP Capture.xml</objectiveScenario>
-				<objectiveScenario>Frontline VIP Capture.xml</objectiveScenario>
+				<objectiveScenario>VIP Ambush.xml</objectiveScenario>
                 <objectiveScenario>Covert Strike.xml</objectiveScenario>
                 <objectiveScenario>Convoy Interdiction.xml</objectiveScenario>
                 <objectiveScenario>Convoy Raid.xml</objectiveScenario>

--- a/MekHQ/data/stratconcontractdefinitions/GuerillaWarfare.xml
+++ b/MekHQ/data/stratconcontractdefinitions/GuerillaWarfare.xml
@@ -36,7 +36,7 @@
                 <objectiveScenario>Heavy Recon Evasion.xml</objectiveScenario>
                 <objectiveScenario>Intercept Engagement.xml</objectiveScenario>
                 <objectiveScenario>Recon Evasion.xml</objectiveScenario>
-                <objectiveScenario>Remote VIP Capture.xml</objectiveScenario>
+                <objectiveScenario>VIP Ambush.xml</objectiveScenario>
                 <objectiveScenario>Skirmish.xml</objectiveScenario>
                 <objectiveScenario>Tactical Withdrawal.xml</objectiveScenario>
             </objectiveScenarios>

--- a/MekHQ/data/stratconcontractdefinitions/ReconRaid.xml
+++ b/MekHQ/data/stratconcontractdefinitions/ReconRaid.xml
@@ -33,7 +33,7 @@
 			<objectiveScenarios>
 				<objectiveScenario>Recon Evasion.xml</objectiveScenario>
 				<objectiveScenario>Heavy Recon Evasion.xml</objectiveScenario>
-				<objectiveScenario>Remote VIP Capture.xml</objectiveScenario>
+				<objectiveScenario>VIP Ambush.xml</objectiveScenario>
 			</objectiveScenarios>
 		</objectiveParameter>
 	</objectiveParameters>


### PR DESCRIPTION
Replaced various "VIP Capture" scenarios with "VIP Ambush" and other mission types in `ExtractionRaid`, `GuerillaWarfare`, and `ReconRaid` definitions. These scenarios were removed from general rotation, but apparently I forgot to clean them up.

Fixes #5500