### PR TITLE
Fixed Personality Loading

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2585,44 +2585,61 @@ public class Person {
                 } else if (wn2.getNodeName().equalsIgnoreCase("aggression")) {
                     try {
                         // <50.01 compatibility handler
-                        retVal.aggression = Aggression.parseFromString(wn2.getTextContent());
-                    } catch (Exception e) {
+                        retVal.aggression = Aggression.valueOf(wn2.getTextContent()
+                            .toUpperCase()
+                            .replaceAll("-", "_")
+                            .replaceAll(" ", "_"));
+                    } catch (IllegalArgumentException e) {
                         retVal.aggression = Aggression.fromOrdinal(Integer.parseInt(wn2.getTextContent()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("ambition")) {
                     try {
                         // <50.01 compatibility handler
-                        retVal.ambition = Ambition.parseFromString(wn2.getTextContent());
-                    } catch (Exception e) {
+                        retVal.ambition = Ambition.valueOf(wn2.getTextContent()
+                            .toUpperCase()
+                            .replaceAll("-", "_")
+                            .replaceAll(" ", "_"));
+                    } catch (IllegalArgumentException e) {
                         retVal.ambition = Ambition.fromOrdinal(Integer.parseInt(wn2.getTextContent()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("greed")) {
                     try {
                         // <50.01 compatibility handler
-                        retVal.greed = Greed.parseFromString(wn2.getTextContent());
-                    } catch (Exception e) {
+                        retVal.greed = Greed.valueOf(wn2.getTextContent()
+                            .toUpperCase()
+                            .replaceAll("-", "_")
+                            .replaceAll(" ", "_"));
+                    } catch (IllegalArgumentException e) {
                         retVal.greed = Greed.fromOrdinal(Integer.parseInt(wn2.getTextContent()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("social")) {
                     try {
                         // <50.01 compatibility handler
-                        retVal.social = Social.parseFromString(wn2.getTextContent());
-                    } catch (Exception e) {
+                        retVal.social = Social.valueOf(wn2.getTextContent()
+                            .toUpperCase()
+                            .replaceAll("-", "_")
+                            .replaceAll(" ", "_"));
+                    } catch (IllegalArgumentException e) {
                         retVal.social = Social.fromOrdinal(Integer.parseInt(wn2.getTextContent()));
                     }
-                    retVal.social = Social.parseFromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("personalityQuirk")) {
                     try {
                         // <50.01 compatibility handler
-                        retVal.personalityQuirk = PersonalityQuirk.parseFromString(wn2.getTextContent());
-                    } catch (Exception e) {
+                        retVal.personalityQuirk = PersonalityQuirk.valueOf(wn2.getTextContent()
+                            .toUpperCase()
+                            .replaceAll("-", "_")
+                            .replaceAll(" ", "_"));
+                    } catch (IllegalArgumentException e) {
                         retVal.personalityQuirk = PersonalityQuirk.fromOrdinal(Integer.parseInt(wn2.getTextContent()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("intelligence")) {
                     try {
                         // <50.01 compatibility handler
-                        retVal.intelligence = Intelligence.parseFromString(wn2.getTextContent());
-                    } catch (Exception e) {
+                        retVal.intelligence = Intelligence.valueOf(wn2.getTextContent()
+                            .toUpperCase()
+                            .replaceAll("-", "_")
+                            .replaceAll(" ", "_"));
+                    } catch (IllegalArgumentException e) {
                         retVal.intelligence = Intelligence.fromOrdinal(Integer.parseInt(wn2.getTextContent()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("personalityDescription")) {

--- a/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/Aggression.java
+++ b/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/Aggression.java
@@ -111,58 +111,6 @@ public enum Aggression {
 
     // region File I/O
     /**
-     * Parses a given string and returns the corresponding Aggression enum.
-     * Accepts either the ENUM ordinal value or its name
-     *
-     * @param aggression the string to be parsed
-     * @return the Aggression enum that corresponds to the given string
-     * @throws IllegalStateException if the given string does not match any valid
-     *                               Aggression
-     */
-    @Deprecated
-    public static Aggression parseFromString(final String aggression) {
-        return switch (aggression) {
-            case "0", "None" -> NONE;
-            // Minor Characteristics
-            case "1", "Bold" -> BOLD;
-            case "2", "Aggressive" -> AGGRESSIVE;
-            case "3", "Assertive" -> ASSERTIVE;
-            case "4", "Belligerent" -> BELLIGERENT;
-            case "5", "Brash" -> BRASH;
-            case "6", "Confident" -> CONFIDENT;
-            case "7", "Courageous" -> COURAGEOUS;
-            case "8", "Daring" -> DARING;
-            case "9", "Decisive" -> DECISIVE;
-            case "10", "Determined" -> DETERMINED;
-            case "11", "Domineering" -> DOMINEERING;
-            case "12", "Fearless" -> FEARLESS;
-            case "13", "Hostile" -> HOSTILE;
-            case "14", "Hot-Headed" -> HOT_HEADED;
-            case "15", "Impetuous" -> IMPETUOUS;
-            case "16", "Impulsive" -> IMPULSIVE;
-            case "17", "Inflexible" -> INFLEXIBLE;
-            case "18", "Intrepid" -> INTREPID;
-            case "19", "Overbearing" -> OVERBEARING;
-            case "20", "Reckless" -> RECKLESS;
-            case "21", "Resolute" -> RESOLUTE;
-            case "22", "Stubborn" -> STUBBORN;
-            case "23", "Tenacious" -> TENACIOUS;
-            case "24", "Vigilant" -> VIGILANT;
-            // Major Characteristics
-            case "25", "Bloodthirsty" -> BLOODTHIRSTY;
-            case "26", "Diplomatic" -> DIPLOMATIC;
-            case "27", "Murderous" -> MURDEROUS;
-            case "28", "Pacifistic" -> PACIFISTIC;
-            case "29", "Sadistic" -> SADISTIC;
-            case "30", "Savage" -> SAVAGE;
-            default ->
-                throw new IllegalStateException(
-                        "Unexpected value in mekhq/campaign/personnel/enums/randomEvents/personalities/Aggression.java/parseFromString: "
-                                + aggression);
-        };
-    }
-
-    /**
      * Returns the {@link Aggression} associated with the given ordinal.
      *
      * @param ordinal the ordinal value of the {@link Aggression}
@@ -170,13 +118,11 @@ public enum Aggression {
      * {@code NONE} if not found
      */
     public static Aggression fromOrdinal(int ordinal) {
-        for (Aggression aggression : values()) {
-            if (aggression.ordinal() == ordinal) {
-                return aggression;
-            }
+        if ((ordinal >= 0) && (ordinal < values().length)) {
+            return values()[ordinal];
         }
 
-        final MMLogger logger = MMLogger.create(Aggression.class);
+        MMLogger logger = MMLogger.create(Aggression.class);
         logger.error(String.format("Unknown Aggression ordinal: %s - returning NONE.", ordinal));
 
         return NONE;

--- a/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/Ambition.java
+++ b/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/Ambition.java
@@ -109,58 +109,6 @@ public enum Ambition {
 
     // region File I/O
     /**
-     * Parses a given string and returns the corresponding Ambition enum.
-     * Accepts either the ENUM ordinal value or its name
-     *
-     * @param ambition the string to be parsed
-     * @return the Ambition enum that corresponds to the given string
-     * @throws IllegalStateException if the given string does not match any valid
-     *                               Ambition
-     */
-    @Deprecated
-    public static Ambition parseFromString(final String ambition) {
-        return switch (ambition) {
-            case "0", "None" -> NONE;
-            // Minor Characteristics
-            case "1", "Ambitious" -> AMBITIOUS;
-            case "2", "Arrogant" -> ARROGANT;
-            case "3", "Aspiring" -> ASPIRING;
-            case "4", "Calculating" -> CALCULATING;
-            case "5", "Conniving" -> CONNIVING;
-            case "6", "Controlling" -> CONTROLLING;
-            case "7", "Cutthroat" -> CUTTHROAT;
-            case "8", "Diligent" -> DILIGENT;
-            case "9", "Driven" -> DRIVEN;
-            case "10", "Energetic" -> ENERGETIC;
-            case "11", "Excessive" -> EXCESSIVE;
-            case "12", "Focused" -> FOCUSED;
-            case "13", "Goal-Oriented" -> GOAL_ORIENTED;
-            case "14", "Motivated" -> MOTIVATED;
-            case "15", "Opportunistic" -> OPPORTUNISTIC;
-            case "16", "Overconfident" -> OVERCONFIDENT;
-            case "17", "Persistent" -> PERSISTENT;
-            case "18", "Proactive" -> PROACTIVE;
-            case "19", "Resilient" -> RESILIENT;
-            case "20", "Ruthless" -> RUTHLESS;
-            case "21", "Selfish" -> SELFISH;
-            case "22", "Strategic" -> STRATEGIC;
-            case "23", "Unambitious" -> UNAMBITIOUS;
-            case "24", "Unscrupulous" -> UNSCRUPULOUS;
-            // Major Characteristics
-            case "25", "Dishonest" -> DISHONEST;
-            case "26", "Innovative" -> INNOVATIVE;
-            case "27", "Manipulative" -> MANIPULATIVE;
-            case "28", "Resourceful" -> RESOURCEFUL;
-            case "29", "Tyrannical" -> TYRANNICAL;
-            case "30", "Visionary" -> VISIONARY;
-            default ->
-                throw new IllegalStateException(
-                        "Unexpected value in mekhq/campaign/personnel/enums/randomEvents/personalities/Ambition.java/parseFromString: "
-                                + ambition);
-        };
-    }
-
-    /**
      * Returns the {@link Ambition} associated with the given ordinal.
      *
      * @param ordinal the ordinal value of the {@link Ambition}
@@ -168,13 +116,11 @@ public enum Ambition {
      * {@code NONE} if not found
      */
     public static Ambition fromOrdinal(int ordinal) {
-        for (Ambition ambition : values()) {
-            if (ambition.ordinal() == ordinal) {
-                return ambition;
-            }
+        if ((ordinal >= 0) && (ordinal < values().length)) {
+            return values()[ordinal];
         }
 
-        final MMLogger logger = MMLogger.create(Ambition.class);
+        MMLogger logger = MMLogger.create(Ambition.class);
         logger.error(String.format("Unknown Ambition ordinal: %s - returning NONE.", ordinal));
 
         return NONE;

--- a/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/Greed.java
+++ b/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/Greed.java
@@ -109,58 +109,6 @@ public enum Greed {
 
     // region File I/O
     /**
-     * Parses a given string and returns the corresponding Greed enum.
-     * Accepts either the ENUM ordinal value, or its name
-     *
-     * @param greed the string to be parsed
-     * @return the Greed enum that corresponds to the given string
-     * @throws IllegalStateException if the given string does not match any valid
-     *                               Greed
-     */
-    @Deprecated
-    public static Greed parseFromString(final String greed) {
-        return switch (greed) {
-            case "0", "None" -> NONE;
-            // Minor Characteristics
-            case "1", "Astute" -> ASTUTE;
-            case "2", "Adept" -> ADEPT;
-            case "3", "Avaricious" -> AVARICIOUS;
-            case "4", "Dynamic" -> DYNAMIC;
-            case "5", "Eager" -> EAGER;
-            case "6", "Exploitative" -> EXPLOITATIVE;
-            case "7", "Fraudulent" -> FRAUDULENT;
-            case "8", "Generous" -> GENEROUS;
-            case "9", "Greedy" -> GREEDY;
-            case "10", "Hoarding" -> HOARDING;
-            case "11", "Insatiable" -> INSATIABLE;
-            case "12", "Insightful" -> INSIGHTFUL;
-            case "13", "Judicious" -> JUDICIOUS;
-            case "14", "Lustful" -> LUSTFUL;
-            case "15", "Mercenary" -> MERCENARY;
-            case "16", "Overreaching" -> OVERREACHING;
-            case "17", "Profitable" -> PROFITABLE;
-            case "18", "Savvy" -> SAVVY;
-            case "19", "Self-Serving" -> SELF_SERVING;
-            case "20", "Shameless" -> SHAMELESS;
-            case "21", "Shrewd" -> SHREWD;
-            case "22", "Tactical" -> TACTICAL;
-            case "23", "Unprincipled" -> UNPRINCIPLED;
-            case "24", "Voracious" -> VORACIOUS;
-            // Major Characteristics
-            case "25", "Corrupt" -> CORRUPT;
-            case "26", "Enterprising" -> ENTERPRISING;
-            case "27", "Intuitive" -> INTUITIVE;
-            case "28", "Meticulous" -> METICULOUS;
-            case "29", "Nefarious" -> NEFARIOUS;
-            case "30", "Thief" -> THIEF;
-            default ->
-                throw new IllegalStateException(
-                        "Unexpected value in mekhq/campaign/personnel/enums/randomEvents/personalities/Greed.java/parseFromString: "
-                                + greed);
-        };
-    }
-
-    /**
      * Returns the {@link Greed} associated with the given ordinal.
      *
      * @param ordinal the ordinal value of the {@link Greed}
@@ -168,13 +116,11 @@ public enum Greed {
      * {@code NONE} if not found
      */
     public static Greed fromOrdinal(int ordinal) {
-        for (Greed greed : values()) {
-            if (greed.ordinal() == ordinal) {
-                return greed;
-            }
+        if ((ordinal >= 0) && (ordinal < values().length)) {
+            return values()[ordinal];
         }
 
-        final MMLogger logger = MMLogger.create(Greed.class);
+        MMLogger logger = MMLogger.create(Greed.class);
         logger.error(String.format("Unknown Greed ordinal: %s - returning NONE.", ordinal));
 
         return NONE;

--- a/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/Intelligence.java
+++ b/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/Intelligence.java
@@ -81,50 +81,6 @@ public enum Intelligence {
 
     // region File I/O
     /**
-     * Parses a given string and returns the corresponding Quirk enum.
-     * Accepts either the ENUM ordinal value, or its name
-     *
-     * @param quirk the string to be parsed
-     * @return the Greed enum that corresponds to the given string
-     * @throws IllegalStateException if the given string does not match any valid
-     *                               Quirk
-     */
-    @Deprecated
-    public static Intelligence parseFromString(final String quirk) {
-        return switch (quirk) {
-            case "0", "Brain Dead" -> BRAIN_DEAD;
-            case "1", "Unintelligent" -> UNINTELLIGENT;
-            case "2", "Feeble Minded", "Foolish" -> FOOLISH;
-            case "3", "Simple" -> SIMPLE;
-            case "4", "Slow to Comprehend", "Slow" -> SLOW;
-            case "5", "Uninspired" -> UNINSPIRED;
-            case "6", "Dull" -> DULL;
-            case "7", "Dimwitted" -> DIMWITTED;
-            case "8", "Obtuse" -> OBTUSE;
-            case "9", "Below Average" -> BELOW_AVERAGE;
-            case "10", "Under Performing" -> UNDER_PERFORMING;
-            case "11", "Limited Insight" -> LIMITED_INSIGHT;
-            case "12", "Average" -> AVERAGE;
-            case "13", "Above Average" -> ABOVE_AVERAGE;
-            case "14", "Studious" -> STUDIOUS;
-            case "15", "Discerning" -> DISCERNING;
-            case "16", "Sharp" -> SHARP;
-            case "17", "Quick-Witted" -> QUICK_WITTED;
-            case "18", "Perceptive" -> PERCEPTIVE;
-            case "19", "Bright" -> BRIGHT;
-            case "20", "Clever" -> CLEVER;
-            case "21", "Intellectual" -> INTELLECTUAL;
-            case "22", "Brilliant" -> BRILLIANT;
-            case "23", "Exceptional" -> EXCEPTIONAL;
-            case "24", "Genius" -> GENIUS;
-            default ->
-                throw new IllegalStateException(
-                        "Unexpected value in mekhq/campaign/personnel/enums/randomEvents/personalities/PersonalityQuirk.java/parseFromString: "
-                                + quirk);
-        };
-    }
-
-    /**
      * Returns the {@link Intelligence} associated with the given ordinal.
      *
      * @param ordinal the ordinal value of the {@link Intelligence}
@@ -132,13 +88,11 @@ public enum Intelligence {
      * {@code AVERAGE} if not found
      */
     public static Intelligence fromOrdinal(int ordinal) {
-        for (Intelligence intelligence : values()) {
-            if (intelligence.ordinal() == ordinal) {
-                return intelligence;
-            }
+        if ((ordinal >= 0) && (ordinal < values().length)) {
+            return values()[ordinal];
         }
 
-        final MMLogger logger = MMLogger.create(Intelligence.class);
+        MMLogger logger = MMLogger.create(Intelligence.class);
         logger.error(String.format("Unknown Intelligence ordinal: %s - returning AVERAGE.", ordinal));
 
         return AVERAGE;

--- a/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/PersonalityQuirk.java
+++ b/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/PersonalityQuirk.java
@@ -274,127 +274,6 @@ public enum PersonalityQuirk {
 
     // region File I/O
     /**
-     * Parses a given string and returns the corresponding Quirk enum.
-     * Accepts either the ENUM ordinal value, or its name
-     *
-     * @param quirk the string to be parsed
-     * @return the Greed enum that corresponds to the given string
-     * @throws IllegalStateException if the given string does not match any valid
-     *                               Quirk
-     */
-    @Deprecated
-    public static PersonalityQuirk parseFromString(final String quirk) {
-        return switch (quirk) {
-            case "0", "none" -> NONE;
-            case "1", "Constantly Adjusting Clothes" -> ADJUSTS_CLOTHES;
-            case "2", "Overly Affectionate" -> AFFECTIONATE;
-            case "3", "Overly Apologetic" -> APOLOGETIC;
-            case "4", "Always Reading" -> BOOKWORM;
-            case "5", "Keeps a Personal Calendar" -> CALENDAR;
-            case "6", "Fond of Scented Candles" -> CANDLES;
-            case "7", "Always Chewing Gum" -> CHEWING_GUM;
-            case "8", "Chronically Late" -> CHRONIC_LATENESS;
-            case "9", "Compulsive Cleaner" -> CLEANER;
-            case "10", "Collects Odd Items" -> COLLECTOR;
-            case "11", "Competitive Nature" -> COMPETITIVE_NATURE;
-            case "12", "Excessive Complimenter" -> COMPLIMENTS;
-            case "13", "Prone to Daydreaming" -> DAYDREAMER;
-            case "14", "Compulsive Doodler" -> DOODLER;
-            case "15", "Talks to Animals" -> DOOLITTLE;
-            case "16", "Overly Dramatic" -> DRAMATIC;
-            case "17", "Unpredictable Eating Habits" -> EATING_HABITS;
-            case "18", "Extreme Environmental Sensitivity" -> ENVIRONMENTAL_SENSITIVITY;
-            case "19", "Excessive Caution" -> EXCESSIVE_CAUTION;
-            case "20", "Over-the-Top Greetings" -> EXCESSIVE_GREETING;
-            case "21", "Intense Eye Contact" -> EYE_CONTACT;
-            case "22", "Eccentric Fashion Choices" -> FASHION_CHOICES;
-            case "23", "Constantly Fidgeting" -> FIDGETS;
-            case "24", "Extreme Personal Fitness Routine" -> FITNESS;
-            case "25", "Fixates on One Topic" -> FIXATES;
-            case "26", "Carries a Flask" -> FLASK;
-            case "27", "Always Tapping Foot" -> FOOT_TAPPER;
-            case "28", "Chronically Forgetful" -> FORGETFUL;
-            case "29", "Overly Formal Speech" -> FORMAL_SPEECH;
-            case "30", "Constantly Rearranges Furniture" -> FURNITURE;
-            case "31", "Constantly Adjusts Glasses" -> GLASSES;
-            case "32", "Always Wearing Gloves" -> GLOVES;
-            case "33", "Excessive Hand Gestures" -> HAND_GESTURES;
-            case "34", "Compulsive Hand-Wringer" -> HAND_WRINGER;
-            case "35", "Overly Enthusiastic Handshake" -> HANDSHAKE;
-            case "36", "Always Wearing Headphones" -> HEADPHONES;
-            case "37", "Frequently Snacking on Healthy Foods" -> HEALTHY_SNACKS;
-            case "38", "Passionate about History" -> HISTORIAN;
-            case "39", "Habitual Hummer" -> HUMMER;
-            case "40", "Obsessed with Hygiene" -> HYGIENIC;
-            case "41", "Unusual Sleep Patterns" -> IRREGULAR_SLEEPER;
-            case "42", "Fond of Puns" -> JOKER;
-            case "43", "Compulsive List Maker" -> LISTS;
-            case "44", "Overly Literal" -> LITERAL;
-            case "45", "Checks Locks Repeatedly" -> LOCKS;
-            case "46", "Tends to Speak in a Measured Pace" -> MEASURED_TALKER;
-            case "47", "Extreme Minimalism" -> MINIMALIST;
-            case "48", "Prefers Using a Specific Mug" -> MUG;
-            case "49", "Constant Nail Biter" -> NAIL_BITER;
-            case "50", "Frequent Nicknaming" -> NICKNAMING;
-            case "51", "Night Owl" -> NIGHT_OWL;
-            case "52", "Compulsive Note-Taking" -> NOTE_TAKER;
-            case "53", "Always Carrying a Notebook" -> NOTEBOOK;
-            case "54", "Carries a Personal Object" -> OBJECT;
-            case "55", "Obsessive Organizational Tendencies" -> ORGANIZATIONAL_TENDENCIES;
-            case "56", "Always Organizing" -> ORGANIZER;
-            case "57", "Fond of Origami" -> ORIGAMI;
-            case "58", "Obsessive Over-Planner" -> OVER_PLANNER;
-            case "59", "Chronic Overexplainer" -> OVEREXPLAINER;
-            case "60", "abitual Pen Clicker" -> PEN_CLICKER;
-            case "61", "Habitual Pen Twirler" -> PEN_TWIRLER;
-            case "62", "Overly Friendly with Equipment" -> PERSONIFICATION;
-            case "63", "Habitual Pessimist" -> PESSIMIST;
-            case "64", "Tends to Use Specific Phrases" -> PHRASES;
-            case "65", "Loves Plants" -> PLANTS;
-            case "66", "Excessive Politeness" -> POLITE;
-            case "67", "Loves Practical Jokes" -> PRACTICAL_JOKER;
-            case "68", "Always Prepared" -> PREPARED;
-            case "69", "Overly Punctual" -> PUNCTUAL;
-            case "70", "Obsessed with Puzzles" -> PUZZLES;
-            case "71", "Collects Quotes" -> QUOTES;
-            case "72", "Rarely Sleeps" -> RARELY_SLEEPS;
-            case "73", "Has a Routine for Small Tasks" -> ROUTINE;
-            case "74", "Constantly Seeking Approval" -> SEEKS_APPROVAL;
-            case "75", "Overly Sentimental" -> SENTIMENTAL;
-            case "76", "Compulsive Sharpening" -> SHARPENING;
-            case "77", "Sings to Themselves" -> SINGS;
-            case "78", "Chronically Skeptical" -> SKEPTICAL;
-            case "79", "Talks in Sleep" -> SLEEP_TALKER;
-            case "80", "Compulsive Smiler" -> SMILER;
-            case "81", "Always Has a Snack" -> SNACKS;
-            case "82", "Compulsive Storytelling" -> STORYTELLING;
-            case "83", "Constantly Stretching" -> STRETCHING;
-            case "84", "Superstitious Rituals" -> SUPERSTITIOUS_RITUALS;
-            case "85", "Highly Supervised Habits" -> SUPERVISED_HABITS;
-            case "86", "Incessant Tech Talk" -> TECH_TALK;
-            case "87", "Phobia of Technology" -> TECHNOPHOBIA;
-            case "88", "Uses Obscure Words" -> THESAURUS;
-            case "89", "Speaks in Third Person" -> THIRD_PERSON;
-            case "90", "Obsessed with Time Management" -> TIME_MANAGEMENT;
-            case "91", "Compulsive Tinkerer" -> TINKERER;
-            case "92", "Habitual Truth-Teller" -> TRUTH_TELLER;
-            case "93", "Unnecessary Caution" -> UNNECESSARY_CAUTION;
-            case "94", "Unpredictable Speech" -> UNPREDICTABLE_SPEECH;
-            case "95", "Unusual Hobbies" -> UNUSUAL_HOBBIES;
-            case "96", "Constantly Checking the Time" -> WATCH;
-            case "97", "Obsessed with Weather" -> WEATHERMAN;
-            case "98", "Frequent Whistler" -> WHISTLER;
-            case "99", "Persistent Worrier" -> WORRIER;
-            case "100", "Writes Everything Down" -> WRITER;
-            case "101", "Constantly Reminiscing" -> BATTLEFIELD_NOSTALGIA;
-            default ->
-                throw new IllegalStateException(
-                        "Unexpected value in mekhq/campaign/personnel/enums/randomEvents/personalities/PersonalityQuirk.java/parseFromString: "
-                                + quirk);
-        };
-    }
-
-    /**
      * Returns the {@link PersonalityQuirk} associated with the given ordinal.
      *
      * @param ordinal the ordinal value of the {@link PersonalityQuirk}
@@ -402,13 +281,11 @@ public enum PersonalityQuirk {
      * {@code NONE} if not found
      */
     public static PersonalityQuirk fromOrdinal(int ordinal) {
-        for (PersonalityQuirk quirk : values()) {
-            if (quirk.ordinal() == ordinal) {
-                return quirk;
-            }
+        if ((ordinal >= 0) && (ordinal < values().length)) {
+            return values()[ordinal];
         }
 
-        final MMLogger logger = MMLogger.create(PersonalityQuirk.class);
+        MMLogger logger = MMLogger.create(PersonalityQuirk.class);
         logger.error(String.format("Unknown PersonalityQuirk ordinal: %s - returning NONE.", ordinal));
 
         return NONE;

--- a/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/Social.java
+++ b/MekHQ/src/mekhq/campaign/personnel/randomEvents/enums/personalities/Social.java
@@ -109,58 +109,6 @@ public enum Social {
 
     // region File I/O
     /**
-     * Parses a given string and returns the corresponding Social enum.
-     * Accepts either the ENUM ordinal value or its name
-     *
-     * @param social the string to be parsed
-     * @return the Social enum that corresponds to the given string
-     * @throws IllegalStateException if the given string does not match any valid
-     *                               Social
-     */
-    @Deprecated
-    public static Social parseFromString(final String social) {
-        return switch (social) {
-            case "0", "None" -> NONE;
-            // Minor Characteristics
-            case "1", "Apathetic" -> APATHETIC;
-            case "2", "Authentic" -> AUTHENTIC;
-            case "3", "Blunt" -> BLUNT;
-            case "4", "Callous" -> CALLOUS;
-            case "5", "Condescending" -> CONDESCENDING;
-            case "6", "Considerate" -> CONSIDERATE;
-            case "7", "Disingenuous" -> DISINGENUOUS;
-            case "8", "Dismissive" -> DISMISSIVE;
-            case "9", "Encouraging" -> ENCOURAGING;
-            case "10", "Erratic" -> ERRATIC;
-            case "11", "Empathetic" -> EMPATHETIC;
-            case "12", "Friendly" -> FRIENDLY;
-            case "13", "Inspiring" -> INSPIRING;
-            case "14", "Indifferent" -> INDIFFERENT;
-            case "15", "Introverted" -> INTROVERTED;
-            case "16", "Irritable" -> IRRITABLE;
-            case "17", "Neglectful" -> NEGLECTFUL;
-            case "18", "Petty" -> PETTY;
-            case "19", "Persuasive" -> PERSUASIVE;
-            case "20", "Receptive" -> RECEPTIVE;
-            case "21", "Sincere" -> SINCERE;
-            case "22", "Supportive" -> SUPPORTIVE;
-            case "23", "Tactful" -> TACTFUL;
-            case "24", "Untrustworthy" -> UNTRUSTWORTHY;
-            // Major Characteristics
-            case "25", "Altruistic" -> ALTRUISTIC;
-            case "26", "Compassionate" -> COMPASSIONATE;
-            case "27", "Gregarious" -> GREGARIOUS;
-            case "28", "Narcissistic" -> NARCISSISTIC;
-            case "29", "Pompous" -> POMPOUS;
-            case "30", "Scheming" -> SCHEMING;
-            default ->
-                throw new IllegalStateException(
-                        "Unexpected value in mekhq/campaign/personnel/enums/randomEvents/personalities/Social.java/parseFromString: "
-                                + social);
-        };
-    }
-
-    /**
      * Returns the {@link Social} associated with the given ordinal.
      *
      * @param ordinal the ordinal value of the {@link Social}
@@ -168,13 +116,11 @@ public enum Social {
      * {@code NONE} if not found
      */
     public static Social fromOrdinal(int ordinal) {
-        for (Social social : values()) {
-            if (social.ordinal() == ordinal) {
-                return social;
-            }
+        if ((ordinal >= 0) && (ordinal < values().length)) {
+            return values()[ordinal];
         }
 
-        final MMLogger logger = MMLogger.create(Social.class);
+        MMLogger logger = MMLogger.create(Social.class);
         logger.error(String.format("Unknown Social ordinal: %s - returning NONE.", ordinal));
 
         return NONE;


### PR DESCRIPTION
- Replaced deprecated `parseFromString` methods across enums with `valueOf` to improve readability and maintainability.
- Fixed the loading of personality traits. These were incorrectly being caught by the <50.01 compatibility handler. As the trait ordinal and the integer used by the compatibility handler were not 1:1 this caused character's personality to 'wander' upon load.
- Removed deprecated parse from String methods.

Fix #5628