### PR TITLE
Fixed Incorrect Condition for VTOL Unit Check

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
@@ -196,7 +196,7 @@ public class ResupplyUtilities {
                 continue;
             }
 
-            if (!entity.isAirborneVTOLorWIGE()) {
+            if (entity.isAirborneVTOLorWIGE()) {
                 vtolCount++;
             }
         }


### PR DESCRIPTION
- Reversed a conditional check that incorrectly excluded airborne units such as VTOLs and WIGEs.

This update ensures the `vtolCount` is correctly incremented for such units during resupply utility processing.