### PR TITLE
fix: PACAR auto-start only when using CommanderGUI

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -543,15 +543,15 @@ public class AtBGameThread extends GameThread {
                         botClient.sendDone(true);
                     }
                     Thread.sleep(MekHQ.getMHQOptions().getStartGameBotClientDelay());
-                    if (swingGui != null && swingGui instanceof CommanderGUI commanderGUI) {
-                        commanderGUI.enableReady();
-                        commanderGUI.getLocalBots().put(bot.getName(), bot);
-                    }
                     if (swingGui instanceof ILocalBots iLocalBots) {
                         iLocalBots.getLocalBots().put(bot.getName(), bot);
                     }
-                    client.getLocalPlayer().setDone(true);
-                    client.sendDone(true);
+                    if (swingGui instanceof CommanderGUI commanderGUI) {
+                        commanderGUI.enableReady();
+                        commanderGUI.getLocalBots().put(bot.getName(), bot);
+                        client.getLocalPlayer().setDone(true);
+                        client.sendDone(true);
+                    }
                 }
             }
 


### PR DESCRIPTION
Stops PACAR from starting the game before the player has a chance to setup the scenario, game rules and units in the way they want when running with the legacy Client GUI.

- closes #6059 (it lists as an RFE, but after reflection, the behavior was wrong and should not be starting the game automatically, so I am treating as a bug instead)