### PR TITLE
Corrected Weight Class Initialization of Artillery Units

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1840,7 +1840,7 @@ public class AtBDynamicScenarioFactory {
         if (unitData == null) {
             if (!params.getMissionRoles().isEmpty()) {
                 logger.warn(String.format("Unable to randomly generate %s %s with roles: %s",
-                        EntityWeightClass.getClassName(params.getWeightClass()),
+                        params.getWeightClass(),
                         getTypeName(TANK),
                         params.getMissionRoles().stream().map(Enum::name).collect(Collectors.joining(","))));
             }

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -77,6 +77,7 @@ import static mekhq.campaign.mission.Scenario.T_GROUND;
 import static mekhq.campaign.mission.ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_AERO_MIX;
 import static mekhq.campaign.mission.ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_CIVILIANS;
 import static mekhq.campaign.mission.ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX;
+import static mekhq.campaign.universe.IUnitGenerator.unitTypeSupportsWeightClass;
 
 /**
  * This class handles the creation and substantive manipulation of
@@ -671,10 +672,10 @@ public class AtBDynamicScenarioFactory {
                     // Formations composed entirely of Meks, aerospace fighters (but not conventional),
                     // and ground vehicles use weight categories as do SPECIAL_UNIT_TYPE_ATB_MIX.
                     // Formations of other types, plus artillery formations do not use weight classes.
+                    boolean supportsWeightClass = unitTypeSupportsWeightClass(actualUnitType);
                     if ((actualUnitType == SPECIAL_UNIT_TYPE_ATB_MIX
                         || actualUnitType == SPECIAL_UNIT_TYPE_ATB_CIVILIANS
-                        || IUnitGenerator.unitTypeSupportsWeightClass(actualUnitType))
-                        && !forceTemplate.getUseArtillery()) {
+                        || supportsWeightClass)) {
 
                         // Generate a specific weight class for each unit based on the formation weight
                         // class and lower/upper bounds


### PR DESCRIPTION
- Scenario generation was treated artillery formations as if they did not use weight classes, resulting in generation failing due to an illegal weight class of -1.
- Changed artillery formations to now be treated like any other formation, allowing for unit substitution in instances where generation fails.
- Changed generation failure messaging to cite weight class integer, not name. This means that if we ever try passing an illegal weight class we will be able to see exactly what was passed, rather than getting an `IllegalArgumentException`

Fix #5694