### PR TITLE
[RFE 4364] Add campaign option to allow duplicate portraits

### DIFF
--- a/MekHQ/campaigns/Fist and Falcon/Binary Bravo, 1st Falcon Strikers.cpnx
+++ b/MekHQ/campaigns/Fist and Falcon/Binary Bravo, 1st Falcon Strikers.cpnx
@@ -243,6 +243,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+		<allowDuplicatePortraits>false</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Fist and Falcon/Binary Bravo, 1st Falcon Strikers.cpnx
+++ b/MekHQ/campaigns/Fist and Falcon/Binary Bravo, 1st Falcon Strikers.cpnx
@@ -243,7 +243,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowDuplicatePortraits>false</allowDuplicatePortraits>
+		<allowDuplicatePortraits>true</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Fist and Falcon/Kewran Wolfhounds, C Company, 3rd Battalion, 25th Arcturan Guards RCT.cpnx
+++ b/MekHQ/campaigns/Fist and Falcon/Kewran Wolfhounds, C Company, 3rd Battalion, 25th Arcturan Guards RCT.cpnx
@@ -245,6 +245,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+		<allowDuplicatePortraits>false</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Fist and Falcon/Kewran Wolfhounds, C Company, 3rd Battalion, 25th Arcturan Guards RCT.cpnx
+++ b/MekHQ/campaigns/Fist and Falcon/Kewran Wolfhounds, C Company, 3rd Battalion, 25th Arcturan Guards RCT.cpnx
@@ -245,7 +245,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowDuplicatePortraits>false</allowDuplicatePortraits>
+		<allowDuplicatePortraits>true</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Sword and Dragon/Fox's Teeth, McKinnon's Company, Vausur's Battalion, Seventh Crucis Lancers RCT.cpnx
+++ b/MekHQ/campaigns/Sword and Dragon/Fox's Teeth, McKinnon's Company, Vausur's Battalion, Seventh Crucis Lancers RCT.cpnx
@@ -245,6 +245,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+		<allowDuplicatePortraits>false</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Sword and Dragon/Fox's Teeth, McKinnon's Company, Vausur's Battalion, Seventh Crucis Lancers RCT.cpnx
+++ b/MekHQ/campaigns/Sword and Dragon/Fox's Teeth, McKinnon's Company, Vausur's Battalion, Seventh Crucis Lancers RCT.cpnx
@@ -245,7 +245,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowDuplicatePortraits>false</allowDuplicatePortraits>
+		<allowDuplicatePortraits>true</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Sword and Dragon/Sorenson Sabres, Jisatsu Company, Otomo, formerly Third Company, Tarwater's Battalion, Fifth Sword of Light.cpnx
+++ b/MekHQ/campaigns/Sword and Dragon/Sorenson Sabres, Jisatsu Company, Otomo, formerly Third Company, Tarwater's Battalion, Fifth Sword of Light.cpnx
@@ -243,6 +243,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+		<allowDuplicatePortraits>false</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Sword and Dragon/Sorenson Sabres, Jisatsu Company, Otomo, formerly Third Company, Tarwater's Battalion, Fifth Sword of Light.cpnx
+++ b/MekHQ/campaigns/Sword and Dragon/Sorenson Sabres, Jisatsu Company, Otomo, formerly Third Company, Tarwater's Battalion, Fifth Sword of Light.cpnx
@@ -243,7 +243,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowDuplicatePortraits>false</allowDuplicatePortraits>
+		<allowDuplicatePortraits>true</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Wolf and Blake/Black Widow Company, Church's Independent Company, Wolf's Dragoons.cpnx
+++ b/MekHQ/campaigns/Wolf and Blake/Black Widow Company, Church's Independent Company, Wolf's Dragoons.cpnx
@@ -243,6 +243,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+		<allowDuplicatePortraits>false</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Wolf and Blake/Black Widow Company, Church's Independent Company, Wolf's Dragoons.cpnx
+++ b/MekHQ/campaigns/Wolf and Blake/Black Widow Company, Church's Independent Company, Wolf's Dragoons.cpnx
@@ -243,7 +243,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowDuplicatePortraits>false</allowDuplicatePortraits>
+		<allowDuplicatePortraits>true</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Wolf and Blake/Shadow Hunters, Opacus Venatori, Fifty-second Shadow Division.cpnx
+++ b/MekHQ/campaigns/Wolf and Blake/Shadow Hunters, Opacus Venatori, Fifty-second Shadow Division.cpnx
@@ -243,6 +243,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+		<allowDuplicatePortraits>false</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/campaigns/Wolf and Blake/Shadow Hunters, Opacus Venatori, Fifty-second Shadow Division.cpnx
+++ b/MekHQ/campaigns/Wolf and Blake/Shadow Hunters, Opacus Venatori, Fifty-second Shadow Division.cpnx
@@ -243,7 +243,7 @@
 		<contractMarketReportRefresh>true</contractMarketReportRefresh>
 		<unitMarketReportRefresh>true</unitMarketReportRefresh>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-		<allowDuplicatePortraits>false</allowDuplicatePortraits>
+		<allowDuplicatePortraits>true</allowDuplicatePortraits>
 		<allowOpforAeros>false</allowOpforAeros>
 		<allowOpforLocalUnits>false</allowOpforLocalUnits>
 		<opforAeroChance>5</opforAeroChance>

--- a/MekHQ/mmconf/campaignPresets/CampaignOperations.xml
+++ b/MekHQ/mmconf/campaignPresets/CampaignOperations.xml
@@ -541,6 +541,7 @@
 		<limitLanceWeight>false</limitLanceWeight>
 		<limitLanceNumUnits>false</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+        <allowDuplicatePortraits>false</allowDuplicatePortraits>
 		<allowOpForAeros>false</allowOpForAeros>
 		<allowOpForLocalUnits>false</allowOpForLocalUnits>
 		<opForAeroChance>5</opForAeroChance>

--- a/MekHQ/mmconf/campaignPresets/CampaignOperations.xml
+++ b/MekHQ/mmconf/campaignPresets/CampaignOperations.xml
@@ -541,7 +541,7 @@
 		<limitLanceWeight>false</limitLanceWeight>
 		<limitLanceNumUnits>false</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-        <allowDuplicatePortraits>false</allowDuplicatePortraits>
+        <allowDuplicatePortraits>true</allowDuplicatePortraits>
 		<allowOpForAeros>false</allowOpForAeros>
 		<allowOpForLocalUnits>false</allowOpForLocalUnits>
 		<opForAeroChance>5</opForAeroChance>

--- a/MekHQ/mmconf/campaignPresets/CampaignOperationsStratCon.xml
+++ b/MekHQ/mmconf/campaignPresets/CampaignOperationsStratCon.xml
@@ -541,6 +541,7 @@
 		<limitLanceWeight>false</limitLanceWeight>
 		<limitLanceNumUnits>false</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+        <allowDuplicatePortraits>false</allowDuplicatePortraits>
 		<allowOpForAeros>false</allowOpForAeros>
 		<allowOpForLocalUnits>false</allowOpForLocalUnits>
 		<opForAeroChance>5</opForAeroChance>

--- a/MekHQ/mmconf/campaignPresets/CampaignOperationsStratCon.xml
+++ b/MekHQ/mmconf/campaignPresets/CampaignOperationsStratCon.xml
@@ -541,7 +541,7 @@
 		<limitLanceWeight>false</limitLanceWeight>
 		<limitLanceNumUnits>false</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-        <allowDuplicatePortraits>false</allowDuplicatePortraits>
+        <allowDuplicatePortraits>true</allowDuplicatePortraits>
 		<allowOpForAeros>false</allowOpForAeros>
 		<allowOpForLocalUnits>false</allowOpForLocalUnits>
 		<opForAeroChance>5</opForAeroChance>

--- a/MekHQ/mmconf/campaignPresets/NewPilotProgram.xml
+++ b/MekHQ/mmconf/campaignPresets/NewPilotProgram.xml
@@ -541,6 +541,7 @@
 		<limitLanceWeight>false</limitLanceWeight>
 		<limitLanceNumUnits>false</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+        <allowDuplicatePortraits>false</allowDuplicatePortraits>
 		<allowOpForAeros>false</allowOpForAeros>
 		<allowOpForLocalUnits>false</allowOpForLocalUnits>
 		<opForAeroChance>5</opForAeroChance>

--- a/MekHQ/mmconf/campaignPresets/NewPilotProgram.xml
+++ b/MekHQ/mmconf/campaignPresets/NewPilotProgram.xml
@@ -541,7 +541,7 @@
 		<limitLanceWeight>false</limitLanceWeight>
 		<limitLanceNumUnits>false</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-        <allowDuplicatePortraits>false</allowDuplicatePortraits>
+        <allowDuplicatePortraits>true</allowDuplicatePortraits>
 		<allowOpForAeros>false</allowOpForAeros>
 		<allowOpForLocalUnits>false</allowOpForLocalUnits>
 		<opForAeroChance>5</opForAeroChance>

--- a/MekHQ/mmconf/campaignPresets/TheCompleteExperience.xml
+++ b/MekHQ/mmconf/campaignPresets/TheCompleteExperience.xml
@@ -542,7 +542,7 @@
 		<limitLanceWeight>false</limitLanceWeight>
 		<limitLanceNumUnits>false</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
-        <allowDuplicatePortraits>false</allowDuplicatePortraits>
+        <allowDuplicatePortraits>true</allowDuplicatePortraits>
 		<allowOpForAeros>false</allowOpForAeros>
 		<allowOpForLocalUnits>false</allowOpForLocalUnits>
 		<opForAeroChance>5</opForAeroChance>

--- a/MekHQ/mmconf/campaignPresets/TheCompleteExperience.xml
+++ b/MekHQ/mmconf/campaignPresets/TheCompleteExperience.xml
@@ -542,6 +542,7 @@
 		<limitLanceWeight>false</limitLanceWeight>
 		<limitLanceNumUnits>false</limitLanceNumUnits>
 		<assignPortraitOnRoleChange>false</assignPortraitOnRoleChange>
+        <allowDuplicatePortraits>false</allowDuplicatePortraits>
 		<allowOpForAeros>false</allowOpForAeros>
 		<allowOpForLocalUnits>false</allowOpForLocalUnits>
 		<opForAeroChance>5</opForAeroChance>

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -902,8 +902,8 @@ lblAssignPortraitOnRoleChange.text=Reassign Portrait on Role Change
 lblAssignPortraitOnRoleChange.tooltip=With this enabled, a person without a portrait will\
   \ automatically gain a random portrait when their primary role is changed switched.
 lblAllowDuplicatePortraits.text=Allow Duplicate Portraits
-lblAllowDuplicatePortraits.tooltip=With this enabled, the random name generator\
-  \ will generate portraits even if all available portraits have already been used.
+lblAllowDuplicatePortraits.tooltip=With this enabled, random portraits are no longer unique\
+  \ and several different people can have the same portrait.
 
 # createRandomPortraitPanel
 lblRandomPortraitPanel.text=Portrait Assignment

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -901,6 +901,9 @@ lblFactionNames.tooltip=All names will be generated based on the selected factio
 lblAssignPortraitOnRoleChange.text=Reassign Portrait on Role Change
 lblAssignPortraitOnRoleChange.tooltip=With this enabled, a person without a portrait will\
   \ automatically gain a random portrait when their primary role is changed switched.
+lblAllowDuplicatePortraits.text=Allow Duplicate Portraits
+lblAllowDuplicatePortraits.tooltip=With this enabled, the random name generator\
+  \ will generate portraits even if all available portraits have already been used.
 
 # createRandomPortraitPanel
 lblRandomPortraitPanel.text=Portrait Assignment

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7457,7 +7457,8 @@ public class Campaign implements ITechManager {
      * @param person The {@link Person} who should receive a randomized portrait.
      */
     public void assignRandomPortraitFor(final Person person) {
-        final Portrait portrait = RandomPortraitGenerator.generate(getPersonnel(), person);
+        final Boolean allowDuplicatePortraits = getCampaignOptions().isAllowDuplicatePortraits();
+        final Portrait portrait = RandomPortraitGenerator.generate(getPersonnel(), person, allowDuplicatePortraits);
         if (!portrait.isDefault()) {
             person.setPortrait(portrait);
         }

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -508,6 +508,7 @@ public class CampaignOptions {
     private boolean useOriginFactionForNames;
     private final boolean[] usePortraitForRole;
     private boolean assignPortraitOnRoleChange;
+    private boolean allowDuplicatePortraits;
     // endregion Name and Portrait Generation
 
     // region Markets Tab
@@ -1103,6 +1104,7 @@ public class CampaignOptions {
         Arrays.fill(usePortraitForRole, false);
         usePortraitForRole[PersonnelRole.MEKWARRIOR.ordinal()] = true;
         assignPortraitOnRoleChange = false;
+        allowDuplicatePortraits = true;
         // endregion Name and Portrait Generation Tab
 
         // region Markets Tab
@@ -3770,6 +3772,14 @@ public class CampaignOptions {
         this.assignPortraitOnRoleChange = assignPortraitOnRoleChange;
     }
 
+    public boolean isAllowDuplicatePortraits() {
+        return allowDuplicatePortraits;
+    }
+
+    public void setAllowDuplicatePortraits(final boolean allowDuplicatePortraits) {
+        this.allowDuplicatePortraits = allowDuplicatePortraits;
+    }
+
     public int getVocationalXP() {
         return vocationalXP;
     }
@@ -5081,6 +5091,7 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "limitLanceWeight", limitLanceWeight);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "limitLanceNumUnits", limitLanceNumUnits);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "assignPortraitOnRoleChange", assignPortraitOnRoleChange);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "allowDuplicatePortraits", allowDuplicatePortraits);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "allowOpForAeros", isAllowOpForAeros());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "allowOpForLocalUnits", isAllowOpForLocalUnits());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "opForAeroChance", getOpForAeroChance());
@@ -5313,6 +5324,8 @@ public class CampaignOptions {
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("assignPortraitOnRoleChange")) {
                     retVal.assignPortraitOnRoleChange = Boolean.parseBoolean(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("allowDuplicatePortraits")) {
+                    retVal.allowDuplicatePortraits = Boolean.parseBoolean(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("destroyByMargin")) {
                     retVal.destroyByMargin = Boolean.parseBoolean(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("destroyMargin")) {

--- a/MekHQ/src/mekhq/campaign/personnel/generator/RandomPortraitGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/RandomPortraitGenerator.java
@@ -42,13 +42,16 @@ public class RandomPortraitGenerator {
      * @param p         the {@link Person} to generate a unique portrait for
      * @return the generated portrait
      */
-    public static Portrait generate(Collection<Person> personnel, Person p) {
+    public static Portrait generate(Collection<Person> personnel, Person p,
+            Boolean allowDuplicatePortraits) {
         // first create a list of existing portrait strings, so we can check for
-        // duplicates
+        // duplicates - unless they are allowed in campaign options
         Set<String> existingPortraits = new HashSet<>();
-        for (Person existingPerson : personnel) {
-            existingPortraits.add(existingPerson.getPortrait().getCategory() + ':'
+        if (!allowDuplicatePortraits) {
+            for (Person existingPerson : personnel) {
+                existingPortraits.add(existingPerson.getPortrait().getCategory() + ':'
                     + existingPerson.getPortrait().getFilename());
+            }
         }
 
         List<String> possiblePortraits;

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -159,6 +159,7 @@ public class BiographyTab {
     private JButton btnEnableAllPortraits;
     private JButton btnDisableAllPortraits;
     private JCheckBox chkAssignPortraitOnRoleChange;
+    private JCheckBox chkAllowDuplicatePortraits;
     //end Name and Portrait Tab
 
     //start Rank Tab
@@ -215,6 +216,7 @@ public class BiographyTab {
         lblFactionNames = new JLabel();
         comboFactionNames = new MMComboBox<>("comboFactionNames", getFactionNamesModel());
         chkAssignPortraitOnRoleChange = new JCheckBox();
+        chkAllowDuplicatePortraits = new JCheckBox();
 
         pnlRandomPortrait = new JPanel();
         chkUsePortrait = new JCheckBox[1]; // We're going to properly initialize this later
@@ -1108,6 +1110,8 @@ public class BiographyTab {
         // Contents
         chkAssignPortraitOnRoleChange = new CampaignOptionsCheckBox("AssignPortraitOnRoleChange");
 
+        chkAllowDuplicatePortraits = new CampaignOptionsCheckBox("AllowDuplicatePortraits");
+
         chkUseOriginFactionForNames = new CampaignOptionsCheckBox("UseOriginFactionForNames");
 
         lblFactionNames = new CampaignOptionsLabel("FactionNames");
@@ -1122,6 +1126,8 @@ public class BiographyTab {
         layoutTop.gridx = 0;
         layoutTop.gridy = 0;
         panelTop.add(chkAssignPortraitOnRoleChange, layoutTop);
+        layoutTop.gridy++;
+        panelTop.add(chkAllowDuplicatePortraits, layoutTop);
 
         layoutTop.gridy++;
         panelTop.add(chkUseOriginFactionForNames, layoutTop);
@@ -1327,6 +1333,7 @@ public class BiographyTab {
         // 'RandomNameGenerator' is not stored in a Preset
         comboFactionNames.setSelectedItem(RandomNameGenerator.getInstance().getChosenFaction());
         chkAssignPortraitOnRoleChange.setSelected(options.isAssignPortraitOnRoleChange());
+        chkAllowDuplicatePortraits.setSelected(options.isAllowDuplicatePortraits());
 
         final boolean[] usePortraitForRole = options.isUsePortraitForRoles();
         for (int i = 0; i < chkUsePortrait.length; i++) {
@@ -1413,6 +1420,7 @@ public class BiographyTab {
         // Name and Portraits
         options.setUseOriginFactionForNames(chkUseOriginFactionForNames.isSelected());
         options.setAssignPortraitOnRoleChange(chkAssignPortraitOnRoleChange.isSelected());
+        options.setAllowDuplicatePortraits(chkAllowDuplicatePortraits.isSelected());
         RandomNameGenerator.getInstance().setChosenFaction(comboFactionNames.getSelectedItem());
         for (int i = 0; i < chkUsePortrait.length; i++) {
             options.setUsePortraitForRole(i, chkUsePortrait[i].isSelected());


### PR DESCRIPTION
Implements #4364

When the option "Allow Duplicate Portraits" is enabled, random portrait generator ignores existing personnel and feels okay with potentially using the same portrait. Defaults to true.

![Screenshot](https://github.com/user-attachments/assets/2edab010-1aae-404c-82af-9980e6cd3911)