### PR TITLE
Issue 5799: Differentiating between IS & Clan DHS & unbreaking commas in Parts in use

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -83,8 +83,10 @@ public class PartInUse {
         if (null != partToBuy) {
             this.cost = partToBuy.getBuyCost();
             String descString = partToBuy.getAcquisitionName();
-            descString = descString.split(",")[0];
-            descString = descString.split("<")[0];
+            if( !(descString.contains("(") && descString.contains(")"))) {
+                descString = descString.split(",")[0];
+                descString = descString.split("<")[0];
+            }
             if(descString.equals("Turret")) {
                 descString += " " + part.getTonnage() + " tons";
             }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/HeatSink.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/HeatSink.java
@@ -25,6 +25,8 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.enums.PartRepairType;
 
+import java.util.StringJoiner;
+
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
@@ -113,5 +115,30 @@ public class HeatSink extends EquipmentPart {
     @Override
     public boolean isOmniPoddable() {
         return true;
+    }
+
+    /**
+     * Gets a string containing details regarding the part,
+     * and optionally include information on its repair
+     * status.
+     *
+     * @param includeRepairDetails {@code true} if the details
+     *                             should include information such as the number of
+     *                             hits or how much it would cost to repair the
+     *                             part.
+     * @return A string containing details regarding the part.
+     */
+    @Override
+    public String getDetails(boolean includeRepairDetails) {
+        StringJoiner sj = new StringJoiner(", ");
+        if (getName() != null && getName().equals("Double Heat Sink")) {
+            sj.add(getTechBaseName());
+        }
+
+        if( !super.getDetails(includeRepairDetails).isEmpty()) {
+            sj.add(super.getDetails(includeRepairDetails));
+        }
+
+        return sj.toString();
     }
 }


### PR DESCRIPTION
Fixes #5799 

IS and Clan Double Heat Sinks have the exact same name, how confusing! This adds "details" to Double Heat Sinks (only) that is the heat sink's tech base (Clan or IS). 

I also found commas in the parts in use was broken - it would cut off details in parenthesis after the first comma. I tweaked it some to hopefully work how the the last dev wanted.