### PR TITLE
Updated `RandomDependents.java`: Fixed Reporting & Optimized

### DIFF
--- a/MekHQ/resources/mekhq/resources/RandomDependents.properties
+++ b/MekHQ/resources/mekhq/resources/RandomDependents.properties
@@ -1,5 +1,2 @@
-dependentJoinsForce.report={0} has started traveling with the force as a {0}.
-dependentLeavesForce.report={0} {1} have departed the force.
-
-dependent.singular=Dependent
-dependent.plural=Dependents
+dependentJoinsForce.report={0} has started traveling with the force as a {1}.
+dependentLeavesForce.report={0} {1, choice, 0#Dependents|1#Dependent|2#Dependents} have left the force.

--- a/MekHQ/unittests/mekhq/campaign/personnel/RandomDependentsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/RandomDependentsTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
 
 class RandomDependentsTest {
     @Test
-    void testGetActiveNonDependents() {
+    void testPrepareData() {
         final int NUMBER_OF_NON_DEPENDENTS = 20;
         final int NUMBER_OF_DEPENDENTS = 5;
 
@@ -67,11 +67,11 @@ class RandomDependentsTest {
             activeNonDependent.add(nonDependent);
         }
         activeNonDependent.addAll(activeDependents);
-        when(mockCampaign.getActivePersonnel()).thenReturn(activeNonDependent);
+        when(mockCampaign.getActivePersonnel(false)).thenReturn(activeNonDependent);
 
         // Act
         RandomDependents randomDependents = new RandomDependents(mockCampaign);
-        int actualValue = randomDependents.getActiveNonDependents();
+        int actualValue = randomDependents.prepareData();
         int expectedValue = NUMBER_OF_NON_DEPENDENTS;
 
         // Assert


### PR DESCRIPTION
- Renamed `getActiveNonDependents` to `prepareData` to better reflect its functionality.
- Refactored `RandomDependents` class to use boolean fields (`isUseRandomDependentAddition` and `isUseRandomDependentRemoval`) instead of accessing campaign options directly multiple times.
- Rewrote `prepareData` to initialize `activeDependents` directly and ensure reuse across the class.
- Updated logic in `dependentsRollForRemoval` to remove dependents directly from `activeDependents` after processing, eliminating redundant reassignment.
- Cleaned up and improved readability of dependent addition and removal logic by leveraging class fields.
- Simplified test cases to align with the refactored `prepareData` method and ensure accuracy.
- Refined resource bundle formatting logic for dependent messages and added pluralization handling within `dependentLeavesForce.report`.

Fix #6174

### Dev Notes
This PR just fixes a couple of reports and refactors some of the Dependent Addition|Removal methods so that we don't need to keep passing campaign options around, when we only need two values. I highly doubt anyone will notice the performance gains from this optimization, but it's there; I promise! :D

I would have really liked to remove direct calls to `campaign`, but too much functionality (such as the addition of personnel, and the posting of reports) is tied directly to the Campaign class and cannot be easily detached (at least I don't know how).