### PR TITLE
Refactored `ReputationFactor` To Use `Double` Instead Of `Integer`

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
@@ -106,7 +106,7 @@ public class CamOpsContractMarket extends AbstractContractMarket {
 
     @Override
     public double calculatePaymentMultiplier(Campaign campaign, AtBContract contract) {
-        int reputationFactor = campaign.getReputation().getReputationFactor();
+        double reputationFactor = campaign.getReputation().getReputationFactor();
         ContractTerms terms = getContractTerms(campaign, contract);
         return terms.getEmploymentMultiplier() * terms.getOperationsTempoMultiplier() * reputationFactor;
     }

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/ContractTerms.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/ContractTerms.java
@@ -38,7 +38,7 @@ public class ContractTerms {
     private int supportModifier;
     private int transportModifier;
 
-    public ContractTerms(AtBContractType mission, Faction employer, int reputationFactor, LocalDate date) {
+    public ContractTerms(AtBContractType mission, Faction employer, double reputationFactor, LocalDate date) {
         operationsTempoMultiplier = mission.getOperationsTempoMultiplier();
         baseLength = mission.getConstantLength();
         addMissionTypeModifiers(mission);
@@ -296,30 +296,32 @@ public class ContractTerms {
         }
     }
 
-    private void addUnitReputationModifiers(int reputationFactor) {
-        switch(MathUtility.clamp(reputationFactor, 0, 10)) {
+    private void addUnitReputationModifiers(double reputationFactor) {
+        int flooredReputationFactor = (int) Math.floor(reputationFactor);
+
+        switch(MathUtility.clamp(flooredReputationFactor, 0, 10)) {
             case 0:
-                commandModifier += -2;
-                salvageModifier += -1;
-                supportModifier += -1;
-                transportModifier += -3;
+                commandModifier -= 2;
+                salvageModifier -= 1;
+                supportModifier -= 1;
+                transportModifier -= 3;
                 break;
             case 1:
-                commandModifier += -1;
-                salvageModifier += -1;
-                supportModifier += -1;
-                transportModifier += -2;
+                commandModifier -= 1;
+                salvageModifier -= 1;
+                supportModifier -= 1;
+                transportModifier -= 2;
                 break;
             case 2:
-                commandModifier += -1;
-                transportModifier += -2;
+                commandModifier -= 1;
+                transportModifier -= 2;
                 break;
             case 3:
-                commandModifier += -1;
-                transportModifier += -1;
+                commandModifier -= 1;
+                transportModifier -= 1;
                 break;
             case 4:
-                transportModifier += -1;
+                transportModifier -= 1;
                 break;
             case 6:
             case 7:

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/ReputationController.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/ReputationController.java
@@ -106,8 +106,8 @@ public class ReputationController {
         return this.reputationRating;
     }
 
-    public int getReputationFactor() {
-        return (int) (getReputationModifier() * 0.2 + 0.5);
+    public double getReputationFactor() {
+        return getReputationModifier() * 0.2 + 0.5;
     }
     // endregion Getters and Setters
 


### PR DESCRIPTION
- Changed `reputationFactor` data type from `int` to `double` in multiple classes for improved precision.
- Updated `ContractTerms` constructor and `addUnitReputationModifiers` to work with `double` values, including proper flooring and clamping.
- Modified `calculatePaymentMultiplier` in `CamOpsContractMarket` to utilize the new `double` type for `reputationFactor`.
- Adjusted `getReputationFactor` in `ReputationController` to return a `double` for consistency with related changes.

Fix #6117

### Dev Notes
Because Reputation Factor was being stored as an integer it was effectively flooring the value. That meant that any value between 0 and 1 (but less than 1) would be stored as 0. Essentially meaning the user would get a zero base pay. Rules as Written the minimal value is 0.5. However, other parts of CamOps expect integer values, in those cases I locally floor the value, ensuring those values are working as expected without compromising other calculations.