### PR TITLE
Fixed Image Scaling Stopping Campaign Options IIC from Launching

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/SelectPresetDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/SelectPresetDialog.java
@@ -31,6 +31,7 @@ import java.awt.*;
 import java.util.ResourceBundle;
 
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createGroupLayout;
+import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
 
 /**
  * A dialog for selecting campaign presets. Extends {@link JDialog}.
@@ -85,14 +86,8 @@ public class SelectPresetDialog extends JDialog {
         setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
 
         ImageIcon imageIcon = new ImageIcon("data/images/misc/megamek-splash.png");
+        imageIcon = scaleImageIconToWidth(imageIcon, UIUtil.scaleForGUI(400));
 
-        int width = UIUtil.scaleForGUI(imageIcon.getIconWidth());
-        int height = UIUtil.scaleForGUI(imageIcon.getIconHeight());
-
-        Image image = imageIcon.getImage();
-        Image scaledImage = image.getScaledInstance(width, height, Image.SCALE_SMOOTH);
-
-        imageIcon = new ImageIcon(scaledImage);
         JLabel imageLabel = new JLabel(imageIcon);
         add(imageLabel, BorderLayout.NORTH);
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsHeaderPanel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsHeaderPanel.java
@@ -24,8 +24,8 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.ResourceBundle;
 
-import static java.lang.Math.round;
 import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
+import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
 
 /**
  * A specialized {@link JPanel} designed for headers in the campaign options dialog.
@@ -78,11 +78,7 @@ public class CampaignOptionsHeaderPanel extends JPanel {
     public CampaignOptionsHeaderPanel(String name, String imageAddress, boolean includeBodyText) {
         // Load and scale the image using the provided file path
         ImageIcon imageIcon = new ImageIcon(imageAddress);
-        int width = (int) UIUtil.scaleForGUI(round(imageIcon.getIconWidth() * 0.75));
-        int height = (int) UIUtil.scaleForGUI(round(imageIcon.getIconHeight() * 0.75));
-        Image image = imageIcon.getImage();
-        Image scaledImage = image.getScaledInstance(width, height, Image.SCALE_SMOOTH);
-        imageIcon = new ImageIcon(scaledImage);
+        imageIcon = scaleImageIconToWidth(imageIcon, UIUtil.scaleForGUI(100));
 
         // Create a JLabel to display the image in the panel
         JLabel lblImage = new JLabel(imageIcon);

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -35,14 +35,7 @@ import mekhq.gui.baseComponents.AbstractMHQScrollablePanel;
 import mekhq.gui.baseComponents.AbstractMHQTabbedPane;
 import mekhq.gui.baseComponents.DefaultMHQScrollablePanel;
 import mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode;
-import mekhq.gui.campaignOptions.components.CampaignOptionsButton;
-import mekhq.gui.campaignOptions.components.CampaignOptionsCheckBox;
-import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
-import mekhq.gui.campaignOptions.components.CampaignOptionsHeaderPanel;
-import mekhq.gui.campaignOptions.components.CampaignOptionsLabel;
-import mekhq.gui.campaignOptions.components.CampaignOptionsSpinner;
-import mekhq.gui.campaignOptions.components.CampaignOptionsStandardPanel;
-import mekhq.gui.campaignOptions.components.CampaignOptionsTextField;
+import mekhq.gui.campaignOptions.components.*;
 import mekhq.gui.dialog.DateChooser;
 import mekhq.gui.dialog.iconDialogs.UnitIconDialog;
 import mekhq.gui.displayWrappers.FactionDisplay;
@@ -57,6 +50,7 @@ import java.util.ResourceBundle;
 import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
 import static megamek.common.options.OptionsConstants.ALLOWED_YEAR;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createGroupLayout;
+import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
 
 /**
  * Represents a tab within the campaign options UI that allows the user to configure
@@ -279,6 +273,7 @@ public class GeneralTab {
      */
     private static JPanel createGeneralHeader() {
         ImageIcon imageIcon = new ImageIcon("data/images/misc/MekHQ.png");
+        imageIcon = scaleImageIconToWidth(imageIcon, UIUtil.scaleForGUI(200));
         JLabel imageLabel = new JLabel(imageIcon);
 
         final JLabel lblHeader = new JLabel(resources.getString("lblGeneral.text"), SwingConstants.CENTER);


### PR DESCRIPTION
- Replaced manual image scaling logic with `scaleImageIconToWidth` utility function.
- Simplified and cleaned up code in `SelectPresetDialog`, `GeneralTab`, and `CampaignOptionsHeaderPanel` by leveraging the utility.

Fix #5975

### Dev Notes
Basically, this was caused by image-size hitting 0. At which point the scaling broke because you can't have a 0 dimension in an object. The naughty bit of code actually predated the image utility and never got updated (whoops).