### PR TITLE
Corrected Scenario info Visibility Logic in `StratconPanel`

### DIFF
--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -945,7 +945,7 @@ public class StratconPanel extends JPanel implements ActionListener {
 
         StratconScenario selectedScenario = getSelectedScenario();
         if ((selectedScenario != null) &&
-                ((selectedScenario.getDeploymentDate() != null) || currentTrack.isGmRevealed())) {
+                (coordsRevealed || currentTrack.isGmRevealed())) {
             infoBuilder.append(selectedScenario.getInfo(campaign));
         }
 


### PR DESCRIPTION
- Replaced deployment date check with a `coordsRevealed` flag. This ensures proper control over when scenario info is displayed.

Fix #5800