### PR TITLE
Fixed Field Kitchen Ignore Non-Combatants Option

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/TurnoverAndRetentionTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/TurnoverAndRetentionTab.java
@@ -905,6 +905,7 @@ public class TurnoverAndRetentionTab {
         options.setFatigueRate((int) spnFatigueRate.getValue());
         options.setUseInjuryFatigue(chkUseInjuryFatigue.isSelected());
         options.setFieldKitchenCapacity((int) spnFieldKitchenCapacity.getValue());
+        options.setFieldKitchenIgnoreNonCombatants(chkFieldKitchenIgnoreNonCombatants.isSelected());
         options.setFatigueLeaveThreshold((int) spnFatigueLeaveThreshold.getValue());
     }
 }


### PR DESCRIPTION
- Implemented the `setFieldKitchenIgnoreNonCombatants` method in `TurnoverAndRetentionTab.java` to allow toggling whether field kitchens ignore non-combatants.