### PR TITLE
Improved Vocational (Idle) Experience Gain; Expanded Immersive Dialog Functionality

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -106,3 +106,5 @@ understrength.text=%s is %s<b>under strength</b>%s and is not counting towards t
   \ or <i>Auxiliary</i>.
 contractBreach.text=Failure to meet the requirements of contract %s resulted in the %s<b>loss of a\
   \ CVP</b>%s.
+gainedExperience.text=%s<b>%s</b>%s personnel <a href='PERSONNEL_ADVANCEMENT|'>gained vocational</a>\
+  \ XP.

--- a/MekHQ/resources/mekhq/resources/VocationalExperienceAwardDialog.properties
+++ b/MekHQ/resources/mekhq/resources/VocationalExperienceAwardDialog.properties
@@ -1,5 +1,10 @@
 confirm.button=Understood
 dialog.message=, our line-officers have flagged the following personnel as having made noticeable\
-  \ improvement in the past few months. It might be worth reviewing their records.
-dialog.ooc=Each of the listed characters has gained %d xp. This represents improvements made\
-  \ naturally while performing the duties required by their assigned roles.
+  \ improvement in the past few months.\
+  <br>\
+  <br>It might be worth reviewing their records.\
+  <br>\
+  <br>
+dialog.ooc=Each of the listed characters has gained %d xp.\
+  <br>This represents improvements made naturally while performing the duties required by their\
+  \ assigned roles.

--- a/MekHQ/resources/mekhq/resources/VocationalExperienceAwardDialog.properties
+++ b/MekHQ/resources/mekhq/resources/VocationalExperienceAwardDialog.properties
@@ -1,0 +1,5 @@
+confirm.button=Understood
+dialog.message=, our line-officers have flagged the following personnel as having made noticeable\
+  \ improvement in the past few months. It might be worth reviewing their records.
+dialog.ooc=Each of the listed characters has gained %d xp. This represents improvements made\
+  \ naturally while performing the duties required by their assigned roles.

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4307,7 +4307,9 @@ public class Campaign implements ITechManager {
         }
 
         if (!personnelWhoAdvancedInXP.isEmpty()) {
-            addReport("personnel <a href='PERSONNEL_ADVANCEMENT|'>advanced</a> in vocational XP: ");
+            addReport(String.format(resources.getString("gainedExperience.text"),
+                spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor()),
+                personnelWhoAdvancedInXP.size(), CLOSING_SPAN_TAG));
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -665,10 +665,21 @@ public class Campaign implements ITechManager {
         return retirementDefectionTracker;
     }
 
+    /**
+     * Sets the list of personnel who have advanced in experience points (XP) via vocational xp.
+     *
+     * @param personnelWhoAdvancedInXP a {@link List} of {@link Person} objects representing personnel
+     *                                 who have gained XP.
+     */
     public void setPersonnelWhoAdvancedInXP(List<Person> personnelWhoAdvancedInXP) {
         this.personnelWhoAdvancedInXP = personnelWhoAdvancedInXP;
     }
 
+    /**
+     * Retrieves the list of personnel who have advanced in experience points (XP) via vocational xp.
+     *
+     * @return a {@link List} of {@link Person} objects representing personnel who have gained XP.
+     */
     public List<Person> getPersonnelWhoAdvancedInXP() {
         return personnelWhoAdvancedInXP;
     }
@@ -4344,24 +4355,36 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Processes monthly vocational experience (XP) for a given person, awarding XP if certain
-     * conditions are met.
+     * Processes the monthly vocational experience (XP) gain for a given person based on specific
+     * eligibility criteria. If the person meets the conditions, XP is awarded and their progress
+     * is tracked.
      *
-     * <p>The method evaluates eligibility for XP gain based on the following criteria:
+     * <p>The method checks the following conditions to determine eligibility for XP gain:
      * <ul>
-     *     <li>The person must be active (e.g., not retired, deceased, or in edcuation).</li>
-     *     <li>The person must not be a child at the current date.</li>
-     *     <li>The person must not be a dependent.</li>
-     *     <li>The campaign must have idle XP enabled, and it must be the first day of the month.</li>
-     *     <li>The person must not currently have the status of a prisoner (Bondsmen, however, are eligible for XP).</li>
+     *     <li>The person must have an active status (e.g., not retired, deceased, or in education).</li>
+     *     <li>The person must not be a child on the current date.</li>
+     *     <li>The person must not be categorized as a dependent.</li>
+     *     <li>The campaign must enable idle XP, and the current date must be the first day of the month.</li>
+     *     <li>The person must not have the status of a prisoner (Bondsmen are exempt from this
+     *     and remain eligible for XP).</li>
      * </ul>
      *
-     * <p>If all conditions are met, the person accumulates idle months.
-     * Once the accumulated idle months reach the threshold defined in the campaign options, the
-     * person is eligible for an idle XP roll using a 2d6 check. If the roll meets or exceeds
-     * the target threshold, XP is awarded to the person, and their idle month count is reset.</p>
+     * <p>If all of these conditions are satisfied:
+     * <ul>
+     *     <li>The person’s idle month count is incremented.</li>
+     *     <li>If the accumulated idle months reach the threshold defined in the campaign options,
+     *     an idle XP roll (2d6) is performed.</li>
+     *     <li>If the roll result meets or exceeds the target threshold:
+     *         <ul>
+     *             <li>XP is awarded to the person based on the campaign's idle XP configuration.</li>
+     *             <li>The idle month count is reset.</li>
+     *         </ul>
+     *     </li>
+     *     <li>If the roll is unsuccessful, the idle month count is still reset.</li>
+     * </ul>
      *
-     * @param person the {@link Person} whose monthly vocational XP gain is being processed.
+     * @param person the {@link Person} whose monthly vocational XP is to be processed
+     * @return {@code true} if XP was successfully awarded during the process, {@code false} otherwise
      */
     private boolean processMonthlyVocationalXp(Person person) {
         if (!person.getStatus().isActive()) {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -294,6 +294,8 @@ public class CampaignXmlParser {
                 } else if (xn.equalsIgnoreCase("retirementDefectionTracker")) {
                     retVal.setRetirementDefectionTracker(
                             RetirementDefectionTracker.generateInstanceFromXML(wn, retVal));
+                } else if (xn.equalsIgnoreCase("personnelWhoAdvancedInXP")) {
+                    retVal.setPersonnelWhoAdvancedInXP(processPersonnelWhoAdvancedInXP(wn, retVal));
                 } else if (xn.equalsIgnoreCase("automatedMothballUnits")) {
                     retVal.setAutomatedMothballUnits(processAutomatedMothballNodes(wn, retVal));
                 } else if (xn.equalsIgnoreCase("shipSearchStart")) {
@@ -973,6 +975,53 @@ public class CampaignXmlParser {
     private static void processFameAndInfamyNodes(Campaign relativeValue, Node workingNode) {
         logger.info("Loading Fame and Infamy Nodes from XML...");
         FameAndInfamyController.parseFromXML(workingNode.getChildNodes(), relativeValue);
+    }
+
+    /**
+     * Processes a list of personnel who advanced in experience points (XP) from a given XML node.
+     * <p>
+     * This method reads the child nodes of the provided XML {@code workingNode} and extracts the personnel
+     * listed under the "personWhoAdvancedInXP" nodes. It retrieves the corresponding {@link Person} objects
+     * from the provided {@link Campaign} using their unique UUIDs. If a person cannot be found, an error
+     * is logged. The method returns a list of processed {@link Person} objects.
+     * </p>
+     *
+     * @param workingNode The XML node containing the "personWhoAdvancedInXP" elements to be processed.
+     * @param campaign    The {@link Campaign} instance used to fetch the {@link Person} objects based on UUIDs.
+     * @return A {@link List} of {@link Person} objects representing the personnel who advanced in XP.
+     *         If no valid personnel are found, an empty list is returned.
+     */
+    private static List<Person> processPersonnelWhoAdvancedInXP(Node workingNode, Campaign campaign) {
+        logger.info("Loading personnelWhoAdvancedInXP Nodes from XML...");
+
+        List<Person> personWhoAdvancedInXP = new ArrayList<>();
+
+        NodeList workingList = workingNode.getChildNodes();
+        for (int x = 0; x < workingList.getLength(); x++) {
+            Node childNode = workingList.item(x);
+
+            // If it's not an element node, we ignore it.
+            if (childNode.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+
+            if (!childNode.getNodeName().equalsIgnoreCase("personWhoAdvancedInXP")) {
+                logger.error("Unknown node type not loaded in personnelWhoAdvancedInXP nodes: "
+                    + childNode.getNodeName());
+                continue;
+            }
+
+            Person person = campaign.getPerson(UUID.fromString(childNode.getTextContent()));
+
+            if (person == null) {
+                logger.error("Unknown UUID: " + childNode.getTextContent());
+            }
+
+            personWhoAdvancedInXP.add(person);
+        }
+
+        logger.info("Load personWhoAdvancedInXP Nodes Complete!");
+        return personWhoAdvancedInXP;
     }
 
     private static List<Unit> processAutomatedMothballNodes(Node workingNode, Campaign campaign) {

--- a/MekHQ/src/mekhq/gui/ReportHyperlinkListener.java
+++ b/MekHQ/src/mekhq/gui/ReportHyperlinkListener.java
@@ -21,14 +21,15 @@
  */
 package mekhq.gui;
 
-import java.util.UUID;
-
-import javax.swing.event.HyperlinkEvent;
-import javax.swing.event.HyperlinkListener;
-
 import megamek.logging.MMLogger;
 import mekhq.campaign.unit.Unit;
+import mekhq.gui.dialog.VocationalExperienceAwardDialog;
 import mekhq.gui.dialog.reportDialogs.MaintenanceReportDialog;
+
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkEvent.EventType;
+import javax.swing.event.HyperlinkListener;
+import java.util.UUID;
 
 public class ReportHyperlinkListener implements HyperlinkListener {
     private static final MMLogger logger = MMLogger.create(ReportHyperlinkListener.class);
@@ -44,6 +45,7 @@ public class ReportHyperlinkListener implements HyperlinkListener {
     public static final String REPAIR = "REPAIR";
     public static final String CONTRACT_MARKET = "CONTRACT_MARKET";
     public static final String UNIT_MARKET = "UNIT_MARKET";
+    public static final String PERSONNEL_ADVANCEMENT = "PERSONNEL_ADVANCEMENT";
     // endregion Variable Declarations
 
     // region Constructors
@@ -54,7 +56,7 @@ public class ReportHyperlinkListener implements HyperlinkListener {
 
     @Override
     public void hyperlinkUpdate(final HyperlinkEvent evt) {
-        if (evt.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+        if (evt.getEventType() == EventType.ACTIVATED) {
             if (evt.getDescription().startsWith(UNIT_MARKET)) { // Must come before UNIT since it starts with UNIT as
                                                                 // well
                 campaignGUI.showUnitMarket();
@@ -68,13 +70,6 @@ public class ReportHyperlinkListener implements HyperlinkListener {
             } else if (evt.getDescription().startsWith(PERSONNEL_MARKET)) { // Must come before PERSON since it starts
                                                                             // with PERSON as well
                 campaignGUI.hirePersonMarket();
-            } else if (evt.getDescription().startsWith(PERSON)) {
-                try {
-                    final UUID id = UUID.fromString(evt.getDescription().split(":")[1]);
-                    campaignGUI.focusOnPerson(id);
-                } catch (Exception e) {
-                    logger.error("", e);
-                }
             } else if (evt.getDescription().startsWith(NEWS)) {
                 try {
                     final int id = Integer.parseInt(evt.getDescription().split("\\|")[1]);
@@ -103,6 +98,20 @@ public class ReportHyperlinkListener implements HyperlinkListener {
                 }
             } else if (evt.getDescription().startsWith(CONTRACT_MARKET)) {
                 campaignGUI.showContractMarket();
+            } else if (evt.getDescription().startsWith(PERSONNEL_ADVANCEMENT)) { // Must come before PERSON since it starts
+                                                                                 // with PERSON as well
+                try {
+                    new VocationalExperienceAwardDialog(campaignGUI.getCampaign());
+                } catch (Exception e) {
+                    logger.error("", e);
+                }
+            } else if (evt.getDescription().startsWith(PERSON)) {
+                try {
+                    final UUID id = UUID.fromString(evt.getDescription().split(":")[1]);
+                    campaignGUI.focusOnPerson(id);
+                } catch (Exception e) {
+                    logger.error("", e);
+                }
             }
         }
     }

--- a/MekHQ/src/mekhq/gui/ReportHyperlinkListener.java
+++ b/MekHQ/src/mekhq/gui/ReportHyperlinkListener.java
@@ -2,7 +2,7 @@
  * ReportHyperlinkListener.java
  *
  * Copyright (c) 2009 - Jay Lawson (jaylawson39 at yahoo.com). All Rights Reserved.
- * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2021-2025 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/baseComponents/MHQDialogImmersive.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/MHQDialogImmersive.java
@@ -20,6 +20,7 @@ package mekhq.gui.baseComponents;
 
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
+import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
@@ -45,6 +46,7 @@ public class MHQDialogImmersive extends JDialog {
     private final int INSERT_SIZE = UIUtil.scaleForGUI(10);
     private final int IMAGE_WIDTH = 100; // This is scaled to GUI by 'scaleImageIconToWidth'
 
+    private JPanel northPanel;
     private JPanel southPanel;
     private JPanel buttonPanel;
     private final Person leftSpeaker;
@@ -52,8 +54,7 @@ public class MHQDialogImmersive extends JDialog {
 
     private int dialogChoice;
 
-    private final transient ResourceBundle resources = ResourceBundle.getBundle(
-        "mekhq.resources.GUI", MekHQ.getMHQOptions().getLocale());
+    private static final MMLogger logger = MMLogger.create(MHQDialogImmersive.class);
 
     /**
      * Retrieves the user's selected dialog choice.
@@ -113,6 +114,8 @@ public class MHQDialogImmersive extends JDialog {
 
         int gridx = 0;
 
+        ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
+            MekHQ.getMHQOptions().getLocale());
         setTitle(resources.getString("incomingTransmission.title"));
 
         // Main Panel to hold all boxes
@@ -190,34 +193,17 @@ public class MHQDialogImmersive extends JDialog {
     }
 
     /**
-     * Creates and displays an instance of the {@link MHQDialogImmersive}.
+     * Handles hyperlink clicks from HTML content.
      * <p>
-     * This method acts as a factory for generating and displaying the dialog,
-     * allowing easy instantiation without requiring custom panel widths.
+     * This method provides a default implementation that does nothing. Subclasses should override
+     * this to provide specific behavior when hyperlinks are clicked.
+     * </p>
      *
-     * @param campaign              The {@link Campaign} tied to the dialog.
-     * @param leftSpeaker           The optional {@link Person} to display as the left speaker in
-     *                              the dialog. Can be {@code null}.
-     * @param rightSpeaker          The optional {@link Person} to display as the right speaker in
-     *                             the dialog. Can be {@code null}.
-     * @param centerMessage         The main message to display in the dialog.
-     * @param buttons               A list of {@link ButtonLabelTooltipPair} buttons with labels
-     *                             and optional tooltips.
-     * @param outOfCharacterMessage An optional custom OOC message displayed beneath the buttons.
-     *                             Can be {@code null}.
-     * @param defaultChoiceIndex    The default index selected if no user action is taken.
-     * @return A newly created and displayed instance of {@link MHQDialogImmersive}.
-     *
-     * @see #MHQDialogImmersive(Campaign, Person, Person, String, List, String, int, Integer,
-     * Integer, Integer)
+     * @param campaign The {@link Campaign} instance that contains relevant data.
+     * @param href The hyperlink reference (e.g., a URL or a specific identifier).
      */
-    public static MHQDialogImmersive createMHQDialogImmersive(Campaign campaign, @Nullable Person leftSpeaker,
-                                                @Nullable Person rightSpeaker, String centerMessage,
-                                                List<ButtonLabelTooltipPair> buttons,
-                                                @Nullable String outOfCharacterMessage,
-                                                int defaultChoiceIndex) {
-        return new MHQDialogImmersive(campaign, leftSpeaker, rightSpeaker, centerMessage, buttons,
-            outOfCharacterMessage, defaultChoiceIndex, null, null, null);
+    protected void handleHyperlinkClick(Campaign campaign, String href) {
+        logger.error("handleHyperlinkClick() was not overridden in the subclass.");
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/baseComponents/MHQDialogImmersive.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/MHQDialogImmersive.java
@@ -29,15 +29,28 @@ import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.Unit;
 
 import javax.swing.*;
+import javax.swing.event.HyperlinkEvent.EventType;
 import java.awt.*;
 import java.util.List;
 import java.util.ResourceBundle;
 
+import static java.lang.Math.round;
 import static mekhq.campaign.force.Force.FORCE_NONE;
 import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
 
+/**
+ * An immersive dialog used in MekHQ to display interactions between speakers,
+ * messages, and actions. The dialog supports entities such as speakers, campaign,
+ * buttons, and optional details for enhanced storytelling.
+ *
+ * <p>It allows displaying one or more speakers in a dialog alongside a central message,
+ * optional out-of-character notes, and UI buttons for user interaction.</p>
+ *
+ * <p>The dialog is flexible in terms of panel layout and width adjustments,
+ * allowing for dynamic configurations based on the input parameters.</p>
+ */
 public class MHQDialogImmersive extends JDialog {
-    private final Campaign campaign;
+    private Campaign campaign;
 
     private int LEFT_WIDTH = UIUtil.scaleForGUI(200);
     private int CENTER_WIDTH = UIUtil.scaleForGUI(400);
@@ -49,8 +62,8 @@ public class MHQDialogImmersive extends JDialog {
     private JPanel northPanel;
     private JPanel southPanel;
     private JPanel buttonPanel;
-    private final Person leftSpeaker;
-    private final Person rightSpeaker;
+    private Person leftSpeaker;
+    private Person rightSpeaker;
 
     private int dialogChoice;
 
@@ -74,27 +87,38 @@ public class MHQDialogImmersive extends JDialog {
     }
 
     /**
-     * Constructs an immersive dialog for displaying speakers, a message, and action buttons.
+     * Minimal constructor for initializing the immersive dialog with default width configurations.
      *
-     * @param campaign              The {@link Campaign} tied to the dialog.
-     * @param leftSpeaker           The optional {@link Person} to display as the left speaker in the dialog.
-     *                              Pass {@code null} for no left speaker.
-     * @param rightSpeaker          The optional {@link Person} to display as the right speaker in the dialog.
-     *                              Pass {@code null} for no right speaker.
-     * @param centerMessage         The main message displayed in the center of the dialog.
-     * @param buttons               A list of {@link ButtonLabelTooltipPair} controls to add below the message. Button
-     *                              labels and tooltips are defined in these pairs.
-     * @param outOfCharacterMessage An optional message displayed below the buttons (normally for
-     *                             OOC notes). Pass {@code null} for no message.
-     * @param leftWidth             Optional custom width for the left speaker panel. Pass {@code null}
-     *                             to use default width.
-     * @param defaultChoiceIndex   The index of the button included in {@code buttons} that is
-     *                            presumed to have been selected if the user cancels the dialog.
-     *                            Essentially, the default user choice if no other choice is made.
-     * @param centerWidth           Optional custom width for the center panel. Pass {@code null} to
-     *                             use default width.
-     * @param rightWidth            Optional custom width for the right speaker panel. Pass {@code null}
-     *                             to use default width.
+     * @param campaign The {@link Campaign} associated with the dialog.
+     * @param leftSpeaker The optional left-side speaker; {@code null} if none.
+     * @param rightSpeaker The optional right-side speaker; {@code null} if none.
+     * @param centerMessage The message displayed at the center of the dialog.
+     * @param buttons The list of buttons to display, each accompanied by a tooltip.
+     * @param outOfCharacterMessage Optional out-of-character notes; {@code null} if none.
+     * @param defaultChoiceIndex The default choice index if no button is explicitly selected.
+     */
+    public MHQDialogImmersive(Campaign campaign, @Nullable Person leftSpeaker,
+                              @Nullable Person rightSpeaker, String centerMessage,
+                              List<ButtonLabelTooltipPair> buttons,
+                              @Nullable String outOfCharacterMessage, int defaultChoiceIndex) {
+        new MHQDialogImmersive(campaign, leftSpeaker, rightSpeaker, centerMessage, buttons,
+            outOfCharacterMessage, defaultChoiceIndex,
+            null, null, null);
+    }
+
+    /**
+     * Full constructor for initializing the immersive dialog with detailed layouts.
+     *
+     * @param campaign The {@link Campaign} tied to the dialog.
+     * @param leftSpeaker Optional left-side {@link Person}; {@code null} if none.
+     * @param rightSpeaker Optional right-side {@link Person}; {@code null} if none.
+     * @param centerMessage The main message displayed in the dialog's center.
+     * @param buttons The list of {@link ButtonLabelTooltipPair} actions for the dialog.
+     * @param outOfCharacterMessage Optional out-of-character message below the buttons.
+     * @param defaultChoiceIndex Default button index assumed when the user closes the dialog.
+     * @param leftWidth Optional width for the left panel; defaults to a pre-defined width if null.
+     * @param centerWidth Optional width for the center panel; defaults if null.
+     * @param rightWidth Optional width for the right panel; defaults if null.
      */
     public MHQDialogImmersive(Campaign campaign, @Nullable Person leftSpeaker,
                               @Nullable Person rightSpeaker, String centerMessage,
@@ -102,18 +126,15 @@ public class MHQDialogImmersive extends JDialog {
                               @Nullable String outOfCharacterMessage, int defaultChoiceIndex,
                               @Nullable Integer leftWidth, @Nullable Integer centerWidth,
                               @Nullable Integer rightWidth) {
+        // Initialize
         this.campaign = campaign;
         this.leftSpeaker = leftSpeaker;
         this.rightSpeaker = rightSpeaker;
 
-        dialogChoice = defaultChoiceIndex;
+        initialize(leftSpeaker, rightSpeaker, defaultChoiceIndex, leftWidth, centerWidth,
+            rightWidth);
 
-        LEFT_WIDTH = (leftWidth != null) ? leftWidth : LEFT_WIDTH;
-        CENTER_WIDTH = (centerWidth != null) ? centerWidth : CENTER_WIDTH;
-        RIGHT_WIDTH = (rightWidth != null) ? rightWidth : RIGHT_WIDTH;
-
-        int gridx = 0;
-
+        // Title
         ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
             MekHQ.getMHQOptions().getLocale());
         setTitle(resources.getString("incomingTransmission.title"));
@@ -125,6 +146,8 @@ public class MHQDialogImmersive extends JDialog {
         constraints.fill = GridBagConstraints.BOTH;
         constraints.weighty = 1;
 
+        int gridx = 0;
+
         // Left box for speaker details
         if (leftSpeaker != null) {
             JPanel pnlLeftSpeaker = buildSpeakerPanel(true);
@@ -132,27 +155,19 @@ public class MHQDialogImmersive extends JDialog {
             // Add pnlLeftSpeaker to mainPanel
             constraints.gridx = gridx;
             constraints.gridy = 0;
-            constraints.weightx = 0;
+            constraints.weightx = 1;
+            constraints.weighty = 1;
             mainPanel.add(pnlLeftSpeaker, constraints);
-
             gridx++;
         }
 
-        // Center box: for message
-        JPanel pnlCenter = new JPanel(new BorderLayout());
-        pnlCenter.setBorder(BorderFactory.createEtchedBorder());
-        JLabel lblCenterMessage = new JLabel(
-            String.format("<html><div style='width: %s; text-align:center;'>%s</div></html>",
-                CENTER_WIDTH, centerMessage)
-        );
-        pnlCenter.add(lblCenterMessage);
-
-        // Add mainPanel to dialog
+        // Center box for the message
+        JPanel pnlCenter = createCenterBox(centerMessage);
         constraints.gridx = gridx;
         constraints.gridy = 0;
-        constraints.weightx = 0;
+        constraints.weightx = 2;
+        constraints.weighty = 2;
         mainPanel.add(pnlCenter, constraints);
-
         gridx++;
 
         // Right box for speaker details
@@ -162,7 +177,8 @@ public class MHQDialogImmersive extends JDialog {
             // Add pnlRightSpeaker to mainPanel
             constraints.gridx = gridx;
             constraints.gridy = 0;
-            constraints.weightx = 0;
+            constraints.weightx = 1;
+            constraints.weighty = 1;
             mainPanel.add(pnlRightSpeaker, constraints);
         }
 
@@ -188,15 +204,85 @@ public class MHQDialogImmersive extends JDialog {
         setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
         setModal(true);
         setLocationRelativeTo(null);
+        int preferredWidth = (int) round(CENTER_WIDTH + LEFT_WIDTH + RIGHT_WIDTH * 1.1);
+        setPreferredSize(new Dimension(preferredWidth, UIUtil.scaleForGUI(400)));
         pack();
         setVisible(true);
     }
 
     /**
+     * Performs initialization logic for setting default dialog settings and widths.
+     *
+     * @param leftSpeaker The left speaker for the dialog.
+     * @param rightSpeaker The right speaker for the dialog.
+     * @param defaultChoiceIndex Default choice assigned when dialog is dismissed.
+     * @param leftWidth Optional custom width for the left panel.
+     * @param centerWidth Optional custom width for the center panel.
+     * @param rightWidth Optional custom width for the right panel.
+     */
+    private void initialize(@Nullable Person leftSpeaker, @Nullable Person rightSpeaker,
+                            int defaultChoiceIndex, @Nullable Integer leftWidth,
+                            @Nullable Integer centerWidth, @Nullable Integer rightWidth) {
+        dialogChoice = defaultChoiceIndex;
+
+        if (leftSpeaker == null) {
+            LEFT_WIDTH = 0;
+        } else {
+            LEFT_WIDTH = (leftWidth != null) ? leftWidth : LEFT_WIDTH;
+        }
+
+        CENTER_WIDTH = (centerWidth != null) ? centerWidth : CENTER_WIDTH;
+
+        if (rightSpeaker == null) {
+            RIGHT_WIDTH = 0;
+        } else {
+            RIGHT_WIDTH = (rightWidth != null) ? rightWidth : RIGHT_WIDTH;
+        }
+    }
+
+    /**
+     * Creates and returns the central panel that contains the main dialog message.
+     *
+     * @param centerMessage The main message as a string, typically in HTML format.
+     * @return A {@link JPanel} containing the message displayed at the center.
+     */
+    private JPanel createCenterBox(String centerMessage) {
+        northPanel = new JPanel(new BorderLayout());
+        northPanel.setBorder(BorderFactory.createEtchedBorder());
+
+        // Create a JEditorPane for the center message
+        JEditorPane editorPane = new JEditorPane();
+        editorPane.setContentType("text/html");
+        editorPane.setEditable(false);
+        editorPane.setText(
+            String.format("<div style='text-align:center;'>%s</div>", centerMessage)
+        );
+
+        // Add a HyperlinkListener to capture hyperlink clicks
+        editorPane.addHyperlinkListener(evt -> {
+            if (evt.getEventType() == EventType.ACTIVATED) {
+                handleHyperlinkClick(campaign, evt.getDescription());
+            }
+        });
+
+        // Wrap the JEditorPane in a JScrollPane
+        JScrollPane scrollPane = new JScrollPane(editorPane);
+        scrollPane.setMinimumSize(new Dimension(CENTER_WIDTH, scrollPane.getHeight()));
+
+        northPanel.add(scrollPane, BorderLayout.CENTER);
+
+        // Ensure the scrollbars default to the top-left position
+        SwingUtilities.invokeLater(() -> scrollPane.getViewport().setViewPosition(new Point(0, 0)));
+
+        return northPanel;
+    }
+
+    /**
      * Handles hyperlink clicks from HTML content.
      * <p>
-     * This method provides a default implementation that does nothing. Subclasses should override
-     * this to provide specific behavior when hyperlinks are clicked.
+     *     <b>Usage</b><br>
+     *     This method provides a default implementation that does nothing. Subclasses should
+     *     override this to provide specific behavior when hyperlinks are clicked.
      * </p>
      *
      * @param campaign The {@link Campaign} instance that contains relevant data.
@@ -218,9 +304,7 @@ public class MHQDialogImmersive extends JDialog {
         JPanel pnlOutOfCharacter = new JPanel(new BorderLayout());
         pnlOutOfCharacter.setBorder(BorderFactory.createEtchedBorder());
 
-        int bottomPanelWidth = CENTER_WIDTH;
-        bottomPanelWidth += leftSpeaker == null ? 0 : LEFT_WIDTH;
-        bottomPanelWidth += rightSpeaker == null ? 0 : RIGHT_WIDTH;
+        int bottomPanelWidth = CENTER_WIDTH + LEFT_WIDTH + RIGHT_WIDTH;
 
         JLabel lblOutOfCharacter = new JLabel(
             String.format("<html><div style='width: %s; text-align:center;'>%s</div></html>",
@@ -379,10 +463,8 @@ public class MHQDialogImmersive extends JDialog {
     }
 
     /**
-     * A class to store and represent a button label and its associated tooltip.
-     * <p>
-     * This class is useful for scenarios where you want to pair a button's display label
-     * with an optional tooltip message.
+     * Represents a label-tooltip pair for constructing UI buttons.
+     * Each button displays a label and optionally provides a tooltip when hovered.
      */
     public record ButtonLabelTooltipPair(String btnLabel, String btnTooltip) {
         /**

--- a/MekHQ/src/mekhq/gui/dialog/CampaignHasProblemOnLoad.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignHasProblemOnLoad.java
@@ -60,8 +60,7 @@ public class CampaignHasProblemOnLoad extends MHQDialogImmersive {
      */
     public CampaignHasProblemOnLoad(Campaign campaign, CampaignProblemType problemType) {
         super(campaign, getSpeaker(campaign), null, createInCharacterMessage(campaign, problemType),
-            createButtons(problemType), createOutOfCharacterMessage(problemType), 0,
-            null, null, null);
+            createButtons(problemType), createOutOfCharacterMessage(problemType), 0);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/VocationalExperienceAwardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/VocationalExperienceAwardDialog.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.gui.dialog;
+
+import megamek.common.annotations.Nullable;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.gui.CampaignGUI;
+import mekhq.gui.baseComponents.MHQDialogImmersive;
+
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.UUID;
+
+import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
+
+public class VocationalExperienceAwardDialog extends MHQDialogImmersive {
+    private static final String BUNDLE_KEY = "mekhq.resources.VocationalExperienceAwardDialog";
+    private static final ResourceBundle resources = ResourceBundle.getBundle(
+        BUNDLE_KEY, MekHQ.getMHQOptions().getLocale());
+
+    public VocationalExperienceAwardDialog(Campaign campaign) {
+        super(campaign, getSpeaker(campaign), null, createInCharacterMessage(campaign),
+            createButtons(), createOutOfCharacterMessage(campaign), 0,
+            null, null, null);
+
+        setModal(false);
+        setAlwaysOnTop(true);
+    }
+
+    @Override
+    protected void handleHyperlinkClick(Campaign campaign, String href) {
+        CampaignGUI campaignGUI = campaign.getApp().getCampaigngui();
+
+        final UUID id = UUID.fromString(href.split(":")[1]);
+        campaignGUI.focusOnPerson(id);
+    }
+
+    private static List<ButtonLabelTooltipPair> createButtons() {
+        ButtonLabelTooltipPair btnConfirm = new ButtonLabelTooltipPair(
+            resources.getString("confirm.button"), null);
+
+        return List.of(btnConfirm);
+    }
+
+    private static @Nullable Person getSpeaker(Campaign campaign) {
+        return campaign.getSeniorAdminPerson(HR);
+    }
+
+    private static String createInCharacterMessage(Campaign campaign) {
+        List<Person> personnelWhoAdvanced = campaign.getPersonnelWhoAdvancedInXP();
+
+        String commanderAddress = campaign.getCommanderAddress(false);
+
+        StringBuilder message = new StringBuilder();
+        message.append(commanderAddress);
+        message.append(resources.getString("dialog.message"));
+
+        for (Person person : personnelWhoAdvanced) {
+            message.append("<br>- ").append(person.getHyperlinkedFullTitle());
+        }
+
+        return message.toString();
+    }
+
+    private static String createOutOfCharacterMessage(Campaign campaign) {
+        int advancement = campaign.getCampaignOptions().getIdleXP();
+        return String.format(resources.getString("dialog.ooc"), advancement);
+    }
+}


### PR DESCRIPTION
- Expanded 'MHQImmersiveDialog.java` to allow for the usage of html triggers. This significantly expands the stuff we can do with dialogs extending this class.
- Expanded the same class to incorporate a scrollbar (vertical or horizontal) whenever necessary.
- Added hyperlink for personnel gaining xp to the report hyperlink listener.
- Replaced 'wall of text' xp gain with a single hyperlink that allows users to bring up an immersive dialog that details who has received xp. Selecting characters in this dialog will jump the user to that character. This dialog is set to 'always on top' and not modal, allowing users to keep it up indefinitely while they jump back and forth between characters.

I anticipate this being a big quality of life improvement for users with larger campaigns.

Before...
(there are several 'pages' of this):
<img width="389" alt="image" src="https://github.com/user-attachments/assets/8d84193a-ec51-4152-8d2e-4a1e8ce00ada" />

After...
(hyperlinked report message)
<img width="283" alt="image" src="https://github.com/user-attachments/assets/d05cb374-b739-4e36-a79a-ad3c38937d82" />

(immersive dialog)
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/a1388a9f-9b91-4b8d-8cb2-cb93210ac6f3" />

Fix #5591
