### PR TITLE
Fixed Gray Monday Loans; Improved AtB Modifier Handling

### DIFF
--- a/MekHQ/resources/mekhq/resources/NewLoanDialog.properties
+++ b/MekHQ/resources/mekhq/resources/NewLoanDialog.properties
@@ -2,6 +2,7 @@ title.text=Take Out A Loan
 btnCancel.text=Cancel
 btnOkay.text=Add
 lblName.text=Institution
+lblName.grayMonday=Predatory Loan
 lblReference.text=Reference Number:
 lblPrincipal.text=Principal:
 lblAnnualInterest.text=Annual Interest:

--- a/MekHQ/src/mekhq/campaign/finances/Loan.java
+++ b/MekHQ/src/mekhq/campaign/finances/Loan.java
@@ -40,6 +40,7 @@ import java.io.PrintWriter;
 import java.time.LocalDate;
 import java.util.Objects;
 
+import static megamek.codeUtilities.MathUtility.clamp;
 import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
 
 /**
@@ -254,7 +255,7 @@ public class Loan {
 
         if (isGrayMonday(date, simulateGrayMonday)) {
             // This simulates the player taking out a predatory loan
-            return new Loan(10000000, 70, 1, FinancialTerm.MONTHLY, 100, date);
+            return new Loan(10000000, 60, 1, FinancialTerm.MONTHLY, 100, date);
         }
 
         if (rating <= 0) {
@@ -305,16 +306,21 @@ public class Loan {
         }
     }
 
-    public static int getMaxYears(final int rating) {
-        if (rating < 5) {
-            return 1;
-        } else if (rating < 9) {
-            return 2;
-        } else if (rating < 14) {
-            return 3;
-        } else {
-            return 5;
-        }
+    /**
+     * Determines the maximum number of years by clamping the given rating to a valid range.
+     *
+     * <p>This method returns a value that ensures the input {@code rating} falls within the specified
+     * range of 1 to 7. Ratings below 1 are clamped to 1, and ratings above 7 are clamped to 7. The
+     * clamped value is directly returned.</p>
+     *
+     * <p>The clamped values coincide with the Experience Level ordinals (Ultra-Green, Green, etc).
+     * This means a Veteran-rated campaign (ordinal 4) could take up to a 4-year loan.</p>
+     *
+     * @param rating the input rating value to be clamped.
+     * @return the clamped rating, guaranteed to be a value between 1 and 7 (inclusive).
+     */
+    public static int getMaxYears(int rating) {
+        return clamp(rating, 1, 7);
     }
 
     public static int getCollateralIncrement(final int rating, final boolean interestPositive) {

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
@@ -97,25 +97,6 @@ public class AverageExperienceRating {
     }
 
     /**
-     * Calculates a modifier for Against the Bot's various systems, based on the
-     * average skill level.
-     *
-     * @param campaign the campaign from which to calculate the ATB modifier
-     * @return the ATB modifier as an integer value
-     */
-    public static int getAtBModifier(Campaign campaign) {
-        SkillLevel averageSkillLevel = getSkillLevel(campaign, false);
-
-        return switch (averageSkillLevel) {
-            case NONE, ULTRA_GREEN -> 0;
-            case GREEN -> 1;
-            case REGULAR -> 2;
-            case VETERAN -> 3;
-            case ELITE, HEROIC, LEGENDARY -> 4;
-        };
-    }
-
-    /**
      * Calculates the average experience rating of combat personnel in the given
      * campaign.
      *

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/ReputationController.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/ReputationController.java
@@ -43,7 +43,6 @@ import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static mekhq.campaign.rating.CamOpsReputation.AverageExperienceRating.getAtBModifier;
 import static mekhq.campaign.rating.CamOpsReputation.AverageExperienceRating.getAverageExperienceModifier;
 import static mekhq.campaign.rating.CamOpsReputation.AverageExperienceRating.getSkillLevel;
 import static mekhq.campaign.rating.CamOpsReputation.CombatRecordRating.calculateCombatRecordRating;
@@ -136,7 +135,7 @@ public class ReputationController {
         // step one: calculate average experience rating
         averageSkillLevel = getSkillLevel(campaign, true);
         averageExperienceRating = getAverageExperienceModifier(averageSkillLevel);
-        atbModifier = getAtBModifier(campaign);
+        atbModifier = averageSkillLevel.ordinal();
 
         // step two: calculate command rating
         commanderMap = calculateCommanderRating(campaign, campaign.getFlaggedCommander());

--- a/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewLoanDialog.java
@@ -52,6 +52,8 @@ import java.text.NumberFormat;
 import java.util.Objects;
 import java.util.ResourceBundle;
 
+import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
+
 /**
  * @author Taharqa
  */
@@ -142,7 +144,11 @@ public class NewLoanDialog extends JDialog implements ActionListener, ChangeList
         panMain.setLayout(new GridBagLayout());
         panBtn.setLayout(new GridLayout(0, 2));
 
-        txtName = new JTextField(loan.getInstitution());
+        if (isGrayMonday(campaign.getLocalDate(), campaign.getCampaignOptions().isSimulateGrayMonday())) {
+            txtName = new JTextField(resourceMap.getString("lblName.grayMonday"));
+        } else {
+            txtName = new JTextField(loan.getInstitution());
+        }
         txtName.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void changedUpdate(DocumentEvent e) {
@@ -580,9 +586,12 @@ public class NewLoanDialog extends JDialog implements ActionListener, ChangeList
     }
 
     private void setSliders() {
+        boolean isGrayMonday = isGrayMonday(campaign.getLocalDate(), campaign.getCampaignOptions().isSimulateGrayMonday());
+
         if (campaign.getCampaignOptions().isUseLoanLimits()) {
             int[] interest = Loan.getInterestBracket(rating);
             sldInterest = new JSlider(interest[0], interest[2], loan.getRate());
+            sldInterest.setEnabled(!isGrayMonday);
             if (interest[2] - interest[0] > 30) {
                 sldInterest.setMajorTickSpacing(10);
             } else {
@@ -600,6 +609,7 @@ public class NewLoanDialog extends JDialog implements ActionListener, ChangeList
             }
             sldCollateral.setPaintTicks(true);
             sldCollateral.setPaintLabels(true);
+            sldCollateral.setEnabled(!isGrayMonday);
 
             sldLength = new JSlider(1, Loan.getMaxYears(rating), loan.getYears());
             sldLength.setMajorTickSpacing(1);
@@ -610,11 +620,13 @@ public class NewLoanDialog extends JDialog implements ActionListener, ChangeList
             sldInterest.setMajorTickSpacing(10);
             sldInterest.setPaintTicks(true);
             sldInterest.setPaintLabels(true);
+            sldInterest.setEnabled(!isGrayMonday);
 
             sldCollateral = new JSlider(0, 300, loan.getCollateral());
             sldCollateral.setMajorTickSpacing(50);
             sldCollateral.setPaintTicks(true);
             sldCollateral.setPaintLabels(true);
+            sldCollateral.setEnabled(!isGrayMonday);
 
             sldLength = new JSlider(1, 10, loan.getYears());
             sldLength.setMajorTickSpacing(1);

--- a/MekHQ/unittests/mekhq/campaign/rating/CamOpsReputation/ReputationControllerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CamOpsReputation/ReputationControllerTest.java
@@ -36,7 +36,7 @@ import org.mockito.MockedStatic;
 
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -90,9 +90,6 @@ class ReputationControllerTest {
         averageExperienceRating.when(() ->
             AverageExperienceRating.getAverageExperienceModifier(SkillLevel.VETERAN))
             .thenReturn(20);
-        averageExperienceRating.when(() ->
-            AverageExperienceRating.getAtBModifier(campaign))
-            .thenReturn(3);
         commandRating.when(() ->
             CommandRating.calculateCommanderRating(campaign, null))
             .thenReturn(Collections.singletonMap("total", 3));
@@ -139,9 +136,6 @@ class ReputationControllerTest {
         averageExperienceRating.when(() ->
                 AverageExperienceRating.getAverageExperienceModifier(SkillLevel.ULTRA_GREEN))
             .thenReturn(5);
-        averageExperienceRating.when(() ->
-                AverageExperienceRating.getAtBModifier(campaign))
-            .thenReturn(0);
         commandRating.when(() ->
                 CommandRating.calculateCommanderRating(campaign, null))
             .thenReturn(Collections.singletonMap("total", 0));


### PR DESCRIPTION
- Removed the `getAtBModifier` method and its references, replacing its logic with `SkillLevel.ordinal()` for streamlined reputation functionality.
- Updated the loan duration calculation to clamp ratings within a bounded range, matching skill level ordinals for better alignment.
- Adjusted predatory loan settings with Gray Monday scenario-specific behaviors in the loan dialog, including disabling sliders and showing unique labels.

### Dev Notes
There were a couple of bugs with Gray Monday loans that I wanted to close off. Chief among them players could avoid having to accept the predatory loan by just changing the sliders a little bit. So I disabled those sliders during Gray Monday. Now if players want to take out loans to survive the year of chaos they need to accept some pretty stern rates.

While fixing those issues I spotted that we weren't handling AtB modifiers in a sensible manner. AtB modifiers are basically us forcing CamOps Reputation to play nicely with the old AtB systems. However, due to some poor programming on my part whenever we fetched the modifier we basically recalculated skill rating - completely unnecessarily. Now we just return the already calculated skill rating as an ordinal - much better.

I also adjusted loan max years to better play with CamOps Reputation.