### PR TITLE
Fixed Campaign Victory Point Handling For Resupply and Jailbreak

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4263,13 +4263,12 @@ public class Campaign implements ITechManager {
 
                         if (stub) {
                             ScenarioType scenarioType = scenario.getStratConScenarioType();
-                            if (scenarioType.isResupply()) {
-                                processAbandonedConvoy(this, contract, (AtBDynamicScenario) scenario);
+                            if (scenarioType.isSpecial()) {
                                 campaignState.updateVictoryPoints(-1);
                             }
 
-                            if (scenarioType.isJailBreak()) {
-                                campaignState.changeSupportPoints(-1);
+                            if (scenarioType.isResupply()) {
+                                processAbandonedConvoy(this, contract, (AtBDynamicScenario) scenario);
                             }
 
                             scenario.convertToStub(this, ScenarioStatus.REFUSED_ENGAGEMENT);

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4252,17 +4252,23 @@ public class Campaign implements ITechManager {
             for (final Scenario scenario : contract.getCurrentAtBScenarios()) {
                 if ((scenario.getDate() != null) && scenario.getDate().isBefore(getLocalDate())) {
                     if (getCampaignOptions().isUseStratCon() && (scenario instanceof AtBDynamicScenario)) {
+                        StratconCampaignState campaignState = contract.getStratconCampaignState();
+
+                        if (campaignState == null) {
+                            return;
+                        }
+
                         final boolean stub = StratconRulesManager.processIgnoredScenario(
-                                (AtBDynamicScenario) scenario, contract.getStratconCampaignState());
+                                (AtBDynamicScenario) scenario, campaignState);
 
                         if (stub) {
                             ScenarioType scenarioType = scenario.getStratConScenarioType();
                             if (scenarioType.isResupply()) {
                                 processAbandonedConvoy(this, contract, (AtBDynamicScenario) scenario);
+                                campaignState.updateVictoryPoints(-1);
                             }
 
                             if (scenarioType.isJailBreak()) {
-                                StratconCampaignState campaignState = contract.getStratconCampaignState();
                                 campaignState.changeSupportPoints(-1);
                             }
 

--- a/MekHQ/src/mekhq/campaign/mission/enums/ScenarioType.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/ScenarioType.java
@@ -83,6 +83,13 @@ public enum ScenarioType {
     }
 
     /**
+     * @return {@code true} if the instance is one of the special types; {@code false} otherwise.
+     */
+    public boolean isSpecial() {
+        return this == SPECIAL_LOSTECH || this == SPECIAL_RESUPPLY || this == SPECIAL_JAIL_BREAK;
+    }
+
+    /**
      * Parses a {@code ScenarioType} from a string input.
      *
      * <p>This method attempts to interpret the given string as either:</p>

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -2813,7 +2813,7 @@ public class StratconRulesManager {
                     }
 
                     ScenarioType scenarioType = backingScenario.getStratConScenarioType();
-                    if (scenarioType.isResupply() || scenarioType.isJailBreak()) {
+                    if (scenarioType.isSpecial()) {
                         if (!backingScenario.getStatus().isOverallVictory()) {
                             // If the player loses this scenario, they lose -1 CVP. This represents
                             // the importance of the intel the prisoners hold, or the penalty for

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -2812,6 +2812,16 @@ public class StratconRulesManager {
                         campaignState.updateVictoryPoints(victory ? 1 : -1);
                     }
 
+                    ScenarioType scenarioType = backingScenario.getStratConScenarioType();
+                    if (scenarioType.isResupply() || scenarioType.isJailBreak()) {
+                        if (!backingScenario.getStatus().isOverallVictory()) {
+                            // If the player loses this scenario, they lose -1 CVP. This represents
+                            // the importance of the intel the prisoners hold, or the penalty for
+                            // allowing an enemy force free reign in the player's logistics line.
+                            campaignState.updateVictoryPoints(-1);
+                        }
+                    }
+
                     // this must be done before removing the scenario from the track
                     // in case any objectives are linked to the scenario's coordinates
                     updateStrategicObjectives(victory, scenario, track);

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -33,6 +33,7 @@ import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.mission.enums.ScenarioStatus;
+import mekhq.campaign.mission.enums.ScenarioType;
 import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconCoords;
 import mekhq.campaign.stratcon.StratconScenario;
@@ -129,17 +130,32 @@ public class ScenarioTableModel extends DataTableModel {
 
                     if (stratconScenario != null) {
                         boolean isTurningPoint = stratconScenario.isTurningPoint();
-                        String openingSpan = isTurningPoint
-                            ? spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorWarningHexColor())
-                            : "";
+                        ScenarioType scenarioType = scenario.getStratConScenarioType();
 
-                        String turningPointText = isTurningPoint ? ' ' + resources.getString("col_status.turningPoint") : "";
+                        // Determine the appropriate opening span based on the scenario type
+                        String openingSpan = "";
+                        if (scenarioType.isSpecial()) {
+                            openingSpan = spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorWarningHexColor());
+                        } else if (isTurningPoint) {
+                            openingSpan = spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor());
+                        }
 
-                        String closingSpan = isTurningPoint ? CLOSING_SPAN_TAG : "";
+                        String turningPointText = isTurningPoint
+                              ? ' ' + resources.getString("col_status.turningPoint")
+                              : "";
 
-                        // We bold the text to assist colorblind players
-                        return String.format("<html>%s%s<b>%s</b>%s</html", scenario.getStatus().toString(),
-                            openingSpan, turningPointText, closingSpan);
+                        String closingSpan = (!openingSpan.isEmpty())
+                              ? CLOSING_SPAN_TAG :
+                              "";
+
+                        // Wrap the entire segment in <html> tags, bold text for accessibility
+                        return String.format(
+                              "<html>%s%s<b>%s</b>%s</html>",
+                              scenario.getStatus(),
+                              openingSpan,
+                              turningPointText,
+                              closingSpan
+                        );
                     }
                 }
             }


### PR DESCRIPTION
- Consolidated `isSpecial` logic into `ScenarioType` to centralize special scenario checks.
- Ensured proper decrement of Campaign Victory Points (CVP) for lost 'special' scenarios.
- Moved `StratconCampaignState` null check earlier to prevent potential null pointer exceptions.
- Updated GUI handling to improve visual differentiation for special scenarios, including color coding and accessibility.

### Dev Notes
With 'Jail Break' scenarios we introduced a new scenario type 'Special' (or critical, whatever you want to go with). These are scenarios which inflict a 1 CVP penalty if lost, but won't _award_ CVP if won - unlike Turning Points. The idea is that these represent critical scenarios where the penalty for their loss is significant. For Jail Breaks that means the enemy has recaptured their personnel gaining vital intel. For Resupply interceptions, it's the penalty for not routing the incursion force, resulting in them being able to play merry havoc on yours and your employer's supply lines.

All of this would have been pretty fantastic, if I remembered to actually put it in the game. This PR corrects that oversight.