### PR TITLE
Extract AtB Event Types to enum

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -117,19 +117,6 @@ import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
 public class AtBContract extends Contract {
     private static final MMLogger logger = MMLogger.create(AtBContract.class);
 
-    public static final int EVT_NOEVENT = -1;
-    public static final int EVT_BONUSROLL = 0;
-    public static final int EVT_SPECIAL_SCENARIO = 1;
-    public static final int EVT_CIVILDISTURBANCE = 2;
-    public static final int EVT_SPORADICUPRISINGS = 3;
-    public static final int EVT_REBELLION = 4;
-    public static final int EVT_BETRAYAL = 5;
-    public static final int EVT_TREACHERY = 6;
-    public static final int EVT_LOGISTICSFAILURE = 7;
-    public static final int EVT_REINFORCEMENTS = 8;
-    public static final int EVT_SPECIALEVENTS = 9;
-    public static final int EVT_BIGBATTLE = 10;
-
     /** The minimum intensity below which no scenarios will be generated */
     public static final double MINIMUM_INTENSITY = 0.01;
 
@@ -942,29 +929,29 @@ public class AtBContract extends Contract {
             }
 
             switch (getContractType().generateEventType(campaign)) {
-                case EVT_BONUSROLL:
+                case BONUSROLL:
                     campaign.addReport("<b>Special Event:</b> ");
                     doBonusRoll(campaign, false);
                     break;
-                case EVT_SPECIAL_SCENARIO:
+                case SPECIAL_SCENARIO:
                     campaign.addReport("<b>Special Event:</b> Special scenario this month");
                     specialEventScenarioDate = getRandomDayOfMonth(campaign.getLocalDate());
                     specialEventScenarioType = getContractType().generateSpecialScenarioType(campaign);
                     break;
-                case EVT_CIVILDISTURBANCE:
+                case CIVILDISTURBANCE:
                     campaign.addReport("<b>Special Event:</b> Civil disturbance<br />Next enemy morale roll gets +1 modifier");
                     moraleMod++;
                     break;
-                case EVT_SPORADICUPRISINGS:
+                case SPORADICUPRISINGS:
                     campaign.addReport("<b>Special Event:</b> Sporadic uprisings<br />+2 to next enemy morale roll");
                     moraleMod += 2;
                     break;
-                case EVT_REBELLION:
+                case REBELLION:
                     campaign.addReport("<b>Special Event:</b> Rebellion<br />+2 to next enemy morale roll");
                     specialEventScenarioDate = getRandomDayOfMonth(campaign.getLocalDate());
                     specialEventScenarioType = AtBScenario.CIVILIANRIOT;
                     break;
-                case EVT_BETRAYAL:
+                case BETRAYAL:
                     String text = "<b>Special Event:</b> Betrayal (employer minor breach)<br />";
                     switch (d6()) {
                         case 1:
@@ -992,23 +979,23 @@ public class AtBContract extends Contract {
                     employerMinorBreaches++;
                     campaign.addReport(text);
                     break;
-                case EVT_TREACHERY:
+                case TREACHERY:
                     campaign.addReport(
                             "<b>Special Event:</b> Treachery<br />Bad information from employer. Next Enemy Morale roll gets +1. Employer minor breach.");
                     moraleMod++;
                     employerMinorBreaches++;
                     break;
-                case EVT_LOGISTICSFAILURE:
+                case LOGISTICSFAILURE:
                     campaign.addReport(
                             "<b>Special Event:</b> Logistics Failure<br />Parts availability for the next month are one level lower.");
                     partsAvailabilityLevel--;
                     priorLogisticsFailure = true;
                     break;
-                case EVT_REINFORCEMENTS:
+                case REINFORCEMENTS:
                     campaign.addReport("<b>Special Event:</b> Reinforcements<br />The next Enemy Morale roll gets a -1.");
                     moraleMod--;
                     break;
-                case EVT_SPECIALEVENTS:
+                case SPECIALEVENTS:
                     text = "<b>Special Event:</b> ";
                     switch (d6()) {
                         case 1:
@@ -1054,7 +1041,7 @@ public class AtBContract extends Contract {
                     }
                     campaign.addReport(text);
                     break;
-                case EVT_BIGBATTLE:
+                case BIGBATTLE:
                     campaign.addReport("<b>Special Event:</b> Big battle this month");
                     specialEventScenarioDate = getRandomDayOfMonth(campaign.getLocalDate());
                     specialEventScenarioType = getContractType().generateBigBattleType();

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
@@ -218,9 +218,9 @@ public enum AtBContractType {
      * {@link #generateStratConEvent()} method.</p>
      *
      * @param campaign the {@link Campaign} instance for which the event is being generated.
-     * @return an integer representing the event type.
+     * @return an AtBEvent enum representing the event type.
      */
-    public int generateEventType(Campaign campaign) {
+    public AtBEventType generateEventType(Campaign campaign) {
         if (campaign.getCampaignOptions().isUseStratCon()) {
             return generateStratConEvent();
         }
@@ -233,107 +233,107 @@ public enum AtBContractType {
             case RECON_RAID:
             case EXTRACTION_RAID:
                 if (roll < 10) {
-                    return AtBContract.EVT_BONUSROLL;
+                    return AtBEventType.BONUSROLL;
                 } else if (roll < 14) {
-                    return AtBContract.EVT_SPECIAL_SCENARIO;
+                    return AtBEventType.SPECIAL_SCENARIO;
                 } else if (roll < 16) {
-                    return AtBContract.EVT_BETRAYAL;
+                    return AtBEventType.BETRAYAL;
                 } else if (roll < 17) {
-                    return AtBContract.EVT_TREACHERY;
+                    return AtBEventType.TREACHERY;
                 } else if (roll < 18) {
-                    return AtBContract.EVT_LOGISTICSFAILURE;
+                    return AtBEventType.LOGISTICSFAILURE;
                 } else if (roll < 19) {
-                    return AtBContract.EVT_REINFORCEMENTS;
+                    return AtBEventType.REINFORCEMENTS;
                 } else if (roll < 20) {
-                    return AtBContract.EVT_SPECIALEVENTS;
+                    return AtBEventType.SPECIALEVENTS;
                 } else {
-                    return AtBContract.EVT_BIGBATTLE;
+                    return AtBEventType.BIGBATTLE;
                 }
             case GARRISON_DUTY:
                 if (roll < 8) {
-                    return AtBContract.EVT_BONUSROLL;
+                    return AtBEventType.BONUSROLL;
                 } else if (roll < 12) {
-                    return AtBContract.EVT_SPECIAL_SCENARIO;
+                    return AtBEventType.SPECIAL_SCENARIO;
                 } else if (roll < 13) {
-                    return AtBContract.EVT_CIVILDISTURBANCE;
+                    return AtBEventType.CIVILDISTURBANCE;
                 } else if (roll < 14) {
-                    return AtBContract.EVT_SPORADICUPRISINGS;
+                    return AtBEventType.SPORADICUPRISINGS;
                 } else if (roll < 15) {
-                    return AtBContract.EVT_REBELLION;
+                    return AtBEventType.REBELLION;
                 } else if (roll < 16) {
-                    return AtBContract.EVT_BETRAYAL;
+                    return AtBEventType.BETRAYAL;
                 } else if (roll < 17) {
-                    return AtBContract.EVT_TREACHERY;
+                    return AtBEventType.TREACHERY;
                 } else if (roll < 18) {
-                    return AtBContract.EVT_LOGISTICSFAILURE;
+                    return AtBEventType.LOGISTICSFAILURE;
                 } else if (roll < 19) {
-                    return AtBContract.EVT_REINFORCEMENTS;
+                    return AtBEventType.REINFORCEMENTS;
                 } else if (roll < 20) {
-                    return AtBContract.EVT_SPECIALEVENTS;
+                    return AtBEventType.SPECIALEVENTS;
                 } else {
-                    return AtBContract.EVT_BIGBATTLE;
+                    return AtBEventType.BIGBATTLE;
                 }
             case RIOT_DUTY:
                 if (roll < 8) {
-                    return AtBContract.EVT_BONUSROLL;
+                    return AtBEventType.BONUSROLL;
                 } else if (roll < 11) {
-                    return AtBContract.EVT_SPECIAL_SCENARIO;
+                    return AtBEventType.SPECIAL_SCENARIO;
                 } else if (roll < 12) {
-                    return AtBContract.EVT_CIVILDISTURBANCE;
+                    return AtBEventType.CIVILDISTURBANCE;
                 } else if (roll < 13) {
-                    return AtBContract.EVT_SPORADICUPRISINGS;
+                    return AtBEventType.SPORADICUPRISINGS;
                 } else if (roll < 15) {
-                    return AtBContract.EVT_REBELLION;
+                    return AtBEventType.REBELLION;
                 } else if (roll < 16) {
-                    return AtBContract.EVT_BETRAYAL;
+                    return AtBEventType.BETRAYAL;
                 } else if (roll < 17) {
-                    return AtBContract.EVT_TREACHERY;
+                    return AtBEventType.TREACHERY;
                 } else if (roll < 18) {
-                    return AtBContract.EVT_LOGISTICSFAILURE;
+                    return AtBEventType.LOGISTICSFAILURE;
                 } else if (roll < 19) {
-                    return AtBContract.EVT_REINFORCEMENTS;
+                    return AtBEventType.REINFORCEMENTS;
                 } else if (roll < 20) {
-                    return AtBContract.EVT_SPECIALEVENTS;
+                    return AtBEventType.SPECIALEVENTS;
                 } else {
-                    return AtBContract.EVT_BIGBATTLE;
+                    return AtBEventType.BIGBATTLE;
                 }
             case PIRATE_HUNTING:
                 if (roll < 10) {
-                    return AtBContract.EVT_BONUSROLL;
+                    return AtBEventType.BONUSROLL;
                 } else if (roll < 14) {
-                    return AtBContract.EVT_SPECIAL_SCENARIO;
+                    return AtBEventType.SPECIAL_SCENARIO;
                 } else if (roll < 15) {
-                    return AtBContract.EVT_CIVILDISTURBANCE;
+                    return AtBEventType.CIVILDISTURBANCE;
                 } else if (roll < 16) {
-                    return AtBContract.EVT_BETRAYAL;
+                    return AtBEventType.BETRAYAL;
                 } else if (roll < 17) {
-                    return AtBContract.EVT_TREACHERY;
+                    return AtBEventType.TREACHERY;
                 } else if (roll < 18) {
-                    return AtBContract.EVT_LOGISTICSFAILURE;
+                    return AtBEventType.LOGISTICSFAILURE;
                 } else if (roll < 19) {
-                    return AtBContract.EVT_REINFORCEMENTS;
+                    return AtBEventType.REINFORCEMENTS;
                 } else if (roll < 20) {
-                    return AtBContract.EVT_SPECIALEVENTS;
+                    return AtBEventType.SPECIALEVENTS;
                 } else {
-                    return AtBContract.EVT_BIGBATTLE;
+                    return AtBEventType.BIGBATTLE;
                 }
             default:
                 if (roll < 10) {
-                    return AtBContract.EVT_BONUSROLL;
+                    return AtBEventType.BONUSROLL;
                 } else if (roll < 15) {
-                    return AtBContract.EVT_SPECIAL_SCENARIO;
+                    return AtBEventType.SPECIAL_SCENARIO;
                 } else if (roll < 16) {
-                    return AtBContract.EVT_BETRAYAL;
+                    return AtBEventType.BETRAYAL;
                 } else if (roll < 17) {
-                    return AtBContract.EVT_TREACHERY;
+                    return AtBEventType.TREACHERY;
                 } else if (roll < 18) {
-                    return AtBContract.EVT_LOGISTICSFAILURE;
+                    return AtBEventType.LOGISTICSFAILURE;
                 } else if (roll < 19) {
-                    return AtBContract.EVT_REINFORCEMENTS;
+                    return AtBEventType.REINFORCEMENTS;
                 } else if (roll < 20) {
-                    return AtBContract.EVT_SPECIALEVENTS;
+                    return AtBEventType.SPECIALEVENTS;
                 } else {
-                    return AtBContract.EVT_BIGBATTLE;
+                    return AtBEventType.BIGBATTLE;
                 }
         }
     }
@@ -347,97 +347,97 @@ public enum AtBContractType {
      *
      * @return an integer representing the event type.
      */
-    public int generateStratConEvent() {
+    public AtBEventType generateStratConEvent() {
         final int roll = Compute.randomInt(20) + 1;
 
         return switch (this) {
             case DIVERSIONARY_RAID, OBJECTIVE_RAID, RECON_RAID, EXTRACTION_RAID -> {
                 if (roll < 14) {
-                    yield AtBContract.EVT_BONUSROLL;
+                    yield AtBEventType.BONUSROLL;
                 } else if (roll < 16) {
-                    yield AtBContract.EVT_BETRAYAL;
+                    yield AtBEventType.BETRAYAL;
                 } else if (roll < 17) {
-                    yield AtBContract.EVT_TREACHERY;
+                    yield AtBEventType.TREACHERY;
                 } else if (roll < 18) {
-                    yield AtBContract.EVT_LOGISTICSFAILURE;
+                    yield AtBEventType.LOGISTICSFAILURE;
                 } else if (roll < 19) {
-                    yield AtBContract.EVT_REINFORCEMENTS;
+                    yield AtBEventType.REINFORCEMENTS;
                 } else {
-                    yield AtBContract.EVT_SPECIALEVENTS;
+                    yield AtBEventType.SPECIALEVENTS;
                 }
             }
             case GARRISON_DUTY -> {
                 if (roll < 12) {
-                    yield AtBContract.EVT_BONUSROLL;
+                    yield AtBEventType.BONUSROLL;
                 } else if (roll < 13) {
-                    yield AtBContract.EVT_CIVILDISTURBANCE;
+                    yield AtBEventType.CIVILDISTURBANCE;
                 } else if (roll < 14) {
-                    yield AtBContract.EVT_SPORADICUPRISINGS;
+                    yield AtBEventType.SPORADICUPRISINGS;
                 } else if (roll < 15) {
-                    yield AtBContract.EVT_REBELLION;
+                    yield AtBEventType.REBELLION;
                 } else if (roll < 16) {
-                    yield AtBContract.EVT_BETRAYAL;
+                    yield AtBEventType.BETRAYAL;
                 } else if (roll < 17) {
-                    yield AtBContract.EVT_TREACHERY;
+                    yield AtBEventType.TREACHERY;
                 } else if (roll < 18) {
-                    yield AtBContract.EVT_LOGISTICSFAILURE;
+                    yield AtBEventType.LOGISTICSFAILURE;
                 } else if (roll < 19) {
-                    yield AtBContract.EVT_REINFORCEMENTS;
+                    yield AtBEventType.REINFORCEMENTS;
                 } else {
-                    yield AtBContract.EVT_SPECIALEVENTS;
+                    yield AtBEventType.SPECIALEVENTS;
                 }
             }
             case RIOT_DUTY -> {
                 if (roll < 11) {
-                    yield AtBContract.EVT_BONUSROLL;
+                    yield AtBEventType.BONUSROLL;
                 } else if (roll < 12) {
-                    yield AtBContract.EVT_CIVILDISTURBANCE;
+                    yield AtBEventType.CIVILDISTURBANCE;
                 } else if (roll < 13) {
-                    yield AtBContract.EVT_SPORADICUPRISINGS;
+                    yield AtBEventType.SPORADICUPRISINGS;
                 } else if (roll < 15) {
-                    yield AtBContract.EVT_REBELLION;
+                    yield AtBEventType.REBELLION;
                 } else if (roll < 16) {
-                    yield AtBContract.EVT_BETRAYAL;
+                    yield AtBEventType.BETRAYAL;
                 } else if (roll < 17) {
-                    yield AtBContract.EVT_TREACHERY;
+                    yield AtBEventType.TREACHERY;
                 } else if (roll < 18) {
-                    yield AtBContract.EVT_LOGISTICSFAILURE;
+                    yield AtBEventType.LOGISTICSFAILURE;
                 } else if (roll < 19) {
-                    yield AtBContract.EVT_REINFORCEMENTS;
+                    yield AtBEventType.REINFORCEMENTS;
                 } else {
-                    yield AtBContract.EVT_SPECIALEVENTS;
+                    yield AtBEventType.SPECIALEVENTS;
                 }
             }
             case PIRATE_HUNTING -> {
                 if (roll < 14) {
-                    yield AtBContract.EVT_BONUSROLL;
+                    yield AtBEventType.BONUSROLL;
                 } else if (roll < 15) {
-                    yield AtBContract.EVT_CIVILDISTURBANCE;
+                    yield AtBEventType.CIVILDISTURBANCE;
                 } else if (roll < 16) {
-                    yield AtBContract.EVT_BETRAYAL;
+                    yield AtBEventType.BETRAYAL;
                 } else if (roll < 17) {
-                    yield AtBContract.EVT_TREACHERY;
+                    yield AtBEventType.TREACHERY;
                 } else if (roll < 18) {
-                    yield AtBContract.EVT_LOGISTICSFAILURE;
+                    yield AtBEventType.LOGISTICSFAILURE;
                 } else if (roll < 19) {
-                    yield AtBContract.EVT_REINFORCEMENTS;
+                    yield AtBEventType.REINFORCEMENTS;
                 } else {
-                    yield AtBContract.EVT_SPECIALEVENTS;
+                    yield AtBEventType.SPECIALEVENTS;
                 }
             }
             default -> {
                 if (roll < 15) {
-                    yield AtBContract.EVT_BONUSROLL;
+                    yield AtBEventType.BONUSROLL;
                 } else if (roll < 16) {
-                    yield AtBContract.EVT_BETRAYAL;
+                    yield AtBEventType.BETRAYAL;
                 } else if (roll < 17) {
-                    yield AtBContract.EVT_TREACHERY;
+                    yield AtBEventType.TREACHERY;
                 } else if (roll < 18) {
-                    yield AtBContract.EVT_LOGISTICSFAILURE;
+                    yield AtBEventType.LOGISTICSFAILURE;
                 } else if (roll < 19) {
-                    yield AtBContract.EVT_REINFORCEMENTS;
+                    yield AtBEventType.REINFORCEMENTS;
                 } else {
-                    yield AtBContract.EVT_SPECIALEVENTS;
+                    yield AtBEventType.SPECIALEVENTS;
                 }
             }
         };

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
@@ -308,97 +308,65 @@ public enum AtBContractType {
     public AtBEventType generateStratConEvent() {
         final int roll = Compute.randomInt(20) + 1;
 
-        return switch (this) {
+        switch (this) {
             case DIVERSIONARY_RAID, OBJECTIVE_RAID, RECON_RAID, EXTRACTION_RAID -> {
-                if (roll < 14) {
-                    yield AtBEventType.BONUSROLL;
-                } else if (roll < 16) {
-                    yield AtBEventType.BETRAYAL;
-                } else if (roll < 17) {
-                    yield AtBEventType.TREACHERY;
-                } else if (roll < 18) {
-                    yield AtBEventType.LOGISTICSFAILURE;
-                } else if (roll < 19) {
-                    yield AtBEventType.REINFORCEMENTS;
-                } else {
-                    yield AtBEventType.SPECIALEVENTS;
+                switch (roll) {
+                    case 21, 20, 19 -> { return AtBEventType.SPECIALEVENTS; }
+                    case 18 -> { return AtBEventType.REINFORCEMENTS; }
+                    case 17 -> { return AtBEventType.LOGISTICSFAILURE; }
+                    case 16 -> { return AtBEventType.TREACHERY; }
+                    case 15, 14 -> { return AtBEventType.BETRAYAL; }
+                    default -> { return AtBEventType.BONUSROLL; }
                 }
             }
             case GARRISON_DUTY -> {
-                if (roll < 12) {
-                    yield AtBEventType.BONUSROLL;
-                } else if (roll < 13) {
-                    yield AtBEventType.CIVILDISTURBANCE;
-                } else if (roll < 14) {
-                    yield AtBEventType.SPORADICUPRISINGS;
-                } else if (roll < 15) {
-                    yield AtBEventType.REBELLION;
-                } else if (roll < 16) {
-                    yield AtBEventType.BETRAYAL;
-                } else if (roll < 17) {
-                    yield AtBEventType.TREACHERY;
-                } else if (roll < 18) {
-                    yield AtBEventType.LOGISTICSFAILURE;
-                } else if (roll < 19) {
-                    yield AtBEventType.REINFORCEMENTS;
-                } else {
-                    yield AtBEventType.SPECIALEVENTS;
+                switch (roll) {
+                    case 21, 20, 19 -> { return AtBEventType.SPECIALEVENTS; }
+                    case 18 -> { return AtBEventType.REINFORCEMENTS; }
+                    case 17 -> { return AtBEventType.LOGISTICSFAILURE; }
+                    case 16 -> { return AtBEventType.TREACHERY; }
+                    case 15 -> { return AtBEventType.BETRAYAL; }
+                    case 14 -> { return AtBEventType.REBELLION; }
+                    case 13 -> { return AtBEventType.SPORADICUPRISINGS; }
+                    case 12 -> { return AtBEventType.CIVILDISTURBANCE; }
+                    default -> { return AtBEventType.BONUSROLL; }
                 }
             }
             case RIOT_DUTY -> {
-                if (roll < 11) {
-                    yield AtBEventType.BONUSROLL;
-                } else if (roll < 12) {
-                    yield AtBEventType.CIVILDISTURBANCE;
-                } else if (roll < 13) {
-                    yield AtBEventType.SPORADICUPRISINGS;
-                } else if (roll < 15) {
-                    yield AtBEventType.REBELLION;
-                } else if (roll < 16) {
-                    yield AtBEventType.BETRAYAL;
-                } else if (roll < 17) {
-                    yield AtBEventType.TREACHERY;
-                } else if (roll < 18) {
-                    yield AtBEventType.LOGISTICSFAILURE;
-                } else if (roll < 19) {
-                    yield AtBEventType.REINFORCEMENTS;
-                } else {
-                    yield AtBEventType.SPECIALEVENTS;
+                switch (roll) {
+                    case 21, 20, 19 -> { return AtBEventType.SPECIALEVENTS; }
+                    case 18 -> { return AtBEventType.REINFORCEMENTS; }
+                    case 17 -> { return AtBEventType.LOGISTICSFAILURE; }
+                    case 16 -> { return AtBEventType.TREACHERY; }
+                    case 15 -> { return AtBEventType.BETRAYAL; }
+                    case 14, 13 -> { return AtBEventType.REBELLION; }
+                    case 12 -> { return AtBEventType.SPORADICUPRISINGS; }
+                    case 11 -> { return AtBEventType.CIVILDISTURBANCE; }
+                    default -> { return AtBEventType.BONUSROLL; }
                 }
             }
             case PIRATE_HUNTING -> {
-                if (roll < 14) {
-                    yield AtBEventType.BONUSROLL;
-                } else if (roll < 15) {
-                    yield AtBEventType.CIVILDISTURBANCE;
-                } else if (roll < 16) {
-                    yield AtBEventType.BETRAYAL;
-                } else if (roll < 17) {
-                    yield AtBEventType.TREACHERY;
-                } else if (roll < 18) {
-                    yield AtBEventType.LOGISTICSFAILURE;
-                } else if (roll < 19) {
-                    yield AtBEventType.REINFORCEMENTS;
-                } else {
-                    yield AtBEventType.SPECIALEVENTS;
+                switch (roll) {
+                    case 21, 20, 19 -> { return AtBEventType.SPECIALEVENTS; }
+                    case 18 -> { return AtBEventType.REINFORCEMENTS; }
+                    case 17 -> { return AtBEventType.LOGISTICSFAILURE; }
+                    case 16 -> { return AtBEventType.TREACHERY; }
+                    case 15 -> { return AtBEventType.BETRAYAL; }
+                    case 14 -> { return AtBEventType.CIVILDISTURBANCE; }
+                    default -> { return AtBEventType.BONUSROLL; }
                 }
             }
             default -> {
-                if (roll < 15) {
-                    yield AtBEventType.BONUSROLL;
-                } else if (roll < 16) {
-                    yield AtBEventType.BETRAYAL;
-                } else if (roll < 17) {
-                    yield AtBEventType.TREACHERY;
-                } else if (roll < 18) {
-                    yield AtBEventType.LOGISTICSFAILURE;
-                } else if (roll < 19) {
-                    yield AtBEventType.REINFORCEMENTS;
-                } else {
-                    yield AtBEventType.SPECIALEVENTS;
+                switch (roll) {
+                    case 21, 20, 19 -> { return AtBEventType.SPECIALEVENTS; }
+                    case 18 -> { return AtBEventType.REINFORCEMENTS; }
+                    case 17 -> { return AtBEventType.LOGISTICSFAILURE; }
+                    case 16 -> { return AtBEventType.TREACHERY; }
+                    case 15 -> { return AtBEventType.BETRAYAL; }
+                    default -> { return AtBEventType.BONUSROLL; }
                 }
             }
-        };
+        }
     }
 
     public int generateSpecialScenarioType(final Campaign campaign) {

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBContractType.java
@@ -232,108 +232,66 @@ public enum AtBContractType {
             case OBJECTIVE_RAID:
             case RECON_RAID:
             case EXTRACTION_RAID:
-                if (roll < 10) {
-                    return AtBEventType.BONUSROLL;
-                } else if (roll < 14) {
-                    return AtBEventType.SPECIAL_SCENARIO;
-                } else if (roll < 16) {
-                    return AtBEventType.BETRAYAL;
-                } else if (roll < 17) {
-                    return AtBEventType.TREACHERY;
-                } else if (roll < 18) {
-                    return AtBEventType.LOGISTICSFAILURE;
-                } else if (roll < 19) {
-                    return AtBEventType.REINFORCEMENTS;
-                } else if (roll < 20) {
-                    return AtBEventType.SPECIALEVENTS;
-                } else {
-                    return AtBEventType.BIGBATTLE;
+                switch (roll) {
+                    case 21, 20 -> { return AtBEventType.BIGBATTLE; }
+                    case 19 -> { return AtBEventType.SPECIALEVENTS; }
+                    case 18 -> { return AtBEventType.REINFORCEMENTS; }
+                    case 17 -> { return AtBEventType.LOGISTICSFAILURE; }
+                    case 16 -> { return AtBEventType.TREACHERY; }
+                    case 15, 14 -> { return AtBEventType.BETRAYAL; }
+                    case 13, 12, 11, 10 -> { return AtBEventType.SPECIAL_SCENARIO; }
+                    default -> { return AtBEventType.BONUSROLL; }
                 }
             case GARRISON_DUTY:
-                if (roll < 8) {
-                    return AtBEventType.BONUSROLL;
-                } else if (roll < 12) {
-                    return AtBEventType.SPECIAL_SCENARIO;
-                } else if (roll < 13) {
-                    return AtBEventType.CIVILDISTURBANCE;
-                } else if (roll < 14) {
-                    return AtBEventType.SPORADICUPRISINGS;
-                } else if (roll < 15) {
-                    return AtBEventType.REBELLION;
-                } else if (roll < 16) {
-                    return AtBEventType.BETRAYAL;
-                } else if (roll < 17) {
-                    return AtBEventType.TREACHERY;
-                } else if (roll < 18) {
-                    return AtBEventType.LOGISTICSFAILURE;
-                } else if (roll < 19) {
-                    return AtBEventType.REINFORCEMENTS;
-                } else if (roll < 20) {
-                    return AtBEventType.SPECIALEVENTS;
-                } else {
-                    return AtBEventType.BIGBATTLE;
+                switch (roll) {
+                    case 21, 20 -> { return AtBEventType.BIGBATTLE; }
+                    case 19 -> { return AtBEventType.SPECIALEVENTS; }
+                    case 18 -> { return AtBEventType.REINFORCEMENTS; }
+                    case 17 -> { return AtBEventType.LOGISTICSFAILURE; }
+                    case 16 -> { return AtBEventType.TREACHERY; }
+                    case 15 -> { return AtBEventType.BETRAYAL; }
+                    case 14 -> { return AtBEventType.REBELLION; }
+                    case 13 -> { return AtBEventType.SPORADICUPRISINGS; }
+                    case 12 -> { return AtBEventType.CIVILDISTURBANCE; }
+                    case 11, 10, 9, 8 -> { return AtBEventType.SPECIAL_SCENARIO; }
+                    default -> { return AtBEventType.BONUSROLL; }
                 }
             case RIOT_DUTY:
-                if (roll < 8) {
-                    return AtBEventType.BONUSROLL;
-                } else if (roll < 11) {
-                    return AtBEventType.SPECIAL_SCENARIO;
-                } else if (roll < 12) {
-                    return AtBEventType.CIVILDISTURBANCE;
-                } else if (roll < 13) {
-                    return AtBEventType.SPORADICUPRISINGS;
-                } else if (roll < 15) {
-                    return AtBEventType.REBELLION;
-                } else if (roll < 16) {
-                    return AtBEventType.BETRAYAL;
-                } else if (roll < 17) {
-                    return AtBEventType.TREACHERY;
-                } else if (roll < 18) {
-                    return AtBEventType.LOGISTICSFAILURE;
-                } else if (roll < 19) {
-                    return AtBEventType.REINFORCEMENTS;
-                } else if (roll < 20) {
-                    return AtBEventType.SPECIALEVENTS;
-                } else {
-                    return AtBEventType.BIGBATTLE;
+                switch (roll) {
+                    case 21, 20 -> { return AtBEventType.BIGBATTLE; }
+                    case 19 -> { return AtBEventType.SPECIALEVENTS; }
+                    case 18 -> { return AtBEventType.REINFORCEMENTS; }
+                    case 17 -> { return AtBEventType.LOGISTICSFAILURE; }
+                    case 16 -> { return AtBEventType.TREACHERY; }
+                    case 15 -> { return AtBEventType.BETRAYAL; }
+                    case 14, 13 -> { return AtBEventType.REBELLION; }
+                    case 12 -> { return AtBEventType.SPORADICUPRISINGS; }
+                    case 11 -> { return AtBEventType.CIVILDISTURBANCE; }
+                    case 10, 9, 8 -> { return AtBEventType.SPECIAL_SCENARIO; }
+                    default -> { return AtBEventType.BONUSROLL; }
                 }
             case PIRATE_HUNTING:
-                if (roll < 10) {
-                    return AtBEventType.BONUSROLL;
-                } else if (roll < 14) {
-                    return AtBEventType.SPECIAL_SCENARIO;
-                } else if (roll < 15) {
-                    return AtBEventType.CIVILDISTURBANCE;
-                } else if (roll < 16) {
-                    return AtBEventType.BETRAYAL;
-                } else if (roll < 17) {
-                    return AtBEventType.TREACHERY;
-                } else if (roll < 18) {
-                    return AtBEventType.LOGISTICSFAILURE;
-                } else if (roll < 19) {
-                    return AtBEventType.REINFORCEMENTS;
-                } else if (roll < 20) {
-                    return AtBEventType.SPECIALEVENTS;
-                } else {
-                    return AtBEventType.BIGBATTLE;
+                switch (roll) {
+                    case 21, 20 -> { return AtBEventType.BIGBATTLE; }
+                    case 19 -> { return AtBEventType.SPECIALEVENTS; }
+                    case 18 -> { return AtBEventType.REINFORCEMENTS; }
+                    case 17 -> { return AtBEventType.LOGISTICSFAILURE; }
+                    case 16 -> { return AtBEventType.TREACHERY; }
+                    case 15 -> { return AtBEventType.BETRAYAL; }
+                    case 14 -> { return AtBEventType.CIVILDISTURBANCE; }
+                    case 13, 12, 11, 10 -> { return AtBEventType.SPECIAL_SCENARIO; }
+                    default -> { return AtBEventType.BONUSROLL; }
                 }
             default:
-                if (roll < 10) {
-                    return AtBEventType.BONUSROLL;
-                } else if (roll < 15) {
-                    return AtBEventType.SPECIAL_SCENARIO;
-                } else if (roll < 16) {
-                    return AtBEventType.BETRAYAL;
-                } else if (roll < 17) {
-                    return AtBEventType.TREACHERY;
-                } else if (roll < 18) {
-                    return AtBEventType.LOGISTICSFAILURE;
-                } else if (roll < 19) {
-                    return AtBEventType.REINFORCEMENTS;
-                } else if (roll < 20) {
-                    return AtBEventType.SPECIALEVENTS;
-                } else {
-                    return AtBEventType.BIGBATTLE;
+                switch (roll) {
+                    case 21, 20 -> { return AtBEventType.BIGBATTLE; }
+                    case 19 -> { return AtBEventType.SPECIALEVENTS; }
+                    case 18 -> { return AtBEventType.REINFORCEMENTS; }
+                    case 17 -> { return AtBEventType.LOGISTICSFAILURE; }
+                    case 16 -> { return AtBEventType.TREACHERY; }
+                    case 15 -> { return AtBEventType.BETRAYAL; }
+                    case 14, 13, 12, 11, 10 -> { return AtBEventType.SPECIAL_SCENARIO; }
+                    default -> { return AtBEventType.BONUSROLL; }
                 }
         }
     }

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBEventType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBEventType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+package mekhq.campaign.mission.enums;
+
+public enum AtBEventType {
+    BONUSROLL,
+    SPECIAL_SCENARIO,
+    CIVILDISTURBANCE,
+    SPORADICUPRISINGS,
+    REBELLION,
+    BETRAYAL,
+    TREACHERY,
+    LOGISTICSFAILURE,
+    REINFORCEMENTS,
+    SPECIALEVENTS,
+    BIGBATTLE
+}


### PR DESCRIPTION
This simply moves the hardcoded ATB Event Type constants from static variables to an enum. This supports further refactoring work on AtBContract by reducing the number of public variables that other classes need to call, therefore simplifying the public interface. My understanding was also that there was an initiative to try and use enums instead of static ints throughout the codebase.