### PR TITLE
Refactored `PostScenarioDialogHandler` to use Generic `Scenario`

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -551,8 +551,7 @@ public class MekHQ implements GameListener {
                 return;
             }
 
-            PostScenarioDialogHandler.handle(
-                campaignGUI, getCampaign(), (AtBScenario) currentScenario, tracker, control);
+            PostScenarioDialogHandler.handle(campaignGUI, getCampaign(), currentScenario, tracker, control);
 
             gameThread.requestStop();
         } catch (Exception ex) {
@@ -587,8 +586,7 @@ public class MekHQ implements GameListener {
             return;
         }
 
-        PostScenarioDialogHandler.handle(
-            campaignGUI, getCampaign(), (AtBScenario) selectedScenario, tracker, control);
+        PostScenarioDialogHandler.handle(campaignGUI, getCampaign(), selectedScenario, tracker, control);
     }
 
     private boolean yourSideControlsTheBattlefieldDialogAsk(String message, String title) {
@@ -699,8 +697,8 @@ public class MekHQ implements GameListener {
                 }
                 return;
             }
-            PostScenarioDialogHandler.handle(
-                campaignGUI, getCampaign(), scenario, tracker, autoResolveConcludedEvent.controlledScenario());
+            PostScenarioDialogHandler.handle(campaignGUI, getCampaign(), scenario, tracker,
+                autoResolveConcludedEvent.controlledScenario());
         } catch (Exception ex) {
             logger.error("Error during auto resolve concluded", ex);
         }

--- a/MekHQ/src/mekhq/campaign/handler/PostScenarioDialogHandler.java
+++ b/MekHQ/src/mekhq/campaign/handler/PostScenarioDialogHandler.java
@@ -27,6 +27,7 @@ import mekhq.campaign.Kill;
 import mekhq.campaign.ResolveScenarioTracker;
 import mekhq.campaign.event.ScenarioResolvedEvent;
 import mekhq.campaign.mission.AtBScenario;
+import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
@@ -49,8 +50,8 @@ public class PostScenarioDialogHandler {
      * @param tracker The tracker that contains all the information about the scenario resolution.
      * @param control Whether the player controlled the battlefield at the end of the scenario.
      */
-    public static void handle(
-        CampaignGUI campaignGUI, Campaign campaign, AtBScenario currentScenario, ResolveScenarioTracker tracker, boolean control) {
+    public static void handle(CampaignGUI campaignGUI, Campaign campaign, Scenario currentScenario,
+                              ResolveScenarioTracker tracker, boolean control) {
         postCombatRetirementCheck(campaignGUI, campaign, currentScenario);
         postCombatAutoApplyAward(campaign, tracker);
         postCombatMissingInActionToPrisonerOfWarStatus(campaign, tracker, control);
@@ -83,7 +84,7 @@ public class PostScenarioDialogHandler {
         }
     }
 
-    private static void postCombatRetirementCheck(CampaignGUI campaignGUI, Campaign campaign, AtBScenario currentScenario) {
+    private static void postCombatRetirementCheck(CampaignGUI campaignGUI, Campaign campaign, Scenario currentScenario) {
         if (!campaign.getRetirementDefectionTracker().getRetirees().isEmpty()) {
             RetirementDefectionDialog rdd = new RetirementDefectionDialog(campaignGUI,
                 campaign.getMission(currentScenario.getMissionId()), false);


### PR DESCRIPTION
Replaced `AtBScenario` references with the generic `Scenario` class to enhance code flexibility and maintainability. Updated relevant method signatures and calls to align with the new parameter type. Simplified and cleaned up related code.

Fix #5615