### PR TITLE
Read user force icons data from user directory

### DIFF
--- a/MekHQ/docs/UserDirHelp.html
+++ b/MekHQ/docs/UserDirHelp.html
@@ -13,6 +13,10 @@
     <LI><B>Portrait</B> images must be placed in &lt;user data directory&gt;/data/images/portraits/. In this subfolder, further subfolders can be used (optional).
 
     <LI><B>Unit fluff</B> images must be placed in &lt;user data directory&gt;/data/images/fluff/&lt;unit type&gt;/. To find the exact subfolders to use, go to your megamek folder and open /data/images/fluff/.
+
+    <LI><B>Force Icons</B> images must be placed in &lt;user data directory&gt;/data/images/force/. The directory structure of this folder should mirror that in your mekhq folder at /data/images/force/
+
+    <LI><B>Planetary Systems</B> Correctly formatted yaml files containing a single system can be placed in &lt;user data directory&gt;/data/universe/planetary_systems/.
 </UL>
 
 <P>This is an example of a suitable directory structure with a few example files:
@@ -24,6 +28,9 @@ D:/myBTStuff<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas AS8-XT.mtf<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;/data<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Jura.ttf<BR>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/universe<BR>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/planetary_systems<BR>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mySecretPlanet.yml<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/images<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/camo<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;myForceCamo.png<BR>
@@ -37,3 +44,6 @@ D:/myBTStuff<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas.png<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/DropShip<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Colossus.png<BR>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/force<BR>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/Units<BR>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MyUnitLogo.png<BR>

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -253,6 +253,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String USER_CAMPAIGN_PRESET_DIRECTORY = "userdata/mmconf/campaignPresets/";
     public static final String STRATCON_MUL_FILES_DIRECTORY = "data/scenariotemplates/fixedmuls/";
     public static final String PLANETARY_SYSTEM_DIRECTORY_PATH = "data/universe/planetary_systems";
+    public static final String FORCE_ICON_PATH = "data/images/force";
 
     // region StratCon
     public static final String STRATCON_REQUIRED_HOSTILE_FACILITY_MODS = "./data/scenariomodifiers/requiredHostileFacilityModifiers.xml";

--- a/MekHQ/src/mekhq/MHQStaticDirectoryManager.java
+++ b/MekHQ/src/mekhq/MHQStaticDirectoryManager.java
@@ -22,6 +22,7 @@ import java.io.File;
 
 import megamek.client.ui.swing.tileset.MMStaticDirectoryManager;
 import megamek.common.annotations.Nullable;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.fileUtils.AbstractDirectory;
 import megamek.common.util.fileUtils.DirectoryItems;
 import megamek.common.util.fileUtils.ImageFileFactory;
@@ -80,8 +81,16 @@ public class MHQStaticDirectoryManager extends MMStaticDirectoryManager {
             // something fails
             parseForceIconDirectory = false;
             try {
-                forceIconDirectory = new DirectoryItems(new File("data/images/force"), // TODO : Remove inline file path
+                forceIconDirectory = new DirectoryItems(new File(MHQConstants.FORCE_ICON_PATH),
                         new ImageFileFactory());
+
+                String userDir = PreferenceManager.getClientPreferences().getUserDir();
+                File forceIconUserDir = new File(userDir + "/" + MHQConstants.FORCE_ICON_PATH);
+                if (!userDir.isBlank() && forceIconUserDir.isDirectory()) {
+                    DirectoryItems userDirForceIcon = new DirectoryItems(forceIconUserDir, new ImageFileFactory());
+                    forceIconDirectory.merge(userDirForceIcon);
+                }
+
             } catch (Exception e) {
                 logger.error("Could not parse the force icon directory!", e);
             }


### PR DESCRIPTION
This is a simple quality of life improvement PR. It allows user images for force icons to be kept in the external user custom data directory and be read by MekHQ.

The force icon data should be located in a `data/images/force` subdirectory of their custom data directory and should have the exact same directory structure as the `data/images/force` directory in MekHQ. For example, unit logos should go into the `/data/images/force/Units` subdirectory. 