### PR TITLE
Fixed Incorrect Pass/Fail Logic in Initial Education Evaluation

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -1945,7 +1945,7 @@ public class EducationController {
             : Intelligence.values().length / 2;
         passRate += intelligenceModifier;
 
-        final boolean flunked = Compute.randomInt(100) >= passRate;
+        final boolean flunked = Compute.randomInt(100) <= passRate;
 
         EducationLevel educationLevel;
         if (isCombatRole) {


### PR DESCRIPTION
- Reversed the comparison operator to correctly determine if a character flunked based on the pass rate. This ensures the education evaluation uses the intended logic for pass/fail decisions.

Fix #5761