### PR TITLE
Fixed Unique Interaction when Loading Player Campaigns with Custom Rank Systems

### DIFF
--- a/MekHQ/src/mekhq/gui/panes/RankSystemsPane.java
+++ b/MekHQ/src/mekhq/gui/panes/RankSystemsPane.java
@@ -53,8 +53,8 @@ import javax.swing.GroupLayout.Alignment;
 import javax.swing.table.TableColumn;
 import java.awt.*;
 import java.io.File;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 
 public class RankSystemsPane extends AbstractMHQScrollPane {
     private static final MMLogger logger = MMLogger.create(RankSystemsPane.class);
@@ -519,10 +519,8 @@ public class RankSystemsPane extends AbstractMHQScrollPane {
     // endregion Button Actions
 
     public void applyToCampaign() {
-        if (isChanged()) {
-            exportUserDataRankSystems(false);
-            Ranks.reinitializeRankSystems(getCampaign());
-            getCampaign().setRankSystem(getSelectedRankSystem());
-        }
+        exportUserDataRankSystems(false);
+        Ranks.reinitializeRankSystems(getCampaign());
+        getCampaign().setRankSystem(getSelectedRankSystem());
     }
 }


### PR DESCRIPTION
- Removed redundant `isChanged()` check in `applyToCampaign()` method.

### Dev Notes
This addresses a weird interaction that can occur when working with user campaigns that use a custom rank system. I've included a summary of the interaction below:

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/a868bbf1-01da-44df-bde7-79986c045874" />
