### PR TITLE
Refactored Unsupported Unit Handling

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -593,12 +593,6 @@ DataLoadingDialog.OutOfMemoryError.text=MekHQ ran out of memory attempting to lo
 DataLoadingDialog.ExecutionException.title=Campaign Loading Error
 DataLoadingDialog.ExecutionException.text=The campaign file couldn't be loaded. \nPlease check the MekHQ.log file for details.
 
-## Unsupported Units
-unsupportedUnits.title=Unsupported Units Detected
-unsupportedUnits.body=The following units are not supported by MekHQ and have been sold.\
-  <br>\
-  <br>All assigned personnel have been unassigned.<br><br>
-
 ### GMToolsDialog Class
 GMToolsDialog.title=GM Tools
 ## General Tab

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -22,7 +22,6 @@ import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
-import megamek.common.GunEmplacement;
 import megamek.common.MekSummaryCache;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
@@ -63,8 +62,7 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileInputStream;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
@@ -73,6 +71,7 @@ import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDia
 import static mekhq.gui.campaignOptions.SelectPresetDialog.PRESET_SELECTION_CANCELLED;
 import static mekhq.gui.campaignOptions.SelectPresetDialog.PRESET_SELECTION_CUSTOMIZE;
 import static mekhq.gui.campaignOptions.SelectPresetDialog.PRESET_SELECTION_SELECT;
+import static mekhq.utilities.EntityUtilities.isUnsupportedUnitType;
 
 public class DataLoadingDialog extends AbstractMHQDialogBasic implements PropertyChangeListener {
     private static final MMLogger logger = MMLogger.create(DataLoadingDialog.class);
@@ -415,56 +414,36 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                     campaign.setReputation(reputationController);
                 }
 
-                sellUnsupportedUnits(campaign);
+                unassignCrewFromUnsupportedUnits(campaign.getUnits());
                 // endregion Progress 7
             }
             campaign.setApp(getApplication());
             return campaign;
         }
 
-
-
         /**
-         * Sells unsupported units.
-         * <p>
-         * This method checks all units in the specified campaign and determines if they are unsupported.
-         * Currently, only gun emplacements are identified as unsupported and are sold upon campaign load.
-         * If unsupported units are sold, a notification is displayed to the user detailing the sold units,
-         * including their names and IDs. Additionally, personnel assigned to these units are
-         * automatically unassigned.
-         * </p>
+         * Unassigns the crew from unsupported units in the given collection of units.
          *
-         * @param retVal The campaign being checked for unsupported units. This includes the unit list
-         *              and the quartermaster who handles the selling process.
+         * <p>This method iterates through the provided {@link Collection} of {@link Unit} objects
+         * and checks if each unit's associated {@link Entity} is of an unsupported type.
+         *
+         * <p>If the entity is {@code null}, it is skipped. For unsupported unit types, the unit's
+         * crew is cleared using {@link Unit#clearCrew()}.</p>
+         *
+         * @param units The {@link Collection} of {@link Unit} instances to process.
+         *              Must not be {@code null}.
          */
-        private void sellUnsupportedUnits(Campaign retVal) {
-            List<Unit> soldUnits = new ArrayList<>();
-            for (Unit unit : retVal.getUnits()) {
+        private void unassignCrewFromUnsupportedUnits(Collection<Unit> units) {
+            for (Unit unit : units) {
                 Entity entity = unit.getEntity();
 
                 if (entity == null) {
                     continue;
                 }
 
-                // We don't support Gun Emplacements in mhq.
-                // If the user has somehow acquired one, it is sold on load.
-                if (entity instanceof GunEmplacement) {
-                    soldUnits.add(unit);
+                if (isUnsupportedUnitType(entity.getUnitType())) {
+                    unit.clearCrew();
                 }
-            }
-
-            if (!soldUnits.isEmpty()) {
-                StringBuilder message = new StringBuilder(resources.getString("unsupportedUnits.body"));
-
-                for (Unit soldUnit : soldUnits) {
-                    retVal.getQuartermaster().sellUnit(soldUnit);
-                    message.append("- ").append(soldUnit.getName()).append("<br>");
-                }
-
-                JOptionPane.showMessageDialog(null,
-                    String.format("<html>%s</html>", message),
-                    resources.getString("unsupportedUnits.title"),
-                    JOptionPane.WARNING_MESSAGE);
             }
         }
 

--- a/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.regex.PatternSyntaxException;
 
+import static mekhq.utilities.EntityUtilities.isUnsupportedUnitType;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
@@ -131,7 +132,9 @@ public class MekHQUnitSelectorDialog extends AbstractUnitSelectorDialog {
     protected void select(boolean isGM) {
         if (getSelectedEntity() != null) {
             // Block the purchase if the unit type is unsupported
-            if (selectedUnit.getEntity() instanceof GunEmplacement) {
+            Entity entity = selectedUnit.getEntity();
+
+            if (entity == null || isUnsupportedUnitType(entity.getUnitType())) {
                 final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
                     MekHQ.getMHQOptions().getLocale());
 

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
@@ -18,13 +18,6 @@
  */
 package mekhq.gui.menus;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import javax.swing.JMenuItem;
-
 import megamek.common.*;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
@@ -35,6 +28,14 @@ import mekhq.campaign.personnel.enums.Profession;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.baseComponents.JScrollableMenu;
 import mekhq.gui.sorter.PersonTitleSorter;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static mekhq.utilities.EntityUtilities.isUnsupportedUnitType;
 
 /**
  * This is a standard menu that takes either a unit or multiple units that
@@ -58,6 +59,14 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         // 2) Any units are currently unavailable
         if ((units.length == 0) || Stream.of(units).anyMatch(unit -> !unit.isAvailable())) {
             return;
+        }
+
+        for (Unit unit : units) {
+            Entity entity = unit.getEntity();
+
+            if (entity == null || isUnsupportedUnitType(entity.getUnitType())) {
+                return;
+            }
         }
 
         // Initialize Menu

--- a/MekHQ/src/mekhq/utilities/EntityUtilities.java
+++ b/MekHQ/src/mekhq/utilities/EntityUtilities.java
@@ -19,6 +19,7 @@
 package mekhq.utilities;
 
 import megamek.common.Entity;
+import megamek.common.UnitType;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
@@ -49,5 +50,23 @@ public class EntityUtilities {
         }
 
         return unit.getEntity();
+    }
+
+    /**
+     * Checks if the given unit type is unsupported in MekHQ.
+     *
+     * <p>This method evaluates whether the specified unit type is considered unsupported.
+     * Currently, it checks if the unit type matches {@link UnitType#GUN_EMPLACEMENT}.
+     *
+     * @param unitType The unit type to be checked, represented as an integer.
+     * @return {@code true} if the unit type is unsupported (e.g., {@link UnitType#GUN_EMPLACEMENT}),
+     *         otherwise {@code false}.
+     */
+    public static boolean isUnsupportedUnitType(int unitType) {
+        if (unitType == UnitType.GUN_EMPLACEMENT) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
- Added `isUnsupportedUnitType` utility method to check unsupported units based on type.
- Updated `DataLoadingDialog.java` to unassign crews instead of selling unsupported units like Gun Emplacements.
- Removed GUI properties related to unsupported unit sale notifications.
- Integrated `isUnsupportedUnitType` in `AssignUnitToPersonMenu.java` to block the crewing of unsupported units.
- Integrated `isUnsupportedUnitType` in `MekHQUnitSelectorDialog.java` to block the purchase of unsupported units.

Fix #6089

### Dev Notes
After internal discussions, we decided the best approach is to allow the salvage of Gun Emplacements (and any other unit types that may be declared unsupported in the future) while preventing them from being purchased or crewed. This ensures that players cannot _use_ unsupported units but can still strip them for parts.