### PR TITLE
Fixed Recon Scenario Spawn; Fixed Bugs Related to Role Name Changes

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -218,7 +218,7 @@ public class AtBGameThread extends GameThread {
                  * delay for slower scout units.
                  */
                 boolean useDropship = false;
-                if (scenario.getCombatRole().isScouting()) {
+                if (scenario.getCombatRole().isRecon()) {
                     for (Entity en : scenario.getAlliesPlayer()) {
                         if (en.getUnitType() == UnitType.DROPSHIP) {
                             useDropship = true;
@@ -267,7 +267,7 @@ public class AtBGameThread extends GameThread {
                         // Set scenario type-specific delay
                         deploymentRound = Math.max(entity.getDeployRound(), scenario.getDeploymentDelay() - speed);
                         // Lances deployed in scout roles always deploy units in 6-walking speed turns
-                        if (scenario.getCombatRole().isScouting() && (scenario.getCombatTeamById(campaign) != null)
+                        if (scenario.getCombatRole().isRecon() && (scenario.getCombatTeamById(campaign) != null)
                                 && (scenario.getCombatTeamById(campaign).getForceId() == scenario.getCombatTeamId())
                                 && !useDropship) {
                             deploymentRound = Math.max(deploymentRound, 6 - speed);
@@ -335,7 +335,7 @@ public class AtBGameThread extends GameThread {
                             }
                         }
                         deploymentRound = Math.max(entity.getDeployRound(), scenario.getDeploymentDelay() - speed);
-                        if (!useDropship && scenario.getCombatRole().isScouting()
+                        if (!useDropship && scenario.getCombatRole().isRecon()
                                 && (scenario.getCombatTeamById(campaign).getForceId() == scenario.getCombatTeamId())) {
                             deploymentRound = Math.max(deploymentRound, 6 - speed);
                         }

--- a/MekHQ/src/mekhq/campaign/autoresolve/converter/SetupForces.java
+++ b/MekHQ/src/mekhq/campaign/autoresolve/converter/SetupForces.java
@@ -179,7 +179,7 @@ public class SetupForces {
      */
     private List<Entity> setupPlayerForces(Player player) {
         boolean useDropship = false;
-        if (scenario.getCombatRole().isScouting()) {
+        if (scenario.getCombatRole().isRecon()) {
             for (Entity en : scenario.getAlliesPlayer()) {
                 if (en.getUnitType() == UnitType.DROPSHIP) {
                     useDropship = true;
@@ -228,7 +228,7 @@ public class SetupForces {
                 // Set scenario type-specific delay
                 deploymentRound = Math.max(entity.getDeployRound(), scenario.getDeploymentDelay() - speed);
                 // Lances deployed in scout roles always deploy units in 6-walking speed turns
-                if (scenario.getCombatRole().isScouting() && (scenario.getCombatTeamById(campaign) != null)
+                if (scenario.getCombatRole().isRecon() && (scenario.getCombatTeamById(campaign) != null)
                     && (scenario.getCombatTeamById(campaign).getForceId() == scenario.getCombatTeamId())
                     && !useDropship) {
                     deploymentRound = Math.max(deploymentRound, 6 - speed);
@@ -264,7 +264,7 @@ public class SetupForces {
                     }
                 }
                 deploymentRound = Math.max(entity.getDeployRound(), scenario.getDeploymentDelay() - speed);
-                if (!useDropship && scenario.getCombatRole().isScouting()
+                if (!useDropship && scenario.getCombatRole().isRecon()
                     && (scenario.getCombatTeamById(campaign).getForceId() == scenario.getCombatTeamId())) {
                     deploymentRound = Math.max(deploymentRound, 6 - speed);
                 }

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -702,7 +702,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     private void setStandardScenarioForces(Campaign campaign) {
         /* Find the number of attached units required by the command rights clause */
         int attachedUnitWeight = EntityWeightClass.WEIGHT_MEDIUM;
-        if (combatRole.isScouting() || combatRole.isTraining()) {
+        if (combatRole.isRecon() || combatRole.isTraining()) {
             attachedUnitWeight = EntityWeightClass.WEIGHT_LIGHT;
         }
         int numAttachedPlayer = 0;
@@ -832,7 +832,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                                     getContract(campaign).getEnemy()),
                             EntityWeightClass.WEIGHT_ASSAULT, campaign);
                 }
-            } else if (getCombatRole().isScouting()) {
+            } else if (getCombatRole().isRecon()) {
                 /*
                  * Set allied forces to deploy in (6 - speed) turns just as player's units,
                  * but only if not deploying by DropShip.

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/BaseAttackBuiltInScenario.java
@@ -180,7 +180,7 @@ public class BaseAttackBuiltInScenario extends AtBScenario {
             // Rout for a while
             ObjectiveEffect victoryEffect = new ObjectiveEffect();
             final CombatRole requiredLanceRole = contract.getContractType().getRequiredLanceRole();
-            if (requiredLanceRole.isFrontline() || requiredLanceRole.isScouting()) {
+            if (requiredLanceRole.isFrontline() || requiredLanceRole.isRecon()) {
                 victoryEffect.effectType = ObjectiveEffectType.ContractVictory;
                 destroyHostiles.addDetail(getResourceBundle().getString("battleDetails.baseAttack.attacker.details.winnerFightScout"));
             } else {

--- a/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
@@ -62,7 +62,7 @@ public enum CombatRole {
         return this == GARRISON;
     }
 
-    public boolean isScouting() {
+    public boolean isRecon() {
         return this == RECON;
     }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -111,7 +111,7 @@ public class StratconRulesManager {
         REGULAR,
 
         /**
-         * The Combat Team's deployment orders are "Fight" or "Auxiliary".
+         * The Combat Team's deployment orders are "Frontline" or "Auxiliary".
          * We pay a support point and make an enhanced roll
          */
         AUXILIARY
@@ -860,7 +860,7 @@ public class StratconRulesManager {
             return;
         }
 
-        boolean isScouting = combatTeam.getRole().isScouting();
+        boolean isRecon = combatTeam.getRole().isRecon();
 
         // the following things should happen:
         // 1. call to "process force deployment", which reveals fog of war in or around the coords,
@@ -881,7 +881,7 @@ public class StratconRulesManager {
             return;
         }
 
-        if (isScouting) {
+        if (isRecon) {
             StratconCoords newCoords = getUnoccupiedAdjacentCoords(coords, track);
 
             if (newCoords != null) {
@@ -898,7 +898,7 @@ public class StratconRulesManager {
 
         if (isNonAlliedFacility || spawnScenario) {
             StratconScenario scenario;
-            boolean autoAssignLances = !isScouting;
+            boolean autoAssignLances = !isRecon;
 
             Set<Integer> preDeployedForce = track.getAssignedCoordForces().get(coords);
 
@@ -948,6 +948,7 @@ public class StratconRulesManager {
      *     <li>No scenario is assigned to the coordinate (using {@link StratconTrackState#getScenario})</li>
      *     <li>No facility exists at the coordinate (using {@link StratconTrackState#getFacility})</li>
      *     <li>The coordinate is not occupied by any assigned forces (using {@link StratconTrackState#getAssignedForceCoords})</li>
+     *     <li>The coordinate is on the map</li>
      * </ul>
      * If multiple suitable coordinates are found, one is selected at random and returned.
      * If no suitable coordinates are available, the method returns {@code null}.
@@ -958,8 +959,10 @@ public class StratconRulesManager {
      */
     private static @Nullable StratconCoords getUnoccupiedAdjacentCoords(StratconCoords originCoords,
                                                                        StratconTrackState trackState) {
-        List<StratconCoords> suitableCoords = new ArrayList<>();
+        final int trackWidth = trackState.getWidth();
+        final int trackHeight = trackState.getHeight();
 
+        List<StratconCoords> suitableCoords = new ArrayList<>();
         for (int direction : ALL_DIRECTIONS) {
             StratconCoords newCoords = originCoords.translate(direction);
 
@@ -972,6 +975,14 @@ public class StratconRulesManager {
             }
 
             if (trackState.getAssignedForceCoords().containsValue(newCoords)) {
+                continue;
+            }
+
+            // This is to ensure we're not trying to place a scenario off the map
+            if ((newCoords.getX() < 0)
+                || (newCoords.getX() > trackWidth)
+                || (newCoords.getY() < 0)
+                || (newCoords.getY() > trackHeight)) {
                 continue;
             }
 
@@ -1148,7 +1159,7 @@ public class StratconRulesManager {
 
         // This may return null if we're deploying a force that isn't a Combat Team for whatever reason
         if (combatTeam != null) {
-            if (combatTeam.getRole().isScouting()) {
+            if (combatTeam.getRole().isRecon()) {
                 for (int direction = 0; direction < 6; direction++) {
                     StratconCoords checkCoords = coords.translate(direction);
 

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -44,6 +44,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import static mekhq.campaign.mission.enums.CombatRole.FRONTLINE;
+import static mekhq.campaign.mission.enums.CombatRole.GARRISON;
+import static mekhq.campaign.mission.enums.CombatRole.RECON;
+import static mekhq.campaign.mission.enums.CombatRole.TRAINING;
+
 /**
  * Against the Bot
  * Shows how many lances are required to be deployed on active contracts and
@@ -294,7 +299,8 @@ class RequiredLancesTableModel extends DataTableModel {
     public RequiredLancesTableModel(final Campaign campaign) {
         this.campaign = campaign;
         data = new ArrayList<AtBContract>();
-        columnNames = new String[]{"Contract", "Total", "Fight", "Defend", "Scout", "Training"};
+        columnNames = new String[]{"Contract", "Total", FRONTLINE.toString(), GARRISON.toString(),
+            RECON.toString(), TRAINING.toString()};
     }
 
     @Override


### PR DESCRIPTION
Renamed 'isScouting' to 'isRecon' across various classes to improve terminology consistency with the 'RECON' combat role. Updated related comments, logic checks, and UI labels to reflect the new naming convention.

Fixed bug with scenarios occasionally spawning off the map when deploying a recon force on a Sector's edge.

Fixes #5519