### PR TITLE
Fixed Maternity Leave Activation Logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -608,7 +608,7 @@ public abstract class AbstractProcreation {
 
             if (campaign.getCampaignOptions().isUseMaternityLeave()) {
                 if (person.getStatus().isActive()
-                    && (person.getDueDate().minusWeeks(20).isAfter(today.minusDays(1)))) {
+                    && (person.getDueDate().minusWeeks(20).isBefore(today))) {
                     person.changeStatus(campaign, today, PersonnelStatus.ON_MATERNITY_LEAVE);
                 }
             }


### PR DESCRIPTION
- Updated condition to correctly assess maternity leave activation relative to the due date.
- Adjusted logic to check if due date minus 20 weeks is before today, improving accuracy.

Fix #6107