### PR TITLE
Fixed Enemy Picker Logic And Added Faction Validation

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -468,7 +468,18 @@ public class AtBDynamicScenarioFactory {
                 logger.warn(String.format("Invalid force alignment %d", forceTemplate.getForceAlignment()));
         }
 
+        if (factionCode.isBlank()) {
+            logger.error("Faction code is blank, using fallback faction code." +
+                  " This is indicative of a deeper problem and should be reported.");
+            factionCode = "IS";
+        }
+
         final Faction faction = Factions.getInstance().getFaction(factionCode);
+        if (faction == null) {
+            logger.error("Faction code is null, aborting force generation.");
+            return 0;
+        }
+
         String parentFactionType = AtBConfiguration.getParentFactionType(faction);
         boolean isPlanetOwner = isPlanetOwner(contract, currentDate, factionCode);
 

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -28,16 +28,6 @@
  */
 package mekhq.campaign.universe;
 
-import java.time.LocalDate;
-import java.time.Month;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
-
 import megamek.codeUtilities.ObjectUtility;
 import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
@@ -48,6 +38,13 @@ import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.event.OptionsChangedEvent;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static mekhq.MHQConstants.FORTRESS_REPUBLIC;
 
 /**
  * @author Neoancient
@@ -191,7 +188,7 @@ public class RandomFactionGenerator {
             if (f.isClan() || FactionHints.isEmptyFaction(f)) {
                 continue;
             }
-            if (f.getShortName().equals("ROS") && getCurrentDate().isAfter(MHQConstants.FORTRESS_REPUBLIC)) {
+            if (f.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
                 continue;
             }
 
@@ -340,6 +337,11 @@ public class RandomFactionGenerator {
                     || enemy.getShortName().equals("CLAN")) {
                 continue;
             }
+
+            if (enemy.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
+                continue;
+            }
+
             int totalCount = borderTracker.getBorderSystems(employer, enemy).size();
             double count = totalCount;
             // Split the border between main controlling faction and any contained factions.
@@ -349,6 +351,11 @@ public class RandomFactionGenerator {
                                 employer, getCurrentDate())) {
                     continue;
                 }
+
+                if (cFaction.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
+                    continue;
+                }
+
                 if (factionHints.isNeutral(cFaction, enemy, getCurrentDate())
                         || factionHints.isNeutral(enemy, cFaction, getCurrentDate())) {
                     continue;
@@ -377,7 +384,7 @@ public class RandomFactionGenerator {
             if (!f.isClan() && !FactionHints.isEmptyFaction(f)) {
                 set.add(f.getShortName());
             }
-            if (f.getShortName().equals("ROS") && getCurrentDate().isAfter(MHQConstants.FORTRESS_REPUBLIC)) {
+            if (f.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
                 continue;
             }
             /* Add factions which do not control any planets to the employer list */


### PR DESCRIPTION
- Updated conditional logic to consistently exclude the ROS faction after the FORTRESS_REPUBLIC date.
- Added error handling in `AtBDynamicScenarioFactory`:
  - Logged an error and set a fallback faction if the faction code is blank.
  - Logged an error and aborted force generation if the faction is null.

### Dev Notes
I stumbled onto this completely by accident. But basically, ROS isn't a valid employer or enemy once the Wall goes up. However, there was a single missed instance where the Republic _could_ still be chosen as an enemy. However, because it wasn't valid the faction would be `null` resulting in a bunch of unfortunate weirdness.

While investigating this I also added some null faction protection to force generation.

Marking this as 'high' as this issue is most prevalent in ilClan, the current era.