### PR TITLE
 Replaced Magic Numbers With Constants For Scenario IDs

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -66,8 +66,8 @@ import mekhq.campaign.market.unitMarket.AbstractUnitMarket;
 import mekhq.campaign.market.unitMarket.DisabledUnitMarket;
 import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
-import mekhq.campaign.mission.enums.CombatRole;
 import mekhq.campaign.mission.enums.*;
+import mekhq.campaign.mission.enums.CombatRole;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType;
 import mekhq.campaign.mod.am.InjuryUtil;
@@ -110,8 +110,8 @@ import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconContractInitializer;
 import mekhq.campaign.stratcon.StratconRulesManager;
 import mekhq.campaign.stratcon.StratconTrackState;
-import mekhq.campaign.unit.CrewType;
 import mekhq.campaign.unit.*;
+import mekhq.campaign.unit.CrewType;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.campaign.universe.*;
 import mekhq.campaign.universe.enums.HiringHallLevel;
@@ -153,6 +153,8 @@ import static mekhq.campaign.CampaignOptions.TRANSIT_UNIT_MONTH;
 import static mekhq.campaign.CampaignOptions.TRANSIT_UNIT_WEEK;
 import static mekhq.campaign.force.CombatTeam.getStandardForceSize;
 import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
+import static mekhq.campaign.force.Force.FORCE_NONE;
+import static mekhq.campaign.force.Force.NO_ASSIGNED_SCENARIO;
 import static mekhq.campaign.market.contractMarket.ContractAutomation.performAutomatedActivation;
 import static mekhq.campaign.mission.AtBContract.pickRandomCamouflage;
 import static mekhq.campaign.mission.resupplyAndCaches.PerformResupply.performResupply;
@@ -5387,9 +5389,9 @@ public class Campaign implements ITechManager {
                 continue;
             }
             if (u.getForceId() == fid) {
-                u.setForceId(-1);
+                u.setForceId(FORCE_NONE);
                 if (force.isDeployed()) {
-                    u.setScenarioId(-1);
+                    u.setScenarioId(NO_ASSIGNED_SCENARIO);
                 }
             }
         }
@@ -5423,7 +5425,7 @@ public class Campaign implements ITechManager {
         if (null != force) {
             force.removeUnit(this, u.getId(), true);
             u.setForceId(Force.FORCE_NONE);
-            u.setScenarioId(-1);
+            u.setScenarioId(NO_ASSIGNED_SCENARIO);
             if (u.getEntity().hasNavalC3()
                     && u.getEntity().calculateFreeC3Nodes() < 5) {
                 Vector<Unit> removedUnits = new Vector<>();

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -72,6 +72,8 @@ public class Force {
     public static final int COMBAT_TEAM_OVERRIDE_FALSE = 0;
     public static final int COMBAT_TEAM_OVERRIDE_TRUE = 1;
 
+    public static final int NO_ASSIGNED_SCENARIO = -1;
+
     private String name;
     private StandardForceIcon forceIcon;
     private Camouflage camouflage;
@@ -107,7 +109,7 @@ public class Force {
         this.parentForce = null;
         this.subForces = new Vector<>();
         this.units = new Vector<>();
-        this.scenarioId = -1;
+        this.scenarioId = NO_ASSIGNED_SCENARIO;
     }
     // endregion Constructors
 
@@ -263,7 +265,7 @@ public class Force {
         if ((null != parentForce) && parentForce.isDeployed()) {
             return true;
         }
-        return scenarioId != -1;
+        return scenarioId != NO_ASSIGNED_SCENARIO;
     }
 
     public @Nullable Force getParentForce() {
@@ -521,7 +523,7 @@ public class Force {
                 c.getScenario(getScenarioId()).addUnit(uid);
             }
         }
-        setScenarioId(-1,c);
+        setScenarioId(NO_ASSIGNED_SCENARIO,c);
     }
 
     public int getId() {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -23,8 +23,8 @@ import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.ui.swing.util.PlayerColour;
-import megamek.common.Entity;
 import megamek.common.*;
+import megamek.common.Entity;
 import megamek.common.annotations.Nullable;
 import megamek.common.icons.Camouflage;
 import megamek.common.weapons.bayweapons.BayWeapon;
@@ -64,9 +64,6 @@ import mekhq.campaign.storyarc.StoryArc;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.cleanup.EquipmentUnscrambler;
 import mekhq.campaign.unit.cleanup.EquipmentUnscramblerResult;
-import mekhq.campaign.universe.Planet.PlanetaryEvent;
-import mekhq.campaign.universe.PlanetarySystem.PlanetarySystemEvent;
-import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.fameAndInfamy.FameAndInfamyController;
 import mekhq.io.idReferenceClasses.PersonIdReference;
 import mekhq.module.atb.AtBEventProcessor;
@@ -81,6 +78,7 @@ import java.util.*;
 import java.util.Map.Entry;
 
 import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
+import static mekhq.campaign.force.Force.FORCE_NONE;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 
@@ -417,7 +415,7 @@ public class CampaignXmlParser {
             // lets make sure the force id set actually corresponds to a force
             // TODO: we have some reports of force id relics - need to fix
             if ((unit.getForceId() > 0) && (retVal.getForce(unit.getForceId()) == null)) {
-                unit.setForceId(-1);
+                unit.setForceId(FORCE_NONE);
             }
 
             // It's annoying to have to do this, but this helps to ensure

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -91,11 +91,12 @@ import java.awt.event.*;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 import java.util.stream.IntStream;
 import java.util.zip.GZIPOutputStream;
 
+import static mekhq.campaign.force.Force.NO_ASSIGNED_SCENARIO;
 import static mekhq.gui.dialog.nagDialogs.NagController.triggerDailyNags;
 
 /**
@@ -2389,7 +2390,7 @@ public class CampaignGUI extends JPanel {
             Force parent = f;
             int prevId = f.getId();
             while ((parent = parent.getParentForce()) != null) {
-                if (parent.getScenarioId() == -1) {
+                if (parent.getScenarioId() == NO_ASSIGNED_SCENARIO) {
                     break;
                 }
                 parent.clearScenarioIds(getCampaign(), false);


### PR DESCRIPTION
- Added `NO_ASSIGNED_SCENARIO` as a new constant in the `Force` class.
- Replaced `-1` for unassigned scenario ID with the new `NO_ASSIGNED_SCENARIO` constant across relevant files.
- Updated all references and logic checks to use these new constants.
- Replaced `-1` for a couple of unassigned force IDs with the `FORCE_NONE`. This is far from exhaustive, the couple changed were just those I stumbled over while addressing Scenario ID.