### PR TITLE
Updated StratCon Data Center to Increase Scan Range Instead of Sector Reveal

### DIFF
--- a/MekHQ/data/stratconfacilities/AlliedDataCenter.xml
+++ b/MekHQ/data/stratconfacilities/AlliedDataCenter.xml
@@ -3,7 +3,7 @@
 	<displayableName>Data Center</displayableName>
 	<facilityType>DataCenter</facilityType>
 	<owner>Allied</owner>
-	<revealTrack>true</revealTrack>
-	<userDescription>This facility reveals all information about this track as long as it is active.</userDescription>
+	<increaseScanRange>true</increaseScanRange>
+	<userDescription>Increases the scan range of all friendly forces by 1.</userDescription>
 	<visible>true</visible>
 </StratconFacility>

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconFacility.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconFacility.java
@@ -65,7 +65,7 @@ public class StratconFacility implements Cloneable {
     private List<String> sharedModifiers = new ArrayList<>();
     private List<String> localModifiers = new ArrayList<>();
     private String capturedDefinition;
-    private boolean revealTrack;
+    private boolean increaseScanRange;
     private int scenarioOddsModifier;
     private int monthlySPModifier;
     private boolean preventAerospace;
@@ -93,7 +93,7 @@ public class StratconFacility implements Cloneable {
         clone.sharedModifiers = new ArrayList<>(sharedModifiers);
         clone.localModifiers = new ArrayList<>(localModifiers);
         clone.setCapturedDefinition(capturedDefinition);
-        clone.revealTrack = revealTrack;
+        clone.increaseScanRange = increaseScanRange;
         clone.scenarioOddsModifier = scenarioOddsModifier;
         clone.monthlySPModifier = monthlySPModifier;
         clone.preventAerospace = preventAerospace;
@@ -112,7 +112,7 @@ public class StratconFacility implements Cloneable {
         setLocalModifiers(new ArrayList<>(facility.getLocalModifiers()));
         setSharedModifiers(new ArrayList<>(facility.getSharedModifiers()));
         setOwner(facility.getOwner());
-        setRevealTrack(facility.getRevealTrack());
+        setIncreaseScanRange(facility.getIncreaseScanRange());
         setScenarioOddsModifier(facility.getScenarioOddsModifier());
         setMonthlySPModifier(facility.getMonthlySPModifier());
         setPreventAerospace(facility.preventAerospace());
@@ -237,12 +237,12 @@ public class StratconFacility implements Cloneable {
         this.capturedDefinition = capturedDefinition;
     }
 
-    public boolean getRevealTrack() {
-        return revealTrack;
+    public boolean getIncreaseScanRange() {
+        return increaseScanRange;
     }
 
-    public void setRevealTrack(boolean revealTrack) {
-        this.revealTrack = revealTrack;
+    public void setIncreaseScanRange(boolean increaseScanRange) {
+        this.increaseScanRange = increaseScanRange;
     }
 
     public int getScenarioOddsModifier() {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -49,6 +49,7 @@ import mekhq.campaign.personnel.turnoverAndRetention.Fatigue;
 import mekhq.campaign.stratcon.StratconContractDefinition.StrategicObjectiveType;
 import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
 import mekhq.campaign.unit.Unit;
+import org.apache.commons.math3.util.Pair;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -1213,20 +1214,61 @@ public class StratconRulesManager {
     }
 
     /**
-     * Process the deployment of a force to the given coordinates on the given
-     * track.
-     * This does not include assigning the force to any scenarios
+     * Processes the deployment of a force to the specified coordinates on the given track.
+     *
+     * <p>This includes revealing the deployed coordinates, identifying and revealing facilities
+     * and scenarios within the scan range, and updating necessary game states such as fatigue
+     * and force assignments. It does not include assigning the force to specific scenarios.</p>
+     *
+     * <h3>Behavior:</h3>
+     * <ul>
+     *   <li>If the force's deployment coordinates are unrevealed, fatigue is increased for the force.</li>
+     *   <li>Ensures that fatigue is increased only once during the deployment process.</li>
+     *   <li>Reveals all coordinates, facilities, and scenarios within the force's scan range.</li>
+     *   <li>Handles cloaked scenarios by activating them and updating game states as necessary.</li>
+     *   <li>Updates the track's revealed coordinates to include the deployment and adjacent areas within range.</li>
+     *   <li>Assigns the deployed force to the specified coordinates and clears their previous track assignments.</li>
+     * </ul>
+     *
+     * <h3>Notes:</h3>
+     * <ul>
+     *   <li>Scout or patrol roles may increase the scan range.</li>
+     *   <li>The method uses a breadth-first search (BFS) approach to traverse the hex grid and reveal neighbors
+     *       within the scan range efficiently, avoiding redundant processing using a visited set.</li>
+     * </ul>
+     *
+     * @param coords    The coordinates where the force is being deployed.
+     * @param forceID   The ID of the force being deployed.
+     * @param campaign  The current campaign context, used to retrieve combat teams and update game events.
+     * @param track     The current track state where the deployment is happening.
+     * @param sticky    Whether the force should be persistently assigned to the track.
+     *
+     * @throws IllegalStateException if the force or the associated combat team is missing or invalid.
      */
     public static void processForceDeployment(StratconCoords coords, int forceID, Campaign campaign,
-            StratconTrackState track, boolean sticky) {
-        // plan of action:
-        // increase fatigue if the coordinates are not currently unrevealed reveal deployed coordinates
-        // reveal facility in deployed coordinates (and all adjacent coordinates for scout lances)
-        // reveal scenarios in deployed coordinates (and all adjacent coordinates for scout lances)
-
+                                              StratconTrackState track, boolean sticky) {
         // we want to ensure we only increase Fatigue once
         boolean hasFatigueIncreased = false;
 
+        // BFS queue for coordinates, tracks distance from the starting point
+        Queue<Pair<StratconCoords, Integer>> queue = new LinkedList<>();
+        // Keep a set of visited coordinates to avoid redundancy
+        Set<StratconCoords> visited = new HashSet<>();
+
+        // Start with the initial deployment coordinate at distance 0
+        queue.add(new Pair<>(coords, 0));
+        visited.add(coords);
+
+        // Determine scan range
+        int scanRange = track.getScanRangeIncrease();
+
+        CombatTeam combatTeam = campaign.getCombatTeamsTable().get(forceID);
+
+        if (combatTeam != null && combatTeam.getRole().isPatrol()) {
+            scanRange++;
+        }
+
+        // Process starting point
         if (!track.getRevealedCoords().contains(coords)) {
             increaseFatigue(forceID, campaign);
             hasFatigueIncreased = true;
@@ -1234,9 +1276,9 @@ public class StratconRulesManager {
 
         track.getRevealedCoords().add(coords);
 
-        StratconFacility facility = track.getFacility(coords);
-        if (facility != null) {
-            facility.setVisible(true);
+        StratconFacility targetFacility = track.getFacility(coords);
+        if (targetFacility != null) {
+            targetFacility.setVisible(true);
         }
 
         StratconScenario scenario = track.getScenario(coords);
@@ -1247,34 +1289,40 @@ public class StratconRulesManager {
             MekHQ.triggerEvent(new ScenarioChangedEvent(scenario.getBackingScenario()));
         }
 
-        CombatTeam combatTeam = campaign.getCombatTeamsTable().get(forceID);
+        // Traverse neighboring coordinates up to the specified distance
+        while (!queue.isEmpty()) {
+            Pair<StratconCoords, Integer> current = queue.poll();
+            StratconCoords currentCoords = current.getKey();
+            int distance = current.getValue();
 
-        // This may return null if we're deploying a force that isn't a Combat Team for whatever reason
-        if (combatTeam != null) {
-            if (combatTeam.getRole().isPatrol()) {
+            // Only process neighbors if they're within the max distance
+            if (distance < scanRange) {
                 for (int direction = 0; direction < 6; direction++) {
-                    StratconCoords checkCoords = coords.translate(direction);
+                    StratconCoords checkCoords = currentCoords.translate(direction);
 
-                    facility = track.getFacility(checkCoords);
-                    if (facility != null) {
-                        facility.setVisible(true);
+                    // Skip already visited coordinates
+                    if (visited.contains(checkCoords)) {
+                        continue;
                     }
 
-                    scenario = track.getScenario(checkCoords);
-                    // if we've revealed a scenario and it's "cloaked"
-                    // we have to activate it
-                    if ((scenario != null) && scenario.getBackingScenario().isCloaked()) {
-                        scenario.getBackingScenario().setCloaked(false);
-                        setScenarioDates(0, track, campaign, scenario);
-                        MekHQ.triggerEvent(new ScenarioChangedEvent(scenario.getBackingScenario()));
+                    // Mark as visited
+                    visited.add(checkCoords);
+                    queue.add(new Pair<>(checkCoords, distance + 1)); // Add the neighbor with incremented distance
+
+                    // Process facilities
+                    targetFacility = track.getFacility(checkCoords);
+                    if (targetFacility != null) {
+                        targetFacility.setVisible(true);
                     }
 
-                    if ((!track.getRevealedCoords().contains(checkCoords)) && (!hasFatigueIncreased)) {
+                    // Increase fatigue only once
+                    if (!track.getRevealedCoords().contains(checkCoords) && !hasFatigueIncreased) {
                         increaseFatigue(forceID, campaign);
                         hasFatigueIncreased = true;
                     }
 
-                    track.getRevealedCoords().add(coords.translate(direction));
+                    // Mark the current coordinate as revealed
+                    track.getRevealedCoords().add(checkCoords);
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1220,7 +1220,7 @@ public class StratconRulesManager {
      * and scenarios within the scan range, and updating necessary game states such as fatigue
      * and force assignments. It does not include assigning the force to specific scenarios.</p>
      *
-     * <h3>Behavior:</h3>
+     * <strong>Behavior:</strong>
      * <ul>
      *   <li>If the force's deployment coordinates are unrevealed, fatigue is increased for the force.</li>
      *   <li>Ensures that fatigue is increased only once during the deployment process.</li>
@@ -1230,7 +1230,7 @@ public class StratconRulesManager {
      *   <li>Assigns the deployed force to the specified coordinates and clears their previous track assignments.</li>
      * </ul>
      *
-     * <h3>Notes:</h3>
+     * <strong>Notes:</strong>
      * <ul>
      *   <li>Scout or patrol roles may increase the scan range.</li>
      *   <li>The method uses a breadth-first search (BFS) approach to traverse the hex grid and reveal neighbors

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -435,10 +435,23 @@ public class StratconTrackState {
     }
 
     /**
-     * @return Whether or not this track has a facility on it that reveals the track.
+     * Determines the number of facilities on this track that actively reveal the track.
+     *
+     * <p>This method iterates through all facilities associated with the track and counts
+     * how many of them have the ability to reveal the track, as determined by the facility's
+     * {@link StratconFacility#getIncreaseScanRange()} method.</p>
+     *
+     * @return an integer representing the total number of facilities on this track
+     *         that are actively revealing it.
      */
-    public boolean hasActiveTrackReveal() {
-        return getFacilities().values().stream().anyMatch(StratconFacility::getRevealTrack);
+    public int getScanRangeIncrease() {
+        int scanRange = 0;
+        for (StratconFacility facility : getFacilities().values()) {
+            if (facility.getIncreaseScanRange()) {
+                scanRange++;
+            }
+        }
+        return scanRange;
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -373,8 +373,6 @@ public class StratconPanel extends JPanel implements ActionListener {
         Font newFont = pushFont.deriveFont(Font.BOLD, pushFont.getSize());
         g2D.setFont(newFont);
 
-        boolean trackRevealed = currentTrack.hasActiveTrackReveal();
-
         for (int x = 0; x < currentTrack.getWidth(); x++) {
             for (int y = 0; y < currentTrack.getHeight(); y++) {
                 StratconCoords currentCoords = new StratconCoords(x, y);
@@ -408,7 +406,7 @@ public class StratconPanel extends JPanel implements ActionListener {
                     }
 
                     // draw fog of war if applicable
-                    if (!trackRevealed && !currentTrack.coordsRevealed(x, y)) {
+                    if (!currentTrack.coordsRevealed(x, y)) {
                         BufferedImage fogOfWarLayerImage = getImage(StratconBiomeManifest.FOG_OF_WAR,
                                 ImageType.TerrainTile);
                         if (fogOfWarLayerImage != null) {
@@ -555,8 +553,6 @@ public class StratconPanel extends JPanel implements ActionListener {
 
         Polygon graphHex = generateGraphHex();
 
-        boolean trackRevealed = currentTrack.hasActiveTrackReveal();
-
         for (int x = 0; x < currentTrack.getWidth(); x++) {
             for (int y = 0; y < currentTrack.getHeight(); y++) {
                 StratconCoords currentCoords = new StratconCoords(x, y);
@@ -570,7 +566,7 @@ public class StratconPanel extends JPanel implements ActionListener {
                                 (scenario.isStrategicObjective()
                                         && currentTrack.getRevealedCoords().contains(currentCoords))
                                 ||
-                                currentTrack.isGmRevealed() || trackRevealed)) {
+                                currentTrack.isGmRevealed())) {
                     g2D.setColor(MekHQ.getMHQOptions().getFontColorNegative());
 
                     BufferedImage scenarioImage = getImage(StratconBiomeManifest.FORCE_HOSTILE, ImageType.TerrainTile);
@@ -616,14 +612,12 @@ public class StratconPanel extends JPanel implements ActionListener {
 
         Polygon graphHex = generateGraphHex();
 
-        boolean trackRevealed = currentTrack.hasActiveTrackReveal();
-
         for (int x = 0; x < currentTrack.getWidth(); x++) {
             for (int y = 0; y < currentTrack.getHeight(); y++) {
                 StratconCoords currentCoords = new StratconCoords(x, y);
                 StratconFacility facility = currentTrack.getFacility(currentCoords);
 
-                if ((facility != null) && (facility.isVisible() || trackRevealed || currentTrack.isGmRevealed())) {
+                if ((facility != null) && (facility.isVisible() || currentTrack.isGmRevealed())) {
                     g2D.setColor(facility.getOwner() == Allied ? Color.CYAN : Color.RED);
 
                     BufferedImage facilityImage = getFacilityImage(facility);
@@ -875,8 +869,7 @@ public class StratconPanel extends JPanel implements ActionListener {
         infoBuilder.append(currentTrack.getTerrainTile(boardState.getSelectedCoords()));
         infoBuilder.append("<br/>");
 
-        boolean coordsRevealed = currentTrack.hasActiveTrackReveal()
-                || currentTrack.getRevealedCoords().contains(boardState.getSelectedCoords());
+        boolean coordsRevealed = currentTrack.getRevealedCoords().contains(boardState.getSelectedCoords());
         if (coordsRevealed) {
             infoBuilder.append("<span color='").append(MekHQ.getMHQOptions().getFontColorPositiveHexColor())
                 .append("'><i>Recon Complete</i></span><br/>");


### PR DESCRIPTION
Replaced the "track reveal" mechanic with a new "scan range" system, allowing facilities and units to extend the area they can reveal. Updated all relevant classes, methods, and XML definitions to reflect this change.

This change was made to reduce the effectiveness of Allied Data Centers. In prior versions the presence of a single Data Center completely removed the scouting stage from a contract for an entire Sector.

Now for each Allied Data Center present in the Sector the player's scan range will be increased by 1. This means, with a single Data Center the sight range of Patrol Forces will be increased from 1 to 2. While other combat roles will have their sight range increased from 0 to 1. The effectiveness of Allied Data centers stack. So a Patrol force, supported by two Data Centers, would have a sight range of 3.

This does not devalue Patrol forces, as Patrol forces will never have scenarios spawn directly on top of them, when scouting. Making deploying Patrols still the optimum strategy for exploring the sector.

In addition, I have adjusted how scouting works. Previously, if you revealed a fixed scenario when scouting, that scenario would immediately 'activate'. This meant that you never wanted to scout unless you had a second force on hand to immediately respond if you stumble across an objective scenario. We've had a lot of feedback from the players about this, and while I get the logic, it was creating a lot of poor experiences. Now, when a fixed scenario is uncovered it remains dormant until interacted with by a player force - identical to the behavior seen when the player GM Reveals a Sector.