### PR TITLE
Added Reputation Sanity Options to Campaign Settings

### DIFF
--- a/MekHQ/mmconf/campaignPresets/CampaignOperations.xml
+++ b/MekHQ/mmconf/campaignPresets/CampaignOperations.xml
@@ -7,6 +7,9 @@
 	<gm>true</gm>
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
+		<clampReputationPayMultiplier>false</clampReputationPayMultiplier>
+		<reduceReputationPerformanceModifier>false</reduceReputationPerformanceModifier>
+		<reputationPerformanceModifierCutOff>false</reputationPerformanceModifierCutOff>
 		<logMaintenance>false</logMaintenance>
 		<defaultMaintenanceTime>4</defaultMaintenanceTime>
 		<mrmsUseRepair>true</mrmsUseRepair>

--- a/MekHQ/mmconf/campaignPresets/CampaignOperationsStratCon.xml
+++ b/MekHQ/mmconf/campaignPresets/CampaignOperationsStratCon.xml
@@ -7,6 +7,9 @@
 	<gm>true</gm>
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
+        <clampReputationPayMultiplier>false</clampReputationPayMultiplier>
+        <reduceReputationPerformanceModifier>false</reduceReputationPerformanceModifier>
+        <reputationPerformanceModifierCutOff>false</reputationPerformanceModifierCutOff>
 		<logMaintenance>false</logMaintenance>
 		<defaultMaintenanceTime>4</defaultMaintenanceTime>
 		<mrmsUseRepair>true</mrmsUseRepair>

--- a/MekHQ/mmconf/campaignPresets/NewPilotProgram.xml
+++ b/MekHQ/mmconf/campaignPresets/NewPilotProgram.xml
@@ -7,6 +7,9 @@
 	<gm>false</gm>
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
+        <clampReputationPayMultiplier>true</clampReputationPayMultiplier>
+        <reduceReputationPerformanceModifier>true</reduceReputationPerformanceModifier>
+        <reputationPerformanceModifierCutOff>true</reputationPerformanceModifierCutOff>
 		<logMaintenance>false</logMaintenance>
 		<defaultMaintenanceTime>4</defaultMaintenanceTime>
 		<mrmsUseRepair>true</mrmsUseRepair>

--- a/MekHQ/mmconf/campaignPresets/TheCompleteExperience.xml
+++ b/MekHQ/mmconf/campaignPresets/TheCompleteExperience.xml
@@ -8,6 +8,9 @@
 	<gm>false</gm>
 	<campaignOptions>
 		<manualUnitRatingModifier>0</manualUnitRatingModifier>
+        <clampReputationPayMultiplier>true</clampReputationPayMultiplier>
+        <reduceReputationPerformanceModifier>true</reduceReputationPerformanceModifier>
+        <reputationPerformanceModifierCutOff>true</reputationPerformanceModifierCutOff>
 		<logMaintenance>false</logMaintenance>
 		<defaultMaintenanceTime>4</defaultMaintenanceTime>
 		<mrmsUseRepair>true</mrmsUseRepair>

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -57,6 +57,35 @@ lblReputation.tooltip=Which reputation method should your campaign be graded aga
   <br><b>Recommended:</b> Campaign Operations
 lblManualUnitRatingModifier.text=Manual Modifier
 lblManualUnitRatingModifier.tooltip=This allows you to manually adjust your reputation rating.
+lblClampReputationPayMultiplier.text=Clamp Reputation Pay Multiplier \u26A0 \u2714
+lblClampReputationPayMultiplier.tooltip=When using CamOps Reputation your unit's reputation score\
+  \ affects contract pay. This option clamps the reputation-based multiplier between 50 and 200%.\
+  <br>\
+  <br><b>Warning:</b> As CamOps Reputation has no maximum or minimum value disabling this option\
+  \ will result in contract pay becoming increasingly inflated as the campaign progresses. This is\
+  \ particularly a problem for generational campaigns expected to last decades or longer.\
+  <br>\
+  <br><b>Recommended</b>: Leave enabled.
+lblReduceReputationPerformanceModifier.text=Reduce Mission Performance Score \u26A0 \u2714
+lblReduceReputationPerformanceModifier.tooltip=When using CamOps Reputation your unit's past\
+  \ contract performance affects contract pay. This option reduces the impact of successes,\
+  \ failures, and breaches by 80%.\
+  <br>\
+  <br><b>Warning:</b> CamOps was never designed for the kind of contract tempo we can achieve\
+  \ through MekHQ. Resulting in longer campaigns reaching astronomical heights in terms of\
+  \ Reputation. This has knock-on effects whenever Reputation is used to influence a system.\
+  <br>\
+  <br><b>Recommended</b>: This option helps slow growth to more sane levels. Leave enabled.
+lblReputationPerformanceModifierCutOff.text=Ignore Old Missions \u26A0 \u2714
+lblReputationPerformanceModifierCutOff.tooltip=When using CamOps Reputation all past contracts\
+  \ affect future contract pay. This option tells MekHQ to ignore any contracts that were completed\
+  \ over a decade ago. Only Legacy AtB and StratCon contracts are affected.\
+  <br>\
+  <br><b>Warning:</b> CamOps was never designed for campaigns lasting as long as those enjoyed by\
+  \ many users of MekHQ. This results in progressive Reputation bloat over a long enough period.\
+  <br>\
+  <br><b>Recommended</b>: This option helps ensure reputation doesn't spiral out of control. Leave\
+  \ enabled.
 lblDate.text=Start Date
 lblDate.tooltip=When should the campaign begin?
 lblCamo.text=Unit Camouflage

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -79,6 +79,8 @@ public class CampaignOptions {
     public static final double MAXIMUM_JUMPSHIP_EQUIPMENT_PERCENT = 1.0;
     public static final double MAXIMUM_WARSHIP_EQUIPMENT_PERCENT = 1.0;
 
+    public static final int REPUTATION_PERFORMANCE_CUT_OFF_YEARS = 10;
+
     public static String getTechLevelName(final int techLevel) {
         return switch (techLevel) {
             case TECH_INTRO -> TechConstants.T_SIMPLE_NAMES[TechConstants.T_SIMPLE_INTRO];
@@ -95,6 +97,9 @@ public class CampaignOptions {
     // region General Tab
     private UnitRatingMethod unitRatingMethod;
     private int manualUnitRatingModifier;
+    private boolean clampReputationPayMultiplier;
+    private boolean reduceReputationPerformanceModifier;
+    private boolean reputationPerformanceModifierCutOff;
     // endregion General Tab
 
     // region Repair and Maintenance Tab
@@ -603,6 +608,9 @@ public class CampaignOptions {
         // region General Tab
         unitRatingMethod = UnitRatingMethod.CAMPAIGN_OPS;
         manualUnitRatingModifier = 0;
+        clampReputationPayMultiplier = false;
+        reduceReputationPerformanceModifier = false;
+        reputationPerformanceModifierCutOff = false;
         // endregion General Tab
 
         // region Repair and Maintenance Tab
@@ -1224,6 +1232,30 @@ public class CampaignOptions {
 
     public void setManualUnitRatingModifier(final int manualUnitRatingModifier) {
         this.manualUnitRatingModifier = manualUnitRatingModifier;
+    }
+
+    public boolean isClampReputationPayMultiplier() {
+        return clampReputationPayMultiplier;
+    }
+
+    public void setClampReputationPayMultiplier(final boolean clampReputationPayMultiplier) {
+        this.clampReputationPayMultiplier = clampReputationPayMultiplier;
+    }
+
+    public boolean isReduceReputationPerformanceModifier() {
+        return reduceReputationPerformanceModifier;
+    }
+
+    public void setReduceReputationPerformanceModifier(final boolean reduceReputationPerformanceModifier) {
+        this.reduceReputationPerformanceModifier = reduceReputationPerformanceModifier;
+    }
+
+    public boolean isReputationPerformanceModifierCutOff() {
+        return reputationPerformanceModifierCutOff;
+    }
+
+    public void setReputationPerformanceModifierCutOff(final boolean reputationPerformanceModifierCutOff) {
+        this.reputationPerformanceModifierCutOff = reputationPerformanceModifierCutOff;
     }
     // endregion General Tab
 
@@ -4579,6 +4611,9 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "campaignOptions");
         // region General Tab
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "manualUnitRatingModifier", getManualUnitRatingModifier());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "clampReputationPayMultiplier", isClampReputationPayMultiplier());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "reduceReputationPerformanceModifier", isReduceReputationPerformanceModifier());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "reputationPerformanceModifierCutOff", isReputationPerformanceModifierCutOff());
         // endregion General Tab
 
         // region Repair and Maintenance Tab
@@ -5313,6 +5348,12 @@ public class CampaignOptions {
                     retVal.setUnitRatingMethod(UnitRatingMethod.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("manualUnitRatingModifier")) {
                     retVal.setManualUnitRatingModifier(Integer.parseInt(wn2.getTextContent()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("clampReputationPayMultiplier")) {
+                    retVal.setClampReputationPayMultiplier(Boolean.parseBoolean(wn2.getTextContent()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("reduceReputationPerformanceModifier")) {
+                    retVal.setReduceReputationPerformanceModifier(Boolean.parseBoolean(wn2.getTextContent()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("reputationPerformanceModifierCutOff")) {
+                    retVal.setReputationPerformanceModifierCutOff(Boolean.parseBoolean(wn2.getTextContent()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("usePortraitForType")) {
                     String[] values = wn2.getTextContent().split(",");
                     for (int i = 0; i < values.length; i++) {

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -80,6 +80,9 @@ public class GeneralTab {
     private MMComboBox<UnitRatingMethod> unitRatingMethodCombo;
     private JLabel lblManualUnitRatingModifier;
     private JSpinner manualUnitRatingModifier;
+    private JCheckBox chkClampReputationPayMultiplier;
+    private JCheckBox chkReduceReputationPerformanceModifier;
+    private JCheckBox chkReputationPerformanceModifierCutOff;
     private JLabel lblDate;
     private JButton btnDate;
     private LocalDate date;
@@ -149,6 +152,9 @@ public class GeneralTab {
         lblManualUnitRatingModifier = new CampaignOptionsLabel("ManualUnitRatingModifier");
         manualUnitRatingModifier = new CampaignOptionsSpinner("ManualUnitRatingModifier",
             0, -200, 200, 1);
+        chkClampReputationPayMultiplier = new CampaignOptionsCheckBox("ClampReputationPayMultiplier");
+        chkReduceReputationPerformanceModifier = new CampaignOptionsCheckBox("ReduceReputationPerformanceModifier");
+        chkReputationPerformanceModifierCutOff = new CampaignOptionsCheckBox("ReputationPerformanceModifierCutOff");
 
         // Date
         lblDate = new CampaignOptionsLabel("Date");
@@ -213,6 +219,13 @@ public class GeneralTab {
         layout.gridy++;
         panel.add(lblManualUnitRatingModifier, layout);
         panel.add(manualUnitRatingModifier, layout);
+        layout.gridy++;
+        layout.gridwidth = 3;
+        panel.add(chkClampReputationPayMultiplier, layout);
+        layout.gridy++;
+        panel.add(chkReduceReputationPerformanceModifier, layout);
+        layout.gridy++;
+        panel.add(chkReputationPerformanceModifierCutOff, layout);
 
         layout.gridy++;
         layout.gridwidth = 5;
@@ -301,6 +314,10 @@ public class GeneralTab {
 
         lblManualUnitRatingModifier = new JLabel();
         manualUnitRatingModifier = new JSpinner();
+
+        chkClampReputationPayMultiplier = new JCheckBox();
+        chkReduceReputationPerformanceModifier = new JCheckBox();
+         chkReputationPerformanceModifierCutOff = new JCheckBox();
 
         lblDate = new JLabel();
         btnDate = new JButton();
@@ -498,6 +515,9 @@ public class GeneralTab {
 
         unitRatingMethodCombo.setSelectedItem(options.getUnitRatingMethod());
         manualUnitRatingModifier.setValue(options.getManualUnitRatingModifier());
+        chkClampReputationPayMultiplier.setSelected(options.isClampReputationPayMultiplier());
+        chkReduceReputationPerformanceModifier.setSelected(options.isReduceReputationPerformanceModifier());
+        chkReputationPerformanceModifierCutOff.setSelected(options.isReputationPerformanceModifierCutOff());
 
         date = campaign.getLocalDate();
         if (presetDate != null) {
@@ -554,5 +574,8 @@ public class GeneralTab {
 
         options.setUnitRatingMethod(unitRatingMethodCombo.getSelectedItem());
         options.setManualUnitRatingModifier((int) manualUnitRatingModifier.getValue());
+        options.setClampReputationPayMultiplier(chkClampReputationPayMultiplier.isSelected());
+        options.setReduceReputationPerformanceModifier(chkReduceReputationPerformanceModifier.isSelected());
+        options.setReputationPerformanceModifierCutOff(chkReputationPerformanceModifierCutOff.isSelected());
     }
 }


### PR DESCRIPTION
- Introduced options to clamp reputation-based pay, reduce mission performance score impact, and apply a cutoff for old missions in reputation calculations.

These changes aim to prevent excessive reputation inflation, particularly in long-running campaigns.

## Dev Notes
### Rampant Reputation and the 50.03 Update  
The issue of **Rampant Reputation** emerged in version 50.03 when we fixed a bug that had been preventing contract pay from correctly factoring in Reputation. This fix led to an extreme spike in contract pay—so significant that it was initially mistaken for a new bug. However, after investigation, we confirmed that the system was functioning according to **Rules as Written** and that the issue stemmed from the adaptation of **CamOps** mechanics into **MekHQ**.  

CamOps was designed for in-person groups who typically play only a few times a month, essentially a **D&D-style campaign with Meks**. A full campaign that would take an in-person group **a year or more** to complete can be finished in MekHQ in under an hour, especially with Luana's fantastic **auto-resolve** options. When combined with MekHQ’s **robust personnel simulation**, this encourages players to engage in **generational campaigns**—campaigns that span **decades of in-game time**, where personnel **age, marry, have children, and pass the campaign on to the next generation**.  

As a result, over time, **Reputation scores of 300, 600, or even higher** become inevitable. This becomes a serious issue when calculating **contract pay**, which uses an **uncapped multiplier** with no limiters. In a long-running campaign spanning from the **Age of War to ilClan**, Reputation could theoretically reach **1,000 or more**, with no upper boundary.  

Following the release of version 50.03, we extensively discussed possible solutions but struggled to find a single approach that effectively controlled the issue. Every proposal we considered failed to fully address the problem. Ultimately, we decided on a **three-pronged resolution**. 

### The Three-Pronged Solution  
1. **Capping Reputation’s Effect on Contract Pay**  
When this setting is enabled, the contract pay multiplier from Reputation is limited to a range between **0.5 and 2.0**. This ensures that no matter how high or low a campaign’s Reputation becomes, contract pay remains within a **reasonable range**.

The chosen band matches the **old FM:Mercenaries (revised) values**, keeping it in line with established mechanics.  

2. **Reducing Performance Impact on Reputation Gains**
When this option is enabled, the modifier to **Reputation gains from contract performance** is reduced by **80%**.  

- A **successful contract** will now increase Reputation by **1** instead of 5.  
- A **failed contract** will reduce Reputation by **2** instead of 10.  
- A **contract breach** now results in a **5-point reduction** instead of 25.  

By slowing the rate of Reputation progression, this change helps mitigate the impact of MekHQ’s accelerated contract completion speed.  

3. **Disregarding Old Contracts**
When enabled, **AtB and StratCon contracts that ended more than 10 years ago** are ignored when calculating Reputation modifiers. This ensures that campaigns are measured based on **current performance** rather than being artificially inflated by past successes. It also acts as a **sanity pass** for some of the **exceptionally long-running campaigns** that players have maintained over the years.  

### Implementation and Defaults  
All three of these options can be toggled in **Campaign Options** and apply **retroactively**.  

- In the **New Pilot Program** and **Complete Experience** presets, all three settings are **enabled by default**.  
- In contrast, they remain **disabled by default** in the two **CamOps presets**, as those presets are designed to adhere to **Rules as Written**. 

All three options are **disabled by default** in existing campaigns.
