### PR TITLE
Corrected Glossary Links For Fatigue

### DIFF
--- a/MekHQ/resources/mekhq/resources/PrisonerEvents.properties
+++ b/MekHQ/resources/mekhq/resources/PrisonerEvents.properties
@@ -34,8 +34,8 @@ LOYALTY_ONE.report=The <a href='GLOSSARY:LOYALTY'>Loyalty</a> of a <b>{0}</b> ha
 LOYALTY_ALL.report=The <a href='GLOSSARY:LOYALTY'>Loyalty</a> of all <b>{0}</b> has {1}<b>{2}</b>{3}\
   \ by <b>{4}</b>.
 ESCAPE.report=<b>{0}</b> {1} {2} {3}<b>escaped</b>{4}!
-FATIGUE_ONE.report=The <a href='GLOSSARY:Fatigue'>Fatigue</a> of a <b>{0}</b> has {1}<b>{2}</b>{3} by <b>{4}</b>.
-FATIGUE_ALL.report=The <a href='GLOSSARY:Fatigue'>Fatigue</a> of all <b>{0}</b> has {1}<b>{2}</b>{3} by <b>{4}</b>.
+FATIGUE_ONE.report=The <a href='GLOSSARY:FATIGUE'>Fatigue</a> of a <b>{0}</b> has {1}<b>{2}</b>{3} by <b>{4}</b>.
+FATIGUE_ALL.report=The <a href='GLOSSARY:FATIGUE'>Fatigue</a> of all <b>{0}</b> has {1}<b>{2}</b>{3} by <b>{4}</b>.
 SUPPORT_POINT.report=Our available <b>Support {0}</b> for {1} has {2}<b>{3}</b>{4} by <b>{5}</b>.
 SUPPORT_POINT.singular=Point
 SUPPORT_POINT.plural=Points
@@ -44,7 +44,7 @@ BARTERING.report=Allied Command has reported an {0}<b>increase</b>{1} in the num
   \ OpFors.
 MISTAKE.report=<b>{0}</b> has been returned to their cell.
 POISON.report=Personnel across your unit are reporting symptoms similar to <b>dysentery</b>. You\
-  \ should suspend active combat until the <a href='GLOSSARY:Fatigue'>Fatigue</a> subsides.
+  \ should suspend active combat until the <a href='GLOSSARY:FATIGUE'>Fatigue</a> subsides.
 ABANDONED_TO_DIE.report.crime=\ Your <a href='GLOSSARY:REPUTATION'>Reputation</a> has been\
   \ {0}<b>decreased</b>{1} by <b>{2}</b>.
 ABANDONED_TO_DIE.report.prisoners=<b>{0}</b> {1} {2} been escorted to the holding area by your\


### PR DESCRIPTION
- Fixed incorrect glossary link references for "Fatigue" by changing `GLOSSARY:Fatigue` to `GLOSSARY:FATIGUE`.