### PR TITLE
Fixed Overwriting of 'Brand New' Part State

### DIFF
--- a/MekHQ/src/mekhq/campaign/Quartermaster.java
+++ b/MekHQ/src/mekhq/campaign/Quartermaster.java
@@ -103,7 +103,6 @@ public class Quartermaster {
         }
 
         part.setDaysToArrival(Math.max(transitDays, 0));
-        part.setBrandNew(false);
 
         // be careful in using this next line
         part.postProcessCampaignAddition();


### PR DESCRIPTION
- Removed a call to `setBrandNew(false)` when adding parts to the campaign. This boolean already initializes as `false`, so including it here just meant we were overwriting any instance where we set brand new to `true`.