### PR TITLE
Disabled Time Traveling in Campaign Options; Fixed Campaign Options Start Up in Abridged Mode

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
@@ -29,9 +29,6 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.ResourceBundle;
 
-import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.ABRIDGED;
-import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.NORMAL;
-import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP;
 import static mekhq.gui.campaignOptions.SelectPresetDialog.PRESET_SELECTION_CANCELLED;
 
 /**
@@ -66,6 +63,7 @@ public class CampaignOptionsDialog extends AbstractMHQButtonDialog {
     public enum CampaignOptionsDialogMode {
         NORMAL,
         STARTUP,
+        STARTUP_ABRIDGED,
         ABRIDGED
     }
 
@@ -79,8 +77,8 @@ public class CampaignOptionsDialog extends AbstractMHQButtonDialog {
     public CampaignOptionsDialog(final JFrame frame, final Campaign campaign) {
         super(frame, true, resources, "CampaignOptionsDialog", "campaignOptions.title");
         this.campaign = campaign;
-        this.campaignOptionsPane = new CampaignOptionsPane(frame, campaign, NORMAL);
-        this.mode = NORMAL;
+        this.campaignOptionsPane = new CampaignOptionsPane(frame, campaign, CampaignOptionsDialogMode.NORMAL);
+        this.mode = CampaignOptionsDialogMode.NORMAL;
         initialize();
 
         setLocationRelativeTo(frame);
@@ -146,7 +144,8 @@ public class CampaignOptionsDialog extends AbstractMHQButtonDialog {
         JButton btnApplySettings = new CampaignOptionsButton("ApplySettings");
         btnApplySettings.addActionListener(evt -> {
             wasCanceled = false;
-            campaignOptionsPane.applyCampaignOptionsToCampaign(null, mode == STARTUP,
+            campaignOptionsPane.applyCampaignOptionsToCampaign(null,
+                mode == CampaignOptionsDialogMode.STARTUP || mode == CampaignOptionsDialogMode.STARTUP_ABRIDGED,
                 false);
             dispose();
             showStratConNotice();
@@ -154,7 +153,7 @@ public class CampaignOptionsDialog extends AbstractMHQButtonDialog {
         pnlButtons.add(btnApplySettings);
 
         // Save Preset
-        if (mode != ABRIDGED) {
+        if (mode != CampaignOptionsDialogMode.ABRIDGED && mode != CampaignOptionsDialogMode.STARTUP_ABRIDGED) {
             JButton btnSavePreset = new CampaignOptionsButton("SavePreset");
             btnSavePreset.addActionListener(evt -> btnSaveActionPerformed());
             pnlButtons.add(btnSavePreset);
@@ -190,7 +189,9 @@ public class CampaignOptionsDialog extends AbstractMHQButtonDialog {
             return;
         }
 
-        campaignOptionsPane.applyCampaignOptionsToCampaign(preset, mode == STARTUP, true);
+        campaignOptionsPane.applyCampaignOptionsToCampaign(preset,
+            mode == CampaignOptionsDialogMode.STARTUP || mode == CampaignOptionsDialogMode.STARTUP_ABRIDGED,
+            true);
 
         preset.writeToFile(null,
             FileDialogs.saveCampaignPreset(null, preset).orElse(null));

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -121,7 +121,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         } catch (Exception ignored) {}
 
         addTab(String.format("<html><font size=%s><b>%s</b></font></html>", round(HEADER_FONT_SIZE * uiScale),
-            resources.getString("generalPanel.title")), createGeneralTab());
+            resources.getString("generalPanel.title")), createGeneralTab(mode));
 
         JTabbedPane humanResourcesParentTab = createHumanResourcesParentTab();
         createTab("humanResourcesParentTab", humanResourcesParentTab);
@@ -169,10 +169,12 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
      * Creates the panel for general campaign options. Loads settings for general preferences
      * and initializes it with current campaign options.
      *
+     * @param mode the state in which the dialog was triggered.
+     *
      * @return a {@link JScrollPane} containing the general tab panel
      */
-    private JScrollPane createGeneralTab() {
-        generalTab = new GeneralTab(campaign, getFrame());
+    private JScrollPane createGeneralTab(CampaignOptionsDialogMode mode) {
+        generalTab = new GeneralTab(campaign, getFrame(), mode);
         JPanel createdGeneralTab = generalTab.createGeneralTab();
         generalTab.loadValuesFromCampaignOptions();
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -40,6 +40,7 @@ import java.util.ResourceBundle;
 import static java.lang.Math.round;
 import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
 import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.ABRIDGED;
+import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP_ABRIDGED;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createSubTabs;
 
 /**
@@ -156,7 +157,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             uiScale = Double.parseDouble(System.getProperty("flatlaf.uiScale"));
         } catch (Exception ignored) {}
 
-        if (mode != ABRIDGED) {
+        if (mode != ABRIDGED && mode != STARTUP_ABRIDGED) {
             addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
                 round(HEADER_FONT_SIZE * uiScale),
                 resources.getString(resourceName + ".title")),

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -34,6 +34,7 @@ import mekhq.campaign.universe.Factions;
 import mekhq.gui.baseComponents.AbstractMHQScrollablePanel;
 import mekhq.gui.baseComponents.AbstractMHQTabbedPane;
 import mekhq.gui.baseComponents.DefaultMHQScrollablePanel;
+import mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode;
 import mekhq.gui.campaignOptions.components.CampaignOptionsButton;
 import mekhq.gui.campaignOptions.components.CampaignOptionsCheckBox;
 import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
@@ -77,6 +78,7 @@ public class GeneralTab {
     private final JFrame frame;
     private final Campaign campaign;
     private final CampaignOptions campaignOptions;
+    private final CampaignOptionsDialogMode mode;
 
     private JLabel lblName;
     private JTextField txtName;
@@ -105,8 +107,10 @@ public class GeneralTab {
      *
      * @param campaign The {@link Campaign} associated with this tab, which contains the core game data.
      * @param frame    The parent {@link JFrame} used to display this tab.
+     * @param mode     The {@link CampaignOptionsDialogMode} enum determining what state caused the
+     *                dialog to be triggered.
      */
-    public GeneralTab(Campaign campaign, JFrame frame) {
+    public GeneralTab(Campaign campaign, JFrame frame, CampaignOptionsDialogMode mode) {
         // region Variable Declarations
         this.frame = frame;
         this.campaign = campaign;
@@ -114,6 +118,7 @@ public class GeneralTab {
         this.date = campaign.getLocalDate();
         this.camouflage = campaign.getCamouflage();
         this.unitIcon = campaign.getUnitIcon();
+        this.mode = mode;
 
         initialize();
     }
@@ -168,6 +173,12 @@ public class GeneralTab {
         btnDate = new CampaignOptionsButton("Date");
         btnDate.setText(MekHQ.getMHQOptions().getDisplayFormattedDate(date));
         btnDate.addActionListener(this::btnDateActionPerformed);
+
+        if (mode != CampaignOptionsDialogMode.STARTUP
+            && mode != CampaignOptionsDialogMode.STARTUP_ABRIDGED) {
+            lblDate.setEnabled(false);
+            btnDate.setEnabled(false);
+        }
 
         // Camouflage
         lblCamo = new CampaignOptionsLabel("Camo");

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -23,7 +23,6 @@ import megamek.client.ui.dialogs.CamoChooserDialog;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
 import megamek.common.icons.Camouflage;
-import megamek.common.options.OptionsConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
@@ -35,7 +34,14 @@ import mekhq.campaign.universe.Factions;
 import mekhq.gui.baseComponents.AbstractMHQScrollablePanel;
 import mekhq.gui.baseComponents.AbstractMHQTabbedPane;
 import mekhq.gui.baseComponents.DefaultMHQScrollablePanel;
-import mekhq.gui.campaignOptions.components.*;
+import mekhq.gui.campaignOptions.components.CampaignOptionsButton;
+import mekhq.gui.campaignOptions.components.CampaignOptionsCheckBox;
+import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
+import mekhq.gui.campaignOptions.components.CampaignOptionsHeaderPanel;
+import mekhq.gui.campaignOptions.components.CampaignOptionsLabel;
+import mekhq.gui.campaignOptions.components.CampaignOptionsSpinner;
+import mekhq.gui.campaignOptions.components.CampaignOptionsStandardPanel;
+import mekhq.gui.campaignOptions.components.CampaignOptionsTextField;
 import mekhq.gui.dialog.DateChooser;
 import mekhq.gui.dialog.iconDialogs.UnitIconDialog;
 import mekhq.gui.displayWrappers.FactionDisplay;
@@ -48,6 +54,7 @@ import java.time.LocalDate;
 import java.util.ResourceBundle;
 
 import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
+import static megamek.common.options.OptionsConstants.ALLOWED_YEAR;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createGroupLayout;
 
 /**
@@ -546,15 +553,15 @@ public class GeneralTab {
 
             if (isStartUp) {
                 campaign.getForces().setName(campaign.getName());
+                campaign.setLocalDate(date);
             }
-            campaign.setLocalDate(date);
 
             if ((campaign.getCampaignStartDate() == null)
                 || (campaign.getCampaignStartDate().isAfter(campaign.getLocalDate()))) {
                 campaign.setCampaignStartDate(date);
             }
             // Ensure that the MegaMek year GameOption matches the campaign year
-            campaign.getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(campaign.getGameYear());
+            campaign.getGameOptions().getOption(ALLOWED_YEAR).setValue(campaign.getGameYear());
 
             // Null state handled during validation
             FactionDisplay newFaction = comboFaction.getSelectedItem();

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -66,8 +66,8 @@ import java.util.Collection;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
-import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.ABRIDGED;
 import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP;
+import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP_ABRIDGED;
 import static mekhq.gui.campaignOptions.SelectPresetDialog.PRESET_SELECTION_CANCELLED;
 import static mekhq.gui.campaignOptions.SelectPresetDialog.PRESET_SELECTION_CUSTOMIZE;
 import static mekhq.gui.campaignOptions.SelectPresetDialog.PRESET_SELECTION_SELECT;
@@ -332,7 +332,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 campaign.getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(campaign.getGameYear());
                 campaign.setStartingSystem((preset == null) ? null : preset.getPlanet());
 
-                CampaignOptionsDialogMode mode = isSelect ? ABRIDGED : STARTUP;
+                CampaignOptionsDialogMode mode = isSelect ? STARTUP_ABRIDGED : STARTUP;
                 CampaignOptionsDialog optionsDialog =
                     new CampaignOptionsDialog(getFrame(), campaign, preset, mode);
                 setVisible(false); // cede visibility to `optionsDialog`


### PR DESCRIPTION
- Introduced a new `STARTUP_ABRIDGED` mode to `CampaignOptionsDialogMode` enum.
- Updated `CampaignOptionsDialog` logic to handle the new mode, including button behaviors and campaign option application logic.
- Adjusted tab creation in `CampaignOptionsPane` to exclude tabs for `STARTUP_ABRIDGED` mode.
- Modified `DataLoadingDialog` to use `STARTUP_ABRIDGED` for specific workflows instead of `ABRIDGED`.
- Refactored related portions of `GeneralTab` to ensure proper initialization for the new mode and cleanup of redundant checks.

Fix #5639

### Dev Note
I want to start by mentioning that this was a planned change prior to Raoz posting their issue report (so sling any grumps at me, not them). Basically time traveling causes a number of issues with the underlying simulation - in particular galaxy information. Players have access to tools to advance time in chunks (advance multiple days) so DeLoreans have been banned.