### PR TITLE
Corrected `isUseAtB` to account for `useStratCon`

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -4266,7 +4266,7 @@ public class CampaignOptions {
     }
 
     public boolean isUseAtB() {
-        return useAtB;
+        return useAtB || useStratCon;
     }
 
     public void setUseAtB(final boolean useAtB) {


### PR DESCRIPTION
- Modified the isUseAtB method to return true if useStratCon is enabled.

This change was made a little while ago, but got overwritten at some point (probably by CO IIC). I checked `getAtBBattleChance` which had a similar change to account for StratCon and that change hasn't been overwritten.

Fix #5841