### PR TITLE
Adjusted AtB Bonus Events

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioObjectiveProcessor.java
@@ -433,9 +433,8 @@ public class ScenarioObjectiveProcessor {
                     } else {
                         int dropSize = 0;
                         for (int x = 0; x < numBonuses; x++) {
-                            if (contract.doBonusRoll(tracker.getCampaign())) {
-                                dropSize++;
-                            }
+                            dropSize += contract.doBonusRoll(tracker.getCampaign(), true)
+                                ? 1 : 0;
                         }
 
                         if (dropSize > 0) {


### PR DESCRIPTION
AtB Bonus Events could sometimes trigger a resupply, which created a lot of confusion as users would end a month; get their normal resupply, then get a second seemingly out of nowhere.

Now only post-scenario bonus events can trigger a resupply. Normal, monthly, events give 1 SP instead.

Also expended a few other options so that if users had certain settings enabled they would still get a bonus.