### PR TITLE
Converted Honor Rating into an Enum

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -21,20 +21,26 @@
  */
 package mekhq.campaign.universe;
 
-import java.awt.Color;
-import java.time.LocalDate;
-import java.util.*;
-import java.util.Map.Entry;
-
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.universe.enums.HonorRating;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.awt.*;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.*;
+import java.util.Map.Entry;
+
+import static megamek.common.Compute.randomInt;
+import static mekhq.campaign.universe.enums.HonorRating.LIBERAL;
+import static mekhq.campaign.universe.enums.HonorRating.OPPORTUNISTIC;
+import static mekhq.campaign.universe.enums.HonorRating.STRICT;
 
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
@@ -507,5 +513,45 @@ public class Faction {
         CONTROLLING,
         /** Faction is lenient with mercenary command rights (Camops p. 42) */
         LENIENT
+    }
+
+    /**
+     * Calculates the honor rating for a given Clan.
+     *
+     * @param campaign    the ongoing campaign
+     * @return the honor rating as an {@link HonorRating} enum
+     */
+    public HonorRating getHonorRating(Campaign campaign) {
+        // Our research showed the post-Invasion shift in Clan doctrine to occur between 3053 and 3055
+        boolean isPostInvasion = campaign.getLocalDate().getYear() >= 3053 + randomInt(2);
+
+        // This is based on the table found on page 274 of Total Warfare
+        // Any Clan not mentioned on that table is assumed to be Strict → Opportunistic
+        return switch (shortName) {
+            case "CCC", "CHH", "CIH", "CNC", "CSR" -> OPPORTUNISTIC;
+            case "CCO", "CGS", "CSV" -> STRICT;
+            case "CGB", "CWIE" -> {
+                if (isPostInvasion) {
+                    yield LIBERAL;
+                } else {
+                    yield STRICT;
+                }
+            }
+            case "CDS" -> LIBERAL;
+            case "CW" -> {
+                if (isPostInvasion) {
+                    yield LIBERAL;
+                } else {
+                    yield OPPORTUNISTIC;
+                }
+            }
+            default -> {
+                if (isPostInvasion) {
+                    yield OPPORTUNISTIC;
+                } else {
+                    yield STRICT;
+                }
+            }
+        };
     }
 }

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -2,7 +2,7 @@
  * Faction.java
  *
  * Copyright (c) 2009 - Jay Lawson (jaylawson39 at yahoo.com). All Rights Reserved.
- * Copyright (c) 2009-2021 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2009-2025 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/universe/enums/HonorRating.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/HonorRating.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
 package mekhq.campaign.universe.enums;
 
 /**

--- a/MekHQ/src/mekhq/campaign/universe/enums/HonorRating.java
+++ b/MekHQ/src/mekhq/campaign/universe/enums/HonorRating.java
@@ -1,0 +1,44 @@
+package mekhq.campaign.universe.enums;
+
+/**
+ * Represents the honor of a Clan
+ */
+public enum HonorRating {
+    NONE(0.0, Integer.MAX_VALUE),
+    LIBERAL(1.25, Integer.MAX_VALUE),
+    OPPORTUNISTIC(1.0, 5),
+    STRICT(0.75, 0);
+
+    private final double bvMultiplier;
+    private final int bondsmanTargetNumber;
+
+    /**
+     * Constructor for HonorRating enum to initialize its properties.
+     *
+     * @param bvMultiplier       Battle Value multiplier associated with the honor level - used by
+     *                          Clan Bidding
+     * @param bondsmanTargetNumber Target number for determining bondsmen with this style
+     */
+    HonorRating(double bvMultiplier, int bondsmanTargetNumber) {
+        this.bvMultiplier = bvMultiplier;
+        this.bondsmanTargetNumber = bondsmanTargetNumber;
+    }
+
+    /**
+     * Gets the Battle Value multiplier associated with this capture style.
+     *
+     * @return the bvMultiplier
+     */
+    public double getBvMultiplier() {
+        return bvMultiplier;
+    }
+
+    /**
+     * Gets the target number for becoming a bondsman.
+     *
+     * @return the bondsmanTargetNumber
+     */
+    public int getBondsmanTargetNumber() {
+        return bondsmanTargetNumber;
+    }
+}


### PR DESCRIPTION
- Replaced hardcoded honor rating logic with an `HonorRating` enum for better readability and maintainability.
- Moved honor rating computation to the `Faction` class, simplifying related code in `AtBDynamicScenarioFactory`.