### PR TITLE
Fix 6267: Set each entity starting position explicitly

### DIFF
--- a/MekHQ/src/mekhq/AtBGameThread.java
+++ b/MekHQ/src/mekhq/AtBGameThread.java
@@ -739,6 +739,7 @@ public class AtBGameThread extends GameThread {
             entity.setOwner(botClient.getLocalPlayer());
             String fName = String.format(forceName, lanceName, forceIdLance);
             entity.setForceString(fName);
+            entity.setStartingPos(botForce.getStartingPos());
             entities.add(entity);
             i++;
 


### PR DESCRIPTION
Fixes bug where opfor units might deploy with "any" deployment zone instead of the zone specified for their owner's force in the scenario.

Testing:
- Ran all three projects' unit tests
- Started various scenarios and confirmed units were set to the correct deployment zones and actually deployed there.

Close #6267 