### PR TITLE
Fixed Support Point Generation Soft Cap

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/SupportPointNegotiation.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/SupportPointNegotiation.java
@@ -156,7 +156,9 @@ public class SupportPointNegotiation {
             return;
         }
 
-        if (campaignState.getSupportPoints() >= maxSupportPoints) {
+        int currentSupportPoints = campaignState.getSupportPoints();
+
+        if (currentSupportPoints >= maxSupportPoints) {
             String pluralizer = (maxSupportPoints > 1) || (maxSupportPoints == 0) ? "s" : "";
 
             campaign.addReport(String.format(
@@ -172,7 +174,8 @@ public class SupportPointNegotiation {
 
         Iterator<Person> iterator = adminTransport.iterator();
 
-        while (iterator.hasNext() && negotiatedSupportPoints < maxSupportPoints) {
+        while (iterator.hasNext()
+              && ((negotiatedSupportPoints + currentSupportPoints) < maxSupportPoints)) {
             Person admin = iterator.next();
             int rollResult = Compute.d6(2);
 


### PR DESCRIPTION
- Introduced a local variable to store current support points for improved readability.
- Updated the condition in the `while` loop to account for both negotiated and current support points.

### Dev Notes
Basically if support points were 1+ below cap the player's Admin personnel would generate support points up to the current amount + the cap. Essentially allowing the player to negotiate above the intended soft cap, so long as they ended each week with at least 1 SP below the soft cap.

This likely contributed significantly to the sense that players had 'infinite' SP.

I've marked this as 'high' because improving the SP economics is a particular pain point in 50.03 and I've been working hard  to see it in a more stable state in 50.04.