### PR TITLE
Added Handling for When Unit Quality is Manually Set to Empty or `null` Quality

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -216,6 +216,10 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                     "Set Quality", JOptionPane.PLAIN_MESSAGE, null, possibilities,
                     PartQuality.QUALITY_D.toName(reverse));
 
+            if (quality == null || quality.isBlank()) {
+                return;
+            }
+
             PartQuality q = PartQuality.fromName(quality, reverse);
             for (Unit unit : units) {
                 if (null != unit) {


### PR DESCRIPTION
- Prevented `NullPointerException` by adding a check for null or blank input when setting the quality level.
- Ensures the method exits early if the user provides invalid input.

Fix Sentry `bbf5a2e3b53b4d488bb199996c7759a1`