### PR TITLE
Added Compatibility Handlers for Legacy Save File Support

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
@@ -108,10 +108,27 @@ public enum CombatRole {
             return valueOf(text);
         } catch (Exception ignored) {}
 
-        MMLogger.create(CombatRole.class)
-            .error("Unable to parse " + text + " into an CombatRole. Returning IN_RESERVE.");
+        // <50.02 compatibility handler
+        return switch (text) {
+            case "FIGHTING" -> FRONTLINE;
+            case "SCOUTING" -> RECON;
+            case "DEFENCE" -> GARRISON;
+            case "IN_RESERVE", "UNASSIGNED" -> RESERVE;
+            default -> {
+                MMLogger.create(CombatRole.class)
+                    .warn(String.format("Unable to parse %s into an CombatRole. Returning RESERVE.",
+                        text));
 
-        return RESERVE;
+                yield RESERVE;
+            }
+
+        };
+
+        // To be uncommented once the above compatibility handler is removed.
+//        MMLogger.create(CombatRole.class)
+//            .error("Unable to parse " + text + " into an CombatRole. Returning RESERVE.");
+//
+//        return RESERVE;
     }
     // endregion File I/O
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -141,10 +141,20 @@ public class StratconScenario implements IStratconDisplayable {
     @XmlElementWrapper(name = "primaryForceIDs")
     @XmlElement(name = "primaryForceID")
     public ArrayList<Integer> getPrimaryForceIDs() {
+        // <50.02 compatibility handler
+        if (primaryForceIDs == null) {
+            primaryForceIDs = new ArrayList<>();
+        }
+
         return primaryForceIDs;
     }
 
     public void setPrimaryForceIDs(ArrayList<Integer> primaryForceIDs) {
+        // <50.02 compatibility handler
+        if (primaryForceIDs == null) {
+            primaryForceIDs = new ArrayList<>();
+        }
+
         this.primaryForceIDs = primaryForceIDs;
     }
 


### PR DESCRIPTION
Updated `CombatRole` and `StratconScenario` to handle pre-50.02 data formats gracefully. Ensured backward compatibility by adding conversion logic and null checks where necessary.

Failure to include this resulted in some rather serious load bugs, so I'm going to be merging this immediately.