### PR TITLE
[Issue 5724] Fix astech time calculations for units that do not require maintenance

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -5910,10 +5910,20 @@ public class Unit implements ITechnology {
         return !(getEntity() instanceof Infantry) || getEntity() instanceof BattleArmor;
     }
 
+    /**
+     * Not always opposite to isUnmaintained() - both are false for units that do not require maintenance.
+     * @return true if unit requires maintenance and has a tech assigned, false otherwise.
+     * @see #isUnmaintained()
+     */
     public boolean isMaintained() {
         return requiresMaintenance() && (getTech() != null);
     }
 
+    /**
+     * Not always opposite to isMaintained() - both are false for units that do not require maintenance.
+     * @return true if unit requires maintenance and does not have a tech assigned, false otherwise.
+     * @see #isMaintained()
+     */
     public boolean isUnmaintained() {
         return requiresMaintenance() && (getTech() == null);
     }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -5910,6 +5910,10 @@ public class Unit implements ITechnology {
         return !(getEntity() instanceof Infantry) || getEntity() instanceof BattleArmor;
     }
 
+    public boolean isMaintained() {
+        return requiresMaintenance() && (getTech() != null);
+    }
+
     public boolean isUnmaintained() {
         return requiresMaintenance() && (getTech() == null);
     }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/InsufficientAstechTimeNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/InsufficientAstechTimeNagLogic.java
@@ -44,7 +44,7 @@ public class InsufficientAstechTimeNagLogic {
         // Calculate the total maintenance time needed using a traditional loop
         int need = 0;
         for (Unit unit : campaign.getHangar().getUnits()) {
-            if (!unit.isUnmaintained() && unit.isPresent() && !unit.isSelfCrewed()) {
+            if (unit.isMaintained() && unit.isPresent() && !unit.isSelfCrewed()) {
                 need += unit.getMaintenanceTime() * 6;
             }
         }


### PR DESCRIPTION
Fixes #5724

Implemented a proper method for checking if a unit is being actively maintained. The "isUnmaintained()" method should not be used for these purposes, such an approach gives incorrect results for units that do not require maintenance - for example, mothballed Mechs.