### PR TITLE
fix: addresses the off by one issue presenting the wrong filtering re…

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -170,8 +170,8 @@ public final class BatchXPDialog extends JDialog {
         choiceExp.setMaximumSize(new Dimension(Short.MAX_VALUE, (int) choiceType.getPreferredSize().getHeight()));
         DefaultComboBoxModel<PersonTypeItem> personExpModel = new DefaultComboBoxModel<>();
         personExpModel.addElement(new PersonTypeItem(resourceMap.getString("experience.choice.text"), null));
-        for (int i = SkillLevel.ULTRA_GREEN.ordinal(); i < SkillLevel.ELITE.ordinal(); i++) {
-            personExpModel.addElement(new PersonTypeItem(Skills.SKILL_LEVELS[i].toString(), i));
+        for (int i = SkillLevel.ULTRA_GREEN.ordinal(); i <= SkillLevel.ELITE.ordinal(); i++) {
+            personExpModel.addElement(new PersonTypeItem(SkillLevel.parseFromInteger(i).toString(), SkillLevel.parseFromInteger(i).getAdjustedValue()));
         }
         choiceExp.setModel(personExpModel);
         choiceExp.setSelectedIndex(0);

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -171,7 +171,8 @@ public final class BatchXPDialog extends JDialog {
         DefaultComboBoxModel<PersonTypeItem> personExpModel = new DefaultComboBoxModel<>();
         personExpModel.addElement(new PersonTypeItem(resourceMap.getString("experience.choice.text"), null));
         for (int i = SkillLevel.ULTRA_GREEN.ordinal(); i <= SkillLevel.ELITE.ordinal(); i++) {
-            personExpModel.addElement(new PersonTypeItem(SkillLevel.parseFromInteger(i).toString(), SkillLevel.parseFromInteger(i).getAdjustedValue()));
+            final SkillLevel skillLevel = SkillLevel.parseFromInteger(i);
+            personExpModel.addElement(new PersonTypeItem(skillLevel.toString(), skillLevel.getAdjustedValue()));
         }
         choiceExp.setModel(personExpModel);
         choiceExp.setSelectedIndex(0);


### PR DESCRIPTION
…sults for skill level for mass training, fixes issue #5922

Second attempt here at a fix.

I assume `Elite` level personnel should be selectable as a dropdown in the filter for mass training?  Without this fix, Elite does not show up in the dropdown.  This also correctly shows the right personnel given the example save provided in the referenced issue.

If I'm misunderstanding something here, please correct me.