### PR TITLE
Refactored Personnel Market Generation & Fixed Capital/Hiring Hall Checks

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -128,7 +128,7 @@ public class PersonnelMarket {
             removePersonnelForDay(campaign);
 
             // If only capitals/hiring halls are allowed and the location fails both conditions, clear personnel
-            if (isOnPlanet || (useCapitalsHiringHallsOnly && !isHiringHall && !isCapital)) {
+            if (!isOnPlanet || (useCapitalsHiringHallsOnly && !isHiringHall && !isCapital)) {
                 removeAll();
                 return;
             }


### PR DESCRIPTION
- Simplified and modularized personnel market logic by adding a dedicated report generation method and improving clarity in personnel filtering conditions.
- Changed 'is capital' check to use the same logic as the Interstellar map. This is both cheaper and more reliable than the previous method.
- Corrected absence of 'is on planet' check. This was always intended, but got removed/forgotten at some point.

Fix #5705