### PR TITLE
Updated Unit Count Logic When Determining if There is a Force Deployment Deficit

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -117,8 +117,6 @@ import mekhq.campaign.unit.CrewType;
 import mekhq.campaign.unit.*;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.campaign.universe.*;
-import mekhq.campaign.universe.Planet.PlanetaryEvent;
-import mekhq.campaign.universe.PlanetarySystem.PlanetarySystemEvent;
 import mekhq.campaign.universe.enums.HiringHallLevel;
 import mekhq.campaign.universe.eras.Era;
 import mekhq.campaign.universe.eras.Eras;
@@ -4096,13 +4094,20 @@ public class Campaign implements ITechManager {
         for (CombatTeam combatTeam : combatTeams.values()) {
             CombatRole combatRole = combatTeam.getRole();
 
-            Force force = null;
+            Force force;
             int unitCount = 0;
             try {
                 int forceId = combatTeam.getForceId();
                 force = getForce(forceId);
 
-                unitCount += force.getAllUnits(true).size();
+                Vector<UUID> unitsInForce = force.getAllUnits(true);
+
+                for (UUID unitId : unitsInForce) {
+                    Unit unit = getUnit(unitId);
+                    if (unit != null && unit.isFullyCrewed()) {
+                        unitCount++;
+                    }
+                }
             } catch (Exception ignored) {
                 continue;
             }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4104,7 +4104,7 @@ public class Campaign implements ITechManager {
 
                 for (UUID unitId : unitsInForce) {
                     Unit unit = getUnit(unitId);
-                    if (unit != null && unit.isFullyCrewed() && unit.isSalvage()) {
+                    if (unit != null && unit.isFullyCrewed() && !unit.isSalvage()) {
                         unitCount++;
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4104,7 +4104,7 @@ public class Campaign implements ITechManager {
 
                 for (UUID unitId : unitsInForce) {
                     Unit unit = getUnit(unitId);
-                    if (unit != null && unit.isFullyCrewed()) {
+                    if (unit != null && unit.isFullyCrewed() && unit.isSalvage()) {
                         unitCount++;
                     }
                 }


### PR DESCRIPTION
- Modified `Campaign` class to count only fully crewed units when processing forces for the purposes of determining if there is a deployment deficit.
- Replaced direct counting of units with a validation check using `isFullyCrewed()`.
- Added a check to include only salvage units in the unit count logic.
- Enhanced safety by ensuring null units are skipped during iteration.

Fix #6002

### Dev Notes
This change means that when determining whether there is enough units in a Combat Team, to count towards the requirements of a contract, we no longer count units that are not fully crewed. This means that the employer is only counting units that are combat operational, i.e. fully crewed and not marked as salvage.