### PR TITLE
Added Handling for Unsupported Unit Types

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -49,6 +49,7 @@ miMHQOptions.text=MekHQ Options...
 miMHQOptions.toolTipText=This launches the MekHQ Options Dialog.
 menuThemes.text=Themes
 menuExit.text=Exit
+mekSelectorDialog.unsupported.gunEmplacement=Gun Emplacements are %s<b>not supported</b>%s by MekHQ.
 
 # Marketplace Menu
 menuMarket.text=Marketplace

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -593,6 +593,12 @@ DataLoadingDialog.OutOfMemoryError.text=MekHQ ran out of memory attempting to lo
 DataLoadingDialog.ExecutionException.title=Campaign Loading Error
 DataLoadingDialog.ExecutionException.text=The campaign file couldn't be loaded. \nPlease check the MekHQ.log file for details.
 
+## Unsupported Units
+unsupportedUnits.title=Unsupported Units Detected
+unsupportedUnits.body=The following units are not supported by MekHQ and have been sold.\
+  <br>\
+  <br>All assigned personnel have been unassigned.<br><br>
+
 ### GMToolsDialog Class
 GMToolsDialog.title=GM Tools
 ## General Tab

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -368,6 +368,11 @@ public class ResolveScenarioTracker {
                     }
                 }
             } else if (wreck.getOwner().isEnemyOf(client.getLocalPlayer())) {
+                // MekHQ doesn't support gun emplacements, so we don't want the player salvaging them
+                if (wreck instanceof GunEmplacement) {
+                    continue;
+                }
+
                 if (wreck.isDropShip() && scenario.getBoardType() != Scenario.T_SPACE) {
                     double dropShipBonusPercentage =
                         (double) campaign.getCampaignOptions().getDropShipBonusPercentage() / 100;

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -21,6 +21,8 @@ package mekhq.gui.dialog;
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.Entity;
+import megamek.common.GunEmplacement;
 import megamek.common.MekSummaryCache;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
@@ -44,6 +46,7 @@ import mekhq.campaign.personnel.ranks.Ranks;
 import mekhq.campaign.rating.CamOpsReputation.ReputationController;
 import mekhq.campaign.storyarc.StoryArc;
 import mekhq.campaign.storyarc.StoryArcStub;
+import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.RATManager;
 import mekhq.campaign.universe.Systems;
@@ -58,6 +61,8 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileInputStream;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
@@ -422,10 +427,58 @@ public class DataLoadingDialog extends AbstractMHQDialog implements PropertyChan
                     reputationController.initializeReputation(campaign);
                     campaign.setReputation(reputationController);
                 }
+
+                sellUnsupportedUnits(campaign);
                 // endregion Progress 7
             }
             campaign.setApp(getApplication());
             return campaign;
+        }
+
+
+
+        /**
+         * Sells unsupported units.
+         * <p>
+         * This method checks all units in the specified campaign and determines if they are unsupported.
+         * Currently, only gun emplacements are identified as unsupported and are sold upon campaign load.
+         * If unsupported units are sold, a notification is displayed to the user detailing the sold units,
+         * including their names and IDs. Additionally, personnel assigned to these units are
+         * automatically unassigned.
+         * </p>
+         *
+         * @param retVal The campaign being checked for unsupported units. This includes the unit list
+         *              and the quartermaster who handles the selling process.
+         */
+        private static void sellUnsupportedUnits(Campaign retVal) {
+            List<Unit> soldUnits = new ArrayList<>();
+            for (Unit unit : retVal.getUnits()) {
+                Entity entity = unit.getEntity();
+
+                if (entity == null) {
+                    continue;
+                }
+
+                // We don't support Gun Emplacements in mhq.
+                // If the user has somehow acquired one, it is sold on load.
+                if (entity instanceof GunEmplacement) {
+                    soldUnits.add(unit);
+                }
+            }
+
+            if (!soldUnits.isEmpty()) {
+                StringBuilder message = new StringBuilder(resources.getString("unsupportedUnits.body"));
+
+                for (Unit soldUnit : soldUnits) {
+                    retVal.getQuartermaster().sellUnit(soldUnit);
+                    message.append("- ").append(soldUnit.getName()).append("<br>");
+                }
+
+                JOptionPane.showMessageDialog(null,
+                    String.format("<html>%s</html>", message),
+                    resources.getString("unsupportedUnits.title"),
+                    JOptionPane.WARNING_MESSAGE);
+            }
         }
 
         /**

--- a/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
@@ -23,6 +23,7 @@ import megamek.client.ui.advancedsearch.MekSearchFilter;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.dialog.AbstractUnitSelectorDialog;
 import megamek.common.*;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.enums.PartQuality;
 import mekhq.campaign.unit.UnitOrder;
@@ -32,7 +33,11 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ResourceBundle;
 import java.util.regex.PatternSyntaxException;
+
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 public class MekHQUnitSelectorDialog extends AbstractUnitSelectorDialog {
     //region Variable Declarations
@@ -125,6 +130,20 @@ public class MekHQUnitSelectorDialog extends AbstractUnitSelectorDialog {
     @Override
     protected void select(boolean isGM) {
         if (getSelectedEntity() != null) {
+            // Block the purchase if the unit type is unsupported
+            if (selectedUnit.getEntity() instanceof GunEmplacement) {
+                final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
+                    MekHQ.getMHQOptions().getLocale());
+
+                campaign.addReport(String.format(
+                    resources.getString("mekSelectorDialog.unsupported.gunEmplacement"),
+                    spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
+                    CLOSING_SPAN_TAG));
+
+                dispose();
+                return;
+            }
+
             if (isGM) {
                 PartQuality quality = PartQuality.QUALITY_D;
 


### PR DESCRIPTION
- Added handling for unsupported unit types (currently only Gun Emplacements).

Unsupported unit types are handled in the following manner:
1. Automatically sold on load (to handle older campaigns).
2. Blocked from being salvaged.
3. Blocked from purchase (including GM purchase).