### PR TITLE
fix: addresses bug #5663 where the financeTable is empty (has zero ro…

### DIFF
--- a/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/FinanceTableModel.java
@@ -75,6 +75,9 @@ public class FinanceTableModel extends DataTableModel {
 
     @Override
     public Object getValueAt(int row, int col) {
+        if (row < 0 || row >= getRowCount() || col < 0 || col >= getColumnCount()) {
+            return "";
+        }
         Transaction transaction = getTransaction(row);
         Money amount = transaction.getAmount();
         Money balance = Money.zero();


### PR DESCRIPTION
…ws) resulting in array out of bounds exception

Addresses #5663 

Sorry about that, I *think* this should fix it.  At least it did in my minimal testing.