### PR TITLE
Fix Issue #6065: Unit History in UnitViewPanel does not wrap.

### DIFF
--- a/MekHQ/src/mekhq/gui/baseComponents/JScrollablePanel.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/JScrollablePanel.java
@@ -28,7 +28,6 @@ import javax.swing.*;
  *
  * @author aarong original author
  */
-@Deprecated // Replace with AbstractMHQScrollablePanel and DefaultMHQScrollablePanel
 public class JScrollablePanel extends JPanel implements Scrollable {
     //region Variable Declarations
     // by default, track the width, and re-size as needed.

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -25,6 +25,7 @@ import megamek.common.TechConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
+import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.utilities.ImgLabel;
 import mekhq.gui.utilities.MarkdownRenderer;
 
@@ -36,7 +37,7 @@ import java.util.ResourceBundle;
  * A custom panel that gets filled in with goodies from a unit record
  * @author  Jay Lawson (jaylawson39 at yahoo.com)
  */
-public class UnitViewPanel extends JPanel {
+public class UnitViewPanel extends JScrollablePanel {
     private Unit unit;
     private Entity entity;
     private Campaign campaign;
@@ -86,7 +87,7 @@ public class UnitViewPanel extends JPanel {
             gridBagConstraints.gridx = 1;
             gridBagConstraints.gridy = 0;
             gridBagConstraints.gridheight = 3;
-            gridBagConstraints.weightx = 1.0;
+            gridBagConstraints.weightx = 0.5;
             gridBagConstraints.insets = new Insets(5, 5, 5, 5);
             gridBagConstraints.fill = GridBagConstraints.BOTH;
             gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
@@ -103,7 +104,7 @@ public class UnitViewPanel extends JPanel {
                 gridBagConstraints.gridx = 1;
                 gridBagConstraints.gridy = 0;
                 gridBagConstraints.gridheight = 1;
-                gridBagConstraints.weightx = 1.0;
+                gridBagConstraints.weightx = 0.0;
                 gridBagConstraints.fill = GridBagConstraints.BOTH;
                 gridBagConstraints.anchor = GridBagConstraints.CENTER;
                 add(lblImage, gridBagConstraints);
@@ -116,7 +117,7 @@ public class UnitViewPanel extends JPanel {
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
-        gridBagConstraints.weightx = 0.0;
+        gridBagConstraints.weightx = 0.5;
         gridBagConstraints.gridwidth = 1;
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         gridBagConstraints.fill = GridBagConstraints.BOTH;
@@ -135,7 +136,7 @@ public class UnitViewPanel extends JPanel {
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
-        gridBagConstraints.weightx = 0.0;
+        gridBagConstraints.weightx = 0.5;
         gridBagConstraints.gridwidth = compWidth;
         if (unit.getHistory().isBlank()) {
             gridBagConstraints.weighty = 1.0;
@@ -156,7 +157,7 @@ public class UnitViewPanel extends JPanel {
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = 2;
-            gridBagConstraints.weightx = 0.0;
+            gridBagConstraints.weightx = 0.5;
             gridBagConstraints.weighty = 1.0;
             gridBagConstraints.gridwidth = compWidth;
             gridBagConstraints.insets = new Insets(5, 5, 5, 5);


### PR DESCRIPTION
Fixes #6065. The simple solution to this was to make `UnitViewPanel` a `JScrollablePanel`. The class was marked as deprecated, but I think that is inaccurate as we still use it for all of our view panels (e.g. PersonViewPanel, ScenarioViewPanel), and the suggested replacement (`AbstractMHQScrollablePanel`) does not work for any of these view panels, as it requires things in its constructor that these view panels don't have access to. Therefore, I have removed the deprecated tag. Long live `JScrollablePanel`. 