### PR TITLE
Added Mothball Option for Unit Market Deliveries

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1521,6 +1521,9 @@ lblUnitMarketRarityModifier.tooltip=This setting increases or decreases the roll
 lblInstantUnitMarketDelivery.text=Enable Instant Deliveries
 lblInstantUnitMarketDelivery.tooltip=Units bought from the unit market appear in the hangar\
   \ immediately rather than having to wait for delivery.
+lblMothballUnitMarketDeliveries.text=Deliver Units Mothballed
+lblMothballUnitMarketDeliveries.tooltip=Units bought from the unit market will arrive in a\
+  \ mothballed state.
 lblUnitMarketReportRefresh.text=Post Report on Market Refresh
 lblUnitMarketReportRefresh.tooltip=Adds a report to the daily log when the unit market refreshes.
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -66,8 +66,8 @@ import mekhq.campaign.market.unitMarket.AbstractUnitMarket;
 import mekhq.campaign.market.unitMarket.DisabledUnitMarket;
 import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
-import mekhq.campaign.mission.enums.CombatRole;
 import mekhq.campaign.mission.enums.*;
+import mekhq.campaign.mission.enums.CombatRole;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType;
 import mekhq.campaign.mod.am.InjuryUtil;
@@ -110,8 +110,8 @@ import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconContractInitializer;
 import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.stratcon.StratconTrackState;
-import mekhq.campaign.unit.CrewType;
 import mekhq.campaign.unit.*;
+import mekhq.campaign.unit.CrewType;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.campaign.universe.*;
 import mekhq.campaign.universe.enums.HiringHallLevel;
@@ -1580,6 +1580,10 @@ public class Campaign implements ITechManager {
         }
 
         unit.setDaysToArrival(days);
+
+        if (days > 0) {
+            unit.setMothballed(campaignOptions.isMothballUnitMarketDeliveries());
+        }
 
         if (allowNewPilots) {
             Map<CrewType, Collection<Person>> newCrew = Utilities

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -528,6 +528,7 @@ public class CampaignOptions {
     private int unitMarketSpecialUnitChance;
     private int unitMarketRarityModifier;
     private boolean instantUnitMarketDelivery;
+    private boolean mothballUnitMarketDeliveries;
     private boolean unitMarketReportRefresh;
 
     // Contract Market
@@ -3468,6 +3469,14 @@ public class CampaignOptions {
         this.instantUnitMarketDelivery = instantUnitMarketDelivery;
     }
 
+    public boolean isMothballUnitMarketDeliveries() {
+        return mothballUnitMarketDeliveries;
+    }
+
+    public void setMothballUnitMarketDeliveries(final boolean mothballUnitMarketDeliveries) {
+        this.mothballUnitMarketDeliveries = mothballUnitMarketDeliveries;
+    }
+
     public boolean isUnitMarketReportRefresh() {
         return unitMarketReportRefresh;
     }
@@ -5065,6 +5074,7 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "unitMarketSpecialUnitChance", getUnitMarketSpecialUnitChance());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "unitMarketRarityModifier", getUnitMarketRarityModifier());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "instantUnitMarketDelivery", isInstantUnitMarketDelivery());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mothballUnitMarketDeliveries", isMothballUnitMarketDeliveries());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "unitMarketReportRefresh", isUnitMarketReportRefresh());
         // endregion Unit Market
 
@@ -5995,6 +6005,8 @@ public class CampaignOptions {
                     retVal.setUnitMarketRarityModifier(Integer.parseInt(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("instantUnitMarketDelivery")) {
                     retVal.setInstantUnitMarketDelivery(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("mothballUnitMarketDeliveries")) {
+                    retVal.setMothballUnitMarketDeliveries(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("unitMarketReportRefresh")) {
                     retVal.setUnitMarketReportRefresh(Boolean.parseBoolean(wn2.getTextContent().trim()));
                     // endregion Unit Market

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -74,8 +74,8 @@ import java.awt.*;
 import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -242,7 +242,15 @@ public class Unit implements ITechnology {
                 return "Mothballing (" + getMothballTime() + "m)";
             }
         } else if (isMothballed()) {
-            return "Mothballed";
+            int arrivalTime = getDaysToArrival();
+
+            // This means that, while the item is mothballed, it actually hasn't arrived yet, so we
+            // treat it as if had a status of 'in transit')
+            if (arrivalTime > 0) {
+                return "In transit (" + getDaysToArrival() + " days)";
+            } else {
+                return "Mothballed";
+            }
         } else if (isDeployed()) {
             return "Deployed";
         } else if (!isPresent()) {

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
@@ -90,6 +90,7 @@ public class MarketsTab {
     private JLabel lblUnitMarketRarityModifier;
     private JSpinner spnUnitMarketRarityModifier;
     private JCheckBox chkInstantUnitMarketDelivery;
+    private JCheckBox chkMothballUnitMarketDeliveries;
     private JCheckBox chkUnitMarketReportRefresh;
     //end Unit Market
 
@@ -366,6 +367,7 @@ public class MarketsTab {
         lblUnitMarketRarityModifier = new JLabel();
         spnUnitMarketRarityModifier = new JSpinner();
         chkInstantUnitMarketDelivery = new JCheckBox();
+        chkMothballUnitMarketDeliveries = new JCheckBox();
         chkUnitMarketReportRefresh = new JCheckBox();
     }
 
@@ -397,6 +399,8 @@ public class MarketsTab {
             0, -10, 10, 1);
 
         chkInstantUnitMarketDelivery = new CampaignOptionsCheckBox("InstantUnitMarketDelivery");
+
+        chkMothballUnitMarketDeliveries = new CampaignOptionsCheckBox("MothballUnitMarketDeliveries");
 
         chkUnitMarketReportRefresh = new CampaignOptionsCheckBox("UnitMarketReportRefresh");
 
@@ -437,6 +441,9 @@ public class MarketsTab {
         layout.gridy++;
         layout.gridwidth = 2;
         panel.add(chkInstantUnitMarketDelivery, layout);
+
+        layout.gridy++;
+        panel.add(chkMothballUnitMarketDeliveries, layout);
 
         layout.gridy++;
         panel.add(chkUnitMarketReportRefresh, layout);
@@ -742,6 +749,7 @@ public class MarketsTab {
         spnUnitMarketSpecialUnitChance.setValue(options.getUnitMarketSpecialUnitChance());
         spnUnitMarketRarityModifier.setValue(options.getUnitMarketRarityModifier());
         chkInstantUnitMarketDelivery.setSelected(options.isInstantUnitMarketDelivery());
+        chkMothballUnitMarketDeliveries.setSelected(options.isMothballUnitMarketDeliveries());
         chkUnitMarketReportRefresh.setSelected(options.isContractMarketReportRefresh());
 
         // Contract Market
@@ -793,6 +801,7 @@ public class MarketsTab {
         options.setUnitMarketSpecialUnitChance((int) spnUnitMarketSpecialUnitChance.getValue());
         options.setUnitMarketRarityModifier((int) spnUnitMarketRarityModifier.getValue());
         options.setInstantUnitMarketDelivery(chkInstantUnitMarketDelivery.isSelected());
+        options.setMothballUnitMarketDeliveries(chkMothballUnitMarketDeliveries.isSelected());
         options.setUnitMarketReportRefresh(chkUnitMarketReportRefresh.isSelected());
 
         // Contract Market


### PR DESCRIPTION
- Introduced a new campaign option: "Deliver Units Mothballed".
    - Units purchased from the unit market will now arrive in a mothballed state if enabled.
- Updated `Unit` logic to reflect the mothballed delivery state.
    - Units marked as mothballed but still in transit will display as "In transit (`n` days)".
- Enhanced `CampaignOptions` to handle the new `mothballUnitMarketDeliveries` flag.
    - Added appropriate getter, setter, and XML persistence updates.
- UI changes:
    - Added a checkbox in the Markets Tab of the campaign options dialog for enabling "Deliver Units Mothballed".
    - Updated tooltips and labels to describe the new functionality.

Fix #5734