### PR TITLE
Fixed Scenario Info Display for Uncloaked Scenarios

### DIFF
--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -944,9 +944,14 @@ public class StratconPanel extends JPanel implements ActionListener {
         infoBuilder.append("<br/>");
 
         StratconScenario selectedScenario = getSelectedScenario();
-        if ((selectedScenario != null) &&
-                (coordsRevealed || currentTrack.isGmRevealed())) {
-            infoBuilder.append(selectedScenario.getInfo(campaign));
+        if (selectedScenario != null) {
+            AtBDynamicScenario backingScenario = selectedScenario.getBackingScenario();
+
+            if (coordsRevealed
+                || !backingScenario.isCloaked()
+                || currentTrack.isGmRevealed()) {
+                infoBuilder.append(selectedScenario.getInfo(campaign));
+            }
         }
 
         infoBuilder.append("</html>");


### PR DESCRIPTION
- Adjusted condition to ensure uncloaked scenarios are properly handled. Scenario info is now displayed if coordinates are revealed, the scenario is not cloaked, or the GM has revealed it.

Fix #5826