### PR TITLE
Fixed Routed Contracts Resulting in Truncated Payouts

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7802,10 +7802,15 @@ public class Campaign implements ITechManager {
             // check for money in escrow
             // According to FMM(r) pg 179, both failure and breach lead to no
             // further payment even though this seems foolish
-            if ((contract.getStatus().isSuccess())
-                    && (contract.getMonthsLeft(getLocalDate()) > 0)) {
+            if (contract.getStatus().isSuccess()) {
                 remainingMoney = contract.getMonthlyPayOut()
-                        .multipliedBy(contract.getMonthsLeft(getLocalDate()));
+                    .multipliedBy(contract.getMonthsLeft(getLocalDate()));
+
+                if (contract instanceof AtBContract) {
+                    Money routedPayout = ((AtBContract) contract).getRoutedPayout();
+
+                    remainingMoney = routedPayout == null ? remainingMoney : routedPayout;
+                }
             }
 
             // If overage repayment is enabled, we first need to check if the salvage


### PR DESCRIPTION
- Added support for calculating and storing routed payouts when AtB contracts end due to the enemy being routed.
- Updated XML serialization and deserialization to include routed payout data.

When the enemy is routed, for non-Garrison Type contracts, we change the contract end date. This resulted in players being shortchanged payouts. This PR adds tracking so that we know how much the player was due at the pre-rout contract conclusion. Then, when making a contract conclusion payout we ignore the calculated value and use the pre-stored value (where relevant). This allows us to shorten the contract, due to rout early finish, without truncating the users' payout.

Fix #5727