### PR TITLE
 Updated Battlefield Control Logic in Scenarios

### DIFF
--- a/MekHQ/data/scenariotemplates/Annihilation.xml
+++ b/MekHQ/data/scenariotemplates/Annihilation.xml
@@ -2,7 +2,10 @@
 <ScenarioTemplate>
     <name>Annihilation</name>
     <shortBriefing>Obliterate the enemy force.</shortBriefing>
-    <detailedBriefing>Your orders are clear. This is not a surgical strike, nor a precision raid—this is extermination. The enemy force in this sector must be wiped out, with 95% confirmed casualties before we consider this battlefield secured. Their continued presence is unacceptable, and we cannot afford to let even a remnant regroup for future operations. The victor controls the field, and we will be the ones standing when the dust settles.</detailedBriefing>
+    <detailedBriefing>Your orders are clear. This is not a surgical strike, nor a precision raid—this is extermination. The enemy force in this sector must be wiped out, with 95% confirmed casualties before we consider this battlefield secured. Their continued presence is unacceptable, and we cannot afford to let even a remnant regroup for future operations.
+
+The victor controls the field, and we will be the ones standing when the dust settles.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Assassination.xml
+++ b/MekHQ/data/scenariotemplates/Assassination.xml
@@ -5,6 +5,7 @@
     <detailedBriefing>This is a precision strike inside an active warzone. The enemy dominates the field, but we’re not here for a prolonged engagement—we’re here for a kill mission. Your primary objective is to assassinate a high-value target before they can escape. This individual is critical to the enemy’s war effort, and their elimination will shift the balance in our favor.
 
 We expect a fierce but contained battle. Your forces will be operating behind enemy lines, deep within hostile territory. Extraction is not a priority—the enemy will retain control of the battlefield when the dust settles. Your task is to neutralize the VIP and preserve at least 50% of your forces while executing the operation.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Base Defense.xml
+++ b/MekHQ/data/scenariotemplates/Base Defense.xml
@@ -7,6 +7,7 @@
 At the same time, this is not just about survival. You are to destroy at least 50% of enemy forces before the battle concludes.
 
 The victor will control the field when this is over. Ensure that it is us.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>true</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Breakthrough.xml
@@ -7,6 +7,7 @@
 If the enemy resistance proves too strong, you have an alternative path to victory: destroy at least 50% of enemy forces to force them into disarray and open the way.
 
 Be advised: the enemy will control the field when this is over. Move fast, strike hard, and don’t look back.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>true</allowRotation>

--- a/MekHQ/data/scenariotemplates/Chasing a Rumor.xml
+++ b/MekHQ/data/scenariotemplates/Chasing a Rumor.xml
@@ -6,6 +6,7 @@
     <detailedBriefing>Intel suggests there is a hidden cache in this region. Unfortunately, enemy forces seem to have caught wind of this intel. The objective is to either destroy or force them to retreat. At least 50% of the enemy must be neutralized, while maintaining 50% of friendly forces.
 
     If this scenario is lost, so too is the hidden cache.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Close Air Support.xml
+++ b/MekHQ/data/scenariotemplates/Close Air Support.xml
@@ -7,6 +7,7 @@
 Your primary objective is to preserve at least 50% of allied forces. Their survival is paramount to maintaining battlefield cohesion. Simultaneously, you must destroy or route at least 50% of the enemy forces. This engagement is about turning the tide, forcing them to break, and ensuring our ground forces can hold firm.
 
 The winner of this battle will control the field when the engagement is over. You must ensure that victory belongs to us. Strike hard, strike true, and do not let the enemy dictate the pace of battle. Your firepower will decide the outcome.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -7,6 +7,7 @@
 Should the enemy resistance prove too strong for a full escort, you have an alternative means to secure victory. If at least 50% of the convoy survives while you destroy or route 50% of the enemy forces, the mission will be considered a success. Breaking the enemy’s will to fight will give the convoy a clear path forward.
 
 We will control the field at the conclusion of the battle. This means you have full authority to dictate the engagement on your terms. Use the terrain, control the tempo, and eliminate threats efficiently. Hold the line, protect the convoy, and ensure that these supplies reach their destination.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
@@ -7,6 +7,7 @@
 There is no need to concern yourself with minimizing damage or securing the spoils. We do not have the luxury of holding the field, and enemy reinforcements will arrive quickly. Do not waste time engaging the escorts unless necessary—focus all efforts on neutralizing the convoy itself. Once the job is done, withdraw immediately.
 
 No distractions. No delays. No mercy. Execute the raid, cripple their supply line, and get out before the enemy can mount a counterattack.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Convoy Raid.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Raid.xml
@@ -7,6 +7,7 @@
 Your primary objective is to prevent at least 50% of the convoy from reaching the far side of the engagement zone. Disrupt their formation, destroy their transports, and force them to abandon their mission. If their escort force proves too formidable, you have an alternative route to success—destroy at least 50% of the convoy’s escorts to force the remaining defenders to surrender. With their protection shattered, the convoy will have no choice but to stand down.
 
 The more convoy units that survive, the greater the spoils. Disabling transports instead of outright destruction may increase salvage potential, but that is a secondary concern to stopping the convoy itself. However, do not linger. The enemy will respond quickly, and we will not control the field once the battle ends. Execute the raid with precision, neutralize the targets, and withdraw before the enemy's full force arrives.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Covert Strike.xml
+++ b/MekHQ/data/scenariotemplates/Covert Strike.xml
@@ -7,6 +7,7 @@
 The enemy will not allow this to happen easily. Expect heavy resistance, tight security, and potential countermeasures to obscure or protect the target. Do not waste time engaging unnecessary forces—strike fast, neutralize the VIP, and disengage before the enemy can fully react.
 
 Be advised, the enemy will control the field at the end of the engagement. You will not be able to hold ground or claim battlefield salvage. This is an execution, not a siege. Kill the target and get out—nothing else matters.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -7,6 +7,7 @@
 The enemy will come in force, but their attack is not unstoppable. If a full escort proves untenable, you have an alternative path to victory. Should at least 50% of the convoy survive while you destroy or route 50% of the attacking enemy force, the mission will be considered a success. Breaking their offensive will allow our convoy to continue forward without further resistance.
 
 We will control the field at the end of the battle, giving you full authority to dictate the engagement on our terms. Use the terrain, stagger your defenses, and counter their assault with precision. Hold the line, protect the convoy, and ensure these supplies reach their destination. Victory here will secure our war effort in this sector.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Decoy Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Engagement.xml
@@ -9,6 +9,7 @@ This engagement is about endurance, misdirection, and tactical maneuvering. The 
 Should you succeed in routing 75% of the enemy force, they will lose cohesion, and we will control the battlefield at the end of the engagement. This will allow us full access to any salvageable assets left behind. Victory here will not only ensure the success of our allies but also give us a chance to recover valuable battlefield resources.
 
 Hold the line, weather the storm, and outlast them. If they break, the field is ours.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Decoy Interception.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Interception.xml
@@ -9,6 +9,7 @@ This battle is about control and endurance. The longer you keep the enemy occupi
 Should you succeed in routing 75% of their forces, we will seize control of the battlefield at the end of the engagement. This will allow us to recover any remaining assets and deny the enemy any chance of regrouping. Whether by sheer endurance or decisive firepower, your success here will determine the outcome of operations across the sector.
 
 Stand firm, draw them in, and ensure they never reach their goal. If they break, the field is ours.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -7,6 +7,7 @@
 Expect long-range bombardment. The enemy is likely to deploy artillery strikes to weaken our defenses before engaging directly. You must counter their firepower while maintaining a strong perimeter around the DropShip. Close the distance where possible, neutralize their artillery assets, and prevent them from overwhelming our position before liftoff.
 
 We will control the battlefield at the end of the engagement, ensuring access to salvage and preventing any lingering enemy forces from regrouping. Hold the line, protect the DropShip, and make the enemy pay dearly for their incursion.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Deep Raid.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid.xml
@@ -7,6 +7,7 @@
 Expect rapid enemy response forces as the enemy scrambles to defend their asset. They will attempt to delay and stall you long enough for the DropShip to achieve liftoff. Speed is critical—push through their defenses, disable or destroy the DropShip, and exfiltrate before enemy reinforcements overwhelm your position.
 
 This engagement takes place in enemy territory, meaning we will not control the field at the end. There will be no opportunity for salvage or recovery, so focus solely on mission success. Strike fast, eliminate the target, and get out before the enemy locks down the area.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Diversion Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Diversion Engagement.xml
@@ -7,6 +7,7 @@
 Victory can be achieved in one of two ways. Ensure at least 50% of your forces reach the far edge of the engagement zone, bypassing the enemy’s attempt to hold you in place. Alternatively, if they commit too heavily to blocking your path, destroy at least 75% of their forces, breaking their ability to resist and forcing them to withdraw.
 
 Be advised: the enemy will control the field at the end of the engagement. There will be no time for salvage or securing the area. Speed and decisive action are key—either break through or break them entirely, but do not allow them to stall our momentum.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/DropShip Raid.xml
+++ b/MekHQ/data/scenariotemplates/DropShip Raid.xml
@@ -7,6 +7,7 @@
 Expect organized resistance. The enemy will fight to defend their stranded vessel, and their escort forces will attempt to buy time for emergency repairs or reinforcement. You must strike decisively, breaking their formation and overwhelming their defenses before they can rally.
 
 Victory in this engagement will determine control of the battlefield. If we succeed, we will hold the field at the end of the battle, giving us access to any remaining salvage and denying the enemy any chance of recovery. This is a rare chance to cripple enemy operations—strike hard, break them completely, and ensure they leave nothing behind but wreckage.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
@@ -8,6 +8,7 @@
 The enemy has chosen a pincer formation to box you in, which means they are expecting to trap and overwhelm your forces. Break their formation before they can fully close the noose. Use superior positioning, speed, and tactical maneuvers to punch through their weakest link and deny them the ability to completely surround the convoy. If necessary, sacrifice the convoy to ensure the enemy force is broken—routing them is the priority, as failure to do so will allow them to wreak havoc on our logistics in future operations.
 
 We will control the battlefield at the end of this engagement, ensuring that any salvageable assets fall into our hands. This battle determines more than just one convoy’s fate—crush the enemy’s ability to operate in our skies and secure our logistics for the future.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
@@ -8,6 +8,7 @@
 The enemy is built for speed and pursuit, meaning direct engagements may not always be favorable. Use ambush tactics, force them into unfavorable terrain, and disrupt their ability to maneuver. They rely on overwhelming pursuit capabilities—deny them the chance to use it effectively. If the convoy can be safely extracted, do so, but not at the expense of allowing the enemy to regroup for future strikes.
 
 We will control the battlefield at the conclusion of this engagement, ensuring that any remaining salvage remains in our possession. Turn the hunters into the hunted, cripple their forces, and make certain they never threaten our supply lines again.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
@@ -8,6 +8,7 @@
 The enemy is executing a relentless pursuit, attempting to isolate and destroy the convoy before it can escape. If they are not routed here, they will continue striking at our logistics, inflicting immeasurable damage over time. Prioritize extracting the convoy, but if necessary, sacrificing the supplies is acceptable if it means crushing the enemy force beyond recovery.
 
 We will control the battlefield at the end of the engagement, ensuring that any remaining salvage or assets fall into our hands. This battle is about more than just one convoy—it is about securing the future of our supply lines. Break through, break them, and ensure they never threaten our logistics again.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -8,6 +8,7 @@
 This enemy assault is a direct attempt to cripple our supply chain. If they are not stopped here, they will continue to strike at our convoys, causing immeasurable damage to our war effort. The convoy is a priority, but if ensuring the destruction of the enemy requires sacrificing the supplies, do not hesitate. Breaking their offensive strength is the ultimate objective.
 
 We will control the battlefield at the end of this engagement, allowing us to recover whatever remains and prevent further incursions. Ensure the convoy escapes if possible, but above all, crush the enemy’s ability to wage war in our territory. This ends here.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Engagement.xml
@@ -7,6 +7,7 @@
 This battle will determine control of the battlefield. The victor will hold the field at the end of the engagement, securing any salvage and denying the enemy any chance of recovery. Every enemy unit destroyed weakens their ability to wage war—make sure they do not leave this battlefield intact.
 
 Strike hard, eliminate the opposition, and take control. Victory is absolute, or it is meaningless.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Frontier Assassination.xml
+++ b/MekHQ/data/scenariotemplates/Frontier Assassination.xml
@@ -7,6 +7,7 @@
 The enemy may attempt an emergency extraction or stall for reinforcements. Do not let them escape. Strike hard, eliminate the target, and ensure their escort is crippled beyond recovery. If the enemy attempts to dig in, break their defensive perimeter and neutralize them with overwhelming force.
 
 The victor will control the battlefield at the end of the engagement, securing any salvage and eliminating remaining resistance. This is a chance to change the course of the conflict—do not let it slip away.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Frontline Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Breakthrough.xml
@@ -7,6 +7,7 @@
 Expect heavy resistance, as the enemy will not yield ground easily. Their forces are well-positioned to block your advance, and delaying tactics may be used to slow you down. Speed, decisive strikes, and tactical maneuvering will be key to achieving your objective. If you can break their formation or force them into disarray, the path forward will open.
 
 The enemy will control the battlefield once the engagement concludes, preventing any opportunity for salvage or recovery. This is a mission of mobility and force—break through, or break them. There is no room for hesitation.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>true</allowRotation>

--- a/MekHQ/data/scenariotemplates/Frontline Disruption.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Disruption.xml
@@ -7,6 +7,7 @@
 Expect a determined push, as the enemy will prioritize speed and aggression to force their way through. They may attempt to overwhelm your defenses with sheer numbers or concentrated strikes against weak points. You must hold firm, break their momentum, and deny them passage. Use the terrain, stagger your defenses, and eliminate high-value targets to throw their advance into disarray.
 
 We will control the battlefield at the conclusion of this engagement, ensuring that any remaining enemy assets are left for us to claim or destroy. This is our ground—stand fast, hold the line, and make certain they go no further.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Frontline Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Engagement.xml
@@ -7,6 +7,7 @@
 Expect a determined enemy response. They will not withdraw easily and may attempt to reinforce their position as losses mount. Strike hard, exploit weaknesses, and maintain battlefield control. This is not a delaying action—this is a battle for dominance.
 
 The victor will control the battlefield at the end of the engagement, securing salvage and eliminating any remaining resistance. Ensure that when the dust settles, it is our forces standing over the wreckage. Crush them and claim the field.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -7,6 +7,7 @@
 If you are compromised, expect a swift and overwhelming response. Avoid unnecessary confrontations and prioritize evasion over combat. At least one of your units must survive.
 
 The enemy will control the field at the end of the engagement, meaning there will be no reinforcements or recovery options. Get in, gather intel, and get out—undetected and alive.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Hostile Facility.xml
+++ b/MekHQ/data/scenariotemplates/Hostile Facility.xml
@@ -7,6 +7,7 @@
 The priority is destruction, not capture. Do not concern yourself with securing the facility unless it becomes strategically viable after the defenders are wiped out. The enemy will fight to protect this installation, but their defenses will crumble under sustained pressure. Crush their forces, level their defenses, and ensure that when this battle is over, the facility is either in our hands or of no use to anyone.
 
 The victor will control the battlefield at the end of the engagement. If the facility remains salvageable after the assault, we will claim it. If not, the enemy will be left with nothing but ruins. Execute with overwhelming force and leave no doubt who owns this battlefield.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>true</isHostileFacility>
     <mapParameters>
         <allowedTerrainTypes>

--- a/MekHQ/data/scenariotemplates/Intercept Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Intercept Engagement.xml
@@ -7,6 +7,7 @@
 The enemy holds the advantage in numbers and positioning, but they are not unbeatable. A direct breakthrough will require speed, coordination, and decisive strikes against their weakest points. If a clean escape is not possible, you must shift to a battle of attrition—eliminating 75% of their forces will ensure they can no longer threaten your retreat.
 
 The enemy will control the battlefield at the end of the engagement, meaning no recovery of fallen assets will be possible. Time is against you—break out before they close the trap, or break them so thoroughly that they can no longer fight.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Intercept the Escapees.xml
+++ b/MekHQ/data/scenariotemplates/Intercept the Escapees.xml
@@ -10,6 +10,7 @@ The enemy will likely deploy fast-moving extraction units or specialized recover
 Failure to prevent the enemy from rescuing the prisoners will grant them valuable intelligence, jeopardizing operations in this sector (the loss of 1 CVP, StratCon only). That is not an option. The victor will control the battlefield at the end of the engagement, giving us the opportunity to secure the area and eliminate any remaining threats.
 
 Execute with precision. The enemy must leave empty-handed.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Interception Defense.xml
+++ b/MekHQ/data/scenariotemplates/Interception Defense.xml
@@ -7,6 +7,7 @@
 Expect the enemy to favor speed and mobility, avoiding prolonged engagements as they push toward their objective. Deny them their escape route, break their formation, and ensure they do not reach their goal intact. They may attempt to punch through with concentrated force or use diversionary tactics to slip past your defenses—anticipate their maneuvers and shut them down.
 
 We will control the battlefield at the end of the engagement, securing any remaining assets and preventing any further movement from enemy reinforcements. This mission is about disruption and dominance—cripple their forces, seize the field, and ensure that whatever they were planning never comes to pass.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
@@ -7,6 +7,7 @@
 Expect a mix of tactics—the insurgents will use terrain, ambushes, and guerrilla warfare, while the frontline units will provide structured firepower and coordination. Do not underestimate either force. Eliminate them with precision, break their ability to fight, and ensure this sector is pacified.
 
 The victor will control the battlefield at the end of the engagement, securing any remaining assets and preventing further insurgent activity. This is a mission of suppression and dominance—strike hard, eliminate resistance, and leave no doubt who commands this region.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Irregular Force Suppression.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Suppression.xml
@@ -7,6 +7,7 @@
 Expect a blend of unconventional tactics and structured military resistance. The insurgents will use ambushes, terrain familiarity, and hit-and-run attacks, while their military allies will bring firepower, coordination, and heavier assets into the fight. Dismantle their cohesion, eliminate key targets, and disrupt their ability to function as a fighting force.
 
 The victor will control the battlefield at the end of the engagement, securing any remaining assets and ensuring this region remains under our command. This mission is about eradication—strike hard, leave no room for recovery, and establish total dominance.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -7,6 +7,7 @@
 Expect a relentless assault from multiple directions, with enemy units prioritizing disabling the DropShip before it can launch. They may attempt to immobilize it, breach its hull, or delay its departure long enough for reinforcements to arrive. You must hold the line, intercept high-threat targets, and keep the DropShip secure until it achieves liftoff. If the situation demands it, eliminating half of the enemy force will force them to retreat, buying the DropShip a chance to escape.
 
 The enemy will control the field at the end of the engagement, meaning no salvage or recovery will be possible. This is a battle of survival—ensure the DropShip gets out or cripple the enemy so thoroughly that they can no longer threaten it.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
@@ -7,6 +7,7 @@
 Expect high-speed engagements, aggressive maneuvers, and coordinated enemy tactics. Control the airspace, dictate the terms of engagement, and eliminate their ability to regroup. Do not allow them to disengage intact—press the attack and ensure their losses are irreversible.
 
 The victor will control the battlefield at the end of the engagement, securing dominance over the skies and denying the enemy future operational capabilities in this region. Strike fast, strike hard, and establish air superiority.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Assault.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Assault.xml
@@ -7,6 +7,7 @@
 Expect the enemy to deploy defensive escorts and countermeasures to protect their vessel. They may attempt evasive maneuvers or a high-speed burn to reach the upper atmosphere. You must strike decisively and disable or destroy the DropShip before it leaves your engagement range.
 
 We will control the field at the end of the engagement, ensuring that any wreckage or surviving assets remain in our hands. This is a one-shot opportunity—do not let them escape.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
@@ -7,6 +7,7 @@
 Expect aggressive aerial engagements, fast-moving strike craft, and possible long-range missile attacks. Use superior positioning, coordinated fire, and defensive tactics to neutralize threats before they can bring down our DropShip. Every enemy unit destroyed increases the DropShip’s chance of survival—hit them hard and make them pay for their assault.
 
 The victor will control the battlefield at the end of the engagement, ensuring we hold the airspace and any remaining salvage. Defend the DropShip, eliminate the threat, and dominate the skies.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
@@ -7,6 +7,7 @@
 The enemy will press hard to keep you contained, using aggressive maneuvers and potentially overwhelming numbers to delay your advance. Do not get bogged down in a prolonged engagement—focus fire, break their cohesion, and force them into retreat. Once their losses become unsustainable, the path forward will be clear.
 
 There will be no time to secure the battlefield at the end of the engagement, meaning any salvage will be lost. Speed is essential—eliminate the enemy and move out before reinforcements arrive.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Minor Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Minor Engagement.xml
@@ -7,6 +7,7 @@
 This is a show of strength—hit them hard, make them bleed, and leave no doubt that further resistance is futile. They may attempt a counteroffensive, but once their losses mount, they will have no choice but to retreat.
 
 The victor will control the battlefield at the end of the engagement, securing the area and denying the enemy any future foothold here. Send a message—this ground belongs to us.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
@@ -7,6 +7,7 @@
 Expect light screening forces supported by rapid response elements. The enemy will attempt to stall your advance while preparing a counterattack. Speed, decisive strikes, and maintaining momentum will be key to breaking through before they can reinforce.
 
 As you will be pushing into enemy territory, we will be unable to secure the battlefield following the engagement. Any salvage or wreckage left behind will be lost, so prioritize survival and mission success over prolonged engagements. Punch through, force them to react, and establish dominance beyond their lines.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>true</allowRotation>

--- a/MekHQ/data/scenariotemplates/Pivotal Battle.xml
+++ b/MekHQ/data/scenariotemplates/Pivotal Battle.xml
@@ -7,6 +7,7 @@
 The enemy is relying on overwhelming numbers, expecting to steamroll our defenses. Target high-value units, disrupt their formations, and make them bleed for every inch of ground. If they hesitate or falter, their offensive will collapse before it can reach full strength.
 
 The victor will control the battlefield at the end of the engagement, ensuring we hold the ground and any remaining salvage. Stand firm, inflict maximum damage, and break their momentum before it’s too late.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Recon Evasion.xml
@@ -9,6 +9,7 @@ The enemy is unaware of our presence, but if discovered, they will respond with 
 The enemy will control the field at the end of the engagement, meaning there will be no opportunity for salvage or reinforcement. This is about intelligence, not confrontation—stay hidden, gather what we need, and withdraw before they know you were ever there. At least one of your units must survive.</detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
@@ -2,9 +2,14 @@
 <ScenarioTemplate>
     <name>Reconnaissance Interdiction</name>
     <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing>Hostile reconnaissance units are attempting to gather critical intelligence. Destroy or rout 50% of the opposing force within the specified time frame. Preserve at least 50% of your own forces to ensure the mission's success.</detailedBriefing>
+    <detailedBriefing>Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+
+Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
+
+We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.</detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>
@@ -116,8 +121,9 @@
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>Destroy</objectiveCriterion>
             <percentage>95</percentage>
-            <timeLimitAtMost>true</timeLimitAtMost>
-            <timeLimitType>None</timeLimitType>
+            <timeLimitAtMost>false</timeLimitAtMost>
+            <timeLimitScaleFactor>2</timeLimitScaleFactor>
+            <timeLimitType>ScaledToPrimaryUnitCount</timeLimitType>
         </scenarioObjective>
     </scenarioObjectives>
 </ScenarioTemplate>

--- a/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
@@ -7,6 +7,7 @@
 Expect the enemy to hold strong defensive positions, using suppression tactics to keep your forces contained. Focus on eliminating key threats, breaking their formation, and forcing their forces into disarray. Speed and precision will be critical—you must deal enough damage to secure an escape route before more reinforcements arrive.
 
 There is no time to secure the battlefield at the end of the engagement, meaning any salvage will be lost. This is a fight for survival and mobility, not territory. Break their grip, get our forces out, and resume the mission.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/Space Aerospace Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space Aerospace Intercept.xml
@@ -7,6 +7,7 @@
 Expect high-speed engagements with agile enemy fighters and possible bomber or support craft in formation. Control the skies, dictate the terms of engagement, and press the attack until the enemy is forced to retreat or is completely neutralized. Do not allow them to escape unscathed—this is an opportunity to cripple their airpower.
 
 The victor will control the battlefield at the end of the engagement, securing dominance over the airspace and ensuring enemy forces are unable to reestablish a foothold. Strike hard, eliminate the threat, and claim the skies as our own.</detailedBriefing>
+    <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Space Blockade Run.xml
+++ b/MekHQ/data/scenariotemplates/Space Blockade Run.xml
@@ -7,6 +7,7 @@
 The enemy will attempt to intercept, disable, or destroy the DropShip before it can escape. Expect interdiction fighters and AeroSpace superiority craft. Protect the DropShip at all costs—keep the enemy occupied, disrupt their formations, and eliminate high-threat targets before they can close in.
 
 The enemy will control the battlefield at the end of the engagement, meaning there will be no chance for salvage or recovery. Your priority is to see the DropShip through or cripple enough enemy forces to force a retreat. Ensure the mission succeeds—our strategic mobility depends on it.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
@@ -7,6 +7,7 @@
 Expect the target to engage in evasive maneuvers, using vector thrusting, and potential escort craft to delay or deflect your attack. You must act swiftly and decisively—disable their engines, breach their hull, and ensure they do not survive this encounter.
 
 We will control the battlefield at the end of the engagement, guaranteeing any wreckage or surviving assets remain in our hands. Eliminate the DropShip, secure the battlespace, and leave nothing for the enemy to salvage.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
@@ -7,6 +7,7 @@
 The enemy will press the attack, seeking to pin your reinforcements down and eliminate them before they can regroup. Expect high-speed dogfights, coordinated fire from multiple vectors, and no room for retreat. Strike hard, cripple their numbers, and shatter their formation before they can overwhelm you.
 
 There will be no time to secure the battlefield after the engagement, meaning any salvage or wreckage will be lost. This is about survival and operational integrity—break free, push forward, and ensure your reinforcements reach their objective.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
+++ b/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
@@ -7,6 +7,7 @@
 Expect the enemy to use speed, encirclement tactics, and suppression fire to slow your advance. They have the numbers, but you have the initiative—use terrain, evasive maneuvers, and covering fire to outmaneuver them. If they manage to pin you down, your escape will become far more difficult. Keep moving and do not allow them to dictate the fight.
 
 The enemy will control the battlefield at the end of the engagement, meaning there will be no chance to recover fallen assets. This is a fight for survival—get clear, regroup, and live to fight another day.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/VIP Ambush.xml
+++ b/MekHQ/data/scenariotemplates/VIP Ambush.xml
@@ -7,6 +7,7 @@
 Expect the enemy to stall for time, deploying fast-moving elements or defensive tactics to delay your strike. Speed and precision are critical—do not allow them the time to reinforce or extract the target. If you hesitate, they will escape or be reinforced, and this opportunity will be lost.
 
 The enemy will control the battlefield at the end of the engagement, meaning there will be no chance for recovery or salvage. This is a surgical strike—neutralize the target and withdraw before the enemy locks down the area.</detailedBriefing>
+    <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/data/scenariotemplates/VIP Defense.xml
+++ b/MekHQ/data/scenariotemplates/VIP Defense.xml
@@ -7,6 +7,7 @@
 Expect the enemy to employ fast-moving strike teams, precision fire support, and possibly infiltration tactics to bypass defenses and reach the VIP. You must identify and eliminate key threats quickly while maintaining a defensive perimeter around the target. Every second counts—if the enemy is allowed to press their attack unchecked, the VIP will not survive.
 
 We will control the battlefield at the end of the engagement, ensuring that any surviving enemy forces are neutralized and that all salvageable assets remain in our hands. Hold the line, eliminate the attackers, and ensure our VIP lives to fight another day.</detailedBriefing>
+    <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
         <allowRotation>false</allowRotation>

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1537,12 +1537,15 @@ AutoResolveMethod.progress.99=Finalizing combat scenario results...
 AutoResolveDialog.title=Auto Resolve Battle
 AutoResolveDialog.messageFailedCalc=Commander, we were unable to simulate any combat scenarios. Do you want to proceed?
 AutoResolveDialog.messageSimulated=Commander, we ran {0} simulated combat scenarios and our forces came out victorious in {1}, lost {2}, and drew {3} times. This gives us a {4}% chance of victory. Do you want to proceed?
-AutoResolveDialog.message.victory=Your forces won the scenario. Did your side control the battlefield at the end of the scenario?
-AutoResolveDialog.message.defeat=Your forces lost the scenario. Do you want to declare your side as controlling the battlefield at the end of the scenario?
+AutoResolveDialog.message.victory=Your forces won the scenario.
+AutoResolveDialog.message.defeat=Your forces lost the scenario.
 AutoResolveDialog.victory=Victory!
 AutoResolveDialog.defeat=Defeat!
-ResolveDialog.control.title=Control of Battlefield?
-ResolveDialog.control.message=Did your side control the battlefield at the end of the scenario?
+ResolveDialog.control.title=Control of the Battlefield?
+ResolveDialog.control.PLAYER=The scenario template states that you always retain battlefield control.
+ResolveDialog.control.ENEMY=The scenario template states that the enemy always retains battlefield control.
+ResolveDialog.control.VICTOR=The scenario template states that the victor retains battlefield control.
+ResolveDialog.control.message=Do you want to declare your side as controlling the battlefield?
 
 
 AutoResolveMethod.PRINCESS.text=Princess (PACAR)

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -54,8 +54,11 @@ import mekhq.campaign.ResolveScenarioTracker;
 import mekhq.campaign.autoresolve.AtBSetupForces;
 import mekhq.campaign.handler.PostScenarioDialogHandler;
 import mekhq.campaign.handler.XPHandler;
+import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.mission.ScenarioTemplate;
+import mekhq.campaign.mission.ScenarioTemplate.BattlefieldControlType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.unit.Unit;
@@ -544,8 +547,22 @@ public class MekHQ implements GameListener {
             return;
         }
         try {
-            boolean control = yourSideControlsTheBattlefieldDialogAsk(
-                MHQInternationalization.getText("ResolveDialog.control.message"),
+            String victoryMessage = MHQInternationalization.getText("ResolveDialog.control.message");
+
+            if (currentScenario instanceof AtBDynamicScenario) {
+                ScenarioTemplate template = ((AtBDynamicScenario) currentScenario).getTemplate();
+
+                if (template != null) {
+                    BattlefieldControlType battlefieldControl = template.getBattlefieldControl();
+
+                    String controlMessage = MHQInternationalization.getText("ResolveDialog.control."
+                        + battlefieldControl.name());
+
+                    victoryMessage = String.format("%s\n\n%s", controlMessage, victoryMessage);
+                }
+            }
+
+            boolean control = yourSideControlsTheBattlefieldDialogAsk(victoryMessage,
                 MHQInternationalization.getText("ResolveDialog.control.title"));
             ResolveScenarioTracker tracker = new ResolveScenarioTracker(currentScenario, getCampaign(), control);
             tracker.setClient(gameThread.getClient());
@@ -577,8 +594,23 @@ public class MekHQ implements GameListener {
         if (null == selectedScenario) {
             return;
         }
-        boolean control = yourSideControlsTheBattlefieldDialogAsk(
-            MHQInternationalization.getText("ResolveDialog.control.message"),
+
+        String victoryMessage = MHQInternationalization.getText("ResolveDialog.control.message");
+
+        if (selectedScenario instanceof AtBDynamicScenario) {
+            ScenarioTemplate template = ((AtBDynamicScenario) selectedScenario).getTemplate();
+
+            if (template != null) {
+                BattlefieldControlType battlefieldControl = template.getBattlefieldControl();
+
+                String controlMessage = MHQInternationalization.getText("ResolveDialog.control."
+                    + battlefieldControl.name());
+
+                victoryMessage = String.format("%s\n\n%s", controlMessage, victoryMessage);
+            }
+        }
+
+        boolean control = yourSideControlsTheBattlefieldDialogAsk(victoryMessage,
             MHQInternationalization.getText("ResolveDialog.control.title"));
 
         ResolveScenarioTracker tracker = new ResolveScenarioTracker(selectedScenario, getCampaign(), control);
@@ -688,13 +720,29 @@ public class MekHQ implements GameListener {
      */
     public void autoResolveConcluded(AutoResolveConcludedEvent autoResolveConcludedEvent, AtBScenario scenario) {
         try {
-            String message = autoResolveConcludedEvent.controlledScenario() ?
+            String victoryMessage = autoResolveConcludedEvent.controlledScenario() ?
                 MHQInternationalization.getText("AutoResolveDialog.message.victory") :
                 MHQInternationalization.getText("AutoResolveDialog.message.defeat");
+
+            String decisionMessage = MHQInternationalization.getText("ResolveDialog.control.message");
+
+            if (scenario instanceof AtBDynamicScenario) {
+                ScenarioTemplate template = ((AtBDynamicScenario) scenario).getTemplate();
+
+                if (template != null) {
+                    BattlefieldControlType battlefieldControl = template.getBattlefieldControl();
+
+                    String controlMessage = MHQInternationalization.getText("ResolveDialog.control."
+                        + battlefieldControl.name());
+
+                    victoryMessage = String.format("%s\n\n%s\n\n%s", controlMessage, victoryMessage, decisionMessage);
+                }
+            }
+
             String title = autoResolveConcludedEvent.controlledScenario() ?
                 MHQInternationalization.getText("AutoResolveDialog.victory") :
                 MHQInternationalization.getText("AutoResolveDialog.defeat");
-            boolean control = yourSideControlsTheBattlefieldDialogAsk(message, title);
+            boolean control = yourSideControlsTheBattlefieldDialogAsk(victoryMessage, title);
 
             ResolveScenarioTracker tracker = new ResolveScenarioTracker(scenario, getCampaign(), control);
             tracker.setClient(new SimulatedClient(autoResolveConcludedEvent.getGame()));

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioTemplate.java
@@ -73,6 +73,10 @@ public class ScenarioTemplate implements Cloneable {
     public boolean isHostileFacility;
     public boolean isAlliedFacility;
 
+    @XmlElement(name = "battlefieldControl")
+    @XmlJavaTypeAdapter(value = BattlefieldControlTypeAdapter.class)
+    public BattlefieldControlType battlefieldControl = BattlefieldControlType.VICTOR;
+
     public ScenarioMapParameters mapParameters = new ScenarioMapParameters();
     public List<String> scenarioModifiers = new ArrayList<>();
 
@@ -81,6 +85,26 @@ public class ScenarioTemplate implements Cloneable {
     @XmlElementWrapper(name = "scenarioObjectives")
     @XmlElement(name = "scenarioObjective")
     public List<ScenarioObjective> scenarioObjectives = new ArrayList<>();
+
+    /**
+     * Enum representing the different types of battlefield control during a scenario.
+     */
+    public enum BattlefieldControlType {
+        /**
+         * Indicates the victor controls the field.
+         */
+        VICTOR,
+
+        /**
+         * Battlefield control is always assigned to the player.
+         */
+        PLAYER,
+
+        /**
+         * Battlefield control is always assigned to the enemy.
+         */
+        ENEMY
+    }
 
     @Override
     public ScenarioTemplate clone() {
@@ -91,6 +115,7 @@ public class ScenarioTemplate implements Cloneable {
         template.detailedBriefing = this.detailedBriefing;
         template.isHostileFacility = this.isHostileFacility;
         template.isAlliedFacility = this.isAlliedFacility;
+        template.battlefieldControl = this.battlefieldControl;
         for (ScenarioForceTemplate sft : scenarioForces.values()) {
             template.scenarioForces.put(sft.getForceName(), sft.clone());
         }
@@ -155,6 +180,10 @@ public class ScenarioTemplate implements Cloneable {
 
     public boolean isFacilityScenario() {
         return isHostileFacility || isAlliedFacility;
+    }
+
+    public BattlefieldControlType getBattlefieldControl() {
+        return battlefieldControl;
     }
 
     public List<ScenarioForceTemplate> getAllBotControlledAllies() {
@@ -334,6 +363,29 @@ public class ScenarioTemplate implements Cloneable {
         public String marshal(ScenarioType scenarioType) {
             // Converts Enum back to String for XML
             return String.valueOf(scenarioType);
+        }
+    }
+
+    /**
+     * Adapter for converting between String and BattlefieldControlType during XML (un)marshalling.
+     */
+    public static class BattlefieldControlTypeAdapter extends XmlAdapter<String, BattlefieldControlType> {
+
+        @Override
+        public BattlefieldControlType unmarshal(String value) throws Exception {
+            try {
+                // Convert the string value to a BattlefieldControlType enum
+                return BattlefieldControlType.valueOf(value.trim().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                // If the string does not match any enum, handle it gracefully (e.g., return a default value)
+                return BattlefieldControlType.VICTOR;
+            }
+        }
+
+        @Override
+        public String marshal(BattlefieldControlType value) throws Exception {
+            // Convert the BattlefieldControlType enum back to its string representation
+            return value.name();
         }
     }
 }


### PR DESCRIPTION
- Introduced `BattlefieldControlType` in `ScenarioTemplate` to handle battlefield control logic with options: `VICTOR`, `PLAYER`, and `ENEMY`.
- Updated dialogs to include detailed messages based on the battlefield control type from scenario templates.
- Modified `autoResolveConcluded` and other resolution methods to display control-specific logic and messages.
- Added XML serialization and deserialization support for `BattlefieldControlType` using `BattlefieldControlTypeAdapter`.
- Enhanced scenario cloning to include battlefield control configuration.
- Introduced a new <battlefieldControl> tag with appropriate values to all scenario templates.

![image](https://github.com/user-attachments/assets/875f050b-aded-416d-9335-2ef021c57493)

### Dev Notes
Battlefield control is a crucial balancing tool that we’ve largely underutilized in recent months. When players don’t control the field during a scenario, they miss out on valuable salvage. The less salvage they can collect, the slower their overall progression—helping to maintain balance.

It also adds another layer of strategy when choosing non-Turning Point scenarios. If a scenario isn’t a Turning Point but offers salvage, players are more likely to take the risk. This encourages more thoughtful decision-making and strategic play.

At some point, we’ll be introducing RAW (or near-RAW) salvage, which will significantly reduce player access to salvage. This PR serves as a small step in that direction, helping to ease the transition so the final reduction doesn’t feel as abrupt.