### PR TITLE
Refactored Personnel Filtering Logic for Field Kitchens...Again

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2117,6 +2117,21 @@ public class Campaign implements ITechManager {
     }
 
     /**
+     * Retrieves a filtered list of personnel who have at least one combat profession.
+     * <p>
+     * This method filters the list of all personnel to include only those whose primary
+     * or secondary role is designated as a combat role.
+     * </p>
+     *
+     * @return a {@link List} of {@link Person} objects representing combat-capable personnel
+     */
+    public List<Person> getActiveCombatPersonnel() {
+        return getPersonnel().stream()
+            .filter(p -> p.getPrimaryRole().isCombat() || p.getSecondaryRole().isCombat())
+            .collect(Collectors.toList());
+    }
+
+    /**
      * Provides a filtered list of personnel including only active Dependents.
      * @return a {@link Person} <code>List</code> containing all active personnel
      */
@@ -5004,15 +5019,12 @@ public class Campaign implements ITechManager {
             int personnelCount;
 
             if (campaignOptions.isUseFieldKitchenIgnoreNonCombatants()) {
-                personnelCount = (int) getActivePersonnel().stream()
-                    .filter(person -> !(person.getPrisonerStatus().isFree() && person.getPrimaryRole().isNone()))
-                    .filter(person -> person.getPrimaryRole().isCombat() || person.getSecondaryRole().isCombat())
-                    .count();
+                personnelCount = getActiveCombatPersonnel().size();
             } else {
-                personnelCount = (int) getActivePersonnel().stream()
-                    .filter(person -> !(person.getPrisonerStatus().isFree() && person.getPrimaryRole().isNone()))
-                    .count();
+                personnelCount = getActivePersonnel().size();
             }
+
+            personnelCount -= getCurrentPrisoners().size();
             fieldKitchenWithinCapacity = personnelCount <= Fatigue.checkFieldKitchenCapacity(this);
         } else {
             fieldKitchenWithinCapacity = false;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2126,7 +2126,7 @@ public class Campaign implements ITechManager {
      * @return a {@link List} of {@link Person} objects representing combat-capable personnel
      */
     public List<Person> getActiveCombatPersonnel() {
-        return getPersonnel().stream()
+        return getActivePersonnel().stream()
             .filter(p -> p.getPrimaryRole().isCombat() || p.getSecondaryRole().isCombat())
             .collect(Collectors.toList());
     }

--- a/MekHQ/src/mekhq/campaign/CampaignSummary.java
+++ b/MekHQ/src/mekhq/campaign/CampaignSummary.java
@@ -373,18 +373,14 @@ public class CampaignSummary {
      */
     public String getFacilityReport() {
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
-        int personnelCount;
 
+        int personnelCount;
         if (campaignOptions.isUseFieldKitchenIgnoreNonCombatants()) {
-            personnelCount = (int) campaign.getActivePersonnel().stream()
-                .filter(person -> !(person.getPrisonerStatus().isFree() && person.getPrimaryRole().isNone()))
-                .filter(person -> person.getPrimaryRole().isCombat() || person.getSecondaryRole().isCombat())
-                .count();
+            personnelCount = campaign.getActiveCombatPersonnel().size();
         } else {
-            personnelCount = (int) campaign.getActivePersonnel().stream()
-                .filter(person -> !(person.getPrisonerStatus().isFree() && person.getPrimaryRole().isNone()))
-                .count();
+            personnelCount = campaign.getActivePersonnel().size();
         }
+        personnelCount -= campaign.getCurrentPrisoners().size();
 
         StringBuilder report = new StringBuilder();
 


### PR DESCRIPTION
Replaced repetitive personnel filtering code with a new helper method `getActiveCombatPersonnel`.

Simplified logic for counting combat-capable and prisoner personnel, when determining Field Kitchen capacity.

Fixes #5517