### PR TITLE
Fixed `NullPointerException` In `RandomizeAroundSpecifiedPlanet`

### DIFF
--- a/MekHQ/src/mekhq/campaign/RandomOriginOptions.java
+++ b/MekHQ/src/mekhq/campaign/RandomOriginOptions.java
@@ -18,16 +18,15 @@
  */
 package mekhq.campaign;
 
-import java.io.PrintWriter;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.Systems;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Justin "Windchild" Bowen
@@ -199,7 +198,7 @@ public class RandomOriginOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "randomizeDependentOrigin", isRandomizeDependentOrigin());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "randomizeAroundSpecifiedPlanet",
                 isRandomizeAroundSpecifiedPlanet());
-        if (isRandomizeAroundSpecifiedPlanet()) {
+        if (isRandomizeAroundSpecifiedPlanet() && getSpecifiedPlanet() != null) {
             MHQXMLUtility.writeSimpleXMLAttributedTag(pw, indent, "specifiedPlanet", "systemId",
                     getSpecifiedPlanet().getParentSystem().getId(), getSpecifiedPlanet().getId());
         }

--- a/MekHQ/src/mekhq/campaign/RandomOriginOptions.java
+++ b/MekHQ/src/mekhq/campaign/RandomOriginOptions.java
@@ -198,12 +198,14 @@ public class RandomOriginOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "randomizeDependentOrigin", isRandomizeDependentOrigin());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "randomizeAroundSpecifiedPlanet",
                 isRandomizeAroundSpecifiedPlanet());
-        if (isRandomizeAroundSpecifiedPlanet() && getSpecifiedPlanet() != null) {
-            MHQXMLUtility.writeSimpleXMLAttributedTag(pw, indent, "specifiedPlanet", "systemId",
-                    getSpecifiedPlanet().getParentSystem().getId(), getSpecifiedPlanet().getId());
-        } else if (getSpecifiedPlanet() == null) {
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "randomizeAroundSpecifiedPlanet",
-                false);
+        if (isRandomizeAroundSpecifiedPlanet()) {
+            if (getSpecifiedPlanet() != null) {
+                MHQXMLUtility.writeSimpleXMLAttributedTag(pw, indent, "specifiedPlanet",
+                    "systemId", getSpecifiedPlanet().getParentSystem().getId(),
+                    getSpecifiedPlanet().getId());
+            } else {
+                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "randomizeAroundSpecifiedPlanet", false);
+            }
         }
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "originSearchRadius", getOriginSearchRadius());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "originDistanceScale", getOriginDistanceScale());

--- a/MekHQ/src/mekhq/campaign/RandomOriginOptions.java
+++ b/MekHQ/src/mekhq/campaign/RandomOriginOptions.java
@@ -201,6 +201,9 @@ public class RandomOriginOptions {
         if (isRandomizeAroundSpecifiedPlanet() && getSpecifiedPlanet() != null) {
             MHQXMLUtility.writeSimpleXMLAttributedTag(pw, indent, "specifiedPlanet", "systemId",
                     getSpecifiedPlanet().getParentSystem().getId(), getSpecifiedPlanet().getId());
+        } else if (getSpecifiedPlanet() == null) {
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "randomizeAroundSpecifiedPlanet",
+                false);
         }
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "originSearchRadius", getOriginSearchRadius());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "originDistanceScale", getOriginDistanceScale());

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -1377,7 +1377,13 @@ public class BiographyTab {
         originOptions.setRandomizeOrigin(chkRandomizeOrigin.isSelected());
         originOptions.setRandomizeDependentOrigin(chkRandomizeDependentsOrigin.isSelected());
         originOptions.setRandomizeAroundSpecifiedPlanet(chkRandomizeAroundSpecifiedPlanet.isSelected());
-        originOptions.setSpecifiedPlanet(comboSpecifiedPlanet.getSelectedItem());
+
+        Planet selectedPlanet = comboSpecifiedPlanet.getSelectedItem();
+        if (selectedPlanet == null && comboSpecifiedPlanet.getItemCount() > 0) {
+            selectedPlanet = comboSpecifiedPlanet.getItemAt(0);
+        }
+        originOptions.setSpecifiedPlanet(selectedPlanet);
+
         originOptions.setOriginSearchRadius((int) spnOriginSearchRadius.getValue());
         originOptions.setOriginDistanceScale((double) spnOriginDistanceScale.getValue());
         originOptions.setAllowClanOrigins(chkAllowClanOrigins.isSelected());


### PR DESCRIPTION
- Added a null check for `getSpecifiedPlanet()` in the condition to avoid potential `NullPointerException`.
- Ensured a fallback to the first available planet if no planet is selected from the dropdown.
- Prevented potential crashes caused by null values when setting the specified planet.

### Dev Notes
This issue was highlighted in the comments of #6067. Without knowing the exact source of the NPE, it's difficult to determine where to add null protection. However, since the only new functionality comes from CO IIC, it made sense that the issue originated there, so I added protection accordingly.