### PR TITLE
Removed Undeploy Option (again); Added Reset Scenario Deployment Option

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -476,9 +476,8 @@ public class StratconScenario implements IStratconDisplayable {
      *             {@link DeploymentChangedEvent} for updates.</li>
      * </ul>
      *
-     * <strong>Note:</strong>
-     *     <li>If the backing scenario ID is invalid or the contract is null, the method exits early
-     *         and performs no further actions.</li>
+     * <strong>Note:</strong> If the backing scenario ID is invalid or the contract is null, the
+     *                method exits early and performs no further actions.
      */
     public void resetScenario(Campaign campaign) {
         setCurrentState(UNRESOLVED);

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -470,19 +470,14 @@ public class StratconScenario implements IStratconDisplayable {
      *     <li>Resets the list of primary forces linked to the scenario.</li>
      *     <li>If the scenario has a backing {@link AtBDynamicScenario}, it fetches the corresponding contract and
      *         {@link StratconCampaignState} to handle associated track and force assignments:</li>
-     *     <ul>
-     *         <li>Clears all forces and units assigned to the scenario, detaching them appropriately.</li>
-     *         <li>Undeploys all units and clears scenario IDs for the forces and units associated with the scenario.</li>
-     *         <li>Unassigns the force from the {@link StratconTrackState} and triggers a
+     *         <li>-- Clears all forces and units assigned to the scenario, detaching them appropriately.</li>
+     *         <li>-- Undeploys all units and clears scenario IDs for the forces and units associated with the scenario.</li>
+     *         <li>-- Unassigns the force from the {@link StratconTrackState} and triggers a
      *             {@link DeploymentChangedEvent} for updates.</li>
-     *     </ul>
-     * </ul>
      *
-     * Note:
-     * <ul>
+     * <strong>Note:</strong>
      *     <li>If the backing scenario ID is invalid or the contract is null, the method exits early
      *         and performs no further actions.</li>
-     * </ul>
      */
     public void resetScenario(Campaign campaign) {
         setCurrentState(UNRESOLVED);

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -474,6 +474,7 @@ public class StratconScenario implements IStratconDisplayable {
      *         <li>-- Undeploys all units and clears scenario IDs for the forces and units associated with the scenario.</li>
      *         <li>-- Unassigns the force from the {@link StratconTrackState} and triggers a
      *             {@link DeploymentChangedEvent} for updates.</li>
+     * </ul>
      *
      * <strong>Note:</strong>
      *     <li>If the backing scenario ID is invalid or the contract is null, the method exits early

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconTrackState.java
@@ -282,6 +282,19 @@ public class StratconTrackState {
     }
 
     /**
+     * Handles the unassignment of a force from this track.
+     */
+    public void unassignUnit(int forceID) {
+        if (assignedForceCoords.containsKey(forceID)) {
+            assignedCoordForces.get(assignedForceCoords.get(forceID)).remove(forceID);
+            assignedForceCoords.remove(forceID);
+            assignedForceReturnDates.remove(forceID);
+            removeStickyForce(forceID);
+            getAssignedForceReturnDatesForStorage().remove(forceID);
+        }
+    }
+
+    /**
      * Restores the look up table of force IDs to return dates
      */
     public void restoreReturnDates() {

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -173,7 +173,7 @@ public class StratconPanel extends JPanel implements ActionListener {
         // except if there is already a non-cloaked scenario here.
         if (StratconRulesManager.canManuallyDeployAnyForce(coords, currentTrack, campaignState.getContract())) {
             menuItemManageForceAssignments = new JMenuItem();
-            menuItemManageForceAssignments.setText("Manage Force Assignment");
+            menuItemManageForceAssignments.setText("Manage Deployment");
             menuItemManageForceAssignments.setActionCommand(RCLICK_COMMAND_MANAGE_FORCES);
             menuItemManageForceAssignments.addActionListener(this);
             rightClickMenu.add(menuItemManageForceAssignments);
@@ -185,7 +185,13 @@ public class StratconPanel extends JPanel implements ActionListener {
 
             if (backingScenario != null && !backingScenario.isCloaked()) {
                 menuItemManageScenario = new JMenuItem();
-                menuItemManageScenario.setText("Manage Reinforcements");
+
+                if (scenario.getCurrentState().equals(UNRESOLVED)) {
+                    menuItemManageScenario.setText("Manage Deployment");
+                } else {
+                    menuItemManageScenario.setText("Manage Reinforcements");
+                }
+
                 menuItemManageScenario.setActionCommand(RCLICK_COMMAND_MANAGE_FORCES);
                 menuItemManageScenario.addActionListener(this);
                 rightClickMenu.add(menuItemManageScenario);
@@ -268,9 +274,9 @@ public class StratconPanel extends JPanel implements ActionListener {
                 rightClickMenu.add(removeScenarioItem);
 
                 JMenuItem resetDeploymentItem = new JMenuItem();
-                removeScenarioItem.setText("Reset Deployment (GM)");
-                removeScenarioItem.setActionCommand(RCLICK_COMMAND_RESET_DEPLOYMENT);
-                removeScenarioItem.addActionListener(this);
+                resetDeploymentItem.setText("Reset Deployment (GM)");
+                resetDeploymentItem.setActionCommand(RCLICK_COMMAND_RESET_DEPLOYMENT);
+                resetDeploymentItem.addActionListener(this);
                 rightClickMenu.add(resetDeploymentItem);
             }
         }

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -66,6 +66,7 @@ public class StratconPanel extends JPanel implements ActionListener {
     private static final String RCLICK_COMMAND_CAPTURE_FACILITY = "CaptureFacility";
     private static final String RCLICK_COMMAND_ADD_FACILITY = "AddFacility";
     private static final String RCLICK_COMMAND_REMOVE_SCENARIO = "RemoveScenario";
+    private static final String RCLICK_COMMAND_RESET_DEPLOYMENT = "ResetDeployment";
 
     /**
      * What to do when drawing a hex
@@ -209,26 +210,26 @@ public class StratconPanel extends JPanel implements ActionListener {
             rightClickMenu.addSeparator();
 
             menuItemGMReveal = new JMenuItem();
-            menuItemGMReveal.setText(currentTrack.isGmRevealed() ? "Hide Sector" : "Reveal Sector");
+            menuItemGMReveal.setText(currentTrack.isGmRevealed() ? "Hide Sector (GM)" : "Reveal Sector (GM)");
             menuItemGMReveal.setActionCommand(RCLICK_COMMAND_REVEAL_TRACK);
             menuItemGMReveal.addActionListener(this);
             rightClickMenu.add(menuItemGMReveal);
 
             if (currentTrack.getFacility(coords) != null) {
                 menuItemRemoveFacility = new JMenuItem();
-                menuItemRemoveFacility.setText("Remove Facility");
+                menuItemRemoveFacility.setText("Remove Facility (GM)");
                 menuItemRemoveFacility.setActionCommand(RCLICK_COMMAND_REMOVE_FACILITY);
                 menuItemRemoveFacility.addActionListener(this);
                 rightClickMenu.add(menuItemRemoveFacility);
 
                 menuItemSwitchOwner = new JMenuItem();
-                menuItemSwitchOwner.setText("Switch Owner");
+                menuItemSwitchOwner.setText("Switch Owner (GM)");
                 menuItemSwitchOwner.setActionCommand(RCLICK_COMMAND_CAPTURE_FACILITY);
                 menuItemSwitchOwner.addActionListener(this);
                 rightClickMenu.add(menuItemSwitchOwner);
             } else {
                 menuItemAddFacility = new JMenu();
-                menuItemAddFacility.setText("Add Facility");
+                menuItemAddFacility.setText("Add Facility (GM)");
 
                 JMenu menuItemAddAlliedFacility = new JMenu();
                 menuItemAddAlliedFacility.setText("Allied");
@@ -261,10 +262,16 @@ public class StratconPanel extends JPanel implements ActionListener {
 
             if (scenario != null) {
                 JMenuItem removeScenarioItem = new JMenuItem();
-                removeScenarioItem.setText("Remove Scenario");
+                removeScenarioItem.setText("Remove Scenario (GM)");
                 removeScenarioItem.setActionCommand(RCLICK_COMMAND_REMOVE_SCENARIO);
                 removeScenarioItem.addActionListener(this);
                 rightClickMenu.add(removeScenarioItem);
+
+                JMenuItem resetDeploymentItem = new JMenuItem();
+                removeScenarioItem.setText("Reset Deployment (GM)");
+                removeScenarioItem.setActionCommand(RCLICK_COMMAND_RESET_DEPLOYMENT);
+                removeScenarioItem.addActionListener(this);
+                rightClickMenu.add(resetDeploymentItem);
             }
         }
     }
@@ -1079,6 +1086,13 @@ public class StratconPanel extends JPanel implements ActionListener {
 
                 if (scenario != null) {
                     campaign.removeScenario(scenario.getBackingScenario());
+                }
+                break;
+            case RCLICK_COMMAND_RESET_DEPLOYMENT:
+                StratconScenario scenarioToReset = getSelectedScenario();
+
+                if (scenarioToReset != null) {
+                    scenarioToReset.resetScenario(campaign);
                 }
                 break;
         }

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1142,7 +1142,7 @@ TOEMouseAdapter extends JPopupMenuAdapter {
             }
 
             if (StaticChecks.areAllForcesDeployed(forces)) {
-                menuItem = new JMenuItem("Undeploy Force (GM)");
+                menuItem = new JMenuItem("Undeploy Force");
                 menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_FORCE + forceIds);
                 menuItem.addActionListener(this);
 
@@ -1156,7 +1156,7 @@ TOEMouseAdapter extends JPopupMenuAdapter {
                         break;
                     }
                 }
-                menuItem.setEnabled(gui.getCampaign().isGM() && enable);
+                menuItem.setEnabled(enable);
                 popup.add(menuItem);
             }
 
@@ -1669,7 +1669,7 @@ TOEMouseAdapter extends JPopupMenuAdapter {
                     }
                 }
 
-                menuItem.setEnabled(gui.getCampaign().isGM() && enable);
+                menuItem.setEnabled(enable);
                 popup.add(menuItem);
             }
 

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -60,7 +60,8 @@ import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_FALSE;
 import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_NONE;
 import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_TRUE;
 
-public class TOEMouseAdapter extends JPopupMenuAdapter {
+public class
+TOEMouseAdapter extends JPopupMenuAdapter {
     private static final MMLogger logger = MMLogger.create(TOEMouseAdapter.class);
 
     private final CampaignGUI gui;
@@ -1144,7 +1145,18 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 menuItem = new JMenuItem("Undeploy Force (GM)");
                 menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_FORCE + forceIds);
                 menuItem.addActionListener(this);
-                menuItem.setEnabled(gui.getCampaign().isGM() || !gui.getCampaign().getCampaignOptions().isUseStratCon());
+
+                boolean enable = true;
+                for (Force individualForce : forces) {
+                    int scenarioId = individualForce.getScenarioId();
+                    Scenario scenario = gui.getCampaign().getScenario(scenarioId);
+
+                    if (scenario != null && scenario.getHasTrack()) {
+                        enable = false;
+                        break;
+                    }
+                }
+                menuItem.setEnabled(gui.getCampaign().isGM() && enable);
                 popup.add(menuItem);
             }
 
@@ -1645,7 +1657,19 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                 menuItem = new JMenuItem("Undeploy Unit (GM)");
                 menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_UNIT + unitIds);
                 menuItem.addActionListener(this);
-                menuItem.setEnabled(gui.getCampaign().isGM() || !gui.getCampaign().getCampaignOptions().isUseStratCon());
+
+                boolean enable = true;
+                for (Unit individualUnit : units) {
+                    int scenarioId = individualUnit.getScenarioId();
+                    Scenario scenario = gui.getCampaign().getScenario(scenarioId);
+
+                    if (scenario != null && scenario.getHasTrack()) {
+                        enable = false;
+                        break;
+                    }
+                }
+
+                menuItem.setEnabled(gui.getCampaign().isGM() && enable);
                 popup.add(menuItem);
             }
 

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -60,8 +60,7 @@ import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_FALSE;
 import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_NONE;
 import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_TRUE;
 
-public class
-TOEMouseAdapter extends JPopupMenuAdapter {
+public class TOEMouseAdapter extends JPopupMenuAdapter {
     private static final MMLogger logger = MMLogger.create(TOEMouseAdapter.class);
 
     private final CampaignGUI gui;

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1653,7 +1653,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             }
 
             if (StaticChecks.areAllUnitsDeployed(units)) {
-                menuItem = new JMenuItem("Undeploy Unit (GM)");
+                menuItem = new JMenuItem("Undeploy Unit");
                 menuItem.setActionCommand(TOEMouseAdapter.COMMAND_UNDEPLOY_UNIT + unitIds);
                 menuItem.addActionListener(this);
 

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -37,6 +37,7 @@ import mekhq.campaign.event.RepairStatusChangedEvent;
 import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
+import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
 import mekhq.campaign.parts.enums.PartQuality;
@@ -1008,10 +1009,19 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                 }
 
                 if (oneDeployed) {
-                    menuItem = new JMenuItem("Undeploy Unit (GM)");
+                    menuItem = new JMenuItem("Undeploy Unit");
                     menuItem.setActionCommand(COMMAND_UNDEPLOY);
                     menuItem.addActionListener(this);
-                    menuItem.setEnabled(gui.getCampaign().isGM() || !gui.getCampaign().getCampaignOptions().isUseStratCon());
+
+                    boolean enable = true;
+                    int scenarioId = unit.getScenarioId();
+                    Scenario scenario = gui.getCampaign().getScenario(scenarioId);
+
+                    if (scenario != null && scenario.getHasTrack()) {
+                        enable = false;
+                    }
+
+                    menuItem.setEnabled(enable);
                     menu.add(menuItem);
                 }
 


### PR DESCRIPTION
- Changed undeploy unit/force option (in various right-click menus) to only be available if the scenario being undeployed from is not a StratCon scenario. Using these options with StratCon scenarios was causing no end of problems. I should have stuck to my guns and never restored these options after removing them last time.
- Changed undeploy unit/force to no longer require GM mode. This will improve usability for users playing non-AtB or Legacy AtB campaigns.
- Updated a number of StratCon right-click menu options to display if they are GM options for clarity.
- Improved clarity of the 'manage scenario' option in the StratCon right-click menu.
- Added a new GM option to the StratCon right-click menu to allow users to reset a scenario's deployment. This allows users to undo mistakes, where necessary. This does not restore any SP spent on reinforcements. And reassigning reinforcements will require additional reinforcement rolls, or the user to use GM Reinforcement.

Fix #5576, #5575