### PR TITLE
Refactored Support Point Negotiation into a Dedicated Class; Fixed Initial Support Point Pool Bug

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -81,3 +81,14 @@ reinforcementConfirmation.confirmButton=Confirm
 reinforcementConfirmation.cancelButton=Cancel
 unitsSelectedLabel.bv=selected (ignores crew skill)
 unitsSelectedLabel.count=selected
+
+### Support Point Negotiation
+supportPoints.initial=Through the <i>Administration</i> skill of your Admin/Transport personnel\
+  \ contract %s will begin with %s<b>%s</b>%s Support Point%s.
+supportPoints.initial.noAdministrators=Your unit has no Admin/Transport personnel. Therefore, contract %s\
+  \ will not begin with %s<b>any</b>%s Support Points.
+
+supportPoints.monthly.noAdministrators=Your unit has no Admin/Transport personnel. Therefore,\
+  \ you will not gain %s<b>any</b>%s additional Support Points this month.
+supportPoints.monthly=The skill of your Admin/Transport personnel has created %s<b>%s</b>%s\
+  \ additional Support Point%s for contract %s.

--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -99,10 +99,6 @@ garrisonDutyRouted.text=Long-ranged sensors detect no enemy activity in the AO.
 contractMoraleReport.text=Current enemy condition is <b>%s</b> on contract %s.\
   <br>\
   <br>%s
-stratConWeeklySupportPoints.text=The skill of your Admin/Transport personnel has created %s<b>%s</b>%s\
-  \ additional Support Points for contract %s.
-stratConWeeklySupportPointsFailed.text=Your Admin/Transport personnel %s<b>failed</b>%s to create\
-  \ any additional Support Points for contract %s.
 understrength.text=%s is %s<b>under strength</b>%s and is not counting towards the minimum number\
   \ of Combat Teams required by your employer. Your employer is demanding that all relevant Combat\
   \ Teams contain at least %s combat units. Consider reassigning this Combat Team to <i>Reserve</i>\

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -154,11 +154,11 @@ import static mekhq.campaign.mission.AtBContract.pickRandomCamouflage;
 import static mekhq.campaign.mission.resupplyAndCaches.PerformResupply.performResupply;
 import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.processAbandonedConvoy;
 import static mekhq.campaign.parts.enums.PartQuality.QUALITY_A;
-import static mekhq.campaign.personnel.SkillType.S_ADMIN;
 import static mekhq.campaign.personnel.backgrounds.BackgroundsController.randomMercenaryCompanyNameGenerator;
 import static mekhq.campaign.personnel.education.EducationController.getAcademy;
 import static mekhq.campaign.personnel.education.TrainingCombatTeams.processTrainingCombatTeams;
 import static mekhq.campaign.personnel.turnoverAndRetention.RetirementDefectionTracker.Payout.isBreakingContract;
+import static mekhq.campaign.stratcon.SupportPointNegotiation.negotiateAdditionalSupportPoints;
 import static mekhq.campaign.unit.Unit.SITE_FACILITY_BASIC;
 import static mekhq.campaign.universe.Factions.getFactionLogo;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
@@ -4013,7 +4013,7 @@ public class Campaign implements ITechManager {
         }
 
         if (campaignOptions.isUseStratCon() && (currentDay.getDayOfMonth() == 1)) {
-            negotiateAdditionalSupportPoints();
+            negotiateAdditionalSupportPoints(this);
         }
 
         processNewDayATBScenarios();
@@ -4026,87 +4026,6 @@ public class Campaign implements ITechManager {
                         contract.setBatchallAccepted(contract.initiateBatchall(this));
                     }
                 }
-            }
-        }
-    }
-
-    /**
-     * Handles monthly negotiation of additional support points for active AtB Contracts.
-     * Admin/Transport personnel skill levels and contract start dates are considered during negotiations.
-     * Side effects include state changes and report generation.
-     */
-    public void negotiateAdditionalSupportPoints() {
-        // Fetch a list of all Admin/Transport personnel
-        List<Person> adminTransport = new ArrayList<>();
-
-        for (Person person : getAdmins()) {
-            if (person.getPrimaryRole().isAdministratorTransport()
-                || person.getSecondaryRole().isAdministratorTransport()) {
-                adminTransport.add(person);
-            }
-        }
-
-        // Sort that list based on skill
-        adminTransport.sort((person1, person2) -> {
-            Skill person1Skill = person1.getSkill(S_ADMIN);
-            int person1SkillValue = person1Skill.getLevel() + person1Skill.getBonus();
-
-            Skill person2Skill = person2.getSkill(S_ADMIN);
-            int person2SkillValue = person2Skill.getLevel() + person2Skill.getBonus();
-
-            return Double.compare(person1SkillValue, person2SkillValue);
-        });
-
-        // Fetch a list of all active AtB Contracts and sort that list oldest -> newest
-        List<AtBContract> activeContracts = getActiveAtBContracts();
-
-        List<AtBContract> sortedContracts = activeContracts.stream()
-            .sorted(Comparator.comparing(AtBContract::getStartDate))
-            .toList();
-
-        // Loop through available contracts, rolling for additional Support Points until we run
-        // out of Admin/Transport personnel, or we run out of active contracts
-        for (AtBContract contract : sortedContracts) {
-            if (adminTransport.isEmpty()) {
-                break;
-            }
-
-            int negoatiatedSupportPoints = 0;
-            int maximumSupportPointsNegotiated = contract.getRequiredLances();
-
-            int availableAdmins = adminTransport.size();
-
-            for (int i = 0; i < availableAdmins; i++) {
-                Person assignedAdmin = adminTransport.get(0);
-                adminTransport.remove(0);
-
-                int targetNumber = assignedAdmin.getSkill(S_ADMIN).getFinalSkillValue();
-                int roll = Compute.d6(2);
-
-                if (roll >= targetNumber) {
-                    negoatiatedSupportPoints++;
-
-                    int marginOfSuccess = (roll - targetNumber) / 4;
-
-                    negoatiatedSupportPoints += marginOfSuccess;
-                }
-
-                if (negoatiatedSupportPoints >= maximumSupportPointsNegotiated) {
-                    negoatiatedSupportPoints = maximumSupportPointsNegotiated;
-                    break;
-                }
-            }
-
-            if (negoatiatedSupportPoints > 0) {
-                contract.getStratconCampaignState().addSupportPoints(negoatiatedSupportPoints);
-
-                addReport(String.format(resources.getString("stratConWeeklySupportPoints.text"),
-                    ReportingUtilities.spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor()),
-                    negoatiatedSupportPoints, CLOSING_SPAN_TAG, contract.getName()));
-            } else {
-                addReport(String.format(resources.getString("stratConWeeklySupportPointsFailed.text"),
-                    ReportingUtilities.spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
-                    CLOSING_SPAN_TAG, contract.getName()));
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Random;
 
 import static java.lang.Math.min;
+import static mekhq.campaign.stratcon.SupportPointNegotiation.negotiateInitialSupportPoints;
 
 /**
  * This class handles StratCon state initialization when a contract is signed.
@@ -222,7 +223,7 @@ public class StratconContractInitializer {
         }
 
         // Determine starting Support Points
-        campaign.negotiateAdditionalSupportPoints();
+        negotiateInitialSupportPoints(campaign, contract);
 
         // Roll to see if a hidden cache is present
         if (campaign.getLocalDate().isAfter(LocalDate.of(2900, 1, 1))) {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -89,6 +89,7 @@ import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
  */
 public class StratconRulesManager {
     public final static int BASE_LEADERSHIP_BUDGET = 1000;
+
     private static final MMLogger logger = MMLogger.create(StratconRulesManager.class);
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratcon/SupportPointNegotiation.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/SupportPointNegotiation.java
@@ -1,0 +1,248 @@
+package mekhq.campaign.stratcon;
+
+import megamek.common.Compute;
+import megamek.common.annotations.Nullable;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.Skill;
+
+import java.util.*;
+
+import static mekhq.campaign.personnel.SkillType.S_ADMIN;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
+
+/**
+ * This class handles Support Point negotiations for StratCon.
+ * <p>
+ * It includes functionality to negotiate both initial and monthly support points for contracts,
+ * based on the skill levels of available Admin/Transport personnel.
+ *
+ * <p>The workflow includes:</p>
+ * <ul>
+ *     <li>Filtering and sorting Admin/Transport personnel by their skill levels.</li>
+ *     <li>Negotiating support points for either a single contract (initial negotiation) or all
+ *     active contracts (monthly negotiation).</li>
+ *     <li>Calculating support points based on dice rolls and personnel skill levels.</li>
+ *     <li>Generating appropriate campaign reports reflecting the success or failure of negotiations.</li>
+ * </ul>
+ */
+public class SupportPointNegotiation {
+    private static final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.AtBStratCon",
+        MekHQ.getMHQOptions().getLocale());
+
+    /**
+     * Negotiates monthly additional support points for all active AtB contracts.
+     *
+     * <p>Uses available Admin/Transport personnel to negotiate support points for contracts, with older contracts
+     * being processed first. Personnel are removed from the available pool as they are assigned to contracts.
+     * If no Admin/Transport personnel are available, an error report is generated, and the method exits early.</p>
+     *
+     * <p>Calculated support points are added to the contract if successful, and reports detailing the
+     * outcome are appended to the campaign reports.</p>
+     *
+     * @param campaign The {@link Campaign} instance managing the current game state.
+     */
+    public static void negotiateAdditionalSupportPoints(Campaign campaign) {
+        // Get sorted Admin/Transport personnel
+        List<Person> adminTransport = getSortedAdminTransportPersonnel(campaign);
+
+        // If no Admin/Transport personnel, exit early
+        if (adminTransport.isEmpty()) {
+            addReportNoPersonnel(campaign, null);
+            return;
+        }
+
+        // Fetch all active contracts and sort them by start date (oldest -> newest)
+        List<AtBContract> sortedContracts = getSortedContractsByStartDate(campaign);
+
+        // Iterate over contracts and negotiate support points
+        for (AtBContract contract : sortedContracts) {
+            if (adminTransport.isEmpty()) {
+                break;
+            }
+
+            processContractSupportPoints(campaign, contract, adminTransport, false);
+        }
+    }
+
+    /**
+     * Negotiates initial support points for a specific AtB contract.
+     *
+     * <p>This method processes a single contract and uses available Admin/Transport personnel to negotiate
+     * support points. If no Admin/Transport personnel are available, an error report is generated, and
+     * the method exits early.</p>
+     *
+     * <p>Calculated support points are added to the contract if successful, and a report detailing the
+     * outcome is appended to the campaign reports.</p>
+     *
+     * @param campaign The {@link Campaign} instance managing the current game state.
+     * @param contract The {@link AtBContract} instance representing the contract for which initial support
+     *                 points are being negotiated.
+     */
+    public static void negotiateInitialSupportPoints(Campaign campaign, AtBContract contract) {
+        // Get sorted Admin/Transport personnel
+        List<Person> adminTransport = getSortedAdminTransportPersonnel(campaign);
+
+        // If no Admin/Transport personnel, exit early
+        if (adminTransport.isEmpty()) {
+            addReportNoPersonnel(campaign, contract);
+            return;
+        }
+
+        // Negotiate support points for the specific contract
+        processContractSupportPoints(campaign, contract, adminTransport, true);
+    }
+
+    /**
+     * Processes the negotiation of support points for a given AtB contract.
+     *
+     * <p>Rolls dice for assigned personnel to determine successful negotiations. Support points
+     * are calculated based on skill levels and the success of the dice rolls. Personnel are
+     * removed from the pool once assigned, and support points are added to the contract if
+     * successfully negotiated.</p>
+     *
+     * @param campaign       The {@link Campaign} instance managing the current game state.
+     * @param contract       The {@link AtBContract} instance for which support points are being processed.
+     * @param adminTransport A {@link List} of available {@link Person} objects representing Admin/Transport personnel.
+     * @param isInitialNegotiation {@code true} if the negotiation took place at the beginning of
+     *                                        the contract, otherwise {@code false}
+     */
+    private static void processContractSupportPoints(Campaign campaign, AtBContract contract,
+                                                     List<Person> adminTransport, boolean isInitialNegotiation) {
+        int negotiatedSupportPoints = 0;
+        int maxSupportPoints = contract.getRequiredLances();
+
+        Iterator<Person> iterator = adminTransport.iterator();
+
+        while (iterator.hasNext() && negotiatedSupportPoints < maxSupportPoints) {
+            Person admin = iterator.next();
+            int rollResult = Compute.d6(2);
+            negotiatedSupportPoints += calculateSupportPoints(admin, rollResult);
+            iterator.remove();
+        }
+
+        // Determine font color based on success or failure
+        String fontColor = (negotiatedSupportPoints > 0)
+            ? MekHQ.getMHQOptions().getFontColorPositiveHexColor()
+            : MekHQ.getMHQOptions().getFontColorNegativeHexColor();
+
+        // Add points to the contract if positive
+        if (negotiatedSupportPoints > 0) {
+            contract.getStratconCampaignState().addSupportPoints(negotiatedSupportPoints);
+        }
+
+        // Add a report
+        String pluralizer = (negotiatedSupportPoints > 1) || (negotiatedSupportPoints == 0) ? "s" : "";
+        if (isInitialNegotiation) {
+            campaign.addReport(String.format(
+                resources.getString("supportPoints.initial"),
+                contract.getName(),
+                spanOpeningWithCustomColor(fontColor),
+                negotiatedSupportPoints,
+                CLOSING_SPAN_TAG,
+                pluralizer));
+        } else {
+            campaign.addReport(String.format(
+                resources.getString("supportPoints.monthly"),
+                spanOpeningWithCustomColor(fontColor),
+                negotiatedSupportPoints,
+                CLOSING_SPAN_TAG,
+                pluralizer,
+                contract.getName()));
+        }
+    }
+
+    /**
+     * Filters and sorts Admin/Transport personnel from the campaign by their skill levels in descending order.
+     *
+     * @param campaign The {@link Campaign} instance containing personnel to be filtered and sorted.
+     * @return A {@link List} of {@link Person} objects representing Admin/Transport personnel, sorted by skill.
+     */
+    private static List<Person> getSortedAdminTransportPersonnel(Campaign campaign) {
+        List<Person> adminTransport = new ArrayList<>();
+        for (Person person : campaign.getAdmins()) {
+            if (person.getPrimaryRole().isAdministratorTransport()
+                || person.getSecondaryRole().isAdministratorTransport()) {
+                adminTransport.add(person);
+            }
+        }
+
+        adminTransport.sort((p1, p2) -> Integer.compare(getSkillValue(p2), getSkillValue(p1)));
+        return adminTransport;
+    }
+
+    /**
+     * Retrieves and sorts all active AtB contracts by their start date in ascending order.
+     *
+     * @param campaign The {@link Campaign} instance containing the active contracts.
+     * @return A {@link List} of {@link AtBContract} instances, sorted by start date.
+     */
+    private static List<AtBContract> getSortedContractsByStartDate(Campaign campaign) {
+        List<AtBContract> activeContracts = campaign.getActiveAtBContracts();
+        activeContracts.sort(Comparator.comparing(AtBContract::getStartDate));
+        return activeContracts;
+    }
+
+    /**
+     * Calculates the number of support points based on a die roll and the skill level of a given Admin/Transport person.
+     *
+     * <p>If the dice roll meets or exceeds the admin's skill level, at least one support point is awarded,
+     * with additional support points depending on the margin of success.</p>
+     *
+     * @param admin      The {@link Person} representing the Admin/Transport personnel rolling for support points.
+     * @param rollResult The result of rolling two six-sided dice (2d6).
+     * @return The number of support points awarded based on the roll and skill level.
+     */
+    private static int calculateSupportPoints(Person admin, int rollResult) {
+        int adminSkill = admin.getSkill(S_ADMIN).getFinalSkillValue();
+        if (rollResult < adminSkill) {
+            return 0;
+        }
+
+        int points = 1; // Base success
+        int marginOfSuccess = (rollResult - adminSkill) / 4;
+        points += marginOfSuccess;
+        return points;
+    }
+
+    /**
+     * Adds a report to the campaign log indicating the absence of Admin/Transport personnel for support point negotiations.
+     *
+     * <p>If a contract is specified, the report is related to that contract. Otherwise, the report is general
+     * (e.g., for monthly negotiations).</p>
+     *
+     * @param campaign The {@link Campaign} instance managing the current game state.
+     * @param contract An optional {@link AtBContract} instance representing the affected contract (can be {@code null}).
+     */
+    private static void addReportNoPersonnel(Campaign campaign, @Nullable AtBContract contract) {
+        String reportKey = String.format("supportPoints.%s.noAdministrators",
+            contract == null ? "initial" : "monthly");
+
+        if (contract != null) {
+            campaign.addReport(String.format(resources.getString(reportKey),
+                contract.getName(),
+                spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
+                CLOSING_SPAN_TAG
+            ));
+        } else {
+            campaign.addReport(String.format(resources.getString(reportKey),
+                spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
+                CLOSING_SPAN_TAG
+            ));
+        }
+    }
+
+    /**
+     * Calculates the total skill value for a given person by summing their skill level and bonuses.
+     *
+     * @param person The {@link Person} whose skill value is being calculated.
+     * @return An {@code int} representing the total skill value (level + bonus).
+     */
+    private static int getSkillValue(Person person) {
+        Skill skill = person.getSkill(S_ADMIN);
+        return skill.getTotalSkillLevel();
+    }
+}


### PR DESCRIPTION
Moved the logic for support point negotiation to a new `SupportPointNegotiation` class, organizing initial and monthly support point calculations. This improves code modularity, readability, and maintainability while simplifying related methods in `Campaign` and `StratconContractInitializer`.

This also corrects a major bug that was preventing contracts from beginning with a pool of starting Support Points.