### PR TITLE
Issue 5818: Fixed assigning/unassigning transports from TOE at the Force level & infantry compartments use the correct weight for infantry squads

### DIFF
--- a/MekHQ/src/mekhq/campaign/utilities/CampaignTransportUtilities.java
+++ b/MekHQ/src/mekhq/campaign/utilities/CampaignTransportUtilities.java
@@ -62,9 +62,12 @@ public class CampaignTransportUtilities {
      * @return how much capacity this unit uses when being transported in this kind of transporter
      */
     public static double transportCapacityUsage(TransporterType transporterType, Entity transportedUnit) {
-        if (transporterType == INFANTRY_BAY || transporterType == INFANTRY_COMPARTMENT) {
-            if (transportedUnit instanceof Infantry) {
+        if (transportedUnit instanceof Infantry) {
+            if (transporterType == INFANTRY_BAY) {
                 return calcInfantryBayWeight(transportedUnit);
+            }
+            else if (transporterType == INFANTRY_COMPARTMENT) {
+                return calcInfantryCompartmentWeight(transportedUnit);
             }
         }
         return 1.0;
@@ -74,15 +77,27 @@ public class CampaignTransportUtilities {
      * Calculates transport bay space required by an infantry platoon,
      * which is not the same as the flat weight of that platoon
      *
-     * @param unit The Entity that we need the weight for
+     * @param entity The Entity that we need the weight for
+     * @return Capacity in tons needed to transport this entity
      */
-    public static double calcInfantryBayWeight(Entity unit) {
-        InfantryBay.PlatoonType type = InfantryBay.PlatoonType.getPlatoonType(unit);
-        if ((unit instanceof Infantry) && (type == InfantryBay.PlatoonType.MECHANIZED)) {
-            return type.getWeight() * ((Infantry) unit).getSquadCount();
+    private static double calcInfantryBayWeight(Entity entity) {
+        InfantryBay.PlatoonType type = InfantryBay.PlatoonType.getPlatoonType(entity);
+
+        if ((entity instanceof Infantry) && (type == InfantryBay.PlatoonType.MECHANIZED)) {
+            return type.getWeight() * ((Infantry) entity).getSquadCount();
         } else {
             return type.getWeight();
         }
+    }
+
+    /**
+     * Calculates transport space required for an infantry compartment
+     *
+     * @param entity The Entity that we need the weight for
+     * @return Capacity in tons needed to transport this entity
+     */
+    private static double calcInfantryCompartmentWeight(Entity entity) {
+        return entity.getWeight();
     }
 
 

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1163,11 +1163,11 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             // This checks to see if the ship is in a basic state that can accept units.
             // Capacity gets checked once the action is submitted.
             if (!unitsInForces.isEmpty()) {
-                JMenuHelpers.addMenuIfNonEmpty(popup, new AssignForceToShipTransportMenu(gui.getCampaign(), new HashSet<>(units)));
-                unassignShipTransportMenuClass(units, popup);
+                JMenuHelpers.addMenuIfNonEmpty(popup, new AssignForceToShipTransportMenu(gui.getCampaign(), new HashSet<>(unitsInForces)));
+                unassignShipTransportMenuClass(unitsInForces, popup);
 
-                JMenuHelpers.addMenuIfNonEmpty(popup, new AssignForceToTacticalTransportMenu(gui.getCampaign(), new HashSet<>(units)));
-                unassignTacticalTransportMenuClass(units, popup);
+                JMenuHelpers.addMenuIfNonEmpty(popup, new AssignForceToTacticalTransportMenu(gui.getCampaign(), new HashSet<>(unitsInForces)));
+                unassignTacticalTransportMenuClass(unitsInForces, popup);
             }
         } else if (unitsSelected) {
             Unit unit = units.get(0);


### PR DESCRIPTION
Fixes #5818 

This fixes a bug with the new MekHQ transporters. 

@UlyssesSockdrawer on Discord observed that infantry **squads** were unable to load into a 3 ton infantry compartment, and that when right-clicking on a "force" it was improperly showing unassign from transport (& it didn't work).

- Infantry loaded into a compartment will use the correct weight
- Right clicking a force has the correct assign/unassign transport options