### PR TITLE
RFE 5604: save refit config from MHQ MekLab tab

### DIFF
--- a/MekHQ/resources/mekhq/resources/MekLabTab.properties
+++ b/MekHQ/resources/mekhq/resources/MekLabTab.properties
@@ -1,0 +1,3 @@
+dialog.saveAs.title=Save As
+dialog.saveAs.message.format=%s %s saved to %s
+dialog.filter.unitFiles=Unit Files (*.mtf; *.blk; *.hmp)

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -153,6 +153,8 @@ public class MekLabTab extends CampaignGuiTab {
             UnitUtil.compactCriticals(entity);
             labPanel.refreshAll(); // The crits may have moved
             fileSaver.saveUnitAs(this.getFrame(), entity);
+            // Refresh unit cache so newly-saved file is available for refits.
+            MekSummaryCache.refreshUnitData(false);
         });
 
         btnClear = new JButton("Clear Changes");

--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -150,6 +150,8 @@ public class MekLabTab extends CampaignGuiTab {
         btnSaveForLater = new JButton("Save For Later");
         btnSaveForLater.addActionListener(evt -> {
             Entity entity = labPanel.getEntity();
+            UnitUtil.compactCriticals(entity);
+            labPanel.refreshAll(); // The crits may have moved
             fileSaver.saveUnitAs(this.getFrame(), entity);
         });
 


### PR DESCRIPTION
This PR aims to add the ability to save a prospective refit configuration from the MekLab tab within MekHQ, per RFE #5604 

Testing:
- Created several refit configs, saved them, and then applied them via the Hangar menu.
- Ran all 3 projects' unit tests.

Close #5604 

NOTE: tests will continue failing until [this](https://github.com/MegaMek/megameklab/pull/1678) MML PR is merged.