### PR TITLE
Fixed Training Logic to Handle Empty Skill Lists

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -165,7 +165,7 @@ public class TrainingCombatTeams {
                     }
                 }
 
-                if (educatorSkills.isEmpty()) {
+                if (educatorSkills.isEmpty() || skillsBeingTrained.isEmpty()) {
                     campaign.addReport(String.format(resources.getString("notLearningAnything.text"),
                             trainee.getHyperlinkedFullTitle(), commander.getFullTitle(),
                             spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
@@ -207,6 +207,10 @@ public class TrainingCombatTeams {
         } else {
             int newEducationTime = trainee.getEduEducationTime() + WEEK_DURATION;
             trainee.setEduEducationTime(newEducationTime);
+
+            if (skillsBeingTrained.isEmpty()) {
+                return;
+            }
 
             // The lowest skill is improved first
             skillsBeingTrained.sort(Comparator.comparingInt(Skill::getExperienceLevel));


### PR DESCRIPTION
Added checks to prevent errors when no skills are available for training. Ensured that training actions are skipped when either educator or trainee skills are missing. This prevents a potential out-of-bounds exception.

We had an OoB reported on Discord, but not issue report logged. This is the only instance I could find that might cause the error. If/when the issue report is filed I can verify the issue is resolved and address it, if it isn't.