### PR TITLE
Updated Reinforcement Logic to Better Support GM Overrides

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -24,8 +24,8 @@ selectForceForTemplate.Text=<html><b>Select a force from the list below.</b>\
 selectReinforcementsForTemplate.Text=<html><b>Select reinforcements from the list below.</b>\
   <br>\
   <br>Each attempt will cost Support Points and may be unsuccessful.</html>
-selectReinforcementsForTemplateNoSupportPoints.Text=<html><b>Unable to assign reinforcements. No\
-  \ Support Points available.</b></html>
+selectReinforcementsForTemplateNoSupportPoints.Text=<html><b>No Support Points available.</b> Only\
+  \ GM Reinforcement available.</html>
 
 reinforcementsAttempt.text=Attempting to reinforce scenario %s, roll <b>%s%s</b> vs. <b>%s</b>:
 reinforcementsAttempt.text.gm=Attempting to reinforce scenario %s:

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -2465,7 +2465,7 @@ public class StratconRulesManager {
                 return ReinforcementEligibilityType.NONE;
             }
 
-            if (campaignState.getSupportPoints() > 0) {
+            if (campaignState.getSupportPoints() > 0 || campaign.isGM()) {
                 if (formation.getRole().isManeuver() || formation.getRole().isAuxiliary()) {
                     return AUXILIARY;
                 } else {

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -673,7 +673,6 @@ public class StratconScenarioWizard extends JDialog {
                 null, false));
         } else {
             btnCommit.addActionListener(evt -> reinforcementConfirmDialog());
-            btnCommit.setEnabled(currentCampaignState.getSupportPoints() > 0);
         }
 
         btnCancel = new JButton(MHQInternationalization.getTextAt(resourcePath, "leadershipCancel.text"));
@@ -861,6 +860,7 @@ public class StratconScenarioWizard extends JDialog {
             btnCommitClicked(evt, finalTargetNumber, false);
             dialog.dispose();
         });
+        reinforceButton.setEnabled(availableSupportPoints > 0);
 
         JButton reinforceButtonGM = new JButton(resources.getString("reinforcementConfirmation.confirmButton.gm"));
         reinforceButtonGM.setToolTipText(resources.getString("reinforcementConfirmation.confirmButton.gm.tooltip"));


### PR DESCRIPTION
- Modified language in AtBStratCon properties to clarify GM reinforcement availability when Support Points are unavailable.
- Updated logic in `StratconRulesManager` to allow GM reinforcements regardless of Support Points.
- Adjusted GUI logic to enable reinforcement buttons based on Support Points availability or GM status.

Fix #6167