### PR TITLE
Add Tests for calculateContractDifficulty()

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -51,6 +51,7 @@ import mekhq.campaign.finances.*;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Force;
+import mekhq.campaign.force.ForceType;
 import mekhq.campaign.icons.StandardForceIcon;
 import mekhq.campaign.icons.UnitIcon;
 import mekhq.campaign.log.HistoricalLogEntry;
@@ -8961,5 +8962,23 @@ public class Campaign implements ITechManager {
             }
         }
         return false;
+    }
+
+    /**
+     * Returns a list of entities (units) from all combat forces.
+     *
+     * @return a list of entities representing all combat units in the player force
+     */
+    public List<Entity> getAllCombatEntities() {
+        List<Entity> units = new ArrayList<>();
+        for (Force force : getAllForces()) {
+            if (!force.isForceType(ForceType.STANDARD)) {
+                continue;
+            }
+            for (UUID unitID : force.getUnits()) {
+                units.add(getUnit(unitID).getEntity());
+            }
+        }
+        return units;
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -178,7 +178,7 @@ public class AtBContractTest {
         return Stream.of(
             Arguments.of(500.0, 0.0, true, 10),
             Arguments.of(500.0, 0.0, false, 10),
-            Arguments.of(500.0, 500.0, false, 5),
+            Arguments.of(500.0, 500.0, true, 5),
             Arguments.of(500.0, 500.0, false, 5),
             Arguments.of(500.0, 2000.0, true, 1),
             Arguments.of(500.0, 2000.0, false, 1),

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -258,7 +258,22 @@ public class AtBContractTest {
         assertEquals(name, contract.getEnemyName(3025));
     }
 
-    @Test
-    void getEmployerName() {
+    private static Stream<Arguments> provideEmployerNamesAndMercStatus() {
+        return Stream.of(
+            Arguments.of(3025, false, "LA", "Lyran Commonwealth"),
+            Arguments.of(3059, false, "LA", "Lyran Alliance"),
+            Arguments.of(3025, true, "LA", "Mercenary (Lyran Commonwealth)"),
+            Arguments.of(3059, true, "LA", "Mercenary (Lyran Alliance)"),
+            Arguments.of(-1, true, "LA", "Mercenary (Lyran Commonwealth)"),
+            Arguments.of(3025, true, "??", "Mercenary (Unknown)")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideEmployerNamesAndMercStatus")
+    void getEmployerNameReturnsCorrectName(int year, boolean isMercSubcontract, String employerCode, String fullName) {
+        contract.setEmployerCode(employerCode, year);
+        contract.setMercSubcontract(isMercSubcontract);
+        assertEquals(fullName, contract.getEmployerName(year));
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -18,15 +18,48 @@
  */
 package mekhq.campaign.mission;
 
+import megamek.common.EquipmentType;
+import megamek.common.enums.SkillLevel;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.mission.AtBContract.AtBContractRef;
+import mekhq.campaign.personnel.ranks.Ranks;
+import mekhq.campaign.universe.Factions;
+import mekhq.campaign.universe.Systems;
+import org.apache.logging.log4j.LogManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class AtBContractTest {
+    private AtBContract contract;
+    private Campaign campaign;
+    private CampaignOptions options;
+
+    @BeforeAll
+    public static void setup() {
+        EquipmentType.initializeTypes();
+        Ranks.initializeRankSystems();
+        try {
+            Factions.setInstance(Factions.loadDefault());
+            Systems.setInstance(Systems.loadDefault());
+        } catch (Exception ex) {
+            LogManager.getLogger().error("", ex);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        campaign = mock(Campaign.class);
+        options = mock(CampaignOptions.class);
+        when(campaign.getCampaignOptions()).thenReturn(options);
+        contract = new AtBContract();
+    }
 
     @Test
     public void atbContractRestoreDoesNothingWithoutParent() {
@@ -130,5 +163,166 @@ public class AtBContractTest {
         AtBContract contract = new AtBContract("Test");
         contract.setAtBSharesPercent(50);
         assertEquals(50, contract.getSharesPercent());
+    }
+
+    /*
+     *  TODO: The following tests prefixed with old_* should be removed along with the deprecated methods
+     *  they're testing when deemed safe to do so (roughly 0.50.4 or 0.50.5).
+     */
+
+    @Test
+    void old_calculateContractDifficultyEqualSkillShouldBe10() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(0.0).when(contract).estimatePlayerPower(any(Campaign.class));
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(campaign);
+        assertEquals(10, difficulty);
+    }
+
+    @Test
+    void old_calculateContractDifficultyEqualSkillShouldBe5() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(500.0).when(contract).estimatePlayerPower(any(Campaign.class));
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(campaign);
+        assertEquals(5, difficulty);
+    }
+
+    @Test
+    void old_calculateContractDifficultyEqualSkillShouldBe1() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(2000.0).when(contract).estimatePlayerPower(any(Campaign.class));
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(campaign);
+        assertEquals(1, difficulty);
+    }
+
+    @Test
+    void old_calculateContractDifficultyEqualSkillShouldBe4() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(525.0).when(contract).estimatePlayerPower(any(Campaign.class));
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(campaign);
+        assertEquals(4, difficulty);
+    }
+
+    @Test
+    void old_calculateContractDifficultyEqualSkillShouldBe7() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(350.0).when(contract).estimatePlayerPower(any(Campaign.class));
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(campaign);
+        assertEquals(7, difficulty);
+    }
+
+    @Test
+    void old_calculateContractDifficultyNoEnemyRatingShouldBeError() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(0.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(0.0).when(contract).estimatePlayerPower(any(Campaign.class));
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(campaign);
+        assertEquals(-99, difficulty);
+    }
+
+    @Test
+    void new_calculateContractDifficultyEqualSkillShouldBe10() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(0.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
+        assertEquals(10, difficulty);
+    }
+
+    @Test
+    void new_calculateContractDifficultyEqualSkillShouldBe5() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(500.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
+        assertEquals(5, difficulty);
+    }
+
+    @Test
+    void new_calculateContractDifficultyEqualSkillShouldBe1() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(2000.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
+        assertEquals(1, difficulty);
+    }
+
+    @Test
+    void new_calculateContractDifficultyEqualSkillShouldBe4() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(525.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
+        assertEquals(4, difficulty);
+    }
+
+    @Test
+    void new_calculateContractDifficultyEqualSkillShouldBe7() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(350.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
+        assertEquals(7, difficulty);
+    }
+
+    @Test
+    void new_calculateContractDifficultyNoEnemyRatingShouldBeError() {
+        contract = spy(contract);
+        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
+        doReturn(0.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(0.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
+        when(campaign.getGameYear()).thenReturn(3025);
+        when(options.isUseGenericBattleValue()).thenReturn(true);
+
+        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
+        assertEquals(-99, difficulty);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -30,8 +30,12 @@ import org.apache.logging.log4j.LogManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -170,159 +174,46 @@ public class AtBContractTest {
      *  they're testing when deemed safe to do so (roughly 0.50.4 or 0.50.5).
      */
 
-    @Test
-    void old_calculateContractDifficultyEqualSkillShouldBe10() {
+    private static Stream<Arguments> provideContractDifficultyParametersGBV() {
+        return Stream.of(
+            Arguments.of(500.0, 0.0, 10),
+            Arguments.of(500.0, 500.0, 5),
+            Arguments.of(500.0, 2000.0, 1),
+            Arguments.of(500.0, 525.0, 4),
+            Arguments.of(500.0, 350.0, 7),
+            Arguments.of(0.0, 0.0, -99)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideContractDifficultyParametersGBV")
+    public void old_calculateContractDifficultySameSkillMatchesExpectedRating(double enemyBV,
+                                                                        double playerBV,
+                                                                        int expectedResult) {
         contract = spy(contract);
         doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(0.0).when(contract).estimatePlayerPower(any(Campaign.class));
+        doReturn(enemyBV).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(playerBV).when(contract).estimatePlayerPower(any(Campaign.class));
         when(campaign.getGameYear()).thenReturn(3025);
         when(options.isUseGenericBattleValue()).thenReturn(true);
 
         int difficulty = contract.calculateContractDifficulty(campaign);
-        assertEquals(10, difficulty);
+        assertEquals(expectedResult, difficulty);
     }
 
-    @Test
-    void old_calculateContractDifficultyEqualSkillShouldBe5() {
+    @ParameterizedTest
+    @MethodSource("provideContractDifficultyParametersGBV")
+    void new_calculateContractDifficultySameSkillMatchesExpectedRating(double enemyBV,
+                                                                       double playerBV,
+                                                                       int expectedResult) {
         contract = spy(contract);
         doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(500.0).when(contract).estimatePlayerPower(any(Campaign.class));
-        when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
-
-        int difficulty = contract.calculateContractDifficulty(campaign);
-        assertEquals(5, difficulty);
-    }
-
-    @Test
-    void old_calculateContractDifficultyEqualSkillShouldBe1() {
-        contract = spy(contract);
-        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(2000.0).when(contract).estimatePlayerPower(any(Campaign.class));
-        when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
-
-        int difficulty = contract.calculateContractDifficulty(campaign);
-        assertEquals(1, difficulty);
-    }
-
-    @Test
-    void old_calculateContractDifficultyEqualSkillShouldBe4() {
-        contract = spy(contract);
-        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(525.0).when(contract).estimatePlayerPower(any(Campaign.class));
-        when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
-
-        int difficulty = contract.calculateContractDifficulty(campaign);
-        assertEquals(4, difficulty);
-    }
-
-    @Test
-    void old_calculateContractDifficultyEqualSkillShouldBe7() {
-        contract = spy(contract);
-        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(350.0).when(contract).estimatePlayerPower(any(Campaign.class));
-        when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
-
-        int difficulty = contract.calculateContractDifficulty(campaign);
-        assertEquals(7, difficulty);
-    }
-
-    @Test
-    void old_calculateContractDifficultyNoEnemyRatingShouldBeError() {
-        contract = spy(contract);
-        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(0.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(0.0).when(contract).estimatePlayerPower(any(Campaign.class));
-        when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
-
-        int difficulty = contract.calculateContractDifficulty(campaign);
-        assertEquals(-99, difficulty);
-    }
-
-    @Test
-    void new_calculateContractDifficultyEqualSkillShouldBe10() {
-        contract = spy(contract);
-        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(0.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
+        doReturn(enemyBV).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
+        doReturn(playerBV).when(contract).estimatePlayerPower(anyList(), anyBoolean());
         when(campaign.getGameYear()).thenReturn(3025);
         when(options.isUseGenericBattleValue()).thenReturn(true);
 
         int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
-        assertEquals(10, difficulty);
-    }
-
-    @Test
-    void new_calculateContractDifficultyEqualSkillShouldBe5() {
-        contract = spy(contract);
-        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(500.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
-        when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
-
-        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
-        assertEquals(5, difficulty);
-    }
-
-    @Test
-    void new_calculateContractDifficultyEqualSkillShouldBe1() {
-        contract = spy(contract);
-        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(2000.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
-        when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
-
-        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
-        assertEquals(1, difficulty);
-    }
-
-    @Test
-    void new_calculateContractDifficultyEqualSkillShouldBe4() {
-        contract = spy(contract);
-        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(525.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
-        when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
-
-        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
-        assertEquals(4, difficulty);
-    }
-
-    @Test
-    void new_calculateContractDifficultyEqualSkillShouldBe7() {
-        contract = spy(contract);
-        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(500.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(350.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
-        when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
-
-        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
-        assertEquals(7, difficulty);
-    }
-
-    @Test
-    void new_calculateContractDifficultyNoEnemyRatingShouldBeError() {
-        contract = spy(contract);
-        doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
-        doReturn(0.0).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
-        doReturn(0.0).when(contract).estimatePlayerPower(anyList(), anyBoolean());
-        when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
-
-        int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
-        assertEquals(-99, difficulty);
+        assertEquals(expectedResult, difficulty);
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -227,7 +227,7 @@ public class AtBContractTest {
     }
 
     @Test
-    void setContractTypeUpdatesParentMissionType() {
+    public void setContractTypeUpdatesParentMissionType() {
         contract.setContractType(AtBContractType.CADRE_DUTY);
         assertEquals(AtBContractType.CADRE_DUTY, contract.getContractType());
         assertEquals("Cadre Duty", contract.getType());
@@ -245,13 +245,13 @@ public class AtBContractTest {
 
     @ParameterizedTest
     @MethodSource("provideEnemyFactionAndYear")
-    void getEnemyNameReturnsCorrectValueInYear(int year, String enemyCode, String fullName) {
+    public void getEnemyNameReturnsCorrectValueInYear(int year, String enemyCode, String fullName) {
         contract.setEnemyCode(enemyCode);
         assertEquals(fullName, contract.getEnemyName(year));
     }
 
     @Test
-    void getEnemyNameReturnsCorrectValueWhenMerc() {
+    public void getEnemyNameReturnsCorrectValueWhenMerc() {
         String name = "Testing Merc";
         contract.setEnemyCode("MERC");
         contract.setEnemyBotName(name);
@@ -271,7 +271,7 @@ public class AtBContractTest {
 
     @ParameterizedTest
     @MethodSource("provideEmployerNamesAndMercStatus")
-    void getEmployerNameReturnsCorrectName(int year, boolean isMercSubcontract, String employerCode, String fullName) {
+    public void getEmployerNameReturnsCorrectName(int year, boolean isMercSubcontract, String employerCode, String fullName) {
         contract.setEmployerCode(employerCode, year);
         contract.setMercSubcontract(isMercSubcontract);
         assertEquals(fullName, contract.getEmployerName(year));

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -203,7 +203,7 @@ public class AtBContractTest {
 
     @ParameterizedTest
     @MethodSource("provideContractDifficultyParametersGBV")
-    void new_calculateContractDifficultySameSkillMatchesExpectedRating(double enemyBV,
+    public void new_calculateContractDifficultySameSkillMatchesExpectedRating(double enemyBV,
                                                                        double playerBV,
                                                                        int expectedResult) {
         contract = spy(contract);

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -247,8 +247,6 @@ public class AtBContractTest {
     @MethodSource("provideEnemyFactionAndYear")
     public void getEnemyNameReturnsCorrectValueInYear(int year, String enemyCode, String fullName) {
         contract.setEnemyCode(enemyCode);
-        // TODO: fix this in the production code
-        RandomCompanyNameGenerator.getInstance(); // Required in this codepath to generate a random merc company name
         assertEquals(fullName, contract.getEnemyName(year));
     }
 
@@ -258,6 +256,14 @@ public class AtBContractTest {
         contract.setEnemyCode("MERC");
         contract.setEnemyBotName(name);
         assertEquals(name, contract.getEnemyName(3025));
+    }
+
+    @Test
+    public void getEnemyNameReturnsNonNullWhenMercAndBotNameNotSet() {
+        contract.setEnemyCode("MERC");
+        // TODO: fix this in the production code
+        RandomCompanyNameGenerator.getInstance(); // Required in this codepath to generate a random merc company name
+        assertNotEquals("", contract.getEnemyName(3025));
     }
 
     private static Stream<Arguments> provideEmployerNamesAndMercStatus() {

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -47,7 +47,7 @@ public class AtBContractTest {
     private CampaignOptions options;
 
     @BeforeAll
-    public static void setup() {
+    public static void initSingletons() {
         EquipmentType.initializeTypes();
         Ranks.initializeRankSystems();
         try {
@@ -59,7 +59,7 @@ public class AtBContractTest {
     }
 
     @BeforeEach
-    void setUp() {
+    void setup() {
         campaign = mock(Campaign.class);
         options = mock(CampaignOptions.class);
         when(campaign.getCampaignOptions()).thenReturn(options);
@@ -256,5 +256,9 @@ public class AtBContractTest {
         contract.setEnemyCode("MERC");
         contract.setEnemyBotName(name);
         assertEquals(name, contract.getEnemyName(3025));
+    }
+
+    @Test
+    void getEmployerName() {
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -24,6 +24,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.mission.AtBContract.AtBContractRef;
 import mekhq.campaign.mission.enums.AtBContractType;
+import mekhq.campaign.personnel.backgrounds.RandomCompanyNameGenerator;
 import mekhq.campaign.personnel.ranks.Ranks;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Systems;
@@ -247,6 +248,8 @@ public class AtBContractTest {
     @MethodSource("provideEnemyFactionAndYear")
     public void getEnemyNameReturnsCorrectValueInYear(int year, String enemyCode, String fullName) {
         contract.setEnemyCode(enemyCode);
+        // TODO: fix this in the production code
+        RandomCompanyNameGenerator.getInstance(); // Required in this codepath to generate a random merc company name
         assertEquals(fullName, contract.getEnemyName(year));
     }
 

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -232,4 +232,29 @@ public class AtBContractTest {
         assertEquals(AtBContractType.CADRE_DUTY, contract.getContractType());
         assertEquals("Cadre Duty", contract.getType());
     }
+
+    private static Stream<Arguments> provideEnemyFactionAndYear() {
+        return Stream.of(
+            Arguments.of(3025, "LA", "Lyran Commonwealth"),
+            Arguments.of(3059, "LA", "Lyran Alliance"),
+            Arguments.of(-1, "LA", "Lyran Commonwealth"),
+            Arguments.of(3025, "??", "Unknown"),
+            Arguments.of(3025, "MERC", "")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideEnemyFactionAndYear")
+    void getEnemyNameReturnsCorrectValueInYear(int year, String enemyCode, String fullName) {
+        contract.setEnemyCode(enemyCode);
+        assertEquals(fullName, contract.getEnemyName(year));
+    }
+
+    @Test
+    void getEnemyNameReturnsCorrectValueWhenMerc() {
+        String name = "Testing Merc";
+        contract.setEnemyCode("MERC");
+        contract.setEnemyBotName(name);
+        assertEquals(name, contract.getEnemyName(3025));
+    }
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -23,6 +23,7 @@ import megamek.common.enums.SkillLevel;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.mission.AtBContract.AtBContractRef;
+import mekhq.campaign.mission.enums.AtBContractType;
 import mekhq.campaign.personnel.ranks.Ranks;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.Systems;
@@ -223,5 +224,12 @@ public class AtBContractTest {
 
         int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
         assertEquals(expectedResult, difficulty);
+    }
+
+    @Test
+    void setContractTypeUpdatesParentMissionType() {
+        contract.setContractType(AtBContractType.CADRE_DUTY);
+        assertEquals(AtBContractType.CADRE_DUTY, contract.getContractType());
+        assertEquals("Cadre Duty", contract.getType());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -52,6 +52,9 @@ public class AtBContractTest {
     public static void initSingletons() {
         EquipmentType.initializeTypes();
         Ranks.initializeRankSystems();
+        // TODO: fix this in the production code
+        RandomCallsignGenerator.getInstance(); // Required in this codepath to generate a random merc company name
+        RandomCompanyNameGenerator.getInstance(); // Required in this codepath to generate a random merc company name
         try {
             Factions.setInstance(Factions.loadDefault());
             Systems.setInstance(Systems.loadDefault());
@@ -262,9 +265,6 @@ public class AtBContractTest {
     @Test
     public void getEnemyNameReturnsNonNullWhenMercAndBotNameNotSet() {
         contract.setEnemyCode("MERC");
-        // TODO: fix this in the production code
-        RandomCallsignGenerator.getInstance(); // Required in this codepath to generate a random merc company name
-        RandomCompanyNameGenerator.getInstance(); // Required in this codepath to generate a random merc company name
         assertNotEquals("", contract.getEnemyName(3025));
     }
 

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -239,8 +239,7 @@ public class AtBContractTest {
             Arguments.of(3025, "LA", "Lyran Commonwealth"),
             Arguments.of(3059, "LA", "Lyran Alliance"),
             Arguments.of(-1, "LA", "Lyran Commonwealth"),
-            Arguments.of(3025, "??", "Unknown"),
-            Arguments.of(3025, "MERC", "")
+            Arguments.of(3025, "??", "Unknown")
         );
     }
 

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -174,44 +174,52 @@ public class AtBContractTest {
      *  they're testing when deemed safe to do so (roughly 0.50.4 or 0.50.5).
      */
 
-    private static Stream<Arguments> provideContractDifficultyParametersGBV() {
+    private static Stream<Arguments> provideContractDifficultyParameters() {
         return Stream.of(
-            Arguments.of(500.0, 0.0, 10),
-            Arguments.of(500.0, 500.0, 5),
-            Arguments.of(500.0, 2000.0, 1),
-            Arguments.of(500.0, 525.0, 4),
-            Arguments.of(500.0, 350.0, 7),
-            Arguments.of(0.0, 0.0, -99)
+            Arguments.of(500.0, 0.0, true, 10),
+            Arguments.of(500.0, 0.0, false, 10),
+            Arguments.of(500.0, 500.0, false, 5),
+            Arguments.of(500.0, 500.0, false, 5),
+            Arguments.of(500.0, 2000.0, true, 1),
+            Arguments.of(500.0, 2000.0, false, 1),
+            Arguments.of(500.0, 525.0, true, 4),
+            Arguments.of(500.0, 525.0, false, 4),
+            Arguments.of(500.0, 350.0, true, 7),
+            Arguments.of(500.0, 350.0, false, 7),
+            Arguments.of(0.0, 0.0, true, -99),
+            Arguments.of(0.0, 0.0, false, -99)
         );
     }
 
     @ParameterizedTest
-    @MethodSource("provideContractDifficultyParametersGBV")
+    @MethodSource("provideContractDifficultyParameters")
     public void old_calculateContractDifficultySameSkillMatchesExpectedRating(double enemyBV,
-                                                                        double playerBV,
-                                                                        int expectedResult) {
+                                                                              double playerBV,
+                                                                              boolean useGenericBattleValue,
+                                                                              int expectedResult) {
         contract = spy(contract);
         doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
         doReturn(enemyBV).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
         doReturn(playerBV).when(contract).estimatePlayerPower(any(Campaign.class));
         when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
+        when(options.isUseGenericBattleValue()).thenReturn(useGenericBattleValue);
 
         int difficulty = contract.calculateContractDifficulty(campaign);
         assertEquals(expectedResult, difficulty);
     }
 
     @ParameterizedTest
-    @MethodSource("provideContractDifficultyParametersGBV")
+    @MethodSource("provideContractDifficultyParameters")
     public void new_calculateContractDifficultySameSkillMatchesExpectedRating(double enemyBV,
-                                                                       double playerBV,
-                                                                       int expectedResult) {
+                                                                              double playerBV,
+                                                                              boolean useGenericBattleValue,
+                                                                              int expectedResult) {
         contract = spy(contract);
         doReturn(SkillLevel.REGULAR).when(contract).modifySkillLevelBasedOnFaction(anyString(), any(SkillLevel.class));
         doReturn(enemyBV).when(contract).estimateMekStrength(anyInt(), anyBoolean(), anyString(), anyInt());
         doReturn(playerBV).when(contract).estimatePlayerPower(anyList(), anyBoolean());
         when(campaign.getGameYear()).thenReturn(3025);
-        when(options.isUseGenericBattleValue()).thenReturn(true);
+        when(options.isUseGenericBattleValue()).thenReturn(useGenericBattleValue);
 
         int difficulty = contract.calculateContractDifficulty(3025, true, new ArrayList<>());
         assertEquals(expectedResult, difficulty);

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -18,6 +18,7 @@
  */
 package mekhq.campaign.mission;
 
+import megamek.client.generator.RandomCallsignGenerator;
 import megamek.common.EquipmentType;
 import megamek.common.enums.SkillLevel;
 import mekhq.campaign.Campaign;
@@ -262,6 +263,7 @@ public class AtBContractTest {
     public void getEnemyNameReturnsNonNullWhenMercAndBotNameNotSet() {
         contract.setEnemyCode("MERC");
         // TODO: fix this in the production code
+        RandomCallsignGenerator.getInstance(); // Required in this codepath to generate a random merc company name
         RandomCompanyNameGenerator.getInstance(); // Required in this codepath to generate a random merc company name
         assertNotEquals("", contract.getEnemyName(3025));
     }


### PR DESCRIPTION
This PR starts a larger effort  for increasing test coverage of the AtBContract and Contract classes. Specifically, this adds tests for the `calculateContractDifficulty()` method to ensure the calculations don't break during later refactoring. (_Note: tests for additional methods have been added while waiting for a review_)

A couple of internal helper functions needed to be changed from `static private` to non-static/package private to enable mocking. I've also attempted to begin transitioning to not using `Campaign` objects as an argument to reduce coupling, in this case by adding new versions of two functions and marking the old ones deprecated. I've covered both the new and old ones with unit tests to make sure the behavior doesn't change between versions.

Regarding the new methods `estimatePlayerPower(List<Entity> units, boolean useGenericBV)` and `Campaign.getAllCombatEntities()`, passing around a list of raw Entities like that feels awkward and I have some reservations about that. `Force` would be ideal in theory but is similarly awkward in that it has to reach through `Campaign` to map UUIDs to Entities which tightens the coupling. No other methods should call these versions until we're ready to remove the deprecated versions, so we have some time to refactor that if there's a better way, just let me know.