### PR TITLE
 Enforced Skill Value Boundaries

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Skill.java
@@ -20,15 +20,17 @@
  */
 package mekhq.campaign.personnel;
 
-import java.io.PrintWriter;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Compute;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 
 /**
  * As ov v0.1.9, we will be tracking a group of skills on the person. These
@@ -69,6 +71,9 @@ import mekhq.utilities.MHQXMLUtility;
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
 public class Skill {
+    private static int COUNT_UP_MAX_VALUE = 10;
+    private static int COUNT_DOWN_MIN_VALUE = 0;
+
     private static final MMLogger logger = MMLogger.create(Skill.class);
 
     private SkillType type;
@@ -92,6 +97,20 @@ public class Skill {
         this.type = type;
         this.level = level;
         this.bonus = bonus;
+    }
+
+    /**
+     * Retrieves the maximum value that can be used for skills that count up.
+     */
+    public static int getCountUpMaxValue() {
+        return COUNT_UP_MAX_VALUE;
+    }
+
+    /**
+     * Retrieves the minimum value that can be used for skills that count down.
+     */
+    public static int getCountDownMaxValue() {
+        return COUNT_DOWN_MIN_VALUE;
     }
 
     /**
@@ -159,9 +178,9 @@ public class Skill {
 
     public int getFinalSkillValue() {
         if (type.countUp()) {
-            return type.getTarget() + level + bonus;
+            return min(COUNT_UP_MAX_VALUE, type.getTarget() + level + bonus);
         } else {
-            return type.getTarget() - level - bonus;
+            return max(COUNT_DOWN_MIN_VALUE, type.getTarget() - level - bonus);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -55,9 +55,14 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.time.LocalDate;
 import java.time.Period;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 import java.util.Map.Entry;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static mekhq.campaign.personnel.Skill.getCountDownMaxValue;
+import static mekhq.campaign.personnel.Skill.getCountUpMaxValue;
 
 /**
  * This dialog is used to create a character in story arcs from a pool of XP
@@ -1313,14 +1318,16 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
             skillLvls.get(type).getModel().setValue(0);
             return;
         }
-        SkillType stype = SkillType.getType(type);
-        int lvl = (Integer) skillLvls.get(type).getModel().getValue();
-        int b = (Integer) skillBonus.get(type).getModel().getValue();
-        int target = stype.getTarget() - lvl - b;
-        if (stype.countUp()) {
-            target = stype.getTarget() + lvl + b;
+        SkillType skillType = SkillType.getType(type);
+
+        int level = (Integer) skillLvls.get(type).getModel().getValue();
+        int bonus = (Integer) skillBonus.get(type).getModel().getValue();
+
+        if (skillType.countUp()) {
+            int target = min(getCountUpMaxValue(), skillType.getTarget() + level + bonus);
             skillValues.get(type).setText("+" + target);
         } else {
+            int target = max(getCountDownMaxValue(), skillType.getTarget() - level - bonus);
             skillValues.get(type).setText(target + "+");
         }
     }

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -60,8 +60,13 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.time.LocalDate;
 import java.time.Period;
-import java.util.List;
 import java.util.*;
+import java.util.List;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static mekhq.campaign.personnel.Skill.getCountDownMaxValue;
+import static mekhq.campaign.personnel.Skill.getCountUpMaxValue;
 
 /**
  * This dialog is used to both hire new pilots and to edit existing ones
@@ -1498,14 +1503,16 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             skillValues.get(type).setText("-");
             return;
         }
-        SkillType stype = SkillType.getType(type);
-        int lvl = (Integer) skillLvls.get(type).getModel().getValue();
-        int b = (Integer) skillBonus.get(type).getModel().getValue();
-        int target = stype.getTarget() - lvl - b;
-        if (stype.countUp()) {
-            target = stype.getTarget() + lvl + b;
+        SkillType skillType = SkillType.getType(type);
+
+        int level = (Integer) skillLvls.get(type).getModel().getValue();
+        int bonus = (Integer) skillBonus.get(type).getModel().getValue();
+
+        if (skillType.countUp()) {
+            int target = min(getCountUpMaxValue(), skillType.getTarget() + level + bonus);
             skillValues.get(type).setText("+" + target);
         } else {
+            int target = max(getCountDownMaxValue(), skillType.getTarget() - level - bonus);
             skillValues.get(type).setText(target + "+");
         }
     }


### PR DESCRIPTION
- Introduced `COUNT_UP_MAX_VALUE` and `COUNT_DOWN_MIN_VALUE` constants in `Skill` to define boundaries for skill values.
- Updated `Skill` methods to use `min` and `max` functions to enforce these boundaries when calculating skill values.
- Refactored `CreateCharacterDialog` and `CustomizePersonDialog` to utilize the new boundary constants and methods for consistent skill value calculations.
- Improved clarity of variable names in relevant methods for better readability and maintainability.

### Dev Notes
On this edition of 'Illiani Hates Fun', I decided to go ahead and clamp skills to a logical upper bound. While I do recognize that some players rather enjoy their -8/-8 übermensch, having skills fall below the expected minimum of 0/0 has previously been a problem (and will almost certainly be again).

For bonuses gained from Education (or elsewhere) this means that characters can reach the 'skill cap' faster than characters without the bonuses, but cannot beat them. With the XP cost increases we added last year such bonuses are still very powerful and I'm hoping players won't be too upset.

- Skills that count up cannot exceed 10.
- Skills that down cannot exceed 0.