### PR TITLE
Update Sector Display in Briefing Room to Show Full Grid Reference

### DIFF
--- a/MekHQ/resources/mekhq/resources/ScenarioTableModel.properties
+++ b/MekHQ/resources/mekhq/resources/ScenarioTableModel.properties
@@ -2,5 +2,5 @@ col_name.text=Scenario Name
 col_status.text=Resolution
 col_date.text=Date
 col_assign.text=Units Assigned
-col_sector.text=Sector
+col_sector.text=Grid Reference
 col_unknown.text=?

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -25,6 +25,7 @@ import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.mission.enums.ScenarioStatus;
 import mekhq.campaign.stratcon.StratconCampaignState;
+import mekhq.campaign.stratcon.StratconCoords;
 import mekhq.campaign.stratcon.StratconScenario;
 import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
@@ -129,7 +130,13 @@ public class ScenarioTableModel extends DataTableModel {
                         for (StratconTrackState track : campaignState.getTracks()) {
                             for (StratconScenario stratconScenario : track.getScenarios().values()) {
                                 if (Objects.equals(stratconScenario.getBackingScenario(), scenario)) {
-                                    return track.getDisplayableName();
+                                    StratconCoords coords = stratconScenario.getCoords();
+
+                                    if (coords == null) {
+                                        return track.getDisplayableName();
+                                    } else {
+                                        return track.getDisplayableName() + '-' + coords.toBTString();
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
- Revised the scenario table model to append Stratcon coordinates to the track display name when available.
- Also updated the column header text from "Sector" to "Grid Reference" now that it's showing the full grid reference and not just sector

This was suggested by @Scoppio and will help debugging ghost scenarios.