### PR TITLE
Multiple Resupply Bug Fixes

### DIFF
--- a/MekHQ/resources/mekhq/resources/Resupply.properties
+++ b/MekHQ/resources/mekhq/resources/Resupply.properties
@@ -67,8 +67,8 @@ usePlayerConvoyOptional.text=%s, our employer has a delivery ready for us but is
   <br>\
   <br>This <b>enhanced</b> delivery requires an estimated <b>%s</b> tons of cargo space across all\
   \ convoys. However, as this is an estimate final tonnage may vary. We currently have a total of\
-  \ <b>%s</b> available space across <b>%s</b> convoy%s. Damaged or partially vehicles are not\
-  \ considered available.\
+  \ <b>%s</b> available space across <b>%s</b> convoy%s. Damaged or partially crewed vehicles are\
+  \ not considered available.\
   <br>\
   <br>Be aware that this can be a risky job and if we fail to defend any intercepted convoys all\
   \ units and personnel will be lost.\
@@ -81,7 +81,7 @@ usePlayerConvoyForced.text=%s, our employer has a delivery ready for us, but we 
   <br>\
   <br>This delivery requires an estimated <b>%s</b> tons of cargo space across all convoys. However,\
   \ as this is an estimate final tonnage may vary. We currently have a total of <b>%s</b> available\
-  \ space across <b>%s</b> convoy%s. Damaged or partially vehicles are not considered available.\
+  \ space across <b>%s</b> convoy%s. Damaged or partially crewed vehicles are not considered available.\
   <br>\
   <br>Be aware that this can be a risky job and if we fail to defend any intercepted convoys all\
   \ units and personnel will be lost.\

--- a/MekHQ/src/mekhq/campaign/market/procurement/Procurement.java
+++ b/MekHQ/src/mekhq/campaign/market/procurement/Procurement.java
@@ -112,8 +112,6 @@ public class Procurement {
             }
         }
 
-        logger.info(successfulParts);
-
         return successfulParts;
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/Loot.java
+++ b/MekHQ/src/mekhq/campaign/mission/Loot.java
@@ -33,8 +33,10 @@ import mekhq.campaign.ResolveScenarioTracker.UnitStatus;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.mission.enums.ScenarioType;
+import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.enums.PartQuality;
+import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
@@ -213,6 +215,12 @@ public class Loot {
         for (Part part : parts) {
             double partWeight = part.getTonnage();
             partWeight = partWeight == 0 ? RESUPPLY_MINIMUM_PART_WEIGHT : partWeight;
+
+            if (part instanceof AmmoBin || part instanceof Armor) {
+                // Ammo and Armor are delivered in batches of 5t,
+                // so we need to make sure we're treating them as 5t no matter their actual weight.
+                partWeight = 5;
+            }
 
             if (isResupply) {
                 if (cargo - partWeight < 0) {

--- a/MekHQ/src/mekhq/campaign/mission/Loot.java
+++ b/MekHQ/src/mekhq/campaign/mission/Loot.java
@@ -47,6 +47,8 @@ import java.io.PrintWriter;
 import java.util.*;
 
 import static mekhq.campaign.mission.resupplyAndCaches.GenerateResupplyContents.RESUPPLY_MINIMUM_PART_WEIGHT;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_AMMO_TONNAGE;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_ARMOR_TONNAGE;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
@@ -216,10 +218,10 @@ public class Loot {
             double partWeight = part.getTonnage();
             partWeight = partWeight == 0 ? RESUPPLY_MINIMUM_PART_WEIGHT : partWeight;
 
-            if (part instanceof AmmoBin || part instanceof Armor) {
-                // Ammo and Armor are delivered in batches of 5t,
-                // so we need to make sure we're treating them as 5t no matter their actual weight.
-                partWeight = 5;
+            if (part instanceof AmmoBin) {
+                partWeight = RESUPPLY_AMMO_TONNAGE;
+            } else if (part instanceof Armor) {
+                partWeight = RESUPPLY_ARMOR_TONNAGE;
             }
 
             if (isResupply) {

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/GenerateResupplyContents.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/GenerateResupplyContents.java
@@ -76,10 +76,6 @@ public class GenerateResupplyContents {
      * @param usePlayerConvoys Indicates whether player convoy cargo capacity should be applied.
      */
     static void getResupplyContents(Resupply resupply, DropType dropType, boolean usePlayerConvoys) {
-        // Ammo and Armor are delivered in batches of 5, so we need to make sure to multiply their
-        // weight by five when picking these items.
-        final int WEIGHT_MULTIPLIER = dropType == DropType.DROP_TYPE_PARTS ? 1 : 5;
-
         double targetCargoTonnage = resupply.getTargetCargoTonnage();
         if (usePlayerConvoys) {
             final int targetCargoTonnagePlayerConvoy = resupply.getTargetCargoTonnagePlayerConvoy();
@@ -112,7 +108,8 @@ public class GenerateResupplyContents {
             case DROP_TYPE_AMMO -> ammoBinPool;
         };
 
-        while ((availableSpace > 0) && (!relevantPartsPool.isEmpty())) {
+        double currentLoad = 0;
+        while ((currentLoad < availableSpace) && (!relevantPartsPool.isEmpty())) {
             Part potentialPart = switch(dropType) {
                 case DROP_TYPE_PARTS -> getRandomDrop(partsPool, negotiatorSkill);
                 case DROP_TYPE_ARMOR -> getRandomDrop(armorPool, negotiatorSkill);
@@ -155,10 +152,16 @@ public class GenerateResupplyContents {
                     case DROP_TYPE_AMMO -> ammoBinPool.remove(potentialPart);
                 }
 
-                double partWeight = potentialPart.getTonnage();
-                partWeight = partWeight == 0 ? RESUPPLY_MINIMUM_PART_WEIGHT : partWeight;
+                // Ammo and Armor are delivered in batches of 5t,
+                // so we need to make sure we're treating them as 5t no matter their actual weight.
+                double partWeight = 5;
 
-                availableSpace -= partWeight * WEIGHT_MULTIPLIER;
+                if (dropType == DropType.DROP_TYPE_PARTS) {
+                    partWeight = potentialPart.getTonnage();
+                    partWeight = partWeight == 0 ? RESUPPLY_MINIMUM_PART_WEIGHT : partWeight;
+                }
+
+                currentLoad += partWeight;
                 droppedItems.add(potentialPart);
             }
         }

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
@@ -45,7 +45,6 @@ import java.util.Map.Entry;
 
 import static mekhq.campaign.mission.enums.AtBMoraleLevel.CRITICAL;
 import static mekhq.campaign.mission.enums.AtBMoraleLevel.DOMINATING;
-import static mekhq.campaign.mission.enums.AtBMoraleLevel.ROUTED;
 import static mekhq.campaign.mission.enums.AtBMoraleLevel.STALEMATE;
 import static mekhq.campaign.mission.resupplyAndCaches.GenerateResupplyContents.DropType.DROP_TYPE_AMMO;
 import static mekhq.campaign.mission.resupplyAndCaches.GenerateResupplyContents.DropType.DROP_TYPE_ARMOR;
@@ -333,17 +332,13 @@ public class PerformResupply {
         // First, we need to identify whether the convoy has been intercepted.
         AtBMoraleLevel morale = contract.getMoraleLevel();
 
-        if (morale.isRouted()) {
-            completeSuccessfulDelivery(resupply, convoyContents);
-        }
-
-        int interceptionChance = morale.ordinal();
-
         // There isn't any chance of an interception if the enemy is Routed, so early-exit
-        if (interceptionChance == ROUTED.ordinal()) {
+        if (morale.isRouted()) {
             completeSuccessfulDelivery(resupply, convoyContents);
             return;
         }
+
+        int interceptionChance = morale.ordinal();
 
         // This chance is modified by convoy weight, for player convoys this is easy - we just
         // calculate the weight of all units in the convoy. For NPC convoys, we need to get a bit

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
@@ -51,6 +51,8 @@ import static mekhq.campaign.mission.resupplyAndCaches.GenerateResupplyContents.
 import static mekhq.campaign.mission.resupplyAndCaches.GenerateResupplyContents.DropType.DROP_TYPE_PARTS;
 import static mekhq.campaign.mission.resupplyAndCaches.GenerateResupplyContents.RESUPPLY_MINIMUM_PART_WEIGHT;
 import static mekhq.campaign.mission.resupplyAndCaches.GenerateResupplyContents.getResupplyContents;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_AMMO_TONNAGE;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_ARMOR_TONNAGE;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType.RESUPPLY_CONTRACT_END;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType.RESUPPLY_LOOT;
 import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.forceContainsMajorityVTOLForces;
@@ -166,10 +168,10 @@ public class PerformResupply {
 
         double totalTonnage = 0;
         for (Part part : resupply.getConvoyContents()) {
-            if (part instanceof AmmoBin || part instanceof Armor) {
-                // Ammo and Armor are delivered in batches of 5t,
-                // so we need to make sure we're treating them as 5t no matter their actual weight.
-                totalTonnage += 5;
+            if (part instanceof AmmoBin) {
+                totalTonnage += RESUPPLY_AMMO_TONNAGE;
+            } else if (part instanceof Armor) {
+                totalTonnage += RESUPPLY_ARMOR_TONNAGE;
             } else {
                 totalTonnage += part.getTonnage();
             }
@@ -212,9 +214,9 @@ public class PerformResupply {
         for (Part part : contents) {
             if (part instanceof AmmoBin) {
                 campaign.getQuartermaster().addAmmo(((AmmoBin) part).getType(),
-                    ((AmmoBin) part).getFullShots() * 5);
+                    ((AmmoBin) part).getFullShots() * RESUPPLY_AMMO_TONNAGE);
             } else if (part instanceof Armor) {
-                int quantity = (int) Math.ceil(((Armor) part).getArmorPointsPerTon() * 5);
+                int quantity = (int) Math.ceil(((Armor) part).getArmorPointsPerTon() * RESUPPLY_ARMOR_TONNAGE);
                 ((Armor) part).setAmount(quantity);
                 campaign.getWarehouse().addPart(part, true);
             } else {
@@ -289,10 +291,10 @@ public class PerformResupply {
                 double tonnage = part.getTonnage();
                 tonnage = tonnage == 0 ? RESUPPLY_MINIMUM_PART_WEIGHT : tonnage;
 
-                if (part instanceof AmmoBin || part instanceof Armor) {
-                    // Ammo and Armor are delivered in batches of 5t,
-                    // so we need to make sure we're treating them as 5t no matter their actual weight.
-                    tonnage = 5;
+                if (part instanceof AmmoBin) {
+                    tonnage = RESUPPLY_AMMO_TONNAGE;
+                } else if (part instanceof Armor) {
+                    tonnage = RESUPPLY_ARMOR_TONNAGE;
                 }
 
                 if (cargoCapacity - tonnage >= 0) {

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
@@ -167,7 +167,13 @@ public class PerformResupply {
 
         double totalTonnage = 0;
         for (Part part : resupply.getConvoyContents()) {
-            totalTonnage += part.getTonnage() * (part instanceof Armor || part instanceof AmmoBin ? 5 : 1);
+            if (part instanceof AmmoBin || part instanceof Armor) {
+                // Ammo and Armor are delivered in batches of 5t,
+                // so we need to make sure we're treating them as 5t no matter their actual weight.
+                totalTonnage += 5;
+            } else {
+                totalTonnage += part.getTonnage();
+            }
         }
 
         logger.info("totalTonnage: " + totalTonnage);
@@ -255,7 +261,6 @@ public class PerformResupply {
     public static void loadPlayerConvoys(Resupply resupply) {
         // Ammo and Armor are delivered in batches of 5, so we need to make sure to multiply their
         // weight by five when picking these items.
-        final int WEIGHT_MULTIPLIER = 5;
         final Campaign campaign = resupply.getCampaign();
         final Map<Force, Double> playerConvoys = resupply.getPlayerConvoys();
 
@@ -286,7 +291,9 @@ public class PerformResupply {
                 tonnage = tonnage == 0 ? RESUPPLY_MINIMUM_PART_WEIGHT : tonnage;
 
                 if (part instanceof AmmoBin || part instanceof Armor) {
-                    tonnage *= WEIGHT_MULTIPLIER;
+                    // Ammo and Armor are delivered in batches of 5t,
+                    // so we need to make sure we're treating them as 5t no matter their actual weight.
+                    tonnage = 5;
                 }
 
                 if (cargoCapacity - tonnage >= 0) {

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -66,6 +66,8 @@ public class Resupply {
     private Money convoyContentsValueCalculated;
 
     public static final int CARGO_MULTIPLIER = 4;
+    public static final int RESUPPLY_AMMO_TONNAGE = 1;
+    public static final int RESUPPLY_ARMOR_TONNAGE = 5;
 
     private static final MMLogger logger = MMLogger.create(Resupply.class);
 
@@ -571,19 +573,21 @@ public class Resupply {
      *
      * <p>The key is a combination of the part's name and its tonnage, separated by a colon.
      * For specific part types such as {@link AmmoBin} and {@link Armor}, the tonnage is
-     * always set to a value of 5, regardless of the actual tonnage.</p>
+     * always set to a set value, regardless of the actual tonnage.</p>
      *
      * @param part The {@link Part} for which the key is generated. Must not be {@code null}.
      * @return A unique key in the format {@code "partName:partTonnage"}, where
      *         {@code partName} is the name of the part and {@code partTonnage} is the
-     *         tonnage of the part or a fixed value of 5 for {@link AmmoBin} and {@link Armor}.
+     *         tonnage of the part or a fixed value for {@link AmmoBin} and {@link Armor}.
      */
     private static String getPartKey(Part part) {
         String partName = part.getName();
         double partTonnage = part.getTonnage();
 
-        if (part instanceof AmmoBin || part instanceof Armor) {
-            partTonnage = 5;
+        if (part instanceof AmmoBin) {
+            partTonnage = RESUPPLY_AMMO_TONNAGE;
+        } else if (part instanceof Armor) {
+            partTonnage = RESUPPLY_ARMOR_TONNAGE;
         }
 
         return partName + ':' + partTonnage;

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -701,6 +701,12 @@ public class Resupply {
         // Adjust based on the quantity in the warehouse
         for (Part part : campaign.getWarehouse().getSpareParts()) {
             int weight = part.getQuantity();
+
+            // We don't want empty AmmoStorage to reduce Resupply weighting
+            if (part instanceof AmmoStorage && (((AmmoStorage) part).getShots() == 0)) {
+                continue;
+            }
+
             PartDetails partDetails = new PartDetails(part, weight);
 
             partsList.merge(getPartKey(part), partDetails, (oldValue, newValue) -> {

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
@@ -35,6 +35,8 @@ import java.util.Vector;
 import static java.lang.Math.floor;
 import static java.lang.Math.max;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.CARGO_MULTIPLIER;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_AMMO_TONNAGE;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_ARMOR_TONNAGE;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.calculateTargetCargoTonnage;
 import static mekhq.campaign.personnel.enums.PersonnelStatus.KIA;
 import static mekhq.utilities.EntityUtilities.getEntityFromUnitId;
@@ -144,8 +146,9 @@ public class ResupplyUtilities {
     public static int estimateCargoRequirements(Campaign campaign, AtBContract contract) {
         double targetTonnage = calculateTargetCargoTonnage(campaign, contract) * CARGO_MULTIPLIER;
 
-        // Armor and ammo are always delivered in blocks of 5t, so cargo will never be less than 10t
-        return max(10, (int) Math.ceil(targetTonnage));
+        // Armor and ammo are always delivered in blocks, so cargo will never be less than the sum
+        // of those blocks
+        return max(RESUPPLY_AMMO_TONNAGE + RESUPPLY_ARMOR_TONNAGE, (int) Math.ceil(targetTonnage));
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
@@ -32,8 +32,8 @@ import mekhq.gui.dialog.resupplyAndCaches.DialogAbandonedConvoy;
 import java.util.UUID;
 import java.util.Vector;
 
-import static java.lang.Math.ceil;
 import static java.lang.Math.floor;
+import static java.lang.Math.max;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.CARGO_MULTIPLIER;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.calculateTargetCargoTonnage;
 import static mekhq.campaign.personnel.enums.PersonnelStatus.KIA;
@@ -143,7 +143,9 @@ public class ResupplyUtilities {
      */
     public static int estimateCargoRequirements(Campaign campaign, AtBContract contract) {
         double targetTonnage = calculateTargetCargoTonnage(campaign, contract) * CARGO_MULTIPLIER;
-        return (int) Math.ceil(targetTonnage);
+
+        // Armor and ammo are always delivered in blocks of 5t, so cargo will never be less than 10t
+        return max(10, (int) Math.ceil(targetTonnage));
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -994,7 +994,7 @@ public class MissionViewPanel extends JScrollablePanel {
             pnlStats.add(lblCargoRequirement, gridBagConstraints);
 
             txtCargoRequirement.setName("txtCargoRequirement");
-            txtCargoRequirement.setText(estimateCargoRequirements(campaign, contract) + "t");
+            txtCargoRequirement.setText(estimateCargoRequirements(campaign, contract) + "t+");
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 1;
             gridBagConstraints.gridy = y++;


### PR DESCRIPTION
**Code**
- Fixed weight calculations for armor and ammo.
- Ammo is now delivered in 1t blocks, not 5t. Armor is still 5t.
- Fixed warehouse parsing so that items have their weight correctly reduced based on items already in the warehouse. This particularly affects ammo, which were previously always being considered as having 0 rounds spare.
- Corrected early exit for Routed morale that would previously delivery convoys twice.

**GUI**
- Corrected typo in Resupply briefing.
- Adjusted estimated cargo requirements to incorporate a minimum of 6t (as a resupply cannot normally be less than the sum of a single ammo and armor block).
- Added indicator to Briefing Room that resupply weight may exceed estimate.

Fix #5668, #5640