### PR TITLE
Null Check for Random Dependents

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/RandomDependents.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RandomDependents.java
@@ -177,7 +177,7 @@ public class RandomDependents {
 
                     Genealogy genealogy = dependent.getGenealogy();
                     for (Person child : genealogy.getChildren()) {
-                        if (child != null && child.isChild(currentDay)) {
+                        if (child.isChild(currentDay)) {
                             dependentsToRemove.add(child);
                         }
                     }

--- a/MekHQ/src/mekhq/campaign/personnel/RandomDependents.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RandomDependents.java
@@ -177,13 +177,13 @@ public class RandomDependents {
 
                     Genealogy genealogy = dependent.getGenealogy();
                     for (Person child : genealogy.getChildren()) {
-                        if (child.isChild(currentDay)) {
+                        if (child != null && child.isChild(currentDay)) {
                             dependentsToRemove.add(child);
                         }
                     }
 
                     Person spouse = genealogy.getSpouse();
-                    if (spouse.isDependent()) {
+                    if (spouse != null && spouse.isDependent()) {
                         dependentsToRemove.add(spouse);
                     }
                 }


### PR DESCRIPTION
I got a NPE in my nightly save. 

`genealogy.isDependent`'s return `Person` is tagged as `@Nullable`.  This will handle that. 

Child above shouldn't need it, if someone doesn't have children it'll return an empty list.