### PR TITLE
Fixed Incorrect Loading/Saving of Options in Campaign Options IIC

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -35,14 +35,7 @@ import mekhq.gui.baseComponents.AbstractMHQScrollablePanel;
 import mekhq.gui.baseComponents.AbstractMHQTabbedPane;
 import mekhq.gui.baseComponents.DefaultMHQScrollablePanel;
 import mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode;
-import mekhq.gui.campaignOptions.components.CampaignOptionsButton;
-import mekhq.gui.campaignOptions.components.CampaignOptionsCheckBox;
-import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
-import mekhq.gui.campaignOptions.components.CampaignOptionsHeaderPanel;
-import mekhq.gui.campaignOptions.components.CampaignOptionsLabel;
-import mekhq.gui.campaignOptions.components.CampaignOptionsSpinner;
-import mekhq.gui.campaignOptions.components.CampaignOptionsStandardPanel;
-import mekhq.gui.campaignOptions.components.CampaignOptionsTextField;
+import mekhq.gui.campaignOptions.components.*;
 import mekhq.gui.dialog.DateChooser;
 import mekhq.gui.dialog.iconDialogs.UnitIconDialog;
 import mekhq.gui.displayWrappers.FactionDisplay;
@@ -526,11 +519,6 @@ public class GeneralTab {
 
         txtName.setText(campaign.getName());
 
-        comboFaction.setSelectedItem(campaign.getFaction());
-        if (presetFaction != null) {
-            comboFaction.setSelectedItem(new FactionDisplay(presetFaction, date));
-        }
-
         unitRatingMethodCombo.setSelectedItem(options.getUnitRatingMethod());
         manualUnitRatingModifier.setValue(options.getManualUnitRatingModifier());
         chkClampReputationPayMultiplier.setSelected(options.isClampReputationPayMultiplier());
@@ -541,6 +529,12 @@ public class GeneralTab {
         if (presetDate != null) {
             date = presetDate;
         }
+
+        comboFaction.setSelectedItem(campaign.getFaction());
+        if (presetFaction != null) {
+            comboFaction.setSelectedItem(new FactionDisplay(presetFaction, date));
+        }
+
         // Button labels are not updated when we repaint, so we have to specifically call it here
         btnDate.setText(MekHQ.getMHQOptions().getDisplayFormattedDate(date));
 
@@ -577,7 +571,7 @@ public class GeneralTab {
             // Null state handled during validation
             FactionDisplay newFaction = comboFaction.getSelectedItem();
             if (newFaction != null) {
-                campaign.setFaction(comboFaction.getSelectedItem().getFaction());
+                campaign.setFaction(newFaction.getFaction());
             }
 
             campaign.setCamouflage(camouflage);

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
@@ -736,7 +736,7 @@ public class MarketsTab {
 
         // Personnel Market
         comboPersonnelMarketType.setSelectedItem(options.getPersonnelMarketName());
-        chkPersonnelMarketReportRefresh.setSelected(options.isContractMarketReportRefresh());
+        chkPersonnelMarketReportRefresh.setSelected(options.isPersonnelMarketReportRefresh());
         chkUsePersonnelHireHiringHallOnly.setSelected(options.isUsePersonnelHireHiringHallOnly());
         spnPersonnelMarketDylansWeight.setValue(options.getPersonnelMarketDylansWeight());
         for (final Entry<SkillLevel, JSpinner> entry : spnPersonnelMarketRandomRemovalTargets.entrySet()) {
@@ -750,7 +750,7 @@ public class MarketsTab {
         spnUnitMarketRarityModifier.setValue(options.getUnitMarketRarityModifier());
         chkInstantUnitMarketDelivery.setSelected(options.isInstantUnitMarketDelivery());
         chkMothballUnitMarketDeliveries.setSelected(options.isMothballUnitMarketDeliveries());
-        chkUnitMarketReportRefresh.setSelected(options.isContractMarketReportRefresh());
+        chkUnitMarketReportRefresh.setSelected(options.isUnitMarketReportRefresh());
 
         // Contract Market
         comboContractMarketMethod.setSelectedItem(options.getContractMarketMethod());

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
@@ -1349,7 +1349,7 @@ public class PersonnelTab {
         }
 
         // General
-        chkUseTactics.setSelected(options.isUseTaxes());
+        chkUseTactics.setSelected(options.isUseTactics());
         chkUseInitiativeBonus.setSelected(options.isUseInitiativeBonus());
         chkUseToughness.setSelected(options.isUseToughness());
         chkUseRandomToughness.setSelected(options.isUseRandomToughness());
@@ -1446,7 +1446,7 @@ public class PersonnelTab {
         }
 
         // General
-        options.setUseTaxes(chkUseTactics.isSelected());
+        options.setUseTactics(chkUseTactics.isSelected());
         options.setUseInitiativeBonus(chkUseInitiativeBonus.isSelected());
         options.setUseToughness(chkUseToughness.isSelected());
         options.setUseRandomToughness(chkUseRandomToughness.isSelected());
@@ -1519,10 +1519,6 @@ public class PersonnelTab {
         options.setUseRandomDependentRemoval(chkUseRandomDependentRemoval.isSelected());
 
         // Salaries
-        options.setDisableSecondaryRoleSalary(chkDisableSecondaryRoleSalary.isSelected());
-        options.setSalaryAntiMekMultiplier((double) spnAntiMekSalary.getValue());
-        options.setSalarySpecialistInfantryMultiplier((double) spnSpecialistInfantrySalary.getValue());
-
         options.setDisableSecondaryRoleSalary(chkDisableSecondaryRoleSalary.isSelected());
         options.setSalaryAntiMekMultiplier((double) spnAntiMekSalary.getValue());
         options.setSalarySpecialistInfantryMultiplier((double) spnSpecialistInfantrySalary.getValue());

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/RelationshipsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/RelationshipsTab.java
@@ -767,7 +767,7 @@ public class RelationshipsTab {
         chkLogMarriageNameChanges.setSelected(options.isLogMarriageNameChanges());
         comboRandomMarriageMethod.setSelectedItem(options.getRandomMarriageMethod());
         chkUseRandomClanPersonnelMarriages.setSelected(options.isUseRandomClanPersonnelMarriages());
-        chkUseRandomPrisonerMarriages.setSelected(options.isUsePrisonerMarriages());
+        chkUseRandomPrisonerMarriages.setSelected(options.isUseRandomPrisonerMarriages());
         spnRandomMarriageAgeRange.setValue(options.getRandomMarriageAgeRange());
         spnRandomMarriageDiceSize.setValue(options.getRandomMarriageDiceSize());
         spnRandomSameSexMarriageDiceSize.setValue(options.getRandomSameSexMarriageDiceSize());
@@ -780,8 +780,8 @@ public class RelationshipsTab {
         comboRandomDivorceMethod.setSelectedItem(options.getRandomDivorceMethod());
         chkUseRandomOppositeSexDivorce.setSelected(options.isUseRandomOppositeSexDivorce());
         chkUseRandomSameSexDivorce.setSelected(options.isUseRandomSameSexDivorce());
-        chkUseRandomClanPersonnelDivorce.setSelected(options.isUseClanPersonnelDivorce());
-        chkUseRandomPrisonerDivorce.setSelected(options.isUsePrisonerDivorce());
+        chkUseRandomClanPersonnelDivorce.setSelected(options.isUseRandomClanPersonnelDivorce());
+        chkUseRandomPrisonerDivorce.setSelected(options.isUseRandomPrisonerDivorce());
         spnRandomDivorceDiceSize.setValue(options.getRandomDivorceDiceSize());
 
         // Procreation


### PR DESCRIPTION
- Corrected the mapping of `chkUseTactics` and `options.setUseTactics` in `PersonnelTab` to align with `isUseTactics` instead of `isUseTaxes`.
- Resolved incorrect option mapping for random clan personnel and prisoner marriages/divorces in `RelationshipsTab`.
- Fixed incorrect connection of personnel and unit market report refresh options in `MarketsTab`.
- Rearranged and corrected the `comboFaction` initialization order in `GeneralTab` for proper functionality.
- Removed redundant salary-related options initialization in `PersonnelTab` to improve clarity and avoid duplication.

Fix #6185

### Dev Notes
This just fixes a handful of instances where we weren't loading or saving options correctly. Thankfully, none of these were critical options, but they're fixed now. I'm marking this as 'critical' because with the issue in place players are unable to correctly save/load the affected options.