### PR TITLE
Adjusted Reinforcement Arrival Time Scaling, Target Number, and Leadership Budget Logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -98,7 +98,7 @@ public class AtBDynamicScenarioFactory {
     // indexed by dragoons rating
     private static final int[] infantryToBAUpgradeTNs = { 12, 10, 8, 6, 4, 2 };
 
-    private static final int REINFORCEMENT_ARRIVAL_SCALE = 20;
+    private static final int REINFORCEMENT_ARRIVAL_SCALE = 30;
 
     private static final ResourceBundle resources = ResourceBundle.getBundle(
             "mekhq.resources.AtBDynamicScenarioFactory",

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -98,7 +98,7 @@ public class AtBDynamicScenarioFactory {
     // indexed by dragoons rating
     private static final int[] infantryToBAUpgradeTNs = { 12, 10, 8, 6, 4, 2 };
 
-    private static final int REINFORCEMENT_ARRIVAL_SCALE = 30;
+    private static final int REINFORCEMENT_ARRIVAL_SCALE = 40;
 
     private static final ResourceBundle resources = ResourceBundle.getBundle(
             "mekhq.resources.AtBDynamicScenarioFactory",

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -98,7 +98,7 @@ public class AtBDynamicScenarioFactory {
     // indexed by dragoons rating
     private static final int[] infantryToBAUpgradeTNs = { 12, 10, 8, 6, 4, 2 };
 
-    private static final int REINFORCEMENT_ARRIVAL_SCALE = 40;
+    private static final int REINFORCEMENT_ARRIVAL_SCALE = 25;
 
     private static final ResourceBundle resources = ResourceBundle.getBundle(
             "mekhq.resources.AtBDynamicScenarioFactory",

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -98,7 +98,7 @@ public class AtBDynamicScenarioFactory {
     // indexed by dragoons rating
     private static final int[] infantryToBAUpgradeTNs = { 12, 10, 8, 6, 4, 2 };
 
-    private static final int REINFORCEMENT_ARRIVAL_SCALE = 15;
+    private static final int REINFORCEMENT_ARRIVAL_SCALE = 20;
 
     private static final ResourceBundle resources = ResourceBundle.getBundle(
             "mekhq.resources.AtBDynamicScenarioFactory",

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -91,7 +91,7 @@ import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
  * @author NickAragua
  */
 public class StratconRulesManager {
-    public final static int BASE_LEADERSHIP_BUDGET = 750;
+    public final static int BASE_LEADERSHIP_BUDGET = 500;
 
     private static final MMLogger logger = MMLogger.create(StratconRulesManager.class);
 


### PR DESCRIPTION
- Increased reinforcement arrival scale to ~~40~~ 25 (from 15).
- Reduced base leadership budget to 500 (from 1,000) for better balancing.
- Refactored skill modifier logic to no longer factor in ally skill. This allowed users to indirectly double-dip and resulted in unintentionally low target numbers.

## Dev Notes  
We received a lot of feedback following the launch of the new reinforcement and leadership system. Rather than rushing into quick fixes, we wanted to let the dust settle to fully understand the pain points and implement meaningful improvements instead of reactionary changes.  

### Arrival Time  
One of the biggest concerns was that the reduced arrival times made lighter units nearly obsolete. The difference between reinforcing with a light unit versus an assault was too small to justify deploying anything but heavier forces.  

To address this, we’ve significantly modified the reinforcement arrival scale while keeping the other changes intact. This ensures that reinforcements arrive faster than in pre-50.02 versions while emphasizing the value of speed.  

Below is a table outlining the different arrival scales considered and the expected arrival times for units based on their speed:  

| Arrival Scale | Speed = 10 | Speed = 8 | Speed = 6 | Speed = 4 |  
|--------------|------------|------------|------------|------------|  
| 15           | 1          | 1          | 2          | 3          |  
| 20           | 2          | 2          | 3          | 5          |  
| 25           | 2          | 3          | 4          | 6          |  
| 30           | 3          | 3          | 5          | 7          |  
| 35           | 3          | 4          | 5          | 8          |  
| 40           | 4          | 5          | 6          | 10         |  
| 45           | 4          | 5          | 7          | 11         |  
| 50           | 5          | 6          | 8          | 12         |  

We ultimately settled on an arrival scale of ~~**40**~~ **25**. This provides a meaningful distinction between unit speeds while still allowing players to reinforce with lighter forces in a reasonable timeframe. Reinforcing with a slow unit (Walk 4) is still a losing proposition in most cases, but a skilled commander may find ways to turn it to their advantage.  

### Leadership Budget  
Before the reinforcement changes in version 50.02, **Leadership** units had some unusual restrictions on attachments. In an effort to simplify things and encourage player freedom, we removed these restrictions—but this led to an unexpected problem. **Leadership** instantly became the most powerful skill in the game.  

With the changes to reinforcement times and target numbers, this issue would only become more pronounced. To balance things, we’ve **significantly nerfed Leadership units**. Now, to fully benefit from the system, players must either:  

- Invest in **cheaper** reinforcements (potentially leveraging combined arms), or  
- Invest in more **Leadership** for their combat team commanders.  

The **Leadership cap of 5** remains in place for this system.  That means **Leadership** greater than 5 has no impact on your **leadership budget**.

While this is undoubtedly a major nerf, players should remember that the **Frontline** combat role allows them to deploy infantry (or Battle Armor) with minimal investment in **Tactics**. Combining these with Leadership units can still provide substantial reinforcement advantages.  

Additionally, since these reinforcement units are not factored into BV-based scenario balancing, even a single **500 BV unit** can have a noticeable impact. However, stacking **Leadership** should no longer be an instant "I Win" button.  

### Target Numbers  
Reinforcement **Target Numbers (TNs)** were far too low. The intent was for players to invest **extra Support Points (SP)** into a reinforcement check to improve their chances—ideally in combination with **Maneuver** combat teams. However, because the TNs were so low, this was unnecessary, making **Maneuver** far less valuable than intended. Why bother investing in it when the TN was always going to be a **4**? 

This had significant knock-on effects for the **SP Economy** allowing players to both easily reinforce **and** stockpile SP.

To fix this, reinforcement checks are now **significantly less reliable**. Players will need to make more strategic decisions, and the impact of receiving a **"delayed" reinforcement result** should now be far more meaningful—especially when combined with the arrival time changes outlined earlier.  

### Conclusion  
These changes aim to create a more balanced and engaging reinforcement and leadership system, ensuring that players have meaningful choices when deploying forces. By adjusting arrival times, refining Leadership mechanics, and increasing the difficulty of reinforcement checks, we’re emphasizing tactical decision-making while preserving player freedom.  

We’ll continue to monitor feedback and make adjustments as necessary.
