### PR TITLE
Added 'None' Generation Method to `ScenarioForceTemplate`

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -624,6 +624,10 @@ public class AtBDynamicScenarioFactory {
         // Generate a tactical formation (lance/star/etc.) until the BV or unit count
         // limits are exceeded
         while (!stopGenerating) {
+            if (forceTemplate.getGenerationMethod() == ForceGenerationMethod.None.ordinal()) {
+                break;
+            }
+
             List<Entity> generatedLance;
 
             // Generate a tactical formations for this force based on the desired weight class.
@@ -965,6 +969,7 @@ public class AtBDynamicScenarioFactory {
         }
 
         if (generatedForce.getTeam() != 1
+            && forceTemplate.getGenerationMethod() != ForceGenerationMethod.None.ordinal()
             && campaign.getCampaignOptions().isUseGenericBattleValue()
             && BatchallFactions.usesBatchalls(factionCode)
             && contract.isBatchallAccepted()) {

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioForceTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2019-2025 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -18,17 +18,6 @@
  */
 package mekhq.campaign.mission;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import org.w3c.dom.Node;
-
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.Unmarshaller;
@@ -41,6 +30,10 @@ import megamek.common.Compute;
 import megamek.common.UnitType;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
+import org.w3c.dom.Node;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> {
     private static final MMLogger logger = MMLogger.create(ScenarioForceTemplate.class);
@@ -156,7 +149,7 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
          */
         BVScaled,
 
-        /*
+        /**
          * Scale on the unit count, based on number of already generated units flagged
          * as contributing towards unit count
          */
@@ -175,7 +168,12 @@ public class ScenarioForceTemplate implements Comparable<ScenarioForceTemplate> 
         /**
          * Using one or more fixed MULs
          */
-        FixedMUL
+        FixedMUL,
+
+        /**
+         * Don't generate units. For use when you want to add units separately
+         */
+        None
     }
 
     /**


### PR DESCRIPTION
- Implemented a 'None' option in `ForceGenerationMethod` to allow bot forces where no units are generated, enabling more flexible scenario templates.
- Adjusted `AtBDynamicScenarioFactory` to account for this method in force generation logic.

This resolves a situation where we need to have all objective-significant Bot Forces generated when the scenario is created. However, if we want the Bot Force to have specific units and not random ones, we then need to remove the already generated ones. By using this method, we're able to generate an empty force during scenario creation which can then be populated later.

This will be used by the upcoming prisoner rework.