### PR TITLE
Fixed Incorrect Tooltips

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -809,10 +809,10 @@ lblRandomDeathMethod.tooltip=This is the method used to determine if a person di
   <br><b>Recommended:</b> Exponential Random Death is the best system as it closely follows a\
   \ realistic death curve.
 lblUseRandomClanPersonnelDeath.text=Enable Random Clan Death
-lblUseRandomClanPersonnelDeath.tooltip=Allow clan-origin personnel to randomly marry other personnel.
+lblUseRandomClanPersonnelDeath.tooltip=Allow clan-origin personnel to randomly die.
 lblUseRandomPrisonerDeath.text=Enable Random Prisoner Death
-lblUseRandomPrisonerDeath.tooltip=Allow prisoners to randomly marry other prisoners. Bondsmen are\
-  \ treated as free personnel when it comes to this option, and are thus not affected by it.
+lblUseRandomPrisonerDeath.tooltip=Allow prisoners to randomly die. Bondsmen are treated as free\
+  \ personnel when it comes to this option, and are thus not affected by it.
 lblUseRandomDeathSuicideCause.text=Enable Cause of Death: Suicide
 lblUseRandomDeathSuicideCause.tooltip=This includes suicide as a potential cause for a random death.
 lblPercentageRandomDeathChance.text=Random Death Percentage \u26A0

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/RelationshipsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/RelationshipsTab.java
@@ -364,7 +364,7 @@ public class RelationshipsTab {
             14, 0, 100000, 1);
 
         lblRandomNewDependentMarriage = new CampaignOptionsLabel("RandomNewDependentMarriage");
-        spnRandomNewDependentMarriage = new CampaignOptionsSpinner("RandomSameSexMarriageDiceSize",
+        spnRandomNewDependentMarriage = new CampaignOptionsSpinner("RandomNewDependentMarriage",
             20, 0, 100000, 1);
 
         // Layout the Panel


### PR DESCRIPTION
- Updated tooltips for random clan and prisoner death to correctly describe their functions.
- Fixed the spinner tooltip for random new dependent marriages.

Fix #5862
Fix #5857