### PR TITLE
Fixed Combat Team Status Logic for Convoy and Support Forces

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -371,6 +371,15 @@ public class CombatTeam {
                 force.setCombatTeamStatus(false);
                 return false;
             }
+
+            if (parentForce.isConvoyForce()) {
+                force.setCombatTeamStatus(false);
+                return false;
+            }
+
+            if (!parentForce.isCombatForce()) {
+                return false;
+            }
         }
 
         force.setCombatTeamStatus(true);


### PR DESCRIPTION
- Adjusted validations to prevent assigning combat team status to convoy forces and non-combat forces.

Fix #5760