### PR TITLE
Enabled Autosave Before Missions By Default

### DIFF
--- a/MekHQ/src/mekhq/MHQOptions.java
+++ b/MekHQ/src/mekhq/MHQOptions.java
@@ -18,17 +18,16 @@
  */
 package mekhq;
 
-import java.awt.Color;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-
-import javax.swing.UIManager;
-
 import megamek.SuiteOptions;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.universe.enums.CompanyGenerationMethod;
 import mekhq.gui.enums.ForceIconOperationalStatusStyle;
 import mekhq.gui.enums.PersonnelFilterStyle;
+
+import javax.swing.*;
+import java.awt.*;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 public final class MHQOptions extends SuiteOptions {
     // region Display Tab
@@ -759,7 +758,7 @@ public final class MHQOptions extends SuiteOptions {
 
     public boolean getAutosaveBeforeMissionsValue() {
         return userPreferences.node(MHQConstants.AUTOSAVE_NODE).getBoolean(MHQConstants.SAVE_BEFORE_MISSIONS_KEY,
-                false);
+                true);
     }
 
     public void setAutosaveBeforeMissionsValue(boolean value) {


### PR DESCRIPTION
- Updated `getAutosaveBeforeMissionsValue` to default to `true` instead of `false`.
- Ensures missions are autosaved by default.

### Dev Notes
I doubt this change will affect installs that were made prior to this change going into effect - namely, users running from master instead of an artifact.

We made this change as it increases the likelihood a player will have a pre-scenario save on hand when it comes to opening issue reports. It also improves user experience by allowing players to more reliably roll back disastrous scenarios, should they wish.