### PR TITLE
Added Clarification to Reinforcement Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -62,13 +62,14 @@ btnConfirm.text=Confirm
 scenarioSetupWizard.title=Scenario Setup Wizard
 unitSelectLabelDefaultValue.text=0 selected
 incomingTransmission.title=++INCOMING TRANSMISSION++
-reinforcementConfirmation.introduction=%s, we've run the numbers. If we reinforce now, here is our\
-  \ likelihood of success.<br><br>
+reinforcementConfirmation.introduction=%s, I've run the numbers. If we reinforce now, here is our\
+  \ likelihood of success. Forces assigned to <b>Maneuver</b> or <b>Auxiliary</b> duties are more\
+  \ likely to succeed than other forces.<br><br>
 reinforcementConfirmation.breakdown=<b>Breakdown</b><br>
 reinforcementConfirmation.breakdown.total=Target Number
 reinforcementConfirmation.addendum=For more information, please see 'Combat Teams, Roles, Training\
   \ & Reinforcements.pdf'.\
-  <br>This can be found in 'MekHQ/Docs'.
+  <br>This can be found in 'MekHQ/Docs/Stratcon and Against the Bot'.
 reinforcementConfirmation.spinnerLabel=Support Points
 reinforcementConfirmation.spinnerLabel.tooltip=Each Support Point, after the first, will reduce the\
   \ target number by 2.


### PR DESCRIPTION
Clarified the introduction text to specify that forces on Maneuver or Auxiliary duties are more likely to succeed.