### PR TITLE
fix: don't use floats in for loops

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -172,12 +172,14 @@ public class PartsStore {
             } else if (et instanceof MiscType && ((MiscType) et).hasFlag(MiscType.F_MASC)) {
                 if (et.hasSubType(MiscType.S_SUPERCHARGER)) {
                     for (int rating = 10; rating <= 400; rating += 5) {
-                        for (double eton = 0.5; eton <= 10.5; eton += 0.5) {
+                        // eton 0.5 to 10.5 inclusive
+                        for (int i = 1; i <= 21; i++) {
+                            double eton = i * 0.5;
                             double weight = Engine.ENGINE_RATINGS[(int) Math.ceil(rating / 5.0)];
-                            double minweight = weight * 0.5f;
+                            double minweight = weight * 0.5;
                             minweight = Math.ceil(
                                     (TestEntity.ceilMaxHalf(minweight, TestEntity.Ceil.HALFTON) / 10.0) * 2.0) / 2.0;
-                            double maxweight = weight * 2.0f;
+                            double maxweight = weight * 2.0;
                             maxweight = Math.ceil(
                                     (TestEntity.ceilMaxHalf(maxweight, TestEntity.Ceil.HALFTON) / 10.0) * 2.0) / 2.0;
                             if (eton < minweight || eton > maxweight) {

--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -360,7 +360,9 @@ public class PartsStore {
     }
 
     private void stockGyros(Campaign c) {
-        for (double i = 0.5; i <= 8.0; i += 0.5) {
+        // values of 0.5 to 8.0 inclusive
+        for (int r = 1; r <= 16; r++) {
+            double i = r * 0.5;
             // standard at intervals of 1.0, up to 4
             if (i % 1.0 == 0 && i <= 4.0) {
                 parts.add(new MekGyro(0, Mek.GYRO_STANDARD, i, false, c));
@@ -371,7 +373,7 @@ public class PartsStore {
                 parts.add(new MekGyro(0, Mek.GYRO_COMPACT, i, false, c));
             }
             // XL at 0.5 intervals up to 2
-            if (i % 0.5 == 0 && i <= 2.0) {
+            if (i <= 2.0) {
                 parts.add(new MekGyro(0, Mek.GYRO_XL, i, false, c));
             }
             // Heavy duty at 2.0 intervals


### PR DESCRIPTION
Do not use floating-point variables as loop counters
Using floating-point variables should not be used as loop counters, as they are not precise, which may result in incorrect loops. A loop counter is a variable that is changed with each iteration and controls when the loop should terminate. It is decreased or increased by a fixed amount each iteration.
See rule NUM09-J.

Bug kind and pattern: FL - FL_FLOATS_AS_LOOP_COUNTERS

Found via [SpotBugs](https://spotbugs.readthedocs.io/en/stable/index.html)

Also has a few other cleanups like consistency with doubles (don't use `f`) and an unneeded conditional check for modulus.
