### PR TITLE
Fixed Multiple StratCon Bugs

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1351,6 +1351,7 @@ public class AtBDynamicScenarioFactory {
         scenario.getScenarioObjectives().clear();
 
         for (ScenarioObjective templateObjective : scenario.getTemplate().scenarioObjectives) {
+            logger.info("templateObjective:"+ templateObjective.toString());
             ScenarioObjective actualObjective = translateTemplateObjective(scenario, campaign, templateObjective);
 
             scenario.getScenarioObjectives().add(actualObjective);
@@ -1464,7 +1465,7 @@ public class AtBDynamicScenarioFactory {
      * Scale the scenario's objective time limits, if called for, by the number of
      * units that have associated force templates that "contribute to the unit count".
      */
-    private static void scaleObjectiveTimeLimits(AtBDynamicScenario scenario, Campaign campaign) {
+    public static void scaleObjectiveTimeLimits(AtBDynamicScenario scenario, Campaign campaign) {
         final int DEFAULT_TIME_LIMIT = 6;
         int primaryUnitCount = 0;
 

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -28,8 +28,11 @@ import megamek.common.options.OptionsConstants;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.mission.*;
+import mekhq.campaign.mission.AtBDynamicScenario;
+import mekhq.campaign.mission.BotForce;
+import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
+import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.campaign.mission.atb.AtBScenarioModifier.EventTiming;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.Skills;
@@ -41,8 +44,7 @@ import mekhq.campaign.universe.Factions;
 import java.util.UUID;
 
 import static mekhq.campaign.force.CombatTeam.getStandardForceSize;
-import static mekhq.campaign.mission.AtBDynamicScenarioFactory.generateForce;
-import static mekhq.campaign.mission.AtBDynamicScenarioFactory.randomForceWeight;
+import static mekhq.campaign.mission.AtBDynamicScenarioFactory.*;
 
 /**
  * Class that handles the application of scenario modifier actions to
@@ -74,9 +76,9 @@ public class AtBScenarioModifierApplicator {
      */
     private static void postAddForce(Campaign campaign, AtBDynamicScenario scenario,
             ScenarioForceTemplate templateToApply) {
-        int effectiveBV = AtBDynamicScenarioFactory.calculateEffectiveBV(scenario, campaign, false);
-        int effectiveUnitCount = AtBDynamicScenarioFactory.calculateEffectiveUnitCount(scenario, campaign, false);
-        int deploymentZone = AtBDynamicScenarioFactory.calculateDeploymentZone(templateToApply, scenario,
+        int effectiveBV = calculateEffectiveBV(scenario, campaign, false);
+        int effectiveUnitCount = calculateEffectiveUnitCount(scenario, campaign, false);
+        int deploymentZone = calculateDeploymentZone(templateToApply, scenario,
                 templateToApply.getForceName());
 
         int weightClass = randomForceWeight();
@@ -90,12 +92,13 @@ public class AtBScenarioModifierApplicator {
         // the most recently added bot force is the one we just generated
         BotForce generatedBotForce = scenario.getBotForce(scenario.getNumBots() - 1);
         generatedBotForce.setStartingPos(deploymentZone);
-        AtBDynamicScenarioFactory.setDeploymentTurns(generatedBotForce, templateToApply, scenario, campaign);
-        AtBDynamicScenarioFactory.setDestinationZone(generatedBotForce, templateToApply);
+        setDeploymentTurns(generatedBotForce, templateToApply, scenario, campaign);
+        setDestinationZone(generatedBotForce, templateToApply);
 
         // at this point, we have to re-translate the scenario objectives
         // since we're adding a force that could potentially go into any of them
-        AtBDynamicScenarioFactory.translateTemplateObjectives(scenario, campaign);
+        translateTemplateObjectives(scenario, campaign);
+        scaleObjectiveTimeLimits(scenario, campaign);
     }
 
     /**
@@ -380,7 +383,7 @@ public class AtBScenarioModifierApplicator {
 
             // if we're doing it after, we have to translate it individually
             if (timing == EventTiming.PostForceGeneration) {
-                ScenarioObjective actualObjective = AtBDynamicScenarioFactory.translateTemplateObjective(scenario,
+                ScenarioObjective actualObjective = translateTemplateObjective(scenario,
                         campaign, objective);
                 scenario.getScenarioObjectives().add(actualObjective);
             }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1282,11 +1282,21 @@ public class StratconRulesManager {
         }
 
         StratconScenario scenario = track.getScenario(coords);
-        // if we're deploying on top of a scenario, and it's "cloaked" then we have to activate it
-        if ((scenario != null) && scenario.getBackingScenario().isCloaked()) {
-            scenario.getBackingScenario().setCloaked(false);
-            setScenarioDates(0, track, campaign, scenario); // must be called before commitPrimaryForces
-            MekHQ.triggerEvent(new ScenarioChangedEvent(scenario.getBackingScenario()));
+
+        if (scenario != null) {
+            AtBDynamicScenario backingScenario = scenario.getBackingScenario();
+
+            if (backingScenario != null) {
+                if (backingScenario.isCloaked()) {
+                    backingScenario.setCloaked(false);
+                }
+
+                if (backingScenario.getDate() == null) {
+                    setScenarioDates(0, track, campaign, scenario);
+                }
+
+                MekHQ.triggerEvent(new ScenarioChangedEvent(backingScenario));
+            }
         }
 
         // Traverse neighboring coordinates up to the specified distance

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -66,6 +66,7 @@ import static megamek.common.Coords.ALL_DIRECTIONS;
 import static megamek.common.UnitType.*;
 import static mekhq.campaign.force.Force.FORCE_NONE;
 import static mekhq.campaign.icons.enums.OperationalStatus.determineLayeredForceIconOperationalStatus;
+import static mekhq.campaign.mission.AtBDynamicScenarioFactory.finalizeScenario;
 import static mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment.Allied;
 import static mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment.Opposing;
 import static mekhq.campaign.mission.ScenarioMapParameters.MapLocation.AllGroundTerrain;
@@ -594,7 +595,7 @@ public class StratconRulesManager {
         }
 
         // Finally, finish scenario set up
-        AtBDynamicScenarioFactory.finalizeScenario(backingScenario, contract, campaign);
+        finalizeScenario(backingScenario, contract, campaign);
         setScenarioParametersFromBiome(track, scenario);
         swapInPlayerUnits(scenario, campaign, FORCE_NONE);
 
@@ -973,9 +974,11 @@ public class StratconRulesManager {
         // afterward
         StratconScenario revealedScenario = track.getScenario(coords);
         if (revealedScenario != null) {
+            if (!revealedScenario.getBackingScenario().isFinalized()) {
+                finalizeScenario(revealedScenario.getBackingScenario(), contract, campaign);
+                setScenarioParametersFromBiome(track, revealedScenario);
+            }
             revealedScenario.addPrimaryForce(forceID);
-            AtBDynamicScenarioFactory.finalizeScenario(revealedScenario.getBackingScenario(), contract, campaign);
-            setScenarioParametersFromBiome(track, revealedScenario);
             commitPrimaryForces(campaign, revealedScenario, track);
             return;
         }

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -32,7 +32,6 @@ import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconRulesManager;
-import mekhq.campaign.stratcon.StratconRulesManager.*;
 import mekhq.campaign.stratcon.StratconScenario;
 import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
 import mekhq.campaign.stratcon.StratconTrackState;
@@ -46,6 +45,7 @@ import java.awt.event.ActionEvent;
 import java.util.List;
 import java.util.*;
 
+import static mekhq.campaign.mission.AtBDynamicScenarioFactory.scaleObjectiveTimeLimits;
 import static mekhq.campaign.mission.AtBDynamicScenarioFactory.translateTemplateObjectives;
 import static mekhq.campaign.personnel.SkillType.S_LEADER;
 import static mekhq.campaign.stratcon.StratconRulesManager.*;
@@ -907,6 +907,7 @@ public class StratconScenarioWizard extends JDialog {
         currentScenario.updateMinefieldCount(Minefield.TYPE_CONVENTIONAL, getNumMinefields());
 
         translateTemplateObjectives(currentScenario.getBackingScenario(), campaign);
+        scaleObjectiveTimeLimits(currentScenario.getBackingScenario(), campaign);
 
         this.getParent().repaint();
 

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -28,13 +28,11 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Campaign.AdministratorSpecialization;
 import mekhq.campaign.force.Force;
-import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconRulesManager;
-import mekhq.campaign.stratcon.StratconRulesManager.ReinforcementEligibilityType;
-import mekhq.campaign.stratcon.StratconRulesManager.ReinforcementResultsType;
+import mekhq.campaign.stratcon.StratconRulesManager.*;
 import mekhq.campaign.stratcon.StratconScenario;
 import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
 import mekhq.campaign.stratcon.StratconTrackState;
@@ -50,12 +48,9 @@ import java.util.*;
 
 import static mekhq.campaign.mission.AtBDynamicScenarioFactory.translateTemplateObjectives;
 import static mekhq.campaign.personnel.SkillType.S_LEADER;
-import static mekhq.campaign.stratcon.StratconRulesManager.BASE_LEADERSHIP_BUDGET;
+import static mekhq.campaign.stratcon.StratconRulesManager.*;
 import static mekhq.campaign.stratcon.StratconRulesManager.ReinforcementResultsType.DELAYED;
 import static mekhq.campaign.stratcon.StratconRulesManager.ReinforcementResultsType.FAILED;
-import static mekhq.campaign.stratcon.StratconRulesManager.calculateReinforcementTargetNumber;
-import static mekhq.campaign.stratcon.StratconRulesManager.getEligibleLeadershipUnits;
-import static mekhq.campaign.stratcon.StratconRulesManager.processReinforcementDeployment;
 import static mekhq.gui.baseComponents.AbstractMHQNagDialog.getSpeakerDescription;
 import static mekhq.gui.dialog.resupplyAndCaches.ResupplyDialogUtilities.getSpeakerIcon;
 import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
@@ -557,7 +552,7 @@ public class StratconScenarioWizard extends JDialog {
         StringBuilder costBuilder = new StringBuilder();
         costBuilder.append('(');
 
-        switch (StratconRulesManager.getReinforcementType(forceID, currentTrackState, campaign, currentCampaignState)) {
+        switch (getReinforcementType(forceID, currentTrackState, campaign, currentCampaignState)) {
             case REGULAR:
                 costBuilder.append(resources.getString("regular.text"));
                 break;
@@ -858,23 +853,9 @@ public class StratconScenarioWizard extends JDialog {
         // go through all the force lists and add the selected forces to the scenario
         for (String templateID : availableForceLists.keySet()) {
             for (Force force : availableForceLists.get(templateID).getSelectedValuesList()) {
-                if (templateID.equals(ScenarioForceTemplate.PRIMARY_FORCE_TEMPLATE_ID)) {
-                    if (currentScenario.getCurrentState() == ScenarioState.UNRESOLVED) {
-                        currentScenario.addForce(force, templateID, campaign);
-                    }
-                } else if (currentScenario.getCurrentState() == ScenarioState.PRIMARY_FORCES_COMMITTED) {
-                    ReinforcementEligibilityType reinforcementType = StratconRulesManager.getReinforcementType(
-                        force.getId(), currentTrackState,
-                        campaign, currentCampaignState);
-
-                    // if we failed to deploy as reinforcements, move on to the next force
-                    if (reinforcementTargetNumber == null) {
-                        // If we've passed a null value into a reinforcement attempt, treat it as
-                        // an impossibly large number, so that it's clear something is wrong.
-                        reinforcementTargetNumber = 999;
-                        logger.error("null reinforcementTargetNumber incorrectly passed into" +
-                            " btnCommitClicked for reinforcement attempt");
-                    }
+                if (currentScenario.getCurrentState() == ScenarioState.PRIMARY_FORCES_COMMITTED) {
+                    ReinforcementEligibilityType reinforcementType = getReinforcementType(
+                        force.getId(), currentTrackState, campaign, currentCampaignState);
 
                     ReinforcementResultsType reinforcementResults = processReinforcementDeployment(force,
                         reinforcementType, currentCampaignState, currentScenario, campaign,
@@ -923,30 +904,13 @@ public class StratconScenarioWizard extends JDialog {
                     forceID, campaign, currentTrackState, false);
         }
 
-        // scenarios that haven't had primary forces committed yet get those committed
-        // now and the scenario gets published to the campaign and may be played immediately
-        // from the briefing room that being said, give the player a chance to commit reinforcements too
-        if (currentScenario.getCurrentState() == ScenarioState.UNRESOLVED) {
-            // if we've already generated forces and applied modifiers, no need to do it twice
-            if (!currentScenario.getBackingScenario().isFinalized()) {
-                AtBDynamicScenarioFactory.finalizeScenario(currentScenario.getBackingScenario(),
-                        currentCampaignState.getContract(), campaign);
-                StratconRulesManager.setScenarioParametersFromBiome(currentTrackState, currentScenario);
-            }
-
-            setCurrentScenario(currentScenario, currentTrackState, currentCampaignState, true);
-            currentScenario.updateMinefieldCount(Minefield.TYPE_CONVENTIONAL, getNumMinefields());
-            StratconRulesManager.commitPrimaryForces(campaign, currentScenario, currentTrackState);
-            setVisible(true);
-        // if we've just committed reinforcements then simply close it down
-        } else {
-            currentScenario.updateMinefieldCount(Minefield.TYPE_CONVENTIONAL, getNumMinefields());
-            setVisible(false);
-        }
+        currentScenario.updateMinefieldCount(Minefield.TYPE_CONVENTIONAL, getNumMinefields());
 
         translateTemplateObjectives(currentScenario.getBackingScenario(), campaign);
 
         this.getParent().repaint();
+
+        dispose();
     }
 
     /**


### PR DESCRIPTION
- Stopped scenarios regenerating when reinforcements were applied.
- Stopped Patrol forces failing to generate scenarios if they land on top of an enemy facility
- Cleaned up some leftover code from prior to 50.02
- Ensured scenario objective time limits are recalculated when recalculating objectives

Fix #5636, #5697, #5603