### PR TITLE
Added Soldier Requirements Handling in `UnitTableModel`

### DIFF
--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -163,6 +163,9 @@ public class UnitTableModel extends DataTableModel {
         int driversAssigned = unit.getDrivers().size();
 
         Entity entity = unit.getEntity();
+        int soldiersNeeded = entity instanceof Infantry ? gunnersNeeded : 0;
+        int soldiersAssigned = entity instanceof Infantry ? gunnersAssigned : 0;
+
         int navigatorsNeeded = entity instanceof Jumpship && !(entity instanceof SpaceStation) ? 1 : 0;
         int navigatorsAssigned = unit.getNavigator() == null ? 0 : 1;
 
@@ -171,13 +174,19 @@ public class UnitTableModel extends DataTableModel {
 
         StringBuilder report = new StringBuilder("<html>");
 
-        if (driversNeeded > 0) {
+
+        if (driversNeeded > 0 && soldiersNeeded == 0) {
             appendReport(report, "Drivers", driversAssigned, driversNeeded);
         }
 
-        if (gunnersNeeded > 0) {
+        if (gunnersNeeded > 0 && soldiersNeeded == 0) {
             report.append("<br>");
             appendReport(report, "Gunners", gunnersAssigned, gunnersNeeded);
+        }
+
+        if (soldiersNeeded > 0) {
+            report.append("<br>");
+            appendReport(report, "Soldiers", soldiersAssigned, soldiersNeeded);
         }
 
         if (crewNeeded > 0) {


### PR DESCRIPTION
Previously, infantry units did not specifically track soldier assignments and requirements. This update introduces logic to account for soldiers needed and assigned, ensuring accurate reporting for infantry units in the personnel report. Other behaviors remain unchanged.

Fix #5917