### PR TITLE
Restrict Distance Label to AtB Contracts Only

### DIFF
--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -234,7 +234,8 @@ public class ContractSummaryPanel extends JPanel {
         gridBagConstraintsText.gridy = y;
         mainPanel.add(txtLocation, gridBagConstraintsText);
 
-        if (Systems.getInstance().getSystems().get(contract.getSystemId()) != null) {
+        if (contract instanceof AtBContract
+            && Systems.getInstance().getSystems().get(contract.getSystemId()) != null) {
             JLabel lblDistance = new JLabel(resourceMap.getString("lblDistance.text"));
             lblDistance.setName("lblDistance");
             gridBagConstraintsLabels.gridy = ++y;


### PR DESCRIPTION
Previously, the distance label was added for all contract types, which was incorrect as non-AtB Contracts do not track system. This change ensures it is only displayed for AtB contracts.