### PR TITLE
Issue 5980: Improved commander updating logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -617,25 +617,22 @@ public class Force {
                 overrideForceCommanderID = null;
             }
         }
-        //If our force commander is null or not eligible (not in the force/subforces), let's assign a random person
-        if ((forceCommanderID == null) || (!eligibleCommanders.contains(forceCommanderID))) {
 
-            Collections.shuffle(eligibleCommanders);
-            Person highestRankedPerson = campaign.getPerson(eligibleCommanders.get(0));
+        Collections.shuffle(eligibleCommanders);
+        Person highestRankedPerson = campaign.getPerson(eligibleCommanders.get(0));
 
-            for (UUID eligibleCommanderId : eligibleCommanders) {
-                Person eligibleCommander = campaign.getPerson(eligibleCommanderId);
-                if (eligibleCommander == null) {
-                    continue;
-                }
-
-                if (eligibleCommander.outRanksUsingSkillTiebreaker(campaign, highestRankedPerson)) {
-                    highestRankedPerson = eligibleCommander;
-                }
+        for (UUID eligibleCommanderId : eligibleCommanders) {
+            Person eligibleCommander = campaign.getPerson(eligibleCommanderId);
+            if (eligibleCommander == null) {
+                continue;
             }
 
-            forceCommanderID = highestRankedPerson.getId();
+            if (eligibleCommander.outRanksUsingSkillTiebreaker(campaign, highestRankedPerson)) {
+                highestRankedPerson = eligibleCommander;
+            }
         }
+
+        forceCommanderID = highestRankedPerson.getId();
         updateCombatTeamCommanderIfCombatTeam(campaign);
 
         if (getParentForce() != null) {

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -617,22 +617,25 @@ public class Force {
                 overrideForceCommanderID = null;
             }
         }
+        //If our force commander is null or not eligible (not in the force/subforces), let's assign a random person
+        if ((forceCommanderID == null) || (!eligibleCommanders.contains(forceCommanderID))) {
 
-        Collections.shuffle(eligibleCommanders);
-        Person highestRankedPerson = campaign.getPerson(eligibleCommanders.get(0));
+            Collections.shuffle(eligibleCommanders);
+            Person highestRankedPerson = campaign.getPerson(eligibleCommanders.get(0));
 
-        for (UUID eligibleCommanderId : eligibleCommanders) {
-            Person eligibleCommander = campaign.getPerson(eligibleCommanderId);
-            if (eligibleCommander == null) {
-                continue;
+            for (UUID eligibleCommanderId : eligibleCommanders) {
+                Person eligibleCommander = campaign.getPerson(eligibleCommanderId);
+                if (eligibleCommander == null) {
+                    continue;
+                }
+
+                if (eligibleCommander.outRanksUsingSkillTiebreaker(campaign, highestRankedPerson)) {
+                    highestRankedPerson = eligibleCommander;
+                }
             }
 
-            if (eligibleCommander.outRanksUsingSkillTiebreaker(campaign, highestRankedPerson)) {
-                highestRankedPerson = eligibleCommander;
-            }
+            forceCommanderID = highestRankedPerson.getId();
         }
-
-        forceCommanderID = highestRankedPerson.getId();
         updateCombatTeamCommanderIfCombatTeam(campaign);
 
         if (getParentForce() != null) {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -469,6 +469,11 @@ public class CampaignXmlParser {
                 System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
+        // This removes the risk of having forces with invalid leadership getting locked in
+        for (Force force : retVal.getAllForces()) {
+            force.updateCommander(retVal);
+        }
+
         // ok, once we are sure that campaign has been set for all units, we can
         // now go through and initializeParts and run diagnostics
         List<Unit> removeUnits = new ArrayList<>();
@@ -872,11 +877,6 @@ public class CampaignXmlParser {
             } else {
                 logger.error("More than one type-level force found");
             }
-        }
-
-        // This removes the risk of having forces with invalid leadership getting locked in
-        for (Force force : retVal.getAllForces()) {
-            force.updateCommander(retVal);
         }
 
         recalculateCombatTeams(retVal);


### PR DESCRIPTION
Fixes #5980 

After getting all forces we need to update their commanders. I moved this to happen later in the campaign xml parsing. 

Before, when getting eligible commanders it would get incorrect Unit commanders - it was attempting to determine a `Unit`'s commander before the `Personnel` were initialized. The ranks were all null, so it would wind up the last person (who was often a driver). 

Now, it will update commanders after everyone has been initialized with their ranks.

Related to #5729 