### PR TITLE
Fixed Fatigue Status Report Update Messages

### DIFF
--- a/MekHQ/resources/mekhq/resources/Fatigue.properties
+++ b/MekHQ/resources/mekhq/resources/Fatigue.properties
@@ -1,5 +1,5 @@
-fatigueTired.text=%s is %s<b>tired</b>%s and in need of a break.
-fatigueFatigued.text=%s is %s<b>badly fatigued</b>%s and in need of rest.
-fatigueExhausted.text=%s is %s<b>exhausted</b>%s and in desperate need of rest.
-fatigueCritical.text=%s is %s<b>critically fatigued</b>%s and should be immediately removed from active duty.
-fatigueRecovered.text=%s is %s<b>no longer fatigued</b>%s.
+fatigueTired.text={0} is {1}<b>tired</b>{2} and in need of a break.
+fatigueFatigued.text={0} is {1}<b>badly fatigued</b>{2} and in need of rest.
+fatigueExhausted.text={0} is {1}<b>exhausted</b>{2} and in desperate need of rest.
+fatigueCritical.text={0} is {1}<b>critically fatigued</b>{2} and should be immediately removed from active duty.
+fatigueRecovered.text={0} is {1}<b>no longer fatigued</b>{2}.


### PR DESCRIPTION
- Replaced `%s` placeholders with internationalization placeholders (`{0}`, `{1}`, `{2}`).

Fix #6357