### PR TITLE
Renamed Method For Improved Clarity

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -2212,8 +2212,11 @@ public class StratconRulesManager {
      *                      state for further filtering of eligible forces.
      * @return a {@link List} of unique force IDs that meet all deployment criteria.
      */
-    public static List<Integer> getAvailableForceIDs(int unitType, Campaign campaign, StratconTrackState currentTrack,
-            boolean reinforcements, @Nullable StratconScenario currentScenario, StratconCampaignState campaignState) {
+    public static List<Integer> getAvailableForceIDsForManualDeployment(int unitType, Campaign campaign,
+                                                                        StratconTrackState currentTrack,
+                                                                        boolean reinforcements,
+                                                                        @Nullable StratconScenario currentScenario,
+                                                                        StratconCampaignState campaignState) {
         List<Integer> retVal = new ArrayList<>();
 
         // assemble a set of all force IDs that are currently assigned to tracks that are not this one

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -49,8 +49,8 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static mekhq.campaign.mission.AtBDynamicScenarioFactory.scaleObjectiveTimeLimits;
@@ -464,7 +464,8 @@ public class StratconScenarioWizard extends JDialog {
         JScrollPane forceListContainer = new JScrollPaneWithSpeed();
 
         ScenarioWizardLanceModel lanceModel = new ScenarioWizardLanceModel(campaign,
-            StratconRulesManager.getAvailableForceIDs(forceTemplate.getAllowedUnitType(), campaign, currentTrackState,
+            StratconRulesManager.getAvailableForceIDsForManualDeployment(forceTemplate.getAllowedUnitType(),
+                campaign, currentTrackState,
                 (forceTemplate.getArrivalTurn() == ScenarioForceTemplate.ARRIVAL_TURN_AS_REINFORCEMENTS),
                 currentScenario, currentCampaignState));
 

--- a/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
+++ b/MekHQ/src/mekhq/gui/stratcon/TrackForceAssignmentUI.java
@@ -1,5 +1,5 @@
 /*
-* MegaMek - Copyright (C) 2020 - The MegaMek Team
+* MegaMek - Copyright (C) 2020-2025 - The MegaMek Team
 *
 * This program is free software; you can redistribute it and/or modify it under
 * the terms of the GNU General Public License as published by the Free Software
@@ -74,7 +74,7 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
 
         // if we're waiting to assign primary forces, we can only do so from the current track
         ScenarioWizardLanceModel lanceModel = new ScenarioWizardLanceModel(campaign,
-            StratconRulesManager.getAvailableForceIDs(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX,
+            StratconRulesManager.getAvailableForceIDsForManualDeployment(ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX,
                 campaign, ownerPanel.getCurrentTrack(), false, null, currentCampaignState));
 
         availableForceList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);


### PR DESCRIPTION
- Renamed `getAvailableForceIDs` to `getAvailableForceIDsForManualDeployment` for better clarity and specificity.
- Updated all method calls and references to use the new method name.