### PR TITLE
Use `ModifiedConstantSkillGenerator` for Skill Generation

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/BotForceRandomizer.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForceRandomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 - The Megamek Team. All Rights Reserved.
+ * Copyright (c) 2021-2025 - The Megamek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -23,7 +23,7 @@ import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.generator.enums.SkillGeneratorType;
 import megamek.client.generator.skillGenerators.AbstractSkillGenerator;
-import megamek.client.generator.skillGenerators.TaharqaSkillGenerator;
+import megamek.client.generator.skillGenerators.ModifiedConstantSkillGenerator;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
@@ -491,7 +491,7 @@ public class BotForceRandomizer {
         innerMap.put(Crew.MAP_GIVEN_NAME, crewNameArray[0]);
         innerMap.put(Crew.MAP_SURNAME, crewNameArray[1]);
 
-        final AbstractSkillGenerator skillGenerator = new TaharqaSkillGenerator();
+        final AbstractSkillGenerator skillGenerator = new ModifiedConstantSkillGenerator();
         skillGenerator.setLevel(skill);
         if (faction.isClan()) {
             skillGenerator.setType(SkillGeneratorType.CLAN);

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2019-2025 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -20,7 +20,7 @@ package mekhq.campaign.mission.atb;
 
 import megamek.client.generator.enums.SkillGeneratorType;
 import megamek.client.generator.skillGenerators.AbstractSkillGenerator;
-import megamek.client.generator.skillGenerators.TaharqaSkillGenerator;
+import megamek.client.generator.skillGenerators.ModifiedConstantSkillGenerator;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.*;
 import megamek.common.enums.SkillLevel;
@@ -214,7 +214,7 @@ public class AtBScenarioModifierApplicator {
                 scenario.getEffectiveOpforSkill().ordinal() + skillAdjustment,
                 SkillLevel.ULTRA_GREEN.ordinal(), SkillLevel.LEGENDARY.ordinal())];
         // fire up a skill generator set to the appropriate skill model
-        final AbstractSkillGenerator abstractSkillGenerator = new TaharqaSkillGenerator();
+        final AbstractSkillGenerator abstractSkillGenerator = new ModifiedConstantSkillGenerator();
         abstractSkillGenerator.setLevel(adjustedSkill);
 
         if (Factions.getInstance().getFaction(scenario.getContract(campaign).getEnemyCode()).isClan()) {


### PR DESCRIPTION
- Replaced `TaharqaSkillGenerator` with `ModifiedConstantSkillGenerator` in `AtBScenarioModifierApplicator` and `BotForceRandomizer`.

This ensures consistency with updated skill generation logic used elsewhere in MekHQ. I updated our generation methods back in 2024, but apparently missed these two instances.