### PR TITLE
fix: keep odd number checks using modulus, however, make sure they wi…

### DIFF
--- a/MekHQ/src/mekhq/campaign/finances/enums/FinancialTerm.java
+++ b/MekHQ/src/mekhq/campaign/finances/enums/FinancialTerm.java
@@ -133,7 +133,7 @@ public enum FinancialTerm {
                 // twelve months if today is in an even quarter or nine months otherwise
                 return endsToday(yesterday, today) ? today.plusMonths(6)
                         : today.with(IsoFields.DAY_OF_QUARTER, 1)
-                                .plusMonths(((today.get(IsoFields.QUARTER_OF_YEAR) % 2) == 1) ? 12 : 9);
+                                .plusMonths((today.get(IsoFields.QUARTER_OF_YEAR) % 2 != 0) ? 12 : 9);
             case ANNUALLY:
             default:
                 // First, use today if the term would end today or otherwise adjust to the first
@@ -163,7 +163,7 @@ public enum FinancialTerm {
                 return today.get(IsoFields.QUARTER_OF_YEAR) != yesterday.get(IsoFields.QUARTER_OF_YEAR);
             case SEMIANNUALLY:
                 return (today.get(IsoFields.QUARTER_OF_YEAR) != yesterday.get(IsoFields.QUARTER_OF_YEAR))
-                        && ((today.get(IsoFields.QUARTER_OF_YEAR) % 2) == 1);
+                        && (today.get(IsoFields.QUARTER_OF_YEAR) % 2 != 0);
             case ANNUALLY:
             default:
                 return today.getYear() != yesterday.getYear();

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1875,7 +1875,7 @@ public class AtBContract extends Contract {
             iterations = 5;
         }
 
-        if (iterations % 2 == 1) {
+        if (iterations % 2 != 0) {
             iterations--;
             iterations /= 2;
 


### PR DESCRIPTION
…ll work for negative numbers as well, found via SpotBugs

Check for oddness that won't work for negative numbers The code uses x % 2 == 1 to check to see if a value is odd, but this won't work for negative numbers (e.g., (-5) % 2 == -1). If this code is intending to check for oddness, consider using (x & 1) == 1, or x % 2 != 0.

Bug kind and pattern: IM - IM_BAD_CHECK_FOR_ODD

This should keep all the logic the same, just prevent this from being flagged in SpotBugs or other code checkers.