### PR TITLE
Added Contract Breach CVP Penalties to StratCon Contracts

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -104,3 +104,5 @@ understrength.text=%s is %s<b>under strength</b>%s and is not counting towards t
   \ of Combat Teams required by your employer. Your employer is demanding that all relevant Combat\
   \ Teams contain at least %s combat units. Consider reassigning this Combat Team to <i>Reserve</i>\
   \ or <i>Auxiliary</i>.
+contractBreach.text=Failure to meet the requirements of contract %s resulted in the %s<b>loss of a\
+  \ CVP</b>%s.

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -105,6 +105,7 @@ import mekhq.campaign.rating.FieldManualMercRevDragoonsRating;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.rating.UnitRatingMethod;
 import mekhq.campaign.storyarc.StoryArc;
+import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconContractInitializer;
 import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.stratcon.StratconTrackState;
@@ -3951,7 +3952,16 @@ public class Campaign implements ITechManager {
 
             if (getLocalDate().getDayOfWeek() == DayOfWeek.MONDAY) {
                 int deficit = getDeploymentDeficit(contract);
-                if (deficit > 0) {
+                StratconCampaignState campaignState = contract.getStratconCampaignState();
+
+                if (campaignState != null && deficit > 0) {
+                    addReport(String.format(resources.getString("contractBreach.text"),
+                        contract.getName(),
+                        spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
+                        CLOSING_SPAN_TAG));
+
+                    campaignState.updateVictoryPoints(-1);
+                } else if (deficit > 0) {
                     contract.addPlayerMinorBreaches(deficit);
                     addReport("Failure to meet " + contract.getName() + " requirements resulted in " + deficit
                             + ((deficit == 1) ? " minor contract breach" : " minor contract breaches"));


### PR DESCRIPTION
- Added logic to deduct Combat Victory Points (CVPs) for unmet StratCon deployment requirements.
- Updated user feedback to include a report for this specific breach scenario.

This CVP loss will only occur if the user begins a week with fewer than required assigned Combat Teams.

Fix #5750