### PR TITLE
Fixed Tooltips and Formatting in Campaign Options IIC

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -786,10 +786,10 @@ lblUseSimulatedRelationships.tooltip=Personnel are generated with a random relat
 lblRandomOriginOptionsPanel.text=Origins
 lblRandomizeOrigin.text=Randomize Origin
 lblRandomizeOrigin.tooltip=This option determines whether new characters should randomize their\
-  \ origins based on campaign faction and pla
+  \ origins based on campaign faction and planet.
 lblRandomizeDependentsOrigin.text=Randomize Dependent Origins
 lblRandomizeDependentsOrigin.tooltip=This generates a random origin faction and planet for\
-  \ personnel based on the selected settings
+  \ personnel based on the selected settings.
 lblRandomizeAroundSpecifiedPlanet.text=Randomize Around Specific Planet
 lblRandomizeAroundSpecifiedPlanet.tooltip=Dependents have their origins randomized so that they do\
   \ not come from the current planet and the campaign's faction but instead have origins randomized\
@@ -1339,7 +1339,7 @@ lblFinancesGeneralTab.text=General Options
 # createPaymentsPanel
 lblPaymentsPanel.text=Payments
 lblPayForPartsBox.text=Pay For Parts
-lblPayForPartsBox.tooltip=Pay the cost of any replacement parts
+lblPayForPartsBox.tooltip=Pay the cost of any replacement parts.
 lblPayForRepairsBox.text=Pay For Repairs
 lblPayForRepairsBox.tooltip=Repairs cost 20% of a part's list price. This is for equipment repairs\
   \ only and doesn't count armor repairs.\
@@ -1599,9 +1599,9 @@ legacyTab.border="You know, for 5-tons, I'd expect more than 256 colors!"\
 
 # substantializeUniversalOptions
 lblSkillLevel.text=Difficulty \u2714
-lblSkillLevel.tooltip=This is the difficulty level for generated scenarios.\
+lblSkillLevel.tooltip=<html>This is the difficulty level for generated scenarios.\
   <br>\
-  <br><b>Recommended:</b> New players are recommended to start with Green or Ultra-Green.
+  <br><b>Recommended:</b> New players are recommended to start with Green or Ultra-Green.</html>
 lblOpForLanceTypeMeks.text=Meks
 lblOpForLanceTypeMeks.tooltip=What ratio of enemy forces should be Mek forces?
 lblOpForLanceTypeMixed.text=Mixed
@@ -1698,7 +1698,7 @@ lblUseStratCon.tooltip=StratCon, short for Strategic Context, is a ruleset that 
   \ scenarios that occur while on a contract. StratCon was introduced in 2021 and officially\
   \ replaced Legacy AtB in 2024, alongside the release of v50.02.\
   <br>\
-  <br><b>Warning:</b>If StratCon is enabled, all Legacy options are ignored.
+  <br><b>Warning:</b> If StratCon is enabled, all Legacy options are ignored.
 lblUseGenericBattleValue.text=Enable Force Generation 3
 lblUseGenericBattleValue.tooltip=Bot forces are balanced used Generic Battle Value, an estimation\
   \ of the average battle value for a unit of that type and weight. This ignores pilot skill,\
@@ -1718,7 +1718,7 @@ lblUseAtB.tooltip=AtB was MekHQ's first attempt at a Digital GM. It creates rand
   \ and scenarios, allowing you to experience being a mercenary commander in the Inner Sphere.\
   \ Support for Legacy AtB ended in 2025 with v50.02.\
   <br>\
-  <br><b>Warning:</b>If StratCon is enabled, all Legacy options are ignored.
+  <br><b>Warning:</b> If StratCon is enabled, all Legacy options are ignored.
 
 # createAutoResolvePanel
 lblAutoResolvePanel.text=AutoResolve \u270E \u2318

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsTab.java
@@ -34,12 +34,10 @@ import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.*;
-import java.io.File;
 import java.util.ResourceBundle;
 
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createParentPanel;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
-import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 /**
  * Represents a tab in the campaign options UI for managing ruleset configurations in campaigns.
@@ -274,7 +272,7 @@ public class RulesetsTab {
     private void substantializeUniversalOptions() {
         // General
         lblSkillLevel = new CampaignOptionsLabel("SkillLevel");
-        comboSkillLevel.setToolTipText(resources.getString("lblSkillLevel.tooltip"));
+        comboSkillLevel.setToolTipText(String.format(resources.getString("lblSkillLevel.tooltip")));
 
         // OpFor Generation
         pnlUnitRatioPanel = createUniversalUnitRatioPanel();


### PR DESCRIPTION
- Corrected tooltip strings by adding missing periods for consistency across labels.
- Fixed spacing in warning messages to align with formatting standards.
- Updated `RulesetsTab` to format tooltip strings dynamically using `String.format`.

Fix #6181