### PR TITLE
Fixed Prisoners Check Logic in NagController

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -27,18 +27,18 @@
  */
 package mekhq.gui.dialog.nagDialogs;
 
+import static mekhq.campaign.personnel.turnoverAndRetention.RetirementDefectionTracker.getAdministrativeStrainModifier;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.finances.Finances;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
-
-import java.time.LocalDate;
-import java.util.Collection;
-import java.util.List;
-
-import static mekhq.campaign.personnel.turnoverAndRetention.RetirementDefectionTracker.getAdministrativeStrainModifier;
 
 /**
  * A controller class responsible for managing and triggering daily nag dialogs in the campaign.
@@ -204,7 +204,7 @@ public class NagController {
 
         // Prisoners of War
         final boolean hasActiveContract = campaign.hasActiveContract();
-        final boolean hasPrisoners = campaign.getCurrentPrisoners().isEmpty();
+        final boolean hasPrisoners = !campaign.getCurrentPrisoners().isEmpty();
 
         if (PrisonersNagDialog.checkNag(hasActiveContract, hasPrisoners)) {
             PrisonersNagDialog prisonersNagDialog = new PrisonersNagDialog(campaign);


### PR DESCRIPTION
- Corrected the logic to properly determine if there are prisoners (`isEmpty` to `!isEmpty`).
- Ensured the `PrisonersNagDialog` is displayed when there are current prisoners in an active contract.

Fix #6336

### Dev Notes
During development we had a weird situation where this dialog was triggering when prisoners weren't present. We went ahead and fixed the issue, and it was concluded to have just been faulty logic. Which, it turns out, was correct. Just not in the way we thought. This is now _definitely_ fixed. For realties this time.... I hope.