### PR TITLE
 Improved Effective Fatigue Handling and Fixed Target Selection in POISON Event Effects

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1603,6 +1603,32 @@ public class Person {
         return fatigue;
     }
 
+    /**
+     * Calculates the effective fatigue for a person.
+     *
+     * @param campaign the campaign for which to calculate the effective fatigue
+     * @return the effective fatigue value
+     */
+    public int getEffectiveFatigue(Campaign campaign) {
+        int effectiveFatigue = fatigue;
+
+        if (isClanPersonnel()) {
+            effectiveFatigue -= 2;
+        }
+
+        switch (getSkillLevel(campaign, false)) {
+            case VETERAN -> effectiveFatigue--;
+            case ELITE, HEROIC, LEGENDARY -> effectiveFatigue -= 2;
+            default -> {}
+        }
+
+        if (campaign.getFieldKitchenWithinCapacity()) {
+            effectiveFatigue--;
+        }
+
+        return effectiveFatigue;
+    }
+
     public void setFatigue(final int fatigue) {
         this.fatigue = fatigue;
     }
@@ -4702,42 +4728,6 @@ public class Person {
             case 17 -> -2;
             default -> -3;
         };
-    }
-
-    /**
-     * Calculates the effective fatigue for a person.
-     *
-     * @param campaign the campaign for which to calculate the effective fatigue
-     * @return the effective fatigue value
-     */
-    public int getEffectiveFatigue(Campaign campaign) {
-        int effectiveFatigue = fatigue;
-
-        if (isClanPersonnel()) {
-            effectiveFatigue -= 2;
-        }
-
-        switch (getSkillLevel(campaign, false)) {
-            case NONE:
-            case ULTRA_GREEN:
-            case GREEN:
-            case REGULAR:
-                break;
-            case VETERAN:
-                effectiveFatigue--;
-                break;
-            case ELITE:
-            case HEROIC:
-            case LEGENDARY:
-                effectiveFatigue -= 2;
-                break;
-        }
-
-        if (campaign.getFieldKitchenWithinCapacity()) {
-            effectiveFatigue--;
-        }
-
-        return effectiveFatigue;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/EventEffectsManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/EventEffectsManager.java
@@ -1010,15 +1010,13 @@ public class EventEffectsManager {
 
         final int magnitude = result.magnitude();
 
-        List<Person> potentialTargets = campaign.getActivePersonnel(true);
+        List<Person> potentialTargets = campaign.getActivePersonnel(false);
 
         if (potentialTargets.isEmpty()) {
             return "";
         }
 
-        double percentage = 0.1;
-
-        int targetCount = (int) max(1, potentialTargets.size() * percentage);
+        int targetCount = potentialTargets.size();
 
         for (int i = 0; i < targetCount; i++) {
             Person target = getRandomItem(potentialTargets);

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1599,7 +1599,8 @@ public class PersonViewPanel extends JScrollablePanel {
             firsty++;
         }
 
-        if ((campaign.getCampaignOptions().isUseFatigue()) && (person.getEffectiveFatigue(campaign) > 0)) {
+        int fatigue = person.getFatigue();
+        if (campaign.getCampaignOptions().isUseFatigue() && fatigue > 0) {
             lblFatigue1.setName("lblFatigue1");
             lblFatigue1.setText(resourceMap.getString("lblFatigue1.text"));
             gridBagConstraints = new GridBagConstraints();
@@ -1609,16 +1610,23 @@ public class PersonViewPanel extends JScrollablePanel {
             gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
             pnlSkills.add(lblFatigue1, gridBagConstraints);
 
-            StringBuilder fatigueDisplay = new StringBuilder();
+            StringBuilder fatigueDisplay = new StringBuilder("<html>");
 
             int effectiveFatigue = person.getEffectiveFatigue(campaign);
             int fatigueTurnoverModifier = MathUtility.clamp(((person.getEffectiveFatigue(campaign) - 1) / 4) - 1, 0, 3);
 
-            fatigueDisplay.append(effectiveFatigue);
+            if (effectiveFatigue != fatigue) {
+                fatigueDisplay.append("<s><font color='gray'>").append(fatigue).append("</font></s> ")
+                    .append(effectiveFatigue);
+            } else {
+                fatigueDisplay.append("<font color='gray'>").append(effectiveFatigue).append("</font>");
+            }
 
             if (fatigueTurnoverModifier > 0) {
                 fatigueDisplay.append(" (-").append(fatigueTurnoverModifier).append(')');
             }
+
+            fatigueDisplay.append("</html>");
 
             lblFatigue2.setName("lblFatigue2");
             lblFatigue2.setText(fatigueDisplay.toString());

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
@@ -673,7 +673,7 @@ class EventEffectsManagerTest {
         Person soldier1 = new Person(mockCampaign);
         Person soldier2 = new Person(mockCampaign);
         List<Person> potentialTargets = List.of(soldier0, soldier1, soldier2);
-        when(mockCampaign.getActivePersonnel(true)).thenReturn(new ArrayList<>(potentialTargets));
+        when(mockCampaign.getActivePersonnel(false)).thenReturn(new ArrayList<>(potentialTargets));
 
         // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);
@@ -686,6 +686,6 @@ class EventEffectsManagerTest {
             }
         }
 
-        assertEquals(1, fatiguedCharacters);
+        assertEquals(3, fatiguedCharacters);
     }
 }


### PR DESCRIPTION
- Enhanced fatigue display by showing differences between raw and effective fatigue for better clarity.
- Fixed incorrect parameter in `getActivePersonnel` call in `EventEffectsManager`, ensuring prisoners personnel are excluded for the POISON event.
- Adjusted target selection logic in `EventEffectsManager` to include all potential targets instead of a fraction.
- Updated unit tests to reflect these changes, improving test coverage and fixing assertion logic.

Fix #6121