### PR TITLE
Refactored `ScenarioType` Parsing Logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -1014,7 +1014,7 @@ public class Scenario implements IPlayerSettings {
                 if (wn2.getNodeName().equalsIgnoreCase("name")) {
                     retVal.setName(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("stratConScenarioType")) {
-                    retVal.setStratConScenarioType(ScenarioType.valueOf(wn2.getTextContent().trim().toUpperCase()));
+                    retVal.setStratConScenarioType(ScenarioType.parseFromString(wn2.getTextContent()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("status")) {
                     retVal.setStatus(ScenarioStatus.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("id")) {

--- a/MekHQ/src/mekhq/campaign/mission/enums/ScenarioType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/ScenarioType.java
@@ -18,6 +18,25 @@
  */
 package mekhq.campaign.mission.enums;
 
+import megamek.logging.MMLogger;
+
+/**
+ * Represents the type of scenario within MekHQ.
+ *
+ * <p>This enum defines specific scenario types that can occur in the game. It provides utility
+ * methods to distinguish between various types and supports parsing from string representations,
+ * with graceful error handling.</p>
+ *
+ * <p>Currently available scenario types:</p>
+ * <ul>
+ *   <li>{@code NONE} - Default scenario type.</li>
+ *   <li>{@code SPECIAL_LOSTECH} - Indicates a special LosTech-related scenario.</li>
+ *   <li>{@code SPECIAL_RESUPPLY} - Indicates a resupply-related scenario.</li>
+ * </ul>
+ *
+ * <p>This enum also supports utility methods to determine if a scenario is of a specific
+ * type, such as {@link #isLosTech()} and {@link #isResupply()}.</p>
+ */
 public enum ScenarioType {
     NONE,
     SPECIAL_LOSTECH,
@@ -35,5 +54,47 @@ public enum ScenarioType {
      */
     public boolean isResupply() {
         return this == SPECIAL_RESUPPLY;
+    }
+
+    /**
+     * Parses a {@code ScenarioType} from a string input.
+     *
+     * <p>This method attempts to interpret the given string as either:</p>
+     * <ol>
+     *   <li>An integer index corresponding to the scenario type values, retrieved using {@link #values()}.</li>
+     *   <li>A string matching the name of a specific {@code ScenarioType} constant, case-sensitive.</li>
+     * </ol>
+     *
+     * <p>If parsing fails for both cases, an error is logged and the method returns the default
+     * {@code NONE} value.</p>
+     *
+     * <p><b>Parsing Strategy:</b></p>
+     * <ol>
+     *   <li>First, it tries to parse the input as an integer and use it as an index for {@link #values()}.</li>
+     *   <li>If that fails, it tries to match the input to a constant name using {@link #valueOf(String)}.</li>
+     *   <li>If both attempts fail, it logs an error and returns {@code NONE}.</li>
+     * </ol>
+     *
+     * <p>Note: If the input is invalid (e.g., a non-integer string or out-of-bounds index), the error
+     * is logged via {@link MMLogger} and the fallback {@code NONE} is returned.</p>
+     *
+     * @param text the string to be parsed into a {@code ScenarioType}, representing either
+     *             an integer index or the enum constant name.
+     * @return the parsed {@code ScenarioType}, or {@code NONE} if parsing fails.
+     */
+    public static ScenarioType parseFromString(final String text) {
+        try {
+            int value = Integer.parseInt(text.trim());
+            return values()[value];
+        } catch (Exception ignored) {}
+
+        try {
+            return valueOf(text.trim().toUpperCase());
+        } catch (Exception ignored) {}
+
+        MMLogger.create(ScenarioType.class)
+            .error("Unable to parse " + text + " into an ScenarioType. Returning NONE.");
+
+        return NONE;
     }
 }


### PR DESCRIPTION
Replaced `valueOf` with `parseFromString` in `ScenarioType` to enhance input validation and error handling. Included logging for parsing failures and ensured fallback to `NONE` for invalid inputs.

Fixes #5543