### PR TITLE
Implemented More Neutral Language in Scenario & StratCon Contacts Nags; Added `pack()` Calls to Nag Dialogs

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -325,8 +325,14 @@ InsufficientMedicsNagDialog.title=Medic Shortage
 InsufficientMedicsNagDialog.text=Your Medical Teams require more Astechs. You need %d more medic(s). Do you wish to proceed?
 
 ### OutstandingScenariosNagDialog Class
-OutstandingScenariosNagDialog.title=Pending Battle
-OutstandingScenariosNagDialog.text=You have a pending battle. Failure to deploy will result in a defeat. \nDo you really wish to advance the day?
+OutstandingScenariosNagDialog.title=Pending Engagement
+OutstandingScenariosNagDialog.text=A hostile engagement is due in your area of operations.\
+  \n\
+  \nYou may choose to refuse this engagement by advancing the day.\
+  \n\
+  \nIf StratCon is enabled, refusing this engagement may cost 1 CVP.\
+  \n\
+  \nDo you wish to refuse the engagement?
 
 ### ShortDeploymentNagDialog Class
 ShortDeploymentNagDialog.title=Unmet Deployment Requirements
@@ -357,8 +363,15 @@ EndContractNagDialog.title=Contract Ended
 EndContractNagDialog.text=A contract has concluded and needs resolution. Do you really wish to advance the day?
 
 ### UnresolvedStratConContactsNagDialog Class
-UnresolvedStratConContactsNagDialog.title=Unresolved StratCon Contacts
-UnresolvedStratConContactsNagDialog.text=You have unresolved contacts on the StratCon interface:\n%s\nAdvance day anyway?
+UnresolvedStratConContactsNagDialog.title=Hostile Contacts Detected
+UnresolvedStratConContactsNagDialog.text=Hostile contacts detected in the Area of Operations:\
+  \n\
+  \n%s\
+  \nRefusing a critical engagement costs 1 CVP.\
+  \n\
+  \nThere is no cost for refusing other engagements.\
+  \n\
+  \nDo you wish to refuse the engagement?
 
 ### FactionDestroyedNagDialog Class
 InvalidFactionNagDialog.title=Invalid Faction

--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -124,3 +124,5 @@ ScenarioStatus.DEFEAT.text=Defeat
 ScenarioStatus.DEFEAT.toolTipText=<html>The unit was defeated by their opponent(s). <br>This is also referred to as a "Substantial Defeat" in the BattleTech rules.</html>
 ScenarioStatus.DECISIVE_DEFEAT.text=Decisive Defeat
 ScenarioStatus.DECISIVE_DEFEAT.toolTipText=The unit was decisively defeated by their opponent(s).
+ScenarioStatus.REFUSED_ENGAGEMENT.text=Refused Engagement
+ScenarioStatus.REFUSED_ENGAGEMENT.toolTipText=The unit did not participate in the battle

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3880,8 +3880,7 @@ public class Campaign implements ITechManager {
                                 (AtBDynamicScenario) scenario, contract.getStratconCampaignState());
 
                         if (stub) {
-                            scenario.convertToStub(this, ScenarioStatus.DEFEAT);
-                            addReport("Failure to deploy for " + scenario.getName() + " resulted in defeat.");
+                            scenario.convertToStub(this, ScenarioStatus.REFUSED_ENGAGEMENT);
 
                             if (scenario.getStratConScenarioType().isResupply()) {
                                 processAbandonedConvoy(this, contract, (AtBDynamicScenario) scenario);
@@ -3890,11 +3889,11 @@ public class Campaign implements ITechManager {
                             scenario.clearAllForcesAndPersonnel(this);
                         }
                     } else {
-                        scenario.convertToStub(this, ScenarioStatus.DEFEAT);
+                        scenario.convertToStub(this, ScenarioStatus.REFUSED_ENGAGEMENT);
                         contract.addPlayerMinorBreach();
 
                         addReport("Failure to deploy for " + scenario.getName()
-                                + " resulted in defeat and a minor contract breach.");
+                                + " resulted in a minor contract breach.");
                     }
                 }
             }

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -44,6 +44,7 @@ import mekhq.campaign.market.enums.UnitMarketType;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
 import mekhq.campaign.mission.enums.AtBContractType;
 import mekhq.campaign.mission.enums.AtBMoraleLevel;
+import mekhq.campaign.mission.enums.ScenarioStatus;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType;
 import mekhq.campaign.personnel.Bloodname;
@@ -566,17 +567,19 @@ public class AtBContract extends Contract {
                 continue;
             }
 
-            if (scenario.getStatus().isOverallVictory()) {
+            ScenarioStatus scenarioStatus = scenario.getStatus();
+
+            if (scenarioStatus.isOverallVictory()) {
                 victories++;
-            } else if (scenario.getStatus().isOverallDefeat()) {
+            } else if (scenarioStatus.isOverallDefeat() || scenarioStatus.isRefusedEngagement()) {
                 defeats++;
             }
 
-            if (scenario.getStatus().isDecisiveVictory()) {
+            if (scenarioStatus.isDecisiveVictory()) {
                 victories++;
-            } else if (scenario.getStatus().isDecisiveDefeat()) {
+            } else if (scenarioStatus.isDecisiveDefeat()) {
                 defeats++;
-            } else if (scenario.getStatus().isPyrrhicVictory()) {
+            } else if (scenarioStatus.isPyrrhicVictory()) {
                 victories--;
             }
         }
@@ -711,7 +714,7 @@ public class AtBContract extends Contract {
         for (Scenario s : getCompletedScenarios()) {
             // Special Scenarios get no points for victory and only -1 for defeat.
             if ((s instanceof AtBScenario) && ((AtBScenario) s).isSpecialScenario()) {
-                if (s.getStatus().isOverallDefeat()) {
+                if (s.getStatus().isOverallDefeat() || s.getStatus().isRefusedEngagement()) {
                     score--;
                 }
             } else {

--- a/MekHQ/src/mekhq/campaign/mission/enums/ScenarioStatus.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/ScenarioStatus.java
@@ -18,10 +18,10 @@
  */
 package mekhq.campaign.mission.enums;
 
-import java.util.ResourceBundle;
-
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
+
+import java.util.ResourceBundle;
 
 public enum ScenarioStatus {
     // region Enum Declarations
@@ -33,7 +33,8 @@ public enum ScenarioStatus {
     DRAW("ScenarioStatus.DRAW.text", "ScenarioStatus.DRAW.toolTipText"),
     MARGINAL_DEFEAT("ScenarioStatus.MARGINAL_DEFEAT.text", "ScenarioStatus.MARGINAL_DEFEAT.toolTipText"),
     DEFEAT("ScenarioStatus.DEFEAT.text", "ScenarioStatus.DEFEAT.toolTipText"),
-    DECISIVE_DEFEAT("ScenarioStatus.DECISIVE_DEFEAT.text", "ScenarioStatus.DECISIVE_DEFEAT.toolTipText");
+    DECISIVE_DEFEAT("ScenarioStatus.DECISIVE_DEFEAT.text", "ScenarioStatus.DECISIVE_DEFEAT.toolTipText"),
+    REFUSED_ENGAGEMENT("ScenarioStatus.REFUSED_ENGAGEMENT.text", "ScenarioStatus.REFUSED_ENGAGEMENT.toolTipText");
     // endregion Enum Declarations
 
     // region Variable Declarations
@@ -91,6 +92,10 @@ public enum ScenarioStatus {
 
     public boolean isDecisiveDefeat() {
         return this == DECISIVE_DEFEAT;
+    }
+
+    public boolean isRefusedEngagement() {
+        return this == REFUSED_ENGAGEMENT;
     }
 
     public boolean isOverallVictory() {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1719,7 +1719,9 @@ public class StratconRulesManager {
         applyFacilityModifiers(scenario, track, coords);
         applyGlobalModifiers(scenario, contract.getStratconCampaignState());
 
-        if (contract.getCommandRights().isHouse() || contract.getCommandRights().isIntegrated()) {
+        if (contract.getCommandRights().isHouse()
+            || contract.getCommandRights().isIntegrated()
+            || contract.getCommandRights().isIndependent()) {
             scenario.setRequiredScenario(true);
         }
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/EndContractNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/EndContractNagDialog.java
@@ -67,6 +67,7 @@ public class EndContractNagDialog extends AbstractMHQNagDialog {
      */
     public EndContractNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_CONTRACT_ENDED);
+        pack();
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechTimeNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechTimeNagDialog.java
@@ -78,6 +78,7 @@ public class InsufficientAstechTimeNagDialog extends AbstractMHQNagDialog {
      */
     public InsufficientAstechTimeNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechsNagDialog.java
@@ -53,6 +53,7 @@ public class InsufficientAstechsNagDialog extends AbstractMHQNagDialog {
      */
     public InsufficientAstechsNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_INSUFFICIENT_ASTECHS);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientMedicsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientMedicsNagDialog.java
@@ -52,6 +52,7 @@ public class InsufficientMedicsNagDialog extends AbstractMHQNagDialog {
      */
     public InsufficientMedicsNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_INSUFFICIENT_MEDICS);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InvalidFactionNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InvalidFactionNagDialog.java
@@ -101,6 +101,7 @@ public class InvalidFactionNagDialog extends AbstractMHQNagDialog {
      */
     public InvalidFactionNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_INVALID_FACTION);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NoCommanderNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NoCommanderNagDialog.java
@@ -53,6 +53,7 @@ public class NoCommanderNagDialog extends AbstractMHQNagDialog {
      */
     public NoCommanderNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_NO_COMMANDER);
+        pack();
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/OutstandingScenariosNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/OutstandingScenariosNagDialog.java
@@ -23,6 +23,9 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBScenario;
+import mekhq.campaign.stratcon.StratconScenario;
+import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
+import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.gui.baseComponents.AbstractMHQNagDialog;
 
 import javax.swing.*;
@@ -55,6 +58,16 @@ public class OutstandingScenariosNagDialog extends AbstractMHQNagDialog {
                 LocalDate scenarioDate = scenario.getDate();
 
                 if (scenarioDate.equals(today)) {
+                    if (scenario.getHasTrack()) {
+                        for (StratconTrackState track : contract.getStratconCampaignState().getTracks()) {
+                            for (StratconScenario stratconScenario : track.getScenarios().values()) {
+                                if (stratconScenario.getBackingScenario().equals(scenario)) {
+                                    return stratconScenario.getCurrentState() != ScenarioState.UNRESOLVED;
+                                }
+                            }
+                        }
+                    }
+
                     return true;
                 }
             }
@@ -72,6 +85,7 @@ public class OutstandingScenariosNagDialog extends AbstractMHQNagDialog {
      */
     public OutstandingScenariosNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_OUTSTANDING_SCENARIOS);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/PregnantCombatantNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/PregnantCombatantNagDialog.java
@@ -76,6 +76,7 @@ public class PregnantCombatantNagDialog extends AbstractMHQNagDialog {
      */
     public PregnantCombatantNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_PREGNANT_COMBATANT);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
@@ -59,6 +59,7 @@ public class PrisonersNagDialog extends AbstractMHQNagDialog {
      */
     public PrisonersNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_PRISONERS);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/ShortDeploymentNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/ShortDeploymentNagDialog.java
@@ -72,6 +72,7 @@ public class ShortDeploymentNagDialog extends AbstractMHQNagDialog {
      */
     public ShortDeploymentNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_SHORT_DEPLOYMENT);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordExpensesNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordExpensesNagDialog.java
@@ -73,6 +73,7 @@ public class UnableToAffordExpensesNagDialog extends AbstractMHQNagDialog {
      */
     public UnableToAffordExpensesNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_UNABLE_TO_AFFORD_EXPENSES);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
@@ -91,6 +91,7 @@ public class UnableToAffordJumpNagDialog extends AbstractMHQNagDialog {
      */
     public UnableToAffordJumpNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordLoanPaymentNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordLoanPaymentNagDialog.java
@@ -86,6 +86,7 @@ public class UnableToAffordLoanPaymentNagDialog extends AbstractMHQNagDialog {
      */
     public UnableToAffordLoanPaymentNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_UNABLE_TO_AFFORD_LOAN_PAYMENT);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
@@ -59,6 +59,7 @@ public class UnmaintainedUnitsNagDialog extends AbstractMHQNagDialog {
     //region Constructors
     public UnmaintainedUnitsNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_UNMAINTAINED_UNITS);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnresolvedStratConContactsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnresolvedStratConContactsNagDialog.java
@@ -81,9 +81,12 @@ public class UnresolvedStratConContactsNagDialog extends AbstractMHQNagDialog {
                 for (StratconScenario scenario : track.getScenarios().values()) {
                     if ((scenario.getCurrentState() == ScenarioState.UNRESOLVED)
                             && (campaign.getLocalDate().equals(scenario.getDeploymentDate()))) {
-                        String resolvedScenario = String.format("%s, %s\n",
-                                scenario.getName(),
-                                track.getDisplayableName());
+                        String resolvedScenario = String.format("%s, %s-%s %s\n",
+                            scenario.getName(),
+                            track.getDisplayableName(),
+                            scenario.getCoords().toBTString(),
+                            scenario.isRequiredScenario() ? " (Critical)" : ""
+                        );
 
                         unresolvedContacts.append(resolvedScenario);
                     }
@@ -103,6 +106,7 @@ public class UnresolvedStratConContactsNagDialog extends AbstractMHQNagDialog {
      */
     public UnresolvedStratConContactsNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, DIALOG_NAME, DIALOG_TITLE, DIALOG_BODY, campaign, MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS);
+        pack();
     }
     //endregion Constructors
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
@@ -36,6 +36,7 @@ public class UntreatedPersonnelNagDialog extends AbstractMHQNagDialog {
     public UntreatedPersonnelNagDialog(final JFrame frame, final Campaign campaign) {
         super(frame, "UntreatedPersonnelNagDialog", "UntreatedPersonnelNagDialog.title",
                 "UntreatedPersonnelNagDialog.text", campaign, MHQConstants.NAG_UNTREATED_PERSONNEL);
+        pack();
     }
     //endregion Constructors
 


### PR DESCRIPTION
We received some Discord feedback that the current language used around scenarios was producing a 'bad feels' experience.

With 50.02 we started to introduce higher scenario volume, designed to test the player and their forces. Leading to more details and a more difficult campaign experience. One of the big changes in attitude was towards scenarios. Prior to 50.02 all scenarios were, in many ways, essential. Now, the player is encouraged to more judiciously determine whether they can afford to ignore a scenario, or have to fight it. Putting the choice more firmly in the player's hands.

However, a lot of the language in nags and the Briefing Tab was still nested in the idea that all scenarios needed to be fought.

This PR introduces a new scenario state: "Refused Engagement" for when a scenario is ignored. It also updates the Outstanding StratCon Contact and Pending Scenario nags to use more neutral language, so that the user knows ignoring a scenario is a perfectly valid option; though may come at a cost.

Finally, I added `pack()` calls to all existing nags so that they will also size according to their contents, rather than risking some information being cut off.

Fixes #5515