### PR TITLE
Disabled Remove CVP and Remove SP Options if GM Mode is Disabled; Allowed GMs to Take SP and CVP into Negative

### DIFF
--- a/MekHQ/src/mekhq/gui/stratcon/CampaignManagementDialog.java
+++ b/MekHQ/src/mekhq/gui/stratcon/CampaignManagementDialog.java
@@ -71,8 +71,8 @@ public class CampaignManagementDialog extends JDialog {
                         StratconTrackState currentTrack, boolean gmMode) {
         currentCampaignState = campaignState;
 
-        btnRemoveCVP.setEnabled(currentCampaignState.getVictoryPoints() > 0);
-        btnGMRemoveSP.setEnabled(currentCampaignState.getSupportPoints() > 0);
+        btnRemoveCVP.setEnabled(gmMode);
+        btnGMRemoveSP.setEnabled(gmMode);
         btnGMAddVP.setEnabled(gmMode);
         btnGMAddSP.setEnabled(gmMode);
 


### PR DESCRIPTION
- Changed `btnRemoveCVP` and `btnGMRemoveSP` to enable based on `gmMode` instead of point counts.
- Ensured consistency in button enabling logic for GM mode in the Campaign Management Dialog.

### Dev Notes
This just ensures these options are only usable if GM Mode is enabled, while also allowing GMs to take CVP and SP into negative, should they wish.