### PR TITLE
Fixed File Path Separator for `RandomEventLibraries` on Windows

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/RandomEventLibraries.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/RandomEventLibraries.java
@@ -25,9 +25,10 @@ import mekhq.campaign.randomEvents.prisoners.yaml.PrisonerEventDataWrapper;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+
+import static java.io.File.separator;
 
 /**
  * A utility class that manages the loading and retrieval of random event data
@@ -38,15 +39,15 @@ public class RandomEventLibraries {
     /**
      * Directory path where event YAML files are located.
      */
-    private final String DIRECTORY = "data/randomEvents/";
+    private final String DIRECTORY = "data" + separator + "randomEvents" + separator;
 
     /**
      * File extension for the YAML files.
      */
     private final String EXTENSION = ".yml";
 
-    private final String PRISONER_EVENTS_MAJOR = Paths.get(DIRECTORY + "PrisonerMajorEventData" + EXTENSION).toString();
-    private final String PRISONER_EVENTS_MINOR = Paths.get(DIRECTORY + "PrisonerMinorEventData" + EXTENSION).toString();
+    private final String PRISONER_EVENTS_MAJOR = DIRECTORY + "PrisonerMajorEventData" + EXTENSION;
+    private final String PRISONER_EVENTS_MINOR = DIRECTORY + "PrisonerMinorEventData" + EXTENSION;
 
     // lists
     private List<PrisonerEventData> prisonerEventsMajor = new ArrayList<>();

--- a/MekHQ/src/mekhq/campaign/randomEvents/RandomEventLibraries.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/RandomEventLibraries.java
@@ -37,7 +37,7 @@ public class RandomEventLibraries {
     /**
      * Directory path where event YAML files are located.
      */
-    private final String DIRECTORY = "data/randomEvents/";
+    private final String DIRECTORY = "data\\randomEvents\\";
 
     /**
      * File extension for the YAML files.

--- a/MekHQ/src/mekhq/campaign/randomEvents/RandomEventLibraries.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/RandomEventLibraries.java
@@ -25,6 +25,7 @@ import mekhq.campaign.randomEvents.prisoners.yaml.PrisonerEventDataWrapper;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,15 +38,15 @@ public class RandomEventLibraries {
     /**
      * Directory path where event YAML files are located.
      */
-    private final String DIRECTORY = "data\\randomEvents\\";
+    private final String DIRECTORY = "data/randomEvents/";
 
     /**
      * File extension for the YAML files.
      */
     private final String EXTENSION = ".yml";
 
-    private final String PRISONER_EVENTS_MAJOR = DIRECTORY + "PrisonerMajorEventData" + EXTENSION;
-    private final String PRISONER_EVENTS_MINOR = DIRECTORY + "PrisonerMinorEventData" + EXTENSION;
+    private final String PRISONER_EVENTS_MAJOR = Paths.get(DIRECTORY + "PrisonerMajorEventData" + EXTENSION).toString();
+    private final String PRISONER_EVENTS_MINOR = Paths.get(DIRECTORY + "PrisonerMinorEventData" + EXTENSION).toString();
 
     // lists
     private List<PrisonerEventData> prisonerEventsMajor = new ArrayList<>();

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonEscapeScenario.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonEscapeScenario.java
@@ -36,6 +36,7 @@ import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.dialog.randomEvents.prisonerDialogs.PrisonerEscapeeScenarioDialog;
 
+import java.nio.file.Paths;
 import java.util.*;
 
 import static megamek.common.Board.START_SW;
@@ -218,7 +219,7 @@ public class PrisonEscapeScenario {
      */
     private void createEscapeeScenario(List<Unit> mobUnits) {
         final String DIRECTORY = "data/scenariotemplates/";
-        final String GENERIC = DIRECTORY + "Intercept the Escapees.xml";
+        final String GENERIC = Paths.get(DIRECTORY + "Intercept the Escapees.xml").toString();
 
         ScenarioTemplate template = ScenarioTemplate.Deserialize(GENERIC);
 

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonEscapeScenario.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonEscapeScenario.java
@@ -36,9 +36,9 @@ import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.dialog.randomEvents.prisonerDialogs.PrisonerEscapeeScenarioDialog;
 
-import java.nio.file.Paths;
 import java.util.*;
 
+import static java.io.File.separator;
 import static megamek.common.Board.START_SW;
 import static megamek.common.Compute.randomInt;
 import static mekhq.campaign.mission.ScenarioMapParameters.MapLocation.AllGroundTerrain;
@@ -218,8 +218,8 @@ public class PrisonEscapeScenario {
      * @param mobUnits A list of {@link Unit} objects representing the escapee mobs to be included in the scenario.
      */
     private void createEscapeeScenario(List<Unit> mobUnits) {
-        final String DIRECTORY = "data/scenariotemplates/";
-        final String GENERIC = Paths.get(DIRECTORY + "Intercept the Escapees.xml").toString();
+        final String DIRECTORY = "data" + separator + "scenariotemplates" + separator;
+        final String GENERIC = DIRECTORY + "Intercept the Escapees.xml";
 
         ScenarioTemplate template = ScenarioTemplate.Deserialize(GENERIC);
 


### PR DESCRIPTION
- Updated the DIRECTORY constant to use backslashes, ensuring compatibility with Windows systems.

This resolves potential issues with file paths being incorrectly interpreted.

Fix #6081