### PR TITLE
Fix Support Point Acquisition Visual Bug

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/SupportPointNegotiation.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/SupportPointNegotiation.java
@@ -137,7 +137,7 @@ public class SupportPointNegotiation {
                 contract.getName(),
                 spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorWarningHexColor()),
                 CLOSING_SPAN_TAG,
-                negotiatedSupportPoints,
+                maxSupportPoints,
                 pluralizer));
 
             return;


### PR DESCRIPTION
- Replaced the use of `negotiatedSupportPoints` with `maxSupportPoints` to ensure the correct value is displayed in messages. 

Fix #5726