### PR TITLE
 Updated `PartsTableModel.java` To Better Indicate Brand-New Status in Quality Column

### DIFF
--- a/MekHQ/resources/mekhq/resources/PartsTableModel.properties
+++ b/MekHQ/resources/mekhq/resources/PartsTableModel.properties
@@ -1,0 +1,13 @@
+label.COL_NAME=Name
+label.COL_COST=Value per Unit
+label.COL_TOTAL_COST=Total Value
+label.COL_QUANTITY=#
+label.COL_QUALITY=Quality
+label.COL_TON=Tonnage
+label.COL_STATUS=Status
+label.COL_DETAIL=Details
+label.COL_TECH_BASE=Tech Base
+label.COL_REPAIR=Repair Details
+
+addendum.brandNew=Brand New
+addendum.used=Used

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -196,7 +196,7 @@ public abstract class Part implements IPartWork, ITechnology {
         this.usedForRefitPlanning = false;
         this.daysToArrival = 0;
         this.campaign = c;
-        this.brandNew = false;
+        this.brandNew = true;
         this.quantity = 1;
         this.quality = PartQuality.QUALITY_D;
         this.childParts = new ArrayList<>();
@@ -305,8 +305,8 @@ public abstract class Part implements IPartWork, ITechnology {
         return brandNew;
     }
 
-    public void setBrandNew(boolean brandNew) {
-        this.brandNew = brandNew;
+    public void setBrandNew(boolean b) {
+        this.brandNew = b;
     }
 
     /**
@@ -610,10 +610,11 @@ public abstract class Part implements IPartWork, ITechnology {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "daysToArrival", daysToArrival);
         }
 
-        if (brandNew) {
-            // The default value for Part.brandNew is false. Only store the tag if the value
-            // is true. The lack of tag in the save file will ALWAYS result in FALSE.
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "brandNew", true);
+        if (!brandNew) {
+            // The default value for Part.brandNew is true. Only store the tag if the value
+            // is false.
+            // The lack of tag in the save file will ALWAYS result in TRUE.
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "brandNew", false);
         }
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "quantity", quantity);
 
@@ -731,7 +732,7 @@ public abstract class Part implements IPartWork, ITechnology {
                 } else if (wn2.getNodeName().equalsIgnoreCase("isTeamSalvaging")) {
                     retVal.isTeamSalvaging = wn2.getTextContent().equalsIgnoreCase("true");
                 } else if (wn2.getNodeName().equalsIgnoreCase("brandNew")) {
-                    retVal.brandNew = Boolean.parseBoolean(wn2.getTextContent());
+                    retVal.brandNew = wn2.getTextContent().equalsIgnoreCase("true");
                 } else if (wn2.getNodeName().equalsIgnoreCase("replacementId")) {
                     retVal.replacementPart = new PartRef(Integer.parseInt(wn2.getTextContent()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("quality")) {

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -29,8 +29,8 @@ import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
-import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.enums.PartQuality;
+import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.personnel.Person;
@@ -196,7 +196,7 @@ public abstract class Part implements IPartWork, ITechnology {
         this.usedForRefitPlanning = false;
         this.daysToArrival = 0;
         this.campaign = c;
-        this.brandNew = true;
+        this.brandNew = false;
         this.quantity = 1;
         this.quality = PartQuality.QUALITY_D;
         this.childParts = new ArrayList<>();
@@ -305,8 +305,8 @@ public abstract class Part implements IPartWork, ITechnology {
         return brandNew;
     }
 
-    public void setBrandNew(boolean b) {
-        this.brandNew = b;
+    public void setBrandNew(boolean brandNew) {
+        this.brandNew = brandNew;
     }
 
     /**
@@ -610,11 +610,10 @@ public abstract class Part implements IPartWork, ITechnology {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "daysToArrival", daysToArrival);
         }
 
-        if (!brandNew) {
-            // The default value for Part.brandNew is true. Only store the tag if the value
-            // is false.
-            // The lack of tag in the save file will ALWAYS result in TRUE.
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "brandNew", false);
+        if (brandNew) {
+            // The default value for Part.brandNew is false. Only store the tag if the value
+            // is true. The lack of tag in the save file will ALWAYS result in FALSE.
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "brandNew", true);
         }
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "quantity", quantity);
 
@@ -732,7 +731,7 @@ public abstract class Part implements IPartWork, ITechnology {
                 } else if (wn2.getNodeName().equalsIgnoreCase("isTeamSalvaging")) {
                     retVal.isTeamSalvaging = wn2.getTextContent().equalsIgnoreCase("true");
                 } else if (wn2.getNodeName().equalsIgnoreCase("brandNew")) {
-                    retVal.brandNew = wn2.getTextContent().equalsIgnoreCase("true");
+                    retVal.brandNew = Boolean.parseBoolean(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("replacementId")) {
                     retVal.replacementPart = new PartRef(Integer.parseInt(wn2.getTextContent()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("quality")) {

--- a/MekHQ/src/mekhq/gui/model/PartsTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsTableModel.java
@@ -26,10 +26,14 @@ import javax.swing.table.DefaultTableCellRenderer;
 import java.awt.*;
 import java.util.ArrayList;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
 /**
  * A table model for displaying parts
  */
 public class PartsTableModel extends DataTableModel {
+    private static final String RESOURCE_BUNDLE = "mekhq.resources." + PartsTableModel.class.getSimpleName();
+
     public final static int COL_QUANTITY = 0;
     public final static int COL_NAME = 1;
     public final static int COL_DETAIL = 2;
@@ -58,30 +62,19 @@ public class PartsTableModel extends DataTableModel {
 
     @Override
     public String getColumnName(int column) {
-        switch (column) {
-            case COL_NAME:
-                return "Name";
-            case COL_COST:
-                return "Value per Unit";
-            case COL_TOTAL_COST:
-                return "Total Value";
-            case COL_QUANTITY:
-                return "#";
-            case COL_QUALITY:
-                return "Quality";
-            case COL_TON:
-                return "Tonnage";
-            case COL_STATUS:
-                return "Status";
-            case COL_DETAIL:
-                return "Detail";
-            case COL_TECH_BASE:
-                return "Tech Base";
-            case COL_REPAIR:
-                return "Repair Details";
-            default:
-                return "?";
-        }
+        return switch (column) {
+            case COL_NAME -> getFormattedTextAt(RESOURCE_BUNDLE, "label.COL_NAME");
+            case COL_COST -> getFormattedTextAt(RESOURCE_BUNDLE, "label.COL_COST");
+            case COL_TOTAL_COST -> getFormattedTextAt(RESOURCE_BUNDLE, "label.COL_TOTAL_COST");
+            case COL_QUANTITY -> getFormattedTextAt(RESOURCE_BUNDLE, "label.COL_QUANTITY");
+            case COL_QUALITY -> getFormattedTextAt(RESOURCE_BUNDLE, "label.COL_QUALITY");
+            case COL_TON -> getFormattedTextAt(RESOURCE_BUNDLE, "label.COL_TON");
+            case COL_STATUS -> getFormattedTextAt(RESOURCE_BUNDLE, "label.COL_STATUS");
+            case COL_DETAIL -> getFormattedTextAt(RESOURCE_BUNDLE, "label.COL_DETAIL");
+            case COL_TECH_BASE -> getFormattedTextAt(RESOURCE_BUNDLE, "label.COL_TECH_BASE");
+            case COL_REPAIR -> getFormattedTextAt(RESOURCE_BUNDLE, "label.COL_REPAIR");
+            default -> "?";
+        };
     }
 
     @Override
@@ -109,12 +102,14 @@ public class PartsTableModel extends DataTableModel {
             return part.getQuantity();
         }
         if (col == COL_QUALITY) {
-            String appendum = "";
+            String appendum;
 
             if (part.isBrandNew()) {
-                appendum = " (Brand New)";
+                appendum = getFormattedTextAt(RESOURCE_BUNDLE, "addendum.brandNew");
+            } else {
+                appendum = getFormattedTextAt(RESOURCE_BUNDLE, "addendum.used");
             }
-            return part.getQualityName() + appendum;
+            return part.getQualityName() + " (" + appendum + ')';
         }
         if (col == COL_TON) {
             return Math.round(part.getTonnage() * 100) / 100.0;

--- a/MekHQ/src/mekhq/gui/model/PartsTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsTableModel.java
@@ -94,15 +94,7 @@ public class PartsTableModel extends DataTableModel {
         }
 
         if (col == COL_NAME) {
-            String openBrace = "";
-            String closeBrace = "";
-
-            if (part.isBrandNew()) {
-                openBrace = "<i>";
-                closeBrace = "</i>";
-            }
-
-            return "<html><nobr>" + openBrace + part.getName() + closeBrace + "</nobr></html>";
+            return "<html><nobr>" + part.getName() + "</nobr></html>";
         }
         if (col == COL_DETAIL) {
             return "<html><nobr>" + part.getDetails() + "</nobr></html>";
@@ -117,7 +109,12 @@ public class PartsTableModel extends DataTableModel {
             return part.getQuantity();
         }
         if (col == COL_QUALITY) {
-            return part.getQualityName();
+            String appendum = "";
+
+            if (part.isBrandNew()) {
+                appendum = " (Brand New)";
+            }
+            return part.getQualityName() + appendum;
         }
         if (col == COL_TON) {
             return Math.round(part.getTonnage() * 100) / 100.0;


### PR DESCRIPTION
- Removed italicized formatting of brand-new parts in the Name column for a cleaner presentation.
- Introduced a new resource bundle (`PartsTableModel.properties`) to centralize localization strings for `PartsTableModel`.
- Replaced hardcoded column names with calls to `getFormattedTextAt` to dynamically fetch localized strings from the resource bundle
- Removed redundant hardcoded strings to improve maintainability and support for additional localization in the future.
- Simplified and modernized `getColumnName` logic using the `switch` expression.
- Appended "(Brand New)" and "(Used)" to the Quality column for improved clarity and visibility of part status.

### Dev Notes
This should cut back on the number of contacts we get from users asking what the italic name in their warehouse means.