### PR TITLE
fix: addresses off by one issue with dialog filter for skills, addres…

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -394,7 +394,7 @@ public final class BatchXPDialog extends JDialog {
                 return false;
             } else if ((null != primaryRole) && (p.getPrimaryRole() != primaryRole)) {
                 return false;
-            } else if ((null != expLevel) && (p.getExperienceLevel(campaign, false) != expLevel)) {
+            } else if ((null != expLevel) && (p.getExperienceLevel(campaign, false)+1 != expLevel)) {
                 return false;
             } else if (onlyOfficers && !p.getRank().isOfficer()) {
                 return false;


### PR DESCRIPTION
…ses issue: #5922

I'm not sure if this is the correct way to address this issue.  I'm a bit confused as to the consistency surrounding the skill levels.  In some places, ultra green starts at 0 and in some places it starts with 1.  This just hacks in a +1.