### PR TITLE
Fixed Multiple Gray Monday Bugs

### DIFF
--- a/MekHQ/resources/mekhq/resources/GrayMonday.properties
+++ b/MekHQ/resources/mekhq/resources/GrayMonday.properties
@@ -6,32 +6,32 @@ transaction.message=Gray Monday
 employer.report=All employers have withdrawn their contract offers.
 
 # CLARION NOTE
-clarionNoteEvent0.message=<p>{0}, I wanted to bring something odd to your attention. The local HPG relay\
+clarionNoteEvent0.message={0}, I wanted to bring something odd to your attention. The local HPG relay\
   \ station has gone dark. Initial diagnostics suggest it''s not just us - our neighboring systems\
   \ aren''t responding either. At first, I thought this might be a routine system outage or\
-  \ scheduled maintenance, but there''s been no notice from ComStar or the Republic.</p>\
+  \ scheduled maintenance, but there''s been no notice from ComStar or the Republic.\
   <p>I'm attempting to use alternate communication methods to confirm the extent of the disruption.\
   \ I''ll keep you updated. For now, it''s an inconvenience, but nothing we can''t manage
-clarionNoteEvent1.message=<p>{0}, this situation is far worse than we thought. Our attempts to\
+clarionNoteEvent1.message={0}, this situation is far worse than we thought. Our attempts to\
   \ re-establish communication have failed, and reports are coming in through secondary channels\
   \ that this is happening across the sector. Some JumpShip captains we''ve contacted say they''ve\
-  \ been unable to send or receive any transmissions from the HPGs on their routes.</p>\
+  \ been unable to send or receive any transmissions from the HPGs on their routes.\
   <p>The scale of this outage is unprecedented. Entire trade lanes are effectively cut off. Local\
   \ stations are scrambling, and the lack of centralized updates is breeding chaos. This is no\
   \ ordinary technical failure, {0}. Something deliberate or catastrophic has occurred.</p>
-clarionNoteEvent2.message=<p>{0}, I must stress the urgency of this situation. Reports are coming in\
+clarionNoteEvent2.message={0}, I must stress the urgency of this situation. Reports are coming in\
   \ from merchant and military channels that nearly every HPG station across the Inner Sphere has\
   \ gone silent. What little information we''re gathering suggests this isn''t a regional issue but\
-  \ galaxy-wide. Entire star systems are isolated.</p>\
+  \ galaxy-wide. Entire star systems are isolated.\
   <p>We''ve already started to see the ripple effects - panicked citizens, disrupted supply chains,\
   \ and opportunists exploiting the confusion. Without HPGs, the very foundation of our logistics\
   \ and command structure is crumbling. Resupply requests from neighboring systems are coming in by\
   \ JumpShip courier! The time delay is going to cripple our operations.</p>\
   <p>This situation is quickly spiraling out of control.</p>
-clarionNoteEvent3.message=<p>{0}, it''s worse than anyone could imagine. JumpShip captains are now\
+clarionNoteEvent3.message={0}, it''s worse than anyone could imagine. JumpShip captains are now\
   \ reporting signs of sabotage at several HPG sites. Some claim entire facilities are inoperable,\
   \ equipment burned out beyond repair. There are whispers of coordinated attacks, but no one has\
-  \ solid answers.</p>\
+  \ solid answers.\
   <p>The civilian population is in panic. Markets have shut down, transport contracts are failing,\
   \ and rumors of piracy are already circulating. Systems that relied on regular HPG updates to\
   \ coordinate food shipments or medical supplies are completely vulnerable. Our logistical chain\
@@ -42,10 +42,10 @@ clarionNoteEvent3.message=<p>{0}, it''s worse than anyone could imagine. JumpShi
   <p>{0}, what are we going to do?</p>
 
 # GREY MONDAY
-grayMondayEvent1.message=<p>{0}, the situation has escalated beyond sanity. We have confirmation - direct\
+grayMondayEvent1.message={0}, the situation has escalated beyond sanity. We have confirmation - direct\
   \ attacks on HPG facilities have occurred across the Inner Sphere. Reports are flooding in from\
   \ JumpShip captains and emergency couriers: sabotage, armed assaults, and even viral intrusions\
-  \ targeting the systems themselves.</p>\
+  \ targeting the systems themselves.\
   <p>This is no accident, sir. This is a deliberate and widespread operation. Entire stations have\
   \ been destroyed or rendered inoperable. One captain reported seeing the remnants of a station\
   \ near Terra - scorched to the frame, with no survivors. A courier claims another was\
@@ -58,7 +58,7 @@ grayMondayEvent1.message=<p>{0}, the situation has escalated beyond sanity. We h
   <p>Morale is starting to falter. People are looking to us for answers, but I don''t have them. I\
   \ need to know what we''re going to do, Commander. I''m losing control, and I don''t know how much\
   \ longer we can hold things together.</p>
-grayMondayEvent2.message=<p>{0}, it''s over. Everything''s gone. The banks... they''ve collapsed.</p>\
+grayMondayEvent2.message={0}, it''s over. Everything''s gone. The banks... they''ve collapsed.\
   <p>I don''t know how to say this without sounding insane, but every account, every credit, every\
   \ fund we had tied to the banks or electronic systems - it''s just gone. It''s not just us. I''ve\
   \ spoken to couriers and merchants. This is widespread. Whole planetary economies have been wiped\
@@ -73,22 +73,21 @@ grayMondayEvent2.message=<p>{0}, it''s over. Everything''s gone. The banks... th
   \ watching everything we''ve built fall apart, and all I can do is report it while the galaxy\
   \ burns.</p>\
   <p>Tell me you have a plan. Please. Just... tell me what to do.</p>
-grayMondayEvent3.message=<p>{0}, I... I don''t know how to say this. I don''t have any good way to\
-  \ explain what''s happening, but we can''t pay you anymore. The accounts are gone - everything is\
-  \ gone. The banks have collapsed, the markets are dead, and every contract we had is worthless\
-  \ now.</p>\
+grayMondayEvent3.message={0}, I... I don''t know how to say this. I don''t have any good way to\
+  \ explain what''s happening, but our finances are in ruins. The accounts are drained, the markets\
+  \ are barely holding on, and every contract we had is hanging by a thread. We can still pay you\
+  \ - but just barely. It won''t be much, and I won''t insult you by pretending otherwise.\
   <p>But please, I am begging you - don''t abandon us. We''re barely holding things together here. If\
-  \ you and your unit leave, we''re finished. We have no defense, no chance. The riots have started\
-  \ already. People are dying in the streets, and there''s no order left.</p>\
-  <p>I know this isn''t fair. I know what I''m asking of you, but I have nothing else to give. I''ve\
-  \ bumped your salvage rights to 100%. Whatever you can take, whatever you can carry - it''s yours.\
-  \ Every last scrap. Just stay. Help us keep what little we still have.</p>\
-  <p>Please, Commander. I am on my knees right now. You''re our last hope. If you leave, we won''t\
-  \ survive. I''ll do anything to keep you here. Just tell me what you need. Tell me what it will\
-  \ take.</p>
-grayMondayEvent4.message=<p>{0}, we just received a message. At least, we think it was a message.\
+  \ you and your unit leave, we''re finished. We have no defense, no chance. The riots have already\
+  \ started. People are dying in the streets, and there''s no order left.</p>\
+  <p>I know this isn''t fair. I know what I''m asking of you, but we don''t have many options left.\
+  \ I''ve increased your salvage rights as much as I can. Whatever you can take, whatever you can\
+  \ carry - it''s yours. Every last scrap. Just stay. Help us keep what little we still have.</p>\
+  <p>Please, {0}. I am on my knees right now. You''re our last hope. If you leave, we won''t survive.\
+  \ I''ll do anything to keep you here. Just tell me what you need. Tell me what it will take.</p>
+grayMondayEvent4.message={0}, we just received a message. At least, we think it was a message.\
   \ The terminal lit up for a moment - just for a moment - but there was no voice, no text. Just\
-  \ static. Harsh, crackling static.</p>\
+  \ static. Harsh, crackling static.\
   <p>We tried everything to clear the signal, but there was nothing. No identifiers, no content, no\
   \ life. And now the terminal is dead again. Completely dark. It''s like it was trying to speak,\
   \ but the system couldn''t hold on long enough to get the words through.</p>\

--- a/MekHQ/resources/mekhq/resources/GrayMonday.properties
+++ b/MekHQ/resources/mekhq/resources/GrayMonday.properties
@@ -27,7 +27,7 @@ clarionNoteEvent2.message=<p>{0}, I must stress the urgency of this situation. R
   \ and opportunists exploiting the confusion. Without HPGs, the very foundation of our logistics\
   \ and command structure is crumbling. Resupply requests from neighboring systems are coming in by\
   \ JumpShip courier! The time delay is going to cripple our operations.</p>\
-  <p>This situation is quickly spiraling out of contro.</p>
+  <p>This situation is quickly spiraling out of control.</p>
 clarionNoteEvent3.message=<p>{0}, it''s worse than anyone could imagine. JumpShip captains are now\
   \ reporting signs of sabotage at several HPG sites. Some claim entire facilities are inoperable,\
   \ equipment burned out beyond repair. There are whispers of coordinated attacks, but no one has\

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -117,8 +117,6 @@ import mekhq.campaign.unit.CrewType;
 import mekhq.campaign.unit.*;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.campaign.universe.*;
-import mekhq.campaign.universe.Planet.PlanetaryEvent;
-import mekhq.campaign.universe.PlanetarySystem.PlanetarySystemEvent;
 import mekhq.campaign.universe.enums.HiringHallLevel;
 import mekhq.campaign.universe.eras.Era;
 import mekhq.campaign.universe.eras.Eras;
@@ -7004,7 +7002,7 @@ public class Campaign implements ITechManager {
         }
 
 
-        if (isGrayMonday(this)) {
+        if (isGrayMonday(currentDay, campaignOptions.isSimulateGrayMonday())) {
             target.addModifier(4, "Gray Monday");
         }
 

--- a/MekHQ/src/mekhq/campaign/finances/Loan.java
+++ b/MekHQ/src/mekhq/campaign/finances/Loan.java
@@ -2,7 +2,7 @@
  * Loan.java
  *
  * Copyright (c) 2009 - Jay Lawson (jaylawson39 at yahoo.com). All Rights Reserved.
- * Copyright (c) 2020-2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2020-2025 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/finances/Loan.java
+++ b/MekHQ/src/mekhq/campaign/finances/Loan.java
@@ -33,6 +33,8 @@ import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.Objects;
 
+import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
+
 /**
  * TODO : Update loan baseline based on latest Campaign Operations Rules
  *
@@ -216,9 +218,38 @@ public class Loan {
                 || (today.isAfter(getNextPayment())) && (getRemainingPayments() > 0);
     }
 
-    public static Loan getBaseLoan(final int rating, final LocalDate date) {
+    /**
+     * Computes and returns a base loan object based on the player's rating, the current date,
+     * and campaign-specific conditions such as the Gray Monday event.
+     *
+     * <p>This method determines the loan terms that the player is eligible for based on their
+     * performance rating and whether the game is simulating the Gray Monday event. If the
+     * Gray Monday event is active, a special predatory loan with significantly higher interest
+     * rates and penalties is offered. Otherwise, the loan terms are progressively better
+     * as the player's rating improves.</p>
+     *
+     * <p>The returned {@link Loan} object contains all relevant terms such as the principal,
+     * interest rate, repayment duration, financial term, and associated penalty.</p>
+     *
+     * @param rating             The player's performance rating as an integer. Defaults to higher
+     *                           loan penalties and stricter terms for lower ratings.
+     * @param simulateGrayMonday A {@code boolean} flag that indicates whether the Gray Monday
+     *                           event is active, which impacts loan terms significantly.
+     * @param date               The current in-game date as a {@link LocalDate} object, used
+     *                           to determine if Gray Monday conditions apply.
+     *
+     * @return A {@link Loan} object representing the player's base loan terms based on
+     *         their rating and event conditions.
+     */
+    public static Loan getBaseLoan(final int rating, boolean simulateGrayMonday, final LocalDate date) {
         // we are going to treat the score from StellarOps the same as dragoons score
         // TODO: pirates and government forces
+
+        if (isGrayMonday(date, simulateGrayMonday)) {
+            // This simulates the player taking out a predatory loan
+            return new Loan(10000000, 70, 1, FinancialTerm.MONTHLY, 100, date);
+        }
+
         if (rating <= 0) {
             return new Loan(10000000, 35, 1, FinancialTerm.MONTHLY, 80, date);
         } else if (rating < 5) {

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -74,7 +74,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
     @Override
     public void generateContractOffers(Campaign campaign, boolean newCampaign) {
-        boolean isGrayMonday = isGrayMonday(campaign);
+        boolean isGrayMonday = isGrayMonday(campaign.getLocalDate(), campaign.getCampaignOptions().isSimulateGrayMonday());
 
         if (((campaign.getLocalDate().getDayOfMonth() == 1)) || newCampaign) {
             // need to copy to prevent concurrent modification errors
@@ -545,7 +545,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         }
 
         // This should always be last
-        if (isGrayMonday(campaign)) {
+        if (isGrayMonday(campaign.getLocalDate(), campaign.getCampaignOptions().isSimulateGrayMonday())) {
             multiplier *= 0.25;
         }
 

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
@@ -68,7 +68,7 @@ public class CamOpsContractMarket extends AbstractContractMarket {
 
     @Override
     public void generateContractOffers(Campaign campaign, boolean newCampaign) {
-        boolean isGrayMonday = isGrayMonday(campaign);
+        boolean isGrayMonday = isGrayMonday(campaign.getLocalDate(), campaign.getCampaignOptions().isSimulateGrayMonday());
 
         if (!(campaign.getLocalDate().getDayOfMonth() == 1) && !newCampaign) {
             return;

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2020-2025 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AtBMonthlyUnitMarket.java
@@ -214,7 +214,7 @@ public class AtBMonthlyUnitMarket extends AbstractUnitMarket {
     private int getMarketItemCount(Campaign campaign, UnitMarketRarity rarity, int rarityModifier) {
         int totalRarity = rarity.ordinal() + rarityModifier;
 
-        if (isGrayMonday(campaign)) {
+        if (isGrayMonday(campaign.getLocalDate(), campaign.getCampaignOptions().isSimulateGrayMonday())) {
             totalRarity -= 4;
         }
 

--- a/MekHQ/src/mekhq/campaign/randomEvents/GrayMonday.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/GrayMonday.java
@@ -93,6 +93,9 @@ public class GrayMonday {
                     contract.setStraightSupport(0);
                     contract.setTransportComp(0);
                     contract.setTransitAmount(Money.of(0));
+                    contract.calculateContract(campaign);
+
+                    contract.setSalvagePct(100);
                 }
             }
 

--- a/MekHQ/src/mekhq/campaign/randomEvents/GrayMonday.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/GrayMonday.java
@@ -118,24 +118,20 @@ public class GrayMonday {
     }
 
     /**
-     * Determines whether it is within the Gray Monday event period.
+     * Determines whether the current date falls within the Gray Monday event period.
      *
-     * <p>This method checks if the campaign is configured to simulate the Gray Monday event
-     * and whether the current in-game date falls within a certain period around the
-     * predefined Gray Monday date. Specifically, it verifies that today is after one day
-     * prior to the Gray Monday event date and before three months after the event date.</p>
+     * <p>This method checks if the Gray Monday event is enabled and whether the given date
+     * falls within the defined period of the Gray Monday event.
      *
-     * @param campaign the {@link Campaign} object containing the campaign data, including
-     *                 the current date and campaign options
-     * @return {@code true} if the Gray Monday event should be active based on the campaign
-     *         configuration and current date, {@code false} otherwise
+     * @param today           The current date as a {@link LocalDate} object.
+     * @param isUseGrayMonday A {@code boolean} flag indicating whether the campaign is tracking
+     *                       Gray Monday.
+     * @return {@code true} if Gray Monday is active for the given date and campaign configuration,
+     * {@code false} otherwise.
      */
-    public static boolean isGrayMonday(Campaign campaign) {
-        LocalDate today = campaign.getLocalDate();
-        boolean isGrayMonday = campaign.getCampaignOptions().isSimulateGrayMonday();
-        isGrayMonday = isGrayMonday
+    public static boolean isGrayMonday(LocalDate today, boolean isUseGrayMonday) {
+        return isUseGrayMonday
             && today.isAfter(EVENT_DATE_GRAY_MONDAY.minusDays(1))
             && EVENT_DATE_GRAY_MONDAY.isBefore(today.plusMonths(12));
-        return isGrayMonday;
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
@@ -103,7 +103,7 @@ public class NewLoanDialog extends JDialog implements ActionListener, ChangeList
         this.numberFormatter = new NumberFormatter(NumberFormat.getInstance());
 
         rating = campaign.getAtBUnitRatingMod();
-        loan = Loan.getBaseLoan(rating, this.campaign.getLocalDate());
+        loan = Loan.getBaseLoan(rating, this.campaign.getCampaignOptions().isSimulateGrayMonday(), this.campaign.getLocalDate());
         maxCollateralValue = this.campaign.getFinances().getMaxCollateral(this.campaign);
         initComponents();
         setLocationRelativeTo(frame);

--- a/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
@@ -2,6 +2,7 @@
  * NewLoanDialog.java
  *
  * Copyright (c) 2009 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
+ * Copyright (c) 2025 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *


### PR DESCRIPTION
- Corrected a typo in the event message text ("contro" to "control") within the GrayMonday.properties file.
- Added `calculateContract` and set salvage percentage to 100% in Gray Monday contract logic.
- Removed unnecessary HTML tags in Gray Monday event messages to improve formatting.
- Updated text in event messages to no longer say that the player won't be paid, but that the pay will be very low.
- Updated `isGrayMonday` method to accept `LocalDate` and simulation flag directly, improving flexibility and reusability.
- Adjusted all `isGrayMonday` calls across the codebase to use the new parameters.
- Enhanced loan generation logic to incorporate Gray Monday event conditions, allowing for predatory loans.
- Improved documentation for `isGrayMonday` and loan-related methods to describe new parameters and behavior.

Fix #6017

### Dev Notes
The change to contracts from 'no pay' to 'very little pay' is a technical one. Basically, due to the interconnectivity of contract pay it's surprisingly difficult to just zero out a contract's pay without causing a bunch of weirdness. Instead, I lowered contract pay as much as possible. So the player will be getting a pittance.

Regarding loans. It was raised in the original bug report that loans were still available. Not removing loans was a conscious decision as I wanted the player to have a way out. However, it makes sense to change up the loan parameters so that the player forced to take a predatory loan (if they go that route) placing them in a very difficult position when combined with the other Gray Monday penalties.