### PR TITLE
Temporarily Disabled Non-Launch Ready Options

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -291,7 +291,7 @@ public class DataLoadingDialog extends AbstractMHQDialog implements PropertyChan
 
                 // Campaign Preset
                 final SelectPresetDialog presetSelectionDialog =
-                    new SelectPresetDialog(getFrame(), true, true);
+                    new SelectPresetDialog(getFrame(), false, true);
                 CampaignPreset preset;
                 boolean isSelect = false;
 

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -100,6 +100,7 @@ import java.util.stream.IntStream;
 
 import static megamek.client.ui.WrapLayout.wordWrap;
 import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
+import static mekhq.campaign.market.enums.ContractMarketMethod.CAM_OPS;
 
 /**
  * @author Justin 'Windchild' Bowen
@@ -8029,6 +8030,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         comboContractMarketMethod = new MMComboBox<>("comboContractMarketMethod",
                 ContractMarketMethod.values());
+        comboContractMarketMethod.removeItem(CAM_OPS);
         comboContractMarketMethod.setToolTipText(resources.getString("lblContractMarketMethod.toolTipText"));
         comboContractMarketMethod.setRenderer(new DefaultListCellRenderer() {
             @Override


### PR DESCRIPTION
Removed the CAM_OPS item from the comboContractMarketMethod comboBox in CampaignOptionsPane. This option is not ready for general use and will be re-enabled once 50.01 has shipped.

Temporarily Disabled Preset Confirm in New Campaign Dialog. Customize preset is still available. This functionality was set up to enable easy testing of new features and is feature incomplete without the rest of Campaign Options IIC. Once 50.01 has shipped this option will be re-enabled.