### PR TITLE
Issue 6302: Refit will now properly consider different qualities as "used for refit planning"

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -183,6 +183,7 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
         // don't just return with the first part if it is damaged
         return campaign.getWarehouse().streamSpareParts()
             .filter(MissingPart::isAvailableAsReplacement)
+            .filter(p -> !p.isUsedForRefitPlanning() || !refit)
             .reduce(null, (bestPart, part) -> {
                 if (isAcceptableReplacement(part, refit)) {
                     if (bestPart == null) {


### PR DESCRIPTION
Fixes one of the issues in #6302 - Refit will now properly consider items reserved for refit planning.