### PR TITLE
Fixed Clan Bidding

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBDynamicScenarioFactory.properties
+++ b/MekHQ/resources/mekhq/resources/AtBDynamicScenarioFactory.properties
@@ -1,5 +1,5 @@
 # reportResultsOfBidding
-bidAwayForcesVerbose.text=%s has bid away the following forces:<br>%s
+bidAwayForcesVerbose.text=%s has bid away the following forces:<br>%s<br>
 bidAwayForcesLogger.text=%s has bid away the following forces:
 bidAwayForces.text=%s has bid away %s unit%s.
 nothingBidAway.text=%s has not bid away any forces.


### PR DESCRIPTION
- Enhanced logging for bidding and force budget adjustments, including Clan-specific handling and Batchall refusal messages.
- Ensured proper fallback handling for empty forces and set fixed entity lists for generated forces.
- Fixed verbose bidding so that the first two units wouldn't be on the same line.
- Adjusted Clan force generation so that we don't cull units, prior to bidding. This ensures we're not, effectively, double handling everything for minimal benefit. This also has the added benefit of making refusing a Batchall even deadlier (and consequently more rewarding for the brave and foolhardy both).
- Fixed Clan force generation so that units bid away are actually removed from the force.

#5882

So it turned out the Clans were bidding away units, and then fielding them anyway. Meanwhile, they were boasting in the logs about how Strict their honor was.

Typical Clan behavior, if you ask me.

![image](https://github.com/user-attachments/assets/55e41673-30bd-4757-b8f9-71087128941a)
