### PR TITLE
Fixed Cargo Capacity Calculation in For Cargo Items in Body

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -80,10 +80,10 @@ import java.util.Map.Entry;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static mekhq.campaign.enums.CampaignTransportType.SHIP_TRANSPORT;
-import static mekhq.campaign.enums.CampaignTransportType.TACTICAL_TRANSPORT;
 import static java.lang.Math.max;
 import static megamek.common.MiscType.F_CARGO;
+import static mekhq.campaign.enums.CampaignTransportType.SHIP_TRANSPORT;
+import static mekhq.campaign.enums.CampaignTransportType.TACTICAL_TRANSPORT;
 import static mekhq.campaign.parts.enums.PartQuality.*;
 import static mekhq.campaign.unit.enums.TransporterType.*;
 
@@ -1552,7 +1552,7 @@ public class Unit implements ITechnology {
             if (mounted.getType().hasFlag(F_CARGO)) {
                 // isOperable doesn't check if the mounted location still exists, so we check for
                 // that first.
-                if ((entity.getInternal(mounted.getLocation()) > 0) && (mounted.isOperable())) {
+                if ((entity.getInternal(mounted.getLocation()) != 0) && (mounted.isOperable())) {
                     capacity += mounted.getTonnage();
                 }
             }


### PR DESCRIPTION
- Replaced a greater-than check with a non-equal check to handle edge cases where internal structure values might be negative (for example, if the Mounted object is in the body location.

Fix #5951