### PR TITLE
Cache finances balance

### DIFF
--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -69,6 +69,9 @@ public class Finances {
     private int failedCollateral;
     private LocalDate wentIntoDebt;
 
+    private Money balance;
+    private int transactionSize = -2;
+
     public Finances() {
         transactions = new ArrayList<>();
         loans = new ArrayList<>();
@@ -127,8 +130,15 @@ public class Finances {
     }
 
     public Money getBalance() {
-        Money balance = Money.zero();
-        return balance.plus(transactions.stream().map(Transaction::getAmount).collect(Collectors.toList()));
+        if (transactions.size() == transactionSize && balance != null) {
+            return balance;
+        }
+
+        Money newBalance = Money.zero();
+        balance = newBalance.plus(transactions.stream().map(Transaction::getAmount).collect(Collectors.toList()));
+        transactionSize = transactions.size();
+
+        return newBalance;
     }
 
     public Money getLoanBalance() {

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -129,13 +129,25 @@ public class Finances {
         this.wentIntoDebt = wentIntoDebt;
     }
 
+    /**
+     * Current campaign balance. Cached using the current transaction count.
+     * @see #clearBalanceCache()
+     * @return current balance (Money)
+     */
     public Money getBalance() {
+        Money newBalance = Money.zero();
+
+        // If our # of transactions matches what we expect, and the balance isn't null, we should return the cached balance:
         if (transactions.size() == transactionSize && balance != null) {
-            return balance;
+            return newBalance.plus(balance);
         }
 
-        Money newBalance = Money.zero();
-        balance = newBalance.plus(transactions.stream().map(Transaction::getAmount).collect(Collectors.toList()));
+        // This is the expensive calculation
+        newBalance = newBalance.plus(transactions.stream().map(Transaction::getAmount).collect(Collectors.toList()));
+        balance = Money.zero();
+
+        // Update our cached balance & note the transactions size.
+        balance = balance.plus(newBalance);
         transactionSize = transactions.size();
 
         return newBalance;

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -144,9 +144,9 @@ public class Finances {
 
         // This is the expensive calculation
         newBalance = newBalance.plus(transactions.stream().map(Transaction::getAmount).collect(Collectors.toList()));
-        balance = Money.zero();
 
         // Update our cached balance & note the transactions size.
+        balance = Money.zero();
         balance = balance.plus(newBalance);
         transactionSize = transactions.size();
 

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -70,7 +70,7 @@ public class Finances {
     private LocalDate wentIntoDebt;
 
     private Money balance;
-    private int transactionSize = -2;
+    private int transactionSize = -1;
 
     public Finances() {
         transactions = new ArrayList<>();
@@ -139,6 +139,10 @@ public class Finances {
         transactionSize = transactions.size();
 
         return newBalance;
+    }
+
+    public void clearBalanceCache() {
+        transactionSize = -1;
     }
 
     public Money getLoanBalance() {
@@ -256,6 +260,7 @@ public class Finances {
 
         Money carryover = getBalance();
         transactions = new ArrayList<>();
+        clearBalanceCache();
 
         credit(
                 TransactionType.FINANCIAL_TERM_END_CARRYOVER,

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -130,8 +130,9 @@ public class Finances {
     }
 
     /**
-     * Current campaign balance. Cached using the current transaction count.
-     * @see #clearBalanceCache()
+     * Current campaign balance. Will calculate the current campaign balance
+     * based on the campaign's transactions. Cached using the current transaction count.
+     * @see #clearCachedBalance()
      * @return current balance (Money)
      */
     public Money getBalance() {
@@ -142,7 +143,7 @@ public class Finances {
             return newBalance.plus(balance);
         }
 
-        // This is the expensive calculation
+        // Recalculate the current balance
         newBalance = newBalance.plus(transactions.stream().map(Transaction::getAmount).collect(Collectors.toList()));
 
         // Update our cached balance & note the transactions size.
@@ -153,7 +154,13 @@ public class Finances {
         return newBalance;
     }
 
-    public void clearBalanceCache() {
+    /**
+     * Next time getBalance() is called force it to recalculate the current balance
+     * Should be called if transactions are modified or deleted. Should not be needed
+     * when adding new transactions - the balance should automatically recalculate.
+     * @see #getBalance()
+     */
+    public void clearCachedBalance() {
         transactionSize = -1;
     }
 
@@ -272,7 +279,7 @@ public class Finances {
 
         Money carryover = getBalance();
         transactions = new ArrayList<>();
-        clearBalanceCache();
+        clearCachedBalance();
 
         credit(
                 TransactionType.FINANCIAL_TERM_END_CARRYOVER,

--- a/MekHQ/src/mekhq/gui/adapter/FinanceTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/FinanceTableMouseAdapter.java
@@ -57,13 +57,14 @@ public class FinanceTableMouseAdapter extends JPopupMenuAdapter {
         if (command.equalsIgnoreCase("DELETE")) {
             gui.getCampaign().addReport(transaction.voidTransaction());
             financeModel.deleteTransaction(row);
+            gui.getCampaign().getFinances().clearCachedBalance();
             MekHQ.triggerEvent(new TransactionVoidedEvent(transaction));
         } else if (command.contains("EDIT")) {
             EditTransactionDialog dialog = new EditTransactionDialog(gui.getFrame(), transaction, true);
             dialog.setVisible(true);
             if (!transaction.equals(dialog.getOldTransaction())) {
                 financeModel.setTransaction(row, transaction);
-                gui.getCampaign().getFinances().clearBalanceCache();
+                gui.getCampaign().getFinances().clearCachedBalance();
                 MekHQ.triggerEvent(new TransactionChangedEvent(dialog.getOldTransaction(), transaction));
                 gui.getCampaign().addReport(transaction.updateTransaction(dialog.getOldTransaction()));
             }

--- a/MekHQ/src/mekhq/gui/adapter/FinanceTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/FinanceTableMouseAdapter.java
@@ -63,6 +63,7 @@ public class FinanceTableMouseAdapter extends JPopupMenuAdapter {
             dialog.setVisible(true);
             if (!transaction.equals(dialog.getOldTransaction())) {
                 financeModel.setTransaction(row, transaction);
+                gui.getCampaign().getFinances().clearBalanceCache();
                 MekHQ.triggerEvent(new TransactionChangedEvent(dialog.getOldTransaction(), transaction));
                 gui.getCampaign().addReport(transaction.updateTransaction(dialog.getOldTransaction()));
             }


### PR DESCRIPTION
My MekHQ was running slow - taking over 10 seconds to process a new day for a thicc Battalion while off contract. IntelliJ's profiler suggested that `Finances::getBalance` was taking a lot of time, so it's now cached. 

Before caching:
![image1](https://github.com/user-attachments/assets/ddc1d946-4b48-4278-81e7-70625dc02a58)
![image](https://github.com/user-attachments/assets/3668c176-7e53-48f5-afec-4c582f8a5035)



After caching:
![image2](https://github.com/user-attachments/assets/4fe17877-91fb-4a41-82e0-41e3420c0aa7)
