### PR TITLE
[Issue 5810] Fix peacetime operating cost settings

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/FinancesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/FinancesTab.java
@@ -753,7 +753,7 @@ public class FinancesTab {
         options.setLoanLimits(useLoanLimitsBox.isSelected());
         options.setUsePercentageMaint(usePercentageMaintenanceBox.isSelected());
         options.setUseExtendedPartsModifier(useExtendedPartsModifierBox.isSelected());
-        options.setShowPeacetimeCost(usePeacetimeCostBox.isSelected());
+        options.setUsePeacetimeCost(usePeacetimeCostBox.isSelected());
         options.setShowPeacetimeCost(showPeacetimeCostBox.isSelected());
         options.setFinancialYearDuration(comboFinancialYearDuration.getSelectedItem());
         options.setNewFinancialYearFinancesToCSVExport(newFinancialYearFinancesToCSVExportBox.isSelected());
@@ -818,7 +818,7 @@ public class FinancesTab {
         useLoanLimitsBox.setSelected(options.isUseLoanLimits());
         usePercentageMaintenanceBox.setSelected(options.isUsePercentageMaint());
         useExtendedPartsModifierBox.setSelected(options.isUseExtendedPartsModifier());
-        usePeacetimeCostBox.setSelected(options.isShowPeacetimeCost());
+        usePeacetimeCostBox.setSelected(options.isUsePeacetimeCost());
         showPeacetimeCostBox.setSelected(options.isShowPeacetimeCost());
         comboFinancialYearDuration = new MMComboBox<>("comboFinancialYearDuration",
                 FinancialYearDuration.values());


### PR DESCRIPTION
Fixes #5810 

In some cases the assignment of variables for "usePeacetimeCost" was mixed up with "showPeacetimeCost". As a result, the checkbox for using peacetime costs in the settings was effectively overriden by the checkbox for logging peacetime costs.

Users whose campaigns were affected by the bug would need to turn on the peacetime costs after the fix, since their campaign settings are currently saved as having that feature disabled (and not displayed that way).