### PR TITLE
Refactored Part Handling in Resupply Module

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -159,6 +159,7 @@ import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
 import static mekhq.campaign.market.contractMarket.ContractAutomation.performAutomatedActivation;
 import static mekhq.campaign.mission.AtBContract.pickRandomCamouflage;
 import static mekhq.campaign.mission.resupplyAndCaches.PerformResupply.performResupply;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.isProhibitedUnitType;
 import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.processAbandonedConvoy;
 import static mekhq.campaign.parts.enums.PartQuality.QUALITY_A;
 import static mekhq.campaign.personnel.backgrounds.BackgroundsController.randomMercenaryCompanyNameGenerator;
@@ -2583,17 +2584,56 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Create a data set detailing all the parts being used (or not) and their warehouse spares
-     * @param ignoreMothballedUnits don't count parts in mothballed units
-     * @param ignoreSparesUnderQuality don't count spare parts lower than this quality
-     * @return a Set of PartInUse data for display or inspection
+     * Analyzes the warehouse inventory and returns a data set that summarizes the usage state of
+     * all parts, including their use counts, store counts, and planned counts, while filtering
+     * based on specific conditions.
+     *
+     * <p>This method aggregates all parts currently in use or available as spares, while taking
+     * into account constraints like ignoring mothballed units or filtering spares below a specific
+     * quality. It uses a map structure to efficiently track and update parts during processing.</p>
+     *
+     * @param ignoreMothballedUnits If {@code true}, parts from mothballed units will not be
+     *                             included in the results.
+     * @param isResupply If {@code true}, specific units (e.g., prohibited unit types) are skipped
+     *                  based on the current context as defined in {@code Resupply.isProhibitedUnitType()}.
+     * @param ignoreSparesUnderQuality Spare parts of a lower quality than the specified value will
+     *                                be excluded from the results.
+     * @return A {@link Set} of {@link PartInUse} objects detailing the state of each relevant part,
+     * including:
+     *         <ul>
+     *             <li>Use count: How many of this part are currently in use.</li>
+     *             <li>Store count: How many of this part are available as spares in the warehouse.</li>
+     *             <li>Planned count: The quantity of this part included in acquisition orders or
+     *             planned procurement.</li>
+     *             <li>Requested stock: The target or default quantity to maintain, as derived from
+     *             settings or requests.</li>
+     *         </ul>
+     *         Only parts with non-zero counts (use, store, or planned) will be included in the
+     *         result.
      */
+
     public Set<PartInUse> getPartsInUse(boolean ignoreMothballedUnits,
-            PartQuality ignoreSparesUnderQuality) {
+            boolean isResupply, PartQuality ignoreSparesUnderQuality) {
         // java.util.Set doesn't supply a get(Object) method, so we have to use a
         // java.util.Map
         Map<PartInUse, PartInUse> inUse = new HashMap<>();
         getWarehouse().forEachPart(incomingPart -> {
+            if (isResupply) {
+                Unit unit = incomingPart.getUnit();
+
+                Entity entity = null;
+                if (unit != null) {
+                    entity = unit.getEntity();
+                }
+
+                if (entity != null) {
+                    if (isProhibitedUnitType(entity, false)) {
+                        return;
+                    }
+                }
+            }
+
+
             PartInUse partInUse = getPartInUse(incomingPart);
             if (null == partInUse) {
                 return;
@@ -4828,7 +4868,7 @@ public class Campaign implements ITechManager {
         }
 
         if (topUpWeekly && currentDay.getDayOfWeek() == DayOfWeek.MONDAY) {
-            int bought = stockUpPartsInUse(getPartsInUse(ignoreMothballed, ignoreSparesUnderQuality));
+            int bought = stockUpPartsInUse(getPartsInUse(ignoreMothballed, false, ignoreSparesUnderQuality));
             addReport(String.format(resources.getString("weeklyStockCheck.text"), bought));
         }
 

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -2,7 +2,6 @@ package mekhq.campaign.mission.resupplyAndCaches;
 
 import megamek.common.Entity;
 import megamek.common.Mek;
-import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -11,6 +10,7 @@ import mekhq.campaign.force.Force;
 import mekhq.campaign.market.procurement.Procurement;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.parts.*;
+import mekhq.campaign.parts.enums.PartQuality;
 import mekhq.campaign.parts.equipment.*;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.Skill;
@@ -436,7 +436,7 @@ public class Resupply {
      *
      * @param potentialParts   A map of potential parts to include in the supply drop, keyed by part name.
      */
-    private void buildPartsPools(Map<String, PartDetails> potentialParts) {
+    private void buildPartsPools(Map<Part, PartDetails> potentialParts) {
         partsPool = new ArrayList<>();
         armorPool = new ArrayList<>();
         ammoBinPool = new ArrayList<>();
@@ -445,25 +445,18 @@ public class Resupply {
             int weight = (int) Math.round(potentialPart.getWeight());
             for (int entry = 0; entry < weight; entry++) {
                 Part part = potentialPart.getPart();
-                Part preparedPart = preparePart(part);
 
-                // We don't need null protection for 'part' as if 'part' is null preparedPart will
-                // just return 'null', which we catch here.
-                if (preparedPart == null) {
+                if (part instanceof Armor) {
+                    armorPool.add(part);
                     continue;
                 }
 
-                if (preparedPart instanceof Armor) {
-                    armorPool.add(preparedPart);
+                if (part instanceof AmmoBin || part instanceof AmmoStorage) {
+                    ammoBinPool.add(part);
                     continue;
                 }
 
-                if (preparedPart instanceof AmmoBin) {
-                    ammoBinPool.add(preparedPart);
-                    continue;
-                }
-
-                partsPool.add(preparedPart);
+                partsPool.add(part);
             }
         }
 
@@ -481,108 +474,28 @@ public class Resupply {
     }
 
     /**
-     * Prepares a copy of a part for inclusion in the resupply pool. This involves cloning
-     * the part, marking it as new, and fixing any issues. If part cloning fails or the part
-     * is invalid for inclusion, {@code null} is returned.
+     * Collects all eligible parts from campaign units and organizes them into a map, where each part
+     * is associated with its corresponding details. The collection process considers various factors,
+     * including exclusion lists, location validation, and warehouse resources, to determine the
+     * eligibility and weight of each part.
      *
-     * @param originPart   The original part to prepare.
-     * @return The prepared part, or {@code null} if the part cannot be included.
-     */
-    private @Nullable Part preparePart(Part originPart) {
-        Part clonedPart = originPart.clone();
-
-        // If we failed to clone a part, it's likely because the part doesn't exist.
-        // This means it's been destroyed, and what we're detecting is the absence of a part.
-        // This is a major limitation of cloning parts, and one I've not fathomed a solution to.
-        if (clonedPart == null) {
-            return null;
-        }
-
-        // TODO: Improve handling of missing or destroyed locations and equipment.
-        //  This will likely need to be a >50.02 thing, unfortunately.
-
-        try {
-            clonedPart.fix();
-        } catch (Exception e) {
-            clonedPart.setHits(0);
-        }
-
-        clonedPart.setBrandNew(true);
-        clonedPart.setOmniPodded(false);
-
-        return clonedPart;
-    }
-
-    /**
-     * Collects eligible parts from campaign units and organizes them into a map. Each part
-     * is checked for eligibility using methods such as exclusion lists and location validation.
-     * Campaign warehouse resources are also factored into the weight of included resources.
+     * <p>This method leverages the campaign's existing parts in use, filters them based on specific
+     * criteria (e.g., unit exclusion, allowed quality levels), and applies warehouse-specific weight
+     * modifiers to calculate the resulting details.</p>
      *
-     * @return A map of part names with their corresponding details (e.g., weight).
+     * @return A {@link Map} where:
+     *         <ul>
+     *             <li>The key is a {@link Part} object representing the eligible part.</li>
+     *             <li>The value is a {@link PartDetails} object that contains detailed information
+     *                 about the part, such as adjusted weight, based on warehouse modifiers.</li>
+     *         </ul>
      */
-    private Map<String, PartDetails> collectParts() {
-        final Collection<UUID> unitIds = campaign.getForce(0).getAllUnits(true);
-        Map<String, PartDetails> processedParts = new HashMap<>();
 
-        boolean allowClan = (employerIsClan || campaign.getLocalDate().isAfter(BATTLE_OF_TUKAYYID))
-            && campaign.getCampaignOptions().isAllowClanPurchases();
-        boolean allowInnerSphere = campaign.getCampaignOptions().isAllowISPurchases();
+    private Map<Part, PartDetails> collectParts() {
+        Set<PartInUse> partsInUse = campaign.getPartsInUse(true, true,
+            PartQuality.QUALITY_A);
 
-        try {
-            for (UUID unitId : unitIds) {
-                Unit unit = campaign.getUnit(unitId);
-
-                if (unit == null) {
-                    continue;
-                }
-
-                Entity entity = unit.getEntity();
-
-                if (entity == null) {
-                    continue;
-                }
-
-                if (isProhibitedUnitType(entity, false)) {
-                    logger.info("skipping " + unit.getName() + " as it is prohibited.");
-                    continue;
-                }
-
-                if (!unit.isSalvage() && (unit.isAvailable() || unit.isDeployed())) {
-                    List<Part> parts = unit.getParts();
-                    for (Part part : parts) {
-                        if (part.isClan()) {
-                            if (!allowClan) {
-                                continue;
-                            }
-                        } else {
-                            if (!allowInnerSphere) {
-                                continue;
-                            }
-                        }
-
-                        if (isIneligiblePart(part, unit)) {
-                            continue;
-                        }
-
-                        int dropWeight = part instanceof MissingPart ? 10 : 1;
-                        dropWeight = (int) floor(dropWeight * getPartMultiplier(part));
-
-                        PartDetails partDetails = new PartDetails(part, dropWeight);
-
-                        processedParts.merge(getPartKey(part), partDetails, (oldValue, newValue) -> {
-                            oldValue.setWeight(oldValue.getWeight() + newValue.getWeight());
-                            return oldValue;
-                        });
-                    }
-                }
-            }
-
-            applyWarehouseWeightModifiers(processedParts);
-        } catch (Exception exception) {
-            logger.error("Aborted parts collection.", exception);
-        }
-
-        return processedParts;
+        return applyWarehouseWeightModifiers(partsInUse);
     }
 
     /**
@@ -695,65 +608,50 @@ public class Resupply {
     }
 
     /**
-     * Adjusts the provided parts list by applying warehouse weight modifiers.
+     * Applies modifiers to adjust the weight of parts based on their usage and availability
+     * in the warehouse. This method calculates the adjusted weight for each part by taking
+     * into account its use count, store count, and a multiplier specific to the part.
      *
-     * <p>This method compares the in-campaign warehouse's spare parts inventory with the given
-     * parts list and reduces the weight (quantity) of parts in the list based on the warehouse
-     * stock. If the warehouse contains enough resources to fully satisfy the demand for a part,
-     * the part is removed from the parts list.</p>
+     * <p>The resulting adjusted weight is used to determine the importance or priority of the part,
+     * and only parts with a positive weight are included in the output map.</p>
      *
-     * <p>The adjustments are performed as follows:
-     * <ul>
-     *     <li>For each part in the warehouse:
+     * @param partsInUse A {@link Set} of {@link PartInUse} objects containing information about
+     *                   parts currently in use and their quantities in the warehouse.
+     * @return A {@link Map} where:
      *         <ul>
-     *             <li>The weight of the part in the part list is reduced by the quantity available
-     *             in the warehouse.</li>
-     *             <li>If the weight becomes zero or negative, the part is flagged for removal.</li>
+     *             <li>The key is a {@link Part} object representing the eligible part.</li>
+     *             <li>The value is a {@link PartDetails} object containing the adjusted weight of
+     *                 the part, calculated using its usage data and a multiplier.</li>
      *         </ul>
-     *     </li>
-     *     <li>All flagged parts are then removed from the part list.</li>
-     * </ul>
-     * </p>
-     *
-     * @param partsList A map containing part identifiers (keys) and their corresponding {@link PartDetails}.
-     *                  The map will be modified to reflect the warehouse adjustments.
+     *         Only parts with a positive adjusted weight are included in the resulting map.
      */
-    private void applyWarehouseWeightModifiers(Map<String, PartDetails> partsList) {
-        // Adjust based on the quantity in the warehouse
-        for (Part part : campaign.getWarehouse().getSpareParts()) {
-            int weight = part.getQuantity();
 
-            // We don't want empty AmmoStorage to reduce Resupply weighting
-            if (part instanceof AmmoStorage && (((AmmoStorage) part).getShots() == 0)) {
+    private Map<Part, PartDetails> applyWarehouseWeightModifiers(Set<PartInUse> partsInUse) {
+        Map<Part, PartDetails> parts = new HashMap<>();
+
+        // Adjust based on the quantity in the warehouse
+        for (PartInUse partInUse : partsInUse) {
+            int weight = partInUse.getUseCount();
+            weight -= partInUse.getStoreCount();
+
+            Part part = partInUse.getPartToBuy().getAcquisitionPart();
+
+            if (part == null) {
                 continue;
             }
 
-            // This prevents us accidentally adding new items to the pool
-            if (!partsList.containsKey(getPartKey(part))) {
+            weight = (int) floor(weight * getPartMultiplier(part));
+
+            if (weight <= 0) {
                 continue;
             }
 
             PartDetails partDetails = new PartDetails(part, weight);
-            partsList.merge(getPartKey(part), partDetails, (oldValue, newValue) -> {
-                oldValue.setWeight(oldValue.getWeight() - newValue.getWeight());
-                return oldValue;
-            });
+
+            parts.put(part, partDetails);
         }
 
-        // Remove any items that now have 0 (or negative) tickets left in the pool
-        List<String> removalList = new ArrayList<>();
-        for (PartDetails partDetails : partsList.values()) {
-            Part part = partDetails.getPart();
-            double weight = partDetails.getWeight();
-
-            if (weight <= 0) {
-                removalList.add(getPartKey(part));
-            }
-        }
-
-        for (String removalKey : removalList) {
-            partsList.remove(removalKey);
-        }
+        return parts;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -636,13 +636,13 @@ public class Resupply {
 
             Part part = partInUse.getPartToBuy().getAcquisitionPart();
 
+            if (part == null) {
+                continue;
+            }
+
             if ((resupplyType != ResupplyType.RESUPPLY_LOOT)
                 && (resupplyType != ResupplyType.RESUPPLY_SMUGGLER)) {
                 part.setBrandNew(true);
-            }
-
-            if (part == null) {
-                continue;
             }
 
             weight = (int) floor(weight * getPartMultiplier(part));

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -636,6 +636,11 @@ public class Resupply {
 
             Part part = partInUse.getPartToBuy().getAcquisitionPart();
 
+            if ((resupplyType != ResupplyType.RESUPPLY_LOOT)
+                && (resupplyType != ResupplyType.RESUPPLY_SMUGGLER)) {
+                part.setBrandNew(true);
+            }
+
             if (part == null) {
                 continue;
             }

--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -18,36 +18,6 @@
  */
 package mekhq.gui.dialog;
 
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.Insets;
-import java.util.*;
-import java.util.Map.Entry;
-
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.GroupLayout;
-import javax.swing.GroupLayout.Alignment;
-
-import static javax.swing.GroupLayout.Alignment;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.LayoutStyle;
-import javax.swing.RowSorter;
-import javax.swing.SortOrder;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableColumnModel;
-import javax.swing.table.TableRowSorter;
-
 import megamek.client.ui.swing.util.UIUtil;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -61,8 +31,18 @@ import mekhq.gui.model.PartsInUseTableModel;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.TwoNumbersSorter;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
-import mekhq.campaign.parts.AmmoStorage;
-import mekhq.campaign.parts.Armor;
+
+import javax.swing.*;
+import javax.swing.GroupLayout.Alignment;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableRowSorter;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.List;
+import java.util.*;
 
 /**
  * A dialog to show parts in use, ordered, in transit with actionable buttons for buying or adding more
@@ -100,16 +80,16 @@ public class PartsReportDialog extends JDialog {
     }
 
     private void initComponents() {
-   
+
         this.setTitle(resourceMap.getString("Form.title"));
 
         Container container = this.getContentPane();
-        
+
         GroupLayout layout = new GroupLayout(container);
         layout.setAutoCreateGaps(true);
         layout.setAutoCreateContainerGaps(true);
         container.setLayout(layout);
-        
+
         overviewPartsModel = new PartsInUseTableModel();
         overviewPartsInUseTable = new JTable(overviewPartsModel);
         overviewPartsInUseTable.setRowSelectionAllowed(false);
@@ -331,7 +311,7 @@ public class PartsReportDialog extends JDialog {
             setVisible(false);
             onClose();
         });
-        
+
         layout.setHorizontalGroup(layout.createParallelGroup()
             .addComponent(tableScroll)
             .addGroup(layout.createSequentialGroup()
@@ -393,7 +373,7 @@ public class PartsReportDialog extends JDialog {
 
     private void updateOverviewPartsInUse() {
         overviewPartsModel.setData(campaign.getPartsInUse(ignoreMothballedCheck.isSelected(),
-                getMinimumQuality((String) ignoreSparesUnderQualityCB.getSelectedItem())));
+            false, getMinimumQuality((String) ignoreSparesUnderQualityCB.getSelectedItem())));
         TableColumnModel tcm = overviewPartsInUseTable.getColumnModel();
         PartsInUseTableModel.ButtonColumn column = (PartsInUseTableModel.ButtonColumn) tcm
                 .getColumn(PartsInUseTableModel.COL_BUTTON_GMADD)
@@ -464,5 +444,5 @@ public class PartsReportDialog extends JDialog {
 
     private void onClose() {
         storePartInUseRequestedStockMap();
-    }  
+    }
 }


### PR DESCRIPTION
- Reworked part handling to remove redundant preparation steps and optimize collection and weighting logic for resupply operations.
- Improved part eligibility checks for better efficiency and maintainability.

Overall, this should see a decent jump in the usefulness of Resupply drops, as well as improve performance. It also has the added benefit of using the preexisting system used by the parts in use dialog. Which means any improvements and fixes made to that will be passed onto the Resupply module. Using the systems in that dialog was my original intent, but wasn't logical at the time as that dialog was in a state of flux.