### PR TITLE
Fixed Negative Shares Payouts; Removed `TotalEarnings` Tracking and Associated Functionality.

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7830,25 +7830,13 @@ public class Campaign implements ITechManager {
                 ResourceBundle financeResources = ResourceBundle.getBundle("mekhq.resources.Finances",
                         MekHQ.getMHQOptions().getLocale());
 
-                Money shares = remainingMoney.multipliedBy(contract.getSharesPercent()).dividedBy(100);
-                remainingMoney = remainingMoney.minus(shares);
+                if (remainingMoney.isGreaterThan(Money.zero())) {
+                    Money shares = remainingMoney.multipliedBy(contract.getSharesPercent()).dividedBy(100);
+                    remainingMoney = remainingMoney.minus(shares);
 
-                if (getFinances().debit(TransactionType.SALARIES, getLocalDate(), shares,
-                        String.format(financeResources.getString("ContractSharePayment.text"), contract.getName()))) {
-                    addReport(financeResources.getString("DistributedShares.text"), shares.toAmountAndSymbolString());
-
-                    if (getCampaignOptions().isTrackTotalEarnings()) {
-                        boolean sharesForAll = getCampaignOptions().isSharesForAll();
-
-                        int numberOfShares = getActivePersonnel().stream()
-                                .mapToInt(person -> person.getNumShares(this, sharesForAll))
-                                .sum();
-
-                        Money singleShare = shares.dividedBy(numberOfShares);
-
-                        for (Person person : getActivePersonnel()) {
-                            person.payPersonShares(this, singleShare, sharesForAll);
-                        }
+                    if (getFinances().debit(TransactionType.SALARIES, getLocalDate(), shares,
+                            String.format(financeResources.getString("ContractSharePayment.text"), contract.getName()))) {
+                        addReport(financeResources.getString("DistributedShares.text"), shares.toAmountAndSymbolString());
                     }
                 }
             }

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -211,7 +211,6 @@ public class CampaignOptions {
     private TimeInDisplayFormat timeInServiceDisplayFormat;
     private boolean useTimeInRank;
     private TimeInDisplayFormat timeInRankDisplayFormat;
-    private boolean trackTotalEarnings;
     private boolean trackTotalXPEarnings;
     private boolean showOriginFaction;
 
@@ -745,7 +744,6 @@ public class CampaignOptions {
         setTimeInServiceDisplayFormat(TimeInDisplayFormat.YEARS);
         setUseTimeInRank(false);
         setTimeInRankDisplayFormat(TimeInDisplayFormat.MONTHS_YEARS);
-        setTrackTotalEarnings(false);
         setTrackTotalXPEarnings(false);
         setShowOriginFaction(true);
 
@@ -1710,20 +1708,6 @@ public class CampaignOptions {
      */
     public void setTimeInRankDisplayFormat(final TimeInDisplayFormat timeInRankDisplayFormat) {
         this.timeInRankDisplayFormat = timeInRankDisplayFormat;
-    }
-
-    /**
-     * @return whether to track the total earnings of personnel
-     */
-    public boolean isTrackTotalEarnings() {
-        return trackTotalEarnings;
-    }
-
-    /**
-     * @param trackTotalEarnings the new value for whether to track total earnings for personnel
-     */
-    public void setTrackTotalEarnings(final boolean trackTotalEarnings) {
-        this.trackTotalEarnings = trackTotalEarnings;
     }
 
     /**
@@ -4818,7 +4802,6 @@ public class CampaignOptions {
                 getTimeInServiceDisplayFormat().name());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useTimeInRank", isUseTimeInRank());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "timeInRankDisplayFormat", getTimeInRankDisplayFormat().name());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "trackTotalEarnings", isTrackTotalEarnings());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "trackTotalXPEarnings", isTrackTotalXPEarnings());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "showOriginFaction", isShowOriginFaction());
         // endregion Expanded Personnel Information
@@ -5506,8 +5489,6 @@ public class CampaignOptions {
                     retVal.setUseTimeInRank(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("timeInRankDisplayFormat")) {
                     retVal.setTimeInRankDisplayFormat(TimeInDisplayFormat.valueOf(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("trackTotalEarnings")) {
-                    retVal.setTrackTotalEarnings(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("trackTotalXPEarnings")) {
                     retVal.setTrackTotalXPEarnings(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("showOriginFaction")) {

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -19,25 +19,6 @@
  */
 package mekhq.campaign.finances;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.PrintWriter;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.time.LocalDate;
-import java.time.Period;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ResourceBundle;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
@@ -52,6 +33,24 @@ import mekhq.campaign.personnel.Person;
 import mekhq.io.FileType;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.utilities.ReportingUtilities;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
@@ -319,12 +318,6 @@ public class Finances {
                     campaign.addReport(
                             String.format(resourceMap.getString("Salaries.text"),
                                     payRollCost.toAmountAndSymbolString()));
-
-                    if (campaign.getCampaignOptions().isTrackTotalEarnings()) {
-                        for (Person person : campaign.getActivePersonnel()) {
-                            person.payPersonSalary(campaign);
-                        }
-                    }
                 } else {
                     campaign.addReport(
                             String.format("<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>"
@@ -449,24 +442,10 @@ public class Finances {
             if (debit(TransactionType.SALARIES, date, shares,
                     String.format(resourceMap.getString("ContractSharePayment.text"), contract.getName()))) {
                 campaign.addReport(resourceMap.getString("DistributedShares.text"), shares.toAmountAndSymbolString());
-
-                if (campaign.getCampaignOptions().isTrackTotalEarnings()) {
-                    int numberOfShares = 0;
-                    boolean sharesForAll = campaign.getCampaignOptions().isSharesForAll();
-                    for (Person person : campaign.getActivePersonnel()) {
-                        numberOfShares += person.getNumShares(campaign, sharesForAll);
-                    }
-
-                    Money singleShare = shares.dividedBy(numberOfShares);
-                    for (Person person : campaign.getActivePersonnel()) {
-                        person.payPersonShares(campaign, singleShare, sharesForAll);
-                    }
-                }
             } else {
                 /*
                  * This should not happen, as the shares payment should be less than the
-                 * contract
-                 * payment that has just been made.
+                 * contract payment that has just been made.
                  */
                 campaign.addReport("<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>"
                         + resourceMap.getString("InsufficientFunds.text"), resourceMap.getString("Shares.text"),

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -146,7 +146,6 @@ public class Person {
     private int totalXPEarnings;
     private int acquisitions;
     private Money salary;
-    private Money totalEarnings;
     private int hits;
     private int hitsPrior;
     private PrisonerStatus prisonerStatus;
@@ -351,7 +350,6 @@ public class Person {
         nTasks = 0;
         doctorId = null;
         salary = Money.of(-1);
-        totalEarnings = Money.of(0);
         status = PersonnelStatus.ACTIVE;
         prisonerStatus = PrisonerStatus.FREE;
         hits = 0;
@@ -2033,10 +2031,6 @@ public class Person {
             if (!salary.equals(Money.of(-1))) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "salary", salary);
             }
-
-            if (!totalEarnings.equals(Money.of(0))) {
-                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "totalEarnings", totalEarnings);
-            }
             // Always save a person's status, to make it easy to parse the personnel saved
             // data
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "status", status.name());
@@ -2396,8 +2390,6 @@ public class Person {
                     retVal.prisonerStatus = PrisonerStatus.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("salary")) {
                     retVal.salary = Money.fromXmlString(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("totalEarnings")) {
-                    retVal.totalEarnings = Money.fromXmlString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("minutesLeft")) {
                     retVal.minutesLeft = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("overtimeLeft")) {
@@ -2860,49 +2852,6 @@ public class Person {
             } catch (Exception e) {
                 logger.error("Error disabling edge trigger: {}", edgeTrigger);
             }
-        }
-    }
-
-    /**
-     * @return the person's total earnings
-     */
-    public Money getTotalEarnings() {
-        return totalEarnings;
-    }
-
-    /**
-     * This is used to pay a person
-     *
-     * @param money the amount of money to add to their total earnings
-     */
-    public void payPerson(final Money money) {
-        totalEarnings = getTotalEarnings().plus(money);
-    }
-
-    /**
-     * This is used to pay a person their salary
-     *
-     * @param campaign the campaign the person is a part of
-     */
-    public void payPersonSalary(final Campaign campaign) {
-        if (getStatus().isActive()) {
-            payPerson(getSalary(campaign));
-        }
-    }
-
-    /**
-     * This is used to pay a person their share value based on the value of a single
-     * share
-     *
-     * @param campaign     the campaign the person is a part of
-     * @param money        the value of a single share
-     * @param sharesForAll whether or not all personnel have shares
-     */
-    public void payPersonShares(final Campaign campaign, final Money money,
-            final boolean sharesForAll) {
-        final int shares = getNumShares(campaign, sharesForAll);
-        if (shares > 0) {
-            payPerson(money.multipliedBy(shares));
         }
     }
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1103,12 +1103,6 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     return;
                 }
 
-                // pay person
-                for (Person person : people) {
-                    person.payPerson(Money.of(payment));
-                    MekHQ.triggerEvent(new PersonChangedEvent(person));
-                }
-
                 // add expense
                 gui.getCampaign().removeFunds(TransactionType.MISCELLANEOUS, Money.of(payment),
                         String.format(resources.getString("givePayment.format"),

--- a/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/CampaignOptionsPane.java
@@ -8488,7 +8488,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             chkUseTimeInRank.doClick();
         }
         comboTimeInRankDisplayFormat.setSelectedItem(options.getTimeInRankDisplayFormat());
-        chkTrackTotalEarnings.setSelected(options.isTrackTotalEarnings());
         chkTrackTotalXPEarnings.setSelected(options.isTrackTotalXPEarnings());
         chkShowOriginFaction.setSelected(options.isShowOriginFaction());
 
@@ -9229,7 +9228,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             options.setTimeInServiceDisplayFormat(comboTimeInServiceDisplayFormat.getSelectedItem());
             options.setUseTimeInRank(chkUseTimeInRank.isSelected());
             options.setTimeInRankDisplayFormat(comboTimeInRankDisplayFormat.getSelectedItem());
-            options.setTrackTotalEarnings(chkTrackTotalEarnings.isSelected());
             options.setTrackTotalXPEarnings(chkTrackTotalXPEarnings.isSelected());
             options.setShowOriginFaction(chkShowOriginFaction.isSelected());
 

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -27,7 +27,6 @@ import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Kill;
 import mekhq.campaign.event.PersonChangedEvent;
-import mekhq.campaign.finances.Money;
 import mekhq.campaign.log.LogEntry;
 import mekhq.campaign.personnel.*;
 import mekhq.campaign.personnel.education.Academy;
@@ -825,37 +824,8 @@ public class PersonViewPanel extends JScrollablePanel {
             y++;
         }
 
-        // We show the following if track total earnings is on for a free person or if
-        // the
-        // person has previously tracked total earnings
-        if (campaign.getCampaignOptions().isTrackTotalEarnings()
-                && (person.getPrisonerStatus().isFree() || person.getTotalEarnings().isGreaterThan(Money.zero()))) {
-            JLabel lblTotalEarnings1 = new JLabel(resourceMap.getString("lblTotalEarnings1.text"));
-            lblTotalEarnings1.setName("lblTotalEarnings1");
-            gridBagConstraints = new GridBagConstraints();
-            gridBagConstraints.gridx = 0;
-            gridBagConstraints.gridy = y;
-            gridBagConstraints.fill = GridBagConstraints.NONE;
-            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-            pnlInfo.add(lblTotalEarnings1, gridBagConstraints);
-
-            JLabel lblTotalEarnings2 = new JLabel(person.getTotalEarnings().toAmountAndSymbolString());
-            lblTotalEarnings2.setName("lblTotalEarnings2");
-            lblTotalEarnings1.setLabelFor(lblTotalEarnings2);
-            gridBagConstraints = new GridBagConstraints();
-            gridBagConstraints.gridx = 1;
-            gridBagConstraints.gridy = y;
-            gridBagConstraints.weightx = 1.0;
-            gridBagConstraints.insets = new Insets(0, 10, 0, 0);
-            gridBagConstraints.fill = GridBagConstraints.NONE;
-            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-            pnlInfo.add(lblTotalEarnings2, gridBagConstraints);
-            y++;
-        }
-
-        // We show the following if track total xp earnings is on for a free person or
-        // if the
-        // person has previously tracked total xp earnings
+        // We show the following if track total xp earnings are on for a free person or
+        // if the person has previously tracked total xp earnings
         if (campaign.getCampaignOptions().isTrackTotalXPEarnings()
                 && (person.getPrisonerStatus().isFree() || (person.getTotalXPEarnings() != 0))) {
             JLabel lblTotalXPEarnings1 = new JLabel(resourceMap.getString("lblTotalXPEarnings1.text"));


### PR DESCRIPTION
- Added a check to ensure end-of-contract Shares payouts are not made if they would be negative. This would result in the personnel paying the campaign.
- Removed the `TotalEarnings` field, related methods, and all references in the codebase. I opted to remove this data point as from what I can tell it was intended for further shares functionality that was never implemented.

While I expect this data point will be missed by some users, it resulted in a bunch of extra ancillary methods and extra process calls just so users could see how much Joe MechWarrior earned. By reducing the amount of personnel parsing we do we can save a little here and there to improve overall performance.

Fix #5736