### PR TITLE
Added a Soft Cap to Support Point Generation

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -83,6 +83,10 @@ unitsSelectedLabel.bv=selected (ignores crew skill)
 unitsSelectedLabel.count=selected
 
 ### Support Point Negotiation
+supportPoints.maximum=Your Admin/Transport personnel cannot use their <i>Administration</i>\
+  \ skill to create additional Support Points for contract %s, as you have already %s<b>reached the\
+  \ maximum</b>%s of %s Support Point%s.
+
 supportPoints.initial=Through the <i>Administration</i> skill of your Admin/Transport personnel\
   \ contract %s will begin with %s<b>%s</b>%s Support Point%s.
 supportPoints.initial.noAdministrators=Your unit has no Admin/Transport personnel. Therefore, contract %s\

--- a/MekHQ/src/mekhq/campaign/stratcon/SupportPointNegotiation.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/SupportPointNegotiation.java
@@ -123,6 +123,26 @@ public class SupportPointNegotiation {
             ? contract.getRequiredLances() * 3
             : contract.getRequiredLances();
 
+        StratconCampaignState campaignState = contract.getStratconCampaignState();
+
+        if (campaignState == null) {
+            return;
+        }
+
+        if (campaignState.getSupportPoints() >= maxSupportPoints) {
+            String pluralizer = (maxSupportPoints > 1) || (maxSupportPoints == 0) ? "s" : "";
+
+            campaign.addReport(String.format(
+                resources.getString("supportPoints.maximum"),
+                contract.getName(),
+                spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorWarningHexColor()),
+                CLOSING_SPAN_TAG,
+                negotiatedSupportPoints,
+                pluralizer));
+
+            return;
+        }
+
         Iterator<Person> iterator = adminTransport.iterator();
 
         while (iterator.hasNext() && negotiatedSupportPoints < maxSupportPoints) {
@@ -139,7 +159,7 @@ public class SupportPointNegotiation {
 
         // Add points to the contract if positive
         if (negotiatedSupportPoints > 0) {
-            contract.getStratconCampaignState().addSupportPoints(negotiatedSupportPoints);
+            campaignState.addSupportPoints(negotiatedSupportPoints);
         }
 
         // Add a report


### PR DESCRIPTION
- Added a soft cap to Support Points, where Administrators will not add new Support Points (during weekly generation) if Support Points already meet or exceed the number of required forces for the Contract. We received feedback that Support Points were a bit generous, under the current implementation, because the user could just stockpile them indefinitely.