### PR TITLE
Added `null` Protection to Loot Saving

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Loot.java
+++ b/MekHQ/src/mekhq/campaign/mission/Loot.java
@@ -333,12 +333,20 @@ public class Loot {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "loot");
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "name", name);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "cash", getCash());
-        for (Entity e : units) {
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "entityName", e.getShortNameRaw());
+        for (Entity entity : units) {
+            if (entity == null) {
+                continue;
+            }
+
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "entityName", entity.getShortNameRaw());
         }
 
-        for (Part p : parts) {
-            p.writeToXML(pw, indent);
+        for (Part part : parts) {
+            if (part == null) {
+                continue;
+            }
+
+            part.writeToXML(pw, indent);
         }
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "loot");
     }

--- a/MekHQ/src/mekhq/campaign/mission/Loot.java
+++ b/MekHQ/src/mekhq/campaign/mission/Loot.java
@@ -334,6 +334,8 @@ public class Loot {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "name", name);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "cash", getCash());
         for (Entity entity : units) {
+            // This null protection was implemented in 50.03 to guard against a bug in the
+            // depreciated Legacy AtB Digital GM.
             if (entity == null) {
                 continue;
             }
@@ -342,6 +344,8 @@ public class Loot {
         }
 
         for (Part part : parts) {
+            // This null protection was implemented in 50.03 to guard against a bug in the
+            // depreciated Legacy AtB Digital GM.
             if (part == null) {
                 continue;
             }


### PR DESCRIPTION
- Implemented null protection for units and parts to address a known issue in the deprecated Legacy AtB.

As Legacy AtB is deprecated, and the special scenarios that have this issue have been removed from StratCon, I opted not to resolve the root cause of this bug, but to add `null` protections so the writing process would gracefully fail in the event the bug was triggered.

Fix #5745