### PR TITLE
Skipped Scenarios After Contract End Date

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -293,6 +293,15 @@ public class StratconRulesManager {
                 track = getRandomItem(tracks);
             }
 
+            final int deploymentDelay = track.getDeploymentTime();
+            final LocalDate scenarioTargetDate = campaign.getLocalDate().plusDays(deploymentDelay);
+            final LocalDate contractEnd = campaignState.getContract().getEndingDate();
+
+            if (!scenarioTargetDate.isBefore(contractEnd)) {
+                logger.info("Skipping scenario because it is on or after the contract end date.");
+                return;
+            }
+
             if (autoAssignLances && availableForceIDs.isEmpty()) {
                 break;
             }


### PR DESCRIPTION
- Added a check to skip scenarios with a deployment time extending beyond the contract's end date.
- Logged a message when such scenarios are skipped for better debugging and tracing.

Fix #2724

### Dev Notes
This has been a pet peeve for a long time and I don't know why I didn't address this when I implemented less predictable scenario spawning. I'm marking this as a bug, because scenarios spawning after the end of the contract wasn't intended.