### PR TITLE
Added Clan and Inner Sphere Resupply Restrictions

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -524,9 +524,7 @@ public class Resupply {
         final Collection<UUID> unitIds = campaign.getForce(0).getAllUnits(true);
         Map<String, PartDetails> processedParts = new HashMap<>();
 
-        boolean allowClan = (employerIsClan || campaign.getLocalDate().isAfter(BATTLE_OF_TUKAYYID))
-            && campaign.getCampaignOptions().isAllowClanPurchases();
-        boolean allowInnerSphere = campaign.getCampaignOptions().isAllowISPurchases();
+        boolean allowClan = (employerIsClan || campaign.getLocalDate().isAfter(BATTLE_OF_TUKAYYID));
 
         try {
             for (UUID unitId : unitIds) {
@@ -549,14 +547,8 @@ public class Resupply {
                 if (!unit.isSalvage() && (unit.isAvailable() || unit.isDeployed())) {
                     List<Part> parts = unit.getParts();
                     for (Part part : parts) {
-                        if (part.isClan()) {
-                            if (!allowClan) {
-                                continue;
-                            }
-                        } else {
-                            if (!allowInnerSphere) {
-                                continue;
-                            }
+                        if (part.isClan() && !allowClan) {
+                            continue;
                         }
 
                         if (isIneligiblePart(part, unit)) {

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -19,6 +19,7 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 
 import java.math.BigInteger;
+import java.time.LocalDate;
 import java.util.*;
 
 import static java.lang.Math.floor;
@@ -68,6 +69,7 @@ public class Resupply {
     public static final int CARGO_MULTIPLIER = 4;
     public static final int RESUPPLY_AMMO_TONNAGE = 1;
     public static final int RESUPPLY_ARMOR_TONNAGE = 5;
+    final LocalDate BATTLE_OF_TUKAYYID = LocalDate.of(3052, 5, 21);
 
     private static final MMLogger logger = MMLogger.create(Resupply.class);
 
@@ -522,6 +524,10 @@ public class Resupply {
         final Collection<UUID> unitIds = campaign.getForce(0).getAllUnits(true);
         Map<String, PartDetails> processedParts = new HashMap<>();
 
+        boolean allowClan = (employerIsClan || campaign.getLocalDate().isAfter(BATTLE_OF_TUKAYYID))
+            && campaign.getCampaignOptions().isAllowClanPurchases();
+        boolean allowInnerSphere = campaign.getCampaignOptions().isAllowISPurchases();
+
         try {
             for (UUID unitId : unitIds) {
                 Unit unit = campaign.getUnit(unitId);
@@ -543,6 +549,16 @@ public class Resupply {
                 if (!unit.isSalvage() && (unit.isAvailable() || unit.isDeployed())) {
                     List<Part> parts = unit.getParts();
                     for (Part part : parts) {
+                        if (part.isClan()) {
+                            if (!allowClan) {
+                                continue;
+                            }
+                        } else {
+                            if (!allowInnerSphere) {
+                                continue;
+                            }
+                        }
+
                         if (isIneligiblePart(part, unit)) {
                             continue;
                         }

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -524,7 +524,9 @@ public class Resupply {
         final Collection<UUID> unitIds = campaign.getForce(0).getAllUnits(true);
         Map<String, PartDetails> processedParts = new HashMap<>();
 
-        boolean allowClan = (employerIsClan || campaign.getLocalDate().isAfter(BATTLE_OF_TUKAYYID));
+        boolean allowClan = (employerIsClan || campaign.getLocalDate().isAfter(BATTLE_OF_TUKAYYID))
+            && campaign.getCampaignOptions().isAllowClanPurchases();
+        boolean allowInnerSphere = campaign.getCampaignOptions().isAllowISPurchases();
 
         try {
             for (UUID unitId : unitIds) {
@@ -547,8 +549,14 @@ public class Resupply {
                 if (!unit.isSalvage() && (unit.isAvailable() || unit.isDeployed())) {
                     List<Part> parts = unit.getParts();
                     for (Part part : parts) {
-                        if (part.isClan() && !allowClan) {
-                            continue;
+                        if (part.isClan()) {
+                            if (!allowClan) {
+                                continue;
+                            }
+                        } else {
+                            if (!allowInnerSphere) {
+                                continue;
+                            }
                         }
 
                         if (isIneligiblePart(part, unit)) {


### PR DESCRIPTION
- Restricted Clan items to only appear in Resupplies if the employing faction is Clan or the resupply is after the Battle of Tukayyid.
- Restricted Clan items to only appear in Resupplies if the purchase of Clan parts is enabled in Campaign Options
- Restricted Inner Sphere items to only appear in Resupplies if the purchase of Inner Sphere parts is enabled in Campaign Options.

Fix #5746