### PR TITLE
Issue 5828: Kill Credits for killed but not totally destroyed turrets & dropships

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -370,6 +370,7 @@ public class ResolveScenarioTracker {
             } else if (wreck.getOwner().isEnemyOf(client.getLocalPlayer())) {
                 // MekHQ doesn't support gun emplacements, so we don't want the player salvaging them
                 if (wreck instanceof GunEmplacement) {
+                    appendKillCredit(wreck);
                     continue;
                 }
 
@@ -381,7 +382,7 @@ public class ResolveScenarioTracker {
                         dropShipBonus = dropShipBonus.plus(
                             generateNewTestUnit(wreck).getSellValue().multipliedBy(dropShipBonusPercentage));
                     }
-
+                    appendKillCredit(wreck);
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #5828 

It looks like this bug also impacts turrets, so this should also let the player claim kills on turrets.