### PR TITLE
Issue 5979: Force players to use commit when deploying forces

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -13,6 +13,10 @@ lblLeadershipInstructions.Text=<html>The force commander's leadership allows the
   <br><b>Available BV:</b> %s</html
 
 lblLeadershipTransportInstructions.text=<html><b>Transport Type:</b></html>
+lblLeadershipCommitForces.text=Commit {0} and any selected auxiliary units?
+lblLeadershipCommitForces.fallback.text=Commit force?
+leadershipCommit.text=Commit
+leadershipCancel.text=Cancel
 
 selectForceForTemplate.Text=<html><b>Select a force from the list below.</b>\
   <br>\
@@ -85,6 +89,7 @@ reinforcementConfirmation.confirmButton.gm.tooltip=Make a reinforcement attempt,
 reinforcementConfirmation.cancelButton=Cancel
 unitsSelectedLabel.bv=selected (ignores crew skill)
 unitsSelectedLabel.count=selected
+
 
 ### Support Point Negotiation
 supportPoints.maximum=Your Admin/Transport personnel cannot use their <i>Administration</i>\

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -413,12 +413,10 @@ public class Force {
      * @return all the unit ids in this force and all of its subforces
      */
     public Vector<UUID> getAllUnits(boolean standardForcesOnly) {
-        Vector<UUID> allUnits;
+        Vector<UUID> allUnits = new Vector<>();
 
-        if (standardForcesOnly && forceType.isStandard()) {
-            allUnits = new Vector<>();
-        } else {
-            allUnits = new Vector<>(units);
+        if (!standardForcesOnly || forceType.isStandard()) {
+            allUnits.addAll(units);
         }
 
         for (Force force : subForces) {

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -120,7 +120,7 @@ public class StratconPanel extends JPanel implements ActionListener {
 
     private final Map<String, BufferedImage> imageCache = new HashMap<>();
 
-    private List<Force> pendingDeployments = new ArrayList<Force>();
+    private boolean commitForces = false;
 
     /**
      * Constructs a StratconPanel instance, given a parent campaign GUI and a
@@ -1053,16 +1053,17 @@ public class StratconPanel extends JPanel implements ActionListener {
                         isPrimaryForce = true;
                     }
                 }
-                if (selectedScenario != null) {
+                if (selectedScenario != null &&  selectedScenario.getCurrentState() == PRIMARY_FORCES_COMMITTED) {
                     scenarioWizard.setCurrentScenario(currentTrack.getScenario(selectedCoords),
                         currentTrack, campaignState, isPrimaryForce);
 
                     scenarioWizard.toFront();
                     scenarioWizard.setVisible(true);
                 }
-                setPendingDeployments(new ArrayList<>());
+                if (selectedScenario != null && !isCommitForces()) {
+                    selectedScenario.resetScenario(campaign);
+                }
                 break;
-            // Deliberate fall-through
             case RCLICK_COMMAND_MANAGE_SCENARIO:
                 // It's possible a scenario may have been placed when deploying the force, so we
                 // need to recheck
@@ -1118,6 +1119,8 @@ public class StratconPanel extends JPanel implements ActionListener {
                 if (scenarioToReset != null) {
                     scenarioToReset.resetScenario(campaign);
                 }
+
+                setCommitForces(false);
                 break;
         }
 
@@ -1136,21 +1139,11 @@ public class StratconPanel extends JPanel implements ActionListener {
         }
     }
 
-    public List<Force> getPendingDeployments() {
-        return pendingDeployments;
+    public boolean isCommitForces() {
+        return commitForces;
     }
 
-    public void setPendingDeployments(List<Force> pendingDeployments) {
-        this.pendingDeployments = pendingDeployments;
-    }
-
-    public void processPendingDeployments() {
-
-        for (Force force : getPendingDeployments()) {
-            StratconRulesManager.deployForceToCoords(getSelectedCoords(),
-                force.getId(), campaign, campaignState.getContract(), getCurrentTrack(), false);
-        }
-
-        setPendingDeployments(new ArrayList<>());
+    public void setCommitForces(boolean commitForces) {
+        this.commitForces = commitForces;
     }
 }

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -36,6 +36,7 @@ import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.stratcon.StratconScenario;
 import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.campaign.unit.Unit;
+import mekhq.gui.StratconPanel;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
 import mekhq.utilities.MHQInternationalization;
 import org.apache.commons.lang3.ArrayUtils;
@@ -93,8 +94,11 @@ public class StratconScenarioWizard extends JDialog {
 
     private static final MMLogger logger = MMLogger.create(StratconScenarioWizard.class);
 
-    public StratconScenarioWizard(Campaign campaign) {
+    private final StratconPanel parent;
+
+    public StratconScenarioWizard(Campaign campaign, StratconPanel parent) {
         this.campaign = campaign;
+        this.parent = parent;
         this.setModalityType(ModalityType.APPLICATION_MODAL);
 
         for (CampaignTransportType campaignTransportType : getLeadershipDropdownVectorPair().stream().map(Pair::getValue).collect(Collectors.toSet())) {
@@ -900,6 +904,11 @@ public class StratconScenarioWizard extends JDialog {
      */
     private void btnCommitClicked(ActionEvent evt, @Nullable Integer reinforcementTargetNumber,
                                   boolean isGMReinforcement) {
+        //StratconPanel parent = (StratconPanel) getParent();
+        if (parent != null && !(parent.getPendingDeployments().isEmpty())) {
+            parent.processPendingDeployments();
+        }
+
         // go through all the force lists and add the selected forces to the scenario
         for (String templateID : availableForceLists.keySet()) {
             for (Force force : availableForceLists.get(templateID).getSelectedValuesList()) {
@@ -956,7 +965,7 @@ public class StratconScenarioWizard extends JDialog {
 
         currentScenario.updateMinefieldCount(Minefield.TYPE_CONVENTIONAL, getNumMinefields());
 
-        if (currentScenario.getCurrentState().ordinal() < REINFORCEMENTS_COMMITTED.ordinal()) {
+        if (currentScenario.getCurrentState().ordinal() <= REINFORCEMENTS_COMMITTED.ordinal()) {
             translateTemplateObjectives(currentScenario.getBackingScenario(), campaign);
             scaleObjectiveTimeLimits(currentScenario.getBackingScenario(), campaign);
         }

--- a/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
+++ b/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
@@ -114,10 +114,8 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
             // sometimes the scenario templates take a little while to load, we don't want the user
             // clicking the button fifty times and getting a bunch of scenarios.
             btnConfirm.setEnabled(false);
-            for (Force force : availableForceList.getSelectedValuesList()) {
-                StratconRulesManager.deployForceToCoords(ownerPanel.getSelectedCoords(),
-                    force.getId(), campaign, currentCampaignState.getContract(), ownerPanel.getCurrentTrack(), false);
-            }
+
+            ownerPanel.setPendingDeployments(availableForceList.getSelectedValuesList());
             setVisible(false);
             ownerPanel.repaint();
             btnConfirm.setEnabled(true);

--- a/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
+++ b/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
@@ -114,8 +114,10 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
             // sometimes the scenario templates take a little while to load, we don't want the user
             // clicking the button fifty times and getting a bunch of scenarios.
             btnConfirm.setEnabled(false);
-
-            ownerPanel.setPendingDeployments(availableForceList.getSelectedValuesList());
+            for (Force force : availableForceList.getSelectedValuesList()) {
+                StratconRulesManager.deployForceToCoords(ownerPanel.getSelectedCoords(),
+                    force.getId(), campaign, currentCampaignState.getContract(), ownerPanel.getCurrentTrack(), false);
+            }
             setVisible(false);
             ownerPanel.repaint();
             btnConfirm.setEnabled(true);


### PR DESCRIPTION
Fixes #5979 

When deploying forces in Stratcon, the player should be required to hit "commit" on the 2nd deployment window before their primary forces are comitted. This ensures the objective is properly updated.

I also added another message to the 2nd deployment window to make it more clear, and a cancel button per Illiani's request:
![image](https://github.com/user-attachments/assets/7b588336-3742-4427-b055-97fb0d19379b)

(displaying this even if there's no leadership units is intentional - it's a chance for the player to realize they don't get any free leadership units and opt to deploy a different force).