### PR TITLE
Removed Timer Delay for Filter Panel in Interstellar Map Tab

### DIFF
--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -123,7 +123,7 @@ public class InterstellarMapPanel extends JPanel {
         hqview = view;
         jumpPath = new JumpPath();
         optionPanelHidden = true;
-        optionPanelTimer = new Timer(50, new ActionListener() {
+        optionPanelTimer = new Timer(0, new ActionListener() {
             Point viewPoint = new Point();
 
             @Override


### PR DESCRIPTION
- Changed the `optionPanelTimer` delay value from 50 to 0 in `InterstellarMapPanel.java`.
- Likely improves responsiveness of the option panel functionality.

### Dev Notes
This affects the little blue filters tab in the bottom-right of the Interstellar Map Tab. When clicked the panel will expand and contract. Previously we were waiting 50ms per expansion/contraction step. This made the process feel very laggy and non-responsive. This PR changes that so there is no delay between steps, making the whole thing feel _much_ smoother.