### PR TITLE
Added "Refused Engagement" ScenarioStatus

### DIFF
--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -124,3 +124,5 @@ ScenarioStatus.DEFEAT.text=Defeat
 ScenarioStatus.DEFEAT.toolTipText=<html>The unit was defeated by their opponent(s). <br>This is also referred to as a "Substantial Defeat" in the BattleTech rules.</html>
 ScenarioStatus.DECISIVE_DEFEAT.text=Decisive Defeat
 ScenarioStatus.DECISIVE_DEFEAT.toolTipText=The unit was decisively defeated by their opponent(s).
+ScenarioStatus.REFUSED_ENGAGEMENT.text=Refused Engagement
+ScenarioStatus.REFUSED_ENGAGEMENT.toolTipText=The unit did not participate in the battle

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3880,8 +3880,7 @@ public class Campaign implements ITechManager {
                                 (AtBDynamicScenario) scenario, contract.getStratconCampaignState());
 
                         if (stub) {
-                            scenario.convertToStub(this, ScenarioStatus.DEFEAT);
-                            addReport("Failure to deploy for " + scenario.getName() + " resulted in defeat.");
+                            scenario.convertToStub(this, ScenarioStatus.REFUSED_ENGAGEMENT);
 
                             if (scenario.getStratConScenarioType().isResupply()) {
                                 processAbandonedConvoy(this, contract, (AtBDynamicScenario) scenario);
@@ -3890,11 +3889,11 @@ public class Campaign implements ITechManager {
                             scenario.clearAllForcesAndPersonnel(this);
                         }
                     } else {
-                        scenario.convertToStub(this, ScenarioStatus.DEFEAT);
+                        scenario.convertToStub(this, ScenarioStatus.REFUSED_ENGAGEMENT);
                         contract.addPlayerMinorBreach();
 
                         addReport("Failure to deploy for " + scenario.getName()
-                                + " resulted in defeat and a minor contract breach.");
+                                + " resulted in a minor contract breach.");
                     }
                 }
             }

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -44,6 +44,7 @@ import mekhq.campaign.market.enums.UnitMarketType;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
 import mekhq.campaign.mission.enums.AtBContractType;
 import mekhq.campaign.mission.enums.AtBMoraleLevel;
+import mekhq.campaign.mission.enums.ScenarioStatus;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType;
 import mekhq.campaign.personnel.Bloodname;
@@ -566,17 +567,19 @@ public class AtBContract extends Contract {
                 continue;
             }
 
-            if (scenario.getStatus().isOverallVictory()) {
+            ScenarioStatus scenarioStatus = scenario.getStatus();
+
+            if (scenarioStatus.isOverallVictory()) {
                 victories++;
-            } else if (scenario.getStatus().isOverallDefeat()) {
+            } else if (scenarioStatus.isOverallDefeat() || scenarioStatus.isRefusedEngagement()) {
                 defeats++;
             }
 
-            if (scenario.getStatus().isDecisiveVictory()) {
+            if (scenarioStatus.isDecisiveVictory()) {
                 victories++;
-            } else if (scenario.getStatus().isDecisiveDefeat()) {
+            } else if (scenarioStatus.isDecisiveDefeat()) {
                 defeats++;
-            } else if (scenario.getStatus().isPyrrhicVictory()) {
+            } else if (scenarioStatus.isPyrrhicVictory()) {
                 victories--;
             }
         }
@@ -708,14 +711,14 @@ public class AtBContract extends Contract {
         int score = employerMinorBreaches - playerMinorBreaches;
         int battles = 0;
         boolean earlySuccess = false;
-        for (Scenario s : getCompletedScenarios()) {
+        for (Scenario scenario : getCompletedScenarios()) {
             // Special Scenarios get no points for victory and only -1 for defeat.
-            if ((s instanceof AtBScenario) && ((AtBScenario) s).isSpecialScenario()) {
-                if (s.getStatus().isOverallDefeat()) {
+            if ((scenario instanceof AtBScenario) && ((AtBScenario) scenario).isSpecialScenario()) {
+                if (scenario.getStatus().isOverallDefeat() || scenario.getStatus().isRefusedEngagement()) {
                     score--;
                 }
             } else {
-                switch (s.getStatus()) {
+                switch (scenario.getStatus()) {
                     case DECISIVE_VICTORY:
                     case VICTORY:
                     case MARGINAL_VICTORY:
@@ -737,9 +740,9 @@ public class AtBContract extends Contract {
                 }
             }
 
-            if ((s instanceof AtBScenario)
-                    && (((AtBScenario) s).getScenarioType() == AtBScenario.BASEATTACK)
-                    && ((AtBScenario) s).isAttacker() && s.getStatus().isOverallVictory()) {
+            if ((scenario instanceof AtBScenario)
+                    && (((AtBScenario) scenario).getScenarioType() == AtBScenario.BASEATTACK)
+                    && ((AtBScenario) scenario).isAttacker() && scenario.getStatus().isOverallVictory()) {
                 earlySuccess = true;
             } else if (getMoraleLevel().isRouted() && !getContractType().isGarrisonType()) {
                 earlySuccess = true;

--- a/MekHQ/src/mekhq/campaign/mission/enums/ScenarioStatus.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/ScenarioStatus.java
@@ -18,10 +18,10 @@
  */
 package mekhq.campaign.mission.enums;
 
-import java.util.ResourceBundle;
-
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
+
+import java.util.ResourceBundle;
 
 public enum ScenarioStatus {
     // region Enum Declarations
@@ -33,7 +33,8 @@ public enum ScenarioStatus {
     DRAW("ScenarioStatus.DRAW.text", "ScenarioStatus.DRAW.toolTipText"),
     MARGINAL_DEFEAT("ScenarioStatus.MARGINAL_DEFEAT.text", "ScenarioStatus.MARGINAL_DEFEAT.toolTipText"),
     DEFEAT("ScenarioStatus.DEFEAT.text", "ScenarioStatus.DEFEAT.toolTipText"),
-    DECISIVE_DEFEAT("ScenarioStatus.DECISIVE_DEFEAT.text", "ScenarioStatus.DECISIVE_DEFEAT.toolTipText");
+    DECISIVE_DEFEAT("ScenarioStatus.DECISIVE_DEFEAT.text", "ScenarioStatus.DECISIVE_DEFEAT.toolTipText"),
+    REFUSED_ENGAGEMENT("ScenarioStatus.REFUSED_ENGAGEMENT.text", "ScenarioStatus.REFUSED_ENGAGEMENT.toolTipText");
     // endregion Enum Declarations
 
     // region Variable Declarations
@@ -91,6 +92,10 @@ public enum ScenarioStatus {
 
     public boolean isDecisiveDefeat() {
         return this == DECISIVE_DEFEAT;
+    }
+
+    public boolean isRefusedEngagement() {
+        return this == REFUSED_ENGAGEMENT;
     }
 
     public boolean isOverallVictory() {


### PR DESCRIPTION
We received some feedback that the current language used around scenarios was producing a 'bad feels' experience.

With 50.02 we've started to introduce higher scenario volume, designed to test the player and their forces. Leading to more defeats and a more difficult campaign experience. One of the big changes in attitude was towards scenarios. Prior to 50.02 all scenarios were, in many ways, essential. Now, the player is encouraged to more judiciously determine whether they can afford to ignore a scenario, or have to fight it. Putting the choice more firmly in the player's hands.

However, a lot of the language still nested in the idea that all scenarios needed to be fought.

This PR implements the new "Refused Engagement" `ScenarioStatus` to represent scenarios where the player chose not to participate in the battle. Updated related logic in `Campaign` and `AtBContract` to handle this new status. Adjusted resource properties to include corresponding text and tooltips.

Alongside #5522, this PR addresses #5515