### PR TITLE
Issue 6009: Improve Stratcon deployment logic to ensure units aren't deployed twice

### DIFF
--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -1053,6 +1053,10 @@ public class StratconPanel extends JPanel implements ActionListener {
                         isPrimaryForce = true;
                     }
                 }
+
+                // Let's reload the scenario in case it updated
+                selectedScenario = currentTrack.getScenario(selectedCoords);
+
                 if (selectedScenario != null &&  selectedScenario.getCurrentState() == PRIMARY_FORCES_COMMITTED) {
                     scenarioWizard.setCurrentScenario(currentTrack.getScenario(selectedCoords),
                         currentTrack, campaignState, isPrimaryForce);
@@ -1063,6 +1067,8 @@ public class StratconPanel extends JPanel implements ActionListener {
                 if (selectedScenario != null && !isCommitForces()) {
                     selectedScenario.resetScenario(campaign);
                 }
+
+                setCommitForces(false);
                 break;
             case RCLICK_COMMAND_MANAGE_SCENARIO:
                 // It's possible a scenario may have been placed when deploying the force, so we
@@ -1119,8 +1125,6 @@ public class StratconPanel extends JPanel implements ActionListener {
                 if (scenarioToReset != null) {
                     scenarioToReset.resetScenario(campaign);
                 }
-
-                setCommitForces(false);
                 break;
         }
 


### PR DESCRIPTION
Fixes #6009 

- I believe this was fixed by #6003 
- There were some issues with #6003's implementation that were found while investigating this issue that were fixed:
  - If the scenario was null when assigning the initial forces it wouldn't show the leadership bonus units screen
  - If a deployment was comitted the next deployment would not properly clear its deployment if the user didn't commit to that deployment.