### PR TITLE
Removed Non-Current Scenario Status Handling In `CommandCenterTab.java`

### DIFF
--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2020-2025 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -642,25 +642,12 @@ public final class CommandCenterTab extends CampaignGuiTab {
                     model.addElement(String.format("<html><b>" + mission.getName() + "</b></html>"));
 
                     for (Scenario scenario : scenarios) {
-
                         if (scenario.getStatus().isCurrent()) {
                             // StratCon facility contacts that haven't yet been discovered are stored as scenarios with null start dates
                             if (scenario.getDate() != null) {
                                 model.addElement(String.format("<html><b>" + scenario.getName() + ":</b> "
                                         + "<font color='" + MekHQ.getMHQOptions().getFontColorWarningHexColor() + "'>"
                                         + ChronoUnit.DAYS.between(getCampaign().getLocalDate(), scenario.getDate())) + " days</font</html>");
-                            }
-                        } else {
-                            if (scenario.getStatus().isOverallVictory()) {
-                                model.addElement(String.format("<html><b>" + scenario.getName() + ":</b> "
-                                        + "<font color='" + MekHQ.getMHQOptions().getFontColorPositiveHexColor() + "'>"
-                                        + scenario.getStatus().toString()
-                                        + "</font></html>"));
-                            } else {
-                                model.addElement(String.format("<html><b>" + scenario.getName() + ":</b> "
-                                        + "<font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor() + "'>"
-                                        + scenario.getStatus().toString()
-                                        + "</font></html>"));
                             }
                         }
                     }


### PR DESCRIPTION
- Simplified code by eliminating unnecessary handling of non-current scenario statuses.
- Removed code path that displayed overall victory or negative statuses for non-current scenarios, as they were not required.

Fix #6119

### Dev Notes
This change ensures that only current scenarios are displayed in the Command Center. This means that for players with one, or more, subcontracts they don't have to scroll past potentially tens of scenarios to see the upcoming scenarios for their subcontracts.