### PR TITLE
Fixed Typographical Error in GrayMonday Properties

### DIFF
--- a/MekHQ/resources/mekhq/resources/GrayMonday.properties
+++ b/MekHQ/resources/mekhq/resources/GrayMonday.properties
@@ -10,7 +10,7 @@ clarionNoteEvent0.message={0}, I wanted to bring something odd to your attention
   \ station has gone dark. Initial diagnostics suggest it''s not just us - our neighboring systems\
   \ aren''t responding either. At first, I thought this might be a routine system outage or\
   \ scheduled maintenance, but there''s been no notice from ComStar or the Republic.\
-  <p>I'm attempting to use alternate communication methods to confirm the extent of the disruption.\
+  <p>I''m attempting to use alternate communication methods to confirm the extent of the disruption.\
   \ I''ll keep you updated. For now, it''s an inconvenience, but nothing we can''t manage
 clarionNoteEvent1.message={0}, this situation is far worse than we thought. Our attempts to\
   \ re-establish communication have failed, and reports are coming in through secondary channels\


### PR DESCRIPTION
- Corrected a missing escape character for an apostrophe in the GrayMonday.properties file.