### PR TITLE
Corrected Default Theme to Empty String

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -207,7 +207,7 @@ public class MekHQ implements GameListener {
             PreferencesNode preferences = MekHQ.getMHQPreferences().forClass(MekHQ.class);
 
             // TODO: complete integration of Suite Preferences, including GUIPreferences
-            selectedTheme = new ObservableString("selectedTheme", GUIPreferences.UI_THEME);
+            selectedTheme = new ObservableString("selectedTheme", "");
             selectedTheme.addPropertyChangeListener(new MekHqPropertyChangedListener());
             preferences.manage(new StringPreference(selectedTheme));
 


### PR DESCRIPTION
Replaced the default value for the selected UI theme with an empty string. This ensures we replace it with Dracula further down the pipeline. This is also the reason why prior attempts to set a default theme didn't work correctly. We were looking for an empty string, instead of a default value.

Fix #5609