### PR TITLE
Fixed SPA Editing in Campaign Options IIC

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesTab.java
@@ -421,8 +421,14 @@ public class AbilitiesTab {
      *         was canceled.
      */
     private boolean editSPA(SpecialAbility ability) {
+        Map<String, SpecialAbility> temporaryMap = new HashMap<>();
+
+        for (Entry<String, CampaignOptionsAbilityInfo> info : allAbilityInfo.entrySet()) {
+            temporaryMap.put(info.getKey(), info.getValue().getAbility());
+        }
+
         EditSpecialAbilityDialog dialog = new EditSpecialAbilityDialog(null, ability,
-            Map.of(ability.getName(), ability.clone()));
+              temporaryMap);
         dialog.setVisible(true);
 
         return !dialog.wasCancelled();


### PR DESCRIPTION
- Replaced single-ability map with a comprehensive map of all abilities during SPA editing.
- Introduced a temporary map to include all abilities from `allAbilityInfo`.

Fix #5960

### Dev Notes
This has been marked as 'critical' as without the fix players are completely unable to assign prerequisite, incompatible, or automatically removed SPAs without editing their save or preset files.