### PR TITLE
Corrected Weight Class Parameter Setting Logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1823,11 +1823,9 @@ public class AtBDynamicScenarioFactory {
             params.setFilter(mekSummary -> mekSummary.getWalkMp() >= 1);
         }
 
-        if (rolesByType != null && !rolesByType.isEmpty()) {
-            params.setWeightClass(shouldBypassWeightClass(rolesByType)
-                ? UNIT_WEIGHT_UNSPECIFIED
-                : weightClass);
-        }
+        params.setWeightClass(shouldBypassWeightClass(rolesByType)
+            ? UNIT_WEIGHT_UNSPECIFIED
+            : weightClass);
 
         // Vehicles and infantry require some additional processing
         if (unitType == TANK) {


### PR DESCRIPTION
- Removed unnecessary null and emptiness checks for `rolesByType` before setting the weight class. This was preventing units from being generated correctly.