### PR TITLE
Added Potential Difficulty Spikes to Garrison-Type Contracts

### DIFF
--- a/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
@@ -25,4 +25,4 @@ lblSharePct.text=<html><nobr><b>Shares:</b></nobr></html>
 lblCargoRequirement.text=<html><nobr><b>Estimated Cargo Requirement:</b></nobr></html>
 
 txtGarrisonMoraleRouted.text=Peaceful
-txtGarrisonMoraleRouted.tooltip=It's quiet, too quiet...
+txtGarrisonMoraleRouted.tooltip=There is no enemy activity in the Area of Operations.

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -503,7 +503,9 @@ public class AtBContract extends Contract {
                 moraleLevel = newMoraleLevel;
                 routEnd = null;
 
-                updateEnemy(campaign, today); // mix it up a little
+                if (contractType.isGarrisonType() && !contractType.isRiotDuty()) {
+                    updateEnemy(campaign, today); // mix it up a little
+                }
             }
 
             return;

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -27,7 +27,6 @@ import megamek.client.ratgenerator.FactionRecord;
 import megamek.client.ratgenerator.RATGenerator;
 import megamek.client.ratgenerator.UnitTable;
 import megamek.client.ui.swing.util.PlayerColour;
-import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.TargetRoll;
 import megamek.common.UnitType;
@@ -54,6 +53,7 @@ import mekhq.campaign.personnel.enums.Phenotype;
 import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconContractDefinition;
 import mekhq.campaign.stratcon.StratconContractInitializer;
+import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
@@ -81,7 +81,9 @@ import static java.lang.Math.max;
 import static java.lang.Math.round;
 import static megamek.client.ratgenerator.ModelRecord.NETWORK_NONE;
 import static megamek.client.ratgenerator.UnitTable.findTable;
+import static megamek.codeUtilities.ObjectUtility.getRandomItem;
 import static megamek.common.Compute.d6;
+import static megamek.common.Compute.randomInt;
 import static megamek.common.UnitType.MEK;
 import static megamek.common.enums.SkillLevel.ELITE;
 import static megamek.common.enums.SkillLevel.REGULAR;
@@ -93,6 +95,7 @@ import static mekhq.campaign.force.FormationLevel.COMPANY;
 import static mekhq.campaign.mission.AtBDynamicScenarioFactory.getEntity;
 import static mekhq.campaign.mission.BotForceRandomizer.UNIT_WEIGHT_UNSPECIFIED;
 import static mekhq.campaign.rating.IUnitRating.*;
+import static mekhq.campaign.stratcon.StratconContractDefinition.getContractDefinition;
 import static mekhq.campaign.universe.Factions.getFactionLogo;
 import static mekhq.campaign.universe.fameAndInfamy.BatchallFactions.BATCHALL_FACTIONS;
 import static mekhq.gui.dialog.HireBulkPersonnelDialog.overrideSkills;
@@ -458,15 +461,46 @@ public class AtBContract extends Contract {
     public void checkMorale(Campaign campaign, LocalDate today) {
         // Check whether enemy forces have been reinforced, and whether any current rout continues
         // beyond its expected date
-        boolean routContinue = Compute.randomInt(4) == 0;
+        boolean routContinue = randomInt(4) == 0;
 
         // If there is a rout end date, and it's past today, update morale and enemy state accordingly
         if (routEnd != null && !routContinue) {
             if (today.isAfter(routEnd)) {
-                setMoraleLevel(AtBMoraleLevel.STALEMATE);
+                int roll = d6(1);
+
+                // We use variable morale levels to spike morale up to a value above Stalemate.
+                // This works with the regenerated Scenario Odds to crease very high intensity
+                // spikes in otherwise low-key Garrison-type contracts.
+                AtBMoraleLevel newMoraleLevel = switch (roll) {
+                    case 1, 2 -> AtBMoraleLevel.ADVANCING;
+                    case 3, 4 -> AtBMoraleLevel.DOMINATING;
+                    case 5, 6 -> AtBMoraleLevel.OVERWHELMING;
+                    default -> AtBMoraleLevel.STALEMATE;
+                };
+
+                // If we have a StratCon enabled contract, regenerate Scenario Odds
+                StratconCampaignState campaignState = getStratconCampaignState();
+                if (campaignState != null) {
+                    StratconContractDefinition contractDefinition = getContractDefinition(getContractType());
+
+                    if (contractDefinition != null) {
+                        List<Integer> definedScenarioOdds = contractDefinition.getScenarioOdds();
+
+                        int scenarioOddsMultiplier = randomInt(10) == 0 ? 2 : 1;
+
+                        for (StratconTrackState trackState : campaignState.getTracks()) {
+                            int baseScenarioOdds = getRandomItem(definedScenarioOdds);
+
+                            trackState.setScenarioOdds(baseScenarioOdds * scenarioOddsMultiplier);
+                        }
+                    }
+                }
+
+                setMoraleLevel(newMoraleLevel);
                 routEnd = null;
 
                 updateEnemy(campaign, today); // mix it up a little
+
             } else {
                 setMoraleLevel(AtBMoraleLevel.ROUTED);
             }
@@ -818,7 +852,7 @@ public class AtBContract extends Contract {
         String faction = employerCode;
         int quality = allyQuality;
 
-        if (Compute.randomInt(2) > 0) {
+        if (randomInt(2) > 0) {
             faction = enemyCode;
             quality = enemyQuality;
         }
@@ -1007,7 +1041,7 @@ public class AtBContract extends Contract {
 
     public LocalDate getRandomDayOfMonth(LocalDate today) {
         return LocalDate.of(today.getYear(), today.getMonth(),
-                Compute.randomInt(today.getMonth().length(today.isLeapYear())) + 1);
+                randomInt(today.getMonth().length(today.isLeapYear())) + 1);
     }
 
     public boolean contractExtended(final Campaign campaign) {
@@ -1481,7 +1515,7 @@ public class AtBContract extends Contract {
     public void acceptContract(Campaign campaign) {
         if (campaign.getCampaignOptions().isUseStratCon()) {
             StratconContractInitializer.initializeCampaignState(this, campaign,
-                    StratconContractDefinition.getContractDefinition(getContractType()));
+                    getContractDefinition(getContractType()));
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -203,7 +203,7 @@ public class StratconContractInitializer {
         }
 
         // Determine starting morale
-        if (contract.getContractType().isGarrisonType()) {
+        if (contract.getContractType().isGarrisonDuty()) {
             contract.setMoraleLevel(AtBMoraleLevel.ROUTED);
 
             LocalDate routEnd = contract.getStartDate().plusMonths(Math.max(1, Compute.d6() - 3)).minusDays(1);

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -949,7 +949,7 @@ public class MissionViewPanel extends JScrollablePanel {
 
         txtMorale.setName("txtMorale");
 
-        if (contract.getContractType().isGarrisonType() && contract.getMoraleLevel().isRouted()) {
+        if (contract.getContractType().isGarrisonDuty() && contract.getMoraleLevel().isRouted()) {
             txtMorale.setText(resourceMap.getString("txtGarrisonMoraleRouted.text"));
             txtMorale.setToolTipText(wordWrap(resourceMap.getString("txtGarrisonMoraleRouted.tooltip")));
         } else {


### PR DESCRIPTION
- Changed the special handler that causes some contract types to start at 'Routed' to only apply to Garrison contracts. Rather than all Garrison-_type_ contracts.
- Updated 'Peaceful' morale level to include clearer tooltips.
- Added the ability for reinforcements on Garrison-Type contracts to arrive with morale between Stalemate and Overwhelming.
- Added the possibility for reinforcements on Garrison-type contracts to arrive with a substantially spiked scenario chance, representing a more substantial attack.
- Added early contract end to Riot Duty contracts. Once the riots have been quelled these contracts will end, rather than essentially becoming Garrison Duty contracts by another name.

Fix #5689