### PR TITLE
Added Warning for Campaign Dates Before 2470

### DIFF
--- a/MekHQ/resources/mekhq/resources/DateChooser.properties
+++ b/MekHQ/resources/mekhq/resources/DateChooser.properties
@@ -30,16 +30,10 @@ friday.text=Fri
 saturday.text=Sat
 sunday.text=Sun
 dayPicker.tooltip=Click on a day to choose it
-dateField.text=Click on the date to edit it
+dateField.text=<html><div style='text-align: center;'><b>Campaigns prior to 2470 are not supported.</b>\
+  <br>\
+  <br>Click on the date to edit it.</div></html>
 confirmDate.text=Confirm Date
-
-# Min Date dialog
-minDate.title=Warning
-minDate.body=Campaigns prior to 2470 are not recommended.\
-  \n\
-  \nYou may still pick this date, but will not receive any support.
-minDate.confirm=Continue
-minDate.cancel=Cancel
 
 # createEraButtons
 eraAgeOfWar.text=<b>Age of War</b><br>

--- a/MekHQ/resources/mekhq/resources/DateChooser.properties
+++ b/MekHQ/resources/mekhq/resources/DateChooser.properties
@@ -33,6 +33,14 @@ dayPicker.tooltip=Click on a day to choose it
 dateField.text=Click on the date to edit it
 confirmDate.text=Confirm Date
 
+# Min Date dialog
+minDate.title=Warning
+minDate.body=Campaigns prior to 2470 are not recommended.\
+  \n\
+  \nYou may still pick this date, but will not receive any support.
+minDate.confirm=Continue
+minDate.cancel=Cancel
+
 # createEraButtons
 eraAgeOfWar.text=<b>Age of War</b><br>
 eraAgeOfWar.year=(2005-2570)

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -66,7 +66,6 @@ import static megamek.client.ui.WrapLayout.wordWrap;
 public class DateChooser extends JDialog implements ActionListener, FocusListener, KeyListener {
     private static final MMLogger logger = MMLogger.create(DateChooser.class);
 
-    private static final LocalDate MIN_DATE = LocalDate.of(3470, 1, 1);
     public static final int OK_OPTION = 1;
     public static final int CANCEL_OPTION = 2;
     private static final String RESOURCE_PACKAGE = "mekhq/resources/DateChooser";

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -201,7 +201,7 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
         contentPane.add(dayGrid, BorderLayout.CENTER);
 
         // Create the date label
-        JLabel dateLabel = new JLabel(resources.getString("dateField.text"), JLabel.CENTER);
+        JLabel dateLabel = new JLabel(String.format(resources.getString("dateField.text")));
 
         // Set up the date input text field with the current campaign date.
         dateField = new JFormattedTextField(this.date);
@@ -573,25 +573,6 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
                 "Invalid Date Format\nTry: yyyy-MM-dd", "Date Format",
                 JOptionPane.WARNING_MESSAGE);
             return false;
-        }
-
-        if (newDate.isBefore(MIN_DATE)) {
-            int choice = JOptionPane.showOptionDialog(
-                null,
-                resources.getString("minDate.body"),
-                resources.getString("minDate.title"),
-                JOptionPane.YES_NO_OPTION,
-                JOptionPane.QUESTION_MESSAGE,
-                null, // Use default icon
-                new String[]{
-                    resources.getString("minDate.confirm"),
-                    resources.getString("minDate.cancel")},
-                resources.getString("minDate.cancel")
-            );
-
-            if (choice != JOptionPane.YES_OPTION) {
-                return false;
-            }
         }
 
         setDate(newDate);

--- a/MekHQ/src/mekhq/gui/dialog/DateChooser.java
+++ b/MekHQ/src/mekhq/gui/dialog/DateChooser.java
@@ -66,6 +66,7 @@ import static megamek.client.ui.WrapLayout.wordWrap;
 public class DateChooser extends JDialog implements ActionListener, FocusListener, KeyListener {
     private static final MMLogger logger = MMLogger.create(DateChooser.class);
 
+    private static final LocalDate MIN_DATE = LocalDate.of(3470, 1, 1);
     public static final int OK_OPTION = 1;
     public static final int CANCEL_OPTION = 2;
     private static final String RESOURCE_PACKAGE = "mekhq/resources/DateChooser";
@@ -566,11 +567,31 @@ public class DateChooser extends JDialog implements ActionListener, FocusListene
      */
     private boolean updateDateFromDateField() {
         LocalDate newDate = parseDate(dateField.getText());
+
         if (newDate == null) {
-            JOptionPane.showMessageDialog(this,
+            JOptionPane.showMessageDialog(null,
                 "Invalid Date Format\nTry: yyyy-MM-dd", "Date Format",
-                    JOptionPane.WARNING_MESSAGE);
+                JOptionPane.WARNING_MESSAGE);
             return false;
+        }
+
+        if (newDate.isBefore(MIN_DATE)) {
+            int choice = JOptionPane.showOptionDialog(
+                null,
+                resources.getString("minDate.body"),
+                resources.getString("minDate.title"),
+                JOptionPane.YES_NO_OPTION,
+                JOptionPane.QUESTION_MESSAGE,
+                null, // Use default icon
+                new String[]{
+                    resources.getString("minDate.confirm"),
+                    resources.getString("minDate.cancel")},
+                resources.getString("minDate.cancel")
+            );
+
+            if (choice != JOptionPane.YES_OPTION) {
+                return false;
+            }
         }
 
         setDate(newDate);


### PR DESCRIPTION
- Added warning line to advise users that campaigns prior to 2470 are not supported. Users may still pick dates prior to this point, ensuring that AUs are not negatively impacted, however they do so without the expectation of dev support.

Fix #5641