### PR TITLE
Issue 6112: Fix BA Ammo Issues

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -342,6 +342,9 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     }
 
     public AmmoStorage getNewPart() {
+        if (getType().getKgPerShot() > 0) {
+            return new AmmoStorage(1, getType(), (int) Math.ceil(1000 / getType().getKgPerShot()), campaign);
+        }
         return new AmmoStorage(1, getType(), getType().getShots(), campaign);
     }
 

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -321,8 +321,17 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
      */
     protected int requisitionAmmo(AmmoType ammoType, int shotsNeeded) {
         Objects.requireNonNull(ammoType);
+        int shotsLoaded = 0;
+        while (shotsLoaded < shotsNeeded) {
+            int shots = campaign.getQuartermaster().removeAmmo(ammoType, shotsNeeded - shotsLoaded);
+            if (shots < 1) {
+                return shotsLoaded;
+            } else {
+                shotsLoaded += shots;
+            }
+        }
 
-        return campaign.getQuartermaster().removeAmmo(ammoType, shotsNeeded);
+        return shotsLoaded;
     }
 
     /**
@@ -516,7 +525,7 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         if (null != unit) {
             int shotsAvailable = getAmountAvailable();
             PartInventory inventories = campaign.getPartInventory(getNewPart());
-            
+
             StringBuilder toReturn = new StringBuilder();
             toReturn.append(getType().getDesc())
                 .append(", ")

--- a/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/BattleArmorAmmoBin.java
@@ -133,25 +133,35 @@ public class BattleArmorAmmoBin extends AmmoBin {
         }
     }
 
+    /**
+     * Requisition ammo for this bin and remove it
+     * from the warehouse.
+     * Only allow Battle Armor Ammo bins to be loaded
+     * in <code>getNumTroopers()</code> bins at a time.
+     * @see #getNumTroopers()
+     */
     @Override
     public void loadBin() {
         AmmoMounted mounted = (AmmoMounted) getMounted();
         if (mounted != null) {
+
             // Calculate the actual shots needed
             int shotsPerTrooper = shotsNeeded / getNumTroopers();
-            int shots = requisitionAmmo(getType(), shotsPerTrooper * getNumTroopers());
+            int shotsToReload = Math.min(shotsPerTrooper, (int) Math.floor( (double) getAmountAvailable() / getNumTroopers()));
+            for (int shotsPerSuitLoaded = 0; shotsPerSuitLoaded < shotsToReload; shotsPerSuitLoaded++ ) {
+                int shots = requisitionAmmo(getType(), getNumTroopers());
+                shotsNeeded -= shots;
+            }
 
             if (!ammoTypeChanged()) {
                 // Just a simple reload
-                mounted.setShotsLeft(mounted.getBaseShotsLeft() + shotsPerTrooper);
+                mounted.setShotsLeft(mounted.getBaseShotsLeft() + shotsToReload);
             } else {
                 // Loading a new type of ammo
                 unload();
                 mounted.changeAmmoType(getType());
-                mounted.setShotsLeft(shotsPerTrooper);
+                mounted.setShotsLeft(mounted.getBaseShotsLeft() + shotsToReload);
             }
-
-            shotsNeeded -= shots;
         }
     }
 

--- a/MekHQ/unittests/mekhq/campaign/parts/equipment/BattleArmorAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/equipment/BattleArmorAmmoBinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2020-2025 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -20,9 +20,19 @@ package mekhq.campaign.parts.equipment;
 
 import megamek.Version;
 import megamek.common.AmmoType;
+import megamek.common.BattleArmor;
+import megamek.common.Entity;
+import megamek.common.Mounted;
+import megamek.common.equipment.AmmoMounted;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.Quartermaster;
+import mekhq.campaign.Warehouse;
 import mekhq.campaign.parts.Part;
+import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -36,7 +46,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import static mekhq.campaign.parts.AmmoUtilities.getAmmoType;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
 
 public class BattleArmorAmmoBinTest {
     @Test
@@ -270,5 +282,158 @@ public class BattleArmorAmmoBinTest {
         assertEquals(ammoBin.getType(), deserialized.getType());
         assertEquals(ammoBin.getShotsNeeded(), deserialized.getShotsNeeded());
         assertEquals(ammoBin.getName(), deserialized.getName());
+    }
+
+    @Nested
+    public class TestLoadedAmmo {
+        final int SQUAD_SIZE = 5;
+        final int equipmentNum = 42;
+        final AmmoType ammoType = getAmmoType("BA-SRM2 Ammo");
+
+        Campaign mockCampaign;
+        CampaignOptions mockCampaignOptions;
+        Warehouse warehouse;
+        Quartermaster quartermaster;
+        Unit mockUnit;
+        BattleArmor mockEntity;
+        AmmoMounted mockMounted;
+
+        @BeforeEach
+        public void beforeEach() {
+            mockCampaign = mock(Campaign.class);
+            mockCampaignOptions = mock(CampaignOptions.class);
+            when(mockCampaign.getCampaignOptions()).thenReturn(mockCampaignOptions);
+            warehouse = new Warehouse();
+            when(mockCampaign.getWarehouse()).thenReturn(warehouse);
+            quartermaster = new Quartermaster(mockCampaign);
+            when(mockCampaign.getQuartermaster()).thenReturn(quartermaster);
+
+            mockUnit = mock(Unit.class);
+            mockEntity = mock(BattleArmor.class);
+            when(mockEntity.getSquadSize()).thenReturn(SQUAD_SIZE);
+            when(mockUnit.getEntity()).thenReturn(mockEntity);
+            mockMounted = mock(AmmoMounted.class);
+            when(mockMounted.getType()).thenReturn(ammoType);
+            when(mockEntity.getEquipment(eq(equipmentNum))).thenReturn((Mounted) mockMounted);
+        }
+
+
+        @Test
+        public void loadBinWithJustEnoughSpareAmmo() {
+            // ARRANGE
+            // Create an Ammo Bin with no ammo ...
+            int shotsNeeded = ammoType.getShots() * SQUAD_SIZE;
+            BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, mockCampaign);
+
+            // ... place the ammo bin on a unit ...
+            ammoBin.setUnit(mockUnit);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+
+            // ... and add just enough ammo of the right type to the warehouse ...
+            quartermaster.addAmmo(ammoType, ammoType.getShots() * SQUAD_SIZE);
+
+
+            // ACT
+            // ... and try to load it.
+            ammoBin.loadBin();
+
+            // ASSERT
+            // We should have no shots needed ...
+            assertEquals(0, ammoBin.getShotsNeeded());
+            verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded / SQUAD_SIZE));
+
+            // ... and no more ammo available in the warehouse
+            assertEquals(0, quartermaster.getAmmoAvailable(ammoType));
+        }
+
+        @Test
+        public void loadBinWithJustInsufficientSpareAmmo() {
+            // ARRANGE
+            // Create an Ammo Bin with no ammo ...
+            int shotsNeeded = ammoType.getShots() * SQUAD_SIZE;
+            BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, mockCampaign);
+
+            // ... place the ammo bin on a unit ...
+            ammoBin.setUnit(mockUnit);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+
+            // ... and add just barely not enough ammo to the warehouse ...
+            quartermaster.addAmmo(ammoType, (ammoType.getShots() * SQUAD_SIZE) - 1);
+
+
+            // ACT
+            // ... and try to load it.
+            ammoBin.loadBin();
+
+            // ASSERT
+            // We should still need ammo ...
+            assertEquals(shotsNeeded, ammoBin.getShotsNeeded());
+            verify(mockMounted, times(0)).setShotsLeft(eq(shotsNeeded / SQUAD_SIZE));
+
+            // ... and all ammo available in the warehouse
+            assertEquals((ammoType.getShots() * SQUAD_SIZE) - 1, quartermaster.getAmmoAvailable(ammoType));
+        }
+
+        /**
+         * If you partially load BA's ammo and save and reload the game,
+         * it will give them a free shot at the Entity level. The BA
+         * Entity tracks the shots at a per-squad level, not per
+         * individual.
+         */
+        @Test
+        public void loadBinWithPartialSpareAmmo() {
+            // ARRANGE
+            // Create an Ammo Bin with no ammo ...
+            int shotsNeeded = ammoType.getShots() * SQUAD_SIZE * 2;
+            BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, mockCampaign);
+
+            // ... place the ammo bin on a unit ...
+            ammoBin.setUnit(mockUnit);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+
+            // ... and add only enough ammo to load a portion of the battle armor (1 extra ammo) ...
+            quartermaster.addAmmo(ammoType, (ammoType.getShots() * SQUAD_SIZE) + 1);
+
+
+            // ACT
+            // ... and try to load it.
+            ammoBin.loadBin();
+
+            // ASSERT
+            // We should still need some ammo ...
+            assertEquals(shotsNeeded - SQUAD_SIZE, ammoBin.getShotsNeeded());
+            verify(mockMounted, times(1)).setShotsLeft(eq((shotsNeeded / SQUAD_SIZE) - 1));
+
+            // ... and there's one ammo leftover
+            assertEquals(1, quartermaster.getAmmoAvailable(ammoType));
+        }
+
+        @Test
+        public void loadBinWithBountifulSpareAmmo() {
+            // ARRANGE
+            // Create an Ammo Bin with no ammo ...
+            int shotsNeeded = ammoType.getShots() * SQUAD_SIZE;
+            BattleArmorAmmoBin ammoBin = new BattleArmorAmmoBin(0, ammoType, equipmentNum, shotsNeeded, false, mockCampaign);
+
+            // ... place the ammo bin on a unit ...
+            ammoBin.setUnit(mockUnit);
+            when(mockMounted.getBaseShotsLeft()).thenReturn(0);
+
+            // ... and add lots of extra ammo (we're testing if we can overload the unit) ...
+            quartermaster.addAmmo(ammoType, (ammoType.getShots() * SQUAD_SIZE * 10));
+
+
+            // ACT
+            // ... and try to load it.
+            ammoBin.loadBin();
+
+            // ASSERT
+            // We shouldn't need any more ammo ...
+            assertEquals(shotsNeeded - SQUAD_SIZE, ammoBin.getShotsNeeded());
+            verify(mockMounted, times(1)).setShotsLeft(eq(shotsNeeded / SQUAD_SIZE));
+
+            // ... and the correct amount of ammo is left
+            assertEquals(ammoType.getShots() * SQUAD_SIZE * 9, quartermaster.getAmmoAvailable(ammoType));
+        }
     }
 }


### PR DESCRIPTION
Fixes #6112 

- Battle Armor Ammo is now purchased by the ton (50 for SRM ammo) instead of per shot per trooper (1 for SRM ammo) - for reference an Elemental point needs 10 SRM rounds to fully rearm.
- Ammo lookup will consider other qualities of ammo.
- Battle Armor ammo properly partially reloads now - Before this fix I was managing to get _3_ SRM rounds per trooper on an Elemental which isn't right.
- Battle Armor ammo loading now gets ammo in `getNumTrooper()` size batches. An BA unit must have the same ammo in all units, otherwise if even one BA unit has more ammo than the rest then they all have that ammo - I was generating 4 free SRM shots by reloading 6 SRM shots and then reloading the game - and then my elemental is fully armed. 