### PR TITLE
Added Initiative Bonuses from Tactics to Princess Units

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -401,20 +401,14 @@ salariesTab.border="No job too small...no fee too high."\
 # createGeneralTab
 lblPersonnelGeneralTab.text=General Options
 
-lblUseTactics.text=Use Commander Initiative Bonus \u270E \u26A0
+lblUseTactics.text=Use Commander Initiative Bonus \u26A0
 lblUseTactics.tooltip=All initiative rolls are modified by the commander's Tactics skill.\
-  <br>\
-  <br><b>Warning:</b> Princess' units do not currently benefit from this modifier unless it is\
-  \ manually applied in MegaMek.\
   <br>\
   <br><b>Warning:</b> Should not be combined with 'Use Individual Initiative Bonus.'\
   <br>\
   <br><b>Requirement:</b> The commander initiative option must be enabled in MegaMek.
-lblUseInitiativeBonus.text=Use Individual Initiative Bonus \u270E \u26A0
+lblUseInitiativeBonus.text=Use Individual Initiative Bonus \u26A0
 lblUseInitiativeBonus.tooltip=Each unit has their initiative rolls modified by their Tactics skill.\
-  <br>\
-  <br><b>Warning:</b> Princess' units do not currently benefit from this modifier unless it is\
-  \ manually applied in MegaMek.\
   <br>\
   <br><b>Warning:</b> Should not be combined with '=Use Commander Initiative Bonus.'
 lblUseToughness.text=Use Toughness \u270E

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -2579,7 +2579,7 @@ public class AtBDynamicScenarioFactory {
 
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         if (campaignOptions.isUseTactics() || campaignOptions.isUseInitiativeBonus()) {
-            en.getCrew().setCommandBonus(skill.ordinal());
+            en.getCrew().setCommandBonus(skill.getAdjustedValue());
         }
 
         en.setExternalIdAsString(UUID.randomUUID().toString());

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -2577,6 +2577,11 @@ public class AtBDynamicScenarioFactory {
         en.setCrew(new Crew(en.getCrew().getCrewType(), crewName, Compute.getFullCrewSize(en),
                 skills[0], skills[1], gender, faction.isClan(), extraData));
 
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        if (campaignOptions.isUseTactics() || campaignOptions.isUseInitiativeBonus()) {
+            en.getCrew().setCommandBonus(skill.ordinal());
+        }
+
         en.setExternalIdAsString(UUID.randomUUID().toString());
 
         return en;


### PR DESCRIPTION
- Implemented logic to set command bonus for crew if either Tactics initiative bonus option is enabled in campaign settings.

### Dev Notes
So, to be clear, I still think having Tactics apply a direct modifier to initiative is a tad silly and breaks the initiative economics of the game entirely wide open. It is, however, a very popular mechanic and while we don't support ATOW it is undeniably raw within ATOW.

So, if you can't beat them join them: Princess now gets an initiative modifier based on her skill rating. This uses the skill randomization settings for Command Skills that the user has set up in Campaign Options. So crews commanded by Princess have the same chance of getting 'Tactics' as any normal character hired from the Personnel Market. Princess' tactics skill will also be influenced by the 'extra randomness' option.

However, because the player is able to further increase their own Tactics we need to do a bit of finagling. We fetch the crew's faction and from that know the size of a lance-level formation for that faction. We roll a dice with a 1inX chance of them being an officer, where x is the number of units in a lance-level formation of their chosen faction. If the crew has an officer they increase their 'tactics' by 2.

Note that we do not support tactics tracking at the entity level (only unit), which means that the crew does not strictly _have_ any tactics skill. They just have the benefits of whatever tactics they should have.
