### PR TITLE
MegaMek Issue 6416: Ghostbusting - Reset isDestroyed for entities when returning to MekHQ

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7440,6 +7440,7 @@ public class Campaign implements ITechManager {
         entity.resetCoolantFailureAmount();
         entity.setConversionMode(0);
         entity.setDoomed(false);
+        entity.setDestroyed(false);
         entity.setHidden(false);
         entity.clearNarcAndiNarcPods();
         entity.setShutDown(false);


### PR DESCRIPTION
Fixes MegaMek/megamek#6416