### PR TITLE
Fixed Role Eligibility Checks and Ensured Proper Role Assignment

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -894,7 +894,7 @@ public class Person {
         return getSecondaryRole().getName(isClanPersonnel());
     }
 
-    public boolean canPerformRole(LocalDate today, Person person, final PersonnelRole role, final boolean primary) {
+    public boolean canPerformRole(LocalDate today, final PersonnelRole role, final boolean primary) {
         if (primary) {
             // Primary Role:
             // We only do a few here, as it is better on the UX-side to correct the issues
@@ -930,7 +930,7 @@ public class Person {
             }
         }
 
-        if (person.isChild(today)) {
+        if (isChild(today)) {
             return false;
         }
 
@@ -943,8 +943,7 @@ public class Person {
             case NAVAL_VEHICLE_DRIVER -> hasSkill(SkillType.S_PILOT_NVEE);
             case VTOL_PILOT -> hasSkill(SkillType.S_PILOT_VTOL);
             case VEHICLE_GUNNER -> hasSkill(SkillType.S_GUN_VEE);
-            case MECHANIC -> hasSkill(SkillType.S_TECH_MECHANIC)
-                    && (getSkill(SkillType.S_TECH_MECHANIC).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN);
+            case MECHANIC -> hasSkill(SkillType.S_TECH_MECHANIC);
             case VEHICLE_CREW ->
                 Stream.of(SkillType.S_TECH_MEK, SkillType.S_TECH_AERO, SkillType.S_TECH_MECHANIC,
                     SkillType.S_TECH_BA, SkillType.S_DOCTOR, SkillType.S_MEDTECH, SkillType.S_ASTECH)
@@ -958,18 +957,11 @@ public class Person {
             case VESSEL_CREW -> hasSkill(SkillType.S_TECH_VESSEL);
             case VESSEL_GUNNER -> hasSkill(SkillType.S_GUN_SPACE);
             case VESSEL_NAVIGATOR -> hasSkill(SkillType.S_NAV);
-            case MEK_TECH ->
-                hasSkill(SkillType.S_TECH_MEK)
-                        && (getSkill(SkillType.S_TECH_MEK).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN);
-            case AERO_TEK ->
-                hasSkill(SkillType.S_TECH_AERO)
-                        && (getSkill(SkillType.S_TECH_AERO).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN);
-            case BA_TECH ->
-                hasSkill(SkillType.S_TECH_BA)
-                        && (getSkill(SkillType.S_TECH_BA).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN);
+            case MEK_TECH -> hasSkill(SkillType.S_TECH_MEK);
+            case AERO_TEK -> hasSkill(SkillType.S_TECH_AERO);
+            case BA_TECH -> hasSkill(SkillType.S_TECH_BA);
             case ASTECH -> hasSkill(SkillType.S_ASTECH);
-            case DOCTOR -> hasSkill(SkillType.S_DOCTOR)
-                    && (getSkill(SkillType.S_DOCTOR).getExperienceLevel() > SkillType.EXP_ULTRA_GREEN);
+            case DOCTOR -> hasSkill(SkillType.S_DOCTOR);
             case MEDIC -> hasSkill(SkillType.S_MEDTECH);
             case ADMINISTRATOR_COMMAND, ADMINISTRATOR_LOGISTICS, ADMINISTRATOR_TRANSPORT, ADMINISTRATOR_HR ->
                 hasSkill(SkillType.S_ADMIN);
@@ -2714,6 +2706,22 @@ public class Person {
             // I don't know when this metric was added, so we check all versions
             if (retVal.getRecruitment() == null) {
                 retVal.setRecruitment(c.getLocalDate());
+            }
+
+            // This resolves a bug squashed in 2025 (50.03) but lurked in our codebase
+            // potentially as far back as 2014. The next two handlers should never be removed.
+            if (!retVal.canPerformRole(c.getLocalDate(), retVal.getPrimaryRole(), true)) {
+                retVal.setPrimaryRole(c, PersonnelRole.NONE);
+                logger.info(String.format("%s was found to be ineligible for their" +
+                    " primary role. That role has been removed and they were assigned the" +
+                    " NONE role.", retVal.getFullTitle()));
+            }
+
+            if (!retVal.canPerformRole(c.getLocalDate(), retVal.getSecondaryRole(), false)) {
+                retVal.setSecondaryRole(PersonnelRole.NONE);
+                logger.info(String.format("%s was found to be ineligible for their" +
+                    " secondary role. That role has been removed and they were assigned the" +
+                    " NONE role.", retVal.getFullTitle()));
             }
         } catch (Exception e) {
             logger.error("Failed to read person {} from file", retVal.getFullName(), e);

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1489,14 +1489,24 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         }
 
         final PersonnelRole[] roles = PersonnelRole.values();
-        menu = new JMenu(resources.getString("changePrimaryRole.text"));
 
+        menu = new JMenu(resources.getString("changePrimaryRole.text"));
         for (final PersonnelRole role : roles) {
-            if (person.canPerformRole(gui.getCampaign().getLocalDate(), person, role, true)) {
-                cbMenuItem = new JCheckBoxMenuItem(role.getName(person.isClanPersonnel()));
+            boolean allCanPerform = true;
+
+            for (Person selectedPerson : getSelectedPeople()) {
+                if (!selectedPerson.canPerformRole(gui.getCampaign().getLocalDate(), role, true)) {
+                    allCanPerform = false;
+                }
+            }
+
+            if (allCanPerform) {
+                cbMenuItem = new JCheckBoxMenuItem(role.toString());
                 cbMenuItem.setActionCommand(makeCommand(CMD_PRIMARY_ROLE, role.name()));
-                cbMenuItem.setSelected(person.getPrimaryRole() == role);
                 cbMenuItem.addActionListener(this);
+                if (oneSelected && role == person.getPrimaryRole()) {
+                    cbMenuItem.setSelected(true);
+                }
                 menu.add(cbMenuItem);
             }
         }
@@ -1504,11 +1514,21 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         menu = new JMenu(resources.getString("changeSecondaryRole.text"));
         for (final PersonnelRole role : roles) {
-            if (person.canPerformRole(gui.getCampaign().getLocalDate(), person, role, false)) {
-                cbMenuItem = new JCheckBoxMenuItem(role.getName(person.isClanPersonnel()));
+            boolean allCanPerform = true;
+
+            for (Person selectedPerson : getSelectedPeople()) {
+                if (!selectedPerson.canPerformRole(gui.getCampaign().getLocalDate(), role, false)) {
+                    allCanPerform = false;
+                }
+            }
+
+            if (allCanPerform) {
+                cbMenuItem = new JCheckBoxMenuItem(role.toString());
                 cbMenuItem.setActionCommand(makeCommand(CMD_SECONDARY_ROLE, role.name()));
-                cbMenuItem.setSelected(person.getSecondaryRole() == role);
                 cbMenuItem.addActionListener(this);
+                if (oneSelected && role == person.getSecondaryRole()) {
+                    cbMenuItem.setSelected(true);
+                }
                 menu.add(cbMenuItem);
             }
         }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1497,6 +1497,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             for (Person selectedPerson : getSelectedPeople()) {
                 if (!selectedPerson.canPerformRole(gui.getCampaign().getLocalDate(), role, true)) {
                     allCanPerform = false;
+                    break;
                 }
             }
 
@@ -1519,6 +1520,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             for (Person selectedPerson : getSelectedPeople()) {
                 if (!selectedPerson.canPerformRole(gui.getCampaign().getLocalDate(), role, false)) {
                     allCanPerform = false;
+                    break;
                 }
             }
 


### PR DESCRIPTION
- Removed redundant `Person` parameter in `canPerformRole`.
- Removed 'must be Green' expertise requirement from Tech roles -- I could have sworn I removed this before, but apparently not. So, removing it here. This ensures these roles are treated like all others, none of which require minimum expertise.
- Fixed a very long standing bug where, when assigning personnel to roles, we only checked the eligibility of the first selected character and then assumed all other characters' eligibility matched theirs. Now we correctly check the eligibility of all selected characters.
- Added sanitizers to ensure all personnel are eligible for their assigned roles, on load, and unassigning them if they're not.

Fix #5740, Fix #5580