### PR TITLE
Removed Hardcoded Primary Ally Modifier Chances

### DIFF
--- a/MekHQ/data/scenariomodifiers/airBattleModifiers.xml
+++ b/MekHQ/data/scenariomodifiers/airBattleModifiers.xml
@@ -83,5 +83,8 @@
 		<modifier>
 			EnemyASFAce02.xml
 		</modifier-->
+        <modifier>
+            PrimaryAlliesAir.xml
+        </modifier>
 	</modifiers>
 </scenarioModifierManifest>

--- a/MekHQ/data/scenariomodifiers/groundBattleModifiers.xml
+++ b/MekHQ/data/scenariomodifiers/groundBattleModifiers.xml
@@ -243,5 +243,8 @@
 		<modifier>
 			EnemyASFAce02.xml
 		</modifier-->
+        <modifier>
+            PrimaryAlliesGround.xml
+        </modifier>
 	</modifiers>
 </scenarioModifierManifest>

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1925,9 +1925,7 @@ public class StratconRulesManager {
         // by default, certain conditions may make this bigger
         scenario.setRequiredPlayerLances(1);
 
-        // do an appropriate allied force if the contract calls for it
-        // do any attached or integrated units
-        setAlliedForceModifier(scenario, contract);
+        // do any facility or global modifiers
         applyFacilityModifiers(scenario, track, coords);
         applyGlobalModifiers(scenario, contract.getStratconCampaignState());
 
@@ -2010,50 +2008,6 @@ public class StratconRulesManager {
                 modifier.setAdditionalBriefingText('(' + facility.getDisplayableName() + ") "
                     + modifier.getAdditionalBriefingText());
                 scenario.getBackingScenario().addScenarioModifier(modifier);
-            }
-        }
-    }
-
-    /**
-     * Set up the appropriate primary allied force modifier, if any
-     *
-     * @param contract The scenario's contract.
-     */
-    private static void setAlliedForceModifier(StratconScenario scenario, AtBContract contract) {
-        int alliedUnitOdds = 0;
-
-        // first, we determine the odds of having an allied unit present
-        // TODO: move this override out to the contract definition
-        if (contract.getContractType().isReliefDuty()) {
-            alliedUnitOdds = 50;
-        } else {
-            switch (contract.getCommandRights()) {
-                case INTEGRATED:
-                    alliedUnitOdds = 50;
-                    break;
-                case HOUSE:
-                    alliedUnitOdds = 30;
-                    break;
-                case LIAISON:
-                    alliedUnitOdds = 10;
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        AtBDynamicScenario backingScenario = scenario.getBackingScenario();
-
-        // if an allied unit is present, then we want to make sure that
-        // it's ground units for ground battles
-        if (randomInt(100) <= alliedUnitOdds) {
-            if ((backingScenario.getTemplate().mapParameters.getMapLocation() == LowAtmosphere)
-                    || (backingScenario.getTemplate().mapParameters.getMapLocation() == Space)) {
-                backingScenario.addScenarioModifier(
-                        AtBScenarioModifier.getScenarioModifier(MHQConstants.SCENARIO_MODIFIER_ALLIED_AIR_UNITS));
-            } else {
-                backingScenario.addScenarioModifier(
-                        AtBScenarioModifier.getScenarioModifier(MHQConstants.SCENARIO_MODIFIER_ALLIED_GROUND_UNITS));
             }
         }
     }


### PR DESCRIPTION
- Removed hardcoded chance for 'primary allies air' and 'primary allies ground' to be attached to a scenario.
- Added these modifiers to the standard array of modifiers that can spawn for air/ground scenarios.

Previously users were unhappy that these scenario modifiers artificially increased the size of scenarios, so it was decided to remove the BV contribution of these modifiers. Then, much later, players voice concern that other 'good' modifiers were actually making a scenario harder. So the contribution of those modifiers were also removed. Each removal was sound in isolation, however when combined it results in as much as a 50% chance (per scenario) for the scenario to become unbalanced as the result of these two modifiers, as these were hardcoded so could always spawn. By adding these modifiers to the standard modifier table they will appear much less frequently, but be a fun addition when they do.

Fix #5661