### PR TITLE
Changed Filter Panel to Display by Default in Interstellar Map Panel

### DIFF
--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -122,7 +122,7 @@ public class InterstellarMapPanel extends JPanel {
         systems = campaign.getSystems();
         hqview = view;
         jumpPath = new JumpPath();
-        optionPanelHidden = true;
+        optionPanelHidden = false;
         optionPanelTimer = new Timer(50, new ActionListener() {
             Point viewPoint = new Point();
 


### PR DESCRIPTION
- Changed `optionPanelHidden` from `true` to `false`, making the option panel visible by default in `InterstellarMapPanel`.
- Adjusts the initial behavior of the map interface for improved user experience.

### Dev Notes
This is the little blue button in the bottom-right corner of the map display. All this PR does is change the display from being minimized by default, to being expanded. I imagine there are more than a few players who aren't aware those filters exist and some of them are pretty important (or will be) - Hiring Hall display, for example.