### PR TITLE
Added Automatic Assignment of 'Clan Pilot Training' SPA to Clan Personnel

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -59,6 +59,7 @@ import mekhq.campaign.mission.atb.AtBScenarioModifier;
 import mekhq.campaign.mission.atb.AtBScenarioModifier.EventTiming;
 import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.enums.Phenotype;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.campaign.stratcon.*;
@@ -957,6 +958,16 @@ public class AtBDynamicScenarioFactory {
             // Transported units need to filter out battle armor before applying armor changes
             for (Entity curPlatoon : transportedEntities.stream().filter(i -> i.getUnitType() == INFANTRY).toList()) {
                 changeInfantryKit((Infantry) curPlatoon, isLowPressure, isTainted, scenario.getTemperature());
+            }
+        }
+
+        for (Entity entity : generatedEntities) {
+            if (campaign.getCampaignOptions().isUseAbilities()) {
+                if (faction.isClan() && !entity.isInfantry() && !entity.isProtoMek()) {
+                    if (SpecialAbility.getSpecialAbilities().containsKey("clan_pilot_training")) {
+                        entity.getCrew().getOptions().getOption("clan_pilot_training").setValue(true);
+                    }
+                }
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
@@ -32,6 +32,8 @@ import megamek.common.enums.Gender;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.RandomSkillPreferences;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
+import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.backgrounds.BackgroundsController;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.randomEvents.personalities.PersonalityController;
@@ -130,6 +132,15 @@ public class DefaultPersonnelGenerator extends AbstractPersonnelGenerator {
 
         //check for Bloodname
         campaign.checkBloodnameAdd(person, false);
+
+        if (person.getOriginFaction().isClan()
+              && campaign.getCampaignOptions().isUseAbilities()
+              && !(person.getPrimaryRole().isSoldierOrBattleArmour() || person.getPrimaryRole().isProtoMekPilot())) {
+            if (SpecialAbility.getSpecialAbilities().containsKey("clan_pilot_training")) {
+                PersonnelOptions personnelOptions = person.getOptions();
+                personnelOptions.acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, "clan_pilot_training", true);
+            }
+        }
 
         person.setDaysToWaitForHealing(campaign.getCampaignOptions().getNaturalHealingWaitingPeriod());
 


### PR DESCRIPTION
- Implemented the addition of the "Clan Pilot Training" ability to applicable Clan personnel based on faction and role criteria.
- Updated `DefaultPersonnelGenerator` to assign the ability during personnel generation if eligibility conditions are met.
- Modified `AtBDynamicScenarioFactory` to ensure generated Clan unit pilots receive the ability when enabled in campaign options.

Fix #403

### Dev Notes
If the SPA is disabled in Campaign Options Clan personnel will not be assigned it.