### PR TITLE
Enable Auto-Resolve Button Conditionally for AtB Scenarios

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -1302,7 +1302,9 @@ public final class BriefingTab extends CampaignGuiTab {
         btnGetMul.setEnabled(canStartGame);
         btnClearAssignedUnits.setEnabled(canStartGame);
         btnResolveScenario.setEnabled(canStartGame);
-        btnAutoResolveScenario.setEnabled(canStartGame);
+        if (scenario instanceof AtBScenario) {
+            btnAutoResolveScenario.setEnabled(canStartGame);
+        }
         btnPrintRS.setEnabled(canStartGame);
     }
 


### PR DESCRIPTION
Previously, the auto-resolve button was always enabled based on the `canStartGame` flag. This change ensures it is only enabled if the scenario is an `AtBScenario`. Running ACAR on a non-AtB Scenario results in Class Cast Errors.

Posting this PR as a suggested edit, assuming Luana hasn't got plans to expand ACAR to non-AtB Scenarios. If she does, then this can act as a temporary solution until her edits go live.