### PR TITLE
Updated Allied Air Garrison Spawn Location

### DIFF
--- a/MekHQ/data/scenariomodifiers/AlliedAirGarrison.xml
+++ b/MekHQ/data/scenariomodifiers/AlliedAirGarrison.xml
@@ -25,7 +25,8 @@
 		<maxWeightClass>4</maxWeightClass>
 		<retreatThreshold>75</retreatThreshold>
 		<startingAltitude>5</startingAltitude>
-		<syncDeploymentType>None</syncDeploymentType>
+		<syncDeploymentType>Opposite</syncDeploymentType>
+        <syncedForceName>Player</syncedForceName>
 		<useArtillery>false</useArtillery>
 	</forceDefinition>
 </AtBScenarioModifier>


### PR DESCRIPTION
- Changed `<syncDeploymentType>` from "None" to "Opposite" to adjust deployment behavior.
- Added `<syncedForceName>` with value "Player" to specify the linked force for synchronization.

Fix #6343

### Dev Notes
So this was working as intended, but I absolutely see the issues raised by OP. In particular, due to the size of the ground map, ASF starting in the center are liable to just fly off board on turn 1, making deploying them there somewhat redundant. Now they deploy opposite the player, ready to bomb their deployment zone. As Blake intended.