### PR TITLE
Fixed Artillery, Anti-Mek, and Secondary Skill Spinner Min and Max Values in Campaign Options IIC

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
@@ -827,11 +827,11 @@ public class AdvancementTab {
         // Contents
         lblArtyProb = new CampaignOptionsLabel("ArtilleryChance");
         spnArtyProb = new CampaignOptionsSpinner("ArtilleryChance",
-            0, -10, 10, 1);
+            0, 0, 100, 1);
 
         lblArtyBonus = new CampaignOptionsLabel("ArtilleryBonus");
         spnArtyBonus = new CampaignOptionsSpinner("ArtilleryBonus",
-            0, -10, 10, 1);
+            0, 0, 100, 1);
 
         // Layout the Panel
         final JPanel panel = new CampaignOptionsStandardPanel("ArtilleryPanel",
@@ -862,15 +862,15 @@ public class AdvancementTab {
         // Contents
         lblAntiMekSkill = new CampaignOptionsLabel("AntiMekChance");
         spnAntiMekSkill = new CampaignOptionsSpinner("AntiMekChance",
-            0, -10, 10, 1);
+            0, 0, 100, 1);
 
         lblSecondProb = new CampaignOptionsLabel("SecondarySkillChance");
         spnSecondProb = new CampaignOptionsSpinner("SecondarySkillChance",
-            0, -10, 10, 1);
+            0, 0, 100, 1);
 
         lblSecondBonus = new CampaignOptionsLabel("SecondarySkillBonus");
         spnSecondBonus = new CampaignOptionsSpinner("SecondarySkillBonus",
-            0, -10, 10, 1);
+            0, 0, 100, 1);
 
         // Layout the Panel
         final JPanel panel = new CampaignOptionsStandardPanel("SecondarySkillPanel",

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
@@ -831,7 +831,7 @@ public class AdvancementTab {
 
         lblArtyBonus = new CampaignOptionsLabel("ArtilleryBonus");
         spnArtyBonus = new CampaignOptionsSpinner("ArtilleryBonus",
-            0, 0, 100, 1);
+            0, -10, 10, 1);
 
         // Layout the Panel
         final JPanel panel = new CampaignOptionsStandardPanel("ArtilleryPanel",
@@ -870,7 +870,7 @@ public class AdvancementTab {
 
         lblSecondBonus = new CampaignOptionsLabel("SecondarySkillBonus");
         spnSecondBonus = new CampaignOptionsSpinner("SecondarySkillBonus",
-            0, 0, 100, 1);
+            0, -10, 10, 1);
 
         // Layout the Panel
         final JPanel panel = new CampaignOptionsStandardPanel("SecondarySkillPanel",


### PR DESCRIPTION
- Updated spinner value ranges in the `AdvancementTab` to a minimum of 0 and a maximum of 100 (previously -10 to 10).
- Affected spinners include:
  - `ArtilleryChance`
  - `AntiMekChance`
  - `SecondarySkillChance`

### Dev Notes
These were a casualty of a classic copy-paste error. Marking as 'High' as this prevents users from properly setting up these values.