### PR TITLE
Added `null` Protection to `OutstandingScenariosNagLogic` for Outstanding Scenario Nags

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/OutstandingScenariosNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/OutstandingScenariosNagLogic.java
@@ -53,12 +53,12 @@ public class OutstandingScenariosNagLogic {
             for (AtBScenario scenario : contract.getCurrentAtBScenarios()) {
                 LocalDate scenarioDate = scenario.getDate();
 
-                // Skip scenarios not matching today's date
-                if (!scenarioDate.equals(today)) {
+                if (scenario.getDate() == null) {
                     continue;
                 }
 
-                if (scenario.getDate() == null) {
+                // Skip scenarios not matching today's date
+                if (!scenarioDate.equals(today)) {
                     continue;
                 }
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/OutstandingScenariosNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/OutstandingScenariosNagLogic.java
@@ -58,6 +58,10 @@ public class OutstandingScenariosNagLogic {
                     continue;
                 }
 
+                if (scenario.getDate() == null) {
+                    continue;
+                }
+
                 if (scenario.getHasTrack()) {
                     StratconScenario stratconScenario = getStratconScenarioFromAtBScenario(campaign, scenario);
 


### PR DESCRIPTION
- Added a null date check to prevent further processing of scenarios with null dates (such as uninitialized scenarios in StratCon).

Fix #5770