### PR TITLE
Added Early Exit for Objective Determination Self-Correction Loop

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1529,6 +1529,7 @@ public class AtBDynamicScenarioFactory {
                     if (template.getForceName().equals(templateName)) {
                         forceTemplate = template;
                         scenario.getBotForceTemplates().put(force, forceTemplate);
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
- Added a `break` statement to stop unnecessary iterations after finding the correct force template.
- Improved performance and prevented potential overwrites by halting further template checks once a match is found.

### Dev Notes
The correction added in #6317 works perfectly fine, but paranoia called me to double-check everything before launch and I spotted that I missed an opportunity for an early exit. It's not needed, the size of the array we're looping through is tiny, but if it's worth doing, it's doing properly. Or however the saying goes.