### PR TITLE
AutoLogistics fix for issue #5480

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
@@ -47,11 +47,11 @@ public class AeroSensor extends Part {
         this(0, false, null);
     }
 
-    public AeroSensor(int tonnage, boolean lc, Campaign c) {
-        super(tonnage, c);
+    public AeroSensor(int tonnage, boolean largeCraft, Campaign campaign) {
+        super(tonnage, campaign);
         this.name = "Aerospace Sensors";
-        this.largeCraft = lc;
-        this.unitTonnageMatters = !lc;
+        this.largeCraft = largeCraft;
+        this.unitTonnageMatters = !largeCraft;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/AeroSensor.java
@@ -51,7 +51,7 @@ public class AeroSensor extends Part {
         super(tonnage, c);
         this.name = "Aerospace Sensors";
         this.largeCraft = lc;
-        this.unitTonnageMatters = true;
+        this.unitTonnageMatters = !lc;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
@@ -138,14 +138,16 @@ public class MissingAeroSensor extends MissingPart {
         return PartRepairType.ELECTRONICS;
     }
 
+    // This function is over-ridden from it's parent because Aero Sensors depend on tonnage for small craft, but not for dropships/warships
+    //So we have to use regexes to change the acquistion name if the sensors are for spacecraft
     @Override
     public String getAcquisitionName() {
-        String[] parts = super.getAcquisitionName().split("(?<=\\()|(?=\\))");
         for(int i = 0; i < parts.length; i++) {
             System.out.println(parts[i]);
         }
         System.out.println("\n");
         if(dropship) {
+            //The below regex splits by the () characters but keeps them in the description
             String[] sliced = super.getAcquisitionName().split("(?<=\\()|(?=\\))");
             String descString = sliced[0] + sliced[2] + sliced[3];
             return descString;

--- a/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
@@ -142,7 +142,7 @@ public class MissingAeroSensor extends MissingPart {
     //So we have to use regexes to change the acquistion name if the sensors are for spacecraft
     @Override
     public String getAcquisitionName() {
-        if(dropship) {
+        if (dropship) {
             //The below regex splits by the () characters but keeps them in the description
             String[] sliced = super.getAcquisitionName().split("(?<=\\()|(?=\\))");
             String descString = sliced[0] + sliced[2] + sliced[3];

--- a/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
@@ -142,7 +142,6 @@ public class MissingAeroSensor extends MissingPart {
     //So we have to use regexes to change the acquistion name if the sensors are for spacecraft
     @Override
     public String getAcquisitionName() {
-        System.out.println("\n");
         if(dropship) {
             //The below regex splits by the () characters but keeps them in the description
             String[] sliced = super.getAcquisitionName().split("(?<=\\()|(?=\\))");

--- a/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
@@ -142,9 +142,6 @@ public class MissingAeroSensor extends MissingPart {
     //So we have to use regexes to change the acquistion name if the sensors are for spacecraft
     @Override
     public String getAcquisitionName() {
-        for(int i = 0; i < parts.length; i++) {
-            System.out.println(parts[i]);
-        }
         System.out.println("\n");
         if(dropship) {
             //The below regex splits by the () characters but keeps them in the description

--- a/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
@@ -45,10 +45,10 @@ public class MissingAeroSensor extends MissingPart {
         this(0, false, null);
     }
 
-    public MissingAeroSensor(int tonnage, boolean drop, Campaign c) {
-        super(tonnage, c);
+    public MissingAeroSensor(int tonnage, boolean dropship, Campaign campaign) {
+        super(tonnage, campaign);
         this.name = "Aero Sensors";
-        this.dropship = drop;
+        this.dropship = dropship;
     }
 
     @Override
@@ -138,15 +138,17 @@ public class MissingAeroSensor extends MissingPart {
         return PartRepairType.ELECTRONICS;
     }
 
-    // This function is over-ridden from it's parent because Aero Sensors depend on tonnage for small craft, but not for dropships/warships
-    //So we have to use regexes to change the acquistion name if the sensors are for spacecraft
+    /**  This function is over-ridden from it's parent because Aero Sensors depend on tonnage for small craft, but not for dropships/warships
+    * So we have to use regexes to change the acquistion name if the sensors are for spacecraft
+    * @return description string for the missing part
+    */
     @Override
     public String getAcquisitionName() {
         if (dropship) {
             //The below regex splits by the () characters but keeps them in the description
             String[] sliced = super.getAcquisitionName().split("(?<=\\()|(?=\\))");
-            String descString = sliced[0] + sliced[2] + sliced[3];
-            return descString;
+            String description = sliced[0] + sliced[2] + sliced[3];
+            return description;
         } else {
             return super.getAcquisitionName();
         }

--- a/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingAeroSensor.java
@@ -137,4 +137,20 @@ public class MissingAeroSensor extends MissingPart {
     public PartRepairType getMRMSOptionType() {
         return PartRepairType.ELECTRONICS;
     }
+
+    @Override
+    public String getAcquisitionName() {
+        String[] parts = super.getAcquisitionName().split("(?<=\\()|(?=\\))");
+        for(int i = 0; i < parts.length; i++) {
+            System.out.println(parts[i]);
+        }
+        System.out.println("\n");
+        if(dropship) {
+            String[] sliced = super.getAcquisitionName().split("(?<=\\()|(?=\\))");
+            String descString = sliced[0] + sliced[2] + sliced[3];
+            return descString;
+        } else {
+            return super.getAcquisitionName();
+        }
+    }
 }


### PR DESCRIPTION
PR addresses this issue:
https://github.com/MegaMek/mekhq/issues/5480

Aerospace sensors for large spacecraft do not matter depending on tonnage. However small aerospace craft do. The shopping system doesn't take tonnage into account but our AcquisitionWork system did. This adjusts AcquisitionWork and part naming so that spacecraft sensors do not display arbitrary tonnages both internally to the code and externally in the warehouse. This prevents the continuous purchasing through the autologistics system as described in the issue. If there are other parts with this tonnage split within the code, I'd expect that they have the same bug and need to be fixed similarly, but I'm not sure if there are any more.