### PR TITLE
Corrected Resource Bundle Reference In `PrisonerRansomEventDialog`

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerRansomEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerRansomEventDialog.java
@@ -46,7 +46,7 @@ import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
  * messaging and allows the player to accept or decline the offer.</p>
  */
 public class PrisonerRansomEventDialog extends MHQDialogImmersive {
-    private static final String RESOURCE_BUNDLE = "mekhq.resources.PrisonerRansomEvent";
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.PrisonerEvents";
 
     /**
      * Creates a dialog to present a ransom offer for prisoners.


### PR DESCRIPTION
- Changed the resource bundle path from `mekhq.resources.PrisonerRansomEvent` to `mekhq.resources.PrisonerEvents` to correct or align with the proper resource file.
- Will resolve potential issues with missing references in prisoner ransom event dialogs.