### PR TITLE
Refactored Skill Overrides; Added Randomization Logic; Added AeroSpace Ronin

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -863,9 +863,9 @@ public class AtBContract extends Contract {
      * @param campaign the current {@link Campaign} in which the Ronin will be recruited.
      */
     private static void recruitRonin(Campaign campaign) {
-        int roll = randomInt(4);
+        int roll = randomInt(5);
 
-        PersonnelRole role = roll == 3 ? AEROSPACE_PILOT : MEKWARRIOR;
+        PersonnelRole role = roll == 0 ? AEROSPACE_PILOT : MEKWARRIOR;
         Person ronin = campaign.newPerson(role);
 
         RandomSkillPreferences randomSkillPreferences = campaign.getRandomSkillPreferences();

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -104,15 +104,15 @@ import static mekhq.campaign.mission.enums.AtBMoraleLevel.ADVANCING;
 import static mekhq.campaign.mission.enums.AtBMoraleLevel.DOMINATING;
 import static mekhq.campaign.mission.enums.AtBMoraleLevel.OVERWHELMING;
 import static mekhq.campaign.mission.enums.AtBMoraleLevel.STALEMATE;
+import static mekhq.campaign.personnel.PersonUtility.overrideSkills;
+import static mekhq.campaign.personnel.PersonUtility.reRollAdvantages;
+import static mekhq.campaign.personnel.PersonUtility.reRollLoyalty;
 import static mekhq.campaign.personnel.enums.PersonnelRole.AEROSPACE_PILOT;
 import static mekhq.campaign.personnel.enums.PersonnelRole.MEKWARRIOR;
 import static mekhq.campaign.rating.IUnitRating.*;
 import static mekhq.campaign.stratcon.StratconContractDefinition.getContractDefinition;
 import static mekhq.campaign.universe.Factions.getFactionLogo;
 import static mekhq.campaign.universe.fameAndInfamy.BatchallFactions.BATCHALL_FACTIONS;
-import static mekhq.gui.dialog.HireBulkPersonnelDialog.overrideSkills;
-import static mekhq.gui.dialog.HireBulkPersonnelDialog.reRollAdvantages;
-import static mekhq.gui.dialog.HireBulkPersonnelDialog.reRollLoyalty;
 import static mekhq.utilities.EntityUtilities.getEntityFromUnitId;
 import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
 
@@ -873,10 +873,11 @@ public class AtBContract extends Contract {
 
         // We don't care about admin settings, as we're not going to have an admin here
         overrideSkills(false, false, useExtraRandomness,
-              ronin, role, VETERAN.ordinal());
+              ronin, role, VETERAN);
 
-        reRollLoyalty(ronin, ronin.getExperienceLevel(campaign, false));
-        reRollAdvantages(campaign, ronin, ronin.getExperienceLevel(campaign, false));
+        SkillLevel skillLevel = ronin.getSkillLevel(campaign, false);
+        reRollLoyalty(ronin, skillLevel);
+        reRollAdvantages(campaign, ronin, skillLevel);
         ronin.setCallsign(RandomCallsignGenerator.getInstance().generate());
 
         campaign.recruitPerson(ronin, true);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonUtility.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.campaign.personnel;
+
+import megamek.common.enums.SkillLevel;
+import megamek.common.options.IOption;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.RandomSkillPreferences;
+import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.generator.AbstractSpecialAbilityGenerator;
+import mekhq.campaign.personnel.generator.DefaultSpecialAbilityGenerator;
+
+import java.util.*;
+
+import static megamek.codeUtilities.MathUtility.clamp;
+import static megamek.common.Compute.d6;
+import static mekhq.campaign.personnel.SkillType.*;
+import static mekhq.campaign.personnel.enums.PersonnelRole.*;
+import static mekhq.campaign.personnel.generator.AbstractSkillGenerator.addSkill;
+
+/**
+ * Utility class that provides methods for managing and modifying the skills, loyalty,
+ * and advantages of personnel in the campaign, based on their roles and experience levels.
+ */
+public class PersonUtility {
+
+    /**
+     * Re-rolls the Special Piloting Abilities (SPAs) of a person based on their experience level.
+     *
+     * <p>This clears all existing SPAs for the person and generates new ones that align with the
+     * specified experience level.</p>
+     *
+     * @param campaign       the current {@link Campaign} instance.
+     * @param person         the {@link Person} whose SPAs are being re-rolled.
+     * @param skillLevel     the {@link SkillLevel} of the person, used to determine the new SPAs.
+     */
+    public static void reRollAdvantages(Campaign campaign, Person person, SkillLevel skillLevel) {
+        Enumeration<IOption> options = new PersonnelOptions().getOptions(PersonnelOptions.LVL3_ADVANTAGES);
+
+        for (IOption option : Collections.list(options)) {
+            person.getOptions().getOption(option.getName()).clearValue();
+        }
+
+        int skillLevelValue = skillLevel.getExperienceLevel();
+        if (skillLevelValue > 0) {
+            AbstractSpecialAbilityGenerator specialAbilityGenerator = new DefaultSpecialAbilityGenerator();
+            specialAbilityGenerator.setSkillPreferences(new RandomSkillPreferences());
+            specialAbilityGenerator.generateSpecialAbilities(campaign, person, skillLevelValue);
+        }
+    }
+
+    /**
+     * Re-rolls the loyalty of a person based on their experience level.
+     *
+     * <p>The loyalty score is determined by a dice roll and is influenced by the person's skill
+     * level. A higher skill level generally corresponds to lower (worse) loyalty values.</p>
+     *
+     * @param person     the {@link Person} whose loyalty is being re-rolled.
+     * @param skillLevel the {@link SkillLevel} of the person, which affects the loyalty value.
+     */
+    public static void reRollLoyalty(Person person, SkillLevel skillLevel) {
+        int skillLevelValue = skillLevel.getExperienceLevel();
+
+        if (skillLevelValue <= 0) {
+            person.setLoyalty(d6(3) + 2);
+        } else if (skillLevelValue == 1) {
+            person.setLoyalty(d6(3) + 1);
+        } else {
+            person.setLoyalty(d6(3));
+        }
+    }
+
+    /**
+     * Overrides the skills of a person based on their role, experience level, and additional
+     * conditions (such as whether administrators should possess specific skills like Negotiation or
+     * Scrounge).
+     *
+     * @param isAdminsHaveNegotiation whether administrators should have the Negotiation skill.
+     * @param isAdminsHaveScrounge    whether administrators should have the Scrounge Skill.
+     * @param isUseExtraRandom        whether extra randomization should be applied to skill levels.
+     * @param person                  the {@link Person} whose skills are being overridden.
+     * @param primaryRole             the {@link PersonnelRole} of the person.
+     * @param skillLevel              the {@link SkillLevel} of the person, which determines
+     *                               skill-specific values.
+     */
+    public static void overrideSkills(boolean isAdminsHaveNegotiation, boolean isAdminsHaveScrounge,
+                                      boolean isUseExtraRandom, Person person, PersonnelRole primaryRole,
+                                      SkillLevel skillLevel) {
+        // Role-to-Skill Mapping
+        Map<PersonnelRole, List<String>> roleSkills = Map.ofEntries(
+              Map.entry(MEKWARRIOR, List.of(S_PILOT_MEK, S_GUN_MEK)),
+              Map.entry(LAM_PILOT, List.of(S_PILOT_MEK, S_GUN_MEK, S_PILOT_AERO, S_GUN_AERO)),
+              Map.entry(GROUND_VEHICLE_DRIVER, List.of(S_PILOT_GVEE, S_GUN_VEE)),
+              Map.entry(NAVAL_VEHICLE_DRIVER, List.of(S_PILOT_NVEE, S_GUN_VEE)),
+              Map.entry(VTOL_PILOT, List.of(S_PILOT_VTOL, S_GUN_VEE)),
+              Map.entry(VEHICLE_GUNNER, List.of(S_GUN_VEE)),
+              Map.entry(VEHICLE_CREW, List.of(S_TECH_MECHANIC)),
+              Map.entry(MECHANIC, List.of(S_TECH_MECHANIC)),
+              Map.entry(AEROSPACE_PILOT, List.of(S_PILOT_AERO, S_GUN_AERO)),
+              Map.entry(CONVENTIONAL_AIRCRAFT_PILOT, List.of(S_PILOT_JET, S_GUN_JET)),
+              Map.entry(PROTOMEK_PILOT, List.of(S_GUN_PROTO)),
+              Map.entry(BATTLE_ARMOUR, List.of(S_GUN_BA, S_ANTI_MEK)),
+              Map.entry(SOLDIER, List.of(S_SMALL_ARMS)),
+              Map.entry(VESSEL_PILOT, List.of(S_PILOT_SPACE)),
+              Map.entry(VESSEL_GUNNER, List.of(S_GUN_SPACE)),
+              Map.entry(VESSEL_CREW, List.of(S_TECH_VESSEL)),
+              Map.entry(VESSEL_NAVIGATOR, List.of(S_NAV)),
+              Map.entry(MEK_TECH, List.of(S_TECH_MEK)),
+              Map.entry(AERO_TEK, List.of(S_TECH_AERO)),
+              Map.entry(BA_TECH, List.of(S_TECH_BA)),
+              Map.entry(DOCTOR, List.of(S_DOCTOR))
+        );
+
+        // Add admin-specific logic
+        if (primaryRole == ADMINISTRATOR_COMMAND || primaryRole == ADMINISTRATOR_LOGISTICS ||
+              primaryRole == ADMINISTRATOR_TRANSPORT || primaryRole == ADMINISTRATOR_HR) {
+            List<String> adminSkills = new ArrayList<>();
+
+            adminSkills.add(S_ADMIN);
+            if (isAdminsHaveNegotiation) {
+                adminSkills.add(S_NEG);
+            }
+            if (isAdminsHaveScrounge) {
+                adminSkills.add(S_SCROUNGE);
+            }
+
+            addSkillsAndRandomize(person, adminSkills, skillLevel, isUseExtraRandom);
+            return;
+        }
+
+        // Handle Normal Role Skills
+        List<String> skills = roleSkills.getOrDefault(primaryRole, List.of());
+        addSkillsAndRandomize(person, skills, skillLevel, isUseExtraRandom);
+    }
+
+    /**
+     * Adds specified skills to a person and optionally applies randomization to those skills.
+     *
+     * <p>The randomization process can slightly increase or decrease skill levels based on dice
+     * rolls.</p>
+     *
+     * @param person    the {@link Person} to whom the skills are added.
+     * @param skills    a list of skill names to add to the person.
+     * @param skillLevel the {@link SkillLevel} to which the skills should be set.
+     * @param randomize {@code true} if the skill levels should be randomized after being added;
+     *                  {@code false} otherwise.
+     */
+    private static void addSkillsAndRandomize(Person person, List<String> skills, SkillLevel skillLevel,
+                                              boolean randomize) {
+        for (String skill : skills) {
+            addSkillFixedExperienceLevel(person, skill, skillLevel);
+        }
+
+        if (randomize) {
+            randomizeSkills(person, skills);
+        }
+    }
+
+    /**
+     * Randomizes the skill levels of the given person within a specific range.
+     *
+     * <p>Each skill's level may increase, decrease, or stay the same based on a dice roll.</p>
+     *
+     * @param person the {@link Person} whose skills are being randomized.
+     * @param skills a list of skill names that should be randomized.
+     */
+    private static void randomizeSkills(Person person, List<String> skills) {
+        for (String skillName : skills) {
+            Skill skill = person.getSkill(skillName);
+
+            if (skill == null) {
+                continue;
+            }
+
+            int roll = d6(); // Roll once for the skill
+            int adjustedLevel = skill.getLevel() + (roll == 6 ? 1 : roll == 1 ? -1 : 0);
+            skill.setLevel(clamp(adjustedLevel, 0, 10));
+        }
+    }
+
+    /**
+     * Adds a specific skill to a person with a fixed experience level.
+     *
+     * <p>If the person already has the skill, their existing bonus value is retained.
+     * Otherwise, the skill is added with the specified experience level.</p>
+     *
+     * @param person     the {@link Person} to whom the skill is being added.
+     * @param skill      the name of the skill to add.
+     * @param skillLevel the {@link SkillLevel} used to set the skill's experience level.
+     */
+    private static void addSkillFixedExperienceLevel(Person person, String skill, SkillLevel skillLevel) {
+        int bonus = 0;
+
+        if (person.hasSkill(skill)) {
+            bonus = person.getSkill(skill).getBonus();
+        }
+
+        addSkill(person, skill, skillLevel.getExperienceLevel(), bonus);
+    }
+}

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -32,6 +32,7 @@ import megamek.client.ui.dialogs.CamoChooserDialog;
 import megamek.client.ui.swing.UnitEditorDialog;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
+import megamek.common.enums.SkillLevel;
 import megamek.common.icons.Camouflage;
 import megamek.common.loaders.BLKFile;
 import megamek.common.loaders.EntityLoadingException;
@@ -81,7 +82,7 @@ import java.util.stream.Stream;
 
 import static megamek.client.ui.WrapLayout.wordWrap;
 import static megamek.common.enums.SkillLevel.*;
-import static mekhq.gui.dialog.HireBulkPersonnelDialog.overrideSkills;
+import static mekhq.campaign.personnel.PersonUtility.overrideSkills;
 
 public class UnitTableMouseAdapter extends JPopupMenuAdapter {
     private static final MMLogger logger = MMLogger.create(UnitTableMouseAdapter.class);
@@ -347,18 +348,18 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
 
                 boolean fixSkillLevels = false;
 
-                int skillLevel = REGULAR.ordinal();
+                SkillLevel skillLevel = REGULAR;
                 if (command.contains("ELITE")) {
-                    skillLevel = ELITE.ordinal();
+                    skillLevel = ELITE;
                     fixSkillLevels = true;
                 } else if (command.contains("VETERAN")) {
-                    skillLevel = VETERAN.ordinal();
+                    skillLevel = VETERAN;
                     fixSkillLevels = true;
                 } else if (command.contains("ULTRA_GREEN")) {
-                    skillLevel = ULTRA_GREEN.ordinal();
+                    skillLevel = ULTRA_GREEN;
                     fixSkillLevels = true;
                 } else if (command.contains("GREEN")) {
-                    skillLevel = GREEN.ordinal();
+                    skillLevel = GREEN;
                     fixSkillLevels = true;
                 }
 

--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -32,7 +32,6 @@ import megamek.client.ui.dialogs.CamoChooserDialog;
 import megamek.client.ui.swing.UnitEditorDialog;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
-import megamek.common.enums.SkillLevel;
 import megamek.common.icons.Camouflage;
 import megamek.common.loaders.BLKFile;
 import megamek.common.loaders.EntityLoadingException;
@@ -42,6 +41,8 @@ import megamek.logging.MMLogger;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.Utilities;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.RandomSkillPreferences;
 import mekhq.campaign.event.RepairStatusChangedEvent;
 import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.finances.Money;
@@ -79,6 +80,7 @@ import java.util.*;
 import java.util.stream.Stream;
 
 import static megamek.client.ui.WrapLayout.wordWrap;
+import static megamek.common.enums.SkillLevel.*;
 import static mekhq.gui.dialog.HireBulkPersonnelDialog.overrideSkills;
 
 public class UnitTableMouseAdapter extends JPopupMenuAdapter {
@@ -345,18 +347,18 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
 
                 boolean fixSkillLevels = false;
 
-                SkillLevel skillLevel = SkillLevel.REGULAR;
+                int skillLevel = REGULAR.ordinal();
                 if (command.contains("ELITE")) {
-                    skillLevel = SkillLevel.ELITE;
+                    skillLevel = ELITE.ordinal();
                     fixSkillLevels = true;
                 } else if (command.contains("VETERAN")) {
-                    skillLevel = SkillLevel.VETERAN;
+                    skillLevel = VETERAN.ordinal();
                     fixSkillLevels = true;
                 } else if (command.contains("ULTRA_GREEN")) {
-                    skillLevel = SkillLevel.ULTRA_GREEN;
+                    skillLevel = ULTRA_GREEN.ordinal();
                     fixSkillLevels = true;
                 } else if (command.contains("GREEN")) {
-                    skillLevel = SkillLevel.GREEN;
+                    skillLevel = GREEN.ordinal();
                     fixSkillLevels = true;
                 }
 
@@ -366,7 +368,13 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                             continue;
                         }
 
-                        overrideSkills(gui.getCampaign(), person, person.getPrimaryRole(), skillLevel.ordinal());
+                        Campaign campaign = gui.getCampaign();
+                        RandomSkillPreferences randomSkillPreferences = campaign.getRandomSkillPreferences();
+                        boolean useExtraRandomness = randomSkillPreferences.randomizeSkill();
+
+                        // We don't care about admin settings, as we're not going to have an admin here
+                        overrideSkills(false, false, useExtraRandomness,
+                              person, person.getPrimaryRole(), skillLevel);
                     }
                 }
             }


### PR DESCRIPTION
- Centralized skill override logic by refactoring `overrideSkills` to handle admin and role-specific conditions consistently.
- Introduced a new `addSkillsAndRandomize` method to consolidate skill addition with optional randomization for better reusability.
- Implemented a new `randomizeSkills` method to adjust skill levels based on dice rolls within defined constraints.
- Simplified skill level assignments using `SkillLevel` enum ordinals to improve clarity and reduce redundancy.
- Refactored Ronin generation and unit table logic to utilize the updated `overrideSkills` API, incorporating random skill preferences cleanly.

### Requirement
Requires https://github.com/MegaMek/megamek/pull/6703

## Dev Notes  
This adds functionality I thought was already included, but apparently wasn’t.

### Overview  
Currently, players can GM Generate personnel at fixed experience levels — for example, Veteran. However, there’s no way to request a crew that is *overall* Veteran but could include a mix of Regulars and Elites. The "extra randomness" campaign option should cover this, but an oversight meant that that option wasn’t applied to skills when those skills were overridden during generation.

This PR fixes that by applying the "extra randomness" option correctly during generation. It also includes some cleanup to make the code more streamlined.

### Additional Fix  
While I was in that part of the code, I added a check to give Ronin (characters generated during monthly events) a 25% chance of spawning as an AeroSpace Pilot instead of a MekWarrior. This was also functionality I thought already existed but was missing.