### PR TITLE
Updated Space Scenario OpFor Deployment & Arrival

### DIFF
--- a/MekHQ/data/scenariotemplates/Space Blockade Run.xml
+++ b/MekHQ/data/scenariotemplates/Space Blockade Run.xml
@@ -185,7 +185,7 @@
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>9</allowedUnitType>
-                <arrivalTurn>2</arrivalTurn>
+                <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -204,7 +204,7 @@
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>SameEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>

--- a/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
@@ -105,7 +105,7 @@
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>9</allowedUnitType>
-                <arrivalTurn>2</arrivalTurn>
+                <arrivalTurn>0</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
@@ -158,7 +158,7 @@
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>SameEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
@@ -192,7 +192,7 @@
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <subjectToRandomRemoval>false</subjectToRandomRemoval>
-                <syncDeploymentType>SameEdge</syncDeploymentType>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>


### PR DESCRIPTION
Adjusted "Space DropShip Intercept" and "Space Blockade Run" templates to modify arrival turn from 2 to 0 and change sync deployment type to "OppositeEdge".

We received some feedback that the previous set up just resulted in Princess staging a mosh pit in the player's deployment zone, due to Princess' generally poor grasp of the concept of 'fleeing'.