### PR TITLE
Feat/minimap themes

### DIFF
--- a/MekHQ/data/images/hexes/minimap/cyberpunk.theme
+++ b/MekHQ/data/images/hexes/minimap/cyberpunk.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 10 cyber punk
+background 10 10 30
+none 255 20 147
+sinkhole 138 43 226
+woods 0 255 127
+heavywoods 34 139 34
+ultraheavywoods 0 100 0
+rough 75 0 130
+rubble 147 112 219
+water 0 191 255
+pavement 128 128 128
+road 105 105 105
+fire 255 69 0
+smoke 112 128 144
+smokeandfire 255 140 0
+swamp 0 250 154
+building 70 130 180
+bridge 169 169 169
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/darkula.theme
+++ b/MekHQ/data/images/hexes/minimap/darkula.theme
@@ -1,0 +1,24 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+background 39 40 34
+none 249 38 114
+sinkhole 230 219 116
+woods 166 226 46
+heavywoods 102 217 239
+ultraheavywoods 166 226 46
+rough 230 219 116
+rubble 102 217 239
+water 102 217 239
+pavement 166 226 46
+road 249 38 114
+fire 253 151 31
+smoke 166 226 46
+smokeandfire 253 151 31
+swamp 102 217 239
+building 230 219 116
+bridge 117 113 94
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/default.theme
+++ b/MekHQ/data/images/hexes/minimap/default.theme
@@ -1,0 +1,26 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+#
+
+# terrain colours (red,green,blue)
+background 0 0 0
+none 215 211 156
+sinkhole 210 180 150
+woods 180 230 130
+heavywoods 160 200 100
+ultraheavywoods 0 100 0
+rough 186 191 160
+rubble 200 200 200
+water 200 247 253
+pavement 204 204 204
+road 71 79 107
+fire 255 0 0
+smoke 204 204 204
+smokeandfire 153 0 0
+swamp 49 136 74
+building 204 204 204
+bridge 109 55 25
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/dreamy colors.theme
+++ b/MekHQ/data/images/hexes/minimap/dreamy colors.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# PAL 4 light blue pink
+background 0 0 0
+none 212 190 161
+sinkhole 165 176 160
+woods 178 218 224
+heavywoods 165 176 160
+ultraheavywoods 141 159 170
+rough 212 190 161
+rubble 246 224 177
+water 178 218 224
+pavement 165 176 160
+road 141 159 170
+fire 255 165 0
+smoke 165 176 160
+smokeandfire 212 190 161
+swamp 178 218 224
+building 165 176 160
+bridge 141 159 170
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/earth and grass.theme
+++ b/MekHQ/data/images/hexes/minimap/earth and grass.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# PAL 2 Brown Green
+background 0 0 0
+none 80 100 70
+sinkhole 90 70 50
+woods 100 180 100
+heavywoods 70 150 70
+ultraheavywoods 40 120 40
+rough 90 110 80
+rubble 110 120 110
+water 0 130 130
+pavement 90 90 80
+road 60 60 50
+fire 255 120 0
+smoke 100 100 90
+smokeandfire 200 80 0
+swamp 60 100 60
+building 100 100 90
+bridge 80 80 70
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/gbc green.theme
+++ b/MekHQ/data/images/hexes/minimap/gbc green.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 8 GBC
+background 15 56 15
+none 48 98 48
+sinkhole 63 127 63
+woods 79 159 79
+heavywoods 63 127 63
+ultraheavywoods 15 56 15
+rough 48 98 48
+rubble 79 159 79
+water 48 98 48
+pavement 63 127 63
+road 48 98 48
+fire 255 102 0
+smoke 63 127 63
+smokeandfire 79 159 79
+swamp 48 98 48
+building 63 127 63
+bridge 48 98 48
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/noctis.theme
+++ b/MekHQ/data/images/hexes/minimap/noctis.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+#pal 11 noctis
+background 20 20 30
+none 121 133 153
+sinkhole 99 122 142
+woods 76 144 114
+heavywoods 60 113 90
+ultraheavywoods 43 85 70
+rough 121 133 153
+rubble 140 140 150
+water 72 130 180
+pavement 99 108 120
+road 79 90 100
+fire 230 85 55
+smoke 99 108 120
+smokeandfire 230 120 80
+swamp 76 144 114
+building 99 108 120
+bridge 79 90 100
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/non-boolean.theme
+++ b/MekHQ/data/images/hexes/minimap/non-boolean.theme
@@ -1,0 +1,24 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+background 0 0 0
+none 255 255 255
+sinkhole 240 230 140
+woods 255 255 0
+heavywoods 200 200 0
+ultraheavywoods 150 150 0
+rough 211 211 211
+rubble 128 128 128
+water 148 0 211
+pavement 105 105 105
+road 80 80 80
+fire 255 85 0
+smoke 128 128 128
+smokeandfire 200 75 150
+swamp 218 165 32
+building 169 169 169
+bridge 80 80 80
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/phosphor green.theme
+++ b/MekHQ/data/images/hexes/minimap/phosphor green.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 7 phosphor green
+background 0 0 0
+none 227 255 128
+sinkhole 214 247 105
+woods 200 233 93
+heavywoods 182 215 91
+ultraheavywoods 169 214 92
+rough 200 233 93
+rubble 214 247 105
+water 169 214 92
+pavement 200 233 93
+road 182 215 91
+fire 255 165 0
+smoke 182 215 91
+smokeandfire 214 247 105
+swamp 200 233 93
+building 182 215 91
+bridge 169 214 92
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/pink lemonade.theme
+++ b/MekHQ/data/images/hexes/minimap/pink lemonade.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# PAL 5 Pink Lemonade
+background 0 0 0
+none 220 237 191
+sinkhole 255 212 184
+woods 168 230 206
+heavywoods 220 237 191
+ultraheavywoods 168 230 206
+rough 255 173 173
+rubble 220 237 191
+water 168 230 206
+pavement 255 212 184
+road 255 173 173
+fire 255 165 0
+smoke 212 168 255
+smokeandfire 255 173 173
+swamp 168 230 206
+building 212 168 255
+bridge 220 237 191
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/pink world.theme
+++ b/MekHQ/data/images/hexes/minimap/pink world.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 6 full pink world
+background 0 0 0
+none 244 195 211
+sinkhole 246 162 183
+woods 246 121 159
+heavywoods 241 80 123
+ultraheavywoods 230 55 79
+rough 246 162 183
+rubble 244 195 211
+water 246 121 159
+pavement 246 162 183
+road 241 80 123
+fire 255 165 0
+smoke 241 80 123
+smokeandfire 246 162 183
+swamp 246 121 159
+building 241 80 123
+bridge 230 55 79
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/rebirth.theme
+++ b/MekHQ/data/images/hexes/minimap/rebirth.theme
@@ -1,0 +1,24 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+background 15 15 30
+none 255 255 255
+sinkhole 250 200 210
+woods 135 206 235
+heavywoods 85 170 215
+ultraheavywoods 50 115 190
+rough 245 235 240
+rubble 220 220 225
+water 135 206 235
+pavement 180 180 190
+road 140 140 150
+fire 255 85 85
+smoke 200 200 210
+smokeandfire 245 145 170
+swamp 210 185 210
+building 220 220 225
+bridge 180 180 190
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/red amaranth.theme
+++ b/MekHQ/data/images/hexes/minimap/red amaranth.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+#pal 12 Red Amaranth
+background 15 15 15
+none 229 43 80
+sinkhole 180 34 65
+woods 110 20 40
+heavywoods 85 15 30
+ultraheavywoods 50 10 20
+rough 140 30 50
+rubble 200 50 70
+water 20 20 20
+pavement 50 50 50
+road 30 30 30
+fire 255 69 0
+smoke 50 50 50
+smokeandfire 180 30 50
+swamp 110 20 40
+building 100 100 100
+bridge 40 40 40
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/shades of green.theme
+++ b/MekHQ/data/images/hexes/minimap/shades of green.theme
@@ -1,0 +1,24 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+background 0 0 0
+none 209 248 175
+sinkhole 166 231 186
+woods 126 211 195
+heavywoods 77 185 209
+ultraheavywoods 29 160 221
+rough 166 231 186
+rubble 209 248 175
+water 29 160 221
+pavement 166 231 186
+road 126 211 195
+fire 255 165 0
+smoke 77 185 209
+smokeandfire 166 231 186
+swamp 126 211 195
+building 77 185 209
+bridge 29 160 221
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/solarized.theme
+++ b/MekHQ/data/images/hexes/minimap/solarized.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+#
+# solarized
+background 0 43 54
+none 131 148 150
+sinkhole 108 113 196
+woods 133 153 0
+heavywoods 88 110 117
+ultraheavywoods 38 139 210
+rough 101 123 131
+rubble 147 161 161
+water 42 161 152
+pavement 88 110 117
+road 101 123 131
+fire 220 50 47
+smoke 88 110 117
+smokeandfire 203 75 22
+swamp 133 153 0
+building 147 161 161
+bridge 88 110 117
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/synthwave.theme
+++ b/MekHQ/data/images/hexes/minimap/synthwave.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 3 Sinthwave
+background 10 10 45
+none 252 127 237
+sinkhole 141 76 206
+woods 0 255 204
+heavywoods 0 186 148
+ultraheavywoods 0 139 111
+rough 127 0 255
+rubble 204 102 255
+water 0 204 255
+pavement 102 102 153
+road 77 77 128
+fire 255 71 71
+smoke 153 102 204
+smokeandfire 255 112 112
+swamp 0 255 204
+building 102 102 153
+bridge 77 77 128
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/wood cabin.theme
+++ b/MekHQ/data/images/hexes/minimap/wood cabin.theme
@@ -1,0 +1,24 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+background 30 10 10
+none 255 245 245
+sinkhole 255 210 200
+woods 255 140 105
+heavywoods 255 110 80
+ultraheavywoods 220 70 50
+rough 255 190 170
+rubble 235 150 140
+water 255 140 180
+pavement 200 130 120
+road 180 100 90
+fire 255 70 20
+smoke 200 130 120
+smokeandfire 255 100 60
+swamp 255 160 130
+building 235 150 140
+bridge 200 130 120
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/zone of battle.theme
+++ b/MekHQ/data/images/hexes/minimap/zone of battle.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 9 Battlezone
+background 2 56 33
+none 196 245 186
+sinkhole 33 207 33
+woods 2 56 33
+heavywoods 33 207 33
+ultraheavywoods 2 56 33
+rough 196 245 186
+rubble 33 207 33
+water 1 37 51
+pavement 196 245 186
+road 33 207 33
+fire 236 62 11
+smoke 33 207 33
+smokeandfire 236 62 11
+swamp 33 207 33
+building 196 245 186
+bridge 1 37 51
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1721,10 +1721,12 @@ lblAutoResolveVictoryChanceEnabled.tooltip=Determines whether MekHQ should tell 
   \ success before resolving the scenario.\
   <br>\
   <br><b>Requirement:</b> Requires ACAR.
-lblAutoResolveExperimentalPacarGuiEnabled.text=Use experimental PACAR client
-lblAutoResolveExperimentalPacarGuiEnabled.tooltip=Lightweight graphical interface for PACAR.\
-  \ <b>Warning:</b> This is an experimental feature and may not work as expected. Its intended for solo play only.
+lblAutoResolveExperimentalPacarGuiEnabled.text=Experimental Commander's Interface for PACAR \u26A0
+lblAutoResolveExperimentalPacarGuiEnabled.tooltip=A lightweight graphical interface for PACAR.\
+  \ <b>Warning:</b> This is an experimental feature and may not work as expected. It's intended for solo play only.
 
+lblMinimapTheme.text=Strategic View Theme \u26A0
+lblMinimapTheme.tooltip=Select a theme for the strategic view screen on the Commander's Interface
 
 # createLegacyOpForGenerationPanel
 lblLegacyOpForGenerationPanel.text=Force Generation

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -118,11 +118,12 @@ public class MekHQ implements GameListener {
     private CampaignController campaignController;
     private CampaignGUI campaignGUI;
 
-    private IconPackage iconPackage = new IconPackage();
+    private final IconPackage iconPackage = new IconPackage();
 
     private final IAutosaveService autosaveService;
     // endregion Variable Declarations
     private static final SanityInputFilter sanityInputFilter = new SanityInputFilter();
+    private static final String defaultTheme = "com.formdev.flatlaf.FlatDarculaLaf";
 
     public static SuitePreferences getMHQPreferences() {
         return mhqPreferences;
@@ -745,11 +746,28 @@ public class MekHQ implements GameListener {
     }
 
     private static void setLookAndFeel(String themeName) {
-        final String theme = themeName.isBlank() || themeName.equals("UITheme") ? "com.formdev.flatlaf.FlatDarculaLaf" : themeName;
+        final String theme = themeName.isBlank() || themeName.equals("UITheme") ? defaultTheme : themeName;
 
         Runnable runnable = () -> {
             try {
                 UIManager.setLookAndFeel(theme);
+                if (System.getProperty("os.name", "").startsWith("Mac OS X")) {
+                    // Ensure OSX key bindings are used for copy, paste etc
+                    addOSXKeyStrokes((InputMap) UIManager.get("EditorPane.focusInputMap"));
+                    addOSXKeyStrokes((InputMap) UIManager.get("FormattedTextField.focusInputMap"));
+                    addOSXKeyStrokes((InputMap) UIManager.get("TextField.focusInputMap"));
+                    addOSXKeyStrokes((InputMap) UIManager.get("TextPane.focusInputMap"));
+                    addOSXKeyStrokes((InputMap) UIManager.get("TextArea.focusInputMap"));
+                }
+
+                UIUtil.updateAfterUiChange();
+                return;
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+                    | UnsupportedLookAndFeelException e) {
+                logger.error(e, "setLookAndFeel()");
+            }
+            try {
+                UIManager.setLookAndFeel(defaultTheme);
                 if (System.getProperty("os.name", "").startsWith("Mac OS X")) {
                     // Ensure OSX key bindings are used for copy, paste etc
                     addOSXKeyStrokes((InputMap) UIManager.get("EditorPane.focusInputMap"));

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -20,10 +20,15 @@
 package mekhq.campaign;
 
 import megamek.Version;
+import megamek.client.ui.swing.GUIPreferences;
 import megamek.codeUtilities.MathUtility;
+import megamek.common.Configuration;
 import megamek.common.EquipmentType;
 import megamek.common.TechConstants;
 import megamek.common.enums.SkillLevel;
+import megamek.common.preference.ClientPreferences;
+import megamek.common.preference.PreferenceManager;
+import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.Utilities;
@@ -44,6 +49,7 @@ import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import java.io.File;
 import java.io.PrintWriter;
 import java.util.*;
 import java.util.Map.Entry;
@@ -53,7 +59,7 @@ import java.util.Map.Entry;
  */
 public class CampaignOptions {
     private static final MMLogger logger = MMLogger.create(CampaignOptions.class);
-
+    private static final ClientPreferences CLIENT_PREFERENCES = PreferenceManager.getClientPreferences();
     // region Magic Numbers
     public static final int TECH_INTRO = 0;
     public static final int TECH_STANDARD = 1;
@@ -597,6 +603,7 @@ public class CampaignOptions {
     private int scenarioModBV;
     private boolean autoConfigMunitions;
     private AutoResolveMethod autoResolveMethod;
+    private String strategicViewMinimapTheme;
     private boolean autoResolveVictoryChanceEnabled;
     private int autoResolveNumberOfScenarios;
     private boolean autoResolveExperimentalPacarGuiEnabled;
@@ -1199,7 +1206,7 @@ public class CampaignOptions {
         autoResolveVictoryChanceEnabled = false;
         autoResolveNumberOfScenarios = 100;
         autoResolveExperimentalPacarGuiEnabled = false;
-
+        strategicViewMinimapTheme = "gbc green.theme";
         // Unit Administration
         useAero = false;
         useVehicles = true;
@@ -5244,6 +5251,7 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoResolveVictoryChanceEnabled", isAutoResolveVictoryChanceEnabled());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoResolveNumberOfScenarios", getAutoResolveNumberOfScenarios());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoResolveUseExperimentalPacarGui", isAutoResolveExperimentalPacarGuiEnabled());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "strategicViewTheme", getStrategicViewTheme().getName());
         // endregion AtB Tab
 
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "phenotypeProbabilities", phenotypeProbabilities);
@@ -6256,6 +6264,8 @@ public class CampaignOptions {
                     retVal.setAutoResolveNumberOfScenarios(Integer.parseInt(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("autoResolveUseExperimentalPacarGui")) {
                     retVal.setAutoResolveExperimentalPacarGuiEnabled(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("strategicViewTheme")) {
+                    retVal.setStrategicViewTheme(wn2.getTextContent().trim());
                     // endregion ACAR Tab
                     // endregion AtB Tab
 
@@ -6531,6 +6541,17 @@ public class CampaignOptions {
 
     public void setAutoResolveMethod(final AutoResolveMethod autoResolveMethod) {
         this.autoResolveMethod = autoResolveMethod;
+    }
+
+    public void setStrategicViewTheme(String minimapStyle) {
+        // it is persisted here to have something in the campaign options persisted that will change the GUI preference for the theme
+        this.strategicViewMinimapTheme = minimapStyle;
+        CLIENT_PREFERENCES.setStrategicViewTheme(minimapStyle);
+    }
+
+    public File getStrategicViewTheme() {
+        CLIENT_PREFERENCES.setStrategicViewTheme(strategicViewMinimapTheme);
+        return CLIENT_PREFERENCES.getStrategicViewTheme();
     }
 
     public boolean isAutoResolveVictoryChanceEnabled() {

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsTab.java
@@ -18,7 +18,9 @@
  */
 package mekhq.gui.campaignOptions.contents;
 
+import megamek.client.ui.baseComponents.FileNameComboBoxModel;
 import megamek.client.ui.baseComponents.MMComboBox;
+import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.SkillLevel;
 import mekhq.campaign.CampaignOptions;
@@ -32,10 +34,12 @@ import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.*;
+import java.io.File;
 import java.util.ResourceBundle;
 
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createParentPanel;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 /**
  * Represents a tab in the campaign options UI for managing ruleset configurations in campaigns.
@@ -117,6 +121,7 @@ public class RulesetsTab {
     private JPanel pnlAutoResolve;
     private JLabel lblAutoResolveMethod;
     private MMComboBox<AutoResolveMethod> comboAutoResolveMethod;
+    private MMComboBox<String> minimapThemeSelector;
     private JCheckBox chkAutoResolveVictoryChanceEnabled;
     private JCheckBox chkAutoResolveExperimentalPacarGuiEnabled;
     private JLabel lblAutoResolveNumberOfScenarios;
@@ -248,6 +253,8 @@ public class RulesetsTab {
         final DefaultComboBoxModel<AutoResolveMethod> autoResolveTypeModel = new DefaultComboBoxModel<>(
                 AutoResolveMethod.values());
         comboAutoResolveMethod = new MMComboBox<>("comboAutoResolveMethod", autoResolveTypeModel);
+        minimapThemeSelector = new MMComboBox<>("minimapThemeSelector",
+            new FileNameComboBoxModel(GUIPreferences.getInstance().getMinimapThemes()));
         chkAutoResolveVictoryChanceEnabled = new JCheckBox();
         lblAutoResolveNumberOfScenarios = new JLabel();
         spnAutoResolveNumberOfScenarios = new JSpinner();
@@ -385,6 +392,7 @@ public class RulesetsTab {
         spnAutoResolveNumberOfScenarios = new CampaignOptionsSpinner("AutoResolveNumberOfScenarios",
                 250, 10, 1000, 10);
         chkAutoResolveVictoryChanceEnabled = new CampaignOptionsCheckBox("AutoResolveVictoryChanceEnabled");
+        var lblMinimapTheme = new CampaignOptionsLabel("MinimapTheme");
         chkAutoResolveExperimentalPacarGuiEnabled = new CampaignOptionsCheckBox("AutoResolveExperimentalPacarGuiEnabled");
 
         // Layout the panel
@@ -405,8 +413,14 @@ public class RulesetsTab {
         layout.gridwidth = 1;
         panel.add(chkAutoResolveExperimentalPacarGuiEnabled, layout);
 
+        layout.gridx = 0;
         layout.gridwidth = 1;
         layout.gridy++;
+        panel.add(lblMinimapTheme, layout);
+        layout.gridx++;
+        panel.add(minimapThemeSelector, layout);
+        layout.gridx++;
+        layout.gridx++;
         panel.add(lblAutoResolveNumberOfScenarios, layout);
         layout.gridx++;
         panel.add(spnAutoResolveNumberOfScenarios, layout);
@@ -1059,6 +1073,7 @@ public class RulesetsTab {
         options.setBaseStrategyDeployment((int) spnBaseStrategyDeployment.getValue());
         options.setAdditionalStrategyDeployment((int) spnAdditionalStrategyDeployment.getValue());
         options.setAutoResolveMethod(comboAutoResolveMethod.getSelectedItem());
+        options.setStrategicViewTheme(minimapThemeSelector.getSelectedItem());
         options.setAutoResolveVictoryChanceEnabled(chkAutoResolveVictoryChanceEnabled.isSelected());
         options.setAutoResolveNumberOfScenarios((int) spnAutoResolveNumberOfScenarios.getValue());
         options.setAutoResolveExperimentalPacarGuiEnabled(chkAutoResolveExperimentalPacarGuiEnabled.isSelected());
@@ -1133,6 +1148,7 @@ public class RulesetsTab {
         spnBaseStrategyDeployment.setValue(options.getBaseStrategyDeployment());
         spnAdditionalStrategyDeployment.setValue(options.getAdditionalStrategyDeployment());
         comboAutoResolveMethod.setSelectedItem(options.getAutoResolveMethod());
+        minimapThemeSelector.setSelectedItem(options.getStrategicViewTheme().getName());
         chkAutoResolveVictoryChanceEnabled.setSelected(options.isAutoResolveVictoryChanceEnabled());
         chkAutoResolveExperimentalPacarGuiEnabled.setSelected(options.isAutoResolveExperimentalPacarGuiEnabled());
         spnAutoResolveNumberOfScenarios.setValue(options.getAutoResolveNumberOfScenarios());


### PR DESCRIPTION
Adds new theme selection for strategic view, depends on [#6436](https://github.com/MegaMek/megamek/pull/6436) in megamek. Includes 18 themes.

<img width="565" alt="Screenshot 2025-01-24 at 01 37 15" src="https://github.com/user-attachments/assets/8a77e6da-5e4c-4902-bcb6-6a5ab2127b15" />
<img width="570" alt="Screenshot 2025-01-24 at 01 37 57" src="https://github.com/user-attachments/assets/3b9df2a1-0df6-4b46-a2cb-ff03296381d7" />
<img width="764" alt="Screenshot_2025-01-24_at_01 06 28" src="https://github.com/user-attachments/assets/2f3973a2-da10-4132-825b-f0b888fb4469" />
<img width="758" alt="Screenshot_2025-01-24_at_01 08 16" src="https://github.com/user-attachments/assets/bcd60e29-11ca-4d51-a2cf-32c8160878ee" />
<img width="738" alt="Screenshot_2025-01-24_at_01 09 39" src="https://github.com/user-attachments/assets/9165e5c3-ff11-45b6-852b-45893b65d4a9" />
