### PR TITLE
Added Travel Description Report to Transit Automation

### DIFF
--- a/MekHQ/resources/mekhq/resources/ContractAutomation.properties
+++ b/MekHQ/resources/mekhq/resources/ContractAutomation.properties
@@ -27,6 +27,8 @@ transitDescription.text=Our target system is <b>%s</b>. %s has already calculate
   <br>If we decline, you will need to manually order route calculation from the Interstellar Map.\
   \ This can be done by selecting the target system in your Briefing Room, followed by 'Calculate\
   \ Jump Path' and 'Begin Transit.'
+transitDescription.supplemental=Our target system is <b>%s</b>. This journey will take us\
+  \ approximately <b>%s</b> days.
 
 # Reports
 mothballingFailed.text=%s was not eligible to be automatically mothballed. Units cannot be\

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
@@ -104,6 +104,9 @@ public class ContractAutomation {
             campaign.getUnits().forEach(unit -> unit.setSite(Unit.SITE_FACILITY_BASIC));
             campaign.getApp().getCampaigngui().refreshAllTabs();
             campaign.getApp().getCampaigngui().refreshLocation();
+
+            campaign.addReport(String.format(resources.getString("transitDescription.supplemental"),
+                targetSystem, travelDays));
         }
     }
 


### PR DESCRIPTION
When the player is presented with the offer to automatically begin transit to their contract destination they are given an estimate of how long this would take. However, the player is required to remember this value when they want to use the Advance Multiple Days option. This value is very easily missed, resulting in a poor play experience.

This PR simply posts the destination and travel duration estimate to the Command Center log, when the offer is accepted.