### PR TITLE
Fixed Prisoner Capture And Processing Logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/CapturePrisoners.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/CapturePrisoners.java
@@ -193,7 +193,7 @@ public class CapturePrisoners {
         processPrisoner(prisoner, campaignFaction, prisonerCaptureStyle.isMekHQ(), true);
 
         // Have they been removed via Bondsref?
-        if (!campaign.getPersonnel().contains(prisoner)) {
+        if (prisoner.getStatus().isDead()) {
             return;
         }
 
@@ -344,7 +344,7 @@ public class CapturePrisoners {
             return;
         }
 
-        processPrisoner(prisoner, searchingFaction, prisonerCaptureStyle.isMekHQ(), true);
+        processPrisoner(prisoner, searchingFaction, prisonerCaptureStyle.isMekHQ(), false);
 
         // Have they dead? Usually from performing Bondsref
         if (prisoner.getStatus().isDead()) {


### PR DESCRIPTION
- Corrected prisoner status check to ensure it specifically checks for death instead of absence from personnel.
- Updated `processPrisoner` call to properly handle the `addingToCapturePersonnel` parameter with a `false` value when appropriate.
- Improved logic clarity for handling prisoner death scenarios during Bondsref processing.

Fix #6094

### Dev Notes
This was a classic whoopsie caused by refactoring just prior to release. Basically we had a check that shortcutted prisoner capture if the prisoner performed Bondsref. However, the conditional was checking whether the character was in the campaign or not, because Bondsrefing NPC prisoners were just removed. However, the refactoring changed this so that they were just not added to the campaign. However, this meant they were never present _in_ the campaign, causing the Bondsref check to always return `true` and the process to shortcut.

Morale of the story: double-check everything when refactoring.