### PR TITLE
Issue 6123: Mark drones as unsupported in MHQ.

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -48,7 +48,7 @@ miMHQOptions.toolTipText=This launches the MekHQ Options Dialog.
 menuThemes.text=Themes
 menuExit.text=Exit
 mekSelectorDialog.unsupported.gunEmplacement=Gun Emplacements are %s<b>not supported</b>%s by MekHQ.
-mekSelectorDialog.unsupported.droneOs=Units with drone os are %s<b>not supported</b>%s by MekHQ.
+mekSelectorDialog.unsupported.droneOs=Drone units are %s<b>not supported</b>%s by MekHQ.
 mekSelectorDialog.unsupported.null=Unit does not have an entity.
 
 # Marketplace Menu

--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -48,6 +48,8 @@ miMHQOptions.toolTipText=This launches the MekHQ Options Dialog.
 menuThemes.text=Themes
 menuExit.text=Exit
 mekSelectorDialog.unsupported.gunEmplacement=Gun Emplacements are %s<b>not supported</b>%s by MekHQ.
+mekSelectorDialog.unsupported.droneOs=Units with drone os are %s<b>not supported</b>%s by MekHQ.
+mekSelectorDialog.unsupported.null=Unit does not have an entity.
 
 # Marketplace Menu
 menuMarket.text=Marketplace

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -68,10 +68,8 @@ import java.util.concurrent.ExecutionException;
 
 import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP;
 import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP_ABRIDGED;
-import static mekhq.gui.campaignOptions.SelectPresetDialog.PRESET_SELECTION_CANCELLED;
-import static mekhq.gui.campaignOptions.SelectPresetDialog.PRESET_SELECTION_CUSTOMIZE;
-import static mekhq.gui.campaignOptions.SelectPresetDialog.PRESET_SELECTION_SELECT;
-import static mekhq.utilities.EntityUtilities.isUnsupportedUnitType;
+import static mekhq.gui.campaignOptions.SelectPresetDialog.*;
+import static mekhq.utilities.EntityUtilities.isUnsupportedEntity;
 
 public class DataLoadingDialog extends AbstractMHQDialogBasic implements PropertyChangeListener {
     private static final MMLogger logger = MMLogger.create(DataLoadingDialog.class);
@@ -441,7 +439,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                     continue;
                 }
 
-                if (isUnsupportedUnitType(entity.getUnitType())) {
+                if (isUnsupportedEntity(entity)) {
                     unit.clearCrew();
                 }
             }

--- a/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MekHQUnitSelectorDialog.java
@@ -28,6 +28,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.enums.PartQuality;
 import mekhq.campaign.unit.UnitOrder;
 import mekhq.campaign.unit.UnitTechProgression;
+import mekhq.utilities.MHQInternationalization;
 
 import javax.swing.*;
 import java.awt.*;
@@ -36,7 +37,7 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.regex.PatternSyntaxException;
 
-import static mekhq.utilities.EntityUtilities.isUnsupportedUnitType;
+import static mekhq.utilities.EntityUtilities.isUnsupportedEntity;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
@@ -134,12 +135,24 @@ public class MekHQUnitSelectorDialog extends AbstractUnitSelectorDialog {
             // Block the purchase if the unit type is unsupported
             Entity entity = selectedUnit.getEntity();
 
-            if (entity == null || isUnsupportedUnitType(entity.getUnitType())) {
+            if (entity == null || isUnsupportedEntity(entity)) {
                 final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
                     MekHQ.getMHQOptions().getLocale());
 
+                String reason;
+                if (entity == null) {
+                    reason = MHQInternationalization.getTextAt(resources.getBaseBundleName(),
+                        "mekSelectorDialog.unsupported.null");
+                } else if (entity.getUnitType() == UnitType.GUN_EMPLACEMENT) {
+                    reason = MHQInternationalization.getTextAt(resources.getBaseBundleName(),
+                        "mekSelectorDialog.unsupported.gunEmplacement");
+                } else {
+                    reason = MHQInternationalization.getTextAt(resources.getBaseBundleName(),
+                        "mekSelectorDialog.unsupported.droneOs");
+                }
+
                 campaign.addReport(String.format(
-                    resources.getString("mekSelectorDialog.unsupported.gunEmplacement"),
+                    reason,
                     spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
                     CLOSING_SPAN_TAG));
 

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static mekhq.utilities.EntityUtilities.isUnsupportedUnitType;
+import static mekhq.utilities.EntityUtilities.isUnsupportedEntity;
 
 /**
  * This is a standard menu that takes either a unit or multiple units that
@@ -64,7 +64,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         for (Unit unit : units) {
             Entity entity = unit.getEntity();
 
-            if (entity == null || isUnsupportedUnitType(entity.getUnitType())) {
+            if (entity == null || isUnsupportedEntity(entity)) {
                 return;
             }
         }

--- a/MekHQ/src/mekhq/utilities/EntityUtilities.java
+++ b/MekHQ/src/mekhq/utilities/EntityUtilities.java
@@ -53,20 +53,18 @@ public class EntityUtilities {
     }
 
     /**
-     * Checks if the given unit type is unsupported in MekHQ.
+     * Checks if the given entity is unsupported in MekHQ.
      *
      * <p>This method evaluates whether the specified unit type is considered unsupported.
-     * Currently, it checks if the unit type matches {@link UnitType#GUN_EMPLACEMENT}.
+     * Currently, it checks if the unit type matches {@link UnitType#GUN_EMPLACEMENT} or
+     * uses drone OS {@link Entity#hasDroneOs()}.
      *
-     * @param unitType The unit type to be checked, represented as an integer.
-     * @return {@code true} if the unit type is unsupported (e.g., {@link UnitType#GUN_EMPLACEMENT}),
-     *         otherwise {@code false}.
+     * @param entity The entity to be checked
+     * @return {@code true} if the entity is unsupported (e.g., a {@link UnitType#GUN_EMPLACEMENT}),
+     * otherwise {@code false}.
      */
-    public static boolean isUnsupportedUnitType(int unitType) {
-        if (unitType == UnitType.GUN_EMPLACEMENT) {
-            return true;
-        }
-
-        return false;
+    public static boolean isUnsupportedEntity(Entity entity) {
+        return entity.getUnitType() == UnitType.GUN_EMPLACEMENT
+            || entity.hasDroneOs();
     }
 }

--- a/MekHQ/src/mekhq/utilities/EntityUtilities.java
+++ b/MekHQ/src/mekhq/utilities/EntityUtilities.java
@@ -55,9 +55,9 @@ public class EntityUtilities {
     /**
      * Checks if the given entity is unsupported in MekHQ.
      *
-     * <p>This method evaluates whether the specified unit type is considered unsupported.
+     * <p>This method evaluates whether the specified entity is considered unsupported.
      * Currently, it checks if the unit type matches {@link UnitType#GUN_EMPLACEMENT} or
-     * uses drone OS {@link Entity#hasDroneOs()}.
+     * if the entity uses drone OS {@link Entity#hasDroneOs()}.
      *
      * @param entity The entity to be checked
      * @return {@code true} if the entity is unsupported (e.g., a {@link UnitType#GUN_EMPLACEMENT}),


### PR DESCRIPTION
Relates to #6123 

Drones are currently not supported by MekHQ. This change prevents the player from acquiring them.