### PR TITLE
Remove User Preferences Handling from `BatchXPDialog`

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 - The MegaMek Team. All Rights Reserved
+ * Copyright (c) 2016-2024 - The MegaMek Team. All Rights Reserved
  *
  * This file is part of MekHQ.
  *
@@ -19,7 +19,6 @@
 package mekhq.gui.dialog;
 
 import megamek.client.ui.models.XTableColumnModel;
-import megamek.client.ui.preferences.*;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
@@ -91,8 +90,6 @@ public final class BatchXPDialog extends JDialog {
         personnelModel.refreshData();
 
         initComponents();
-
-        setUserPreferences();
     }
 
     private void initComponents() {
@@ -103,41 +100,6 @@ public final class BatchXPDialog extends JDialog {
 
         pack();
         setLocationRelativeTo(getParent());
-    }
-
-    private void setUserPreferences() {
-        try {
-            PreferencesNode preferences = MekHQ.getMHQPreferences().forClass(BatchXPDialog.class);
-
-            choiceType.setName("primaryRole");
-            preferences.manage(new JComboBoxPreference(choiceType));
-
-            choiceExp.setName("experienceLevel");
-            preferences.manage(new JComboBoxPreference(choiceExp));
-
-            choiceRank.setName("rank");
-            preferences.manage(new JComboBoxPreference(choiceRank));
-
-            onlyOfficers.setName("onlyOfficers");
-            preferences.manage(new JToggleButtonPreference(onlyOfficers));
-
-            noOfficers.setName("noOfficers");
-            preferences.manage(new JToggleButtonPreference(noOfficers));
-
-            choiceSkill.setName("skill");
-            preferences.manage(new JComboBoxPreference(choiceSkill));
-
-            skillLevel.setName("skillLevel");
-            preferences.manage(new JIntNumberSpinnerPreference(skillLevel));
-
-            allowPrisoners.setName("allowPrisoners");
-            preferences.manage(new JToggleButtonPreference(allowPrisoners));
-
-            this.setName("dialog");
-            preferences.manage(new JWindowPreference(this));
-        } catch (Exception ex) {
-            logger.error("Failed to set user preferences", ex);
-        }
     }
 
     private JComponent getPersonnelTable() {


### PR DESCRIPTION
Removed the entire `setUserPreferences` method, along with associated imports.

Storing preferences caused a lot of fragility with this system. It was very easy for a user to accidentally brick their Mass Training dialog by moving between different campaigns if those campaigns had different skill set ups. For example, if Campaign A had Piloting/Mek cap out at 8, while B had it cap out at 10. Moving from B to A could prevent the Mass Training dialog being used entirely if the user had their target level set to 9 or 10.

User preferences, in this instance, just stored the last known configuration for the Mass Training dialog. Given how few options there are - and the fact that it doesn't appear to have stored configurations on a per-skill basis - I opted to remove preferences entirely.

Fixes #5542