### PR TITLE
bug: address potential int and double issue from SpotBugs

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
@@ -142,7 +142,8 @@ public class ResupplyUtilities {
      * @return the estimated cargo requirement in tons.
      */
     public static int estimateCargoRequirements(Campaign campaign, AtBContract contract) {
-        return (int) ceil(calculateTargetCargoTonnage(campaign, contract) * CARGO_MULTIPLIER);
+        double targetTonnage = calculateTargetCargoTonnage(campaign, contract) * CARGO_MULTIPLIER;
+        return (int) Math.ceil(targetTonnage);
     }
 
     /**


### PR DESCRIPTION
Integral value cast to double and then passed to Math.ceil This code converts an integral value (e.g., int or long) to a double precision floating point number and then passing the result to the Math.ceil() function, which rounds a double to the next higher integer value. This operation should always be a no-op, since converting an integer to a double should give a number with no fractional part. It is likely that the operation that generated the value to be passed to Math.ceil was intended to be performed using double precision floating point arithmetic.

Bug kind and pattern: ICAST - ICAST_INT_CAST_TO_DOUBLE_PASSED_TO_CEIL

Found via [SpotBugs](https://spotbugs.readthedocs.io/en/stable/index.html)