### PR TITLE
Updated Part Saving to Always Save 'Brand New' Status

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -617,12 +617,7 @@ public abstract class Part implements IPartWork, ITechnology {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "daysToArrival", daysToArrival);
         }
 
-        if (!brandNew) {
-            // The default value for Part.brandNew is true. Only store the tag if the value
-            // is false.
-            // The lack of tag in the save file will ALWAYS result in TRUE.
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "brandNew", false);
-        }
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "brandNew", brandNew);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "quantity", quantity);
 
         if (daysToWait > 0) {
@@ -739,7 +734,7 @@ public abstract class Part implements IPartWork, ITechnology {
                 } else if (wn2.getNodeName().equalsIgnoreCase("isTeamSalvaging")) {
                     retVal.isTeamSalvaging = wn2.getTextContent().equalsIgnoreCase("true");
                 } else if (wn2.getNodeName().equalsIgnoreCase("brandNew")) {
-                    retVal.brandNew = wn2.getTextContent().equalsIgnoreCase("true");
+                    retVal.brandNew = Boolean.parseBoolean(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("replacementId")) {
                     retVal.replacementPart = new PartRef(Integer.parseInt(wn2.getTextContent()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("quality")) {


### PR DESCRIPTION
- Changed `brandNew` serialization to always save its value, regardless of its state, rather than omitting it when `false`.
- Fixed deserialization of `brandNew` by replacing `equalsIgnoreCase("true")` with `Boolean.parseBoolean(trimmedText)`.

### Dev Notes
We’re aiming for **50.04** to be a milestone, so I want to implement this change in **50.04** to prepare for [#6168](#) (which will be merged in **50.05**).  

Currently, due to legacy decisions, a part’s **‘Brand New’** status defaults to `true` and is only saved if the status is explicitly set to `false`.  

In [#6168](#), we plan to change the default **‘Brand New’** status to `false`, since parts are more often used than brand new.  

This change creates an issue:  
- Parts whose brand new status was never stored were previously assumed to be brand new.  
- After the change, those parts would be considered used, which could lead to confusion and unintended status changes.  

To prevent unexpected status changes in **50.05**, we should start storing the brand new status consistently in **50.04**.  This will ensure that status consistency is maintained when the default is updated in **50.05**. Implementing this in **50.04** will help protect users from status flip-flopping and make the transition smoother. 
