### PR TITLE
Autologistics Reporting fixes

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -94,7 +94,7 @@ generalFallbackAddress.text=Commander
 generalFallbackAddressInformal.text=Boss
 informalAddressMale.text=Bossman
 informalAddressFemale.text=Bossma'am
-weeklyStockCheck.text="Weekly Stock Check: %d different kinds of parts are under requested stock levels, orders have been put in to buy them"
+weeklyStockCheck.text=Weekly Stock Check: %d different kinds of parts are under requested stock levels, orders have been put in to buy them
 garrisonDutyRouted.text=Long-ranged sensors detect no enemy activity in the AO.
 contractMoraleReport.text=Current enemy condition is <b>%s</b> on contract %s.\
   <br>\

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8680,8 +8680,8 @@ public class Campaign implements ITechManager {
             if (toBuy > 0) {
                 IAcquisitionWork partToBuy = partInUse.getPartToBuy();
                 getShoppingList().addShoppingItem(partToBuy, toBuy, this);
+                bought += 1;
             }
-            bought += 1;
         }
         return bought;
     }


### PR DESCRIPTION
Two really small changes here that fix two things that are just some dumb mistakes I made.
1) The weekly stock update text was surrounded by quotations, these have been removed
2) adding to the 'bought' local variable on the stockUpPartsInUse function has been properly nested, it was previously reporting every part, regardless of if it was being bought, as a kind of part that was understocked.