### PR TITLE
Refactored Age Checks; Updated Unit Tests for Procreation and Marriage

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -925,7 +925,7 @@ public class Utilities {
 
         // Clamp age, if necessary
         if (experienceLevel != EXP_NONE) {
-            age = max(18, age);
+            age = max(16, age);
         }
 
         return age;

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1473,8 +1473,33 @@ public class Person {
         return id;
     }
 
+    /**
+     * Checks if the person is considered a child based on their age and today's date.
+     *
+     * <p>This method uses the default context where the person is not being checked
+     * for procreation-specific thresholds.</p>
+     *
+     * @param today the current date to calculate the age against
+     * @return {@code true} if the person's age is less than 16; {@code false} otherwise
+     */
     public boolean isChild(final LocalDate today) {
-        return getAge(today) < 18;
+        return isChild(today, false);
+    }
+
+    /**
+     * Checks if the person is considered a child based on their age, today's date, and procreation
+     * status.
+     *
+     * @param today the current date to calculate the age against
+     * @param use18 if {@code true}, the threshold considers a person a child
+     *                      if their age is less than 18; otherwise, the default age threshold of
+     *                      16 applies
+     * @return {@code true} if the person's age is less than the specified threshold
+     *         (procreation or default), {@code false} otherwise
+     */
+    public boolean isChild(final LocalDate today, boolean use18) {
+        int age = getAge(today);
+        return age < (use18 ? 18 : 16);
     }
 
     public Genealogy getGenealogy() {

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -833,7 +833,9 @@ public class EducationController {
         int adultDiceSize = campaign.getCampaignOptions().getAdultDropoutChance();
         int childDiceSize = campaign.getCampaignOptions().getChildrenDropoutChance();
 
-        if (person.isChild(campaign.getLocalDate())) {
+        // Under 18s don't generally have the same capacity for self-determination as 18+
+        // characters, so we treat them as children - even though at 16 they can take Roles.
+        if (person.isChild(campaign.getLocalDate(), true)) {
             if (childDiceSize > 1) {
                 roll = Compute.randomInt(childDiceSize);
             } else {
@@ -996,7 +998,12 @@ public class EducationController {
         // been destroyed too.
         if ((campaign.getLocalDate().getYear() >= academy.getDestructionYear())
                 || (campaign.getSystemById(person.getEduAcademySystem()).getPopulation(campaign.getLocalDate()) == 0)) {
-            if ((!person.isChild(campaign.getLocalDate())) || (campaign.getCampaignOptions().isAllAges())) {
+
+            // We use the 'use18' clause here because we don't want to upset players by having
+            // children killed when their academy is attacked unless the player has explicitly
+            // opted in. While players can assign 16-year-olds to combat roles and have them killed
+            // there, that doesn't have the same connotations.
+            if ((!person.isChild(campaign.getLocalDate(), true)) || (campaign.getCampaignOptions().isAllAges())) {
                 if (d6(2) >= 5) {
                     String reportMessage = String.format(resources.getString("eventDestruction.text"),
                             person.getHyperlinkedFullTitle(),

--- a/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
@@ -112,19 +112,33 @@ public abstract class AbstractMarriage {
     public @Nullable String canMarry(final LocalDate today, final Person person, final boolean randomMarriage) {
         if (!person.isMarriageable()) {
             return resources.getString("cannotMarry.NotMarriageable.text");
-        } else if (person.getGenealogy().hasSpouse()) {
+        }
+
+        if (person.getGenealogy().hasSpouse()) {
             return resources.getString("cannotMarry.AlreadyMarried.text");
-        } else if (!person.getStatus().isActive()) {
+        }
+
+        if (!person.getStatus().isActive()) {
             return resources.getString("cannotMarry.Inactive.text");
-        } else if (person.isDeployed()) {
+        }
+
+        if (person.isDeployed()) {
             return resources.getString("cannotMarry.Deployed.text");
-        } else if (person.isChild(today)) {
+        }
+
+        // Not allowing under-18s to marry is project policy
+        if (person.isChild(today, true)) {
             return resources.getString("cannotMarry.TooYoung.text");
-        } else if (!isUseClanPersonnelMarriages() && person.isClanPersonnel()) {
+        }
+
+        if (!isUseClanPersonnelMarriages() && person.isClanPersonnel()) {
             return resources.getString("cannotMarry.ClanPersonnel.text");
-        } else if (!isUsePrisonerMarriages() && person.getPrisonerStatus().isCurrentPrisoner()) {
+        }
+
+        if (!isUsePrisonerMarriages() && person.getPrisonerStatus().isCurrentPrisoner()) {
             return resources.getString("cannotMarry.Prisoner.text");
-        } else if (randomMarriage) {
+        }
+        if (randomMarriage) {
             if (!isUseRandomClanPersonnelMarriages() && person.isClanPersonnel()) {
                 return resources.getString("cannotMarry.RandomClanPersonnel.text");
             } else if (!isUseRandomPrisonerMarriages() && person.getPrisonerStatus().isCurrentPrisoner()) {

--- a/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
@@ -138,6 +138,7 @@ public abstract class AbstractMarriage {
         if (!isUsePrisonerMarriages() && person.getPrisonerStatus().isCurrentPrisoner()) {
             return resources.getString("cannotMarry.Prisoner.text");
         }
+
         if (randomMarriage) {
             if (!isUseRandomClanPersonnelMarriages() && person.isClanPersonnel()) {
                 return resources.getString("cannotMarry.RandomClanPersonnel.text");

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -202,7 +202,8 @@ public abstract class AbstractProcreation {
             return resources.getString("cannotProcreate.Inactive.text");
         } else if (person.isDeployed()) {
             return resources.getString("cannotProcreate.Deployed.text");
-        } else if (person.isChild(today)) {
+        // Not allowing under-18s to procreate is project policy
+        } else if (person.isChild(today, true)) {
             return resources.getString("cannotProcreate.Child.text");
         } else if (person.getAge(today) >= 51) {
             return resources.getString("cannotProcreate.TooOld.text");
@@ -226,7 +227,11 @@ public abstract class AbstractProcreation {
                     return resources.getString("cannotProcreate.InactiveSpouse.text");
                 } else if (person.getGenealogy().getSpouse().isDeployed()) {
                     return resources.getString("cannotProcreate.DeployedSpouse.text");
-                } else if (person.getGenealogy().getSpouse().isChild(today)) {
+                // Not allowing under-18s to procreate is project policy
+                // This conditional shouldn't be relevant in 2025, due to changes made in 2024.
+                // However, we're keeping it as we don't want campaigns from pre-policy
+                // implementation being able to circumnavigate project policy.
+                } else if (person.getGenealogy().getSpouse().isChild(today, true)) {
                     return resources.getString("cannotProcreate.ChildSpouse.text");
                 } else if (!isUseRandomClanPersonnelProcreation() && person.getGenealogy().getSpouse().isClanPersonnel()) {
                     return resources.getString("cannotProcreate.ClanPersonnelSpouse.text");

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -194,48 +194,84 @@ public abstract class AbstractProcreation {
                                          final boolean randomProcreation) {
         if (person.getGender().isMale()) {
             return resources.getString("cannotProcreate.Gender.text");
-        } else if (!person.isTryingToConceive()) {
+        }
+
+        if (!person.isTryingToConceive()) {
             return resources.getString("cannotProcreate.NotTryingForABaby.text");
-        } else if (person.isPregnant()) {
+        }
+
+        if (person.isPregnant()) {
             return resources.getString("cannotProcreate.AlreadyPregnant.text");
-        } else if (!person.getStatus().isActive()) {
+        }
+
+        if (!person.getStatus().isActive()) {
             return resources.getString("cannotProcreate.Inactive.text");
-        } else if (person.isDeployed()) {
+        }
+
+        if (person.isDeployed()) {
             return resources.getString("cannotProcreate.Deployed.text");
+        }
+
         // Not allowing under-18s to procreate is project policy
-        } else if (person.isChild(today, true)) {
+        if (person.isChild(today, true)) {
             return resources.getString("cannotProcreate.Child.text");
-        } else if (person.getAge(today) >= 51) {
+        }
+
+        if (person.getAge(today) >= 51) {
             return resources.getString("cannotProcreate.TooOld.text");
-        } else if (!isUseClanPersonnelProcreation() && person.isClanPersonnel()) {
+        }
+
+        if (!isUseClanPersonnelProcreation() && person.isClanPersonnel()) {
             return resources.getString("cannotProcreate.ClanPersonnel.text");
-        } else if (!isUsePrisonerProcreation() && person.getPrisonerStatus().isCurrentPrisoner()) {
+        }
+
+        if (!isUsePrisonerProcreation() && person.getPrisonerStatus().isCurrentPrisoner()) {
             return resources.getString("cannotProcreate.Prisoner.text");
-        } else if (randomProcreation) {
+        }
+
+        if (randomProcreation) {
             if (!isUseRelationshiplessProcreation() && !person.getGenealogy().hasSpouse()) {
                 return resources.getString("cannotProcreate.NoSpouse.text");
-            } else if (!isUseRandomClanPersonnelProcreation() && person.isClanPersonnel()) {
+            }
+
+            if (!isUseRandomClanPersonnelProcreation() && person.isClanPersonnel()) {
                 return resources.getString("cannotProcreate.RandomClanPersonnel.text");
-            } else if (!isUseRandomPrisonerProcreation() && person.getPrisonerStatus().isCurrentPrisoner()) {
+            }
+
+            if (!isUseRandomPrisonerProcreation() && person.getPrisonerStatus().isCurrentPrisoner()) {
                 return resources.getString("cannotProcreate.RandomPrisoner.text");
-            } else if (person.getGenealogy().hasSpouse()) {
+            }
+
+            if (person.getGenealogy().hasSpouse()) {
                 if (person.getGenealogy().getSpouse().getGender().isFemale()) {
                     return resources.getString("cannotProcreate.FemaleSpouse.text");
-                } else if (!person.getGenealogy().getSpouse().isTryingToConceive()) {
+                }
+
+                if (!person.getGenealogy().getSpouse().isTryingToConceive()) {
                     return resources.getString("cannotProcreate.SpouseNotTryingForABaby.text");
-                } else if (!person.getGenealogy().getSpouse().getStatus().isActive()) {
+                }
+
+                if (!person.getGenealogy().getSpouse().getStatus().isActive()) {
                     return resources.getString("cannotProcreate.InactiveSpouse.text");
-                } else if (person.getGenealogy().getSpouse().isDeployed()) {
+                }
+
+                if (person.getGenealogy().getSpouse().isDeployed()) {
                     return resources.getString("cannotProcreate.DeployedSpouse.text");
+                }
+
                 // Not allowing under-18s to procreate is project policy
                 // This conditional shouldn't be relevant in 2025, due to changes made in 2024.
                 // However, we're keeping it as we don't want campaigns from pre-policy
                 // implementation being able to circumnavigate project policy.
-                } else if (person.getGenealogy().getSpouse().isChild(today, true)) {
+                if (person.getGenealogy().getSpouse().isChild(today, true)) {
                     return resources.getString("cannotProcreate.ChildSpouse.text");
-                } else if (!isUseRandomClanPersonnelProcreation() && person.getGenealogy().getSpouse().isClanPersonnel()) {
+                }
+
+                if (!isUseRandomClanPersonnelProcreation() && person.getGenealogy().getSpouse().isClanPersonnel()) {
                     return resources.getString("cannotProcreate.ClanPersonnelSpouse.text");
-                } else if (!isUseRandomPrisonerProcreation()
+                }
+
+                if (!isUseRandomPrisonerProcreation()
                         && person.getGenealogy().getSpouse().getPrisonerStatus().isCurrentPrisoner()) {
                     return resources.getString("cannotProcreate.PrisonerSpouse.text");
                 }

--- a/MekHQ/unittests/mekhq/campaign/personnel/marriage/AbstractMarriageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/marriage/AbstractMarriageTest.java
@@ -77,90 +77,290 @@ public class AbstractMarriageTest {
     //endregion Getters/Setters
 
     @Test
-    public void testCanMarry() {
-        doCallRealMethod().when(mockMarriage).canMarry(any(), any(), anyBoolean());
+    public void testNotMarriageable() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
 
-        final Genealogy mockGenealogy = mock(Genealogy.class);
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
 
-        final Person mockPerson = mock(Person.class);
-        when(mockPerson.getGenealogy()).thenReturn(mockGenealogy);
+        when(person.isMarriageable()).thenReturn(false);
 
-        // Have to be marriageable
-        when(mockPerson.isMarriageable()).thenReturn(false);
-        assertNotNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        // Act
+        String result = marriage.canMarry(date, person, false);
 
-        // Can't be married
-        when(mockPerson.isMarriageable()).thenReturn(true);
-        when(mockGenealogy.hasSpouse()).thenReturn(true);
-        assertNotNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, false));
-
-        // Must be active
-        when(mockGenealogy.hasSpouse()).thenReturn(false);
-        when(mockPerson.getStatus()).thenReturn(PersonnelStatus.KIA);
-        assertNotNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, false));
-
-        // Can't be deployed
-        when(mockPerson.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
-        when(mockPerson.isDeployed()).thenReturn(true);
-        assertNotNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, false));
-
-        // Can't be younger than the minimum marriage age
-        when(mockPerson.isDeployed()).thenReturn(false);
-        when(mockPerson.isChild(any())).thenReturn(true);
-        when(mockPerson.isChild(any())).thenReturn(true);
-        assertNotNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, false));
-
-        // Can't be Clan Personnel with Clan Marriage Disabled
-        when(mockPerson.isChild(any())).thenReturn(false);
-        when(mockPerson.isClanPersonnel()).thenReturn(true);
-        lenient().when(mockMarriage.isUseClanPersonnelMarriages()).thenReturn(false);
-        lenient().when(mockMarriage.isUsePrisonerMarriages()).thenReturn(true);
-        assertNotNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, false));
-
-        // Can be Non-Clan Personnel with Clan Marriage Disabled
-        when(mockPerson.isClanPersonnel()).thenReturn(false);
-        when(mockPerson.isChild(any())).thenReturn(false);
-        assertNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, false));
-
-        // Can be a Non-Prisoner with Prisoner Marriage Disabled
-        when(mockPerson.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
-        when(mockMarriage.isUsePrisonerMarriages()).thenReturn(false);
-        assertNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, false));
-
-        // Can't be a Prisoner with Prisoner Marriage Disabled
-        when(mockPerson.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER);
-        assertNotNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, false));
-
-        // Can be a Non-Random Clan Prisoner with Clan and Prisoner Marriage Enabled and Random Marriage Disabled
-        when(mockPerson.isClanPersonnel()).thenReturn(true);
-        when(mockMarriage.isUseClanPersonnelMarriages()).thenReturn(true);
-        when(mockMarriage.isUsePrisonerMarriages()).thenReturn(true);
-        assertNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, false));
-
-        // Can't be Clan Personnel with Random Clan Marriage Disabled
-        when(mockMarriage.isUseRandomClanPersonnelMarriages()).thenReturn(false);
-        when(mockMarriage.isUseRandomPrisonerMarriages()).thenReturn(true);
-        assertNotNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, true));
-
-        // Can be Non-Clan Personnel with Random Clan Marriage Disabled
-        when(mockPerson.isClanPersonnel()).thenReturn(false);
-        assertNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, true));
-
-        // Can be a Non-Prisoner with Random Prisoner Marriage Disabled
-        when(mockPerson.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
-        when(mockMarriage.isUseRandomPrisonerMarriages()).thenReturn(false);
-        assertNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, true));
-
-        // Can't be a Prisoner with Random Prisoner Marriage Disabled
-        when(mockPerson.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER);
-        assertNotNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, true));
-
-        // Can be a Clan Prisoner with Random Clan and Random Prisoner Marriage Enabled
-        lenient().when(mockPerson.isClanPersonnel()).thenReturn(true);
-        when(mockMarriage.isUseRandomClanPersonnelMarriages()).thenReturn(true);
-        when(mockMarriage.isUseRandomPrisonerMarriages()).thenReturn(true);
-        assertNull(mockMarriage.canMarry(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        // Assert
+        assertNotNull(result);
     }
+
+    @Test
+    public void testAlreadyMarried() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(true);
+
+        // Act
+        String result = marriage.canMarry(date, person, false);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testInactiveStatus() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.STUDENT);
+
+        // Act
+        String result = marriage.canMarry(date, person, false);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testDeployed() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(true);
+
+        // Act
+        String result = marriage.canMarry(date, person, false);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testUnderage() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(true);
+
+        // Act
+        String result = marriage.canMarry(date, person, false);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testClanPersonnelMarriageDisabled() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+        marriage.setUseClanPersonnelMarriages(false);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.isClanPersonnel()).thenReturn(true);
+
+        // Act
+        String result = marriage.canMarry(date, person, false);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testPrisonerMarriageDisabled() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+        marriage.setUsePrisonerMarriages(false);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER);
+
+        // Act
+        String result = marriage.canMarry(date, person, false);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testPrisonerMarriageDisabledBondsman() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+        marriage.setUsePrisonerMarriages(false);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.BONDSMAN);
+
+        // Act
+        String result = marriage.canMarry(date, person, false);
+
+        // Assert
+        assertNull(result);
+    }
+
+    @Test
+    public void testRandomClanMarriageDisabled() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+        marriage.setUseClanPersonnelMarriages(true);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.isClanPersonnel()).thenReturn(true);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+
+        // Act
+        String result = marriage.canMarry(date, person, true);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRandomPrisonerMarriageDisabled() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+        marriage.setUsePrisonerMarriages(true);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER);
+
+        // Act
+        String result = marriage.canMarry(date, person, true);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRandomPrisonerMarriageDisabledBondsman() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+        marriage.setUsePrisonerMarriages(true);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.BONDSMAN);
+
+        // Act
+        String result = marriage.canMarry(date, person, true);
+
+        // Assert
+        assertNull(result);
+    }
+
+    @Test
+    public void testNoBlockers() {
+        // Arrange
+        AbstractMarriage marriage = new RandomMarriage(mockCampaignOptions);
+        marriage.setUseClanPersonnelMarriages(true);
+        marriage.setUseRandomClanPersonnelMarriages(true);
+        marriage.setUsePrisonerMarriages(true);
+        marriage.setUseRandomPrisonerMarriages(true);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+        Genealogy genealogy = mock(Genealogy.class);
+
+        when(person.isMarriageable()).thenReturn(true);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+
+        // Act
+        String result = marriage.canMarry(date, person, true);
+
+        // Assert
+        assertNull(result);
+    }
+
 
     @Test
     public void testSafeSpouse() {

--- a/MekHQ/unittests/mekhq/campaign/personnel/procreation/AbstractProcreationTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/procreation/AbstractProcreationTest.java
@@ -142,159 +142,557 @@ public class AbstractProcreationTest {
     //endregion Determination Methods
 
     @Test
-    public void testCanProcreate() {
-        doCallRealMethod().when(mockProcreation).canProcreate(any(), any(), anyBoolean());
+    public void testIsMale() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
 
-        final Person mockPerson = mock(Person.class);
-        final Person mockSpouse = mock(Person.class);
-        final Genealogy mockGenealogy = mock(Genealogy.class);
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
 
-        when(mockPerson.getGenealogy()).thenReturn(mockGenealogy);
+        when(person.getGender()).thenReturn(Gender.MALE);
 
-        // Males can't procreate
-        when(mockPerson.getGender()).thenReturn(Gender.MALE);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        // Act
+        String result = procreation.canProcreate(date, person, false);
 
-        // Have to be trying to conceive
-        when(mockPerson.getGender()).thenReturn(Gender.FEMALE);
-        when(mockPerson.isTryingToConceive()).thenReturn(false);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        // Assert
+        assertNotNull(result);
+    }
 
-        // Can't already be pregnant
-        when(mockPerson.isTryingToConceive()).thenReturn(true);
-        when(mockPerson.isPregnant()).thenReturn(true);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+    @Test
+    public void testNotInterestInChildren() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
 
-        // Must be active
-        when(mockPerson.isPregnant()).thenReturn(false);
-        when(mockPerson.getStatus()).thenReturn(PersonnelStatus.RETIRED);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
 
-        // Can't be deployed
-        when(mockPerson.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
-        when(mockPerson.isDeployed()).thenReturn(true);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(false);
 
-        // Can't be a child
-        when(mockPerson.isDeployed()).thenReturn(false);
-        when(mockPerson.isChild(any())).thenReturn(true);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        // Act
+        String result = procreation.canProcreate(date, person, false);
 
-        // Must be younger than 51
-        when(mockPerson.isChild(any())).thenReturn(false);
-        when(mockPerson.getAge(any())).thenReturn(51);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        // Assert
+        assertNotNull(result);
+    }
 
-        // Can't be Clan Personnel with Clan Procreation Disabled
-        when(mockPerson.getAge(any())).thenReturn(25);
-        when(mockPerson.isClanPersonnel()).thenReturn(true);
-        when(mockProcreation.isUseClanPersonnelProcreation()).thenReturn(false);
-        when(mockProcreation.isUsePrisonerProcreation()).thenReturn(true);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+    @Test
+    public void testIsAlreadyPregnant() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
 
-        // Can be Non-Clan Personnel with Clan Procreation Disabled
-        when(mockPerson.isClanPersonnel()).thenReturn(false);
-        assertNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
 
-        // Can be a Non-Prisoner with Prisoner Procreation Disabled
-        when(mockPerson.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
-        when(mockProcreation.isUsePrisonerProcreation()).thenReturn(false);
-        assertNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(true);
 
-        // Can't be a Prisoner with Prisoner Procreation Disabled
-        when(mockPerson.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        // Act
+        String result = procreation.canProcreate(date, person, false);
 
-        // Can be a Non-Random Clan Prisoner with Clan and Prisoner Procreation Enabled and Random Procreation Disabled
-        when(mockPerson.isClanPersonnel()).thenReturn(true);
-        when(mockProcreation.isUseClanPersonnelProcreation()).thenReturn(true);
-        when(mockProcreation.isUsePrisonerProcreation()).thenReturn(true);
-        assertNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, false));
+        // Assert
+        assertNotNull(result);
+    }
 
-        // Can't be Single with Relationshipless Random Procreation Disabled
-        when(mockGenealogy.hasSpouse()).thenReturn(false);
-        when(mockProcreation.isUseRelationshiplessProcreation()).thenReturn(false);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+    @Test
+    public void testIsInactive() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
 
-        // Can't be Clan Personnel with Random Clan Procreation Disabled
-        when(mockProcreation.isUseRelationshiplessProcreation()).thenReturn(true);
-        when(mockProcreation.isUseRandomClanPersonnelProcreation()).thenReturn(false);
-        when(mockProcreation.isUseRandomPrisonerProcreation()).thenReturn(true);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
 
-        // Can be Non-Clan Personnel with Random Clan Procreation Disabled
-        when(mockPerson.isClanPersonnel()).thenReturn(false);
-        assertNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.STUDENT);
 
-        // Can be a Non-Prisoner with Random Prisoner Procreation Disabled
-        when(mockPerson.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
-        when(mockProcreation.isUseRandomPrisonerProcreation()).thenReturn(false);
-        assertNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        // Act
+        String result = procreation.canProcreate(date, person, false);
 
-        // Can't be a Prisoner with Random Prisoner Procreation Disabled
-        when(mockPerson.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        // Assert
+        assertNotNull(result);
+    }
 
-        // Can be a Clan Prisoner with no Spouse with Random Relationshipless, Random Clan, and
-        // Random Prisoner Procreation Enabled
-        when(mockPerson.isClanPersonnel()).thenReturn(true);
-        when(mockProcreation.isUseRandomClanPersonnelProcreation()).thenReturn(true);
-        when(mockProcreation.isUseRandomPrisonerProcreation()).thenReturn(true);
-        assertNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+    @Test
+    public void testIsDeployed() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
 
-        // Can't have a Same-sex Spouse
-        when(mockSpouse.getGender()).thenReturn(Gender.FEMALE);
-        when(mockGenealogy.hasSpouse()).thenReturn(true);
-        when(mockGenealogy.getSpouse()).thenReturn(mockSpouse);
-        when(mockProcreation.isUseRelationshiplessProcreation()).thenReturn(false);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
 
-        // Spouse must also be trying to conceive
-        when(mockSpouse.getGender()).thenReturn(Gender.MALE);
-        when(mockSpouse.isTryingToConceive()).thenReturn(false);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(true);
 
-        // Spouse must be active
-        when(mockSpouse.getStatus()).thenReturn(PersonnelStatus.RETIRED);
-        when(mockSpouse.isTryingToConceive()).thenReturn(true);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        // Act
+        String result = procreation.canProcreate(date, person, false);
 
-        // Spouse can't be deployed
-        when(mockSpouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
-        when(mockSpouse.isDeployed()).thenReturn(true);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        // Assert
+        assertNotNull(result);
+    }
 
-        // Spouse can't be a child
-        when(mockSpouse.isDeployed()).thenReturn(false);
-        when(mockSpouse.isChild(any())).thenReturn(true);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+    @Test
+    public void testIsChild() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
 
-        // Spouse can't be Clan Personnel with Random Clan Procreation Disabled
-        when(mockPerson.isClanPersonnel()).thenReturn(false);
-        when(mockSpouse.isClanPersonnel()).thenReturn(true);
-        when(mockSpouse.isChild(any())).thenReturn(false);
-        when(mockProcreation.isUseRandomClanPersonnelProcreation()).thenReturn(false);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
 
-        // Spouse can be Non-Clan Personnel with Random Clan Procreation Disabled
-        when(mockSpouse.isClanPersonnel()).thenReturn(false);
-        assertNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(true);
 
-        // Spouse can be a Non-Prisoner with Random Prisoner Procreation Disabled
-        when(mockPerson.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
-        when(mockSpouse.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
-        when(mockProcreation.isUseRandomPrisonerProcreation()).thenReturn(false);
-        assertNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        // Act
+        String result = procreation.canProcreate(date, person, false);
 
-        // Spouse can't be a Prisoner with Prisoner Procreation Disabled
-        when(mockSpouse.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER);
-        assertNotNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+        // Assert
+        assertNotNull(result);
+    }
 
-        // Spouse can be a Prisoner Clan Personnel with Random Clan and Prisoner Procreation Enabled
-        lenient().when(mockSpouse.isClanPersonnel()).thenReturn(true);
-        when(mockProcreation.isUseRandomClanPersonnelProcreation()).thenReturn(true);
-        when(mockProcreation.isUseRandomPrisonerProcreation()).thenReturn(true);
-        assertNull(mockProcreation.canProcreate(LocalDate.ofYearDay(3025, 1), mockPerson, true));
+    @Test
+    public void testIsTooOld() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(356);
+
+        // Act
+        String result = procreation.canProcreate(date, person, false);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testIsClanAndClanProcreationDisabled() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(true);
+
+        // Act
+        String result = procreation.canProcreate(date, person, false);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testIsPrisonerAndPrisonerProcreationDisabled() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER);
+
+        // Act
+        String result = procreation.canProcreate(date, person, false);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testIsPrisonerAndPrisonerProcreationDisabledBondsman() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.BONDSMAN);
+
+        // Act
+        String result = procreation.canProcreate(date, person, false);
+
+        // Assert
+        assertNull(result);
+    }
+
+    @Test
+    public void testRandomProcreationRelationshiplessProcreationDisabled() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        Genealogy genealogy = mock(Genealogy.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(false);
+
+        // Act
+        String result = procreation.canProcreate(date, person, true);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRandomProcreationSpouseIsFemale() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        Person spouse = mock(Person.class);
+        Genealogy genealogy = mock(Genealogy.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(true);
+        when(genealogy.getSpouse()).thenReturn(spouse);
+        when(spouse.getGender()).thenReturn(Gender.FEMALE);
+
+        // Act
+        String result = procreation.canProcreate(date, person, true);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRandomProcreationSpouseHasNoInterestInChildren() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        Person spouse = mock(Person.class);
+        Genealogy genealogy = mock(Genealogy.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(true);
+        when(genealogy.getSpouse()).thenReturn(spouse);
+        when(spouse.getGender()).thenReturn(Gender.MALE);
+        when(spouse.isTryingToConceive()).thenReturn(false);
+
+        // Act
+        String result = procreation.canProcreate(date, person, true);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRandomProcreationSpouseIsInactive() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        Person spouse = mock(Person.class);
+        Genealogy genealogy = mock(Genealogy.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(true);
+        when(genealogy.getSpouse()).thenReturn(spouse);
+        when(spouse.getGender()).thenReturn(Gender.MALE);
+        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.getStatus()).thenReturn(PersonnelStatus.STUDENT);
+
+        // Act
+        String result = procreation.canProcreate(date, person, true);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRandomProcreationSpouseIsDeployed() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        Person spouse = mock(Person.class);
+        Genealogy genealogy = mock(Genealogy.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(true);
+        when(genealogy.getSpouse()).thenReturn(spouse);
+        when(spouse.getGender()).thenReturn(Gender.MALE);
+        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(spouse.isDeployed()).thenReturn(true);
+
+        // Act
+        String result = procreation.canProcreate(date, person, true);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRandomProcreationSpouseIsChild() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        Person spouse = mock(Person.class);
+        Genealogy genealogy = mock(Genealogy.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(true);
+        when(genealogy.getSpouse()).thenReturn(spouse);
+        when(spouse.getGender()).thenReturn(Gender.MALE);
+        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(spouse.isDeployed()).thenReturn(false);
+        when(spouse.isChild(date, true)).thenReturn(true);
+
+        // Act
+        String result = procreation.canProcreate(date, person, true);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRandomProcreationSpouseIsClanAndClanRandomProcreationDisabled() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        Person spouse = mock(Person.class);
+        Genealogy genealogy = mock(Genealogy.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(true);
+        when(genealogy.getSpouse()).thenReturn(spouse);
+        when(spouse.getGender()).thenReturn(Gender.MALE);
+        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(spouse.isDeployed()).thenReturn(false);
+        when(spouse.isChild(date, true)).thenReturn(false);
+        when(spouse.isClanPersonnel()).thenReturn(true);
+
+        // Act
+        String result = procreation.canProcreate(date, person, true);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRandomProcreationSpouseIsPrisonAndPrisonerRandomProcreationDisabled() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        Person spouse = mock(Person.class);
+        Genealogy genealogy = mock(Genealogy.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(true);
+        when(genealogy.getSpouse()).thenReturn(spouse);
+        when(spouse.getGender()).thenReturn(Gender.MALE);
+        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(spouse.isDeployed()).thenReturn(false);
+        when(spouse.isChild(date, true)).thenReturn(false);
+        when(spouse.isClanPersonnel()).thenReturn(false);
+        when(spouse.getPrisonerStatus()).thenReturn(PrisonerStatus.PRISONER);
+
+        // Act
+        String result = procreation.canProcreate(date, person, true);
+
+        // Assert
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRandomProcreationSpouseIsPrisonAndPrisonerRandomProcreationDisabledBondsman() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        Person spouse = mock(Person.class);
+        Genealogy genealogy = mock(Genealogy.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(true);
+        when(genealogy.getSpouse()).thenReturn(spouse);
+        when(spouse.getGender()).thenReturn(Gender.MALE);
+        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(spouse.isDeployed()).thenReturn(false);
+        when(spouse.isChild(date, true)).thenReturn(false);
+        when(spouse.isClanPersonnel()).thenReturn(false);
+        when(spouse.getPrisonerStatus()).thenReturn(PrisonerStatus.BONDSMAN);
+
+        // Act
+        String result = procreation.canProcreate(date, person, true);
+
+        // Assert
+        assertNull(result);
+    }
+
+    @Test
+    public void testProcreationNoBlockers() {
+        // Arrange
+        AbstractProcreation procreation = new RandomProcreation(mockCampaignOptions);
+
+        Person person = mock(Person.class);
+        Person spouse = mock(Person.class);
+        Genealogy genealogy = mock(Genealogy.class);
+        LocalDate date = LocalDate.of(3025, 1, 1);
+
+        when(person.getGender()).thenReturn(Gender.FEMALE);
+        when(person.isTryingToConceive()).thenReturn(true);
+        when(person.isPregnant()).thenReturn(false);
+        when(person.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(person.isDeployed()).thenReturn(false);
+        when(person.isChild(date, true)).thenReturn(false);
+        when(person.getAge(date)).thenReturn(21);
+        when(person.isClanPersonnel()).thenReturn(false);
+        when(person.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+        when(person.getGenealogy()).thenReturn(genealogy);
+        when(genealogy.hasSpouse()).thenReturn(true);
+        when(genealogy.getSpouse()).thenReturn(spouse);
+        when(spouse.getGender()).thenReturn(Gender.MALE);
+        when(spouse.isTryingToConceive()).thenReturn(true);
+        when(spouse.getStatus()).thenReturn(PersonnelStatus.ACTIVE);
+        when(spouse.isDeployed()).thenReturn(false);
+        when(spouse.isChild(date, true)).thenReturn(false);
+        when(spouse.isClanPersonnel()).thenReturn(false);
+        when(spouse.getPrisonerStatus()).thenReturn(PrisonerStatus.FREE);
+
+        // Act
+        String result = procreation.canProcreate(date, person, true);
+
+        // Assert
+        assertNull(result);
     }
 
     @Test


### PR DESCRIPTION
- Updated methods and test cases to consistently use `isChild` with an 18-year-old threshold override where required.
- Clarified project policies on age restrictions for marriage, procreation, and academy-related events.
- Improved readability and maintainability of `canMarry` and 'canProcreate'.
- Rewrote `canMarry` and `canProcreate` Unit Tests

# Age Policy
Mid-2024 we settled on a policy of 18+ for marriage, procreation, and roles. This was to cut back on the child soldier problem that had been in mhq since ages were introduced. There were other reasons, but that's the main one. Since then, we've received feedback to reduce the strictness specifically for Roles, given how many 16 year old pilots and such there are in the lore.

After discussing it with Hammer we opted to update the policy so that marriage and procreation would still be limited to 18+, but professions could be assigned to 16+ characters. I added some other limiters in the code, surrounding academy destruction and dropout events, which have been commented accordingly.

For academy destruction events we're treating any character under 18 to be a 'child' for the purposes of whether they can be killed during such events. This was chosen due to real world problems that might cause players to become uncomfortable if such a thing happens and they did not explicitly opt-in.

# Unit Tests
I have had enough of every time I even _look_ at marriage or procreation the unit tests would explode in a mass fit of rage. I have tweaked them and adjusted them so many times I think I knew them by heart. So, with no great sorrow, I nuked the ones this PR touched and just rewrote them to be more modular and therefore a lot easier to maintain. Now, instead of a single monolithic unit test for `canMarry` and `canProcreate` that tested all conditionals, I added individual tests that did the same thing but in an easier to follow manner. I don't know if this is the right way to handle it, but it feels better to be.

Feedback, as always, welcomed and encouraged - I'm still learning what, when, and how to Unit Test. :)

Fix #5884