### PR TITLE
Autologistics Fix for issue #5479

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -87,7 +87,7 @@ public class PartsReportDialog extends JDialog {
         this.gui = gui;
         this.campaign = gui.getCampaign();
         initComponents();
-        refreshOverviewPartsInUse();
+        updateOverviewPartsInUse();
         pack();
         setLocationRelativeTo(gui.getFrame());
 
@@ -379,6 +379,7 @@ public class PartsReportDialog extends JDialog {
     }
 
     private void refreshOverviewSpecificPart(int row, PartInUse partInUse, IAcquisitionWork newPart) {
+        storePartInUseRequestedStock(partInUse);
         if (partInUse.equals(new PartInUse((Part) newPart))) {
             // Simple update
             campaign.updatePartInUse(partInUse, ignoreMothballedCheck.isSelected(),
@@ -390,7 +391,7 @@ public class PartsReportDialog extends JDialog {
         }
     }
 
-    private void refreshOverviewPartsInUse() {
+    private void updateOverviewPartsInUse() {
         overviewPartsModel.setData(campaign.getPartsInUse(ignoreMothballedCheck.isSelected(),
                 getMinimumQuality((String) ignoreSparesUnderQualityCB.getSelectedItem())));
         TableColumnModel tcm = overviewPartsInUseTable.getColumnModel();
@@ -402,6 +403,11 @@ public class PartsReportDialog extends JDialog {
                 .getCellRenderer();
         column.setEnabled(campaign.isGM());
         topUpGMButton.setEnabled(campaign.isGM());
+    }
+
+    private void refreshOverviewPartsInUse() {
+        storePartInUseRequestedStockMap();
+        updateOverviewPartsInUse();
     }
 
     private Set<PartInUse> getPartsInUseFromTable() {
@@ -439,6 +445,21 @@ public class PartsReportDialog extends JDialog {
             stockMap.put(partInUse.getDescription(), partInUse.getRequestedStock());
         }
         campaign.setPartsInUseRequestedStockMap(stockMap);
+    }
+
+    private void storePartInUseRequestedStock(PartInUse partInUse) {
+        Map<String,Double> stockMap = campaign.getPartsInUseRequestedStockMap();
+        stockMap.put(partInUse.getDescription(), partInUse.getRequestedStock());
+    }
+
+    private Map<String,Double> getCurrentRequestedStockMap() {
+        Map<String,Double> stockMap = new LinkedHashMap<>();
+        for (int row = 0; row < overviewPartsInUseTable.getRowCount(); row++) {
+            PartInUse partInUse = overviewPartsModel.getPartInUse(row);
+            stockMap.put(partInUse.getDescription(), partInUse.getRequestedStock());
+        }
+
+        return stockMap;
     }
 
     private void onClose() {


### PR DESCRIPTION
PR addresses the issue [here](https://github.com/MegaMek/mekhq/issues/5479)

Requested stock values for parts in use were not properly saving on certain checkbox tick/untick or buying singular parts. I wasn't saving changes to the requested stock map during these changes and the refereshOverviewPartsInUse() method would reset their values. I've split the method in two, one that saves the stock map before and then continues, and one that doesn't. this is because we can't save the stock map on initialization or it messes everything up). I've also implemented a function that saves the requested stock for a singular part that has been implemented in refreshOverviewSpecificPart() to prevent singular part purchases in the menu from resetting that part's value.