### PR TITLE
Added Employer Modifiers to Contract Negotiations

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -706,23 +706,18 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         Faction employerFaction = contract.getEmployerFaction();
 
         if (employerFaction.isISMajorOrSuperPower()) {
-            mods.mods[CLAUSE_SALVAGE] += -1;
+            mods.mods[CLAUSE_SALVAGE] -= 1;
             mods.mods[CLAUSE_TRANSPORT] += 1;
-        }
-        if (employerFaction.isMinorPower()) {
-            mods.mods[CLAUSE_SALVAGE] += -2;
-        }
-        if (employerFaction.isMercenary()) {
-            mods.mods[CLAUSE_COMMAND] += -1;
+        } else if (employerFaction.isMinorPower()) {
+            mods.mods[CLAUSE_SALVAGE] -= 2;
+        } else if (employerFaction.isMercenary()) {
+            mods.mods[CLAUSE_COMMAND] -= 1;
             mods.mods[CLAUSE_SALVAGE] += 2;
             mods.mods[CLAUSE_SUPPORT] += 1;
             mods.mods[CLAUSE_TRANSPORT] += 1;
-        }
-        if (employerFaction.equals("IND")) {
-            mods.mods[CLAUSE_COMMAND] += 0;
-            mods.mods[CLAUSE_SALVAGE] += -1;
-            mods.mods[CLAUSE_SUPPORT] += -1;
-            mods.mods[CLAUSE_TRANSPORT] += 0;
+        } else if (employerFaction.getShortName().equals("IND")) {
+            mods.mods[CLAUSE_SALVAGE] -= 1;
+            mods.mods[CLAUSE_SUPPORT] -= 1;
         }
 
         int modifier = getEmployerNegotiatorModifier(employerFaction);

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -30,7 +30,6 @@ package mekhq.campaign.market.contractMarket;
 
 import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
-import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -53,6 +52,10 @@ import java.util.Set;
 import static java.lang.Math.floor;
 import static megamek.codeUtilities.MathUtility.clamp;
 import static megamek.common.Compute.d6;
+import static megamek.common.enums.SkillLevel.ELITE;
+import static megamek.common.enums.SkillLevel.GREEN;
+import static megamek.common.enums.SkillLevel.REGULAR;
+import static megamek.common.enums.SkillLevel.VETERAN;
 import static mekhq.campaign.mission.AtBContract.getEffectiveNumUnits;
 import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
 
@@ -331,7 +334,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         setEnemyRating(contract, campaign.getGameYear());
 
         if (contract.getContractType().isCadreDuty()) {
-            contract.setAllySkill(SkillLevel.GREEN);
+            contract.setAllySkill(GREEN);
             contract.setAllyQuality(IUnitRating.DRAGOON_F);
         }
 
@@ -415,7 +418,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         setEnemyRating(contract, campaign.getGameYear());
 
         if (contract.getContractType().isCadreDuty()) {
-            contract.setAllySkill(SkillLevel.GREEN);
+            contract.setAllySkill(GREEN);
             contract.setAllyQuality(IUnitRating.DRAGOON_F);
         }
         contract.calculateLength(campaign.getCampaignOptions().isVariableContractLength());
@@ -700,25 +703,33 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
             mods.mods[i] += missionMods[contract.getContractType().ordinal()][i];
         }
 
-        if (Factions.getInstance().getFaction(contract.getEmployerCode()).isISMajorOrSuperPower()) {
+        Faction employerFaction = contract.getEmployerFaction();
+
+        if (employerFaction.isISMajorOrSuperPower()) {
             mods.mods[CLAUSE_SALVAGE] += -1;
             mods.mods[CLAUSE_TRANSPORT] += 1;
         }
-        if (AtBContract.isMinorPower(contract.getEmployerCode())) {
+        if (employerFaction.isMinorPower()) {
             mods.mods[CLAUSE_SALVAGE] += -2;
         }
-        if (contract.getEmployerFaction().isMercenary()) {
+        if (employerFaction.isMercenary()) {
             mods.mods[CLAUSE_COMMAND] += -1;
             mods.mods[CLAUSE_SALVAGE] += 2;
             mods.mods[CLAUSE_SUPPORT] += 1;
             mods.mods[CLAUSE_TRANSPORT] += 1;
         }
-        if (contract.getEmployerCode().equals("IND")) {
+        if (employerFaction.equals("IND")) {
             mods.mods[CLAUSE_COMMAND] += 0;
             mods.mods[CLAUSE_SALVAGE] += -1;
             mods.mods[CLAUSE_SUPPORT] += -1;
             mods.mods[CLAUSE_TRANSPORT] += 0;
         }
+
+        int modifier = getEmployerNegotiatorModifier(employerFaction);
+        mods.mods[CLAUSE_COMMAND] -= modifier;
+        mods.mods[CLAUSE_SALVAGE] -= modifier;
+        mods.mods[CLAUSE_SUPPORT] -= modifier;
+        mods.mods[CLAUSE_TRANSPORT] -= modifier;
 
         if (campaign.getFaction().isMercenary()) {
             rollCommandClause(contract, mods.mods[CLAUSE_COMMAND]);
@@ -729,5 +740,33 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                 campaign.getCampaignOptions().getContractMaxSalvagePercentage());
         rollSupportClause(contract, mods.mods[CLAUSE_SUPPORT]);
         rollTransportClause(contract, mods.mods[CLAUSE_TRANSPORT]);
+    }
+
+    /**
+     * Calculates the negotiation modifier for a contract based on the employer's faction type.
+     * The modifier reflects the negotiation capabilities of the employer, making it harder to
+     * achieve favorable results with more influential or powerful employers.
+     *
+     * <p>The negotiation modifier is determined as follows:
+     * <ul>
+     *   <li>Default: A "Green" modifier is used for most employers.</li>
+     *   <li>Major or superpower faction: A "Regular" modifier is applied.</li>
+     *   <li>Clan faction: A "Veteran" modifier is applied.</li>
+     *   <li>ComStar or Word of Blake (WoB): An "Elite" modifier is applied.</li>
+     * </ul>
+     *
+     * @param employerFaction The {@link Faction} that is performing the negotiation.
+     * @return An integer representing the negotiation modifier corresponding to the employer's capabilities.
+     */
+    private static int getEmployerNegotiatorModifier(Faction employerFaction) {
+        if (employerFaction.isMajorOrSuperPower()) {
+            return REGULAR.getExperienceLevel();
+        } else if (employerFaction.isClan()) {
+            return VETERAN.getExperienceLevel();
+        } else if (employerFaction.isComStarOrWoB()) {
+            return ELITE.getExperienceLevel();
+        }
+
+        return GREEN.getExperienceLevel();
     }
 }


### PR DESCRIPTION
- Consolidated skill level imports for cleaner code and to avoid fully qualified calls.
- Replaced `getEmployerCode()` and employer code string checks with `getEmployerFaction()` and `Faction` object methods for clarity and consistency.
- Added `getEmployerNegotiatorModifier` method to calculate negotiation modifiers based on employer faction type, incorporating new logic for faction-specific negotiation difficulty.
- Adjusted contract negotiation logic to include the newly calculated negotiation modifiers across relevant clauses (command, salvage, support, transport).

### Dev Notes
This was added by QA request. In short, all it does is add some negative modifiers to the contract clause rolls to simulate counter negotiations from the employer. While this doesn't move things in a strictly RAW direction, it is RAW influenced. Without these modifiers it becomes very easy for users to gravitate towards the best possible clauses.

I, personally, think this should be in 50.04. However, I leave that decision to greater minds.