### PR TITLE
Adjusted Force Role Weighting in DropShip Defense Scenario Templates

### DIFF
--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -183,6 +183,12 @@
                     <forceRole>MISSILE_ARTILLERY</forceRole>
                     <forceRole>MIXED_ARTILLERY</forceRole>
                     <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
                     <forceRole>SR_FIRE_SUPPORT</forceRole>
                 </roleChoices>
             </value>

--- a/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -184,6 +184,12 @@
                     <forceRole>MISSILE_ARTILLERY</forceRole>
                     <forceRole>MIXED_ARTILLERY</forceRole>
                     <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
+                    <forceRole>SR_FIRE_SUPPORT</forceRole>
                     <forceRole>SR_FIRE_SUPPORT</forceRole>
                 </roleChoices>
             </value>


### PR DESCRIPTION
Reduced the weight of artillery units in DropShip defense scenario templates.

Fixes #5535