### PR TITLE
Added Auto-Logistics Support For Actuators, Jump Jets, And Engines

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -258,6 +258,15 @@ lblAutoLogisticsAmmunition.tooltip=autoLogistics counts the tonnage of ammo in u
 lblAutoLogisticsHeatSink.text=Heat Sink Restock Percent
 lblAutoLogisticsHeatSink.tooltip=autoLogistics counts the number of heat sinks in use and then\
   \ automatically orders replacement spares equal to the percentage set in this option.
+lblAutoLogisticsActuators.text=Actuators Restock Percent
+lblAutoLogisticsActuators.tooltip=autoLogistics counts the number of 'Mek actuators in use and then\
+  \ automatically orders replacement spares equal to the percentage set in this option.
+lblAutoLogisticsJumpJets.text=Jump Jets Restock Percent
+lblAutoLogisticsJumpJets.tooltip=autoLogistics counts the number of jump jets in use and then\
+  \ automatically orders replacement spares equal to the percentage set in this option.
+lblAutoLogisticsEngines.text=Engine Restock Percent
+lblAutoLogisticsEngines.tooltip=autoLogistics counts the number of engines in use and then\
+  \ automatically orders replacement spares equal to the percentage set in this option.
 lblAutoLogisticsOther.text=Other Restock Percent
 lblAutoLogisticsOther.tooltip=autoLogistics counts each part in use, that is not covered by one of\
   \ the other options, and automatically orders replacement spares equal to the percentage set in\

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -73,10 +73,7 @@ import mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType;
 import mekhq.campaign.mod.am.InjuryUtil;
 import mekhq.campaign.parts.*;
 import mekhq.campaign.parts.enums.PartQuality;
-import mekhq.campaign.parts.equipment.AmmoBin;
-import mekhq.campaign.parts.equipment.EquipmentPart;
-import mekhq.campaign.parts.equipment.HeatSink;
-import mekhq.campaign.parts.equipment.MissingEquipmentPart;
+import mekhq.campaign.parts.equipment.*;
 import mekhq.campaign.personnel.*;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.death.RandomDeath;
@@ -117,8 +114,6 @@ import mekhq.campaign.unit.CrewType;
 import mekhq.campaign.unit.*;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.campaign.universe.*;
-import mekhq.campaign.universe.Planet.PlanetaryEvent;
-import mekhq.campaign.universe.PlanetarySystem.PlanetarySystemEvent;
 import mekhq.campaign.universe.enums.HiringHallLevel;
 import mekhq.campaign.universe.eras.Era;
 import mekhq.campaign.universe.eras.Eras;
@@ -2593,6 +2588,12 @@ public class Campaign implements ITechManager {
             return campaignOptions.getAutoLogisticsAmmunition();
         } else if (part instanceof Armor ) {
             return campaignOptions.getAutoLogisticsArmor();
+        } else if (part instanceof MekActuator) {
+            return campaignOptions.getAutoLogisticsActuators();
+        } else if (part instanceof JumpJet) {
+            return campaignOptions.getAutoLogisticsJumpJets();
+        } else if (part instanceof EnginePart) {
+            return campaignOptions.getAutoLogisticsEngines();
         }
 
         return campaignOptions.getAutoLogisticsOther();

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -154,6 +154,9 @@ public class CampaignOptions {
     private int autoLogisticsNonRepairableLocation;
     private int autoLogisticsArmor;
     private int autoLogisticsAmmunition;
+    private int autoLogisticsActuators;
+    private int autoLogisticsJumpJets;
+    private int autoLogisticsEngines;
     private int autoLogisticsOther;
 
     // Delivery
@@ -659,13 +662,16 @@ public class CampaignOptions {
         maxAcquisitions = 0;
 
         // autoLogistics
-        autoLogisticsHeatSink = 250;
-        autoLogisticsMekHead = 200;
-        autoLogisticsMekLocation = 100;
+        autoLogisticsHeatSink = 50;
+        autoLogisticsMekHead = 40;
+        autoLogisticsMekLocation = 25;
         autoLogisticsNonRepairableLocation = 0;
-        autoLogisticsArmor = 500;
-        autoLogisticsAmmunition = 500;
-        autoLogisticsOther = 50;
+        autoLogisticsArmor = 100;
+        autoLogisticsAmmunition = 100;
+        autoLogisticsActuators = 100;
+        autoLogisticsJumpJets = 50;
+        autoLogisticsEngines = 0;
+        autoLogisticsOther = 0;
 
         // Delivery
         unitTransitTime = TRANSIT_UNIT_MONTH;
@@ -4150,6 +4156,30 @@ public class CampaignOptions {
         this.autoLogisticsAmmunition = autoLogisticsAmmunition;
     }
 
+    public int getAutoLogisticsActuators() {
+        return autoLogisticsActuators;
+    }
+
+    public void setAutoLogisticsActuators(int autoLogisticsActuators) {
+        this.autoLogisticsActuators = autoLogisticsActuators;
+    }
+
+    public int getAutoLogisticsJumpJets() {
+        return autoLogisticsJumpJets;
+    }
+
+    public void setAutoLogisticsJumpJets(int autoLogisticsJumpJets) {
+        this.autoLogisticsJumpJets = autoLogisticsJumpJets;
+    }
+
+    public int getAutoLogisticsEngines() {
+        return autoLogisticsEngines;
+    }
+
+    public void setAutoLogisticsEngines(int autoLogisticsEngines) {
+        this.autoLogisticsEngines = autoLogisticsEngines;
+    }
+
     public int getAutoLogisticsOther() {
         return autoLogisticsOther;
     }
@@ -4688,6 +4718,9 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsNonRepairableLocation", autoLogisticsNonRepairableLocation);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsArmor", autoLogisticsArmor);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsAmmunition", autoLogisticsAmmunition);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsActuators", autoLogisticsActuators);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsJumpJets", autoLogisticsJumpJets);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsEngines", autoLogisticsEngines);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoLogisticsOther", autoLogisticsOther);
 
         // region Personnel Tab
@@ -5350,6 +5383,12 @@ public class CampaignOptions {
                     retVal.autoLogisticsArmor = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsAmmunition")) {
                     retVal.autoLogisticsAmmunition = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsActuators")) {
+                    retVal.autoLogisticsActuators = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsJumpJets")) {
+                    retVal.autoLogisticsJumpJets = Integer.parseInt(wn2.getTextContent().trim());
+                } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsEngines")) {
+                    retVal.autoLogisticsEngines = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("autoLogisticsOther")) {
                     retVal.autoLogisticsOther = Integer.parseInt(wn2.getTextContent().trim());
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
@@ -89,6 +89,12 @@ public class EquipmentAndSuppliesTab {
     private JSpinner spnAutoLogisticsArmor;
     private JLabel lblAutoLogisticsAmmunition;
     private JSpinner spnAutoLogisticsAmmunition;
+    private JLabel lblAutoLogisticsActuators;
+    private JSpinner spnAutoLogisticsActuators;
+    private JLabel lblAutoLogisticsJumpJets;
+    private JSpinner spnAutoLogisticsJumpJets;
+    private JLabel lblAutoLogisticsEngines;
+    private JSpinner spnAutoLogisticsEngines;
     private JLabel lblAutoLogisticsOther;
     private JSpinner spnAutoLogisticsOther;
     //end autoLogistics Tab
@@ -272,6 +278,12 @@ public class EquipmentAndSuppliesTab {
         spnAutoLogisticsArmor = new JSpinner();
         lblAutoLogisticsAmmunition = new JLabel();
         spnAutoLogisticsAmmunition = new JSpinner();
+        lblAutoLogisticsActuators = new JLabel();
+        spnAutoLogisticsActuators = new JSpinner();
+        lblAutoLogisticsJumpJets = new JLabel();
+        spnAutoLogisticsJumpJets = new JSpinner();
+        lblAutoLogisticsEngines = new JLabel();
+        spnAutoLogisticsEngines = new JSpinner();
         lblAutoLogisticsOther = new JLabel();
         spnAutoLogisticsOther = new JSpinner();
     }
@@ -445,6 +457,18 @@ public class EquipmentAndSuppliesTab {
         spnAutoLogisticsHeatSink = new CampaignOptionsSpinner("AutoLogisticsHeatSink",
             250, 0, 10000, 1);
 
+        lblAutoLogisticsActuators = new CampaignOptionsLabel("AutoLogisticsActuators");
+        spnAutoLogisticsActuators = new CampaignOptionsSpinner("AutoLogisticsActuators",
+            250, 0, 10000, 1);
+
+        lblAutoLogisticsJumpJets = new CampaignOptionsLabel("AutoLogisticsJumpJets");
+        spnAutoLogisticsJumpJets = new CampaignOptionsSpinner("AutoLogisticsJumpJets",
+            250, 0, 10000, 1);
+
+        lblAutoLogisticsEngines = new CampaignOptionsLabel("AutoLogisticsEngines");
+        spnAutoLogisticsEngines = new CampaignOptionsSpinner("AutoLogisticsEngines",
+            250, 0, 10000, 1);
+
         lblAutoLogisticsOther = new CampaignOptionsLabel("AutoLogisticsOther");
         spnAutoLogisticsOther = new CampaignOptionsSpinner("AutoLogisticsOther",
             50, 0, 10000, 1);
@@ -490,6 +514,24 @@ public class EquipmentAndSuppliesTab {
         panel.add(lblAutoLogisticsAmmunition, layout);
         layout.gridx++;
         panel.add(spnAutoLogisticsAmmunition, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(lblAutoLogisticsActuators, layout);
+        layout.gridx++;
+        panel.add(spnAutoLogisticsActuators, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(lblAutoLogisticsJumpJets, layout);
+        layout.gridx++;
+        panel.add(spnAutoLogisticsJumpJets, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(lblAutoLogisticsEngines, layout);
+        layout.gridx++;
+        panel.add(spnAutoLogisticsEngines, layout);
 
         layout.gridx = 0;
         layout.gridy++;
@@ -1014,6 +1056,9 @@ public class EquipmentAndSuppliesTab {
         options.setAutoLogisticsNonRepairableLocation((int) spnAutoLogisticsNonRepairableLocation.getValue());
         options.setAutoLogisticsArmor((int) spnAutoLogisticsArmor.getValue());
         options.setAutoLogisticsAmmunition((int) spnAutoLogisticsAmmunition.getValue());
+        options.setAutoLogisticsActuators((int) spnAutoLogisticsActuators.getValue());
+        options.setAutoLogisticsJumpJets((int) spnAutoLogisticsJumpJets.getValue());
+        options.setAutoLogisticsEngines((int) spnAutoLogisticsEngines.getValue());
         options.setAutoLogisticsHeatSink((int) spnAutoLogisticsHeatSink.getValue());
         options.setAutoLogisticsOther((int) spnAutoLogisticsOther.getValue());
 
@@ -1087,6 +1132,9 @@ public class EquipmentAndSuppliesTab {
         spnAutoLogisticsNonRepairableLocation.setValue(options.getAutoLogisticsNonRepairableLocation());
         spnAutoLogisticsArmor.setValue(options.getAutoLogisticsArmor());
         spnAutoLogisticsAmmunition.setValue(options.getAutoLogisticsAmmunition());
+        spnAutoLogisticsActuators.setValue(options.getAutoLogisticsActuators());
+        spnAutoLogisticsJumpJets.setValue(options.getAutoLogisticsJumpJets());
+        spnAutoLogisticsEngines.setValue(options.getAutoLogisticsEngines());
         spnAutoLogisticsHeatSink.setValue(options.getAutoLogisticsHeatSink());
         spnAutoLogisticsOther.setValue(options.getAutoLogisticsOther());
 


### PR DESCRIPTION
- Introduced auto-logistics options for actuators, jump jets, and engines, allowing automated restocking based on usage.
- Updated `CampaignOptions` to include new fields and their default values for these categories.
- Enhanced `EquipmentAndSuppliesTab` to display new UI components for these options.
- Adjusted XML read/write methods to handle new auto-logistics fields.
- Refactored imports to consolidate equipment-related imports into a single wildcard.
- Updated resource properties to include labels and tooltips for the new options.
- Updated default values for the various options (roughly reducing them by 80%). Based on player feedback these were a tad high. Apparently ya'll play better than I do and need fewer spares! :D'

Fix #6023

<img width="346" alt="image" src="https://github.com/user-attachments/assets/898de687-13f9-4f51-8b3b-75dd47b87e5a" />
