### PR TITLE
fix: due to how things work the ai player cant have : in its name

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -511,7 +511,7 @@ public class AtBGameThread extends GameThread {
     }
 
     private void setupPlayerBotForAutoResolve(Player player) throws InterruptedException, PrincessException {
-        var botName = player.getName() + ":AI";
+        var botName = player.getName() + "@AI";
 
         Thread.sleep(MekHQ.getMHQOptions().getStartGameBotClientDelay());
         var botClient = new Princess(botName, client.getHost(), client.getPort());

--- a/MekHQ/src/mekhq/gui/dialog/AutoResolveBehaviorSettingsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AutoResolveBehaviorSettingsDialog.java
@@ -37,7 +37,7 @@ public class AutoResolveBehaviorSettingsDialog
      * @param campaign The campaign to get the auto resolve behavior settings from.
      */
     public AutoResolveBehaviorSettingsDialog(final JFrame frame, final Campaign campaign) {
-        super(frame, campaign.getName() + ":AI", campaign.getAutoResolveBehaviorSettings(), null);
+        super(frame, campaign.getName() + "@AI", campaign.getAutoResolveBehaviorSettings(), null);
         setAlwaysOnTop(true);
         setCampaign(campaign);
     }
@@ -77,7 +77,7 @@ public class AutoResolveBehaviorSettingsDialog
     private void updateBehaviorSettings() {
         var autoResolveBehaviorSettings = getBehaviorSettings();
         try {
-            autoResolveBehaviorSettings.setDescription(campaign.getName() + ":AI");
+            autoResolveBehaviorSettings.setDescription(campaign.getName() + "@AI");
         } catch (PrincessException e) {
             // This should never happen, but if it does, it is not a critical error.
             // We set the auto resolve behavior setting, ignore that its description


### PR DESCRIPTION
```java
        // Commands should be sent in this format:
        // <botName>: <command> : <arguments>

        StringTokenizer tokenizer = new StringTokenizer(chatEvent.getMessage(), ":");
```

Princess ACAR makes an AI with the template `%s:AI`... so... if I send a message for the AI to flee, it is going to send:
`player:ai: fl : 4` it will receive it as `player, ai, fl, 4` and respond with "nah... I dont know what that means.

This changes the name of the bot from `%s:AI` to `%s@AI`