### PR TITLE
Corrected One-Way Sync Between MegaMek and Campaign Options

### DIFF
--- a/MekHQ/src/mekhq/CampaignPreset.java
+++ b/MekHQ/src/mekhq/CampaignPreset.java
@@ -294,11 +294,17 @@ public class CampaignPreset {
         return presets;
     }
 
+    /**
+     * @deprecated This method is scheduled to be removed following the next milestone
+     * @since 50.04
+     */
+    @Deprecated
     public void applyContinuousToCampaign(final Campaign campaign) {
         if (getGameOptions() != null) {
             campaign.setGameOptions(getGameOptions());
             if (getCampaignOptions() == null) {
-                campaign.updateCampaignOptionsFromGameOptions();
+                campaign.getCampaignOptions().updateCampaignOptionsFromGameOptions(campaign);
+                MekHQ.triggerEvent(new OptionsChangedEvent(campaign));
             }
         }
 

--- a/MekHQ/src/mekhq/CampaignPreset.java
+++ b/MekHQ/src/mekhq/CampaignPreset.java
@@ -303,7 +303,7 @@ public class CampaignPreset {
         if (getGameOptions() != null) {
             campaign.setGameOptions(getGameOptions());
             if (getCampaignOptions() == null) {
-                campaign.getCampaignOptions().updateCampaignOptionsFromGameOptions(campaign);
+                campaign.getCampaignOptions().updateCampaignOptionsFromGameOptions(campaign.getGameOptions());
                 MekHQ.triggerEvent(new OptionsChangedEvent(campaign));
             }
         }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7317,7 +7317,7 @@ public class Campaign implements ITechManager {
         for (final IBasicOption option : options) {
             getGameOptions().getOption(option.getName()).setValue(option.getValue());
         }
-        campaignOptions.updateCampaignOptionsFromGameOptions(this);
+        campaignOptions.updateCampaignOptionsFromGameOptions(gameOptions);
         MekHQ.triggerEvent(new OptionsChangedEvent(this));
     }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7317,28 +7317,7 @@ public class Campaign implements ITechManager {
         for (final IBasicOption option : options) {
             getGameOptions().getOption(option.getName()).setValue(option.getValue());
         }
-        updateCampaignOptionsFromGameOptions();
-    }
-
-    public void updateCampaignOptionsFromGameOptions() {
-        getCampaignOptions()
-                .setUseTactics(getGameOptions().getOption(OptionsConstants.RPG_COMMAND_INIT).booleanValue());
-        getCampaignOptions().setUseInitiativeBonus(
-                getGameOptions().getOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE).booleanValue());
-        getCampaignOptions().setUseToughness(getGameOptions().getOption(OptionsConstants.RPG_TOUGHNESS).booleanValue());
-        getCampaignOptions()
-                .setUseArtillery(getGameOptions().getOption(OptionsConstants.RPG_ARTILLERY_SKILL).booleanValue());
-        getCampaignOptions()
-                .setUseAbilities(getGameOptions().getOption(OptionsConstants.RPG_PILOT_ADVANTAGES).booleanValue());
-        getCampaignOptions().setUseEdge(getGameOptions().getOption(OptionsConstants.EDGE).booleanValue());
-        getCampaignOptions()
-                .setUseImplants(getGameOptions().getOption(OptionsConstants.RPG_MANEI_DOMINI).booleanValue());
-        getCampaignOptions()
-                .setQuirks(getGameOptions().getOption(OptionsConstants.ADVANCED_STRATOPS_QUIRKS).booleanValue());
-        getCampaignOptions()
-                .setAllowCanonOnly(getGameOptions().getOption(OptionsConstants.ALLOWED_CANON_ONLY).booleanValue());
-        getCampaignOptions().setTechLevel(TechConstants
-                .getSimpleLevel(getGameOptions().getOption(OptionsConstants.ALLOWED_TECHLEVEL).stringValue()));
+        campaignOptions.updateCampaignOptionsFromGameOptions(this);
         MekHQ.triggerEvent(new OptionsChangedEvent(this));
     }
 

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -33,6 +33,7 @@ import megamek.codeUtilities.MathUtility;
 import megamek.common.EquipmentType;
 import megamek.common.TechConstants;
 import megamek.common.enums.SkillLevel;
+import megamek.common.options.GameOptions;
 import megamek.common.preference.ClientPreferences;
 import megamek.common.preference.PreferenceManager;
 import megamek.logging.MMLogger;
@@ -40,6 +41,7 @@ import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.autoresolve.AutoResolveMethod;
 import mekhq.campaign.enums.PlanetaryAcquisitionFactionLimit;
+import mekhq.campaign.event.OptionsChangedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.FinancialYearDuration;
 import mekhq.campaign.market.PersonnelMarket;
@@ -60,6 +62,9 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.util.*;
 import java.util.Map.Entry;
+
+import static megamek.common.TechConstants.getSimpleLevel;
+import static megamek.common.options.OptionsConstants.*;
 
 /**
  * @author natit
@@ -6360,5 +6365,59 @@ public class CampaignOptions {
 
     public void setAutoResolveExperimentalPacarGuiEnabled(boolean autoResolveExperimentalPacarGuiEnabled) {
         this.autoResolveExperimentalPacarGuiEnabled = autoResolveExperimentalPacarGuiEnabled;
+    }
+
+    /**
+     * Updates the campaign options to reflect the current game options settings.
+     *
+     * <p>This method retrieves the {@link GameOptions} from the provided {@link Campaign} and updates
+     * various campaign-specific options, such as the use of tactics, initiative bonuses, toughness,
+     * artillery, pilot abilities, edge, implants, quirks, canon restrictions, and allowed tech level.
+     * After updating the options, it triggers an {@link OptionsChangedEvent} to notify relevant systems
+     * of the changes.</p>
+     *
+     * @param campaign the {@link Campaign} whose options should be updated based on the current game options.
+     */
+    public void updateCampaignOptionsFromGameOptions(Campaign campaign) {
+        GameOptions gameOptions = campaign.getGameOptions();
+
+        useTactics = gameOptions.getOption(RPG_COMMAND_INIT).booleanValue();
+        useInitiativeBonus = gameOptions.getOption(RPG_INDIVIDUAL_INITIATIVE).booleanValue();
+        useToughness = gameOptions.getOption(RPG_TOUGHNESS).booleanValue();
+        useArtillery = gameOptions.getOption(RPG_ARTILLERY_SKILL).booleanValue();
+        useAbilities = gameOptions.getOption(RPG_PILOT_ADVANTAGES).booleanValue();
+        useEdge = gameOptions.getOption(EDGE).booleanValue();
+        useImplants = gameOptions.getOption(RPG_MANEI_DOMINI).booleanValue();
+        useQuirks = gameOptions.getOption(ADVANCED_STRATOPS_QUIRKS).booleanValue();
+        allowCanonOnly = gameOptions.getOption(ALLOWED_CANON_ONLY).booleanValue();
+        techLevel = getSimpleLevel(gameOptions.getOption(ALLOWED_TECHLEVEL).stringValue());
+    }
+
+    /**
+     * Updates the game options to reflect the current campaign options settings.
+     *
+     * <p>This method synchronizes the {@link GameOptions} in the provided {@link Campaign} with
+     * the values of the corresponding campaign options. It adjusts settings such as tactics,
+     * initiative bonuses, toughness, artillery, pilot abilities, edge, implants, quirks, canon
+     * restrictions, and allowed tech level based on the current campaign options. After updating
+     * the options, it triggers an {@link OptionsChangedEvent} to notify relevant systems of the changes.</p>
+     *
+     * @param campaign the {@link Campaign} whose game options should be updated based on the current campaign options.
+     */
+    public void updateGameOptionsFromCampaignOptions(Campaign campaign) {
+        GameOptions gameOptions = campaign.getGameOptions();
+
+        gameOptions.getOption(RPG_COMMAND_INIT).setValue(useTactics);
+        gameOptions.getOption(RPG_INDIVIDUAL_INITIATIVE).setValue(useInitiativeBonus);
+        gameOptions.getOption(RPG_TOUGHNESS).setValue(useToughness);
+        gameOptions.getOption(RPG_ARTILLERY_SKILL).setValue(useArtillery);
+        gameOptions.getOption(RPG_PILOT_ADVANTAGES).setValue(useAbilities);
+        gameOptions.getOption(EDGE).setValue(useEdge);
+        gameOptions.getOption(RPG_MANEI_DOMINI).setValue(useImplants);
+        gameOptions.getOption(ADVANCED_STRATOPS_QUIRKS).setValue(useQuirks);
+        gameOptions.getOption(ALLOWED_CANON_ONLY).setValue(allowCanonOnly);
+        gameOptions.getOption(ALLOWED_CANON_ONLY).setValue(allowCanonOnly);
+
+        gameOptions.getOption(ALLOWED_TECHLEVEL).setValue(TechConstants.T_SIMPLE_NAMES[techLevel]);
     }
 }

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -41,7 +41,6 @@ import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.autoresolve.AutoResolveMethod;
 import mekhq.campaign.enums.PlanetaryAcquisitionFactionLimit;
-import mekhq.campaign.event.OptionsChangedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.FinancialYearDuration;
 import mekhq.campaign.market.PersonnelMarket;
@@ -6370,17 +6369,14 @@ public class CampaignOptions {
     /**
      * Updates the campaign options to reflect the current game options settings.
      *
-     * <p>This method retrieves the {@link GameOptions} from the provided {@link Campaign} and updates
-     * various campaign-specific options, such as the use of tactics, initiative bonuses, toughness,
-     * artillery, pilot abilities, edge, implants, quirks, canon restrictions, and allowed tech level.
-     * After updating the options, it triggers an {@link OptionsChangedEvent} to notify relevant systems
-     * of the changes.</p>
+     * <p>This method retrieves the {@link GameOptions} and updates the corresponding campaign-specific
+     * settings, such as the use of tactics, initiative bonuses, toughness, artillery, pilot abilities,
+     * edge, implants, quirks, canon restrictions, and allowed tech level. This synchronization ensures
+     * that the campaign options match the current state of the game options.</p>
      *
-     * @param campaign the {@link Campaign} whose options should be updated based on the current game options.
+     * @param gameOptions the {@link GameOptions} whose values will be used to update the campaign options.
      */
-    public void updateCampaignOptionsFromGameOptions(Campaign campaign) {
-        GameOptions gameOptions = campaign.getGameOptions();
-
+    public void updateCampaignOptionsFromGameOptions(GameOptions gameOptions) {
         useTactics = gameOptions.getOption(RPG_COMMAND_INIT).booleanValue();
         useInitiativeBonus = gameOptions.getOption(RPG_INDIVIDUAL_INITIATIVE).booleanValue();
         useToughness = gameOptions.getOption(RPG_TOUGHNESS).booleanValue();
@@ -6396,17 +6392,14 @@ public class CampaignOptions {
     /**
      * Updates the game options to reflect the current campaign options settings.
      *
-     * <p>This method synchronizes the {@link GameOptions} in the provided {@link Campaign} with
-     * the values of the corresponding campaign options. It adjusts settings such as tactics,
-     * initiative bonuses, toughness, artillery, pilot abilities, edge, implants, quirks, canon
-     * restrictions, and allowed tech level based on the current campaign options. After updating
-     * the options, it triggers an {@link OptionsChangedEvent} to notify relevant systems of the changes.</p>
+     * <p>This method synchronizes the values of the given {@link GameOptions} with the current campaign-specific
+     * options, such as the use of tactics, initiative bonuses, toughness, artillery, pilot abilities, edge,
+     * implants, quirks, canon restrictions, and allowed tech level. These updates ensure parity between the
+     * campaign options and the game options.</p>
      *
-     * @param campaign the {@link Campaign} whose game options should be updated based on the current campaign options.
+     * @param gameOptions the {@link GameOptions} to update based on the current campaign options.
      */
-    public void updateGameOptionsFromCampaignOptions(Campaign campaign) {
-        GameOptions gameOptions = campaign.getGameOptions();
-
+    public void updateGameOptionsFromCampaignOptions(GameOptions gameOptions) {
         gameOptions.getOption(RPG_COMMAND_INIT).setValue(useTactics);
         gameOptions.getOption(RPG_INDIVIDUAL_INITIATIVE).setValue(useInitiativeBonus);
         gameOptions.getOption(RPG_TOUGHNESS).setValue(useToughness);

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -445,6 +445,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         if (preset == null) {
             recalculateCombatTeams(campaign);
             MekHQ.triggerEvent(new OptionsChangedEvent(campaign, options));
+
+            options.updateGameOptionsFromCampaignOptions(campaign);
+            MekHQ.triggerEvent(new OptionsChangedEvent(campaign));
         }
     }
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -446,7 +446,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             recalculateCombatTeams(campaign);
             MekHQ.triggerEvent(new OptionsChangedEvent(campaign, options));
 
-            options.updateGameOptionsFromCampaignOptions(campaign);
+            options.updateGameOptionsFromCampaignOptions(campaign.getGameOptions());
             MekHQ.triggerEvent(new OptionsChangedEvent(campaign));
         }
     }


### PR DESCRIPTION
- Introduced `updateCampaignOptionsFromGameOptions` and `updateGameOptionsFromCampaignOptions` methods in `CampaignOptions` for clearer bidirectional synchronization between game and campaign options.  
- Deprecated `applyContinuousToCampaign` in `CampaignPreset` as it is no longer in use, following the arrival of CO IIC.
- Replaced the previous `updateCampaignOptionsFromGameOptions` logic in `Campaign` with a call to the new encapsulated method in `CampaignOptions`.

## Dev Notes  
Marking this as **high** because we really need this in 50.04. I’m genuinely surprised it’s taken this long for it to cause major problems.  

### Overview  
When the user updates MegaMek's options, some choices (such as tech level) are propagated back into Campaign Options. This makes sense — if the user selects "use edge" in MegaMek’s options, they probably want to use edge. However, this connection was entirely one-directional: MegaMek could affect Campaign Options, but Campaign Options could not affect MegaMek.  

This creates a major issue if you adjust MegaMek's options but don’t enable, say, Edge. Since Edge is not enabled by default in MegaMek, it would become disabled in Campaign Options — even though you might expect it to be enabled, because you yourself enabled it.

Meaning, if you *do* want to use Edge, you need to enable it in both Campaign Options and MegaMek’s options manually. If you forget to enable it in MegaMek, Edge won’t work.

### Fix  
This PR includes some minor refactoring but mainly ensures that option synchronization works in both directions. Now, enabling Edge in MegaMek will enable it in Campaign Options — and enabling Edge in Campaign Options will enable it in MegaMek.  

### Synchronized Options  
The following options are now synced between MegaMek and Campaign Options:  
- Use Commander Tactics Bonus to Initiative  
- Use Individual Tactics Bonuses to Initiative  
- Use Toughness  
- Use Artillery  
- Use SPAs  
- Use Edge  
- Use Implants  
- Use Quirks  
- Allow Canon Units Only  
- Maximum Tech Level  
