### PR TITLE
Replaced Internal Dissension Events in StratCon

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1009,8 +1009,17 @@ public class AtBContract extends Contract {
                             break;
                         case 2:
                             text += "Internal Dissension";
-                            specialEventScenarioDate = getRandomDayOfMonth(campaign.getLocalDate());
-                            specialEventScenarioType = AtBScenario.AMBUSH;
+                            if (!campaign.getCampaignOptions().isUseStratCon()) {
+                                specialEventScenarioDate = getRandomDayOfMonth(campaign.getLocalDate());
+                                specialEventScenarioType = AtBScenario.AMBUSH;
+                            } else {
+                                StratconCampaignState campaignState = getStratconCampaignState();
+
+                                if (campaignState != null) {
+                                    text += ": -1 Support Point";
+                                    campaignState.addSupportPoints(-1);
+                                }
+                            }
                             break;
                         case 3:
                             text += "ComStar Interdict: Base availability level decreases one level for the rest of the contract.";


### PR DESCRIPTION
- Adjusted the logic for Internal Dissension events to account for StratCon-enabled campaigns.
- Added a support point penalty if StratCon is active, while maintaining the original behavior for non-StratCon campaigns.

This ensures _all_ AtB Special Scenarios will not spawn for StratCon enabled campaigns.