### PR TITLE
Fixed Copy-Pasting of Skill Values in Campaign Options IIC

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsTab.java
@@ -27,8 +27,8 @@ import mekhq.gui.campaignOptions.components.*;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 
 import static java.util.Arrays.sort;
 import static megamek.common.enums.SkillLevel.*;
@@ -63,8 +63,8 @@ public class SkillsTab {
     private Map<String, List<JLabel>> allSkillLevels;
     private Map<String, List<JSpinner>> allSkillCosts;
     private Map<String, List<JComboBox<SkillLevel>>> allSkillMilestones;
-    private double storedTargetNumber = 0;
-    private List<Double> storedValuesSpinners = new ArrayList<>();
+    private int storedTargetNumber = 0;
+    private List<Integer> storedValuesSpinners = new ArrayList<>();
     private List<SkillLevel> storedValuesComboBoxes = new ArrayList<>();
 
     private JPanel pnlEdgeCost;
@@ -344,13 +344,13 @@ public class SkillsTab {
 
         JButton copyButton = new JButton(resources.getString("btnCopy.text"));
         copyButton.addActionListener(e -> {
-            storedTargetNumber = (Double) spnTargetNumber.getValue();
+            storedTargetNumber = (Integer) spnTargetNumber.getValue();
 
             storedValuesSpinners = new ArrayList<>();
             storedValuesComboBoxes = new ArrayList<>();
 
             for (int i = 0; i < labels.size(); i++) {
-                storedValuesSpinners.add((Double) spinners.get(i).getValue());
+                storedValuesSpinners.add((Integer) spinners.get(i).getValue());
                 storedValuesComboBoxes.add((SkillLevel) comboBoxes.get(i).getSelectedItem());
             }
         });


### PR DESCRIPTION
- Changed `storedTargetNumber` and `storedValuesSpinners` from `double` to `integer` to ensure consistent and precise data type usage.
- Updated relevant casting in the `copyButton`'s action listener to handle integer values.
- Ensured alignment with integer input expectations from UI elements like `spnTargetNumber` and `spinners`.

Fix #5978

### Dev Notes
This bug was caused by us incorrectly storing (and passing around) skill costs as a double instead of an integer. Normally I would say that probably made sense at the time, but I'm not convinced that decision _ever_ made sense, so it's been fixed.

If only all of CO IIC's bugs could be this simple...