### PR TITLE
CHange meklab check to last index check

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -363,7 +363,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
             }
         } else if (command.equals(COMMAND_CUSTOMIZE)) { // Single Unit only
             ((MekLabTab) gui.getTab(MHQTabType.MEK_LAB)).loadUnit(selectedUnit);
-            gui.getTabMain().setSelectedIndex(MHQTabType.MEK_LAB.ordinal());
+            gui.getTabMain().setSelectedIndex(gui.getTabMain().getTabCount()-1);
         } else if (command.equals(COMMAND_CANCEL_CUSTOMIZE)) {
             Stream.of(units).filter(Unit::isRefitting).forEach(unit -> unit.getRefit().cancel());
         } else if (command.equals(COMMAND_REFIT_GM_COMPLETE)) {


### PR DESCRIPTION
fixes #5814 

 Non Stratcon users currently getting an indexOut of bounds when attempting to use mekLab.   This due to using enums ordinal index when setting up tabs.  Changed the meklab index check to use last index instead of MEK_LAB.ordinal.
 
 Could also swap Stratcon and MekLab enums but that didn't look right.  
 
Tried leaving Statcon tab there but setting it to not visible but for some reason it was always visible. 