### PR TITLE
Implemented Granular autoLogistics Settings

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -206,16 +206,30 @@ lblAcquireWaitingPeriod.text=Acquisition Roll Period Frequency
 lblAcquireWaitingPeriod.tooltip=How many days should pass between acquisition attempts being refreshed?
 lblMaxAcquisitions.text=Max Acquisition Rolls per Period
 lblMaxAcquisitions.tooltip=How many times can a character make an acquisition check per period?
-lblDefaultStockPercent.text=Default Restock Percent \u26A0
-lblDefaultStockPercent.tooltip=This option determines what percentage of parts in use should be\
-  \ automatically placed on order when the warehouse falls below this minimum.\
-  <br>\
-  <br><b>Example:</b> If you have 10 Medium Lasers in use, across all units, and have this value\
-  \ set to 20. The moment your warehouse has less than 2 Medium Lasers in stock, an order for a\
-  \ Medium Laser will be placed.\
-  <br>\
-  <br><b>Warning:</b> This option does not discriminate between types of parts, meaning it will\
-  \ automatically order expensive items, such as engines.
+lblAutoLogisticsMekHead.text='Mek Head Restock Percent
+lblAutoLogisticsMekHead.tooltip=autoLogistics counts the number of each 'Mek head type in use and\
+  \ then automatically orders replacement spares equal to the percentage set in this option.
+lblAutoLogisticsMekLocation.text='Mek Location Restock Percent
+lblAutoLogisticsMekLocation.tooltip=autoLogistics counts the number of each 'Mek location in use and\
+  \ then automatically orders replacement spares equal to the percentage set in this option.
+lblAutoLogisticsNonRepairableLocation.text=Special Location Restock Percent
+lblAutoLogisticsNonRepairableLocation.tooltip=autoLogistics counts the number of each special\
+  \ location in use and then automatically orders replacement spares equal to the percentage set in\
+  \ this option. Special locations are locations you would not normally want to restock such as\
+  \ vehicle locations, or 'Mek center torsos.
+lblAutoLogisticsArmor.text=Armor Restock Percent
+lblAutoLogisticsArmor.tooltip=autoLogistics counts the tonnage of armor in use and then\
+  \ automatically orders replacement spares equal to the percentage set in this option.
+lblAutoLogisticsAmmunition.text=Ammunition Restock Percent
+lblAutoLogisticsAmmunition.tooltip=autoLogistics counts the tonnage of ammo in use and then\
+  \ automatically orders replacement spares equal to the percentage set in this option.
+lblAutoLogisticsHeatSink.text=Heat Sink Restock Percent
+lblAutoLogisticsHeatSink.tooltip=autoLogistics counts the number of heat sinks in use and then\
+  \ automatically orders replacement spares equal to the percentage set in this option.
+lblAutoLogisticsOther.text=Other Restock Percent
+lblAutoLogisticsOther.tooltip=autoLogistics counts each part in use, that is not covered by one of\
+  \ the other options, and automatically orders replacement spares equal to the percentage set in\
+  \ this options.
 
 # createDeliveryPanel
 lblDeliveryPanel.text=Deliveries

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -206,6 +206,9 @@ lblAcquireWaitingPeriod.text=Acquisition Roll Period Frequency
 lblAcquireWaitingPeriod.tooltip=How many days should pass between acquisition attempts being refreshed?
 lblMaxAcquisitions.text=Max Acquisition Rolls per Period
 lblMaxAcquisitions.tooltip=How many times can a character make an acquisition check per period?
+
+# createAutoLogisticsPanel
+lblAutoLogisticsPanel.text=AutoLogistics
 lblAutoLogisticsMekHead.text='Mek Head Restock Percent
 lblAutoLogisticsMekHead.tooltip=autoLogistics counts the number of each 'Mek head type in use and\
   \ then automatically orders replacement spares equal to the percentage set in this option.

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2485,6 +2485,18 @@ public class Campaign implements ITechManager {
         return (null != result.getPartToBuy()) ? result : null;
     }
 
+    /**
+     * Determines the default stock percentage for a given part type.
+     *
+     * <p>This method uses the type of the provided {@link Part} to decide which
+     * default stock percentage to return. The values for each part type are
+     * retrieved from the campaign options.</p>
+     *
+     * @param part The {@link Part} for which the default stock percentage is to
+     *             be determined. The part must not be {@code null}.
+     * @return An {@code int} representing the default stock percentage for the
+     *         given part type, as defined in the campaign options.
+     */
     private int getDefaultStockPercent(Part part) {
         if (part instanceof HeatSink) {
             return campaignOptions.getAutoLogisticsHeatSink();
@@ -2508,8 +2520,6 @@ public class Campaign implements ITechManager {
 
         return campaignOptions.getAutoLogisticsOther();
     }
-
-
 
     /**
      * Add data from an actual part to a PartInUse data element

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -81,6 +81,7 @@ import mekhq.campaign.parts.*;
 import mekhq.campaign.parts.enums.PartQuality;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.equipment.EquipmentPart;
+import mekhq.campaign.parts.equipment.HeatSink;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.personnel.*;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
@@ -2480,9 +2481,35 @@ public class Campaign implements ITechManager {
             part = ((MissingPart) part).getNewPart();
         }
         PartInUse result = new PartInUse(part);
-        result.setRequestedStock(getCampaignOptions().getDefaultStockPercent());
+        result.setRequestedStock(getDefaultStockPercent(part));
         return (null != result.getPartToBuy()) ? result : null;
     }
+
+    private int getDefaultStockPercent(Part part) {
+        if (part instanceof HeatSink) {
+            return campaignOptions.getAutoLogisticsHeatSink();
+        } else if (part instanceof MekLocation) {
+            if (((MekLocation) part).getLoc() == Mek.LOC_HEAD) {
+                return campaignOptions.getAutoLogisticsMekHead();
+            }
+
+            if (((MekLocation) part).getLoc() == Mek.LOC_CT) {
+                return campaignOptions.getAutoLogisticsNonRepairableLocation();
+            }
+
+            return campaignOptions.getAutoLogisticsMekLocation();
+        } else if (part instanceof TankLocation) {
+            return campaignOptions.getAutoLogisticsNonRepairableLocation();
+        } else if (part instanceof AmmoBin) {
+            return campaignOptions.getAutoLogisticsAmmunition();
+        } else if (part instanceof Armor ) {
+            return campaignOptions.getAutoLogisticsArmor();
+        }
+
+        return campaignOptions.getAutoLogisticsOther();
+    }
+
+
 
     /**
      * Add data from an actual part to a PartInUse data element
@@ -2562,7 +2589,7 @@ public class Campaign implements ITechManager {
                 if (partsInUseRequestedStockMap.containsKey(partInUse.getDescription())) {
                     partInUse.setRequestedStock(partsInUseRequestedStockMap.get(partInUse.getDescription()));
                 } else {
-                    partInUse.setRequestedStock(campaignOptions.getDefaultStockPercent());
+                    partInUse.setRequestedStock(getDefaultStockPercent(incomingPart));
                 }
                 inUse.put(partInUse, partInUse);
             }
@@ -2582,7 +2609,7 @@ public class Campaign implements ITechManager {
                 if (partsInUseRequestedStockMap.containsKey(partInUse.getDescription())) {
                     partInUse.setRequestedStock(partsInUseRequestedStockMap.get(partInUse.getDescription()));
                 } else {
-                    partInUse.setRequestedStock(campaignOptions.getDefaultStockPercent());
+                    partInUse.setRequestedStock(getDefaultStockPercent((Part) maybePart));
                 }
                 inUse.put(partInUse, partInUse);
             }

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -148,7 +148,15 @@ public class CampaignOptions {
     private int clanAcquisitionPenalty;
     private int isAcquisitionPenalty;
     private int maxAcquisitions;
-    private double defaultStockPercent;
+
+    // autoLogistics
+    private int autoLogisticsHeatSink;
+    private int autoLogisticsMekHead;
+    private int autoLogisticsMekLocation;
+    private int autoLogisticsNonRepairableLocation;
+    private int autoLogisticsArmor;
+    private int autoLogisticsAmmunition;
+    private int autoLogisticsOther;
 
     // Delivery
     private int nDiceTransitTime;
@@ -662,7 +670,15 @@ public class CampaignOptions {
         clanAcquisitionPenalty = 0;
         isAcquisitionPenalty = 0;
         maxAcquisitions = 0;
-        defaultStockPercent = 10.0;
+
+        // autoLogistics
+        autoLogisticsHeatSink = 250;
+        autoLogisticsMekHead = 200;
+        autoLogisticsMekLocation = 100;
+        autoLogisticsNonRepairableLocation = 0;
+        autoLogisticsArmor = 500;
+        autoLogisticsAmmunition = 500;
+        autoLogisticsOther = 50;
 
         // Delivery
         nDiceTransitTime = 1;
@@ -4257,12 +4273,60 @@ public class CampaignOptions {
         this.maxAcquisitions = maxAcquisitions;
     }
 
-    public double getDefaultStockPercent() {
-        return defaultStockPercent;
+    public int getAutoLogisticsHeatSink() {
+        return autoLogisticsHeatSink;
     }
 
-    public void setDefaultStockPercent(double defaultStockPercent) {
-        this.defaultStockPercent = defaultStockPercent;
+    public void setAutoLogisticsHeatSink(int autoLogisticsHeatSink) {
+        this.autoLogisticsHeatSink = autoLogisticsHeatSink;
+    }
+
+    public int getAutoLogisticsMekHead() {
+        return autoLogisticsMekHead;
+    }
+
+    public void setAutoLogisticsMekHead(int autoLogisticsMekHead) {
+        this.autoLogisticsMekHead = autoLogisticsMekHead;
+    }
+
+    public int getAutoLogisticsMekLocation() {
+        return autoLogisticsMekLocation;
+    }
+
+    public void setAutoLogisticsMekLocation(int autoLogisticsMekLocation) {
+        this.autoLogisticsMekLocation = autoLogisticsMekLocation;
+    }
+
+    public int getAutoLogisticsNonRepairableLocation() {
+        return autoLogisticsNonRepairableLocation;
+    }
+
+    public void setAutoLogisticsNonRepairableLocation(int autoLogisticsNonRepairableLocation) {
+        this.autoLogisticsNonRepairableLocation = autoLogisticsNonRepairableLocation;
+    }
+
+    public int getAutoLogisticsArmor() {
+        return autoLogisticsArmor;
+    }
+
+    public void setAutoLogisticsArmor(int autoLogisticsArmor) {
+        this.autoLogisticsArmor = autoLogisticsArmor;
+    }
+
+    public int getAutoLogisticsAmmunition() {
+        return autoLogisticsAmmunition;
+    }
+
+    public void setAutoLogisticsAmmunition(int autoLogisticsAmmunition) {
+        this.autoLogisticsAmmunition = autoLogisticsAmmunition;
+    }
+
+    public int getAutoLogisticsOther() {
+        return autoLogisticsOther;
+    }
+
+    public void setAutoLogisticsOther(int autoLogisticsOther) {
+        this.autoLogisticsOther = autoLogisticsOther;
     }
 
     public boolean isUseAtB() {
@@ -4790,7 +4854,15 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useUnofficialMaintenance", isUseUnofficialMaintenance());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "checkMaintenance", checkMaintenance);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "maxAcquisitions", maxAcquisitions);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "defaultStockPercent", defaultStockPercent);
+
+        // autoLogistics
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsHeatSink", autoLogisticsHeatSink);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsMekHead", autoLogisticsMekHead);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsMekLocation", autoLogisticsMekLocation);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsNonRepairableLocation", autoLogisticsNonRepairableLocation);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsArmor", autoLogisticsArmor);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsAmmunition", autoLogisticsAmmunition);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsOther", autoLogisticsOther);
 
         // region Personnel Tab
         // region General Personnel
@@ -5455,8 +5527,22 @@ public class CampaignOptions {
                     retVal.useAeroSystemHits = Boolean.parseBoolean(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("maxAcquisitions")) {
                     retVal.maxAcquisitions = Integer.parseInt(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("defaultStockPercent")) {
-                    retVal.defaultStockPercent = Double.parseDouble(wn2.getTextContent().trim());
+
+                    // autoLogistics
+                } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsHeatSink")) {
+                    retVal.autoLogisticsHeatSink = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsMekHead")) {
+                    retVal.autoLogisticsMekHead = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsMekLocation")) {
+                    retVal.autoLogisticsMekLocation = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsNonRepairableLocation")) {
+                    retVal.autoLogisticsNonRepairableLocation = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsArmor")) {
+                    retVal.autoLogisticsArmor = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsAmmunition")) {
+                    retVal.autoLogisticsAmmunition = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsOther")) {
+                    retVal.autoLogisticsOther = Integer.parseInt(wn2.getTextContent().trim());
 
                     // region Personnel Tab
                     // region General Personnel

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
@@ -73,9 +73,25 @@ public class EquipmentAndSuppliesTab {
     private JSpinner spnAcquireWaitingPeriod;
     private JLabel lblMaxAcquisitions;
     private JSpinner spnMaxAcquisitions;
-    private JLabel lblDefaultStockPercent;
-    private JSpinner spnDefaultStockPercent;
     //end Acquisition Tab
+
+    //start autoLogistics Tab
+    private JPanel pnlAutoLogistics;
+    private JLabel lblAutoLogisticsHeatSink;
+    private JSpinner spnAutoLogisticsHeatSink;
+    private JLabel lblAutoLogisticsMekHead;
+    private JSpinner spnAutoLogisticsMekHead;
+    private JLabel lblAutoLogisticsMekLocation;
+    private JSpinner spnAutoLogisticsMekLocation;
+    private JLabel lblAutoLogisticsNonRepairableLocation;
+    private JSpinner spnAutoLogisticsNonRepairableLocation;
+    private JLabel lblAutoLogisticsArmor;
+    private JSpinner spnAutoLogisticsArmor;
+    private JLabel lblAutoLogisticsAmmunition;
+    private JSpinner spnAutoLogisticsAmmunition;
+    private JLabel lblAutoLogisticsOther;
+    private JSpinner spnAutoLogisticsOther;
+    //end autoLogistics Tab
 
     //start Delivery Tab
     private JPanel pnlDeliveries;
@@ -153,6 +169,7 @@ public class EquipmentAndSuppliesTab {
      */
     void initialize() {
         initializeAcquisitionTab();
+        initializeAutoLogisticsTab();
         initializeDelivery();
         initializePlanetaryAcquisitionsTab();
         initializeTechLimitsTab();
@@ -254,8 +271,29 @@ public class EquipmentAndSuppliesTab {
 
         lblMaxAcquisitions = new JLabel();
         spnMaxAcquisitions = new JSpinner();
-        lblDefaultStockPercent = new JLabel();
-        spnDefaultStockPercent = new JSpinner();
+    }
+
+    /**
+     * Initializes the components and settings for the autoLogistics tab in the EquipmentAndSuppliesTab.
+     * This method sets up the GUI components required for configuring acquisition-related options,
+     * including panels, labels, spinners, combo boxes, and checkboxes.
+     */
+    private void initializeAutoLogisticsTab() {
+        pnlAutoLogistics = new JPanel();
+        lblAutoLogisticsHeatSink = new JLabel();
+        spnAutoLogisticsHeatSink = new JSpinner();
+        lblAutoLogisticsMekHead = new JLabel();
+        spnAutoLogisticsMekHead = new JSpinner();
+        lblAutoLogisticsMekLocation = new JLabel();
+        spnAutoLogisticsMekLocation = new JSpinner();
+        lblAutoLogisticsNonRepairableLocation = new JLabel();
+        spnAutoLogisticsNonRepairableLocation = new JSpinner();
+        lblAutoLogisticsArmor = new JLabel();
+        spnAutoLogisticsArmor = new JSpinner();
+        lblAutoLogisticsAmmunition = new JLabel();
+        spnAutoLogisticsAmmunition = new JSpinner();
+        lblAutoLogisticsOther = new JLabel();
+        spnAutoLogisticsOther = new JSpinner();
     }
 
     /**
@@ -290,6 +328,7 @@ public class EquipmentAndSuppliesTab {
             getImageDirectory() + "logo_clan_cloud_cobra.png");
 
         pnlAcquisitions = createAcquisitionPanel();
+        pnlAutoLogistics = createAutoLogisticsPanel();
         pnlDeliveries = createDeliveryPanel();
 
         // Layout the Panel
@@ -307,6 +346,10 @@ public class EquipmentAndSuppliesTab {
 
         layoutParent.gridx++;
         panel.add(pnlDeliveries, layoutParent);
+
+        layoutParent.gridx = 0;
+        layoutParent.gridy++;
+        panel.add(pnlAutoLogistics, layoutParent);
 
 
         // Create Parent Panel and return
@@ -342,10 +385,6 @@ public class EquipmentAndSuppliesTab {
         lblMaxAcquisitions = new CampaignOptionsLabel("MaxAcquisitions");
         spnMaxAcquisitions = new CampaignOptionsSpinner("MaxAcquisitions",
             0,0, 100, 1);
-
-        lblDefaultStockPercent = new CampaignOptionsLabel("DefaultStockPercent");
-        spnDefaultStockPercent = new CampaignOptionsSpinner("DefaultStockPercent",
-                10.0, 0.0, 10000, 0.5);
 
         // Layout the Panel
         final JPanel panel = new CampaignOptionsStandardPanel("AcquisitionPanel", true,
@@ -389,11 +428,94 @@ public class EquipmentAndSuppliesTab {
         layout.gridx++;
         panel.add(spnMaxAcquisitions, layout);
 
+        return panel;
+    }
+
+    /**
+     * Creates and returns a {@code JPanel} for configuring acquisition-related options.
+     * This panel includes various components such as labels, checkboxes, and
+     * spinners to allow users to set values for acquisition settings, including
+     * penalties, waiting periods, maximum acquisitions, and stock percentages.
+     *
+     * @return A {@code JPanel} populated with acquisition configuration components and their layout.
+     */
+    private JPanel createAutoLogisticsPanel() {
+        // Content
+        lblAutoLogisticsMekHead = new CampaignOptionsLabel("AutoLogisticsMekHead");
+        spnAutoLogisticsMekHead = new CampaignOptionsSpinner("AutoLogisticsMekHead",
+            200, 0, 10000, 1);
+
+        lblAutoLogisticsMekLocation = new CampaignOptionsLabel("AutoLogisticsMekLocation");
+        spnAutoLogisticsMekLocation = new CampaignOptionsSpinner("AutoLogisticsMekLocation",
+            100, 0, 10000, 1);
+
+        lblAutoLogisticsNonRepairableLocation = new CampaignOptionsLabel("AutoLogisticsNonRepairableLocation");
+        spnAutoLogisticsNonRepairableLocation = new CampaignOptionsSpinner("AutoLogisticsNonRepairableLocation",
+            0, 0, 10000, 1);
+
+        lblAutoLogisticsArmor = new CampaignOptionsLabel("AutoLogisticsArmor");
+        spnAutoLogisticsArmor = new CampaignOptionsSpinner("AutoLogisticsArmor",
+            500, 0, 10000, 1);
+
+        lblAutoLogisticsAmmunition = new CampaignOptionsLabel("AutoLogisticsAmmunition");
+        spnAutoLogisticsAmmunition = new CampaignOptionsSpinner("AutoLogisticsAmmunition",
+            500, 0, 10000, 1);
+
+        lblAutoLogisticsHeatSink = new CampaignOptionsLabel("AutoLogisticsHeatSink");
+        spnAutoLogisticsHeatSink = new CampaignOptionsSpinner("AutoLogisticsHeatSink",
+            250, 0, 10000, 1);
+
+        lblAutoLogisticsOther = new CampaignOptionsLabel("AutoLogisticsOther");
+        spnAutoLogisticsOther = new CampaignOptionsSpinner("AutoLogisticsOther",
+            50, 0, 10000, 1);
+
+        // Layout the Panel
+        final JPanel panel = new CampaignOptionsStandardPanel("AcquisitionPanel", true,
+            "AcquisitionPanel");
+        final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
+
+        layout.gridy = 0;
+        layout.gridx = 0;
+        layout.gridwidth = 1;
+        panel.add(lblAutoLogisticsMekHead, layout);
+        layout.gridx++;
+        panel.add(spnAutoLogisticsMekHead, layout);
+
         layout.gridx = 0;
         layout.gridy++;
-        panel.add(lblDefaultStockPercent, layout);
+        panel.add(lblAutoLogisticsMekLocation, layout);
         layout.gridx++;
-        panel.add(spnDefaultStockPercent, layout);
+        panel.add(spnAutoLogisticsMekLocation, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(lblAutoLogisticsNonRepairableLocation, layout);
+        layout.gridx++;
+        panel.add(spnAutoLogisticsNonRepairableLocation, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(lblAutoLogisticsHeatSink, layout);
+        layout.gridx++;
+        panel.add(spnAutoLogisticsHeatSink, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(lblAutoLogisticsArmor, layout);
+        layout.gridx++;
+        panel.add(spnAutoLogisticsArmor, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(lblAutoLogisticsAmmunition, layout);
+        layout.gridx++;
+        panel.add(spnAutoLogisticsAmmunition, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(lblAutoLogisticsOther, layout);
+        layout.gridx++;
+        panel.add(spnAutoLogisticsOther, layout);
 
         return panel;
     }
@@ -914,7 +1036,17 @@ public class EquipmentAndSuppliesTab {
         options.setIsAcquisitionPenalty((int) spnAcquireIsPenalty.getValue());
         options.setWaitingPeriod((int) spnAcquireWaitingPeriod.getValue());
         options.setMaxAcquisitions((int) spnMaxAcquisitions.getValue());
-        options.setDefaultStockPercent((double) spnDefaultStockPercent.getValue());
+
+        // autoLogistics
+        options.setAutoLogisticsMekHead((int) spnAutoLogisticsMekHead.getValue());
+        options.setAutoLogisticsMekLocation((int) spnAutoLogisticsMekLocation.getValue());
+        options.setAutoLogisticsNonRepairableLocation((int) spnAutoLogisticsNonRepairableLocation.getValue());
+        options.setAutoLogisticsArmor((int) spnAutoLogisticsArmor.getValue());
+        options.setAutoLogisticsAmmunition((int) spnAutoLogisticsAmmunition.getValue());
+        options.setAutoLogisticsHeatSink((int) spnAutoLogisticsHeatSink.getValue());
+        options.setAutoLogisticsOther((int) spnAutoLogisticsOther.getValue());
+
+
 
         // Delivery
         options.setNDiceTransitTime((int) spnNDiceTransitTime.getValue());
@@ -985,7 +1117,15 @@ public class EquipmentAndSuppliesTab {
         spnAcquireIsPenalty.setValue(options.getIsAcquisitionPenalty());
         spnAcquireWaitingPeriod.setValue(options.getWaitingPeriod());
         spnMaxAcquisitions.setValue(options.getMaxAcquisitions());
-        spnDefaultStockPercent.setValue(options.getDefaultStockPercent());
+
+        // autoLogistics
+        spnAutoLogisticsMekHead.setValue(options.getAutoLogisticsMekHead());
+        spnAutoLogisticsMekLocation.setValue(options.getAutoLogisticsMekLocation());
+        spnAutoLogisticsNonRepairableLocation.setValue(options.getAutoLogisticsNonRepairableLocation());
+        spnAutoLogisticsArmor.setValue(options.getAutoLogisticsArmor());
+        spnAutoLogisticsAmmunition.setValue(options.getAutoLogisticsAmmunition());
+        spnAutoLogisticsHeatSink.setValue(options.getAutoLogisticsHeatSink());
+        spnAutoLogisticsOther.setValue(options.getAutoLogisticsOther());
 
         // Delivery
         spnNDiceTransitTime.setValue(options.getNDiceTransitTime());

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
@@ -470,8 +470,8 @@ public class EquipmentAndSuppliesTab {
             50, 0, 10000, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("AcquisitionPanel", true,
-            "AcquisitionPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("AutoLogisticsPanel", true,
+            "AutoLogisticsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridy = 0;

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
@@ -432,12 +432,12 @@ public class EquipmentAndSuppliesTab {
     }
 
     /**
-     * Creates and returns a {@code JPanel} for configuring acquisition-related options.
+     * Creates and returns a {@code JPanel} for configuring autoLogistics-related options.
      * This panel includes various components such as labels, checkboxes, and
      * spinners to allow users to set values for acquisition settings, including
      * penalties, waiting periods, maximum acquisitions, and stock percentages.
      *
-     * @return A {@code JPanel} populated with acquisition configuration components and their layout.
+     * @return A {@code JPanel} populated with autoLogistics configuration components and their layout.
      */
     private JPanel createAutoLogisticsPanel() {
         // Content


### PR DESCRIPTION
- Replaced the single default restock percent with specific settings for different part categories in autoLogistics. This improves part management by allowing customized restocking thresholds for various items such as armor, weapons, and ammunition.
- Updated UI, campaign options, and logic to support these new settings.

<img width="406" alt="image" src="https://github.com/user-attachments/assets/8bb3f73c-64b9-411f-a564-49dacc890acf" />