### PR TITLE
Added Note About SP Spending in Reinforcement Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -75,9 +75,11 @@ reinforcementConfirmation.introduction=%s, I've run the numbers. If we reinforce
   \ likely to succeed than other forces.<br><br>
 reinforcementConfirmation.breakdown=<b>Breakdown</b><br>
 reinforcementConfirmation.breakdown.total=Target Number
-reinforcementConfirmation.addendum=For more information, please see 'Combat Teams, Roles, Training\
-  \ & Reinforcements.pdf'.\
-  <br>This can be found in 'MekHQ/Docs/Stratcon and Against the Bot'.
+reinforcementConfirmation.addendum=For each additional SP spent, after the first, the target number\
+  \ is reduced by 2.\
+  \
+  <p>For more information, please see 'Combat Teams, Roles, Training\
+  \ & Reinforcements.pdf'. This can be found in 'MekHQ/Docs/Stratcon and Against the Bot'.</p>
 reinforcementConfirmation.spinnerLabel=Support Points
 reinforcementConfirmation.spinnerLabel.tooltip=Each Support Point, after the first, will reduce the\
   \ target number by 2.


### PR DESCRIPTION
- Clarified the ooc text to specify how additional Support Points reduce the target number.

### Dev Notes
In 50.04 players are expected to need to spend more than 1 SP to guarantee reinforcements. The information about this was hidden in a tooltip. General design philosophy is moving away from using tooltips to communicate information. This PR just ensures that vital information is presented clearly to the player.