### PR TITLE
feat: missing minimaps for MekHQ

### DIFF
--- a/MekHQ/data/images/hexes/minimap/cyberpunk.theme
+++ b/MekHQ/data/images/hexes/minimap/cyberpunk.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 10 cyber punk
+background 10 10 30
+none 255 20 147
+sinkhole 138 43 226
+woods 0 255 127
+heavywoods 34 139 34
+ultraheavywoods 0 100 0
+rough 75 0 130
+rubble 147 112 219
+water 0 191 255
+pavement 128 128 128
+road 105 105 105
+fire 255 69 0
+smoke 112 128 144
+smokeandfire 255 140 0
+swamp 0 250 154
+building 70 130 180
+bridge 169 169 169
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/darkula.theme
+++ b/MekHQ/data/images/hexes/minimap/darkula.theme
@@ -1,0 +1,24 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+background 39 40 34
+none 249 38 114
+sinkhole 230 219 116
+woods 166 226 46
+heavywoods 102 217 239
+ultraheavywoods 166 226 46
+rough 230 219 116
+rubble 102 217 239
+water 102 217 239
+pavement 166 226 46
+road 249 38 114
+fire 253 151 31
+smoke 166 226 46
+smokeandfire 253 151 31
+swamp 102 217 239
+building 230 219 116
+bridge 117 113 94
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/defaultminimap.theme
+++ b/MekHQ/data/images/hexes/minimap/defaultminimap.theme
@@ -1,0 +1,26 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+#
+
+# terrain colours (red,green,blue)
+background 0 0 0
+none 215 211 156
+sinkhole 210 180 150
+woods 180 230 130
+heavywoods 160 200 100
+ultraheavywoods 0 100 0
+rough 186 191 160
+rubble 200 200 200
+water 200 247 253
+pavement 204 204 204
+road 71 79 107
+fire 255 0 0
+smoke 204 204 204
+smokeandfire 153 0 0
+swamp 49 136 74
+building 204 204 204
+bridge 109 55 25
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/dreamy colors.theme
+++ b/MekHQ/data/images/hexes/minimap/dreamy colors.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# PAL 4 light blue pink
+background 0 0 0
+none 212 190 161
+sinkhole 165 176 160
+woods 178 218 224
+heavywoods 165 176 160
+ultraheavywoods 141 159 170
+rough 212 190 161
+rubble 246 224 177
+water 178 218 224
+pavement 165 176 160
+road 141 159 170
+fire 255 165 0
+smoke 165 176 160
+smokeandfire 212 190 161
+swamp 178 218 224
+building 165 176 160
+bridge 141 159 170
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/earth and grass.theme
+++ b/MekHQ/data/images/hexes/minimap/earth and grass.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# PAL 2 Brown Green
+background 0 0 0
+none 80 100 70
+sinkhole 90 70 50
+woods 100 180 100
+heavywoods 70 150 70
+ultraheavywoods 40 120 40
+rough 90 110 80
+rubble 110 120 110
+water 0 130 130
+pavement 90 90 80
+road 60 60 50
+fire 255 120 0
+smoke 100 100 90
+smokeandfire 200 80 0
+swamp 60 100 60
+building 100 100 90
+bridge 80 80 70
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/gbc green.theme
+++ b/MekHQ/data/images/hexes/minimap/gbc green.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 8 GBC
+background 15 56 15
+none 48 98 48
+sinkhole 63 127 63
+woods 79 159 79
+heavywoods 63 127 63
+ultraheavywoods 15 56 15
+rough 48 98 48
+rubble 79 159 79
+water 48 98 48
+pavement 63 127 63
+road 48 98 48
+fire 255 102 0
+smoke 63 127 63
+smokeandfire 79 159 79
+swamp 48 98 48
+building 63 127 63
+bridge 48 98 48
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/noctis.theme
+++ b/MekHQ/data/images/hexes/minimap/noctis.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+#pal 11 noctis
+background 20 20 30
+none 121 133 153
+sinkhole 99 122 142
+woods 76 144 114
+heavywoods 60 113 90
+ultraheavywoods 43 85 70
+rough 121 133 153
+rubble 140 140 150
+water 72 130 180
+pavement 99 108 120
+road 79 90 100
+fire 230 85 55
+smoke 99 108 120
+smokeandfire 230 120 80
+swamp 76 144 114
+building 99 108 120
+bridge 79 90 100
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/non-boolean.theme
+++ b/MekHQ/data/images/hexes/minimap/non-boolean.theme
@@ -1,0 +1,24 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+background 0 0 0
+none 255 255 255
+sinkhole 240 230 140
+woods 255 255 0
+heavywoods 200 200 0
+ultraheavywoods 150 150 0
+rough 211 211 211
+rubble 128 128 128
+water 148 0 211
+pavement 105 105 105
+road 80 80 80
+fire 255 85 0
+smoke 128 128 128
+smokeandfire 200 75 150
+swamp 218 165 32
+building 169 169 169
+bridge 80 80 80
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/phosphor green.theme
+++ b/MekHQ/data/images/hexes/minimap/phosphor green.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 7 phosphor green
+background 0 0 0
+none 227 255 128
+sinkhole 214 247 105
+woods 200 233 93
+heavywoods 182 215 91
+ultraheavywoods 169 214 92
+rough 200 233 93
+rubble 214 247 105
+water 169 214 92
+pavement 200 233 93
+road 182 215 91
+fire 255 165 0
+smoke 182 215 91
+smokeandfire 214 247 105
+swamp 200 233 93
+building 182 215 91
+bridge 169 214 92
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/pink lemonade.theme
+++ b/MekHQ/data/images/hexes/minimap/pink lemonade.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# PAL 5 Pink Lemonade
+background 0 0 0
+none 220 237 191
+sinkhole 255 212 184
+woods 168 230 206
+heavywoods 220 237 191
+ultraheavywoods 168 230 206
+rough 255 173 173
+rubble 220 237 191
+water 168 230 206
+pavement 255 212 184
+road 255 173 173
+fire 255 165 0
+smoke 212 168 255
+smokeandfire 255 173 173
+swamp 168 230 206
+building 212 168 255
+bridge 220 237 191
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/pink world.theme
+++ b/MekHQ/data/images/hexes/minimap/pink world.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 6 full pink world
+background 0 0 0
+none 244 195 211
+sinkhole 246 162 183
+woods 246 121 159
+heavywoods 241 80 123
+ultraheavywoods 230 55 79
+rough 246 162 183
+rubble 244 195 211
+water 246 121 159
+pavement 246 162 183
+road 241 80 123
+fire 255 165 0
+smoke 241 80 123
+smokeandfire 246 162 183
+swamp 246 121 159
+building 241 80 123
+bridge 230 55 79
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/rebirth.theme
+++ b/MekHQ/data/images/hexes/minimap/rebirth.theme
@@ -1,0 +1,24 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+background 15 15 30
+none 255 255 255
+sinkhole 250 200 210
+woods 135 206 235
+heavywoods 85 170 215
+ultraheavywoods 50 115 190
+rough 245 235 240
+rubble 220 220 225
+water 135 206 235
+pavement 180 180 190
+road 140 140 150
+fire 255 85 85
+smoke 200 200 210
+smokeandfire 245 145 170
+swamp 210 185 210
+building 220 220 225
+bridge 180 180 190
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/red amaranth.theme
+++ b/MekHQ/data/images/hexes/minimap/red amaranth.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+#pal 12 Red Amaranth
+background 15 15 15
+none 229 43 80
+sinkhole 180 34 65
+woods 110 20 40
+heavywoods 85 15 30
+ultraheavywoods 50 10 20
+rough 140 30 50
+rubble 200 50 70
+water 20 20 20
+pavement 50 50 50
+road 30 30 30
+fire 255 69 0
+smoke 50 50 50
+smokeandfire 180 30 50
+swamp 110 20 40
+building 100 100 100
+bridge 40 40 40
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/shades of green.theme
+++ b/MekHQ/data/images/hexes/minimap/shades of green.theme
@@ -1,0 +1,24 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+background 0 0 0
+none 209 248 175
+sinkhole 166 231 186
+woods 126 211 195
+heavywoods 77 185 209
+ultraheavywoods 29 160 221
+rough 166 231 186
+rubble 209 248 175
+water 29 160 221
+pavement 166 231 186
+road 126 211 195
+fire 255 165 0
+smoke 77 185 209
+smokeandfire 166 231 186
+swamp 126 211 195
+building 77 185 209
+bridge 29 160 221
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/solarized.theme
+++ b/MekHQ/data/images/hexes/minimap/solarized.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+#
+# solarized
+background 0 43 54
+none 131 148 150
+sinkhole 108 113 196
+woods 133 153 0
+heavywoods 88 110 117
+ultraheavywoods 38 139 210
+rough 101 123 131
+rubble 147 161 161
+water 42 161 152
+pavement 88 110 117
+road 101 123 131
+fire 220 50 47
+smoke 88 110 117
+smokeandfire 203 75 22
+swamp 133 153 0
+building 147 161 161
+bridge 88 110 117
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/synthwave.theme
+++ b/MekHQ/data/images/hexes/minimap/synthwave.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 3 Sinthwave
+background 10 10 45
+none 252 127 237
+sinkhole 141 76 206
+woods 0 255 204
+heavywoods 0 186 148
+ultraheavywoods 0 139 111
+rough 127 0 255
+rubble 204 102 255
+water 0 204 255
+pavement 102 102 153
+road 77 77 128
+fire 255 71 71
+smoke 153 102 204
+smokeandfire 255 112 112
+swamp 0 255 204
+building 102 102 153
+bridge 77 77 128
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/wood cabin.theme
+++ b/MekHQ/data/images/hexes/minimap/wood cabin.theme
@@ -1,0 +1,24 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+background 30 10 10
+none 255 245 245
+sinkhole 255 210 200
+woods 255 140 105
+heavywoods 255 110 80
+ultraheavywoods 220 70 50
+rough 255 190 170
+rubble 235 150 140
+water 255 140 180
+pavement 200 130 120
+road 180 100 90
+fire 255 70 20
+smoke 200 130 120
+smokeandfire 255 100 60
+swamp 255 160 130
+building 235 150 140
+bridge 200 130 120
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6

--- a/MekHQ/data/images/hexes/minimap/zone of battle.theme
+++ b/MekHQ/data/images/hexes/minimap/zone of battle.theme
@@ -1,0 +1,25 @@
+#
+# Minimap configuration file
+# Lines starting with "#" (like this one) are comments
+
+# Pal 9 Battlezone
+background 2 56 33
+none 196 245 186
+sinkhole 33 207 33
+woods 2 56 33
+heavywoods 33 207 33
+ultraheavywoods 2 56 33
+rough 196 245 186
+rubble 33 207 33
+water 1 37 51
+pavement 196 245 186
+road 33 207 33
+fire 236 62 11
+smoke 33 207 33
+smokeandfire 236 62 11
+swamp 33 207 33
+building 196 245 186
+bridge 1 37 51
+
+# unit size: defines the size of the triangle for unit representation
+unitsize 6


### PR DESCRIPTION
Just a bunch of minimaps, the same found on MM, but on MekHQ so it does not explode when you play MM from it.