### PR TITLE
Clarify Vocational XP Tooltip

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1847,7 +1847,7 @@ lblMissionsPanel.text=Missions
 lblVocationalXP.text=Vocational XP per \u26A0
 lblVocationalXP.tooltip=How much experience should be awarded per vocational experience check? This\
   \ value is doubled while on any contract not classified as 'Garrison Type' (any contract that\
-  \ ends in 'Duty').
+  \ ends in 'Duty,' other than 'Relief Duty').
 lblVocationalXPFrequency.text=Months
 lblVocationalXPFrequency.tooltip=How many months occur between vocational experience checks?\
   \ Characters will make a vocational experience check every time this many months has passed.


### PR DESCRIPTION
- Updated tooltip text for Vocational XP to specify that 'Relief Duty' contracts are excluded from the doubled XP exclusion. Previously the tooltip stated that all contracts ending in 'Duty' were excluded from granting double xp awards.

This was a visual bug only.