### PR TITLE
Issue 5836: Combat Force commanders should be updated when a Force's Commander is updated.

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -535,7 +535,8 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Returns the {@link Hashtable} containing all the {@link CombatTeam} objects after
+     * Returns the {@link Hashtable} using the combatTeam's {@code forceId} as the key
+     * and containing all the {@link CombatTeam} objects after
      * removing the ineligible ones. Although sanitization might not be necessary, it ensures that
      * there is no need for {@code isEligible()} checks when fetching the {@link Hashtable}.
      *

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -533,7 +533,16 @@ public class Force {
         return forceCommanderID;
     }
 
-    public void setForceCommanderID(UUID commanderID) {
+    /**
+     * Sets the force commander ID to the provided UUID.
+     * You probably want to use
+     * setOverrideForceCommanderID(UUID) followed by
+     * updateCommander(campaign).
+     * @see #setOverrideForceCommanderID(UUID)
+     * @see #updateCommander(Campaign)
+     * @param commanderID UUID of the commander
+     */
+    private void setForceCommanderID(UUID commanderID) {
         forceCommanderID = commanderID;
     }
 
@@ -626,6 +635,16 @@ public class Force {
 
         if (getParentForce() != null) {
             getParentForce().updateCommander(campaign);
+        }
+
+        updateCombatTeamCommanderIfCombatTeam(campaign);
+    }
+
+    private void updateCombatTeamCommanderIfCombatTeam(Campaign campaign) {
+        if (isCombatTeam()) {
+            campaign.getCombatTeamsTable().values().stream().filter(
+                    combatTeam -> combatTeam.getForceId() == getId())
+                    .forEach(combatTeam -> combatTeam.setCommander((UUID) null));
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -600,17 +600,18 @@ public class Force {
         if (eligibleCommanders.isEmpty()) {
             forceCommanderID = null;
             overrideForceCommanderID = null;
+            updateCombatTeamCommanderIfCombatTeam(campaign);
             return;
         }
 
         if (overrideForceCommanderID != null) {
             if (eligibleCommanders.contains(overrideForceCommanderID)) {
                 forceCommanderID = overrideForceCommanderID;
+                updateCombatTeamCommanderIfCombatTeam(campaign);
 
                 if (getParentForce() != null) {
                     getParentForce().updateCommander(campaign);
                 }
-
                 return;
             } else {
                 overrideForceCommanderID = null;
@@ -632,19 +633,19 @@ public class Force {
         }
 
         forceCommanderID = highestRankedPerson.getId();
+        updateCombatTeamCommanderIfCombatTeam(campaign);
 
         if (getParentForce() != null) {
             getParentForce().updateCommander(campaign);
         }
-
-        updateCombatTeamCommanderIfCombatTeam(campaign);
     }
 
     private void updateCombatTeamCommanderIfCombatTeam(Campaign campaign) {
         if (isCombatTeam()) {
-            campaign.getCombatTeamsTable().values().stream().filter(
-                    combatTeam -> combatTeam.getForceId() == getId())
-                    .forEach(combatTeam -> combatTeam.setCommander((UUID) null));
+            CombatTeam combatTeam = campaign.getCombatTeamsTable().getOrDefault(getId(), null);
+            if (combatTeam != null) {
+                combatTeam.setCommander(getForceCommanderID());
+            }
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -99,6 +99,7 @@ public class TrainingCombatTeams {
      */
     private static void processTraining(final Campaign campaign, final CombatTeam combatTeam) {
         // First, identify the Combat Team's commander
+        combatTeam.refreshCommander(campaign);
         Person commander = combatTeam.getCommander(campaign);
 
         if (commander == null) {

--- a/MekHQ/src/mekhq/gui/ForceRenderer.java
+++ b/MekHQ/src/mekhq/gui/ForceRenderer.java
@@ -31,7 +31,6 @@ import mekhq.utilities.ReportingUtilities;
 import javax.swing.*;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import java.awt.*;
-import java.util.Objects;
 
 import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_NONE;
 
@@ -137,7 +136,7 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
             String text = name + ", " + unitName + c3network + transport + tacticalTransport;
 
             Force force = unit.getCampaign().getForce(unit.getForceId());
-            if((null != person) && (null != force) && (Objects.equals(person.getId(), force.getForceCommanderID()))) {
+            if((null != person) && (null != force) && (person.getId().equals(force.getForceCommanderID()))) {
                 text = "<b>" + text + "</b>";
             }
             setText("<html>" + text + "</html>");

--- a/MekHQ/src/mekhq/gui/ForceRenderer.java
+++ b/MekHQ/src/mekhq/gui/ForceRenderer.java
@@ -31,6 +31,7 @@ import mekhq.utilities.ReportingUtilities;
 import javax.swing.*;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import java.awt.*;
+import java.util.Objects;
 
 import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_NONE;
 
@@ -136,7 +137,7 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
             String text = name + ", " + unitName + c3network + transport + tacticalTransport;
 
             Force force = unit.getCampaign().getForce(unit.getForceId());
-            if((null != person) && (null != force) && (person.getId() == force.getForceCommanderID())) {
+            if((null != person) && (null != force) && (Objects.equals(person.getId(), force.getForceCommanderID()))) {
                 text = "<b>" + text + "</b>";
             }
             setText("<html>" + text + "</html>");


### PR DESCRIPTION
Fixes #5836 

A CombatForce should have its commander updated when its force's commander is updated. In addition, to fix broken saves, we'll refresh the CombatForce's commander when doing training.