### PR TITLE
Added Methods for Star Radius Estimation and Spectral Type Parsing

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -1945,7 +1945,7 @@ public class EducationController {
             : Intelligence.values().length / 2;
         passRate += intelligenceModifier;
 
-        final boolean flunked = Compute.randomInt(100) >= passRate;
+        final boolean flunked = Compute.randomInt(100) <= passRate;
 
         EducationLevel educationLevel;
         if (isCombatRole) {


### PR DESCRIPTION
- Implemented a method to estimate a star's radius using luminosity and temperature based on the Stefan-Boltzmann law. - Added a utility function to calculate the spectral type number by combining the spectral class and subclass.

These are leftovers from an aborted attempt to more realistically (visually) model solar systems within mhq. As I can see these methods being useful in the future, I opted to push them as a utility change.