### PR TITLE
Improved Resupply Focus Handling And Dialog Messaging

### DIFF
--- a/MekHQ/resources/mekhq/resources/Resupply.properties
+++ b/MekHQ/resources/mekhq/resources/Resupply.properties
@@ -17,8 +17,6 @@ documentation.prompt=Full documentation can be found in ''MekHQ/docs/Stratcon an
 
 convoySuccessful.text=A convoy has {0}<b>arrived</b>{1}, and its supplies have been distributed by\
   \ your logistics personnel.
-convoyUnsuccessful.text=Despite their best efforts, your negotiator was {0}<b>unsuccessful</b>{1} and\
-  \ any available supplies were assigned to other forces.
 convoySuccessfulSmuggler.text=The smuggler was true to their word, and the supplies have {0}<b>arrived</b>{1}.
 convoyErrorTemplate.text={0}<b>We encountered an ERROR when trying to fetch template (Address: {1}). Please\
   \ report this error.</b>{2}
@@ -153,7 +151,12 @@ optionArmor.tooltip=Deliver armor only. Overall resupply size reduced by 25%.
 focusDescription.text={0}, we might be able to lean a little on our contact and ask them to focus on\
   \ specific types of supplies. This will be at the cost of overall supply quantity.\
   <br>\
-  <br>Would you like to pick a focus?
+  <br>Would you like to pick a focus? I''ve already disabled any options our employer is refusing to\
+  \ fulfill.
+focusDescription.ooc=Your employer will refuse to resupply parts you already have large quantities\
+  \ of. For those items your employer is willing to supply a Negotiation check must be made, if the\
+  \ check is failed the item will be unavailable. If all options are disabled you either have a well\
+  \ stocked warehouse, or your most senior Admin/Logistics character may not be up to the task.
 
 supplyCostFull.text=<br><br>This resupply will cost {0}.\
   <br><br><i>The value of these supplies is {1}.</i>

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
@@ -166,6 +166,16 @@ public class PerformResupply {
 
             // Then allow the player to pick a focus
             new DialogResupplyFocus(resupply);
+
+            final List<Part> partsPool = resupply.getPartsPool();
+            final List<Part> armorPool = resupply.getArmorPool();
+            final List<Part> ammoBinPool = resupply.getAmmoBinPool();
+
+            // If all three pools are empty, there is no reason to continue. We still want the above
+            // dialog triggered, as it tells the user why the pools might be empty.
+            if (partsPool.isEmpty() && armorPool.isEmpty() && ammoBinPool.isEmpty()) {
+                return;
+            }
         }
 
         // With the focus chosen, we determine the contents of the convoy
@@ -191,12 +201,7 @@ public class PerformResupply {
 
         logger.info("totalTonnage: {}", totalTonnage);
 
-
-        // This shouldn't occur, but we include it as insurance.
         if (resupply.getConvoyContents().isEmpty()) {
-            campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE, "convoyUnsuccessful.text",
-                spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
-                CLOSING_SPAN_TAG));
             return;
         }
 

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogResupplyFocus.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogResupplyFocus.java
@@ -22,10 +22,12 @@ import megamek.client.ui.swing.util.UIUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Campaign.AdministratorSpecialization;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply;
+import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.List;
 
 import static mekhq.gui.baseComponents.MHQDialogImmersive.getSpeakerDescription;
 import static mekhq.gui.baseComponents.MHQDialogImmersive.getSpeakerIcon;
@@ -79,6 +81,9 @@ public class DialogResupplyFocus extends JDialog {
      */
     public DialogResupplyFocus(Resupply resupply) {
         final Campaign campaign = resupply.getCampaign();
+        final List<Part> partsPool = resupply.getPartsPool();
+        final List<Part> armorPool = resupply.getArmorPool();
+        final List<Part> ammoBinPool = resupply.getAmmoBinPool();
 
         setTitle(getFormattedTextAt(RESOURCE_BUNDLE, "incomingTransmission.title"));
 
@@ -152,12 +157,13 @@ public class DialogResupplyFocus extends JDialog {
 
         // Create a container panel to hold both the button panel and the new panel
         JPanel containerPanel = new JPanel();
-        containerPanel.setLayout(new BoxLayout(containerPanel, BoxLayout.Y_AXIS)); // Stack vertically
+        containerPanel.setLayout(new BoxLayout(containerPanel, BoxLayout.Y_AXIS));
 
         // Buttons panel
         JPanel buttonPanel = new JPanel();
         JButton optionBalanced = new JButton(getFormattedTextAt(RESOURCE_BUNDLE, "optionBalanced.text"));
         optionBalanced.setToolTipText(getFormattedTextAt(RESOURCE_BUNDLE, "optionBalanced.tooltip"));
+        optionBalanced.setEnabled(!partsPool.isEmpty() || !armorPool.isEmpty() || !ammoBinPool.isEmpty());
         optionBalanced.addActionListener(e -> {
             dispose();
             // The Resupply class initialization assumes a balanced approach
@@ -166,9 +172,9 @@ public class DialogResupplyFocus extends JDialog {
 
         // The player should not be able to focus on parts for game balance reasons.
         // If the player could pick parts, the optimum choice would be to always pick parts.
-
         JButton optionArmor = new JButton(getFormattedTextAt(RESOURCE_BUNDLE, "optionArmor.text"));
         optionArmor.setToolTipText(getFormattedTextAt(RESOURCE_BUNDLE, "optionArmor.tooltip"));
+        optionArmor.setEnabled(!armorPool.isEmpty());
         optionArmor.addActionListener(e -> {
             dispose();
             resupply.setFocusAmmo(0);
@@ -179,6 +185,7 @@ public class DialogResupplyFocus extends JDialog {
 
         JButton optionAmmo = new JButton(getFormattedTextAt(RESOURCE_BUNDLE, "optionAmmo.text"));
         optionAmmo.setToolTipText(getFormattedTextAt(RESOURCE_BUNDLE, "optionAmmo.tooltip"));
+        optionAmmo.setEnabled(!ammoBinPool.isEmpty());
         optionAmmo.addActionListener(e -> {
             dispose();
             resupply.setFocusAmmo(0.75);
@@ -190,12 +197,12 @@ public class DialogResupplyFocus extends JDialog {
         // Add the button panel to the container
         containerPanel.add(buttonPanel);
 
-        // New panel (to be added below the button panel)
+        // OOC panel (to be added below the button panel)
         JPanel infoPanel = new JPanel(new BorderLayout());
         JLabel lblInfo = new JLabel(
-            String.format("<html><div style='width: %s; text-align:center;'>%s</div></html>",
-                RIGHT_WIDTH + LEFT_WIDTH,
-                getFormattedTextAt(RESOURCE_BUNDLE, "documentation.prompt")));
+              String.format("<html><div style='width: %s; text-align:center;'>%s</div></html>",
+                    RIGHT_WIDTH + LEFT_WIDTH,
+                    getFormattedTextAt(RESOURCE_BUNDLE, "focusDescription.ooc")));
         lblInfo.setHorizontalAlignment(SwingConstants.CENTER);
         infoPanel.add(lblInfo, BorderLayout.CENTER);
         infoPanel.setBorder(BorderFactory.createEtchedBorder());


### PR DESCRIPTION
- Added checks to disable resupply options (Balanced, Armor, Ammo) if respective item pools are empty.
- Included a fallback mechanism to exit if all item pools are empty, avoiding unnecessary actions.
- Enhanced dialog messaging with clearer in-character (IC) and out-of-character (OOC) explanations.
- Removed unused "Convoy Unsuccessful" text resource.

Fix #6057

### Dev Notes
This basically adds an OOC panel at the bottom of the dialog that explains what's going on and why some buttons might be disabled.