### PR TITLE
Fixed Negative Contract Base Pay

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -518,12 +518,15 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         }
 
         // Adjust pay based on difficulty if FG3 is enabled
-        int difficulty = clamp(contract.calculateContractDifficulty(campaign), 0, 10);
-        int baseDifficulty = 5; // 2.5 skulls
+        if (campaign.getCampaignOptions().isUseGenericBattleValue()) {
+            int difficulty = clamp(contract.calculateContractDifficulty(campaign), 0, 10);
+            int baseDifficulty = 5; // 2.5 skulls
 
-        double difficultyDifference = ((difficulty - baseDifficulty) / (double) baseDifficulty);
+            double difficultyDifference = ((difficulty - baseDifficulty) / (double) baseDifficulty);
 
-        modifier += difficultyDifference;
+            modifier += difficultyDifference;
+        }
+
         return modifier;
     }
 

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -41,6 +41,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Set;
 
+import static java.lang.Math.floor;
+import static megamek.codeUtilities.MathUtility.clamp;
+import static mekhq.campaign.mission.AtBContract.getEffectiveNumUnits;
+
 /**
  * Contract offers that are generated monthly under AtB rules.
  *
@@ -451,12 +455,16 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
     @Override
     public double calculatePaymentMultiplier(Campaign campaign, AtBContract contract) {
-        int unitRatingMod = campaign.getAtBUnitRatingMod();
         double multiplier = 1.0;
-        // IntOps reputation factor then Dragoons rating
+
+        // Operations tempo
+        multiplier *= contract.getContractType().getOperationsTempoMultiplier();
+
+        // Reputation multiplier
         if (campaign.getCampaignOptions().getUnitRatingMethod().isCampaignOperations()) {
-            multiplier *= (unitRatingMod * 0.2) + 0.5;
+            multiplier *= (campaign.getReputation().getReputationRating() * 0.2) + 0.5;
         } else {
+            int unitRatingMod = campaign.getAtBUnitRatingMod();
             if (unitRatingMod >= IUnitRating.DRAGOON_A) {
                 multiplier *= 2.0;
             } else if (unitRatingMod == IUnitRating.DRAGOON_B) {
@@ -468,8 +476,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
             }
         }
 
-        multiplier *= contract.getContractType().getOperationsTempoMultiplier();
-
+        // Employer multiplier
         final Faction employer = Factions.getInstance().getFaction(contract.getEmployerCode());
         final Faction enemy = contract.getEnemy();
         if (employer.isISMajorOrSuperPower() || employer.isClan()) {
@@ -484,26 +491,33 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
             multiplier *= 1.1;
         }
 
-        // Adjust pay based on the percentage of the players' forces required by the contract
-        int requiredCombatTeams = contract.getRequiredCombatTeams();
-        double totalCombatTeams = campaign.getAllCombatTeams().size();
-        totalCombatTeams /= COMBAT_FORCE_DIVIDER;
+        // Unofficial modifiers
+        double modifier = 0; // we apply these modifiers all together to avoid spiking the final pay
 
-        if (totalCombatTeams > 0) {
-            multiplier *= (double) requiredCombatTeams / totalCombatTeams;
+        // Adjust pay based on the percentage of the players' forces required by the contract
+        int maximumLanceCount = campaign.getAllCombatTeams().size();
+        int reserveLanceCount = (int) floor(maximumLanceCount / COMBAT_FORCE_DIVIDER);
+        int requiredCombatTeams = contract.getRequiredCombatTeams();
+
+        if (reserveLanceCount > 0) { // Ensure we don't divide by zero
+            double reservesDifference = ((requiredCombatTeams - reserveLanceCount) / (double) reserveLanceCount);
+
+            modifier += reservesDifference;
         }
 
         // Adjust pay based on difficulty if FG3 is enabled
-        if (campaign.getCampaignOptions().isUseGenericBattleValue()) {
-            double skulls = contract.calculateContractDifficulty(campaign);
-            skulls -= 5; // 5 skulls (or 2.5) is equivalent to the player force, so no modifier.
+        int difficulty = clamp(contract.calculateContractDifficulty(campaign), 0, 10);
+        int baseDifficulty = 5; // 2.5 skulls
 
-            if (skulls != 0) {
-                skulls *= 0.05; // each half-skull is a 5% pay change
-                multiplier *= (1 + skulls);
-            }
+        double difficultyDifference = ((difficulty - baseDifficulty) / (double) baseDifficulty);
+
+        modifier += difficultyDifference;
+
+        if (modifier > 0) {
+            multiplier *= (1.0 + modifier);
+        } else if (modifier < 0) {
+            multiplier *= (1.0 - modifier);
         }
-
 
         return multiplier;
     }
@@ -552,7 +566,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         if (campaign.getCampaignOptions().isMercSizeLimited() &&
                 campaign.getFaction().isMercenary()) {
             int max = (unitRatingMod + 1) * 12;
-            int numMods = (AtBContract.getEffectiveNumUnits(campaign) - max) / 2;
+            int numMods = (getEffectiveNumUnits(campaign) - max) / 2;
             while (numMods > 0) {
                 mods.mods[Compute.randomInt(4)]--;
                 numMods--;

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -492,6 +492,18 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         }
 
         // Unofficial modifiers
+        double unofficialMultiplier = getUnofficialMultiplier(campaign, contract);
+
+        if (unofficialMultiplier > 0) {
+            multiplier *= (1.0 + unofficialMultiplier);
+        } else if (unofficialMultiplier < 0) {
+            multiplier *= (1.0 - unofficialMultiplier);
+        }
+
+        return multiplier;
+    }
+
+    private static double getUnofficialMultiplier(Campaign campaign, AtBContract contract) {
         double modifier = 0; // we apply these modifiers all together to avoid spiking the final pay
 
         // Adjust pay based on the percentage of the players' forces required by the contract
@@ -512,14 +524,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         double difficultyDifference = ((difficulty - baseDifficulty) / (double) baseDifficulty);
 
         modifier += difficultyDifference;
-
-        if (modifier > 0) {
-            multiplier *= (1.0 + modifier);
-        } else if (modifier < 0) {
-            multiplier *= (1.0 - modifier);
-        }
-
-        return multiplier;
+        return modifier;
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1936,10 +1936,36 @@ public class AtBContract extends Contract {
     }
 
     /**
-     * Calculates the contract difficulty based on the given campaign and parameters.
+     * Calculates the difficulty of a contract based on the relative power of enemy forces,
+     * player forces, and any allied forces involved in the campaign.
      *
-     * @param campaign The campaign object containing the necessary data.
-     * @return The contract difficulty as an integer value.
+     * <p>The method evaluates the enemy's estimated power against the player's strengths
+     * and considers allied contributions depending on the assigned command rights.
+     * The result is a difficulty level mapped between 1 and 10, where higher values
+     * represent more challenging contracts.</p>
+     *
+     * @param campaign The {@link Campaign} object representing the current game state.
+     *                 Used to extract information about the player's forces, enemy forces,
+     *                 and allied forces.
+     *
+     * @return An integer representing the difficulty of the contract:
+     * <ul>
+     *    <li>1 = very easy</li>
+     *    <li>10 = extremely difficult</li>
+     * </ul>
+     * <b>WARNING: </b>Returns `-99` (defined as `ERROR`) if the enemy's power cannot be calculated.
+     *
+     * <h3>Mapped Result Explanation:</h3>
+     * <p>
+     * The method divides the absolute percentage difference between enemy and player forces by 20
+     * (rounding up), then adjusts the difficulty accordingly:
+     * <ul>
+     *   <li>If the player's forces are stronger, the difficulty is adjusted downward from a baseline of 5.</li>
+     *   <li>If the enemy's forces are stronger, the difficulty is adjusted upward from a baseline of 5.</li>
+     *   <li>If an error is encountered, the difficulty is returned as -99</li>
+     * </ul>
+     * The result is clamped to fit between the valid range of 1 and 10. Or -99 if an error is encounterd.
+     * </p>
      */
     public int calculateContractDifficulty(Campaign campaign) {
         final int ERROR = -99;

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1956,8 +1956,7 @@ public class AtBContract extends Contract {
      * <p>
      * <b>WARNING: </b>Returns `-99` (defined as `ERROR`) if the enemy's power cannot be calculated.
      * </p>
-     * <b>Mapped Result Explanation:</b>
-     * <p>
+     * <p><b>Mapped Result Explanation:</b></p>
      * The method divides the absolute percentage difference between enemy and player forces by 20
      * (rounding up), then adjusts the difficulty accordingly:
      * <ul>
@@ -1966,7 +1965,7 @@ public class AtBContract extends Contract {
      *   <li>If an error is encountered, the difficulty is returned as -99</li>
      * </ul>
      * The result is clamped to fit between the valid range of 1 and 10. Or -99 if an error is encounterd.
-     * </p>
+     *
      */
     public int calculateContractDifficulty(Campaign campaign) {
         final int ERROR = -99;

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1954,8 +1954,8 @@ public class AtBContract extends Contract {
      *    <li>10 = extremely difficult</li>
      * </ul>
      * <b>WARNING: </b>Returns `-99` (defined as `ERROR`) if the enemy's power cannot be calculated.
-     *
-     * <h3>Mapped Result Explanation:</h3>
+     * <p>
+     * <b>Mapped Result Explanation:</b>
      * <p>
      * The method divides the absolute percentage difference between enemy and player forces by 20
      * (rounding up), then adjusts the difficulty accordingly:

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1953,8 +1953,9 @@ public class AtBContract extends Contract {
      *    <li>1 = very easy</li>
      *    <li>10 = extremely difficult</li>
      * </ul>
-     * <b>WARNING: </b>Returns `-99` (defined as `ERROR`) if the enemy's power cannot be calculated.
      * <p>
+     * <b>WARNING: </b>Returns `-99` (defined as `ERROR`) if the enemy's power cannot be calculated.
+     * </p>
      * <b>Mapped Result Explanation:</b>
      * <p>
      * The method divides the absolute percentage difference between enemy and player forces by 20


### PR DESCRIPTION
- Adjusted pay multiplier for required lances to better handle both large and small campaigns. Previously we were overcompensating large campaigns.
- Adjusted pay multiplier for difficulty.
- Adjusted how required lances and difficulty multipliers were applied to the overall base pay multiplier so that we're less likely to spike contract pay.
- Added clearer JavaDocs to `calculateContractDifficulty` so developers are aware it can, on occasion, return a value outside of the expected 1-10 bounds. Fix #5898

These changes ensure required lances and difficulty (if FG3 is enabled) properly impact contract pay.