### PR TITLE
Updated Force Refresh Logic in `TOEMouseAdapter`

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -440,7 +440,14 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             for (final Force force : forces) {
                 force.setCombatForce(combatForce, subforces);
                 force.setConvoyForce(false);
+
+
             }
+
+            for (Force formation : gui.getCampaign().getAllForces()) {
+                MekHQ.triggerEvent(new OrganizationChangedEvent(formation));
+            }
+
             gui.getTOETab().refreshForceView();
         } else if (command.contains(TOEMouseAdapter.CHANGE_CONVOY_STATUS)) {
             if (singleForce == null) {
@@ -460,11 +467,11 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 childForce.setConvoyForce(false);
             }
 
-            gui.getTOETab().refreshForceView();
-
             for (Force formation : gui.getCampaign().getAllForces()) {
                 MekHQ.triggerEvent(new OrganizationChangedEvent(formation));
             }
+
+            gui.getTOETab().refreshForceView();
         } else if (command.contains(CHANGE_STRATEGIC_FORCE_OVERRIDE)) {
             if (singleForce == null) {
                 return;


### PR DESCRIPTION
Added event triggering for all forces after modifying their status to ensure consistent updates. Adjusted the `refreshForceView` call position for better logical flow and UI updates.

This fixes a legacy bug that meant non-combat (support) forces were not being correctly removed from the list of Combat Teams if they were eligible to be a Combat Team _before_ receiving the Support designation.