### PR TITLE
fix: makes the preset dialog show up properly in Linux and adjusts th…

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/SelectPresetDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/SelectPresetDialog.java
@@ -183,7 +183,6 @@ public class SelectPresetDialog extends JDialog {
         pack();
         setAlwaysOnTop(true);
         setResizable(false);
-        setSize(UIUtil.scaleForGUI(575, 250));
         setLocationRelativeTo(null);
         setVisible(true);
     }

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -172,7 +172,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
         setSize(getSplash().getPreferredSize());
         pack();
         fitAndCenter();
-        getFrame().setVisible(false);
+        getFrame().setVisible(true);
     }
     // endregion Initialization
 


### PR DESCRIPTION
…e dropdown so it's not cutoff, addresses issue: #3701

This fixes two items:

* First is issue #3701.  This also keeps the main menu visible until you make some selections for the preset.  I tried multiple other avenues, this was the only way I was able to get it to show up properly.  I only tested with Linux (PopOS).  Someone may want to check this on Windows.
* The dropdown for the presets was getting cutoff.  See screenshot:

![image](https://github.com/user-attachments/assets/e6683bac-3555-4082-b622-1873b3d3f900)
