### PR TITLE
Fixed MekHQ Throwing Meks into Low Altitude Scenarios

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -1128,23 +1128,23 @@ public class Force {
     }
 
     /**
-     * Determines whether a convoy consists solely of VTOL (Vertical Take-Off and Landing) or WIGE
+     * Determines whether a force consists solely of VTOL (Vertical Take-Off and Landing) or WIGE
      * (Wing in Ground Effect) units.
      *
-     * <p>This method evaluates the convoy by checking each unit to verify that all resolved units
+     * <p>This method evaluates the force by checking each unit to verify that all resolved units
      * are either VTOLs or WIGE units.</p>
      *
      * <p><strong>Behavior:</strong></p>
      * <ul>
-     *   <li>Retrieves all units in the convoy based on the {@code standardForcesOnly} flag.</li>
+     *   <li>Retrieves all units in the force based on the {@code standardForcesOnly} flag.</li>
      *   <li>Skips any unit that cannot be resolved (null entity).</li>
      *   <li>Returns {@code false} if any resolved unit is not categorized as a VTOL or WIGE unit.</li>
      *   <li>Returns {@code true} if all resolved units meet the VTOL or WIGE criteria.</li>
      * </ul>
      *
      * @param hangar             The {@link Hangar} instance from which to retrieve the {@link Unit}.
-     * @param standardForcesOnly A flag to filter and include only standard forces from the convoy.
-     * @return {@code true} if all resolved units in the convoy are VTOL or WIGE units, {@code false} otherwise.
+     * @param standardForcesOnly A flag to filter and include only standard forces from the force.
+     * @return {@code true} if all resolved units in the force are VTOL or WIGE units, {@code false} otherwise.
      */
     public boolean forceContainsOnlyVTOLForces(Hangar hangar, boolean standardForcesOnly) {
         for (UUID unitId : getAllUnits(standardForcesOnly)) {
@@ -1163,37 +1163,37 @@ public class Force {
     }
 
     /**
-     * Determines whether a convoy contains a majority of VTOL (Vertical Take-Off and Landing) or WIGE
+     * Determines whether a force contains a majority of VTOL (Vertical Take-Off and Landing) or WIGE
      * (Wing in Ground Effect) units.
      *
-     * <p>This method evaluates the convoy by calculating whether at least half of the resolved units
-     * in the convoy are categorized as VTOLs or WIGE units.</p>
+     * <p>This method evaluates the force by calculating whether at least half of the resolved units
+     * in the force are categorized as VTOLs or WIGE units.</p>
      *
      * <p><strong>Behavior:</strong></p>
      * <ul>
-     *   <li>Retrieves all units in the convoy based on the {@code standardForcesOnly} flag.</li>
+     *   <li>Retrieves all units in the force based on the {@code standardForcesOnly} flag.</li>
      *   <li>Counts the number of units categorized as airborne VTOL or WIGE.</li>
-     *   <li>Adjusts the total convoy size if unresolved (null) entities are skipped without counting
+     *   <li>Adjusts the total force size if unresolved (null) entities are skipped without counting
      *       them toward the total size.</li>
      *   <li>Stops counting early if a majority of VTOL or WIGE units is determined before evaluating
      *       all entities.</li>
      * </ul>
      *
      * @param hangar             The {@link Hangar} instance from which to retrieve the {@link Unit}.
-     * @param standardForcesOnly A flag to filter and include only standard forces from the convoy.
-     * @return {@code true} if VTOL or WIGE units constitute at least half of the resolved convoy units,
+     * @param standardForcesOnly A flag to filter and include only standard forces from the force.
+     * @return {@code true} if VTOL or WIGE units constitute at least half of the resolved force units,
      *         {@code false} otherwise.
      */
     public boolean forceContainsMajorityVTOLForces(Hangar hangar, boolean standardForcesOnly) {
         Vector<UUID> allUnits = getAllUnits(standardForcesOnly);
-        int convoySize = allUnits.size();
+        int forceSize = allUnits.size();
         int vtolCount = 0;
 
         for (UUID unitId : allUnits) {
             Entity entity = getEntityFromUnitId(hangar, unitId);
 
             if (entity == null) {
-                convoySize--;
+                forceSize--;
                 continue;
             }
 
@@ -1201,37 +1201,37 @@ public class Force {
                 vtolCount++;
             }
 
-            if (vtolCount >= convoySize / 2) {
+            if (vtolCount >= forceSize / 2) {
                 break;
             }
         }
 
-        return vtolCount >= floor((double) convoySize / 2);
+        return vtolCount >= floor((double) forceSize / 2);
     }
 
     /**
-     * Determines whether a convoy contains only aerospace or conventional fighters.
+     * Determines whether a force contains only aerospace or conventional fighters.
      *
-     * <p>This method checks all units in the convoy to confirm if they consist exclusively of aerial
+     * <p>This method checks all units in the force to confirm if they consist exclusively of aerial
      * units based on their type.</p>
      *
      * <p><strong>Behavior:</strong></p>
      * <ul>
-     *   <li>Filters the convoy's units based on the {@code standardForcesOnly} flag.</li>
-     *   <li>Iterates through all selected units in the convoy.</li>
+     *   <li>Filters the force's units based on the {@code standardForcesOnly} flag.</li>
+     *   <li>Iterates through all selected units in the force.</li>
      *   <li>Skips any unit that cannot be resolved (null entity).</li>
-     *   <li>If {@code excludeConventionalFighters} is {@code true} and the convoy contains any
+     *   <li>If {@code excludeConventionalFighters} is {@code true} and the force contains any
      *       conventional fighters, the method immediately returns {@code false}.</li>
-     *   <li>Returns {@code false} if any unit in the convoy is not an aerial unit (i.e., not an aerospace
+     *   <li>Returns {@code false} if any unit in the force is not an aerial unit (i.e., not an aerospace
      *       unit or conventional fighter).</li>
-     *   <li>Returns {@code true} if all units in the convoy meet the aerial unit criteria.</li>
+     *   <li>Returns {@code true} if all units in the force meet the aerial unit criteria.</li>
      * </ul>
      *
      * @param hangar                     The {@link Hangar} instance from which to retrieve the {@link Unit}.
-     * @param standardForcesOnly         A flag to filter and include only standard forces from the convoy.
+     * @param standardForcesOnly         A flag to filter and include only standard forces from the force.
      * @param excludeConventionalFighters A flag determining if conventional fighters should be excluded from
      *                                    the assessment.
-     * @return {@code true} if the convoy consists only of aerial units (respecting the provided filters),
+     * @return {@code true} if the force consists only of aerial units (respecting the provided filters),
      *         {@code false} otherwise.
      */
     public boolean forceContainsOnlyAerialForces(Hangar hangar, boolean standardForcesOnly,

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -446,7 +446,7 @@ public class AtBContract extends Contract {
             }
 
             for (UUID unitId : force.getAllUnits(true)) {
-                Entity entity = getEntityFromUnitId(campaign, unitId);
+                Entity entity = getEntityFromUnitId(campaign.getHangar(), unitId);
 
                 if (entity == null) {
                     continue;

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
@@ -65,9 +65,6 @@ import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_AMMO_TO
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_ARMOR_TONNAGE;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType.RESUPPLY_CONTRACT_END;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType.RESUPPLY_LOOT;
-import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.forceContainsMajorityVTOLForces;
-import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.forceContainsOnlyAerialForces;
-import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.forceContainsOnlyVTOLForces;
 import static mekhq.campaign.stratcon.StratconContractInitializer.getUnoccupiedCoords;
 import static mekhq.campaign.stratcon.StratconRulesManager.generateExternalScenario;
 import static mekhq.gui.dialog.resupplyAndCaches.DialogItinerary.itineraryDialog;
@@ -371,7 +368,7 @@ public class PerformResupply {
             convoyWeight += npcConvoyWeight;
         } else {
             for (UUID unitId : playerConvoy.getAllUnits(false)) {
-                Entity entity = getEntityFromUnitId(campaign, unitId);
+                Entity entity = getEntityFromUnitId(campaign.getHangar(), unitId);
 
                 if (entity == null) {
                     continue;
@@ -426,7 +423,8 @@ public class PerformResupply {
             }
 
             // Non-ground convoys don't get roleplay events
-            if (forceContainsOnlyVTOLForces(campaign, convoy) || forceContainsOnlyAerialForces(campaign, convoy)) {
+            if (convoy.forceContainsOnlyVTOLForces(campaign.getHangar(), false)
+                  || convoy.forceContainsOnlyAerialForces(campaign.getHangar(), false, false)) {
                 completeSuccessfulDelivery(resupply, convoyContents);
                 return;
             }
@@ -509,9 +507,11 @@ public class PerformResupply {
         String templateAddress = GENERIC;
 
         if (targetConvoy != null) {
-            if (forceContainsOnlyAerialForces(campaign, targetConvoy)) {
+            if (targetConvoy.forceContainsOnlyAerialForces(campaign.getHangar(), false,
+                  false)) {
                 templateAddress = PLAYER_AEROSPACE_CONVOY;
-            } else if (forceContainsMajorityVTOLForces(campaign, targetConvoy)) {
+            } else if (targetConvoy.forceContainsMajorityVTOLForces(campaign.getHangar(),
+                  false)) {
                 templateAddress = PLAYER_VTOL_CONVOY;
             } else {
                 templateAddress = PLAYER_CONVOY;

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -407,7 +407,7 @@ public class Resupply {
             }
 
             for (UUID unitId : force.getAllUnits(true)) {
-                Entity entity = getEntityFromUnitId(campaign, unitId);
+                Entity entity = getEntityFromUnitId(campaign.getHangar(), unitId);
 
                 if (entity == null) {
                     continue;

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/ResupplyUtilities.java
@@ -28,7 +28,6 @@
 package mekhq.campaign.mission.resupplyAndCaches;
 
 import megamek.common.Compute;
-import megamek.common.Entity;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBContract;
@@ -39,9 +38,7 @@ import mekhq.campaign.unit.Unit;
 import mekhq.gui.dialog.resupplyAndCaches.DialogAbandonedConvoy;
 
 import java.util.UUID;
-import java.util.Vector;
 
-import static java.lang.Math.floor;
 import static java.lang.Math.max;
 import static mekhq.campaign.force.ForceType.CONVOY;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.CARGO_MULTIPLIER;
@@ -49,7 +46,6 @@ import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_AMMO_TO
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_ARMOR_TONNAGE;
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.calculateTargetCargoTonnage;
 import static mekhq.campaign.personnel.enums.PersonnelStatus.KIA;
-import static mekhq.utilities.EntityUtilities.getEntityFromUnitId;
 
 /**
  * Utility class for managing resupply operations and events in MekHQ campaigns.
@@ -163,81 +159,5 @@ public class ResupplyUtilities {
         // Armor and ammo are always delivered in blocks, so cargo will never be less than the sum
         // of those blocks
         return max(RESUPPLY_AMMO_TONNAGE + RESUPPLY_ARMOR_TONNAGE, (int) Math.ceil(targetTonnage));
-    }
-
-    /**
-     * Determines if a convoy only contains VTOL or similar units.
-     *
-     * @param campaign the {@link Campaign} instance the convoy belongs to.
-     * @param convoy   the {@link Force} representing the convoy to check.
-     * @return {@code true} if the convoy only contains VTOL units, {@code false} otherwise.
-     */
-    public static boolean forceContainsOnlyVTOLForces(Campaign campaign, Force convoy) {
-        for (UUID unitId : convoy.getAllUnits(false)) {
-            Entity entity = getEntityFromUnitId(campaign, unitId);
-
-            if (entity == null) {
-                continue;
-            }
-
-            if (!entity.isAirborneVTOLorWIGE()) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Determines if a convoy contains a majority of VTOL (or similar) units.
-     *
-     * <p>This is calculated by checking if at least half of the units are VTOLs or similarly
-     * airborne types.</p>
-     *
-     * @param campaign      the {@link Campaign} instance the convoy belongs to.
-     * @param convoy  the {@link Force} representing the convoy being evaluated.
-     * @return {@code true} if the VTOL units constitute at least half of the units, {@code false} otherwise.
-     */
-    public static boolean forceContainsMajorityVTOLForces(Campaign campaign, Force convoy) {
-        Vector<UUID> allUnits = convoy.getAllUnits(false);
-        int convoySize = allUnits.size();
-        int vtolCount = 0;
-
-        for (UUID unitId : convoy.getAllUnits(false)) {
-            Entity entity = getEntityFromUnitId(campaign, unitId);
-
-            if (entity == null) {
-                continue;
-            }
-
-            if (entity.isAirborneVTOLorWIGE()) {
-                vtolCount++;
-            }
-        }
-
-        return vtolCount >= floor((double) convoySize / 2);
-    }
-
-    /**
-     * Determines if a convoy only contains aerial units, such as aerospace or conventional fighters.
-     *
-     * @param campaign the {@link Campaign} instance the convoy belongs to.
-     * @param convoy   the {@link Force} representing the convoy to check.
-     * @return {@code true} if the convoy only contains aerial units, {@code false} otherwise.
-     */
-    public static boolean forceContainsOnlyAerialForces(Campaign campaign, Force convoy) {
-        for (UUID unitId : convoy.getAllUnits(false)) {
-            Entity entity = getEntityFromUnitId(campaign, unitId);
-
-            if (entity == null) {
-                continue;
-            }
-
-            if (!entity.isAerospace() && !entity.isConventionalFighter()) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonEscapeScenario.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonEscapeScenario.java
@@ -258,7 +258,8 @@ public class PrisonEscapeScenario {
         }
 
         List<Integer> availableForceIDs = getAvailableForceIDs(campaign, contract, false);
-        Map<MapLocation, List<Integer>> sortedAvailableForceIDs = sortForcesByMapType(availableForceIDs, campaign);
+        Map<MapLocation, List<Integer>> sortedAvailableForceIDs = sortForcesByMapType(availableForceIDs,
+              campaign.getHangar(), campaign.getAllForces());
 
         int randomForceIndex = randomInt(availableForceIDs.size());
         int randomForceID = availableForceIDs.get(randomForceIndex);

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1713,7 +1713,7 @@ public class StratconRulesManager {
         boolean aerospaceOnly = false;
         if (airborneOnly) {
             aerospaceOnly = force.forceContainsOnlyAerialForces(hangar, false,
-                  false);
+                  true);
         }
 
         if (aerospaceOnly && (randomInt(3) == 0)) {
@@ -1953,7 +1953,7 @@ public class StratconRulesManager {
             aerospaceOnly = false;
             if (airborneOnly) {
                 aerospaceOnly = force.forceContainsOnlyAerialForces(hangar, false,
-                      false);
+                      true);
             }
 
             if (aerospaceOnly) {

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -873,8 +873,8 @@ public final class BriefingTab extends CampaignGuiTab {
                     }
                 }
 
-                AtBDynamicScenarioFactory.setDeploymentTurnsForReinforcements(getCampaign(), scenario,
-                      reinforcementEntities, cmdrStrategy);
+                AtBDynamicScenarioFactory.setDeploymentTurnsForReinforcements(getCampaign().getHangar(),
+                      scenario, reinforcementEntities, cmdrStrategy);
             }
         }
 

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogInterception.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogInterception.java
@@ -41,8 +41,6 @@ import java.util.ResourceBundle;
 import java.util.UUID;
 
 import static megamek.common.Compute.randomInt;
-import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.forceContainsOnlyAerialForces;
-import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.forceContainsOnlyVTOLForces;
 import static mekhq.gui.baseComponents.MHQDialogImmersive.getSpeakerDescription;
 import static mekhq.gui.baseComponents.MHQDialogImmersive.getSpeakerIcon;
 import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
@@ -155,8 +153,9 @@ public class DialogInterception extends JDialog{
         String message = "";
 
         if (targetConvoy != null) {
-            if (forceContainsOnlyVTOLForces(campaign, targetConvoy)
-                || forceContainsOnlyAerialForces(campaign, targetConvoy)) {
+            if (targetConvoy.forceContainsOnlyVTOLForces(campaign.getHangar(), false)
+                || targetConvoy.forceContainsOnlyAerialForces(campaign.getHangar(), false,
+                  false)) {
                 message = getFormattedTextAt(RESOURCE_BUNDLE, "statusUpdateIntercepted.boilerplate",
                         campaign.getCommanderAddress(false),
                     getFormattedTextAt(RESOURCE_BUNDLE,"interceptionInstructions.text"));

--- a/MekHQ/src/mekhq/utilities/EntityUtilities.java
+++ b/MekHQ/src/mekhq/utilities/EntityUtilities.java
@@ -31,6 +31,7 @@ import megamek.common.Entity;
 import megamek.common.UnitType;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.Hangar;
 import mekhq.campaign.unit.Unit;
 
 import java.util.UUID;
@@ -46,13 +47,13 @@ public class EntityUtilities {
      * unit ID. If the unit exists, the method returns the associated {@link Entity}. If the unit
      * does not exist or has no associated entity, the method returns {@code null}.
      *
-     * @param campaign The {@link Campaign} instance from which to retrieve the {@link Unit}.
+     * @param hangar The {@link Hangar} instance from which to retrieve the {@link Unit}.
      * @param unitID The {@link UUID} of the unit for which the associated {@link Entity} is requested.
      * @return The {@link Entity} associated with the specified unit ID, or {@code null} if the unit
      *         is not found or has no associated entity.
      */
-    public static @Nullable Entity getEntityFromUnitId(Campaign campaign, UUID unitID) {
-        Unit unit = campaign.getUnit(unitID);
+    public static @Nullable Entity getEntityFromUnitId(Hangar hangar, UUID unitID) {
+        Unit unit = hangar.getUnit(unitID);
 
         if (unit == null) {
             return null;


### PR DESCRIPTION
- Moved VTOL and aerial force utility methods from `ResupplyUtilities` to the `Force` class for better cohesion and encapsulation.
- Replaced `Campaign` references with `Hangar` in force resolution methods to improve decoupling and maintainability.
- Simplified deployment logic and aerial/VTOL determination logic in relevant classes by centralizing functionality in `Force`.
- Updated force sorting logic to improve handling of map types, including better differentiation for airborne and aerospace forces.
- Enhanced error handling to log missing force entries when accessing by ID.

Fix #6315

### Dev Notes
This does three things:
- It moves the various 'does this force contain x' utility methods out of resupplies and into force, so they're more accessible. It also tidies them up a bit so they're more universally useful, rather than being specific to resupply's use case.
- It addresses uses of 'primary unit type', when determining interception scenario type, to instead use the above utility methods so that we're ensuring that forces can only be deployed to scenarios where all units in the force are appropriate for that map type.
- It also updates how we handle Integrated contracts to use the same checks and balances. This will remove the risk we previously had where if a force contains a majority of aerospace units, but also contained a couple of meks (or conventional fighters) the force could still be deployed to a Space scenario with predictably disastrous results.
