### PR TITLE
Added `null` Protection for Units Involved in Automated Mothballing

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5190,7 +5190,10 @@ public class Campaign implements ITechManager {
                     .unloadFromTransportShip(unit);
         }
 
-        // finally remove the unit
+        // remove from automatic mothballing
+        automatedMothballUnits.remove(unit);
+
+        // finally, remove the unit
         getHangar().removeUnit(unit.getId());
 
         checkDuplicateNamesDuringDelete(unit.getEntity());
@@ -5781,10 +5784,28 @@ public class Campaign implements ITechManager {
         return fameAndInfamy;
     }
 
+    /**
+     * Retrieves the list of units that are configured for automated mothballing.
+     *
+     * <p>Automated mothballing is a mechanism where certain units are automatically
+     * placed into a mothballed state, reducing their active maintenance costs
+     * and operational demands over time.</p>
+     *
+     * @return A {@link List} of {@link Unit} objects that are set for automated
+     *         mothballing. Returns an empty list if no units are configured.
+     */
     public List<Unit> getAutomatedMothballUnits() {
         return automatedMothballUnits;
     }
 
+    /**
+     * Sets the list of units that are configured for automated mothballing.
+     *
+     * <p>Replaces the current list of units that have undergone automated mothballing.</p>
+     *
+     * @param automatedMothballUnits A {@link List} of {@link Unit} objects
+     *                               to configure for automated mothballing.
+     */
     public void setAutomatedMothballUnits(List<Unit> automatedMothballUnits) {
         this.automatedMothballUnits = automatedMothballUnits;
     }
@@ -5981,6 +6002,11 @@ public class Campaign implements ITechManager {
 
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "automatedMothballUnits");
         for (Unit unit : automatedMothballUnits) {
+            if (unit == null) {
+                // <50.03 compatibility handler
+                continue;
+            }
+
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mothballedUnit", unit.getId());
         }
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "automatedMothballUnits");

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
@@ -165,6 +165,11 @@ public class ContractAutomation {
         ActivateUnitAction activateUnitAction = new ActivateUnitAction(null, true);
 
         for (Unit unit : units) {
+            if (unit == null) {
+                // <50.03 compatibility handler
+                continue;
+            }
+
             if (unit.isMothballed()) {
                 activateUnitAction.execute(campaign, unit);
                 MekHQ.triggerEvent(new UnitChangedEvent(unit));

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -1945,7 +1945,7 @@ public class EducationController {
             : Intelligence.values().length / 2;
         passRate += intelligenceModifier;
 
-        final boolean flunked = Compute.randomInt(100) >= passRate;
+        final boolean flunked = Compute.randomInt(100) <= passRate;
 
         EducationLevel educationLevel;
         if (isCombatRole) {


### PR DESCRIPTION
- Expanded unit removal to also remove the unit from the list of automatically mothballed units.
- Added `null` checks to ensure compatibility with <50.03 saves. This will self-sanitize the first time the campaign is saved in 50.03

Fix #5831