### PR TITLE
Remove Unnecessary Edge Trigger Logging

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2863,7 +2863,6 @@ public class Person {
      */
     private static void removeUnusedEdgeTriggers(Person retVal, List<String> edgeOptionList) {
         for (String edgeTrigger : edgeOptionList) {
-            logger.info(edgeTrigger);
             String advName = Crew.parseAdvantageName(edgeTrigger);
 
             try {


### PR DESCRIPTION
- Eliminated a logger statement in the `removeUnusedEdgeTriggers` method as it served no functional purpose. This helps reduce unnecessary log noise.

This was added while debugging edge triggers back in 50.01 and I accidentally forgot to remove it afterwards.