### PR TITLE
Corrected Transportation Unit Type Check

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/TransportationRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/TransportationRating.java
@@ -261,8 +261,7 @@ public class TransportationRating {
             Entity entity = unit.getEntity();
 
             // Skip the unit if it doesn't meet the specific criteria
-            if (!(entity.isDropShip()) && !(entity.isJumpShip())
-                    && !(entity.isWarShip()) && !(entity.isSmallCraft())) {
+            if (!entity.isSmallCraft() && !entity.isLargeCraft()) {
                 continue;
             }
 


### PR DESCRIPTION
- Replaced multiple redundant `is` checks with consolidated `isSmallCraft` and `isLargeCraft`. Space Stations were incorrectly missed from the older checks, which this corrects. Plus it's cleaner code.