### PR TITLE
Issue 6090: Updated Gradle build for MekHQ to include new randomEvents directory

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -194,6 +194,7 @@ task stageFiles(type: Copy) {
     include "${data}/images/stratcon/"
     include "${data}/images/universe/"
     include "${data}/images/storysplash/"
+    include "${data}/randomEvents/"
     include "${data}/scenariomodifiers/"
     include "${data}/scenariotemplates/"
     include "${data}/stratconbiomedefinitions/"


### PR DESCRIPTION
Fixes #6090 

Fix suggested by @rjhancock on Discord, thanks!

This was verified by assembling the distribution via buildAllPackages. Before the fix, it was crashing as the bug describes. After this fix, it is able to launch properly.