### PR TITLE
Removed Support For Commander And Individual Initiative Bonus Options

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -400,23 +400,6 @@ salariesTab.border="No job too small...no fee too high."\
 
 # createGeneralTab
 lblPersonnelGeneralTab.text=General Options
-
-lblUseTactics.text=Use Commander Initiative Bonus \u270E \u26A0
-lblUseTactics.tooltip=All initiative rolls are modified by the commander's Tactics skill.\
-  <br>\
-  <br><b>Warning:</b> Princess' units do not currently benefit from this modifier unless it is\
-  \ manually applied in MegaMek.\
-  <br>\
-  <br><b>Warning:</b> Should not be combined with 'Use Individual Initiative Bonus.'\
-  <br>\
-  <br><b>Requirement:</b> The commander initiative option must be enabled in MegaMek.
-lblUseInitiativeBonus.text=Use Individual Initiative Bonus \u270E \u26A0
-lblUseInitiativeBonus.tooltip=Each unit has their initiative rolls modified by their Tactics skill.\
-  <br>\
-  <br><b>Warning:</b> Princess' units do not currently benefit from this modifier unless it is\
-  \ manually applied in MegaMek.\
-  <br>\
-  <br><b>Warning:</b> Should not be combined with '=Use Commander Initiative Bonus.'
 lblUseToughness.text=Use Toughness \u270E
 lblUseToughness.tooltip=A character's Toughness score acts as a modifier to all consciousness checks.
 lblUseRandomToughness.text=Randomize Toughness \u270E

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7321,10 +7321,6 @@ public class Campaign implements ITechManager {
     }
 
     public void updateCampaignOptionsFromGameOptions() {
-        getCampaignOptions()
-                .setUseTactics(getGameOptions().getOption(OptionsConstants.RPG_COMMAND_INIT).booleanValue());
-        getCampaignOptions().setUseInitiativeBonus(
-                getGameOptions().getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE).booleanValue());
         getCampaignOptions().setUseToughness(getGameOptions().getOption(OptionsConstants.RPG_TOUGHNESS).booleanValue());
         getCampaignOptions()
                 .setUseArtillery(getGameOptions().getOption(OptionsConstants.RPG_ARTILLERY_SKILL).booleanValue());

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -199,8 +199,6 @@ public class CampaignOptions {
 
     // region Personnel Tab
     // General Personnel
-    private boolean useTactics;
-    private boolean useInitiativeBonus;
     private boolean useToughness;
     private boolean useRandomToughness;
     private boolean useArtillery;
@@ -733,8 +731,6 @@ public class CampaignOptions {
 
         // region Personnel Tab
         // General Personnel
-        setUseTactics(false);
-        setUseInitiativeBonus(false);
         setUseToughness(false);
         setUseRandomToughness(false);
         setUseArtillery(false);
@@ -1460,22 +1456,6 @@ public class CampaignOptions {
 
     // region Personnel Tab
     // region General Personnel
-    public boolean isUseTactics() {
-        return useTactics;
-    }
-
-    public void setUseTactics(final boolean useTactics) {
-        this.useTactics = useTactics;
-    }
-
-    public boolean isUseInitiativeBonus() {
-        return useInitiativeBonus;
-    }
-
-    public void setUseInitiativeBonus(final boolean useInitiativeBonus) {
-        this.useInitiativeBonus = useInitiativeBonus;
-    }
-
     public boolean isUseToughness() {
         return useToughness;
     }
@@ -4743,8 +4723,6 @@ public class CampaignOptions {
 
         // region Personnel Tab
         // region General Personnel
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useTactics", isUseTactics());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useInitiativeBonus", isUseInitiativeBonus());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useToughness", isUseToughness());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useRandomToughness", isUseRandomToughness());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useArtillery", isUseArtillery());
@@ -5413,10 +5391,6 @@ public class CampaignOptions {
 
                     // region Personnel Tab
                     // region General Personnel
-                } else if (wn2.getNodeName().equalsIgnoreCase("useTactics")) {
-                    retVal.setUseTactics(Boolean.parseBoolean(wn2.getTextContent()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("useInitiativeBonus")) {
-                    retVal.setUseInitiativeBonus(Boolean.parseBoolean(wn2.getTextContent()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("useToughness")) {
                     retVal.setUseToughness(Boolean.parseBoolean(wn2.getTextContent()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("useRandomToughness")) {

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
@@ -96,8 +96,6 @@ public class PersonnelTab {
 
     //start General Tab
     private JPanel pnlPersonnelGeneralOptions;
-    private JCheckBox chkUseTactics;
-    private JCheckBox chkUseInitiativeBonus;
     private JCheckBox chkUseToughness;
     private JCheckBox chkUseRandomToughness;
     private JCheckBox chkUseArtillery;
@@ -372,8 +370,6 @@ public class PersonnelTab {
      */
     private void initializeGeneralTab() {
         pnlPersonnelGeneralOptions = new JPanel();
-        chkUseTactics = new JCheckBox();
-        chkUseInitiativeBonus = new JCheckBox();
         chkUseToughness = new JCheckBox();
         chkUseRandomToughness = new JCheckBox();
         chkUseArtillery = new JCheckBox();
@@ -464,8 +460,6 @@ public class PersonnelTab {
      */
     private JPanel createGeneralOptionsPanel() {
         // Contents
-        chkUseTactics = new CampaignOptionsCheckBox("UseTactics");
-        chkUseInitiativeBonus = new CampaignOptionsCheckBox("UseInitiativeBonus");
         chkUseToughness = new CampaignOptionsCheckBox("UseToughness");
         chkUseRandomToughness = new CampaignOptionsCheckBox("UseRandomToughness");
         chkUseArtillery = new CampaignOptionsCheckBox("UseArtillery");
@@ -481,12 +475,6 @@ public class PersonnelTab {
 
         layout.gridy = 0;
         layout.gridwidth = 1;
-        panel.add(chkUseTactics, layout);
-
-        layout.gridy++;
-        panel.add(chkUseInitiativeBonus, layout);
-
-        layout.gridy++;
         panel.add(chkUseToughness, layout);
 
         layout.gridy++;
@@ -1373,8 +1361,6 @@ public class PersonnelTab {
         }
 
         // General
-        chkUseTactics.setSelected(options.isUseTactics());
-        chkUseInitiativeBonus.setSelected(options.isUseInitiativeBonus());
         chkUseToughness.setSelected(options.isUseToughness());
         chkUseRandomToughness.setSelected(options.isUseRandomToughness());
         chkUseArtillery.setSelected(options.isUseArtillery());
@@ -1470,8 +1456,6 @@ public class PersonnelTab {
         }
 
         // General
-        options.setUseTactics(chkUseTactics.isSelected());
-        options.setUseInitiativeBonus(chkUseInitiativeBonus.isSelected());
         options.setUseToughness(chkUseToughness.isSelected());
         options.setUseRandomToughness(chkUseRandomToughness.isSelected());
         options.setUseArtillery(chkUseArtillery.isSelected());


### PR DESCRIPTION
- Eliminated `UseTactics` and `UseInitiativeBonus` options throughout the codebase.
- Removed associated checkboxes, properties, and configurations from GUI components.
- Deleted XML handling and file persistence logic for the removed options.
- Cleaned up related labels and tooltips from resource files.
- Updated campaign option initialization and synchronization logic to reflect the removal.

## Dev Notes  
Expecting some pushback on this one, so I’m laying it out in detail.  

### What Are the Tactics Initiative Modifiers?  
In MekHQ, players can enable one of two Campaign Options to get a bonus to Initiative rolls based on a character's _Tactics_ skill. For **Commander Initiative**, only one character needs to have _Tactics_, and the bonus is applied to all combatants in the scenario. For **Individual Initiative Bonuses**, each character must invest in _Tactics_ separately.

### Why Is This a Problem?  
First, this system undermines the value of **Command Meks** and **Communications Equipment**. Why invest in a Command Mek if you can spend 30 XP for the same bonus? For just 20 XP more, you could match the benefit of 7 tons of Communications Equipment — without the cost in tonnage, BV, or anything else. On top of that, the bonus applies to **any** unit you pilot. If you lose a Mek, you just jump into the next one and keep the same initiative modifier.  

Second, winning Initiative rolls is a massive advantage. If you consistently win initiative, you control the flow of combat.  
- Want to get behind an enemy Mek and stay there? **Initiative**.  
- Want to protect your damaged units from getting picked off? **Initiative**.  
- Want to bait the OpFor and kick their head off? **Initiative**.  

A good player can sometimes work around bad initiative rolls, but there’s no denying that the player who consistently wins initiative has a serious edge.  

Finally, this system is one-sided. We don’t track Tactics for 'entity' level units, which means the OpFor can’t benefit from stacking _Tactics_ to boost Initiative. Even if they could, it would quickly turn into a contest of who had the higher _Tactics_ modifier, not who rolled better. Facing an elite OpFor with +5 Initiative every round wouldn’t be fun — either you’d have to heavily invest in _Tactics_ or accept that you’d never win initiative. Neither scenario makes for a good experience.

**Edit:** I've been advised that I should also add that currently neither Campaign Option works. I'm not sure when it broke, or why it broke and I've been unable to fix it. I discovered this by accident while trying to make it less one-sided and give the OpFor Tactics.

### So, Is Tactics Useless Now?  
Not at all. _Tactics_ is still valuable. It allows you to reroll scenario attributes like weather, time of day, and map type. Avoiding an F4 tornado, skipping a pitch-black night battle, or securing a favorable map can have a huge impact on a scenario. Being able to shape the battlefield conditions is a strategic advantage that more than justifies investing a few points into _Tactics_.  