### PR TITLE
Corrected Resupply Interception Placeholder Syntax

### DIFF
--- a/MekHQ/resources/mekhq/resources/Resupply.properties
+++ b/MekHQ/resources/mekhq/resources/Resupply.properties
@@ -2199,59 +2199,59 @@ statusUpdateEnemyOverwhelming49.text={0}, we faced a series of well-timed strike
   \ Current assessment indicates a high likelihood of additional attacks in this sector.
 
 statusUpdateIntercepted.boilerplate={0}, hostile interception underway. Incoming contacts unrelenting.\
-  \ Reinforcements needed urgently. They''re closing in fast.{0}
+  \ Reinforcements needed urgently. They''re closing in fast.{1}
 statusUpdateIntercepted0.text={0}, rear assault underway. Hostile ''Meks penetrating our lines.\
   \ Transports are fully exposed; formation in disarray. Incoming contacts on sensors.\
   \ Reinforcements needed urgently. Attempting to fall back, but we''re in serious trouble. They''re closing in\
-  \ fast - holding this position much longer isn''t viable, we''re going to try regrouping.{0}
+  \ fast - holding this position much longer isn''t viable, we''re going to try regrouping.{1}
 statusUpdateIntercepted1.text={0}, losing ground rapidly. Encircled by fast-moving ''Meks. Regroup\
   \ attempt failed; transports are under siege. Last call for reinforcements - our line is\
-  \ collapsing, and command structure is breaking down.{0}
+  \ collapsing, and command structure is breaking down.{1}
 statusUpdateIntercepted2.text={0}, convoy disintegrating under heavy fire. Hostile armor units\
   \ advancing at high speed. Reinforcements required immediately - total defeat imminent. Enemy\
-  \ overwhelming all attempts to break free. We''re going to make one final attempt to withdraw.{0}
+  \ overwhelming all attempts to break free. We''re going to make one final attempt to withdraw.{1}
 statusUpdateIntercepted3.text={0}, we''re surrounded. Our perimeter has collapsed. Crew making a final\
   \ stand, barely holding. Supplies are exposed, no fallback route. Immediate reinforcements needed\
-  \ to prevent total loss.{0}
+  \ to prevent total loss.{1}
 statusUpdateIntercepted4.text={0}, perimeter has been breached by enemy ''Meks. Convoy overrun, cargo\
   \ being seized. If reinforcements are inbound, they must arrive now. Regroup efforts faltering\
-  \ under intense fire.{0}
+  \ under intense fire.{1}
 statusUpdateIntercepted5.text={0}, checkpoint lost. Final defenses shattered by artillery. Command\
   \ and control severely compromised. Immediate support required to hold the line, but position is\
-  \ barely stable. We''re going to try and withdraw.{0}
+  \ barely stable. We''re going to try and withdraw.{1}
 statusUpdateIntercepted6.text={0}, convoy breaking apart. Heavy fire shredding our defenses. Supplies\
   \ falling into enemy hands. Defensive positions have been compromised.\
-  \ Urgent need for reinforcements to make a last stand.{0}
+  \ Urgent need for reinforcements to make a last stand.{1}
 statusUpdateIntercepted7.text={0}, we''re at breaking point. Hostiles control the main supply route,\
   \ regroup attempts have failed. Supplies dwindling, morale fading. Reinforcements must arrive now,\
-  \ or total defeat is inevitable.{0}
+  \ or total defeat is inevitable.{1}
 statusUpdateIntercepted8.text={0}, surrounded on all sides. Hostile forces closing in rapidly.\
   \ Immediate reinforcements essential - without them, complete collapse is certain. Situation\
-  \ critical.{0}
+  \ critical.{1}
 statusUpdateIntercepted9.text={0}, convoy devastated. Sustained bombardment by enemy ''Meks. Supplies\
   \ fully exposed - crew attempting to destroy remaining stock. Reinforcements required urgently;\
-  \ convoy is coming apart.{0}
+  \ convoy is coming apart.{1}
 statusUpdateIntercepted10.text={0}, convoy in disarray. Defensive lines breached in all sectors. Crew\
   \ falling back, supplies being seized. Reinforcements requested urgently.\
-  \ Situation dire.{0}
+  \ Situation dire.{1}
 statusUpdateIntercepted11.text={0}, critical state. Hostiles advancing quickly. Supplies\
-  \ compromised. Reinforcements essential - total defeat imminent without immediate support.{0}
+  \ compromised. Reinforcements essential - total defeat imminent without immediate support.{1}
 statusUpdateIntercepted12.text={0}, surrounded with no escape. Crew attempting fallback\
-  \ but with no clear route available. Immediate support required to avoid total annihilation.{0}
+  \ but with no clear route available. Immediate support required to avoid total annihilation.{1}
 statusUpdateIntercepted13.text={0}, overwhelmed on all sides. Final line breached.\
-  \ Immediate support required, but time is running out.{0}
+  \ Immediate support required, but time is running out.{1}
 statusUpdateIntercepted14.text={0}, we''re at the edge. Convoy in ruins, crew desperately holding\
-  \ ground. Reinforcements needed urgently, or this is the end.{0}
+  \ ground. Reinforcements needed urgently, or this is the end.{1}
 statusUpdateIntercepted15.text={0}, defenses completely breached. Convoy collapsing under enemy\
-  \ pressure. Reinforcements urgently needed to have any chance of survival.{0}
+  \ pressure. Reinforcements urgently needed to have any chance of survival.{1}
 statusUpdateIntercepted16.text={0}, enemy closing in, convoy overrun. Regroup efforts have failed.\
-  \ Reinforcements required urgently to prevent complete collapse.{0}
+  \ Reinforcements required urgently to prevent complete collapse.{1}
 statusUpdateIntercepted17.text={0}, enemy advancing uncontested. Supplies exposed and\
-  \ unable to secure or destroy. Reinforcements required urgently - time is critical.{0}
+  \ unable to secure or destroy. Reinforcements required urgently - time is critical.{1}
 statusUpdateIntercepted18.text={0}, under relentless fire. Supplies compromised, crew taking heavy\
-  \ losses. Reinforcements needed immediately - situation critical.{0}
+  \ losses. Reinforcements needed immediately - situation critical.{1}
 statusUpdateIntercepted19.text={0}, situation hopeless. Last line of defense lost. Convoy collapsing,\
-  \ all units breaking down. Reinforcements needed urgently.{0}
+  \ all units breaking down. Reinforcements needed urgently.{1}
 
 interceptionInstructions.text=<br><br><i>A special scenario has been generated. Failure to complete\
   \ this scenario will result in the loss of all units, personnel, and cargo.</i>


### PR DESCRIPTION
- Replaced placeholders `{0}` with `{1}` in all `statusUpdateIntercepted` properties to ensure consistency.
- No changes to the core content or logic, only syntax refinement.

Fix #6166