### PR TITLE
Fixed Mothball Info Saving & Loading Bug

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -20,19 +20,18 @@
  */
 package mekhq.campaign.unit;
 
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.Version;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * This class is used to store information about a particular unit that is
@@ -138,9 +137,7 @@ public class MothballInfo {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "techId", tech.getId());
         }
 
-        if (forceID > 0) {
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "forceID", forceID);
-        }
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "forceID", forceID);
 
         for (Person driver : drivers) {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "driverId", driver.getId());


### PR DESCRIPTION
- The conditional check for `forceID > 0` was removed, ensuring the `forceID` tag is always written to the XML. As `forceID` will be `-1` in cases where the unit has no assigned force, this caused the behavior in #5877.
- Added initialization of `forceID` to `Force.NO_FORCE` in the parameterless `MothballInfo` constructor. As `forceID` uses the primitive `int` it will initialize as `0` unless provided another value. As `0` coincides with the `forceID` of the origin node (the force normally named after the campaign) this is an undesirable value. Instead, we want to specifically initialize with `-1` (no force).

Fix #5877