### PR TITLE
[RFE Completion]: Ability to reset AutoLogistics requested stock levels to their defaults

### DIFF
--- a/MekHQ/resources/mekhq/resources/PartsReportDialog.properties
+++ b/MekHQ/resources/mekhq/resources/PartsReportDialog.properties
@@ -4,4 +4,5 @@ chkIgnoreMothballed.text=Ignore Parts on Mothballed Units
 chkTopUpWeekly.text=Add Part Orders to Fill Requested Stock Levels Weekly
 topUpBtn.text=Order Parts to Fill Requested Stock
 topUpGMBtn.text=Add Parts to Fill Requested Stock Levels
+resetRequestedStockBtn.text=Reset Requested Stock Levels to Default
 lblIgnoreSparesUnderQuality.text=Ignore Spare Parts Under Quality

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -9119,6 +9119,14 @@ public class Campaign implements ITechManager {
             MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "partInUseMapEntry");
         }
     }
+
+    /** 
+     * Wipes the Parts in use map for the purpose of resetting all values to their default
+     */
+    public void wipePartsInUseMap() {
+        this.partsInUseRequestedStockMap.clear();
+    }
+
     /**
      * Retrieves the campaign faction icon for the specified {@link Campaign}.
      * If a custom icon is defined in the campaign's unit icon configuration, that icon is used.

--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -71,7 +71,7 @@ import mekhq.campaign.parts.Armor;
 public class PartsReportDialog extends JDialog {
 
     private JCheckBox ignoreMothballedCheck, topUpWeeklyCheck;
-    private JButton topUpButton, topUpGMButton;
+    private JButton topUpButton, topUpGMButton, resetRequestedStockButton;
     private JComboBox<String> ignoreSparesUnderQualityCB;
     private JTable overviewPartsInUseTable;
     private PartsInUseTableModel overviewPartsModel;
@@ -305,6 +305,15 @@ public class PartsReportDialog extends JDialog {
         topUpGMButton.setMargin(new Insets(10,20,10,20));
         topUpGMButton.addActionListener(evt -> topUpGM());
 
+        resetRequestedStockButton = new JButton();
+        resetRequestedStockButton.setText(resourceMap.getString("resetRequestedStockBtn.text"));
+        resetRequestedStockButton.setIcon(null);
+        resetRequestedStockButton.setFocusPainted(false);
+        resetRequestedStockButton.setEnabled(true);
+        resetRequestedStockButton.setBorder(null);
+        resetRequestedStockButton.setMargin(new Insets(10,20,10,20));
+        resetRequestedStockButton.addActionListener(evt -> resetRequestedStock());
+
         boolean reverse = campaign.getCampaignOptions().isReverseQualityNames();
         String[] qualities = {
             " ", // Combo box is blank for first one because it accepts everything and is default
@@ -343,6 +352,7 @@ public class PartsReportDialog extends JDialog {
                     .addComponent(topUpWeeklyCheck)
                     .addComponent(topUpButton)
                     .addComponent(topUpGMButton)
+                    .addComponent(resetRequestedStockButton)
                     .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(btnClose))));
 
@@ -355,6 +365,7 @@ public class PartsReportDialog extends JDialog {
                 .addComponent(topUpWeeklyCheck)
                 .addComponent(topUpButton)
                 .addComponent(topUpGMButton)
+                .addComponent(resetRequestedStockButton)
                 .addComponent(btnClose)));
 
         setPreferredSize(UIUtil.scaleForGUI(1400,1000));
@@ -465,4 +476,12 @@ public class PartsReportDialog extends JDialog {
     private void onClose() {
         storePartInUseRequestedStockMap();
     }  
+
+    /**
+     * Wipes the requested stock numbers back to their defaults
+     */
+    private void resetRequestedStock() {
+        campaign.wipePartsInUseMap();
+        updateOverviewPartsInUse();
+    }
 }


### PR DESCRIPTION
closes #5685 

The more robust default percentage levels have already been implemented, this just adds another button to reset your requested stock levels to the default. The method here is really simple,  we just clear the requested stock map and then update our overview table with the cleared stock map. 