### PR TITLE
Added Specific Handling for Legacy Prisoner Capture Styles

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/enums/PrisonerCaptureStyle.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/enums/PrisonerCaptureStyle.java
@@ -27,6 +27,8 @@
  */
 package mekhq.campaign.randomEvents.prisoners.enums;
 
+import megamek.logging.MMLogger;
+
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
@@ -107,6 +109,42 @@ public enum PrisonerCaptureStyle {
         return this == MEKHQ;
     }
     //endregion Boolean Comparison Methods
+
+    // region File I/O
+    /**
+     * Converts the specified string into its corresponding {@link PrisonerCaptureStyle} enum value.
+     * The method attempts to interpret the string as either the name of an enum constant or an
+     * ordinal value of the enum. If the conversion fails, the method logs an error and returns the
+     * default value {@code NONE}.
+     *
+     * @param text the string to be converted into a {@link PrisonerCaptureStyle} enum value. It can
+     *            be the name of the enum constant or its ordinal value as a string.
+     * @return the corresponding {@link PrisonerCaptureStyle} enum constant if the string matches a
+     * name or ordinal value, otherwise {@code NONE}.
+     */
+    public static PrisonerCaptureStyle fromString(String text) {
+        MMLogger logger = MMLogger.create(PrisonerCaptureStyle.class);
+
+        try {
+            return PrisonerCaptureStyle.valueOf(text.toUpperCase().replace(" ", "_"));
+        } catch (Exception ignored) {}
+
+        try {
+            return PrisonerCaptureStyle.values()[Integer.parseInt(text)];
+        } catch (Exception ignored) {}
+
+        // <50.04 compatibility handler
+        if (text.equalsIgnoreCase("ATB") || text.equalsIgnoreCase("TAHARQA")) {
+            // We return NONE here as both CAMPAIGN_OPERATIONS and MEKHQ are significant departures
+            // from either legacy option.
+            logger.info("Legacy PrisonerCaptureStyle ordinal: {} - returning {}.", text, NONE);
+            return NONE;
+        }
+
+        logger.error("Unknown PrisonerCaptureStyle ordinal: {} - returning {}.", text, NONE);
+
+        return NONE;
+    }
 
     /**
      * Converts the capture style to a localized label for display.


### PR DESCRIPTION
- Implemented a conversion method to map strings to `PrisonerCaptureStyle` enum values.
- Added handling for both enum constant names and ordinal values, with compatibility for legacy options.
- Logged errors and information for unknown or legacy values to improve debuggability.

### Dev Notes
This will prevent a barrage of Sentry errors telling us these enums no longer exist. It also adds more robust on-load parsing of this enum from campaign options.