### PR TITLE
Refactored Nag Dialog Checks to Improve Performance

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
@@ -36,8 +36,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.DeploymentShortfallNagLogic.h
  * </p>
  */
 public class DeploymentShortfallNagDialog extends AbstractMHQNagDialog {
-    private Campaign campaign;
-
     /**
      * Constructs the shortfall deployment nag dialog for a given campaign.
      *
@@ -51,34 +49,30 @@ public class DeploymentShortfallNagDialog extends AbstractMHQNagDialog {
     public DeploymentShortfallNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_SHORT_DEPLOYMENT);
 
-        this.campaign = campaign;
-
         final String DIALOG_BODY = "DeploymentShortfallNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false)));
+        showDialog();
     }
 
     /**
-     * Determines whether the nag dialog should be displayed, based on deployment requirements
-     * in the campaign.
+     * Checks if a nag dialog should be displayed for a campaign regarding deployment shortfalls.
      *
-     * <p>
-     * The dialog is displayed if:
+     * <p>The method determines whether to show the nag dialog by verifying the following conditions:</p>
      * <ul>
-     *     <li>AtB campaigns are enabled in the campaign options.</li>
-     *     <li>The nag dialog for short deployments is not ignored in MekHQ options.</li>
-     *     <li>There are unmet deployment requirements, as determined by
-     *     {@code hasDeploymentShortfall()}.</li>
+     *     <li>If the campaign is using AtB rules.</li>
+     *     <li>If the nag dialog for deployment shortfall has not been ignored as per the user options.</li>
+     *     <li>If there is a deployment shortfall in the given campaign.</li>
      * </ul>
-     * If all these conditions are satisfied, the dialog is shown to the user.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    static public boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_SHORT_DEPLOYMENT;
 
-        if (campaign.getCampaignOptions().isUseAtB()
+        return campaign.getCampaignOptions().isUseAtB()
             && !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && hasDeploymentShortfall(campaign)) {
-            showDialog();
-        }
+            && hasDeploymentShortfall(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/EndContractNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/EndContractNagDialog.java
@@ -42,8 +42,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.EndContractNagLogic.isContrac
  * </ul>
  */
 public class EndContractNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs an {@code EndContractNagDialog} for the given campaign.
      *
@@ -58,31 +56,28 @@ public class EndContractNagDialog extends AbstractMHQNagDialog {
     public EndContractNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_CONTRACT_ENDED);
 
-        this.campaign = campaign;
-
         final String DIALOG_BODY = "EndContractNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false)));
+        showDialog();
     }
 
     /**
-     * Checks if the "Contract End" nag dialog should be displayed.
+     * Checks if a nag dialog should be displayed for an ended contract within the given campaign.
      *
-     * <p>
-     * This method evaluates whether the nag dialog for contract end dates should be shown.
-     * It checks the following conditions:
+     * <p>The method evaluates the following conditions:</p>
      * <ul>
-     *   <li>If the "Contract Ended" nag dialog is flagged as ignored in the user’s settings.</li>
-     *   <li>If any active contracts in the campaign are ending on the current date.</li>
+     *     <li>If the nag dialog for an ended contract has not been ignored in the user options.</li>
+     *     <li>If the contract associated with the provided campaign has ended.</li>
      * </ul>
-     * If these conditions are met, the dialog is displayed.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_CONTRACT_ENDED;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && isContractEnded(campaign)) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && isContractEnded(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechTimeNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechTimeNagDialog.java
@@ -44,8 +44,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.InsufficientAstechTimeNagLogi
  * </ul>
  */
 public class InsufficientAstechTimeNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs an {@code InsufficientAstechTimeNagDialog} for the given campaign.
      *
@@ -61,8 +59,6 @@ public class InsufficientAstechTimeNagDialog extends AbstractMHQNagDialog {
     public InsufficientAstechTimeNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME);
 
-        this.campaign = campaign;
-
         int asTechsTimeDeficit = getAsTechTimeDeficit(campaign);
 
         String pluralizer = (asTechsTimeDeficit > 1) ? "s" : "";
@@ -70,27 +66,25 @@ public class InsufficientAstechTimeNagDialog extends AbstractMHQNagDialog {
         final String DIALOG_BODY = "InsufficientAstechTimeNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false), asTechsTimeDeficit, pluralizer));
+        showDialog();
     }
 
     /**
-     * Determines whether the "Insufficient Astech Time" nag dialog should be displayed.
+     * Checks if a nag dialog should be displayed for insufficient AsTech time in the given campaign.
      *
-     * <p>
-     * This method checks the following conditions:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *   <li>If the "Insufficient Astech Time" nag dialog is flagged as ignored in the user settings.</li>
-     *   <li>If there is a time deficit in the astech pool based on the campaign's
-     *   maintenance requirements.</li>
+     *     <li>If the nag dialog for insufficient AsTech time has not been ignored in the user options.</li>
+     *     <li>If there is a deficit in the available AsTech time for the given campaign.</li>
      * </ul>
-     * If both conditions are met, the dialog is displayed to alert the user about
-     * insufficient available time for astechs.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && hasAsTechTimeDeficit(campaign)) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && hasAsTechTimeDeficit(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechsNagDialog.java
@@ -43,8 +43,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.InsufficientAstechsNagLogic.h
  * </ul>
  */
 public class InsufficientAstechsNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs an {@code InsufficientAstechsNagDialog} for the given campaign.
      *
@@ -58,9 +56,6 @@ public class InsufficientAstechsNagDialog extends AbstractMHQNagDialog {
      */
     public InsufficientAstechsNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_INSUFFICIENT_ASTECHS);
-
-        this.campaign = campaign;
-
         int asTechsNeeded = campaign.getAstechNeed();
 
         String pluralizer = (asTechsNeeded > 1) ? "s" : "";
@@ -68,27 +63,25 @@ public class InsufficientAstechsNagDialog extends AbstractMHQNagDialog {
         final String DIALOG_BODY = "InsufficientAstechsNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false), asTechsNeeded, pluralizer));
+        showDialog();
     }
 
     /**
-     * Evaluates whether the "Insufficient Astechs" nag dialog should be displayed.
+     * Checks if a nag dialog should be displayed for insufficient AsTechs in the given campaign.
      *
-     * <p>
-     * This method checks the following conditions:
+     * <p>The method evaluates the following conditions:</p>
      * <ul>
-     *   <li>If the "Insufficient Astechs" nag dialog has not been flagged as ignored
-     *       in the user options.</li>
-     *   <li>If the campaign has an unmet asTech requirement as determined by
-     *       {@code checkAsTechsNeededCount()}.</li>
+     *     <li>If the nag dialog for insufficient AsTechs has not been ignored in the user options.</li>
+     *     <li>If the campaign does not have the required number of AsTechs.</li>
      * </ul>
-     * If both conditions are met, the dialog is displayed.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_INSUFFICIENT_ASTECHS;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && hasAsTechsNeeded(campaign)) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && hasAsTechsNeeded(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientMedicsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientMedicsNagDialog.java
@@ -43,8 +43,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.InsufficientMedicsNagLogic.ha
  * </ul>
  */
 public class InsufficientMedicsNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs an {@code InsufficientMedicsNagDialog} for the given campaign.
      *
@@ -60,8 +58,6 @@ public class InsufficientMedicsNagDialog extends AbstractMHQNagDialog {
     public InsufficientMedicsNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_INSUFFICIENT_MEDICS);
 
-        this.campaign = campaign;
-
         int medicsRequired =  campaign.getMedicsNeed();
 
         String pluralizer = (medicsRequired > 1) ? "s" : "";
@@ -69,27 +65,25 @@ public class InsufficientMedicsNagDialog extends AbstractMHQNagDialog {
         final String DIALOG_BODY = "InsufficientMedicsNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false), medicsRequired, pluralizer));
+        showDialog();
     }
 
     /**
-     * Determines whether the "Insufficient Medics" nag dialog should be displayed.
+     * Checks if a nag dialog should be displayed for insufficient medics in the given campaign.
      *
-     * <p>
-     * This method checks the following conditions:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *   <li>If the "Insufficient Medics" nag dialog is flagged as ignored in the user settings.</li>
-     *   <li>If the campaign currently requires more medics than are available, as determined by
-     *   {@code checkMedicsNeededCount()}.</li>
+     *     <li>If the nag dialog for insufficient medics has not been ignored in the user options.</li>
+     *     <li>If the campaign does not have the required number of medics.</li>
      * </ul>
-     * If both conditions are met, the dialog is displayed to notify the user about
-     * the medic shortage.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_INSUFFICIENT_MEDICS;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && hasMedicsNeeded(campaign)) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && hasMedicsNeeded(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InvalidFactionNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InvalidFactionNagDialog.java
@@ -42,8 +42,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.InvalidFactionNagLogic.isFact
  * </ul>
  */
 public class InvalidFactionNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs an {@code InvalidFactionNagDialog} for the given campaign.
      *
@@ -59,32 +57,28 @@ public class InvalidFactionNagDialog extends AbstractMHQNagDialog {
     public InvalidFactionNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_INVALID_FACTION);
 
-        this.campaign = campaign;
-
         final String DIALOG_BODY = "InvalidFactionNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false)));
+        showDialog();
     }
 
     /**
-     * Determines whether the "Invalid Faction" nag dialog should be displayed.
+     * Checks if a nag dialog should be displayed for an invalid faction in the given campaign.
      *
-     * <p>
-     * This method checks the following conditions:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *   <li>If the "Invalid Faction" nag dialog is flagged as ignored in user settings.</li>
-     *   <li>If the campaign's faction is invalid for the current in-game date,
-     *   as determined by {@code isFactionInvalid()}.</li>
+     *     <li>If the nag dialog for an invalid faction has not been ignored in the user options.</li>
+     *     <li>If the faction associated with the campaign is considered invalid.</li>
      * </ul>
-     * If both conditions are met, the dialog is displayed to notify the user of the issue.
-
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_INVALID_FACTION;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && (isFactionInvalid(campaign))) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && (isFactionInvalid(campaign));
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -42,115 +42,131 @@ public class NagController {
      */
     public static boolean triggerDailyNags(Campaign campaign) {
         // Invalid Faction
-        InvalidFactionNagDialog invalidFactionNagDialog = new InvalidFactionNagDialog(campaign);
-        invalidFactionNagDialog.checkNag();
-        if (invalidFactionNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (InvalidFactionNagDialog.checkNag(campaign)) {
+            InvalidFactionNagDialog invalidFactionNagDialog = new InvalidFactionNagDialog(campaign);
+            if (invalidFactionNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // No Commander
-        NoCommanderNagDialog noCommanderNagDialog = new NoCommanderNagDialog(campaign);
-        noCommanderNagDialog.checkNag();
-        if (noCommanderNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (NoCommanderNagDialog.checkNag(campaign)) {
+            NoCommanderNagDialog noCommanderNagDialog = new NoCommanderNagDialog(campaign);
+            if (noCommanderNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Untreated personnel
-        UntreatedPersonnelNagDialog untreatedPersonnelNagDialog = new UntreatedPersonnelNagDialog(campaign);
-        untreatedPersonnelNagDialog.checkNag();
-        if (untreatedPersonnelNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (UntreatedPersonnelNagDialog.checkNag(campaign)) {
+            UntreatedPersonnelNagDialog untreatedPersonnelNagDialog = new UntreatedPersonnelNagDialog(campaign);
+            if (untreatedPersonnelNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Unable to afford expenses
-        UnableToAffordExpensesNagDialog unableToAffordExpensesNagDialog = new UnableToAffordExpensesNagDialog(campaign);
-        unableToAffordExpensesNagDialog.checkNag();
-        if (unableToAffordExpensesNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (UnableToAffordExpensesNagDialog.checkNag(campaign)) {
+            UnableToAffordExpensesNagDialog unableToAffordExpensesNagDialog = new UnableToAffordExpensesNagDialog(campaign);
+            if (unableToAffordExpensesNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Unable to afford next jump
-        UnableToAffordJumpNagDialog unableToAffordJumpNagDialog = new UnableToAffordJumpNagDialog(campaign);
-        unableToAffordJumpNagDialog.checkNag();
-        if (unableToAffordJumpNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (UnableToAffordJumpNagDialog.checkNag(campaign)) {
+            UnableToAffordJumpNagDialog unableToAffordJumpNagDialog = new UnableToAffordJumpNagDialog(campaign);
+            if (unableToAffordJumpNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Unable to afford next loan payment
-        UnableToAffordLoanPaymentNagDialog unableToAffordLoanPaymentNagDialog = new UnableToAffordLoanPaymentNagDialog(campaign);
-        unableToAffordLoanPaymentNagDialog.checkNag();
-        if (unableToAffordLoanPaymentNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (UnableToAffordLoanPaymentNagDialog.checkNag(campaign)) {
+            UnableToAffordLoanPaymentNagDialog unableToAffordLoanPaymentNagDialog = new UnableToAffordLoanPaymentNagDialog(campaign);
+            if (unableToAffordLoanPaymentNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Unmaintained Units
-        UnmaintainedUnitsNagDialog unmaintainedUnitsNagDialog = new UnmaintainedUnitsNagDialog(campaign);
-        unmaintainedUnitsNagDialog.checkNag();
-        if (unmaintainedUnitsNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (UnmaintainedUnitsNagDialog.checkNag(campaign)) {
+            UnmaintainedUnitsNagDialog unmaintainedUnitsNagDialog = new UnmaintainedUnitsNagDialog(campaign);
+            if (unmaintainedUnitsNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Insufficient Medics
-        InsufficientMedicsNagDialog insufficientMedicsNagDialog = new InsufficientMedicsNagDialog(campaign);
-        insufficientMedicsNagDialog.checkNag();
-        if (insufficientMedicsNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (InsufficientMedicsNagDialog.checkNag(campaign)) {
+            InsufficientMedicsNagDialog insufficientMedicsNagDialog = new InsufficientMedicsNagDialog(campaign);
+            if (insufficientMedicsNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Insufficient AsTechs
-        InsufficientAstechsNagDialog insufficientAstechsNagDialog = new InsufficientAstechsNagDialog(campaign);
-        insufficientAstechsNagDialog.checkNag();
-        if (insufficientAstechsNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (InsufficientAstechsNagDialog.checkNag(campaign)) {
+            InsufficientAstechsNagDialog insufficientAstechsNagDialog = new InsufficientAstechsNagDialog(campaign);
+            if (insufficientAstechsNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Insufficient AsTech Time
-        InsufficientAstechTimeNagDialog insufficientAstechTimeNagDialog = new InsufficientAstechTimeNagDialog(campaign);
-        insufficientAstechTimeNagDialog.checkNag();
-        if (insufficientAstechTimeNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (InsufficientAstechTimeNagDialog.checkNag(campaign)) {
+            InsufficientAstechTimeNagDialog insufficientAstechTimeNagDialog = new InsufficientAstechTimeNagDialog(campaign);
+            if (insufficientAstechTimeNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Unresolved StratCon AO Contacts
-        UnresolvedStratConContactsNagDialog unresolvedStratConContactsNagDialog = new UnresolvedStratConContactsNagDialog(campaign);
-        unresolvedStratConContactsNagDialog.checkNag();
-        if (unresolvedStratConContactsNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (UnresolvedStratConContactsNagDialog.checkNag(campaign)) {
+            UnresolvedStratConContactsNagDialog unresolvedStratConContactsNagDialog = new UnresolvedStratConContactsNagDialog(campaign);
+            if (unresolvedStratConContactsNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Outstanding Scenarios
-        OutstandingScenariosNagDialog outstandingScenariosNagDialog = new OutstandingScenariosNagDialog(campaign);
-        outstandingScenariosNagDialog.checkNag();
-        if (outstandingScenariosNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (OutstandingScenariosNagDialog.checkNag(campaign)) {
+            OutstandingScenariosNagDialog outstandingScenariosNagDialog = new OutstandingScenariosNagDialog(campaign);
+            if (outstandingScenariosNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Deployment Shortfall
-        DeploymentShortfallNagDialog deploymentShortfallNagDialog = new DeploymentShortfallNagDialog(campaign);
-        deploymentShortfallNagDialog.checkNag();
-        if (deploymentShortfallNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (DeploymentShortfallNagDialog.checkNag(campaign)) {
+            DeploymentShortfallNagDialog deploymentShortfallNagDialog = new DeploymentShortfallNagDialog(campaign);
+            if (deploymentShortfallNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Prisoners of War
-        PrisonersNagDialog prisonersNagDialog = new PrisonersNagDialog(campaign);
-        prisonersNagDialog.checkNag();
-        if (prisonersNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (PrisonersNagDialog.checkNag(campaign)) {
+            PrisonersNagDialog prisonersNagDialog = new PrisonersNagDialog(campaign);
+            if (prisonersNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Pregnant Personnel Assigned to Active Force
-        PregnantCombatantNagDialog pregnantCombatantNagDialog = new PregnantCombatantNagDialog(campaign);
-        pregnantCombatantNagDialog.checkNag();
-        if (pregnantCombatantNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (PregnantCombatantNagDialog.checkNag(campaign)) {
+            PregnantCombatantNagDialog pregnantCombatantNagDialog = new PregnantCombatantNagDialog(campaign);
+            if (pregnantCombatantNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Contract Ended
-        EndContractNagDialog endContractNagDialog = new EndContractNagDialog(campaign);
-        endContractNagDialog.checkNag();
-        if (endContractNagDialog.wasAdvanceDayCanceled()) {
-            return true;
+        if (EndContractNagDialog.checkNag(campaign)) {
+            EndContractNagDialog endContractNagDialog = new EndContractNagDialog(campaign);
+            if (endContractNagDialog.wasAdvanceDayCanceled()) {
+                return true;
+            }
         }
 
         // Player did not cancel Advance Day at any point

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NoCommanderNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NoCommanderNagDialog.java
@@ -44,8 +44,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.NoCommanderNagLogic.hasNoComm
  * @see AbstractMHQNagDialog
  */
 public class NoCommanderNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs a {@code NoCommanderNagDialog} for a campaign.
      *
@@ -59,29 +57,27 @@ public class NoCommanderNagDialog extends AbstractMHQNagDialog {
     public NoCommanderNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_NO_COMMANDER);
 
-        this.campaign = campaign;
-
         final String DIALOG_BODY = "NoCommanderNagDialog.text";
         setRightDescriptionMessage(resources.getString(DIALOG_BODY));
+        showDialog();
     }
 
     /**
-     * Checks whether the "No Commander" nag dialog should be displayed.
+     * Checks if a nag dialog should be displayed for the absence of a commander in the given campaign.
      *
-     * <p>
-     * This method evaluates the following conditions:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *   <li>If the "No Commander" nag dialog is not flagged as ignored in the user settings.</li>
-     *   <li>If the campaign currently does not have a flagged commander.</li>
+     *     <li>If the nag dialog for the absence of a commander has not been ignored in the user options.</li>
+     *     <li>If the campaign does not have a commander assigned.</li>
      * </ul>
-     * If both conditions are true, the dialog is displayed.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    static public boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_NO_COMMANDER;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && hasNoCommander(campaign)) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && hasNoCommander(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/OutstandingScenariosNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/OutstandingScenariosNagDialog.java
@@ -42,8 +42,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.OutstandingScenariosNagLogic.
  * </p>
  */
 public class OutstandingScenariosNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs the OutstandingScenariosNagDialog for the given campaign.
      *
@@ -57,8 +55,6 @@ public class OutstandingScenariosNagDialog extends AbstractMHQNagDialog {
     public OutstandingScenariosNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_OUTSTANDING_SCENARIOS);
 
-        this.campaign = campaign;
-
         final String DIALOG_BODY = "OutstandingScenariosNagDialog.text";
 
         String outstandingScenarios = getOutstandingScenarios(campaign);
@@ -70,27 +66,27 @@ public class OutstandingScenariosNagDialog extends AbstractMHQNagDialog {
 
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false), outstandingScenarios, addendum));
+        showDialog();
     }
 
     /**
-     * Checks if the nag dialog should be displayed, based on the current campaign state.
+     * Checks if a nag dialog should be displayed for outstanding scenarios in the given campaign.
      *
-     * <p>
-     * The dialog is displayed if the following conditions are met:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *     <li>AtB campaigns are enabled in the campaign options.</li>
-     *     <li>The nag dialog for outstanding scenarios is not ignored in MekHQ options.</li>
-     *     <li>Outstanding scenarios exist in the campaign.</li>
+     *     <li>If the campaign is set to use AtB (Against the Bot) rules.</li>
+     *     <li>If the nag dialog for outstanding scenarios has not been ignored in the user options.</li>
+     *     <li>If there are outstanding scenarios in the campaign.</li>
      * </ul>
-     * If all these conditions are satisfied, the nag dialog is displayed to the user.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_OUTSTANDING_SCENARIOS;
 
-        if (campaign.getCampaignOptions().isUseAtB()
+        return campaign.getCampaignOptions().isUseAtB()
             && !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && hasOutStandingScenarios(campaign)) {
-            showDialog();
-        }
+            && hasOutStandingScenarios(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/PregnantCombatantNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/PregnantCombatantNagDialog.java
@@ -35,8 +35,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.PregnantCombatantNagLogic.has
  * </p>
  */
 public class PregnantCombatantNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs the pregnant combatant nag dialog for the given campaign.
      *
@@ -51,29 +49,28 @@ public class PregnantCombatantNagDialog extends AbstractMHQNagDialog {
     public PregnantCombatantNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_PREGNANT_COMBATANT);
 
-        this.campaign = campaign;
-
         final String DIALOG_BODY = "PregnantCombatantNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false)));
+        showDialog();
     }
 
     /**
-     * Determines whether the nag dialog should be displayed to the user, based on campaign state
-     * and configuration.
+     * Checks if a nag dialog should be displayed for active pregnant combatants in the given campaign.
      *
-     * <p>
-     * This method checks if MekHQ options allow the "pregnant combatant" nag dialog to be shown,
-     * and if there are any pregnant personnel actively assigned to combat. If both conditions
-     * are met, the dialog is displayed to notify the user.
-     * </p>
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
+     * <ul>
+     *     <li>If the nag dialog for active pregnant combatants has not been ignored in the user options.</li>
+     *     <li>If there are active pregnant combatants in the campaign.</li>
+     * </ul>
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_PREGNANT_COMBATANT;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && (hasActivePregnantCombatant(campaign))) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && (hasActivePregnantCombatant(campaign));
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/PrisonersNagDialog.java
@@ -35,8 +35,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.PrisonersNagLogic.hasPrisoner
  * </p>
  */
 public class PrisonersNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs the prisoners nag dialog for the given campaign.
      *
@@ -50,30 +48,28 @@ public class PrisonersNagDialog extends AbstractMHQNagDialog {
     public PrisonersNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_PRISONERS);
 
-        this.campaign = campaign;
-
         final String DIALOG_BODY = "PrisonersNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false)));
+        showDialog();
     }
 
     /**
-     * Determines whether the prisoners nag dialog should be displayed to the user.
+     * Checks if a nag dialog should be displayed for prisoners in the given campaign.
      *
-     * <p>
-     * The dialog will be shown if the following conditions are met:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *     <li>The nag dialog for prisoners is not ignored in MekHQ options.</li>
-     *     <li>The campaign contains prisoners, as determined by {@code hasPrisoners()}.</li>
+     *     <li>If the nag dialog for prisoners has not been ignored in the user options.</li>
+     *     <li>If the campaign has prisoners.</li>
      * </ul>
-     * If all these conditions are satisfied, the dialog is displayed to notify the user about the prisoners.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_PRISONERS;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && hasPrisoners(campaign)) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && hasPrisoners(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordExpensesNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordExpensesNagDialog.java
@@ -40,8 +40,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.UnableToAffordExpensesNagLogi
  * </p>
  */
 public class UnableToAffordExpensesNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs the nag dialog for insufficient campaign funds.
      *
@@ -56,35 +54,33 @@ public class UnableToAffordExpensesNagDialog extends AbstractMHQNagDialog {
     public UnableToAffordExpensesNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_UNABLE_TO_AFFORD_EXPENSES);
 
-        this.campaign = campaign;
-
         Money monthlyExpenses = getMonthlyExpenses(campaign);
 
         final String DIALOG_BODY = "UnableToAffordExpensesNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false),
             monthlyExpenses.toAmountAndSymbolString()));
+        showDialog();
     }
 
     /**
-     * Determines whether the insufficient funds nag dialog should be displayed to the user.
+     * Checks if a nag dialog should be displayed for the inability to afford expenses in the given campaign.
      *
-     * <p>
-     * The dialog is displayed if:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *     <li>It's the last day of the month.</li>
-     *     <li>The nag dialog for insufficient funds is not ignored in MekHQ options.</li>
-     *     <li>The campaign's available funds are less than the calculated monthly expenses.</li>
+     *     <li>If it is the last day of the month in the campaign.</li>
+     *     <li>If the nag dialog for the inability to afford expenses has not been ignored in the user options.</li>
+     *     <li>If the campaign is unable to afford its expenses.</li>
      * </ul>
-     * If the conditions are met, the dialog is displayed to alert the player.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_UNABLE_TO_AFFORD_EXPENSES;
 
-        if (campaign.getLocalDate().equals(campaign.getLocalDate().with(TemporalAdjusters.lastDayOfMonth()))
+        return campaign.getLocalDate().equals(campaign.getLocalDate().with(TemporalAdjusters.lastDayOfMonth()))
             && !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && unableToAffordExpenses(campaign)) {
-            showDialog();
-        }
+            && unableToAffordExpenses(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordJumpNagDialog.java
@@ -39,8 +39,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.UnableToAffordJumpNagLogic.un
  * </p>
  */
 public class UnableToAffordJumpNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs the nag dialog for insufficient funds to afford a jump.
      *
@@ -55,33 +53,31 @@ public class UnableToAffordJumpNagDialog extends AbstractMHQNagDialog {
     public UnableToAffordJumpNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP);
 
-        this.campaign = campaign;
-
         Money nextJumpCost = getNextJumpCost(campaign);
 
         final String DIALOG_BODY = "UnableToAffordJumpNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false),
             nextJumpCost.toAmountAndSymbolString()));
+        showDialog();
     }
 
     /**
-     * Determines whether the insufficient funds nag dialog for a jump should be displayed.
+     * Checks if a nag dialog should be displayed for the inability to afford the next jump in the given campaign.
      *
-     * <p>
-     * This method calculates the cost of the next jump and alerts the user when:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *     <li>The nag dialog for jump costs is not ignored in MekHQ options.</li>
-     *     <li>The campaign's available funds are less than the cost of the next jump.</li>
+     *     <li>If the nag dialog for the inability to afford the next jump has not been ignored in the user options.</li>
+     *     <li>If the campaign is unable to afford the next jump.</li>
      * </ul>
-     * If both conditions are satisfied, the dialog is displayed to notify the user.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && unableToAffordNextJump(campaign)) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && unableToAffordNextJump(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordLoanPaymentNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnableToAffordLoanPaymentNagDialog.java
@@ -38,8 +38,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.UnableToAffordLoanPaymentNag.
  * </p>
  */
 public class UnableToAffordLoanPaymentNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs the nag dialog for insufficient funds to cover loan payments.
      *
@@ -54,34 +52,31 @@ public class UnableToAffordLoanPaymentNagDialog extends AbstractMHQNagDialog {
     public UnableToAffordLoanPaymentNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_UNABLE_TO_AFFORD_LOAN_PAYMENT);
 
-        this.campaign = campaign;
-
         Money totalPaymentsDue = getTotalPaymentsDue(campaign);
 
         final String DIALOG_BODY = "UnableToAffordLoanPaymentNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false),
             totalPaymentsDue.toAmountAndSymbolString()));
+        showDialog();
     }
 
     /**
-     * Determines whether the insufficient loan payment funds nag dialog should be displayed.
+     * Checks if a nag dialog should be displayed for the inability to afford loan payments in the given campaign.
      *
-     * <p>
-     * The dialog is displayed if:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *     <li>The nag dialog for loan payments is not ignored in MekHQ options.</li>
-     *     <li>The total loan payments due tomorrow exceed the campaign's available funds.</li>
+     *     <li>If the nag dialog for the inability to afford loan payments has not been ignored in the user options.</li>
+     *     <li>If the campaign is unable to afford its loan payments.</li>
      * </ul>
-     * If both conditions are met, the user is shown the dialog to alert them about upcoming
-     * loan payment issues.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_UNABLE_TO_AFFORD_LOAN_PAYMENT;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && unableToAffordLoans(campaign)) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && unableToAffordLoans(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
@@ -35,8 +35,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.UnmaintainedUnitsNagLogic.cam
  * </p>
  */
 public class UnmaintainedUnitsNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs the nag dialog for unmaintained units.
      *
@@ -50,33 +48,29 @@ public class UnmaintainedUnitsNagDialog extends AbstractMHQNagDialog {
     public UnmaintainedUnitsNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_UNMAINTAINED_UNITS);
 
-        this.campaign = campaign;
-
         final String DIALOG_BODY = "UnmaintainedUnitsNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false)));
+        showDialog();
     }
 
     /**
-     * Determines whether the nag dialog for unmaintained units should be displayed.
+     * Checks if a nag dialog should be displayed for the inability to afford loan payments in the given campaign.
      *
-     * <p>
-     * The dialog is shown if:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *     <li>Maintenance checks are enabled.</li>
-     *     <li>The nag dialog for unmaintained units is not ignored in MekHQ options.</li>
-     *     <li>There are unmaintained units in the campaign hangar, as determined by
-     *     {@code campaignHasUnmaintainedUnits()}.</li>
+     *     <li>If the nag dialog for the inability to afford loan payments has not been ignored in the user options.</li>
+     *     <li>If the campaign is unable to afford its loan payments.</li>
      * </ul>
-     * If both conditions are met, the dialog is displayed to alert the player to address unit maintenance.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_UNMAINTAINED_UNITS;
 
-        if (campaign.getCampaignOptions().isCheckMaintenance()
+        return campaign.getCampaignOptions().isCheckMaintenance()
             && !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && campaignHasUnmaintainedUnits(campaign)) {
-            showDialog();
-        }
+            && campaignHasUnmaintainedUnits(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnresolvedStratConContactsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnresolvedStratConContactsNagDialog.java
@@ -36,8 +36,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.UnresolvedStratConContactsNag
  * </p>
  */
 public class UnresolvedStratConContactsNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs the nag dialog for unresolved StratCon contacts.
      *
@@ -52,8 +50,6 @@ public class UnresolvedStratConContactsNagDialog extends AbstractMHQNagDialog {
     public UnresolvedStratConContactsNagDialog(final Campaign campaign) {
         super(campaign, MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS);
 
-        this.campaign = campaign;
-
         String unresolvedContactsReport = determineUnresolvedContacts(campaign);
 
         String addendum = "";
@@ -64,29 +60,27 @@ public class UnresolvedStratConContactsNagDialog extends AbstractMHQNagDialog {
         final String DIALOG_BODY = "UnresolvedStratConContactsNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false), addendum));
+        showDialog();
     }
 
     /**
-     * Determines whether the unresolved StratCon contacts nag dialog should be displayed.
+     * Checks if a nag dialog should be displayed for unresolved StratCon contacts in the given campaign.
      *
-     * <p>
-     * The dialog is displayed if:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *     <li>StratCon is enabled in the campaign options.</li>
-     *     <li>The nag dialog for unresolved StratCon contacts is not ignored in MekHQ options.</li>
-     *     <li>There are unresolved StratCon contacts, as determined by
-     *     {@code determineUnresolvedContacts()}.</li>
+     *     <li>If StratCon is enabled in the campaign options.</li>
+     *     <li>If the nag dialog for unresolved StratCon contacts has not been ignored in the user options.</li>
+     *     <li>If the campaign has unresolved StratCon contacts.</li>
      * </ul>
-     * The dialog warns the player about unresolved scenarios requiring attention before
-     * advancing the campaign.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS;
 
-        if (campaign.getCampaignOptions().isUseStratCon()
+        return campaign.getCampaignOptions().isUseStratCon()
             && !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && hasUnresolvedContacts(campaign)) {
-            showDialog();
-        }
+            && hasUnresolvedContacts(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
@@ -35,8 +35,6 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.UntreatedPersonnelNagLogic.ca
  * </p>
  */
 public class UntreatedPersonnelNagDialog extends AbstractMHQNagDialog {
-    private final Campaign campaign;
-
     /**
      * Constructs the nag dialog for untreated personnel injuries.
      *
@@ -50,31 +48,28 @@ public class UntreatedPersonnelNagDialog extends AbstractMHQNagDialog {
     public UntreatedPersonnelNagDialog(Campaign campaign) {
         super(campaign, MHQConstants.NAG_UNTREATED_PERSONNEL);
 
-        this.campaign = campaign;
-
         final String DIALOG_BODY = "UntreatedPersonnelNagDialog.text";
         setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
             campaign.getCommanderAddress(false)));
+        showDialog();
     }
 
     /**
-     * Determines whether the untreated personnel nag dialog should be displayed.
+     * Checks if a nag dialog should be displayed for untreated personnel injuries in the given campaign.
      *
-     * <p>
-     * The dialog is triggered if:
+     * <p>The method evaluates the following conditions to determine if the nag dialog should appear:</p>
      * <ul>
-     *     <li>The nag dialog for untreated personnel is not ignored in MekHQ options.</li>
-     *     <li>There are untreated injuries in the campaign, as determined by
-     *     {@code campaignHasUntreatedInjuries()}.</li>
+     *     <li>If the nag dialog for untreated personnel injuries has not been ignored in the user options.</li>
+     *     <li>If the campaign has untreated injuries among its personnel.</li>
      * </ul>
-     * If these conditions are met, the dialog is displayed to remind the user to address untreated injuries.
+     *
+     * @param campaign the {@link Campaign} to check for nagging conditions
+     * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise
      */
-    public void checkNag() {
+    public static boolean checkNag(Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_UNTREATED_PERSONNEL;
 
-        if (!MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && campaignHasUntreatedInjuries(campaign)) {
-            showDialog();
-        }
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
+            && campaignHasUntreatedInjuries(campaign);
     }
 }


### PR DESCRIPTION
We ran into an issue where nag dialogs were tanking new day perform. This was caused by a few factors, but predominantly due to the number of JDialogs we were creating on new day. This PR updates the nags and nag controller so that we only initialize a nag JDialog if we intend to use it.