### PR TITLE
Refactored Font Color Handling for Cargo Report

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignSummary.java
+++ b/MekHQ/src/mekhq/campaign/CampaignSummary.java
@@ -300,10 +300,6 @@ public class CampaignSummary {
 
         if (comparison > 0) {
             report.append("<font color='")
-                    .append(MekHQ.getMHQOptions().getFontColorNegativeHexColor())
-                    .append("'>");
-        } else if (comparison == 0) {
-            report.append("<font color='")
                     .append(MekHQ.getMHQOptions().getFontColorWarningHexColor())
                     .append("'>");
         }


### PR DESCRIPTION
- Changed cargo report color to 'warning' (default: orange) from 'negative' (default: red) when cargo capacity is exceeded. Having it use the 'negative' color was making a lot of users mistake this as a far bigger deal than it actually is.