### PR TITLE
Fix MHQ 3175: load Campaign Options and Game Options before everything else

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6020,11 +6020,13 @@ public class Campaign implements ITechManager {
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "info");
         // endregion Basic Campaign Info
 
-        // region Campaign Options
+        // region Options
         if (getCampaignOptions() != null) {
             getCampaignOptions().writeToXml(pw, indent);
         }
-        // endregion Campaign Options
+        getGameOptions().writeToXML(pw, indent);
+        // endregion Options
+
 
         // Lists of objects:
         units.writeToXML(pw, indent, "units"); // Units
@@ -6079,8 +6081,6 @@ public class Campaign implements ITechManager {
 
         // parts is the biggest so it goes last
         parts.writeToXML(pw, indent, "parts"); // Parts
-
-        getGameOptions().writeToXML(pw, indent);
 
         // current story arc
         if (null != storyArc) {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -180,6 +180,10 @@ public class CampaignXmlParser {
                     }
                 } else if (xn.equalsIgnoreCase("custom")) {
                     reloadUnitData |= processCustom(retVal, wn);
+                } else if (xn.equalsIgnoreCase("campaignOptions")) {
+                    retVal.setCampaignOptions(CampaignOptions.generateCampaignOptionsFromXml(wn, version));
+                } else if (xn.equalsIgnoreCase("gameOptions")) {
+                    retVal.getGameOptions().fillFromXML(wn.getChildNodes());
                 }
             } else {
                 // If it's a text node or attribute or whatever at this level,
@@ -246,11 +250,7 @@ public class CampaignXmlParser {
                 // Okay, so what element is it?
                 String xn = wn.getNodeName();
 
-
-
-                if (xn.equalsIgnoreCase("campaignOptions")) {
-                    retVal.setCampaignOptions(CampaignOptions.generateCampaignOptionsFromXml(wn, version));
-                } else if (xn.equalsIgnoreCase("randomSkillPreferences")) {
+                if (xn.equalsIgnoreCase("randomSkillPreferences")) {
                     retVal.setRandomSkillPreferences(
                             RandomSkillPreferences.generateRandomSkillPreferencesFromXml(wn, version));
                 } else if (xn.equalsIgnoreCase("parts")) {
@@ -278,8 +278,6 @@ public class CampaignXmlParser {
                     processStoryArcNodes(retVal, wn, version);
                 } else if (xn.equalsIgnoreCase("fameAndInfamy")) {
                     processFameAndInfamyNodes(retVal, wn);
-                } else if (xn.equalsIgnoreCase("gameOptions")) {
-                    retVal.getGameOptions().fillFromXML(wn.getChildNodes());
                 } else if (xn.equalsIgnoreCase("kills")) {
                     processKillNodes(retVal, wn, version);
                 } else if (xn.equalsIgnoreCase("shoppingList")) {


### PR DESCRIPTION
Fixes the issue where saved enemy forces would not load with SPAs they had at campaign save time.
There may also be some other issues, such as Edge settings reverting to defaults for enemy crews, etc. that were also caused by this behaviour.

Simply put, we rely on the RPG_PILOT_ADVANTAGES game option to decide whether to load SPAs when loading units' crews from the campaign save.
At the same time, the `\<gameOptions\>` block comes after every other block in the save file, and if unread, we get a default value of `false` for RPG_PILOT_ADVANTAGES.
By moving the Campaign and Game Options loading into the first of three loops over the campaign save file, we can ensure that all options are properly populated prior to loading any parts that depend on those options, without spending noticeably more time on reading the file.

This PR also moves the two sets of  options together in the campaign write code for future-proofing.

Testing:
- Loaded campaign from #3175 and confirmed that the original SPA assignments persisted into the MM games.
- Stepped through campaign loading to verify that gameOptions are now loaded before all other blocks.
- Ran all 3 projects' unit tests.

Close: #3175 