### PR TITLE
Fixed Incorrect Alphabetical Sorting of Skills

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsTab.java
@@ -39,7 +39,6 @@ import java.awt.*;
 import java.util.*;
 import java.util.List;
 
-import static java.util.Arrays.sort;
 import static megamek.common.enums.SkillLevel.*;
 import static mekhq.campaign.personnel.SkillType.isCombatSkill;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createParentPanel;
@@ -146,9 +145,6 @@ public class SkillsTab {
         }
 
         // Contents
-        String[] allSkills = SkillType.getSkillList();
-        sort(allSkills);
-
         List<SkillType> relevantSkills = new ArrayList<>();
         for (String skillName : SkillType.getSkillList()) {
             SkillType skill = SkillType.getType(skillName);


### PR DESCRIPTION
- Removed the unnecessary sorting of the skill list in `SkillsTab.java` by eliminating the unused `allSkills` array and the `sort(allSkills)` call.

### Dev Notes
So, it turns out when we read in skills we do so in the order they were saved. Which means if some innocent developer who has never done a single crime happens to sort the skills alphabetically in a campaign options rewrite... suddenly all skills everywhere are sorted alphabetically. Which, after over a decade of non-alphabetical skill sorting, was just _wrong_.

It looked wrong, it felt wrong, and it made some people (understandably) very upset. This fixes it. I'm sure the innocent developer who made that mistake is very sorry.