### PR TITLE
Rebranded 'Tactics Skills' Campaign Options to 'Command Skills'; Expanded Coverage to Include Leadership and Strategy

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1959,43 +1959,43 @@ lblAbilityElite.tooltip=Modifier to the 2d6 roll used to determine whether a cha
   <br><b>10-11:</b> 1 SPA\
   <br><b>12+:</b> 2 SPAs
 
-lblTacticsPanel.text=Tactics
-lblTacticsGreen.text=Green \u26A0
-lblTacticsGreen.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
-  \ with points in the Tactics skill.\
+lblCommandSkillsPanel.text=Command Skills
+lblCommandSkillsGreen.text=Green \u26A0
+lblCommandSkillsGreen.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
+  \ with points in one (or more) of the three command skills: Leadership, Strategy, or Tactics.\
   <br>\
-  <br><b><2:</b> Ultra-Green Tactics\
-  <br><b>2-5:</b> Green Tactics\
-  <br><b>6-9:</b> Regular Tactics\
-  <br><b>10-11:</b> Veteran Tactics\
-  <br><b>12+:</b> Elite Tactics
-lblTacticsRegular.text=Regular \u26A0
-lblTacticsRegular.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
-  \ with points in the Tactics skill.\
+  <br><b><2:</b> Ultra-Green\
+  <br><b>2-5:</b> Green\
+  <br><b>6-9:</b> Regular\
+  <br><b>10-11:</b> Veteran\
+  <br><b>12+:</b> Elite
+lblCommandSkillsRegular.text=Regular \u26A0
+lblCommandSkillsRegular.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
+  \ with points in one (or more) of the three command skills: Leadership, Strategy, or Tactics.\
   <br>\
-  <br><b><2:</b> Ultra-Green Tactics\
-  <br><b>2-5:</b> Green Tactics\
-  <br><b>6-9:</b> Regular Tactics\
-  <br><b>10-11:</b> Veteran Tactics\
-  <br><b>12+:</b> Elite Tactics
-lblTacticsVeteran.text=Veteran \u26A0
-lblTacticsVeteran.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
-  \ with points in the Tactics skill.\
+  <br><b><2:</b> Ultra-Green\
+  <br><b>2-5:</b> Green\
+  <br><b>6-9:</b> Regular\
+  <br><b>10-11:</b> Veteran\
+  <br><b>12+:</b> Elite
+lblCommandSkillsVeteran.text=Veteran \u26A0
+lblCommandSkillsVeteran.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
+  \ with points in one (or more) of the three command skills: Leadership, Strategy, or Tactics.\
   <br>\
-  <br><b><2:</b> Ultra-Green Tactics\
-  <br><b>2-5:</b> Green Tactics\
-  <br><b>6-9:</b> Regular Tactics\
-  <br><b>10-11:</b> Veteran Tactics\
-  <br><b>12+:</b> Elite Tactics
-lblTacticsElite.text=Elite \u26A0
-lblTacticsElite.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
-  \ with points in the Tactics skill.\
+  <br><b><2:</b> Ultra-Green\
+  <br><b>2-5:</b> Green\
+  <br><b>6-9:</b> Regular\
+  <br><b>10-11:</b> Veteran\
+  <br><b>12+:</b> Elite
+lblCommandSkillsElite.text=Elite \u26A0
+lblCommandSkillsElite.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
+  \ with points in one (or more) of the three command skills: Leadership, Strategy, or Tactics.\
   <br>\
-  <br><b><2:</b> Ultra-Green Tactics\
-  <br><b>2-5:</b> Green Tactics\
-  <br><b>6-9:</b> Regular Tactics\
-  <br><b>10-11:</b> Veteran Tactics\
-  <br><b>12+:</b> Elite Tactics
+  <br><b><2:</b> Ultra-Green\
+  <br><b>2-5:</b> Green\
+  <br><b>6-9:</b> Regular\
+  <br><b>10-11:</b> Veteran\
+  <br><b>12+:</b> Elite
 
 lblSmallArmsPanel.text=Small Arms
 lblCombatSmallArms.text=Combatants

--- a/MekHQ/src/mekhq/campaign/RandomSkillPreferences.java
+++ b/MekHQ/src/mekhq/campaign/RandomSkillPreferences.java
@@ -28,15 +28,14 @@
  */
 package mekhq.campaign;
 
-import java.io.PrintWriter;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.Version;
 import megamek.logging.MMLogger;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson
@@ -52,7 +51,7 @@ public class RandomSkillPreferences {
     private int[] specialAbilityBonus;
     private int combatSmallArmsBonus;
     private int supportSmallArmsBonus;
-    private int[] tacticsMod;
+    private int[] commandSkillsModifier;
     private int artilleryProb;
     private int artilleryBonus;
     private int secondSkillProb;
@@ -67,7 +66,7 @@ public class RandomSkillPreferences {
         combatSmallArmsBonus = -3;
         supportSmallArmsBonus = -10;
         specialAbilityBonus = new int[] { -10, -10, -2, 0, 1 };
-        tacticsMod = new int[] { -10, -10, -7, -4, -1 };
+        commandSkillsModifier = new int[] { -10, -10, -7, -4, -1 };
         artilleryProb = 10;
         artilleryBonus = -2;
         secondSkillProb = 0;
@@ -144,13 +143,13 @@ public class RandomSkillPreferences {
         supportSmallArmsBonus = b;
     }
 
-    public int getTacticsMod(int lvl) {
-        return tacticsMod[lvl];
+    public int getCommandSkillsModifier(int lvl) {
+        return commandSkillsModifier[lvl];
     }
 
-    public void setTacticsMod(int lvl, int bonus) {
-        if (lvl < tacticsMod.length) {
-            tacticsMod[lvl] = bonus;
+    public void setCommandSkillsMod(int lvl, int bonus) {
+        if (lvl < commandSkillsModifier.length) {
+            commandSkillsModifier[lvl] = bonus;
         }
     }
 
@@ -191,7 +190,7 @@ public class RandomSkillPreferences {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "overallRecruitBonus", overallRecruitBonus);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "recruitBonuses", recruitBonuses);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "specialAbilityBonus", specialAbilityBonus);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "tacticsMod", tacticsMod);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "commandSkillsModifier", commandSkillsModifier);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "randomizeSkill", randomizeSkill);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useClanBonuses", useClanBonuses);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "antiMekProb", antiMekProb);
@@ -248,10 +247,12 @@ public class RandomSkillPreferences {
                     for (int i = 0; i < values.length; i++) {
                         retVal.recruitBonuses[i] = Integer.parseInt(values[i]);
                     }
-                } else if (wn2.getNodeName().equalsIgnoreCase("tacticsMod")) {
+                } else if (wn2.getNodeName().equalsIgnoreCase("commandSkillsModifier")
+                      // <50.04 compatibility handler
+                      || wn2.getNodeName().equalsIgnoreCase("tacticsMod")) {
                     String[] values = wn2.getTextContent().split(",");
                     for (int i = 0; i < values.length; i++) {
-                        retVal.tacticsMod[i] = Integer.parseInt(values[i]);
+                        retVal.commandSkillsModifier[i] = Integer.parseInt(values[i]);
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("specialAbilityBonus")) {
                     String[] values = wn2.getTextContent().split(",");

--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultSkillGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultSkillGenerator.java
@@ -82,11 +82,21 @@ public class DefaultSkillGenerator extends AbstractSkillGenerator {
             }
         }
 
-        // roll tactics skill
-        if (!(primaryRole.isSupport() || secondaryRole.isSupport(true))) {
-            int tacLvl = Utilities.generateExpLevel(rskillPrefs.getTacticsMod(expLvl));
-            if (tacLvl > SkillType.EXP_ULTRA_GREEN) {
-                addSkill(person, SkillType.S_TACTICS, tacLvl, rskillPrefs.randomizeSkill(), bonus);
+        // roll lesdership skills
+        if (primaryRole.isCombat()) {
+            int leadershipSkillLevel = Utilities.generateExpLevel(rskillPrefs.getCommandSkillsModifier(expLvl));
+            if (leadershipSkillLevel > SkillType.EXP_ULTRA_GREEN) {
+                addSkill(person, SkillType.S_TACTICS, leadershipSkillLevel, rskillPrefs.randomizeSkill(), bonus);
+            }
+
+            leadershipSkillLevel = Utilities.generateExpLevel(rskillPrefs.getCommandSkillsModifier(expLvl));
+            if (leadershipSkillLevel > SkillType.EXP_ULTRA_GREEN) {
+                addSkill(person, SkillType.S_STRATEGY, leadershipSkillLevel, rskillPrefs.randomizeSkill(), bonus);
+            }
+
+            leadershipSkillLevel = Utilities.generateExpLevel(rskillPrefs.getCommandSkillsModifier(expLvl));
+            if (leadershipSkillLevel > SkillType.EXP_ULTRA_GREEN) {
+                addSkill(person, SkillType.S_LEADER, leadershipSkillLevel, rskillPrefs.randomizeSkill(), bonus);
             }
         }
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
@@ -121,14 +121,14 @@ public class AdvancementTab {
     private JPanel pnlSkillGroups;
 
     private JPanel pnlTactics;
-    private JLabel lblTacticsGreen;
-    private JSpinner spnTacticsGreen;
-    private JLabel lblTacticsReg;
-    private JSpinner spnTacticsReg;
-    private JLabel lblTacticsVet;
-    private JSpinner spnTacticsVet;
-    private JLabel lblTacticsElite;
-    private JSpinner spnTacticsElite;
+    private JLabel lblCommandSkillsGreen;
+    private JSpinner spnCommandSkillsGreen;
+    private JLabel lblCommandSkillsReg;
+    private JSpinner spnCommandSkillsReg;
+    private JLabel lblCommandSkillsVet;
+    private JSpinner spnCommandSkillsVet;
+    private JLabel lblCommandSkillsElite;
+    private JSpinner spnCommandSkillsElite;
 
     private JPanel pnlSmallArms;
     private JLabel lblCombatSA;
@@ -517,14 +517,14 @@ public class AdvancementTab {
         pnlSkillGroups = new JPanel();
 
         pnlTactics = new JPanel();
-        lblTacticsGreen = new JLabel();
-        spnTacticsGreen = new JSpinner();
-        lblTacticsReg = new JLabel();
-        spnTacticsReg = new JSpinner();
-        lblTacticsVet = new JLabel();
-        spnTacticsVet = new JSpinner();
-        lblTacticsElite = new JLabel();
-        spnTacticsElite = new JSpinner();
+        lblCommandSkillsGreen = new JLabel();
+        spnCommandSkillsGreen = new JSpinner();
+        lblCommandSkillsReg = new JLabel();
+        spnCommandSkillsReg = new JSpinner();
+        lblCommandSkillsVet = new JLabel();
+        spnCommandSkillsVet = new JSpinner();
+        lblCommandSkillsElite = new JLabel();
+        spnCommandSkillsElite = new JSpinner();
 
         pnlSmallArms = new JPanel();
         lblCombatSA = new JLabel();
@@ -738,46 +738,46 @@ public class AdvancementTab {
      */
     private JPanel createTacticsPanel() {
         // Contents
-        lblTacticsGreen = new CampaignOptionsLabel("TacticsGreen");
-        spnTacticsGreen = new CampaignOptionsSpinner("TacticsGreen",
+        lblCommandSkillsGreen = new CampaignOptionsLabel("CommandSkillsGreen");
+        spnCommandSkillsGreen = new CampaignOptionsSpinner("CommandSkillsGreen",
             0, -10, 10, 1);
 
-        lblTacticsReg = new CampaignOptionsLabel("TacticsRegular");
-        spnTacticsReg = new CampaignOptionsSpinner("TacticsRegular",
+        lblCommandSkillsReg = new CampaignOptionsLabel("CommandSkillsRegular");
+        spnCommandSkillsReg = new CampaignOptionsSpinner("CommandSkillsRegular",
             0, -10, 10, 1);
 
-        lblTacticsVet = new CampaignOptionsLabel("TacticsVeteran");
-        spnTacticsVet = new CampaignOptionsSpinner("TacticsVeteran",
+        lblCommandSkillsVet = new CampaignOptionsLabel("CommandSkillsVeteran");
+        spnCommandSkillsVet = new CampaignOptionsSpinner("CommandSkillsVeteran",
             0, -10, 10, 1);
 
-        lblTacticsElite = new CampaignOptionsLabel("TacticsElite");
-        spnTacticsElite = new CampaignOptionsSpinner("TacticsElite",
+        lblCommandSkillsElite = new CampaignOptionsLabel("CommandSkillsElite");
+        spnCommandSkillsElite = new CampaignOptionsSpinner("CommandSkillsElite",
             0, -10, 10, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("TacticsPanel", true,
-            "TacticsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("CommandSkillsPanel", true,
+            "CommandSkillsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = 0;
         layout.gridy = 0;
-        panel.add(lblTacticsGreen, layout);
+        panel.add(lblCommandSkillsGreen, layout);
         layout.gridx++;
-        panel.add(spnTacticsGreen, layout);
+        panel.add(spnCommandSkillsGreen, layout);
         layout.gridx++;
-        panel.add(lblTacticsReg, layout);
+        panel.add(lblCommandSkillsReg, layout);
         layout.gridx++;
-        panel.add(spnTacticsReg, layout);
+        panel.add(spnCommandSkillsReg, layout);
 
         layout.gridx = 0;
         layout.gridy++;
-        panel.add(lblTacticsVet, layout);
+        panel.add(lblCommandSkillsVet, layout);
         layout.gridx++;
-        panel.add(spnTacticsVet, layout);
+        panel.add(spnCommandSkillsVet, layout);
         layout.gridx++;
-        panel.add(lblTacticsElite, layout);
+        panel.add(lblCommandSkillsElite, layout);
         layout.gridx++;
-        panel.add(spnTacticsElite, layout);
+        panel.add(spnCommandSkillsElite, layout);
 
         return panel;
     }
@@ -954,10 +954,10 @@ public class AdvancementTab {
         spnAbilityReg.setValue(skillPreferences.getSpecialAbilityBonus(SkillType.EXP_REGULAR));
         spnAbilityVet.setValue(skillPreferences.getSpecialAbilityBonus(SkillType.EXP_VETERAN));
         spnAbilityElite.setValue(skillPreferences.getSpecialAbilityBonus(SkillType.EXP_ELITE));
-        spnTacticsGreen.setValue(skillPreferences.getTacticsMod(SkillType.EXP_GREEN));
-        spnTacticsReg.setValue(skillPreferences.getTacticsMod(SkillType.EXP_REGULAR));
-        spnTacticsVet.setValue(skillPreferences.getTacticsMod(SkillType.EXP_VETERAN));
-        spnTacticsElite.setValue(skillPreferences.getTacticsMod(SkillType.EXP_ELITE));
+        spnCommandSkillsGreen.setValue(skillPreferences.getCommandSkillsModifier(SkillType.EXP_GREEN));
+        spnCommandSkillsReg.setValue(skillPreferences.getCommandSkillsModifier(SkillType.EXP_REGULAR));
+        spnCommandSkillsVet.setValue(skillPreferences.getCommandSkillsModifier(SkillType.EXP_VETERAN));
+        spnCommandSkillsElite.setValue(skillPreferences.getCommandSkillsModifier(SkillType.EXP_ELITE));
         spnCombatSA.setValue(skillPreferences.getCombatSmallArmsBonus());
         spnSupportSA.setValue(skillPreferences.getSupportSmallArmsBonus());
         spnArtyProb.setValue(skillPreferences.getArtilleryProb());
@@ -1018,10 +1018,10 @@ public class AdvancementTab {
         skillPreferences.setArtilleryBonus((int) spnArtyBonus.getValue());
         skillPreferences.setSecondSkillProb((int) spnSecondProb.getValue());
         skillPreferences.setSecondSkillBonus((int) spnSecondBonus.getValue());
-        skillPreferences.setTacticsMod(SkillType.EXP_GREEN, (int) spnTacticsGreen.getValue());
-        skillPreferences.setTacticsMod(SkillType.EXP_REGULAR, (int) spnTacticsReg.getValue());
-        skillPreferences.setTacticsMod(SkillType.EXP_VETERAN, (int) spnTacticsVet.getValue());
-        skillPreferences.setTacticsMod(SkillType.EXP_ELITE, (int) spnTacticsElite.getValue());
+        skillPreferences.setCommandSkillsMod(SkillType.EXP_GREEN, (int) spnCommandSkillsGreen.getValue());
+        skillPreferences.setCommandSkillsMod(SkillType.EXP_REGULAR, (int) spnCommandSkillsReg.getValue());
+        skillPreferences.setCommandSkillsMod(SkillType.EXP_VETERAN, (int) spnCommandSkillsVet.getValue());
+        skillPreferences.setCommandSkillsMod(SkillType.EXP_ELITE, (int) spnCommandSkillsElite.getValue());
         skillPreferences.setCombatSmallArmsBonus((int) spnCombatSA.getValue());
         skillPreferences.setSupportSmallArmsBonus((int) spnSupportSA.getValue());
         skillPreferences.setSpecialAbilityBonus(SkillType.EXP_GREEN, (int) spnAbilityGreen.getValue());


### PR DESCRIPTION
- Updated "Tactics" skill to "Command Skills", encompassing Leadership, Strategy, and Tactics.
- Renamed variables, methods, XML tags, labels, and UI components from `Tactics` to `CommandSkills` to reflect the broader scope.
- Added generation for additional leadership skills: Leadership and Strategy, alongside Tactics.
- Maintained backward compatibility with `<50.04` XML files by handling legacy "tacticsMod" tags.
- Adjusted tooltips and UI descriptions to align with the updated functionality.

### Dev Notes
This was added by user request and is something we should have done last year, however I wasn't aware that this isn't already include Strategy and Leadership. Now it does. Go us! :D