### PR TITLE
Enhancement - Allow Battle Armor suits from different squad sizes to be used as replacements

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -54,7 +54,7 @@ import mekhq.utilities.MHQXMLUtility;
  * that modular equipment can now be removed separately. We still need to figure
  * out how to acquire
  * new suits that come pre-packaged with all of their equipment.
- * 
+ *
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
 public class BattleArmorSuit extends Part {
@@ -326,8 +326,13 @@ public class BattleArmorSuit extends Part {
         // return false;
         return part instanceof BattleArmorSuit
                 && chassis.equals(((BattleArmorSuit) part).getChassis())
-                && model.equals(((BattleArmorSuit) part).getModel())
+                && removeBattleArmorSquadSize(model)
+                    .equals(removeBattleArmorSquadSize(((BattleArmorSuit) part).getModel()))
                 && getStickerPrice().equals(part.getStickerPrice());
+    }
+
+    private String removeBattleArmorSquadSize(String model) {
+        return model.replaceAll("(\\(Sqd\\d)\\)$", "");
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -122,7 +122,12 @@ public class MissingBattleArmorSuit extends MissingPart {
     public boolean isAcceptableReplacement(Part part, boolean refit) {
         return part instanceof BattleArmorSuit
                 && chassis.equals(((BattleArmorSuit) part).getChassis())
-                && model.equals(((BattleArmorSuit ) part).getModel());
+                && removeBattleArmorSquadSize(model)
+                    .equals(removeBattleArmorSquadSize(((BattleArmorSuit) part).getModel()));
+    }
+
+    private String removeBattleArmorSquadSize(String model) {
+        return model.replaceAll("(\\(Sqd\\d)\\)$", "");
     }
 
     @Override


### PR DESCRIPTION
When comparing if two BattleArmor parts are the same it will strip (Sqd#) from the model. The price for each part is already the same regardless of part size, so now `Elemental[Flamer](Sqd5)` can be used to replace a missing `Elemental[Flamer](Sqd4)`.