### PR TITLE
Removed Deprecated Label From Kill XP Awards in Campaign Options IIC

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1848,7 +1848,7 @@ lblKillXP.tooltip=How much experience should be awarded per kill?\
   \ at once, such as bomb equipped aircraft pilots.\
   <br>\
   <br><b>Recommended:</b> Keep this disabled.
-lblKills.text=Kills (Deprecated) \u26A0 \u2714
+lblKills.text=Kills \u26A0 \u2714
 lblKills.tooltip=How many kills need to be scored before experience is awarded?\
   <br>\
   <br><b>Warning:</b> This option creates a situation where higher skilled characters get more\


### PR DESCRIPTION
- Updated the label for the "Kills" option to remove "(Deprecated)".
- No functional changes made, only a text adjustment in the properties file.

Fix #5969