### PR TITLE
Updated Manual Unit Rating Modifier Range

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -151,7 +151,7 @@ public class GeneralTab {
             resources.getString("lblReputation.tooltip")));
         lblManualUnitRatingModifier = new CampaignOptionsLabel("ManualUnitRatingModifier");
         manualUnitRatingModifier = new CampaignOptionsSpinner("ManualUnitRatingModifier",
-            0, -200, 200, 1);
+            0, -1000, 1000, 1);
         chkClampReputationPayMultiplier = new CampaignOptionsCheckBox("ClampReputationPayMultiplier");
         chkReduceReputationPerformanceModifier = new CampaignOptionsCheckBox("ReduceReputationPerformanceModifier");
         chkReputationPerformanceModifierCutOff = new CampaignOptionsCheckBox("ReputationPerformanceModifierCutOff");


### PR DESCRIPTION
- Expanded the `ManualUnitRatingModifier` spinner range from [-200, 200] to [-1000, 1000].
- Allows for greater flexibility in campaign customization.

### Dev Notes
During the recent Reputation issues it was observed that [-200, 200] was too small an adjustment for some of our mega campaigns to be able to adjust Reputation in a meaningful way. This update should better factor in those players.