### PR TITLE
Corrected Available Force Check

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -244,6 +244,10 @@ public class StratconRulesManager {
                     continue;
                 }
 
+                if (force.isDeployed()) {
+                    continue;
+                }
+
                 int operationalStatus = 0;
                 int unitCount = 0;
 
@@ -2145,13 +2149,6 @@ public class StratconRulesManager {
                 continue;
             }
 
-            // If the combat team is currently deployed, they aren't eligible to be deployed
-            StratconCampaignState campaignState = contract.getStratconCampaignState();
-
-            if (campaignState.isForceDeployedHere(combatTeam.getForceId())) {
-                continue;
-            }
-
             // So long as the combat team isn't In Reserve or Auxiliary, they are eligible to be deployed
             CombatRole combatRole = combatTeam.getRole();
             if (!combatRole.isReserve() && !combatRole.isAuxiliary()) {
@@ -2215,6 +2212,10 @@ public class StratconRulesManager {
             Force force = campaign.getForce(formation.getForceId());
 
             if (force == null) {
+                continue;
+            }
+
+            if (force.isDeployed()) {
                 continue;
             }
 


### PR DESCRIPTION
- Added missing isDeployed check to `getAvailableForceIDs` (first overload).
- Removed isDeployed check from `getAvailableForceIDs` (second overload). This will prevent Patrol forces from being over-emphasized as seed forces.
- Moved isDeployed check to 'generate weekly scenarios' so that only Integrated contracts care if a force has already been deployed. For all other contract command rights we're just using this information for the purposes of seeding the scenario, so whether the force is deployed or not is irrelevant.