### PR TITLE
Fixed backwards "last compatible version" check

### DIFF
--- a/MekHQ/src/mekhq/CampaignPreset.java
+++ b/MekHQ/src/mekhq/CampaignPreset.java
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
  * @author Justin "Windchild" Bowen
  */
 public class CampaignPreset {
-    static final private Version LAST_COMPATIBLE_VERSION = new Version("0.50.03-SNAPSHOT");
+    static final private Version LAST_COMPATIBLE_VERSION = new Version("0.50.02");
 
     private static final MMLogger logger = MMLogger.create(CampaignPreset.class);
 

--- a/MekHQ/src/mekhq/CampaignPreset.java
+++ b/MekHQ/src/mekhq/CampaignPreset.java
@@ -442,7 +442,7 @@ public class CampaignPreset {
             return null;
         }
 
-        if (LAST_COMPATIBLE_VERSION.isLowerThan(version)) {
+        if (version.isLowerThan(LAST_COMPATIBLE_VERSION)) {
             String message = String.format(
                 "Cannot parse Campaign Preset from %s in newer version %s.",
                 version.toString(), MHQConstants.VERSION);


### PR DESCRIPTION
Reported on Discord, not in GitHub yet.

It isn't possible to load presets made after 50.03-snapshot (like 50.03), but it is possible to load presets made before 50.03-snapshot, like 50.02.

I fixed the check so 50.03-snapshot and 50.03 presets work, and campaign preset versions older than 50.02 (50.01, 50.02-snapshot) won't work.