### PR TITLE
Enhancement - A further enhancement for BA Suit swappability in MekHQ

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -77,7 +77,7 @@ public class BattleArmorSuit extends Part {
     // It is costly looking up entity, which is used to compare if two suits
     // are the same even if the chassis name doesn't match. So let's save these
     // values if we've already calculated them once.
-    private boolean entityDetailsCached = false;
+    private transient boolean entityDetailsCached = false;
     private transient int suitBV;
     private transient int weaponTypeListHash;
 

--- a/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/BattleArmorSuit.java
@@ -328,13 +328,21 @@ public class BattleArmorSuit extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        // because of the linked children parts, we always need to consider these as
-        // different
-        // return false;
-        return part instanceof BattleArmorSuit baSuit
+        refreshEntityDetailsCache();
+        if (entityDetailsCached) {
+            return part instanceof BattleArmorSuit baSuit
                 && getSuitBV() == baSuit.getSuitBV()
                 && getWeaponTypeListHash() == baSuit.getWeaponTypeListHash()
                 && getStickerPrice().equals(baSuit.getStickerPrice());
+        }
+        // If we didn't successfully cache entity details, use the old method for comparing.
+        // because of the linked children parts, we always need to consider these as
+        // different
+        // return false;
+        return part instanceof BattleArmorSuit
+            && chassis.equals(((BattleArmorSuit) part).getChassis())
+            && model.equals(((BattleArmorSuit) part).getModel())
+            && getStickerPrice().equals(part.getStickerPrice());
     }
 
     public int getSuitBV() {
@@ -669,9 +677,11 @@ public class BattleArmorSuit extends Part {
         if (!entityDetailsCached) {
             mekhq.campaign.parts.utilities.BattleArmorSuitUtility battleArmorSuitUtility
                 = new  mekhq.campaign.parts.utilities.BattleArmorSuitUtility(chassis, model);
-            suitBV = battleArmorSuitUtility.getBattleArmorSuitBV();
-            weaponTypeListHash = battleArmorSuitUtility.getWeaponTypeListHash();
-            entityDetailsCached = true;
+            if (battleArmorSuitUtility.hasEntity()) {
+                suitBV = battleArmorSuitUtility.getBattleArmorSuitBV();
+                weaponTypeListHash = battleArmorSuitUtility.getWeaponTypeListHash();
+                entityDetailsCached = true;
+            }
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -127,9 +127,17 @@ public class MissingBattleArmorSuit extends MissingPart {
 
     @Override
     public boolean isAcceptableReplacement(Part part, boolean refit) {
-        return part instanceof BattleArmorSuit baSuit
-            && getSuitBV() == baSuit.getSuitBV()
-            && getWeaponTypeListHash() == baSuit.getWeaponTypeListHash();
+        refreshEntityDetailsCache();
+        if (entityDetailsCached) {
+            return part instanceof BattleArmorSuit baSuit
+                && getSuitBV() == baSuit.getSuitBV()
+                && getWeaponTypeListHash() == baSuit.getWeaponTypeListHash();
+        }
+
+        // If we didn't successfully cache entity details, use the old method for comparing.
+        return part instanceof BattleArmorSuit
+            && chassis.equals(((BattleArmorSuit) part).getChassis())
+            && model.equals(((BattleArmorSuit ) part).getModel());
     }
 
     public int getSuitBV() {
@@ -340,9 +348,11 @@ public class MissingBattleArmorSuit extends MissingPart {
         if (!entityDetailsCached) {
             mekhq.campaign.parts.utilities.BattleArmorSuitUtility battleArmorSuitUtility
                 = new  mekhq.campaign.parts.utilities.BattleArmorSuitUtility(chassis, model);
-            suitBV = battleArmorSuitUtility.getBattleArmorSuitBV();
-            weaponTypeListHash = battleArmorSuitUtility.getWeaponTypeListHash();
-            entityDetailsCached = true;
+            if (battleArmorSuitUtility.hasEntity()) {
+                suitBV = battleArmorSuitUtility.getBattleArmorSuitBV();
+                weaponTypeListHash = battleArmorSuitUtility.getWeaponTypeListHash();
+                entityDetailsCached = true;
+            }
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingBattleArmorSuit.java
@@ -56,7 +56,7 @@ public class MissingBattleArmorSuit extends MissingPart {
     // It is costly looking up entity, which is used to compare if two suits
     // are the same even if the chassis name doesn't match. So let's save these
     // values if we've already calculated them once.
-    private boolean entityDetailsCached = false;
+    private transient boolean entityDetailsCached = false;
     private transient int suitBV;
     private transient int weaponTypeListHash;
 

--- a/MekHQ/src/mekhq/campaign/parts/utilities/BattleArmorSuitUtility.java
+++ b/MekHQ/src/mekhq/campaign/parts/utilities/BattleArmorSuitUtility.java
@@ -32,10 +32,10 @@ import java.util.List;
 /**
  * Battle Armor Suits and Missing Battle Armor Suits do not
  * track enough information to determine if two suits with
- * different chassis are actually the same - for example,
- * an Elemental [Flamer](Sqd5) suit being used for
- * Elemental [Flamer](Sqd3). This utility class will look
- * up a BA part's corresponding entity and can be used
+ * same chassis but different model names are actually the
+ * same - for example, an Elemental [Flamer](Sqd5) suit being
+ * used for Elemental [Flamer](Sqd3). This utility class will
+ * look up a BA part's corresponding entity and can be used
  * to get the information needed for the part/missing part
  * to make the comparison.
  *

--- a/MekHQ/src/mekhq/campaign/parts/utilities/BattleArmorSuitUtility.java
+++ b/MekHQ/src/mekhq/campaign/parts/utilities/BattleArmorSuitUtility.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ *  This file is part of MekHQ.
+ *
+ *  MekHQ is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  MekHQ is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with MekHQ. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mekhq.campaign.parts.utilities;
+
+import megamek.codeUtilities.StringUtility;
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import megamek.common.battlevalue.BVCalculator;
+import megamek.common.battlevalue.BattleArmorBVCalculator;
+import megamek.common.equipment.WeaponMounted;
+import megamek.logging.MMLogger;
+
+import java.util.List;
+
+/**
+ * Battle Armor Suits and Missing Battle Armor Suits do not
+ * track enough information to determine if two suits with
+ * different chassis are actually the same - for example,
+ * an Elemental [Flamer](Sqd5) suit being used for
+ * Elemental [Flamer](Sqd3). This utility class will look
+ * up a BA part's corresponding entity and can be used
+ * to get the information needed for the part/missing part
+ * to make the comparison.
+ *
+ * @see mekhq.campaign.parts.MissingBattleArmorSuit
+ * @see mekhq.campaign.parts.BattleArmorSuit
+ */
+public class BattleArmorSuitUtility {
+    private static final MMLogger logger = MMLogger.create(BattleArmorSuitUtility.class);
+
+    String chassis;
+    String model;
+
+    Entity entity;
+
+    public BattleArmorSuitUtility(String chassis, String model) {
+        this.chassis = chassis;
+        this.model = model;
+
+        entity = getEntity(this.chassis, this.model);
+    }
+
+    /**
+     * The same BA chassis in different sizes should have the same suit BV
+     * @return int BV of the individual BA suit
+     */
+    public int getBattleArmorSuitBV() {
+        return getBattleArmorSuitBV(entity);
+    }
+
+    /**
+     * The same BA chassis in different sizes should have the same weapon
+     * type list hash. It's hashed because we don't actually care about
+     * the details, we just need to compare if two BA entities have the same
+     * weapons. This should do that.
+     * @return int the list of weapon types this BA entity has, hashed
+     */
+    public int getWeaponTypeListHash() {
+        return getWeaponTypeListHash(entity);
+    }
+
+    private static int getWeaponTypeListHash(Entity entity) {
+        List<WeaponMounted> entityWeaponList = entity.getIndividualWeaponList();
+        List<WeaponType> entityWeaponTypeList = entityWeaponList.stream().map(WeaponMounted::getType).toList();
+        return entityWeaponTypeList.hashCode();
+    }
+
+    private static int getBattleArmorSuitBV(Entity entity) {
+        if (entity instanceof BattleArmor ba) {
+            BVCalculator calc = ba.getBvCalculator();
+            if (calc instanceof BattleArmorBVCalculator bvCalc) {
+                return bvCalc.singleTrooperBattleValue();
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Parts don't store their entity. We can look it up in the same way that
+     * the MUL parser does, using the chassis and model. This is based on the
+     * MULParser's implementation.
+     * @see MULParser#getEntity(String, String)
+     */
+    private static Entity getEntity(String chassis, @Nullable String model) {
+        StringBuffer key = new StringBuffer(chassis);
+        MekSummary ms = MekSummaryCache.getInstance().getMek(key.toString());
+        if (!StringUtility.isNullOrBlank(model)) {
+            key.append(" ").append(model);
+            ms = MekSummaryCache.getInstance().getMek(key.toString());
+            // That didn't work. Try swapping model and chassis.
+            if (ms == null) {
+                key = new StringBuffer(model);
+                key.append(" ").append(chassis);
+                ms = MekSummaryCache.getInstance().getMek(key.toString());
+            }
+        }
+        Entity newEntity = null;
+        if (ms != null) {
+            try {
+                newEntity = new MekFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
+            } catch (Exception ex) {
+                logger.error(ex.getMessage(), ex);
+            }}
+        return newEntity;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/parts/utilities/BattleArmorSuitUtility.java
+++ b/MekHQ/src/mekhq/campaign/parts/utilities/BattleArmorSuitUtility.java
@@ -58,6 +58,14 @@ public class BattleArmorSuitUtility {
     }
 
     /**
+     * The entity might be null if there was an exception.
+     * @return true if the entity exists, false if the entity is null
+     */
+    public boolean hasEntity() {
+        return entity != null;
+    }
+
+    /**
      * The same BA chassis in different sizes should have the same suit BV
      * @return int BV of the individual BA suit
      */


### PR DESCRIPTION
This uses some values from the suit's entity to determine if two parts are the same.

If for whatever reason we can't find the suit's entity then it'll fallback to using the original comparison method. 

If it can find the entity, then instead of comparing model name it'll compare the per-suit BV and the weapon types the entity has.