### PR TITLE
Restore Default Font Color when Leadership Selection Valid

### DIFF
--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -1043,6 +1043,7 @@ public class StratconScenarioWizard extends JDialog {
             selectionCountLabel.setForeground(MekHQ.getMHQOptions().getFontColorNegative());
             btnCommit.setEnabled(false);
         } else {
+            selectionCountLabel.setForeground(null);
             btnCommit.setEnabled(true);
         }
 


### PR DESCRIPTION
Previously, `selectionCountLabel` retained a negative font color even when selections were valid. This update resets the font color to its default state to ensure proper visual feedback for users.

Fix #5662