### PR TITLE
Rolled Back Window Size Setting

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -70,9 +70,9 @@ import mekhq.campaign.report.PersonnelReport;
 import mekhq.campaign.report.TransportReport;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.NewsItem;
+import mekhq.gui.campaignOptions.CampaignOptionsDialog;
 import mekhq.gui.dialog.*;
 import mekhq.gui.dialog.CampaignExportWizard.CampaignExportWizardState;
-import mekhq.gui.campaignOptions.CampaignOptionsDialog;
 import mekhq.gui.dialog.reportDialogs.*;
 import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.model.PartsTableModel;
@@ -219,7 +219,6 @@ public class CampaignGUI extends JPanel {
         tabMain.setToolTipText("");
         tabMain.setMinimumSize(new Dimension(600, 200));
         tabMain.setPreferredSize(new Dimension(900, 300));
-        frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
 
         addStandardTab(MHQTabType.COMMAND_CENTER);
         addStandardTab(MHQTabType.TOE);


### PR DESCRIPTION
- Removed the window size initialization code implemented by #5812 as this was causing mhq to open in a window rather than maximized. This does not affect any of the other functionality or changes implemented in #5812.

Discussed with Luana and she advised to just remove it rather than exploring other options.