### PR TITLE
 Prevented New Contract Offers When an Active Contract Exists

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -75,6 +75,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
     @Override
     public void generateContractOffers(Campaign campaign, boolean newCampaign) {
         boolean isGrayMonday = isGrayMonday(campaign);
+        boolean hasActiveContract = campaign.hasActiveContract() || campaign.hasActiveAtBContract(true);
 
         if (((campaign.getLocalDate().getDayOfMonth() == 1)) || newCampaign) {
             // need to copy to prevent concurrent modification errors
@@ -84,6 +85,16 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
             for (AtBContract contract : campaign.getActiveAtBContracts()) {
                 checkForSubcontracts(campaign, contract, unitRatingMod);
+
+                if (!contracts.isEmpty() && hasActiveContract) {
+                    updateReport(campaign);
+                }
+            }
+
+            // If the player has an active contract, they will not be offered new contracts,
+            // as MekHQ doesn't support multiple contracts (outside of subcontracts).
+            if (hasActiveContract) {
+                return;
             }
 
             int numContracts = d6() - 4 + unitRatingMod;

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
@@ -69,10 +69,19 @@ public class CamOpsContractMarket extends AbstractContractMarket {
     @Override
     public void generateContractOffers(Campaign campaign, boolean newCampaign) {
         boolean isGrayMonday = isGrayMonday(campaign);
+        boolean hasActiveContract = campaign.hasActiveContract()
+            || campaign.hasActiveAtBContract(true);
 
         if (!(campaign.getLocalDate().getDayOfMonth() == 1) && !newCampaign) {
             return;
         }
+
+        // If the player has an active contract, they will not be offered new contracts,
+        // as MekHQ doesn't support multiple contracts (outside of subcontracts).
+        if (hasActiveContract) {
+            return;
+        }
+
         new ArrayList<>(contracts).forEach(this::removeContract);
         // TODO: Allow subcontracts?
         //for (AtBContract contract : campaign.getActiveAtBContracts()) {


### PR DESCRIPTION
- Updated `AtbMonthlyContractMarket` and `CamOpsContractMarket` to restrict generating new contract offers if the player has an active contract (AtB or otherwise).
- Ensured MekHQ's limitation of supporting only one main contract (apart from subcontracts) is enforced.