### PR TITLE
Refactored BV Display Logic in `StratconScenario.java`

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconScenario.java
@@ -234,11 +234,15 @@ public class StratconScenario implements IStratconDisplayable {
                     .append("<br/>");
             }
 
+            int hostileBV = backingScenario.getTeamTotalBattleValue(campaign, false);
+            int alliedBV = backingScenario.getTeamTotalBattleValue(campaign, true);
+
             if (campaign != null) {
-                stateBuilder.append(String.format("<b>Hostile BV:</b> %d<br>",
-                    backingScenario.getTeamTotalBattleValue(campaign, false)));
-                stateBuilder.append(String.format("<b>Allied BV:</b> %d",
-                    backingScenario.getTeamTotalBattleValue(campaign, true)));
+                stateBuilder.append(String.format("<b>Hostile BV:</b> %s<br>",
+                    hostileBV == 0 && alliedBV == 0 ? "UNKNOWN" : hostileBV));
+                stateBuilder.append(String.format("<b>Allied BV:</b> %s",
+                    hostileBV == 0 && alliedBV == 0 ? "UNKNOWN" : alliedBV
+                    ));
             }
         }
 


### PR DESCRIPTION
- Modified hostile and allied BV display to handle cases where both values are zero by showing "UNKNOWN."

Previously these would show as `0` which, while correct, gave the impression of a bug where there was none.