### PR TITLE
Updated Curriculums For Local Academy Administration Courses

### DIFF
--- a/MekHQ/data/universe/academies/Local Academies.xml
+++ b/MekHQ/data/universe/academies/Local Academies.xml
@@ -245,10 +245,10 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>Vocational Administrator</qualification>
-        <curriculum>Administration</curriculum>
+        <curriculum>Administration, Negotiation</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Vocational Logistician</qualification>
-        <curriculum>Negotiation, Scrounge</curriculum>
+        <curriculum>Administration, Scrounge</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Nursing School</qualification>
         <curriculum>MedTech</curriculum>
@@ -283,10 +283,10 @@
         <curriculum>Tech/Vessel</curriculum>
         <qualificationStartYear>2490</qualificationStartYear>
         <qualification>Advanced Systems &amp; Technology</qualification>
-        <curriculum>Administration</curriculum>
+        <curriculum>Administration, Negotiation</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Applied Economics</qualification>
-        <curriculum>Negotiation, Scrounge</curriculum>
+        <curriculum>Administration, Scrounge</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Advanced Medicine</qualification>
         <curriculum>Doctor</curriculum>


### PR DESCRIPTION
- Replaced `Negotiation` with `Administration` in certain qualifications and added `Negotiation` alongside `Administration` where applicable.

Fix #6182

### Dev Notes
For reasoning as to why this change was made, please see the write-up in #6182.