### PR TITLE
Updated Academy Training Types in `Unit Education.xml`

### DIFF
--- a/MekHQ/data/universe/academies/Unit Education.xml
+++ b/MekHQ/data/universe/academies/Unit Education.xml
@@ -178,7 +178,7 @@
     </academy>
     <academy>
         <name>In-House NCO Bootcamp</name>
-        <type>Basic Training</type>
+        <type>NCO Academy</type>
         <isMilitary>true</isMilitary>
         <description>The In-House NCO Candidate Bootcamp is led by veteran personnel, blending physical conditioning, simulations, and practical exercises to instill leadership, cohesion, and loyalty.</description>
         <isHomeSchool>true</isHomeSchool>
@@ -197,7 +197,6 @@
     </academy>
     <academy>
         <name>In-House Warrant Officer Bootcamp</name>
-        <type>Basic Training</type>
         <isMilitary>true</isMilitary>
         <description>Led by veteran experts, in-unit Warrant Officer bootcamps focus on advanced technical skills, leadership development, and unit cohesion, preparing candidates for specialized support roles.</description>
         <isHomeSchool>true</isHomeSchool>
@@ -216,7 +215,6 @@
     </academy>
     <academy>
         <name>In-House Officer Bootcamp</name>
-        <type>Basic Training</type>
         <isMilitary>true</isMilitary>
         <description>Officer Bootcamp emphasizes leadership, tactical acumen, and strategic planning, blending classroom instruction, simulations, and field exercises to prepare candidates for command roles.</description>
         <isHomeSchool>true</isHomeSchool>


### PR DESCRIPTION
- Changed "In-House NCO Bootcamp" type from "Basic Training" to "NCO Academy."
- Removed "Basic Training" type from "In-House Warrant Officer Bootcamp."
- Removed "Basic Training" type from "In-House Officer Bootcamp."

Fix #6069

### Dev Notes
Unit education is generally less formal and hands-on than found in actual education institutions. The quality of officer training offered in-unit is drastically lower than that offered by a formal education. Meanwhile, Basic Training and the NCO Bootcamp offer a comparative (albeit lower quality) education to their formal counterparts.

That is why Basic Training and NCO Bootcamp award Awards, while Warrant Officer and Officer Bootcamps do not.

See also the length of in-unit officer bootcamps (70 days) vs. formal officer schooling (300 days).