### PR TITLE
Rebranded Idle XP into Vocational XP

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1821,14 +1821,16 @@ lblKills.tooltip=How many kills need to be scored before experience is awarded?\
 
 # createMissionsPanel
 lblMissionsPanel.text=Missions
-lblIdleXP.text=Milestone XP per
-lblIdleXP.tooltip=How much experience should be awarded per milestone?
-lblMonthsIdleXP.text=Months
-lblMonthsIdleXP.tooltip=How many months are in each experience milestone? Characters will make a\
-  \ milestone experience check every time this many months has passed.
-lblTargetIdleXP.text=Milestone XP Target Number
-lblTargetIdleXP.tooltip=What is the 2d6 target number a character must beat to be awarded milestone\
-  \ experience?
+lblVocationalXP.text=Vocational XP per \u26A0
+lblVocationalXP.tooltip=How much experience should be awarded per vocational experience check? This\
+  \ value is doubled while on any contract not classified as 'Garrison Type' (any contract that\
+  \ ends in 'Duty').
+lblVocationalXPFrequency.text=Months
+lblVocationalXPFrequency.tooltip=How many months occur between vocational experience checks?\
+  \ Characters will make a vocational experience check every time this many months has passed.
+lblVocationalXPTargetNumber.text=Vocational XP Target Number
+lblVocationalXPTargetNumber.tooltip=What is the 2d6 target number a character must beat to be\
+  \ awarded vocational experience?
 lblMissionXpFail.text=Failure
 lblMissionXpFail.tooltip=How much experience is awarded for a failed contract? This is granted to\
   \ all active personnel.

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4276,34 +4276,57 @@ public class Campaign implements ITechManager {
         // This list ensures we don't hit a concurrent modification error
         List<Person> personnel = getPersonnelFilteringOutDeparted();
 
+        // Prep some data for vocational xp
+        int vocationalXpRate = campaignOptions.getVocationalXP();
+        if (hasActiveContract) {
+            if (campaignOptions.isUseAtB()) {
+                for (AtBContract contract : getActiveAtBContracts()) {
+                    if (!contract.getContractType().isGarrisonType()) {
+                        vocationalXpRate *= 2;
+                        break;
+                    }
+                }
+            } else {
+                vocationalXpRate *= 2;
+            }
+        }
+
+        // Process personnel
         for (Person person : personnel) {
             if (person.getStatus().isDepartedUnit()) {
                 continue;
             }
 
+            // Daily events
             if (getDeath().processNewDay(this, getLocalDate(), person)) {
                 // The person has died, so don't continue to process the dead
                 continue;
             }
-
-            processWeeklyRelationshipEvents(person);
 
             person.resetMinutesLeft();
             person.setAcquisition(0);
 
             processAdvancedMedicalEvents(person);
 
-            // Reset edge points to the purchased value each week. This should only
-            // apply for support personnel - combat troops reset with each new mm game
-            processWeeklyEdgeResets(person);
-
-            if (processMonthlyVocationalXp(person)) {
-                personnelWhoAdvancedInXP.add(person);
-            }
-
             processAnniversaries(person);
 
-            processMonthlyAutoAwards(person);
+            // Weekly events
+            if (currentDay.getDayOfWeek() == DayOfWeek.MONDAY) {
+                processWeeklyRelationshipEvents(person);
+
+                processWeeklyEdgeResets(person);
+            }
+
+            // Monthly events
+            if (currentDay.getDayOfMonth() == 1) {
+                processMonthlyAutoAwards(person);
+
+                if (vocationalXpRate > 0) {
+                    if (processMonthlyVocationalXp(person, vocationalXpRate)) {
+                        personnelWhoAdvancedInXP.add(person);
+                    }
+                }
+            }
         }
 
         if (!personnelWhoAdvancedInXP.isEmpty()) {
@@ -4350,45 +4373,29 @@ public class Campaign implements ITechManager {
      * @param person the person for whom weekly Edge resets will be processed
      */
     private void processWeeklyEdgeResets(Person person) {
-        if ((person.hasSupportRole(true) || person.isEngineer())
-                && (getLocalDate().getDayOfWeek() == DayOfWeek.MONDAY)) {
+        if ((person.hasSupportRole(true) || person.isEngineer())) {
             person.resetCurrentEdge();
         }
     }
 
     /**
-     * Processes the monthly vocational experience (XP) gain for a given person based on specific
-     * eligibility criteria. If the person meets the conditions, XP is awarded and their progress
-     * is tracked.
+     * Processes the monthly vocational experience (XP) gain for a given person based on their
+     * eligibility and the vocational experience rules defined in campaign options.
      *
-     * <p>The method checks the following conditions to determine eligibility for XP gain:
+     * <p>Eligibility for receiving vocational XP is determined by checking the following conditions:
      * <ul>
-     *     <li>The person must have an active status (e.g., not retired, deceased, or in education).</li>
-     *     <li>The person must not be a child on the current date.</li>
-     *     <li>The person must not be categorized as a dependent.</li>
-     *     <li>The campaign must enable idle XP, and the current date must be the first day of the month.</li>
-     *     <li>The person must not have the status of a prisoner (Bondsmen are exempt from this
-     *     and remain eligible for XP).</li>
-     * </ul>
-     *
-     * <p>If all of these conditions are satisfied:
-     * <ul>
-     *     <li>The person’s idle month count is incremented.</li>
-     *     <li>If the accumulated idle months reach the threshold defined in the campaign options,
-     *     an idle XP roll (2d6) is performed.</li>
-     *     <li>If the roll result meets or exceeds the target threshold:
-     *         <ul>
-     *             <li>XP is awarded to the person based on the campaign's idle XP configuration.</li>
-     *             <li>The idle month count is reset.</li>
-     *         </ul>
-     *     </li>
-     *     <li>If the roll is unsuccessful, the idle month count is still reset.</li>
+     *     <li>The person must have an <b>active status</b> (e.g., not retired, deceased, or in education).</li>
+     *     <li>The person must not be a <b>child</b> as of the current date.</li>
+     *     <li>The person must not be categorized as a <b>dependent</b>.</li>
+     *     <li>The person must not have the status of a <b>prisoner</b>.</li>
+     *     <b>Note:</b> Bondsmen are exempt from this restriction and are eligible for vocational XP.
      * </ul>
      *
      * @param person the {@link Person} whose monthly vocational XP is to be processed
+     * @param vocationalXpRate the amount of XP awarded on a successful roll
      * @return {@code true} if XP was successfully awarded during the process, {@code false} otherwise
      */
-    private boolean processMonthlyVocationalXp(Person person) {
+    private boolean processMonthlyVocationalXp(Person person, int vocationalXpRate) {
         if (!person.getStatus().isActive()) {
             return false;
         }
@@ -4401,16 +4408,22 @@ public class Campaign implements ITechManager {
             return false;
         }
 
-        if ((getCampaignOptions().getIdleXP() > 0) && (getLocalDate().getDayOfMonth() == 1)
-                && !person.getPrisonerStatus().isCurrentPrisoner()) { // Prisoners can't gain XP, while Bondsmen can
-            person.setIdleMonths(person.getIdleMonths() + 1);
-            if (person.getIdleMonths() >= getCampaignOptions().getMonthsIdleXP()) {
-                if (Compute.d6(2) >= getCampaignOptions().getTargetIdleXP()) {
-                    person.awardXP(this, getCampaignOptions().getIdleXP());
-                    person.setIdleMonths(0);
-                    return true;
-                }
-                person.setIdleMonths(0);
+        if (person.getPrisonerStatus().isCurrentPrisoner()) {
+            // Prisoners can't gain vocational XP, while Bondsmen can
+            return false;
+        }
+
+        int checkFrequency = campaignOptions.getVocationalXPCheckFrequency();
+        int targetNumber = campaignOptions.getVocationalXPTargetNumber();
+
+        person.setVocationalXPTimer(person.getVocationalXPTimer() + 1);
+        if (person.getVocationalXPTimer() >= checkFrequency) {
+            if (Compute.d6(2) >= targetNumber) {
+                person.awardXP(this, vocationalXpRate);
+                person.setVocationalXPTimer(0);
+                return true;
+            } else {
+                person.setVocationalXPTimer(0);
             }
         }
 
@@ -4477,35 +4490,33 @@ public class Campaign implements ITechManager {
      * @param person the person for whom the monthly auto awards are being processed
      */
     private void processMonthlyAutoAwards(Person person) {
-        if (getLocalDate().getDayOfMonth() == 1) {
-            double multiplier = 0;
+        double multiplier = 0;
 
-            int score = 0;
+        int score = 0;
 
-            if (person.getPrimaryRole().isSupport(true)) {
-                int dice = person.getExperienceLevel(this, false);
+        if (person.getPrimaryRole().isSupport(true)) {
+            int dice = person.getExperienceLevel(this, false);
 
-                if (dice > 0) {
-                    score = Compute.d6(dice);
-                }
-
-                multiplier += 0.5;
+            if (dice > 0) {
+                score = Compute.d6(dice);
             }
 
-            if (person.getSecondaryRole().isSupport(true)) {
-                int dice = person.getExperienceLevel(this, true);
-
-                if (dice > 0) {
-                    score += Compute.d6(dice);
-                }
-
-                multiplier += 0.5;
-            } else if (person.getSecondaryRole().isNone()) {
-                multiplier += 0.5;
-            }
-
-            person.changeAutoAwardSupportPoints((int) (score * multiplier));
+            multiplier += 0.5;
         }
+
+        if (person.getSecondaryRole().isSupport(true)) {
+            int dice = person.getExperienceLevel(this, true);
+
+            if (dice > 0) {
+                score += Compute.d6(dice);
+            }
+
+            multiplier += 0.5;
+        } else if (person.getSecondaryRole().isNone()) {
+            multiplier += 0.5;
+        }
+
+        person.changeAutoAwardSupportPoints((int) (score * multiplier));
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -489,9 +489,9 @@ public class CampaignOptions {
     private int nTasksXP;
     private int successXP;
     private int mistakeXP;
-    private int idleXP;
-    private int monthsIdleXP;
-    private int targetIdleXP;
+    private int vocationalXP;
+    private int vocationalXPCheckFrequency;
+    private int vocationalXPTargetNumber;
     private int contractNegotiationXP;
     private int adminXP;
     private int adminXPPeriod;
@@ -1107,9 +1107,9 @@ public class CampaignOptions {
         nTasksXP = 25;
         successXP = 0;
         mistakeXP = 0;
-        idleXP = 0;
-        monthsIdleXP = 2;
-        targetIdleXP = 10;
+        vocationalXP = 1;
+        vocationalXPCheckFrequency = 1;
+        vocationalXPTargetNumber = 7;
         contractNegotiationXP = 0;
         adminXP = 0;
         adminXPPeriod = 1;
@@ -3887,28 +3887,28 @@ public class CampaignOptions {
         this.assignPortraitOnRoleChange = assignPortraitOnRoleChange;
     }
 
-    public int getIdleXP() {
-        return idleXP;
+    public int getVocationalXP() {
+        return vocationalXP;
     }
 
-    public void setIdleXP(final int idleXP) {
-        this.idleXP = idleXP;
+    public void setVocationalXP(final int vocationalXP) {
+        this.vocationalXP = vocationalXP;
     }
 
-    public int getTargetIdleXP() {
-        return targetIdleXP;
+    public int getVocationalXPTargetNumber() {
+        return vocationalXPTargetNumber;
     }
 
-    public void setTargetIdleXP(final int targetIdleXP) {
-        this.targetIdleXP = targetIdleXP;
+    public void setVocationalXPTargetNumber(final int vocationalXPTargetNumber) {
+        this.vocationalXPTargetNumber = vocationalXPTargetNumber;
     }
 
-    public int getMonthsIdleXP() {
-        return monthsIdleXP;
+    public int getVocationalXPCheckFrequency() {
+        return vocationalXPCheckFrequency;
     }
 
-    public void setMonthsIdleXP(final int monthsIdleXP) {
-        this.monthsIdleXP = monthsIdleXP;
+    public void setVocationalXPCheckFrequency(final int vocationalXPCheckFrequency) {
+        this.vocationalXPCheckFrequency = vocationalXPCheckFrequency;
     }
 
     public int getContractNegotiationXP() {
@@ -4728,9 +4728,9 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "tasksXP", tasksXP);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mistakeXP", mistakeXP);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "successXP", successXP);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "idleXP", idleXP);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "targetIdleXP", targetIdleXP);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "monthsIdleXP", monthsIdleXP);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "vocationalXP", vocationalXP);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "vocationalXPTargetNumber", vocationalXPTargetNumber);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "vocationalXPCheckFrequency", vocationalXPCheckFrequency);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "contractNegotiationXP", contractNegotiationXP);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "adminWeeklyXP", adminXP);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "adminXPPeriod", adminXPPeriod);
@@ -5323,12 +5323,18 @@ public class CampaignOptions {
                     retVal.successXP = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("mistakeXP")) {
                     retVal.mistakeXP = Integer.parseInt(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("idleXP")) {
-                    retVal.idleXP = Integer.parseInt(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("targetIdleXP")) {
-                    retVal.targetIdleXP = Integer.parseInt(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("monthsIdleXP")) {
-                    retVal.monthsIdleXP = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("vocationalXP")
+                    // <50.03 compatibility handler
+                    || wn2.getNodeName().equalsIgnoreCase("idleXP")) {
+                    retVal.vocationalXP = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("vocationalXPTargetNumber")
+                    // <50.03 compatibility handler
+                    || wn2.getNodeName().equalsIgnoreCase("targetIdleXP")) {
+                    retVal.vocationalXPTargetNumber = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("vocationalXPCheckFrequency")
+                    // <50.03 compatibility handler
+                    || wn2.getNodeName().equalsIgnoreCase("monthsIdleXP")) {
+                    retVal.vocationalXPCheckFrequency = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("contractNegotiationXP")) {
                     retVal.contractNegotiationXP = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("adminWeeklyXP")) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -167,8 +167,9 @@ public class Person {
     private UUID doctorId;
     private List<Unit> techUnits;
 
+    private int vocationalXPTimer;
+
     // days of rest
-    private int idleMonths;
     private int daysToWaitForHealing;
 
     // Our rank
@@ -1307,12 +1308,12 @@ public class Person {
         this.status = status;
     }
 
-    public int getIdleMonths() {
-        return idleMonths;
+    public int getVocationalXPTimer() {
+        return vocationalXPTimer;
     }
 
-    public void setIdleMonths(final int idleMonths) {
-        this.idleMonths = idleMonths;
+    public void setVocationalXPTimer(final int vocationalXPTimer) {
+        this.vocationalXPTimer = vocationalXPTimer;
     }
 
     public int getDaysToWaitForHealing() {
@@ -1974,8 +1975,8 @@ public class Person {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "biography", biography);
             }
 
-            if (idleMonths > 0) {
-                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "idleMonths", idleMonths);
+            if (vocationalXPTimer > 0) {
+                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "vocationalXPTimer", vocationalXPTimer);
             }
 
             if (!genealogy.isEmpty()) {
@@ -2336,8 +2337,10 @@ public class Person {
                     retVal.secondaryDesignator = ROMDesignation.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("daysToWaitForHealing")) {
                     retVal.daysToWaitForHealing = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("idleMonths")) {
-                    retVal.idleMonths = Integer.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("vocationalXPTimer")
+                    // <50.03 compatibility handler
+                    || wn2.getNodeName().equalsIgnoreCase("idleMonths")) {
+                    retVal.vocationalXPTimer = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("id")) {
                     retVal.id = UUID.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("genealogy")) {

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
@@ -70,12 +70,12 @@ public class AdvancementTab {
     private JSpinner spnKills;
 
     private JPanel pnlMissions;
-    private JLabel lblIdleXP;
-    private JSpinner spnIdleXP;
-    private JLabel lblMonthsIdleXP;
-    private JSpinner spnMonthsIdleXP;
-    private JLabel lblTargetIdleXP;
-    private JSpinner spnTargetIdleXP;
+    private JLabel lblVocationalXP;
+    private JSpinner spnVocationalXP;
+    private JLabel lblVocationalXPFrequency;
+    private JSpinner spnVocationalXPFrequency;
+    private JLabel lblVocationalXPTargetNumber;
+    private JSpinner spnVocationalXPTargetNumber;
     private JLabel lblMissionXpFail;
     private JSpinner spnMissionXpFail;
     private JLabel lblMissionXpSuccess;
@@ -194,12 +194,12 @@ public class AdvancementTab {
         spnKills = new JSpinner();
 
         pnlMissions = new JPanel();
-        lblIdleXP = new JLabel();
-        spnIdleXP = new JSpinner();
-        lblMonthsIdleXP = new JLabel();
-        spnMonthsIdleXP = new JSpinner();
-        lblTargetIdleXP = new JLabel();
-        spnTargetIdleXP = new JSpinner();
+        lblVocationalXP = new JLabel();
+        spnVocationalXP = new JSpinner();
+        lblVocationalXPFrequency = new JLabel();
+        spnVocationalXPFrequency = new JSpinner();
+        lblVocationalXPTargetNumber = new JLabel();
+        spnVocationalXPTargetNumber = new JSpinner();
         lblMissionXpFail = new JLabel();
         spnMissionXpFail = new JSpinner();
         lblMissionXpSuccess = new JLabel();
@@ -382,14 +382,14 @@ public class AdvancementTab {
      */
     private JPanel createMissionsPanel() {
         // Contents
-        lblIdleXP = new CampaignOptionsLabel("IdleXP");
-        spnIdleXP = new CampaignOptionsSpinner("IdleXP",
+        lblVocationalXP = new CampaignOptionsLabel("VocationalXP");
+        spnVocationalXP = new CampaignOptionsSpinner("VocationalXP",
             0, 0, 20, 1);
-        lblMonthsIdleXP = new CampaignOptionsLabel("MonthsIdleXP");
-        spnMonthsIdleXP = new CampaignOptionsSpinner("MonthsIdleXP",
+        lblVocationalXPFrequency = new CampaignOptionsLabel("VocationalXPFrequency");
+        spnVocationalXPFrequency = new CampaignOptionsSpinner("VocationalXPFrequency",
             0, 0, 12, 1);
-        lblTargetIdleXP = new CampaignOptionsLabel("TargetIdleXP");
-        spnTargetIdleXP = new CampaignOptionsSpinner("TargetIdleXP",
+        lblVocationalXPTargetNumber = new CampaignOptionsLabel("VocationalXPTargetNumber");
+        spnVocationalXPTargetNumber = new CampaignOptionsSpinner("VocationalXPTargetNumber",
             2, 0, 12, 1);
 
         lblMissionXpFail = new CampaignOptionsLabel("MissionXpFail");
@@ -411,21 +411,21 @@ public class AdvancementTab {
         layout.gridwidth = 1;
         layout.gridx = 0;
         layout.gridy = 0;
-        panel.add(spnIdleXP, layout);
+        panel.add(spnVocationalXP, layout);
         layout.gridx++;
-        panel.add(lblIdleXP, layout);
+        panel.add(lblVocationalXP, layout);
         layout.gridx++;
-        panel.add(spnMonthsIdleXP, layout);
+        panel.add(spnVocationalXPFrequency, layout);
         layout.gridx++;
-        panel.add(lblMonthsIdleXP, layout);
+        panel.add(lblVocationalXPFrequency, layout);
 
         layout.gridx = 0;
         layout.gridy++;
         layout.gridwidth = 2;
-        panel.add(lblTargetIdleXP, layout);
+        panel.add(lblVocationalXPTargetNumber, layout);
         layout.gridx += 2;
         layout.gridwidth = 1;
-        panel.add(spnTargetIdleXP, layout);
+        panel.add(spnVocationalXPTargetNumber, layout);
 
         layout.gridx = 0;
         layout.gridy++;
@@ -925,9 +925,9 @@ public class AdvancementTab {
         spnScenarioXP.setValue(options.getScenarioXP());
         spnKillXP.setValue(options.getKillXPAward());
         spnKills.setValue(options.getKillsForXP());
-        spnIdleXP.setValue(options.getIdleXP());
-        spnMonthsIdleXP.setValue(options.getMonthsIdleXP());
-        spnTargetIdleXP.setValue(options.getTargetIdleXP());
+        spnVocationalXP.setValue(options.getVocationalXP());
+        spnVocationalXPFrequency.setValue(options.getVocationalXPCheckFrequency());
+        spnVocationalXPTargetNumber.setValue(options.getVocationalXPTargetNumber());
         spnMissionXpFail.setValue(options.getMissionXpFail());
         spnMissionXpSuccess.setValue(options.getMissionXpSuccess());
         spnMissionXpOutstandingSuccess.setValue(options.getMissionXpOutstandingSuccess());
@@ -980,45 +980,45 @@ public class AdvancementTab {
         }
 
         //start XP Awards Tab
-        options.setXpCostMultiplier((Double) spnXpCostMultiplier.getValue());
-        options.setTaskXP((Integer) spnTaskXP.getValue());
-        options.setNTasksXP((Integer) spnNTasksXP.getValue());
-        options.setSuccessXP((Integer) spnSuccessXP.getValue());
-        options.setMistakeXP((Integer) spnMistakeXP.getValue());
-        options.setScenarioXP((Integer) spnScenarioXP.getValue());
-        options.setKillXPAward((Integer) spnKillXP.getValue());
-        options.setKillsForXP((Integer) spnKills.getValue());
-        options.setIdleXP((Integer) spnIdleXP.getValue());
-        options.setMonthsIdleXP((Integer) spnMonthsIdleXP.getValue());
-        options.setTargetIdleXP((Integer) spnTargetIdleXP.getValue());
-        options.setMissionXpFail((Integer) spnMissionXpFail.getValue());
-        options.setMissionXpSuccess((Integer) spnMissionXpSuccess.getValue());
-        options.setMissionXpOutstandingSuccess((Integer) spnMissionXpOutstandingSuccess.getValue());
-        options.setContractNegotiationXP((Integer) spnContractNegotiationXP.getValue());
-        options.setAdminXP((Integer) spnAdminWeeklyXP.getValue());
-        options.setAdminXPPeriod((Integer) spnAdminWeeklyXPPeriod.getValue());
+        options.setXpCostMultiplier((double) spnXpCostMultiplier.getValue());
+        options.setTaskXP((int) spnTaskXP.getValue());
+        options.setNTasksXP((int) spnNTasksXP.getValue());
+        options.setSuccessXP((int) spnSuccessXP.getValue());
+        options.setMistakeXP((int) spnMistakeXP.getValue());
+        options.setScenarioXP((int) spnScenarioXP.getValue());
+        options.setKillXPAward((int) spnKillXP.getValue());
+        options.setKillsForXP((int) spnKills.getValue());
+        options.setVocationalXP((int) spnVocationalXP.getValue());
+        options.setVocationalXPCheckFrequency((int) spnVocationalXPFrequency.getValue());
+        options.setVocationalXPTargetNumber((int) spnVocationalXPTargetNumber.getValue());
+        options.setMissionXpFail((int) spnMissionXpFail.getValue());
+        options.setMissionXpSuccess((int) spnMissionXpSuccess.getValue());
+        options.setMissionXpOutstandingSuccess((int) spnMissionXpOutstandingSuccess.getValue());
+        options.setContractNegotiationXP((int) spnContractNegotiationXP.getValue());
+        options.setAdminXP((int) spnAdminWeeklyXP.getValue());
+        options.setAdminXPPeriod((int) spnAdminWeeklyXPPeriod.getValue());
 
         //start Skill Randomization Tab
         skillPreferences.setRandomizeSkill(chkExtraRandomness.isSelected());
         for (int i = 0; i < phenotypeSpinners.length; i++) {
-            options.setPhenotypeProbability(i, (Integer) phenotypeSpinners[i].getValue());
+            options.setPhenotypeProbability(i, (int) phenotypeSpinners[i].getValue());
         }
 
-        skillPreferences.setAntiMekProb((Integer) spnAntiMekSkill.getValue());
-        skillPreferences.setArtilleryProb((Integer) spnArtyProb.getValue());
-        skillPreferences.setArtilleryBonus((Integer) spnArtyBonus.getValue());
-        skillPreferences.setSecondSkillProb((Integer) spnSecondProb.getValue());
-        skillPreferences.setSecondSkillBonus((Integer) spnSecondBonus.getValue());
-        skillPreferences.setTacticsMod(SkillType.EXP_GREEN, (Integer) spnTacticsGreen.getValue());
-        skillPreferences.setTacticsMod(SkillType.EXP_REGULAR, (Integer) spnTacticsReg.getValue());
-        skillPreferences.setTacticsMod(SkillType.EXP_VETERAN, (Integer) spnTacticsVet.getValue());
-        skillPreferences.setTacticsMod(SkillType.EXP_ELITE, (Integer) spnTacticsElite.getValue());
-        skillPreferences.setCombatSmallArmsBonus((Integer) spnCombatSA.getValue());
-        skillPreferences.setSupportSmallArmsBonus((Integer) spnSupportSA.getValue());
-        skillPreferences.setSpecialAbilityBonus(SkillType.EXP_GREEN, (Integer) spnAbilityGreen.getValue());
-        skillPreferences.setSpecialAbilityBonus(SkillType.EXP_REGULAR, (Integer) spnAbilityReg.getValue());
-        skillPreferences.setSpecialAbilityBonus(SkillType.EXP_VETERAN, (Integer) spnAbilityVet.getValue());
-        skillPreferences.setSpecialAbilityBonus(SkillType.EXP_ELITE, (Integer) spnAbilityElite.getValue());
+        skillPreferences.setAntiMekProb((int) spnAntiMekSkill.getValue());
+        skillPreferences.setArtilleryProb((int) spnArtyProb.getValue());
+        skillPreferences.setArtilleryBonus((int) spnArtyBonus.getValue());
+        skillPreferences.setSecondSkillProb((int) spnSecondProb.getValue());
+        skillPreferences.setSecondSkillBonus((int) spnSecondBonus.getValue());
+        skillPreferences.setTacticsMod(SkillType.EXP_GREEN, (int) spnTacticsGreen.getValue());
+        skillPreferences.setTacticsMod(SkillType.EXP_REGULAR, (int) spnTacticsReg.getValue());
+        skillPreferences.setTacticsMod(SkillType.EXP_VETERAN, (int) spnTacticsVet.getValue());
+        skillPreferences.setTacticsMod(SkillType.EXP_ELITE, (int) spnTacticsElite.getValue());
+        skillPreferences.setCombatSmallArmsBonus((int) spnCombatSA.getValue());
+        skillPreferences.setSupportSmallArmsBonus((int) spnSupportSA.getValue());
+        skillPreferences.setSpecialAbilityBonus(SkillType.EXP_GREEN, (int) spnAbilityGreen.getValue());
+        skillPreferences.setSpecialAbilityBonus(SkillType.EXP_REGULAR, (int) spnAbilityReg.getValue());
+        skillPreferences.setSpecialAbilityBonus(SkillType.EXP_VETERAN, (int) spnAbilityVet.getValue());
+        skillPreferences.setSpecialAbilityBonus(SkillType.EXP_ELITE, (int) spnAbilityElite.getValue());
 
         if (presetRandomSkillPreferences == null) {
             campaign.setRandomSkillPreferences(randomSkillPreferences);

--- a/MekHQ/src/mekhq/gui/dialog/VocationalExperienceAwardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/VocationalExperienceAwardDialog.java
@@ -22,6 +22,8 @@ import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.baseComponents.MHQDialogImmersive;
@@ -150,16 +152,47 @@ public class VocationalExperienceAwardDialog extends MHQDialogImmersive {
     }
 
     /**
-     * Constructs the out-of-character (OOC) message to be displayed in the dialog.
+     * Constructs an out-of-character (OOC) message to provide context for XP advancements
+     * based on the campaign's settings and current state.
      *
-     * <p>This message provides additional context regarding the XP gained, referencing
-     * campaign settings such as the idle XP awarded.</p>
+     * <p>The generated message includes details about the idle XP gained, as determined by
+     * the campaign's configuration and active contracts. If the campaign has an active
+     * contract that is not a garrison type (when using AtB settings), or simply has an
+     * active contract otherwise, the default XP advancement rate is doubled.</p>
      *
-     * @param campaign the {@link Campaign} containing campaign options and XP settings
-     * @return a string representing the out-of-character message
+     * <p>This method integrates campaign options such as:</p>
+     * <ul>
+     *     <li>The default vocational XP advancement rate ({@code VocationalXP})</li>
+     *     <li>The status of whether the campaign is using the AtB (Against the Bot)
+     *         system ({@code isUseAtB})</li>
+     *     <li>The type of active employment contracts (e.g., garrison or non-garrison)</li>
+     * </ul>
+     *
+     * <p>This information is formatted into a predefined message string using localized
+     * resource strings.</p>
+     *
+     * @param campaign the {@link Campaign} containing the current campaign state,
+     *                 settings, and active contracts
+     * @return a string representing the out-of-character (OOC) message to be displayed
      */
     private static String createOutOfCharacterMessage(Campaign campaign) {
-        int advancement = campaign.getCampaignOptions().getIdleXP();
+        final CampaignOptions campaignOptions = campaign.getCampaignOptions();
+
+        int advancement = campaignOptions.getVocationalXP();
+
+        if (campaign.hasActiveContract()) {
+            if (campaignOptions.isUseAtB()) {
+                for (AtBContract contract : campaign.getActiveAtBContracts()) {
+                    if (!contract.getContractType().isGarrisonType()) {
+                        advancement *= 2;
+                        break;
+                    }
+                }
+            } else {
+                advancement *= 2;
+            }
+        }
+
         return String.format(resources.getString("dialog.ooc"), advancement);
     }
 }


### PR DESCRIPTION
- Replaced the idle XP system with a vocational XP mechanism across the codebase.
- The only mechanical change is that vocational XP rate is doubled while on a non-garrison contract. This was added as users pointed out personnel on contract advanced no faster than those off-contract. This is meant to work with presets updated for CO IIC (coming soon) which will reduce 'idle' xp from 5/month to 1/month.
- Legacy compatibility for idle XP is maintained for backward compatibility in older configurations.