### PR TITLE
Refactor/deprecate dead code

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
@@ -194,7 +194,7 @@ public class CamOpsContractMarket extends AbstractContractMarket {
         contractIds.put(lastId, contract);
         // Step 1: Determine Employer
         Faction employer = determineEmployer(campaign, reputation.getReputationModifier(), hiringHallModifiers);
-        contract.setEmployerCode(employer.getShortName(), campaign.getLocalDate());
+        contract.setEmployerCode(employer.getShortName(), campaign.getGameYear());
         if (employer.isMercenary()) {
             contract.setMercSubcontract(true);
         }

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1344,6 +1344,7 @@ public class AtBContract extends Contract {
         return employerCode;
     }
 
+    @Deprecated
     public void setEmployerCode(final String code, final LocalDate date) {
         employerCode = code;
         setEmployer(getEmployerName(date.getYear()));

--- a/MekHQ/src/mekhq/io/migration/FactionMigrator.java
+++ b/MekHQ/src/mekhq/io/migration/FactionMigrator.java
@@ -24,6 +24,7 @@ import mekhq.campaign.mission.BotForce;
 
 import java.util.Objects;
 
+@Deprecated
 public class FactionMigrator {
 
     /**


### PR DESCRIPTION
While writing tests I found a `setEmployerCode()` overload which was only used by CO Contract Market and a dead/unused class called FactionMigrator. This overload also appeared to have a bug where it was setting the enemy camo instead of the ally camo.

This marks the method and class deprecated for later removal and switches the call in CO contract market to the correct version.