### PR TITLE
Corrected Dependent Arrival Reporting

### DIFF
--- a/MekHQ/resources/mekhq/resources/RandomDependents.properties
+++ b/MekHQ/resources/mekhq/resources/RandomDependents.properties
@@ -1,2 +1,2 @@
-dependentJoinsForce.report={0} has started traveling with the force as a {1}.
+dependentJoinsForce.report={0} has started traveling with the force as a Dependent.
 dependentLeavesForce.report={0} {1, choice, 0#Dependents|1#Dependent|2#Dependents} have left the force.

--- a/MekHQ/src/mekhq/campaign/personnel/RandomDependents.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RandomDependents.java
@@ -263,10 +263,8 @@ public class RandomDependents {
 
                     campaign.recruitPerson(dependent, FREE, true, false);
 
-                    String role = getFormattedTextAt(RESOURCE_BUNDLE, "dependent.singular");
-
                     campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE, "dependentJoinsForce.report",
-                        dependent.getFullName(), role));
+                        dependent.getFullName()));
 
                     dependentCount++;
                 }


### PR DESCRIPTION
- Removed dynamic role assignment for dependents, defaulting to "Dependent" in join force reports.
- Updated resource properties to reflect the simplified role reporting.
- Streamlined code by eliminating unnecessary role variable.

Fix #6329