### PR TITLE
Issue 5777: QuadMeks (and QuadVees) that use Gunner & Pilot can be crewed

### DIFF
--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -225,7 +225,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                 // Pilot Menu
                 if (unit.canTakeMoreDrivers()) {
                     // Pilot Menu - Solo Pilot and VTOL Pilot Assignment
-                    if (singlePerson && (unit.usesSoloPilot() || (entity instanceof VTOL) || entity.isSuperHeavy() || entity.isTripodMek())) {
+                    if (singlePerson && (unit.usesSoloPilot() || (entity instanceof VTOL) || entity.isSuperHeavy() || entity.isTripodMek() || entity.isQuadMek())) {
                         final boolean valid;
                         if (entity instanceof Mek) {
                             valid = areAllBattleMekPilots;
@@ -320,7 +320,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     } else if ((entity instanceof SmallCraft)
                             || (entity instanceof Jumpship)) {
                         valid = areAllVesselGunners;
-                    } else if (entity.isTripodMek() || entity.isSuperHeavy()) {
+                    } else if (entity.isTripodMek() || entity.isSuperHeavy() || entity.isQuadMek()) {
                         valid = areAllBattleMekPilots;
                     } else {
                         valid = false;

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
@@ -109,6 +109,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         final boolean isVTOL = entity instanceof VTOL;
         final boolean isMek = entity instanceof Mek;
         final boolean isTripod = entity instanceof TripodMek;
+        final boolean isQuadMek = entity instanceof QuadMek;
         final boolean isSuperHeavyMek = isMek && entity.isSuperHeavy();
         final boolean isProtoMek = entity instanceof ProtoMek;
         final boolean isConventionalAircraft = entity instanceof ConvFighter;
@@ -214,7 +215,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         // Pilot Menu
         if (canTakeMoreDrivers) {
             // Pilot Menu
-            if (usesSoloPilot || isVTOL || isSmallCraftOrJumpShip || isSuperHeavyMek || isTripod) {
+            if (usesSoloPilot || isVTOL || isSmallCraftOrJumpShip || isSuperHeavyMek || isTripod || isQuadMek) {
                 if (isMek) {
                     filteredPersonnel = personnel.stream()
                             .filter(person -> person.getPrimaryRole().isMekWarriorGrouping()
@@ -418,11 +419,11 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         }
 
         // Gunners Menu
-        if (canTakeMoreGunners && (isTank || isSmallCraftOrJumpShip || isSuperHeavyMek || isTripod)) {
+        if (canTakeMoreGunners && (isTank || isSmallCraftOrJumpShip || isSuperHeavyMek || isTripod || isQuadMek)) {
             filteredPersonnel = personnel.stream()
                     .filter(person -> (isSmallCraftOrJumpShip && person.hasRole(PersonnelRole.VESSEL_GUNNER)) ||
                             (isTank && person.hasRole(PersonnelRole.VEHICLE_GUNNER)) ||
-                            ((isSuperHeavyMek || isTripod) && person.getPrimaryRole().isMekWarriorGrouping()
+                            ((isSuperHeavyMek || isTripod || isQuadMek) && person.getPrimaryRole().isMekWarriorGrouping()
                                     || person.getSecondaryRole().isMekWarriorGrouping()))
                     .collect(Collectors.toList());
             if (!filteredPersonnel.isEmpty()) {
@@ -447,7 +448,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                         skillLevel = person.getSkillLevel(campaign, !person.getPrimaryRole().isVesselGunner());
                     } else if (isTank) {
                         skillLevel = person.getSkillLevel(campaign, !person.getPrimaryRole().isVehicleGunner());
-                    } else if (isSuperHeavyMek || isTripod) {
+                    } else if (isSuperHeavyMek || isTripod || isQuadMek) {
                         skillLevel = person.getSkillLevel(campaign, !person.getPrimaryRole().isMekWarriorGrouping());
                     }
 


### PR DESCRIPTION
Fixes #5777 

Fixed both the menus for assigning people to units to support QuadMeks/Vees better.