### PR TITLE
Updated Label Texts for Clarity in Campaign Options IIC

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -488,10 +488,10 @@ lblUseTimeInRank.tooltip=Track the amount of time an active person has had their
 lblTimeInRankDisplayFormat.text=Display Time in Rank
 lblTimeInRankDisplayFormat.tooltip=This is the format used to display the length the person has\
   \ spent in their current rank.
-lblTrackTotalEarnings.text=Track Total Earnings
+lblTrackTotalEarnings.text=Track Total C-Bill Earnings
 lblTrackTotalEarnings.tooltip=This tracks the total amount earned by personnel. The tracking is\
   \ only done when this option is enabled, and it is not backfilled.
-lblTrackTotalXPEarnings.text=Display Total Earnings
+lblTrackTotalXPEarnings.text=Track Total XP Earnings
 lblTrackTotalXPEarnings.tooltip=This tracks the total amount of experience earned by personnel. The\
   \ tracking is only done when this option is enabled, and it is not backfilled.
 lblShowOriginFaction.text=Display Origin Faction


### PR DESCRIPTION
- Revised `lblTrackTotalEarnings.text` to specify "C-Bill" for clearer context.
- Updated `lblTrackTotalXPEarnings.text` to emphasize "Track" instead of "Display" for consistency with functionality.

Fix #5977