### PR TITLE
Updated Cargo Requirement Label And Text Formatting

### DIFF
--- a/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
@@ -22,7 +22,7 @@ lblDistance.text=<html><nobr><b>Days (Jumps) to Location:</b></nobr></html>
 lblOverhead.text=<html><nobr><b>Overhead Compensation:</b></nobr></html>
 lblSupport.text=<html><nobr><b>StraightSupport:</b></nobr></html>
 lblSharePct.text=<html><nobr><b>Shares:</b></nobr></html>
-lblCargoRequirement.text=<html><nobr><b>Estimated Cargo Requirement:</b></nobr></html>
+lblCargoRequirement.text=<html><nobr><b>Convoy Cargo Size:</b></nobr></html>
 
 txtGarrisonMoraleRouted.text=Peaceful
 txtGarrisonMoraleRouted.tooltip=There is no enemy activity in the Area of Operations.

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2024 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2009-2025 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -1000,7 +1000,7 @@ public class MissionViewPanel extends JScrollablePanel {
             pnlStats.add(lblCargoRequirement, gridBagConstraints);
 
             txtCargoRequirement.setName("txtCargoRequirement");
-            txtCargoRequirement.setText(estimateCargoRequirements(campaign, contract) + "t+");
+            txtCargoRequirement.setText("~" + estimateCargoRequirements(campaign, contract) + 't');
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 1;
             gridBagConstraints.gridy = y++;


### PR DESCRIPTION
- Renamed `Estimated Cargo Requirement` label to `Convoy Cargo Size` for improved clarity.
- Modified cargo requirement text formatting by replacing `+` with `~` for consistency and better readability. The text will now read `~25t` where '25' is replaced with the relevant value.

Fix #6056