### PR TITLE
Fixed Maternity Leave Date Handling

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2,7 +2,7 @@
  * Campaign.java
  *
  * Copyright (c) 2009 - Jay Lawson (jaylawson39 at yahoo.com). All Rights Reserved.
- * Copyright (c) 2022 - 2024 The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022 - 2025 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -4277,7 +4277,7 @@ public class Campaign implements ITechManager {
      * @param person The {@link Person} for which to process weekly relationship events
      */
     private void processWeeklyRelationshipEvents(Person person) {
-        if (getLocalDate().getDayOfWeek() == DayOfWeek.MONDAY) {
+        if (currentDay.getDayOfWeek() == DayOfWeek.MONDAY) {
             getDivorce().processNewWeek(this, getLocalDate(), person, false);
             getMarriage().processNewWeek(this, getLocalDate(), person, false);
             getProcreation().processNewWeek(this, getLocalDate(), person);
@@ -4286,9 +4286,9 @@ public class Campaign implements ITechManager {
                 if (campaignOptions.isUseMaternityLeave()) {
                     if ((person.isPregnant())
                             && (person.getStatus().isActive())
-                            && (person.getDueDate().minusWeeks(20).isEqual(getLocalDate()))) {
+                            && (person.getDueDate().minusWeeks(20).isAfter(currentDay.minusDays(1)))) {
 
-                        person.changeStatus(this, getLocalDate(), PersonnelStatus.ON_MATERNITY_LEAVE);
+                        person.changeStatus(this, currentDay, PersonnelStatus.ON_MATERNITY_LEAVE);
                     }
 
                     List<Person> children = person.getGenealogy().getChildren();


### PR DESCRIPTION
- Replaced getLocalDate() with currentDay for consistency and clarity in date handling logic.
- Fixed maternity leave eligibility check to check if maternity leave due date is _after_ the current date and not equal.

This bug was caused by us only checking whether a character is eligible for Maternity Leave once a week, combined with us only checking whether that specific Monday is equal to 20 weeks prior to birth date. Essentially, unless a character was due to give birth on a Monday they would never go on maternity leave.

Fix #5570