### PR TITLE
Refactored StratCon Scenario Retrieval And Table Rendering

### DIFF
--- a/MekHQ/resources/mekhq/resources/ScenarioTableModel.properties
+++ b/MekHQ/resources/mekhq/resources/ScenarioTableModel.properties
@@ -1,5 +1,6 @@
 col_name.text=Scenario Name
 col_status.text=Resolution
+col_status.turningPoint=(Turning Point)
 col_date.text=Date
 col_assign.text=Units Assigned
 col_sector.text=Grid Reference

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -2120,24 +2120,29 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     }
 
     /**
-     * Retrieves the {@link StratconScenario} associated with the current mission ID.
+     * Retrieves the {@link StratconScenario} associated with the given {@link AtBScenario}
+     * for the specified {@link AtBContract}.
      *
-     * <p>The method first retrieves the {@link AtBContract} from the given campaign.
-     * If the contract, its {@link StratconCampaignState}, or any required track data
-     * is unavailable, the method returns {@code null}. It iterates through all
-     * {@link StratconTrackState} objects in the campaign state and their associated scenarios.
-     * If a {@link StratconScenario} contains a non-null {@link AtBDynamicScenario} whose
-     * mission ID matches the current mission ID, it is returned.
+     * <p>This method attempts to locate a {@link StratconScenario} that matches the provided
+     * {@link AtBScenario} within the tracks of the {@link StratconCampaignState} associated
+     * with the provided contract. If the campaign state, tracks, or scenarios are unavailable,
+     * or if no match is found, the method returns {@code null}.
      *
-     * @param campaign the {@link Campaign} instance being queried for the scenario
+     * <p>The search proceeds by iterating through all {@link StratconTrackState} objects
+     * in the campaign state. For each track, it goes through the collection of associated
+     * {@link StratconScenario} instances. If a {@link StratconScenario} has a non-null
+     * {@link AtBDynamicScenario} that matches the provided {@link AtBScenario}, the method
+     * returns that {@link StratconScenario}.
+     *
+     * @param contract    the {@link AtBContract} from which to retrieve the
+     *                    {@link StratconCampaignState} and associated tracks
+     * @param atBScenario the {@link AtBScenario} to match against the backing scenarios
+     *                    of the {@link StratconScenario} instances
      * @return the matching {@link StratconScenario} if found, or {@code null} if no match
      *         is found or any required data is missing
-     * @throws NullPointerException if {@code campaign} is {@code null}
      */
-    public @Nullable StratconScenario getStratconScenario(Campaign campaign) {
-        // Get contract
-        AtBContract contract = getContract(campaign);
-        if (contract == null) {
+    public @Nullable StratconScenario getStratconScenario(AtBContract contract, AtBScenario atBScenario) {
+        if (contract == null || atBScenario == null) {
             return null;
         }
 
@@ -2151,14 +2156,14 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         for (StratconTrackState track : campaignState.getTracks()) {
             Collection<StratconScenario> trackScenarios = track.getScenarios().values();
 
-            for (StratconScenario scenario : trackScenarios) {
-                AtBDynamicScenario backingScenario = scenario.getBackingScenario();
+            for (StratconScenario stratconScenario : trackScenarios) {
+                AtBDynamicScenario backingScenario = stratconScenario.getBackingScenario();
                 if (backingScenario == null) {
                     continue;
                 }
 
-                if (backingScenario.getMissionId() == getMissionId()) {
-                    return scenario;
+                if (Objects.equals(atBScenario, backingScenario)) {
+                    return stratconScenario;
                 }
             }
         }

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -604,7 +604,9 @@ public final class BriefingTab extends CampaignGuiTab {
 
             // This handles StratCon undeployment
             if (scenario instanceof AtBScenario) {
-                StratconScenario stratConScenario = ((AtBScenario) scenario).getStratconScenario(getCampaign());
+                AtBContract contract = ((AtBScenario) scenario).getContract(getCampaign());
+                StratconScenario stratConScenario = ((AtBScenario) scenario).getStratconScenario(contract,
+                    (AtBScenario) scenario);
 
                 if (stratConScenario != null) {
                     stratConScenario.resetScenario(getCampaign());


### PR DESCRIPTION
- Updated `AtBScenario.getStratconScenario` to take `AtBContract` and `AtBScenario` as parameters for improved clarity and separation of responsibilities.
- Refactored `ScenarioTableModel` rendering logic for StratCon scenarios, simplifying status and turning point display.
- Enhanced string formatting to incorporate localized "Turning Point" text from resources.
- Adjusted StratCon scenario coordinate and track name determination for better null handling and accuracy.
- Updated `ScenarioTableModel.properties` to include a new key for "Turning Point" localization.

Fix #6063

### Dev Note
I moved the Turning Point helper to the status column, making it easier to add other helpers if we introduce additional scenario types in the future. This also eliminates any ambiguity in the display.