### PR TITLE
Corrected GUI Theme Retrieval to Use `selectedTheme`

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -758,7 +758,7 @@ public class MekHQ implements GameListener {
 
     public static void updateGuiScaling() {
         System.setProperty("flatlaf.uiScale", Double.toString(GUIPreferences.getInstance().getGUIScale()));
-        setLookAndFeel(GUIPreferences.getInstance().getUITheme());
+        setLookAndFeel(selectedTheme.getValue());
     }
 
     private static class MekHqPropertyChangedListener implements PropertyChangeListener {


### PR DESCRIPTION
Replaced direct theme retrieval from preferences with `selectedTheme`. This ensures that the look and feel updates correctly based on the current theme selection.

Fix #5188, #5410