### PR TITLE
Increased Minimum Skill Requirement For Replacement Limb Procedures to Match RAW

### DIFF
--- a/MekHQ/resources/mekhq/resources/ReplacementLimbDialog.properties
+++ b/MekHQ/resources/mekhq/resources/ReplacementLimbDialog.properties
@@ -26,7 +26,7 @@ message.inCharacter.insufficientFunds={0}, I''ve reviewed the request for replac
   \ time. The cost of surgery is approximately {2} C-Bills, including any additional fees for a\
   \ specialist if required.
 
-message.ooc=Performing this procedure requires a Doctor with at least Level 4 in the <i>Doctor</i>\
+message.ooc=Performing this procedure requires a Doctor with at least {0}+ in the <i>Doctor</i>\
   \ skill. If no suitable character is available, you can hire a specialist while planetside. This\
   \ increases the cost of surgery tenfold.\
   <p>While a character is recovering from surgery, all missing limb penalties will be doubled.\

--- a/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/mod/am/InjuryTypes.java
@@ -69,7 +69,7 @@ public final class InjuryTypes {
     public static final InjuryType SEVERED_SPINE = new InjuryTypes.SeveredSpine();
 
     // Replacement Limbs
-    public static int REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5 = 4;
+    public static int REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5 = 5;
     public static Money REPLACEMENT_LIMB_COST_ARM_TYPE_5 = Money.of(200000);
     public static Money REPLACEMENT_LIMB_COST_HAND_TYPE_5 = Money.of(100000);
     public static Money REPLACEMENT_LIMB_COST_LEG_TYPE_5 = Money.of(125000);

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1266,7 +1266,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             if (person.isDoctor()) {
                 Skill skill = person.getSkill(S_DOCTOR);
 
-                if (skill != null && skill.getLevel() >= REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5) {
+                if (skill != null && skill.getFinalSkillValue() >= REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5) {
                     suitableDoctors.add(person);
                 }
             }

--- a/MekHQ/src/mekhq/gui/dialog/ReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ReplacementLimbDialog.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
+import static mekhq.campaign.mod.am.InjuryTypes.REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
@@ -64,7 +65,8 @@ public class ReplacementLimbDialog extends MHQDialogImmersive {
               createInCharacterMessage(campaign.getLocation().isOnPlanet(), !suitableDoctors.isEmpty(),
                     campaign.getCommanderAddress(false), patient, cost, campaign.getFunds().isGreaterOrEqualThan(cost)),
               createButtons(!suitableDoctors.isEmpty(), campaign.getLocation().isOnPlanet(), campaign.getFunds().isGreaterOrEqualThan(cost)),
-              getFormattedTextAt(RESOURCE_BUNDLE, "message.ooc"), null, false);
+              getFormattedTextAt(RESOURCE_BUNDLE, "message.ooc", REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5),
+              null, false);
     }
 
     /**


### PR DESCRIPTION
- Updated the minimum Doctor skill level required for 'Replacement Limb Types 3, 4, and 5' from to total 5+.
- Adjusted related logic in `PersonnelTableMouseAdapter` to use the `getFinalSkillValue` method for accurate skill evaluation.
- Refactored `ReplacementLimbDialog` to dynamically inject the new skill level requirement into the message description.
- Adjusted the message text in `ReplacementLimbDialog.properties` to make the skill level requirement configurable.