### PR TITLE
MekHQ Issue 3655: Fix vehicle crew requirements for trailers 

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -584,6 +584,11 @@ public class ResolveScenarioTracker {
                         }
                     }
                 }
+                // No crew? All's good, no personnel, next.
+                if (u.isUnmannedTrailer()) {
+                    continue;
+                }
+
                 // check for an ejected entity and if we find one then assign it instead to
                 // switch vees
                 // over to infantry checks for casualties

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -25,6 +25,7 @@ import megamek.Version;
 import megamek.client.ui.swing.tileset.EntityImage;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.*;
+import megamek.common.CrewType;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.ArmorType;
@@ -73,7 +74,6 @@ import java.awt.*;
 import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.math.BigInteger;
 import java.util.List;
 import java.util.*;
 import java.util.Map.Entry;
@@ -1121,7 +1121,7 @@ public class Unit implements ITechnology {
         if (!isFunctional()) {
             return "unit is not functional";
         }
-        if (isUnmanned()) {
+        if (isUnmanned() && !(isUnmannedTrailer())) {
             return "unit has no pilot";
         }
         if (isRefitting()) {
@@ -5282,6 +5282,19 @@ public class Unit implements ITechnology {
 
     public boolean isUnmanned() {
         return (null == getCommander());
+    }
+
+    /**
+     * A trailer with no engine or weapons doesn't ened any crew.
+     * @return true if this Unit is an unmanned trailer, false if it isn't a trailer or has a crew
+     */
+    public boolean isUnmannedTrailer() {
+        if (getEntity() instanceof Tank tank) {
+            if (tank.isTrailer() && (tank.defaultCrewType().equals(CrewType.NONE))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public int getForceId() {

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -936,6 +936,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
 
                 // Only add units that have commanders
                 // Or Gun Emplacements!
+                // Or don't need a crew (trailers)
                 // TODO: Or Robotic Systems!
                 JMenu unsorted = new JMenu("Unsorted");
 
@@ -957,6 +958,18 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                             }
                             unitTypeMenus.get(type).setEnabled(true);
                         }
+                    } else if ((u.getForceId() < 1) && (u.isPresent()) && (u.isUnmannedTrailer())) {
+                        JMenuItem menuItem0 = new JMenuItem(u.getName());
+                        menuItem0.setActionCommand(TOEMouseAdapter.COMMAND_ADD_UNIT + u.getId() + '|' + forceIds);
+                        menuItem0.addActionListener(this);
+                        menuItem0.setEnabled(u.isAvailable());
+                        if (null != weightClassForUnitType.get(type + '_' + className)) {
+                            weightClassForUnitType.get(type + '_' + className).add(menuItem0);
+                            weightClassForUnitType.get(type + '_' + className).setEnabled(true);
+                        } else {
+                            unsorted.add(menuItem0);
+                        }
+                        unitTypeMenus.get(type).setEnabled(true);
                     }
 
                     if (u.getEntity() instanceof GunEmplacement) {

--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -862,7 +862,8 @@ public class ResolveScenarioWizardDialog extends JDialog {
                 index++;
                 if (unit.getEntity() instanceof GunEmplacement) {
                     assignModel.addElement("AutoTurret, " + unit.getName());
-                } else {
+                } else if (unit.hasCommander()) {
+                    // If there's no commander we don't need to show anything because we only credit kills to personnel.
                     assignModel.addElement(unit.getCommander().getFullTitle() + ", " + unit.getName());
                 }
 


### PR DESCRIPTION
**Dependent on MegaMek/megamek#6643 - do not merge until that has been merged.**

Fixes #3655 

Trailers no longer require crew in MekHQ (if appropriate - if a trailer has weapons or an engine it'll need crew). Trailers with no crew can be added to the TOE now. Trailers with no crew are no longer listed as crippled in the hangar. Trailers with no crew can be sent to MegaMek correctly, and work as expected in the `ResolveScenarioWizardDialog.java` (no creating a new "No Commander" person, no assigning kills to unmanned trailers, no NPEs!).