### PR TITLE
Added Age Calculation In Personnel Table Column

### DIFF
--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -484,6 +484,7 @@ public enum PersonnelTableModelColumn {
             case CALLSIGN:
                 return person.getCallsign();
             case AGE:
+                return String.valueOf(person.getAge(campaign.getLocalDate()));
             case BIRTHDAY:
                 return MekHQ.getMHQOptions().getDisplayFormattedDate(person.getDateOfBirth());
             case PERSONNEL_STATUS:


### PR DESCRIPTION
- Updated `PersonnelTableModelColumn.java` to display the calculated age based on the campaign's local date.
- Ensured the age value is returned as a String for proper display.

Fix #6113