### PR TITLE
Adjusted Randomness of Turning Points and Highlighted Them in Briefing Room

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1352,7 +1352,6 @@ public class AtBDynamicScenarioFactory {
         scenario.getScenarioObjectives().clear();
 
         for (ScenarioObjective templateObjective : scenario.getTemplate().scenarioObjectives) {
-            logger.info("templateObjective:"+ templateObjective.toString());
             ScenarioObjective actualObjective = translateTemplateObjective(scenario, campaign, templateObjective);
 
             scenario.getScenarioObjectives().add(actualObjective);

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconContractInitializer.java
@@ -440,6 +440,7 @@ public class StratconContractInitializer {
             scenario.setActionDate(null);
             scenario.setReturnDate(null);
             scenario.setStrategicObjective(true);
+            scenario.setTurningPoint(true);
             scenario.getBackingScenario().setCloaked(true);
             // apply objective mods
             if (objectiveModifiers != null) {

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -691,18 +691,18 @@ public class StratconRulesManager {
             switch (commandRights) {
                 case INTEGRATED -> {
                     scenario.setTurningPoint(true);
-                    if (randomInt(4) == 0) {
+                    if (randomInt(3) == 0) {
                         setAttachedUnitsModifier(scenario, contract);
                     }
                 }
                 case HOUSE, LIAISON -> {
-                    if (randomInt(4) == 0) {
+                    if (randomInt(3) == 0) {
                         scenario.setTurningPoint(true);
                         setAttachedUnitsModifier(scenario, contract);
                     }
                 }
                 case INDEPENDENT -> {
-                    if (randomInt(4) == 0) {
+                    if (randomInt(3) == 0) {
                         scenario.setTurningPoint(true);
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -549,6 +549,7 @@ public class StratconRulesManager {
         scenario.setActionDate(null);
         scenario.setReturnDate(null);
         scenario.setStrategicObjective(true);
+        scenario.setTurningPoint(true);
         scenario.getBackingScenario().setCloaked(true);
 
         trackState.addScenario(scenario);

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -686,23 +686,25 @@ public class StratconRulesManager {
             return;
         }
 
+        boolean isObjective = scenario.isStrategicObjective();
+
         if (template == null || !template.getStratConScenarioType().isResupply()) {
             ContractCommandRights commandRights = contract.getCommandRights();
             switch (commandRights) {
                 case INTEGRATED -> {
                     scenario.setTurningPoint(true);
-                    if (randomInt(3) == 0) {
+                    if (randomInt(3) == 0 || isObjective) {
                         setAttachedUnitsModifier(scenario, contract);
                     }
                 }
                 case HOUSE, LIAISON -> {
-                    if (randomInt(3) == 0) {
+                    if (randomInt(3) == 0 || isObjective) {
                         scenario.setTurningPoint(true);
                         setAttachedUnitsModifier(scenario, contract);
                     }
                 }
                 case INDEPENDENT -> {
-                    if (randomInt(3) == 0) {
+                    if (randomInt(3) == 0 || isObjective) {
                         scenario.setTurningPoint(true);
                     }
                 }

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -129,13 +129,7 @@ public class ScenarioTableModel extends DataTableModel {
 
                         String colorblindHelper = isTurningPoint ? " \u26A0" : "";
 
-                        boolean isObjective = stratconScenario.isStrategicObjective();
-                        openingSpan = isObjective
-                            ? spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor())
-                            : openingSpan;
-                        colorblindHelper += isObjective ? " \u26A1" : "";
-
-                        String closingSpan = isTurningPoint || isObjective ? CLOSING_SPAN_TAG : "";
+                        String closingSpan = isTurningPoint ? CLOSING_SPAN_TAG : "";
 
                         return String.format("<html>%s%s%s%s</html", openingSpan,
                             scenario.getName(), closingSpan, colorblindHelper);

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -36,6 +36,9 @@ import java.util.ArrayList;
 import java.util.Objects;
 import java.util.ResourceBundle;
 
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
+
 /**
  * A table model for displaying scenarios
  */
@@ -109,6 +112,22 @@ public class ScenarioTableModel extends DataTableModel {
         }
 
         if (col == COL_NAME) {
+            if (campaign.getCampaignOptions().isUseStratCon()) {
+                if (scenario instanceof AtBScenario) {
+                    StratconScenario stratconScenario = ((AtBScenario) scenario).getStratconScenario(campaign);
+
+                    if (stratconScenario != null) {
+                        boolean isTurningPoint = stratconScenario.isTurningPoint();
+                        String openingSpan = isTurningPoint
+                            ? spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorWarningHexColor())
+                            : "";
+                        String closingSpan = isTurningPoint ? CLOSING_SPAN_TAG : "";
+                        return String.format("<html>%s%s%s</html", openingSpan,
+                            scenario.getName(), closingSpan);
+                    }
+                }
+            }
+
             return scenario.getName();
         } else if (col == COL_STATUS) {
             return scenario.getStatus();

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Objects;
 import java.util.ResourceBundle;
 
+import static mekhq.campaign.mission.enums.ScenarioStatus.CURRENT;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
@@ -114,6 +115,10 @@ public class ScenarioTableModel extends DataTableModel {
         if (col == COL_NAME) {
             if (campaign.getCampaignOptions().isUseStratCon()) {
                 if (scenario instanceof AtBScenario) {
+                    if (scenario.getStatus() != CURRENT) {
+                        return scenario.getName();
+                    }
+
                     StratconScenario stratconScenario = ((AtBScenario) scenario).getStratconScenario(campaign);
 
                     if (stratconScenario != null) {
@@ -121,9 +126,19 @@ public class ScenarioTableModel extends DataTableModel {
                         String openingSpan = isTurningPoint
                             ? spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorWarningHexColor())
                             : "";
-                        String closingSpan = isTurningPoint ? CLOSING_SPAN_TAG : "";
-                        return String.format("<html>%s%s%s</html", openingSpan,
-                            scenario.getName(), closingSpan);
+
+                        String colorblindHelper = isTurningPoint ? " \u26A0" : "";
+
+                        boolean isObjective = stratconScenario.isStrategicObjective();
+                        openingSpan = isObjective
+                            ? spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor())
+                            : openingSpan;
+                        colorblindHelper += isObjective ? " \u26A1" : "";
+
+                        String closingSpan = isTurningPoint || isObjective ? CLOSING_SPAN_TAG : "";
+
+                        return String.format("<html>%s%s%s%s</html", openingSpan,
+                            scenario.getName(), closingSpan, colorblindHelper);
                     }
                 }
             }


### PR DESCRIPTION
- Updated the random chance for setting attached unit modifiers and turning points to trigger around 33% more often. We've been seeing feedback from users that Turning Points were too rare.
- Corrected Strategic Objectives (scenarios required by the contract) to always be considered Turning Points. This will not be retroactive for scenarios that have already spawned.
- Improved the `ScenarioTableModel` to visually highlight scenarios that are turning points.
- Ensured we accounted for colorblind players.

In the below image the scenario in yellow (uses the user configurable 'warning' color) is a Turning Point:
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/be83074e-5419-4b97-91e0-90a2c7349b16" />

