### PR TITLE
Renamed 'requiredScenario' to 'turningPoint' in StratCon

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -326,7 +326,7 @@ public class StratconRulesManager {
                 // if under liaison command, pick a random scenario from the ones generated
                 // to set as required and attach liaison
                 if (contract.getCommandRights().isLiaison() && (randomInt(4) == 0)) {
-                    scenario.setRequiredScenario(true);
+                    scenario.setTurningPoint(true);
                     setAttachedUnitsModifier(scenario, contract);
                 }
 
@@ -931,7 +931,7 @@ public class StratconRulesManager {
 
             // if under liaison command, randomly determine if this is a Liason scenario
             if (contract.getCommandRights().isLiaison() && (randomInt(4) == 0)) {
-                scenario.setRequiredScenario(true);
+                scenario.setTurningPoint(true);
                 setAttachedUnitsModifier(scenario, contract);
             }
 
@@ -1720,7 +1720,7 @@ public class StratconRulesManager {
         applyGlobalModifiers(scenario, contract.getStratconCampaignState());
 
         if (contract.getCommandRights().isHouse() || contract.getCommandRights().isIntegrated()) {
-            scenario.setRequiredScenario(true);
+            scenario.setTurningPoint(true);
         }
 
         AtBDynamicScenarioFactory.setScenarioModifiers(campaign.getCampaignOptions(),
@@ -1887,7 +1887,7 @@ public class StratconRulesManager {
                                 : MHQConstants.SCENARIO_MODIFIER_HOUSE_CO_GROUND));
                 break;
             case LIAISON:
-                if (scenario.isRequiredScenario()) {
+                if (scenario.isTurningPoint()) {
                     backingScenario.addScenarioModifier(
                             AtBScenarioModifier
                                     .getScenarioModifier(airBattle ? MHQConstants.SCENARIO_MODIFIER_LIAISON_AIR
@@ -2439,7 +2439,7 @@ public class StratconRulesManager {
 
                     StratconFacility facility = track.getFacility(scenario.getCoords());
 
-                    if (scenario.isRequiredScenario() && !backingScenario.getStatus().isDraw()) {
+                    if (scenario.isTurningPoint() && !backingScenario.getStatus().isDraw()) {
                         campaignState.updateVictoryPoints(victory ? 1 : -1);
                     }
 
@@ -2587,7 +2587,7 @@ public class StratconRulesManager {
         for (StratconTrackState track : campaignState.getTracks()) {
             if (track.getScenarios().containsKey(scenario.getCoords())) {
                 // subtract VP if scenario is 'required'
-                if (scenario.isRequiredScenario()) {
+                if (scenario.isTurningPoint()) {
                     campaignState.updateVictoryPoints(-1);
                 }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -70,7 +70,7 @@ public class StratconScenario implements IStratconDisplayable {
     private int backingScenarioID;
     private ScenarioState currentState = ScenarioState.UNRESOLVED;
     private int requiredPlayerLances;
-    private boolean requiredScenario;
+    private boolean turningPoint;
     private boolean isStrategicObjective;
     private LocalDate deploymentDate;
     private LocalDate actionDate;
@@ -202,9 +202,9 @@ public class StratconScenario implements IStratconDisplayable {
                     .append("<br/>");
             }
 
-            if (isRequiredScenario()) {
-                stateBuilder.append("<span color='").append(MekHQ.getMHQOptions().getFontColorNegativeHexColor())
-                    .append("'>-1 VP if lost/ignored; +1 VP if won</span><br/>");
+            if (isTurningPoint()) {
+                stateBuilder.append("<span color='").append(MekHQ.getMHQOptions().getFontColorWarning())
+                    .append("'>Turning Point</span><br/>");
             }
 
             stateBuilder.append("<b>Status:</b> ")
@@ -267,12 +267,12 @@ public class StratconScenario implements IStratconDisplayable {
         requiredPlayerLances++;
     }
 
-    public boolean isRequiredScenario() {
-        return requiredScenario;
+    public boolean isTurningPoint() {
+        return turningPoint;
     }
 
-    public void setRequiredScenario(boolean requiredScenario) {
-        this.requiredScenario = requiredScenario;
+    public void setTurningPoint(boolean turningPoint) {
+        this.turningPoint = turningPoint;
     }
 
     @XmlTransient


### PR DESCRIPTION
Replaced the 'requiredScenario' variable and its related methods with 'turningPoint' . Updated all associated logic, method names, and references to reflect this change.

This decision was made in response to the recent player desire towards more neutral language when referring to scenarios. By renaming 'required' scenarios to 'turning points' we infer their critical nature without making the player feel like they're being punished if they're unable to complete the scenario.

This will likely cause a heap of conflicts with the other PRs I put forth today, and that's not a problem. Just be aware that this probably should be merged last.