### PR TITLE
Added Report for Returning StratCon Forces

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -55,6 +55,8 @@ btnAddSP.text=Add SP (GM)
 btnAddCVP.text=Add CVP (GM)
 btnRemoveCVP.text=Remove CVP (GM)
 
+force.undeployed=<b>%s</b> has returned from deployment.
+
 requestingResupply.title=Requesting Resupply
 supplyPointExpenditure.text=How many Support Points would you like to spend?
 btnConfirm.text=Confirm

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -2686,6 +2686,9 @@ public class StratconRulesManager {
      * return date is on or before the given date.
      */
     public static void processTrackForceReturnDates(StratconTrackState track, Campaign campaign) {
+        final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.AtBStratCon",
+            MekHQ.getMHQOptions().getLocale());
+
         List<Integer> forcesToUndeploy = new ArrayList<>();
         LocalDate date = campaign.getLocalDate();
 
@@ -2700,6 +2703,9 @@ public class StratconRulesManager {
                     && (force != null) && !track.getBackingScenariosMap().containsKey(force.getScenarioId())
                     && !track.getStickyForces().contains(forceID)) {
                 forcesToUndeploy.add(forceID);
+
+                campaign.addReport(String.format(resources.getString("force.undeployed"),
+                    force.getName()));
             }
         }
 


### PR DESCRIPTION
- Updated `StratconRulesManager` to log a message when forces are undeployed, improving visibility for campaign events.
- Introduced a new localized string in `AtBStratCon.properties` to support this logging.

Fix #5630