### PR TITLE
Fixed NPE in `ScenarioTableModel`

### DIFF
--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -125,10 +125,12 @@ public class ScenarioTableModel extends DataTableModel {
                     AtBContract contract = ((AtBScenario) scenario).getContract(campaign);
                     StratconCampaignState campaignState = contract.getStratconCampaignState();
 
-                    for (StratconTrackState track : campaignState.getTracks()) {
-                        for (StratconScenario stratconScenario : track.getScenarios().values()) {
-                            if (Objects.equals(stratconScenario.getBackingScenario(), scenario)) {
-                                return track.getDisplayableName();
+                    if (campaignState != null) {
+                        for (StratconTrackState track : campaignState.getTracks()) {
+                            for (StratconScenario stratconScenario : track.getScenarios().values()) {
+                                if (Objects.equals(stratconScenario.getBackingScenario(), scenario)) {
+                                    return track.getDisplayableName();
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Added a null check for `StratconCampaignState` in `ScenarioTableModel` to prevent potential null pointer exceptions. This ensures more robust handling of scenarios without an associated campaign state.

Fix #5584