### PR TITLE
Fixed Unit Name Reset

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -477,7 +477,8 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                     gui.getFrame(), "Name for this unit?", "Unit Name",
                     JOptionPane.QUESTION_MESSAGE, null, null,
                     selectedUnit.getFluffName());
-            selectedUnit.setFluffName((fluffName != null) ? fluffName : "");
+            String oldFluffName = selectedUnit.getFluffName();
+            selectedUnit.setFluffName((fluffName != null) ? fluffName : oldFluffName);
             if (fluffName != null) {
                 MekHQ.triggerEvent(new UnitChangedEvent(selectedUnit));
             }


### PR DESCRIPTION
- Previously, canceling the unit name prompt reset the unit's name to an empty string. This fix ensures that the unit keeps its original name if the prompt is canceled.

Fix #5612