### PR TITLE
Issue 6180: Fix Parts in Use Dialog selling wrong number of parts

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -200,13 +200,14 @@ public class PartsReportDialog extends JDialog {
                 int i = 0;
                 while (sellQty > 0 && i < spares.size()) {
                     Part spare = spares.get(i);
-                    if (spare.getSellableQuantity() >= sellQty) {
+                    int spareQuantity = spare.getSellableQuantity();
+                    if (spareQuantity >= sellQty) {
                         quartermaster.sellPart(spare, sellQty);
                         break;
                     } else {
                         // Not enough quantity in this spare, so sell them all and move onto the next one
-                        quartermaster.sellPart(spare, spare.getQuantity());
-                        sellQty -= spare.getSellableQuantity();
+                        quartermaster.sellPart(spare, spareQuantity);
+                        sellQty -= spareQuantity;
                     }
                     i++;
                 }


### PR DESCRIPTION
Fixes #6180 

Parts in Use dialog will now consistently use `getSellableQuantity()` for determining how many parts it can sell.