### PR TITLE
Adjusted Gray Monday Employer Dialog to Trigger on the Correct Day

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/GrayMonday.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/GrayMonday.java
@@ -69,7 +69,7 @@ public class GrayMonday {
             }
         }
 
-        if (daysAfterGrayMonday == 1) {
+        if (daysAfterGrayMonday == 2) {
             Finances finances = campaign.getFinances();
             Money balance = finances.getBalance();
             Money adjustedBalance = balance.multipliedBy(0.01);

--- a/MekHQ/src/mekhq/campaign/randomEvents/GrayMonday.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/GrayMonday.java
@@ -52,9 +52,9 @@ public class GrayMonday {
 
         int daysAfterGrayMonday = (int) DAYS.between(EVENT_DATE_GRAY_MONDAY, today);
         if (daysAfterGrayMonday > 0 && daysAfterGrayMonday <= 4) {
-            boolean shouldShowDialog = daysAfterGrayMonday != 2;
+            boolean shouldShowDialog = daysAfterGrayMonday != 3;
 
-            if (daysAfterGrayMonday == 2) {
+            if (daysAfterGrayMonday == 3) {
                 for (AtBContract contract : campaign.getAtBContracts()) {
                     LocalDate startDate = contract.getStartDate();
                     if (!startDate.isBefore(today)) {

--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/GrayMondayDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/GrayMondayDialog.java
@@ -103,7 +103,7 @@ public class GrayMondayDialog extends MHQDialogImmersive {
 
         // Get speaker details
         String speakerName = speaker.getFullTitle();
-        if (campaign.getLocalDate().equals(EVENT_DATE_GRAY_MONDAY.plusDays(2))) {
+        if (campaign.getLocalDate().equals(EVENT_DATE_GRAY_MONDAY.plusDays(3))) {
             if (chosenContract != null) {
                 speakerName = chosenContract.getEmployerName(campaign.getGameYear());
             }
@@ -112,7 +112,7 @@ public class GrayMondayDialog extends MHQDialogImmersive {
         // Add speaker image (icon)
         ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
 
-        if (campaign.getLocalDate().equals(EVENT_DATE_GRAY_MONDAY.plusDays(2))) {
+        if (campaign.getLocalDate().equals(EVENT_DATE_GRAY_MONDAY.plusDays(3))) {
             if (chosenContract != null) {
                 String employerCode = chosenContract.getEmployerCode();
                 speakerIcon = Factions.getFactionLogo(campaign, employerCode, true);


### PR DESCRIPTION
Changed event logic to activate on day 3 after Gray Monday instead of day 2. This ensures consistency in timing for dialog display and related contract interactions.