### PR TITLE
Restored Logic for Facilities to Reveal StratCon Tracks

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconFacility.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconFacility.java
@@ -65,6 +65,7 @@ public class StratconFacility implements Cloneable {
     private List<String> sharedModifiers = new ArrayList<>();
     private List<String> localModifiers = new ArrayList<>();
     private String capturedDefinition;
+    private boolean revealTrack;
     private boolean increaseScanRange;
     private int scenarioOddsModifier;
     private int monthlySPModifier;
@@ -93,6 +94,7 @@ public class StratconFacility implements Cloneable {
         clone.sharedModifiers = new ArrayList<>(sharedModifiers);
         clone.localModifiers = new ArrayList<>(localModifiers);
         clone.setCapturedDefinition(capturedDefinition);
+        clone.revealTrack = revealTrack;
         clone.increaseScanRange = increaseScanRange;
         clone.scenarioOddsModifier = scenarioOddsModifier;
         clone.monthlySPModifier = monthlySPModifier;
@@ -112,6 +114,7 @@ public class StratconFacility implements Cloneable {
         setLocalModifiers(new ArrayList<>(facility.getLocalModifiers()));
         setSharedModifiers(new ArrayList<>(facility.getSharedModifiers()));
         setOwner(facility.getOwner());
+        setRevealTrack(facility.getRevealTrack());
         setIncreaseScanRange(facility.getIncreaseScanRange());
         setScenarioOddsModifier(facility.getScenarioOddsModifier());
         setMonthlySPModifier(facility.getMonthlySPModifier());
@@ -235,6 +238,14 @@ public class StratconFacility implements Cloneable {
 
     public void setCapturedDefinition(String capturedDefinition) {
         this.capturedDefinition = capturedDefinition;
+    }
+
+    public boolean getRevealTrack() {
+        return revealTrack;
+    }
+
+    public void setRevealTrack(boolean revealTrack) {
+        this.revealTrack = revealTrack;
     }
 
     public boolean getIncreaseScanRange() {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -435,6 +435,13 @@ public class StratconTrackState {
     }
 
     /**
+     * @return Whether or not this track has a facility on it that reveals the track.
+     */
+    public boolean hasActiveTrackReveal() {
+        return getFacilities().values().stream().anyMatch(StratconFacility::getRevealTrack);
+    }
+
+    /**
      * Determines the number of facilities on this track that actively reveal the track.
      *
      * <p>This method iterates through all facilities associated with the track and counts

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -373,6 +373,8 @@ public class StratconPanel extends JPanel implements ActionListener {
         Font newFont = pushFont.deriveFont(Font.BOLD, pushFont.getSize());
         g2D.setFont(newFont);
 
+        boolean trackRevealed = currentTrack.hasActiveTrackReveal();
+
         for (int x = 0; x < currentTrack.getWidth(); x++) {
             for (int y = 0; y < currentTrack.getHeight(); y++) {
                 StratconCoords currentCoords = new StratconCoords(x, y);
@@ -406,7 +408,7 @@ public class StratconPanel extends JPanel implements ActionListener {
                     }
 
                     // draw fog of war if applicable
-                    if (!currentTrack.coordsRevealed(x, y)) {
+                    if (!trackRevealed && !currentTrack.coordsRevealed(x, y)) {
                         BufferedImage fogOfWarLayerImage = getImage(StratconBiomeManifest.FOG_OF_WAR,
                                 ImageType.TerrainTile);
                         if (fogOfWarLayerImage != null) {
@@ -553,6 +555,8 @@ public class StratconPanel extends JPanel implements ActionListener {
 
         Polygon graphHex = generateGraphHex();
 
+        boolean trackRevealed = currentTrack.hasActiveTrackReveal();
+
         for (int x = 0; x < currentTrack.getWidth(); x++) {
             for (int y = 0; y < currentTrack.getHeight(); y++) {
                 StratconCoords currentCoords = new StratconCoords(x, y);
@@ -566,7 +570,7 @@ public class StratconPanel extends JPanel implements ActionListener {
                                 (scenario.isStrategicObjective()
                                         && currentTrack.getRevealedCoords().contains(currentCoords))
                                 ||
-                                currentTrack.isGmRevealed())) {
+                                currentTrack.isGmRevealed() || trackRevealed)) {
                     g2D.setColor(MekHQ.getMHQOptions().getFontColorNegative());
 
                     BufferedImage scenarioImage = getImage(StratconBiomeManifest.FORCE_HOSTILE, ImageType.TerrainTile);
@@ -612,12 +616,14 @@ public class StratconPanel extends JPanel implements ActionListener {
 
         Polygon graphHex = generateGraphHex();
 
+        boolean trackRevealed = currentTrack.hasActiveTrackReveal();
+
         for (int x = 0; x < currentTrack.getWidth(); x++) {
             for (int y = 0; y < currentTrack.getHeight(); y++) {
                 StratconCoords currentCoords = new StratconCoords(x, y);
                 StratconFacility facility = currentTrack.getFacility(currentCoords);
 
-                if ((facility != null) && (facility.isVisible() || currentTrack.isGmRevealed())) {
+                if ((facility != null) && (facility.isVisible() || trackRevealed || currentTrack.isGmRevealed())) {
                     g2D.setColor(facility.getOwner() == Allied ? Color.CYAN : Color.RED);
 
                     BufferedImage facilityImage = getFacilityImage(facility);
@@ -869,7 +875,8 @@ public class StratconPanel extends JPanel implements ActionListener {
         infoBuilder.append(currentTrack.getTerrainTile(boardState.getSelectedCoords()));
         infoBuilder.append("<br/>");
 
-        boolean coordsRevealed = currentTrack.getRevealedCoords().contains(boardState.getSelectedCoords());
+        boolean coordsRevealed = currentTrack.hasActiveTrackReveal()
+                || currentTrack.getRevealedCoords().contains(boardState.getSelectedCoords());
         if (coordsRevealed) {
             infoBuilder.append("<span color='").append(MekHQ.getMHQOptions().getFontColorPositiveHexColor())
                 .append("'><i>Recon Complete</i></span><br/>");


### PR DESCRIPTION
Restored the `revealTrack` property in facilities and integrated it into the StratCon logic to determine visibility. Restored drawing and visibility checks accordingly to account for facilities that enable track-wide reveals.

This ensures we have two facility modifiers relating to hex reveal: Scan Range (which increases line of sight), and Reveal Track (which reveals the whole Sector). The latter is not currently used by any Facilities, but might be useful for player custom facilities.