### PR TITLE
Corrected Auxiliary Deployment Restrictions

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -2156,7 +2156,7 @@ public class StratconRulesManager {
                 continue;
             }
 
-            if (formation.getRole().isAuxiliary()) {
+            if (formation.getRole().isAuxiliary() && !reinforcements) {
                 continue;
             }
 


### PR DESCRIPTION
Added missing check to see whether a force is being deployed as reinforcements when excluding Auxiliaries as deployable forces. This bug prevented Auxiliaries from _ever_ being deployed.