### PR TITLE
Corrected `MHQDialogImmersive` Constructor Usage

### DIFF
--- a/MekHQ/src/mekhq/gui/baseComponents/MHQDialogImmersive.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/MHQDialogImmersive.java
@@ -87,26 +87,6 @@ public class MHQDialogImmersive extends JDialog {
     }
 
     /**
-     * Minimal constructor for initializing the immersive dialog with default width configurations.
-     *
-     * @param campaign The {@link Campaign} associated with the dialog.
-     * @param leftSpeaker The optional left-side speaker; {@code null} if none.
-     * @param rightSpeaker The optional right-side speaker; {@code null} if none.
-     * @param centerMessage The message displayed at the center of the dialog.
-     * @param buttons The list of buttons to display, each accompanied by a tooltip.
-     * @param outOfCharacterMessage Optional out-of-character notes; {@code null} if none.
-     * @param defaultChoiceIndex The default choice index if no button is explicitly selected.
-     */
-    public MHQDialogImmersive(Campaign campaign, @Nullable Person leftSpeaker,
-                              @Nullable Person rightSpeaker, String centerMessage,
-                              List<ButtonLabelTooltipPair> buttons,
-                              @Nullable String outOfCharacterMessage, int defaultChoiceIndex) {
-        new MHQDialogImmersive(campaign, leftSpeaker, rightSpeaker, centerMessage, buttons,
-            outOfCharacterMessage, defaultChoiceIndex,
-            null, null, null);
-    }
-
-    /**
      * Full constructor for initializing the immersive dialog with detailed layouts.
      *
      * @param campaign The {@link Campaign} tied to the dialog.

--- a/MekHQ/src/mekhq/gui/dialog/CampaignHasProblemOnLoad.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignHasProblemOnLoad.java
@@ -60,7 +60,8 @@ public class CampaignHasProblemOnLoad extends MHQDialogImmersive {
      */
     public CampaignHasProblemOnLoad(Campaign campaign, CampaignProblemType problemType) {
         super(campaign, getSpeaker(campaign), null, createInCharacterMessage(campaign, problemType),
-            createButtons(problemType), createOutOfCharacterMessage(problemType), 0);
+            createButtons(problemType), createOutOfCharacterMessage(problemType), 0,
+            null, null, null);
     }
 
     /**


### PR DESCRIPTION
- Replaced the minimal constructor for `MHQDialogImmersive` with the full constructor to simplify code maintenance and reduce redundancy.

This was causing a major bug that prevented saves from prior to 50.03 being loaded at all.