### PR TITLE
Refactor shares percent to be polymorphic

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1519,15 +1519,8 @@ public class AtBContract extends Contract {
         this.moraleLevel = moraleLevel;
     }
 
-    /**
-     * Retrieves the dynamic shares percentage for this contract.
-     * This method shouldn't be called directly,
-     * instead use contract.getSharesPercent()
-     *
-     *
-     * @return the dynamic shares percentage
-     */
-    public int getAtBSharesPercentage() {
+    @Override
+    public int getSharesPercent() {
         return sharesPct;
     }
 

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -703,19 +703,13 @@ public class Contract extends Mission {
 
     /**
      * Retrieves the percentage of shares for this contract.
-     * If the instance is of type AtBContract, it retrieves the dynamic Shares
-     * percentage.
-     * Otherwise, it returns a default value of 30.
+     * This currently returns a default value of 30.
      *
      * @return the percentage of shares
      */
     public int getSharesPercent() {
-        if (this instanceof AtBContract) {
-            return ((AtBContract) this).getAtBSharesPercentage();
-        } else {
-            // TODO make this campaign option configurable
-            return 30;
-        }
+        // TODO make this campaign option configurable
+        return 30;
     }
 
     @Override

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -124,4 +124,11 @@ public class AtBContractTest {
         // Ensure the parent is null because it is not the correct type of contract
         assertNull(child.getParentContract());
     }
+
+    @Test
+    public void atbContractSharesPercentMatchesPreviousSetting() {
+        AtBContract contract = new AtBContract("Test");
+        contract.setAtBSharesPercent(50);
+        assertEquals(50, contract.getSharesPercent());
+    }
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/ContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/ContractTest.java
@@ -118,6 +118,12 @@ public class ContractTest {
         assertEquals(Money.of(17.10), contract.getMonthlyPayOut());
     }
 
+    @Test
+    public void testGetSharesPercentDefaultsTo30() {
+        initializeTest();
+        assertEquals(30, contract.getSharesPercent());
+    }
+
     private void initializeTest() {
         final PlanetarySystem mockPlanetarySystem = mock(PlanetarySystem.class);
 


### PR DESCRIPTION
This is a pretty simple change--to prepare for further work on cleaning up the Contract APIs, I've refactored `getSharesPercent()` to simply be overridden by AtBContract rather than defining a new public function that "shouldn't be called" according to the old docstrings. This removes the hard dependency on AtBContract in Contract as it's no longer necessary to check what kind of object it is.

I've also added a couple of basic tests to verify that the existing functionality has not changed.