### PR TITLE
Issue 5845: In Stratcon scenario wizard, leadership units consider transport assignments

### DIFF
--- a/MekHQ/resources/mekhq/resources/AssignForceToTransport.properties
+++ b/MekHQ/resources/mekhq/resources/AssignForceToTransport.properties
@@ -45,3 +45,7 @@ AtBGameThread.loadTransportDialog.LOAD_FTR_DIALOG_TITLE.title =Load Fighters ont
 AtBGameThread.loadTransportDialog.LOAD_GND_DIALOG_TEXT.text =Would you like the ground unit(s) assigned to {0} to deploy loaded into its bays?
 AtBGameThread.loadTransportDialog.LOAD_GND_DIALOG_TITLE.title =Load Ground Units onto Transport?
 
+CampaignTransportUtilities.selectTransport.null.text=None
+CampaignTransportUtilities.selectTransport.TACTICAL_TRANSPORT.text=Tactical
+CampaignTransportUtilities.selectTransport.SHIP_TRANSPORT.text=Ship
+

--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -12,6 +12,8 @@ lblLeadershipInstructions.Text=<html>The force commander's leadership allows the
   <br>\
   <br><b>Available BV:</b> %s</html
 
+lblLeadershipTransportInstructions.text=<html><b>Transport Type:</b></html>
+
 selectForceForTemplate.Text=<html><b>Select a force from the list below.</b>\
   <br>\
   <br>If multiple forces are selected, only the first will be deployed.</html>

--- a/MekHQ/src/mekhq/campaign/utilities/CampaignTransportUtilities.java
+++ b/MekHQ/src/mekhq/campaign/utilities/CampaignTransportUtilities.java
@@ -22,6 +22,8 @@ package mekhq.campaign.utilities;
 import megamek.common.*;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.unit.enums.TransporterType;
+import mekhq.utilities.MHQInternationalization;
+import org.apache.commons.math3.util.Pair;
 
 import java.util.*;
 
@@ -253,6 +255,19 @@ public class CampaignTransportUtilities {
 
     private static Optional<Visitor> getTransportTypeClassifier(Entity entity) {
         return visitors.stream().filter(v -> v.isInterestedIn(entity)).findFirst();
+    }
+
+    /**
+     * Return "None" in the first position
+     * @return vector of transport options, with none first
+     */
+    public static Vector<Pair<String, CampaignTransportType>> getLeadershipDropdownVectorPair() {
+        Vector<Pair<String, CampaignTransportType>> retVal = new Vector<>();
+        retVal.add(new Pair<>(MHQInternationalization.getTextAt("mekhq.resources.AssignForceToTransport", "CampaignTransportUtilities.selectTransport.null.text"), null));
+        retVal.add(new Pair<>(MHQInternationalization.getTextAt("mekhq.resources.AssignForceToTransport", "CampaignTransportUtilities.selectTransport.TACTICAL_TRANSPORT.text"), CampaignTransportType.TACTICAL_TRANSPORT));
+        retVal.add(new Pair<>(MHQInternationalization.getTextAt("mekhq.resources.AssignForceToTransport", "CampaignTransportUtilities.selectTransport.SHIP_TRANSPORT.text"), CampaignTransportType.SHIP_TRANSPORT));
+
+        return retVal;
     }
     // endregion Static Helpers
 }

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -450,7 +450,7 @@ public class StratconScenarioWizard extends JDialog {
         availableLeadershipUnits = addIndividualUnitSelector(eligibleUnits, gbc, maxSelectionSize,
             true);
 
-        ItemListener dropdownChangeListener = evt -> campaignTransportTypeChangeHandler(evt, eligibleUnits, leadershipUnitJPanel);
+        ItemListener dropdownChangeListener = this::campaignTransportTypeChangeHandler;
         cboTransportType.addItemListener(dropdownChangeListener);
         contentPanel.add(leadershipUnitJPanel);
     }
@@ -538,7 +538,7 @@ public class StratconScenarioWizard extends JDialog {
         return availableUnits;
     }
 
-    private void campaignTransportTypeChangeHandler(ItemEvent event, List<Unit> allUnits, JPanel leadershipUnitJPanel) {
+    private void campaignTransportTypeChangeHandler(ItemEvent event) {
         if (!(event.getSource() instanceof JComboBox<?>) || (event.getStateChange() != ItemEvent.SELECTED )) {
             return;
         }

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -27,6 +27,7 @@ import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Campaign.AdministratorSpecialization;
+import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.ScenarioForceTemplate;
 import mekhq.campaign.personnel.Person;
@@ -36,13 +37,20 @@ import mekhq.campaign.stratcon.StratconScenario;
 import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
+import mekhq.utilities.MHQInternationalization;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.math3.util.Pair;
 
 import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.util.List;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static mekhq.campaign.mission.AtBDynamicScenarioFactory.scaleObjectiveTimeLimits;
 import static mekhq.campaign.mission.AtBDynamicScenarioFactory.translateTemplateObjectives;
@@ -52,6 +60,7 @@ import static mekhq.campaign.stratcon.StratconRulesManager.ReinforcementResultsT
 import static mekhq.campaign.stratcon.StratconRulesManager.ReinforcementResultsType.FAILED;
 import static mekhq.campaign.stratcon.StratconScenario.ScenarioState.PRIMARY_FORCES_COMMITTED;
 import static mekhq.campaign.stratcon.StratconScenario.ScenarioState.REINFORCEMENTS_COMMITTED;
+import static mekhq.campaign.utilities.CampaignTransportUtilities.getLeadershipDropdownVectorPair;
 import static mekhq.gui.baseComponents.MHQDialogImmersive.getSpeakerDescription;
 import static mekhq.gui.baseComponents.MHQDialogImmersive.getSpeakerIcon;
 import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
@@ -64,14 +73,20 @@ public class StratconScenarioWizard extends JDialog {
     private final Campaign campaign;
     private StratconTrackState currentTrackState;
     private StratconCampaignState currentCampaignState;
-    private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.AtBStratCon",
+    private final String resourcePath = "mekhq.resources.AtBStratCon";
+    private final transient ResourceBundle resources = ResourceBundle.getBundle(resourcePath,
             MekHQ.getMHQOptions().getLocale());
 
     private final Map<String, JList<Force>> availableForceLists = new HashMap<>();
     private final Map<String, JList<Unit>> availableUnitLists = new HashMap<>();
 
+    private List<Unit> eligibleLeadershipUnits;
     private JList<Unit> availableInfantryUnits = new JList<>();
     private JList<Unit> availableLeadershipUnits = new JList<>();
+    private Map<CampaignTransportType, JList<Unit>> availableTransportedLeadershipUnits = new HashMap<>();
+    private CampaignTransportType selectedCampaignTransportType = null;
+
+    private JComboBox<String> cboTransportType = new JComboBox<>();
 
     private JPanel contentPanel;
     private JButton btnCommit;
@@ -81,6 +96,12 @@ public class StratconScenarioWizard extends JDialog {
     public StratconScenarioWizard(Campaign campaign) {
         this.campaign = campaign;
         this.setModalityType(ModalityType.APPLICATION_MODAL);
+
+        for (CampaignTransportType campaignTransportType : getLeadershipDropdownVectorPair().stream().map(Pair::getValue).collect(Collectors.toSet())) {
+            if (campaignTransportType != null) {
+                availableTransportedLeadershipUnits.put(campaignTransportType, new JList<>());
+            }
+        }
     }
 
     /**
@@ -153,7 +174,7 @@ public class StratconScenarioWizard extends JDialog {
         getContentPane().removeAll();
 
         // Create a new panel to hold all components
-        contentPanel = new JPanel();
+        contentPanel = new JPanel(new CardLayout());
         contentPanel.setLayout(new GridBagLayout());
 
         GridBagConstraints gbc = new GridBagConstraints();
@@ -174,7 +195,7 @@ public class StratconScenarioWizard extends JDialog {
         if (isPrimaryForce) {
             gbc.gridy++;
             int leadershipSkill = currentScenario.getBackingScenario().getLanceCommanderSkill(S_LEADER, campaign);
-            List<Unit> eligibleLeadershipUnits = getEligibleLeadershipUnits(
+            eligibleLeadershipUnits = getEligibleLeadershipUnits(
                 campaign, currentScenario.getPrimaryForceIDs(), leadershipSkill);
             eligibleLeadershipUnits.sort(Comparator.comparing(this::getForceNameReversed));
 
@@ -408,10 +429,30 @@ public class StratconScenarioWizard extends JDialog {
             String.format(resources.getString("lblLeadershipInstructions.Text"), maxSelectionSize));
         contentPanel.add(lblLeadershipInstructions, gbc);
 
+        // Transport Type
         gbc.gridy++;
+        JLabel lblTransportInstructions = new JLabel(MHQInternationalization.getTextAt(resourcePath, "lblLeadershipTransportInstructions.text"));
+        contentPanel.add(lblTransportInstructions, gbc);
+
+        gbc.gridy++;
+
+        cboTransportType = new JComboBox<>(new Vector<>
+            (getLeadershipDropdownVectorPair().stream().map(Pair::getKey).collect(Collectors.toSet())));
+        cboTransportType.setSelectedItem(getLeadershipDropdownVectorPair().firstElement().getKey());
+
+        contentPanel.add(cboTransportType, gbc);
+
+
+        gbc.gridy++;
+        CardLayout leadershipTransportCard = new CardLayout();
+        JPanel leadershipUnitJPanel = new JPanel(leadershipTransportCard);
 
         availableLeadershipUnits = addIndividualUnitSelector(eligibleUnits, gbc, maxSelectionSize,
             true);
+
+        ItemListener dropdownChangeListener = evt -> campaignTransportTypeChangeHandler(evt, eligibleUnits, leadershipUnitJPanel);
+        cboTransportType.addItemListener(dropdownChangeListener);
+        contentPanel.add(leadershipUnitJPanel);
     }
 
     /**
@@ -495,6 +536,19 @@ public class StratconScenarioWizard extends JDialog {
         contentPanel.add(unitPanel, gridBagConstraints);
 
         return availableUnits;
+    }
+
+    private void campaignTransportTypeChangeHandler(ItemEvent event, List<Unit> allUnits, JPanel leadershipUnitJPanel) {
+        if (!(event.getSource() instanceof JComboBox<?>) || (event.getStateChange() != ItemEvent.SELECTED )) {
+            return;
+        }
+
+        for (Pair<String, CampaignTransportType> pair : getLeadershipDropdownVectorPair()) {
+            if (pair.getKey().equals(cboTransportType.getSelectedItem())) {
+                selectedCampaignTransportType = pair.getValue();
+                break;
+            }
+        }
     }
 
     /**
@@ -985,6 +1039,8 @@ public class StratconScenarioWizard extends JDialog {
         }
 
         JList<Unit> changedList = (JList<Unit>) event.getSource();
+        ListSelectionListener[] listeners = (((JList<?>) event.getSource()).getListSelectionListeners());
+        ((JList<?>) event.getSource()).removeListSelectionListener(listeners[0]);
 
         int selectedItems;
         if (usesBV) {
@@ -993,6 +1049,8 @@ public class StratconScenarioWizard extends JDialog {
                 selectedItems += unit.getEntity().calculateBattleValue(true, true);
                 selectionCountLabel.setText(String.format("%d %s", selectedItems,
                     resources.getString("unitsSelectedLabel.bv")));
+                selectTransportedUnitsAndTransport(selectedCampaignTransportType, unit,changedList);
+
             }
         } else {
             selectedItems = changedList.getSelectedIndices().length;
@@ -1037,6 +1095,36 @@ public class StratconScenarioWizard extends JDialog {
 
         unitStatusLabel.setText(sb.toString());
         pack();
+
+        ((JList<?>) event.getSource()).addListSelectionListener(listeners[0]);
+    }
+
+    private void selectTransportedUnitsAndTransport(CampaignTransportType campaignTransportType, Unit unit, JList<Unit> changedList) {
+        if (campaignTransportType != null) {
+            if (unit.hasTransportedUnits(campaignTransportType)) {
+                Set<Unit> potentialTransportedUnits = unit.getTransportedUnits(campaignTransportType);
+                for (Unit transportedUnit : potentialTransportedUnits) {
+                    // if this unit isn't selected but is an eligible leadership unit
+                    if (!changedList.getSelectedValuesList().contains(transportedUnit)
+                            && (eligibleLeadershipUnits.contains(transportedUnit))) {
+
+                        int index = eligibleLeadershipUnits.indexOf(transportedUnit);
+                        changedList.setSelectedIndices(ArrayUtils.add(changedList.getSelectedIndices(), index));
+                    }
+                }
+            }
+
+            if (unit.hasTransportAssignment(campaignTransportType)) {
+                Unit transport = unit.getTransportAssignment(campaignTransportType).getTransport();
+                // if this unit isn't selected but is an eligible leadership unit
+                if (!changedList.getSelectedValuesList().contains(transport)
+                        && (eligibleLeadershipUnits.contains(transport))) {
+
+                    int index = eligibleLeadershipUnits.indexOf(transport);
+                    changedList.setSelectedIndices(ArrayUtils.add(changedList.getSelectedIndices(), index));
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a0b5c632-2b89-45e5-8fa3-33eedc8da5c8)

Fixes #5845 

- In the Scenario Setup Wizard, there is a dropdown for Transport Type
- When a unit is selected from the leadership bonus unit list, if the transport type is not none, it'll check the unit's transport & transported units for the corresponding campaign transport type: If they're also eligible leadership units, let's mark them as selected too.