### PR TITLE
Fixed Unit Role configuration in Resupply Scenario Templates

### DIFF
--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
@@ -77,6 +77,9 @@
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
+                <roleChoices>
+                    <forceRole>ANTI_AIRCRAFT</forceRole>
+                </roleChoices>
             </value>
         </entry>
         <entry>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
@@ -77,9 +77,6 @@
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
-                <roleChoices>
-                    <forceRole>ANTI_AIRCRAFT</forceRole>
-                </roleChoices>
             </value>
         </entry>
     </scenarioForces>


### PR DESCRIPTION
- Moved the `ANTI_AIRCRAFT` force role from the `Emergency Convoy Defense - Player` template to the `Emergency Convoy Defense - Player - VTOL` template. This ensures alignment of role assignments with the intended scenario design.