### PR TITLE
Updated Reinforcement Target Calculation Logic

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -35,7 +35,6 @@ import mekhq.campaign.event.StratconDeploymentEvent;
 import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.*;
-import mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment;
 import mekhq.campaign.mission.ScenarioForceTemplate.ForceGenerationMethod;
 import mekhq.campaign.mission.ScenarioMapParameters.MapLocation;
 import mekhq.campaign.mission.atb.AtBScenarioModifier;
@@ -1646,18 +1645,12 @@ public class StratconRulesManager {
      *             <li>-- If command rights indicate that a liaison is required, the modifier is adjusted.</li>
      * </ol>
      *
-     * @param campaign         the {@link Campaign} instance representing the current operational campaign.
-     * @param scenario         the {@link StratconScenario} for which reinforcement details are being determined.
      * @param commandLiaison   the {@link Person} acting as the command liaison, or {@code null} if no liaison exists.
-     * @param campaignState    the {@link StratconCampaignState} representing the state of the overarching campaign.
      * @param contract         the {@link AtBContract} defining the terms of the contract for this scenario.
      * @return                 a {@link TargetRoll} object representing the calculated reinforcement target number,
      *                         with appropriate modifiers applied.
      */
-    public static TargetRoll calculateReinforcementTargetNumber(Campaign campaign,
-                                                                StratconScenario scenario,
-                                                                @Nullable Person commandLiaison,
-                                                                StratconCampaignState campaignState,
+    public static TargetRoll calculateReinforcementTargetNumber(@Nullable Person commandLiaison,
                                                                 AtBContract contract) {
         // Create Target Roll
         TargetRoll reinforcementTargetNumber = new TargetRoll();
@@ -1683,21 +1676,8 @@ public class StratconRulesManager {
                 "Administration (Unskilled)");
         }
 
-        // Facilities Modifier
-        StratconTrackState track = scenario.getTrackForScenario(campaign, campaignState);
-
-        int facilityModifier = 0;
-        if (track != null) {
-            for (StratconFacility facility : track.getFacilities().values()) {
-                if (facility.getOwner().equals(ForceAlignment.Player) || facility.getOwner().equals(Allied)) {
-                    facilityModifier--;
-                } else {
-                    facilityModifier++;
-                }
-            }
-        }
-
-        reinforcementTargetNumber.addModifier(facilityModifier, "Facilities");
+        // Enemy Morale Modifier
+        reinforcementTargetNumber.addModifier(contract.getMoraleLevel().ordinal(), "Enemy Morale");
 
         // Skill Modifier
         int skillModifier = contract.getEnemySkill().getAdjustedValue() - SkillLevel.REGULAR.getAdjustedValue();

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -785,8 +785,8 @@ public class StratconScenarioWizard extends JDialog {
         JPanel rightBox = new JPanel(new BorderLayout());
         rightBox.setBorder(BorderFactory.createEtchedBorder());
 
-        TargetRoll reinforcementTargetNumber = calculateReinforcementTargetNumber(
-            campaign, currentScenario, commandLiaison, currentCampaignState, currentCampaignState.getContract());
+        TargetRoll reinforcementTargetNumber = calculateReinforcementTargetNumber(commandLiaison,
+              currentCampaignState.getContract());
         int targetNumber = reinforcementTargetNumber.getValue();
 
         StringBuilder rightDescriptionMessage = new StringBuilder();


### PR DESCRIPTION
- Refactored `calculateReinforcementTargetNumber` method by removing unused parameters: `Campaign`, `StratconScenario`, and `StratconCampaignState`.
- Replaced facility-based modifier calculation with an enemy morale-based modifier for better balancing.
- Updated call to `calculateReinforcementTargetNumber` in `StratconScenarioWizard` to match the new method signature.

### Dev Notes
This was a change I actually thought I made the other week. It stops player reinforcements from becoming progressively easier (to the point of being nonsensically easy) as a contract progresses and the player captures more facilities.

The facility modifier was the primary cause being so many negative target numbers, with reinforcements.

The intention of the facility modifier was to reflect the OpFors control of a sector. However, really, Enemy Morale better reflects that and has far better checks and balances to ensure Target Numbers remain within reasonable bounds.