### PR TITLE
Issue 6025: Young Wolves Storyarc doesn't correctly assign main character or Tobias to the Mechwarrior Trueborn Caste

### DIFF
--- a/MekHQ/data/storyarcs/young_wolves/storyArc.xml
+++ b/MekHQ/data/storyarcs/young_wolves/storyArc.xml
@@ -160,8 +160,8 @@
             <firstname>Julius</firstname>
             <age>32</age>
             <clan>true</clan>
-            <phenotype>MekWarrior</phenotype>
-            <primaryRole>MekWarrior</primaryRole>
+            <phenotype>MEKWARRIOR</phenotype>
+            <primaryRole>MEKWARRIOR</primaryRole>
             <edge>3</edge>
             <editOrigin>false</editOrigin>
             <editBirthday>false</editBirthday>

--- a/MekHQ/data/storyarcs/young_wolves/storyArc.xml
+++ b/MekHQ/data/storyarcs/young_wolves/storyArc.xml
@@ -4876,10 +4876,10 @@
                     <id>828189ee-a14f-4c7a-bb33-b62883757152</id>
                     <givenName>Tobias</givenName>
                     <bloodname>Malthus</bloodname>
-                    <primaryRole>MekWarrior</primaryRole>
+                    <primaryRole>MEKWARRIOR</primaryRole>
                     <faction>CJF</faction>
                     <clan>true</clan>
-                    <phenotype>MekWarrior</phenotype>
+                    <phenotype>MEKWARRIOR</phenotype>
                     <portrait>
                         <category></category>
                         <filename>Tobias.jpg</filename>

--- a/MekHQ/src/mekhq/campaign/storyarc/storypoint/CreateCharacterStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyarc/storypoint/CreateCharacterStoryPoint.java
@@ -26,7 +26,6 @@ import megamek.common.options.IOptionGroup;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.RandomSkillPreferences;
 import mekhq.campaign.event.PersonNewEvent;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
@@ -35,8 +34,6 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.backgrounds.BackgroundsController;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.Phenotype;
-import mekhq.campaign.personnel.generator.AbstractSkillGenerator;
-import mekhq.campaign.personnel.generator.DefaultSkillGenerator;
 import mekhq.campaign.personnel.randomEvents.PersonalityController;
 import mekhq.campaign.storyarc.StoryPoint;
 import mekhq.campaign.unit.Unit;
@@ -145,6 +142,40 @@ public class CreateCharacterStoryPoint extends StoryPoint {
         person.setClanPersonnel(clan);
         if (person.isClanPersonnel() && null != phenotype) {
             person.setPhenotype(phenotype);
+
+            switch (phenotype) {
+                case MEKWARRIOR:
+                    person.addSkill(SkillType.S_GUN_MEK, 0, 1);
+                    person.addSkill(SkillType.S_PILOT_MEK, 0, 1);
+                    break;
+                case ELEMENTAL:
+                    person.addSkill(SkillType.S_GUN_BA, 0, 1);
+                    person.addSkill(SkillType.S_ANTI_MEK, 0, 1);
+                    break;
+                case AEROSPACE:
+                    person.addSkill(SkillType.S_GUN_AERO, 0, 1);
+                    person.addSkill(SkillType.S_PILOT_AERO, 0, 1);
+                    person.addSkill(SkillType.S_GUN_JET, 0, 1);
+                    person.addSkill(SkillType.S_PILOT_JET, 0, 1);
+                    break;
+                case VEHICLE:
+                    person.addSkill(SkillType.S_GUN_VEE, 0, 1);
+                    person.addSkill(SkillType.S_PILOT_GVEE, 0, 1);
+                    person.addSkill(SkillType.S_PILOT_NVEE, 0, 1);
+                    person.addSkill(SkillType.S_PILOT_VTOL, 0, 1);
+                    break;
+                case PROTOMEK:
+                    person.addSkill(SkillType.S_GUN_PROTO, 0, 1);
+                    break;
+                case NAVAL:
+                    person.addSkill(SkillType.S_TECH_VESSEL, 0, 1);
+                    person.addSkill(SkillType.S_GUN_SPACE, 0, 1);
+                    person.addSkill(SkillType.S_PILOT_SPACE, 0, 1);
+                    person.addSkill(SkillType.S_NAV, 0, 1);
+                    break;
+                default:
+                    break;
+            }
         }
 
         person.setCommander(commander);
@@ -161,24 +192,6 @@ public class CreateCharacterStoryPoint extends StoryPoint {
         if (null != personId) {
             person.setId(personId);
         }
-
-        // We need to generate basic skills in order to get any phenotype bonuses
-        // everything will be set to just produce the minimum proficiency in the role's
-        // necessary skills
-        RandomSkillPreferences skillPrefs = new RandomSkillPreferences();
-        skillPrefs.setArtilleryProb(0);
-        skillPrefs.setArtilleryBonus(-12);
-        skillPrefs.setRandomizeSkill(false);
-        skillPrefs.setAntiMekProb(0);
-        skillPrefs.setSecondSkillProb(0);
-        skillPrefs.setSecondSkillBonus(-12);
-        skillPrefs.setTacticsMod(0, -12);
-        skillPrefs.setSpecialAbilityBonus(0, -12);
-        skillPrefs.setOverallRecruitBonus(-12);
-        skillPrefs.setCombatSmallArmsBonus(-12);
-        skillPrefs.setSupportSmallArmsBonus(-12);
-        AbstractSkillGenerator skillGenerator = new DefaultSkillGenerator(skillPrefs);
-        skillGenerator.generateSkills(getCampaign(), person, SkillType.EXP_ULTRA_GREEN);
 
         person.setDateOfBirth(getCampaign().getLocalDate().minusYears(age));
 


### PR DESCRIPTION
Fixes #6025 

The main problem was how the phenotype and role enums were loaded, so I just needed to make a quick change to the XML code for the story arc. However, the phenotype bonuses were also not registering, so I had to make some changes to the underlying code to ensure that those phenotype changes would be picked up in the future.