### PR TITLE
Improved Immersive Dialog Behavior

### DIFF
--- a/MekHQ/resources/mekhq/resources/PrisonerEvents.properties
+++ b/MekHQ/resources/mekhq/resources/PrisonerEvents.properties
@@ -5,8 +5,9 @@ bondsref.report={0} has performed {0}<b>Bondsref</b>{1} instead of accepting cap
   \ Their body has been transported to the morgue.
 
 # EVENT GENERAL
-result.ooc=This situation was caused by low <a href=''GLOSSARY:PRISONER_CAPACITY''>Prisoner Capacity</a>.\
-  \ Consider hiring infantry units and assigning them to a <b>Security</b> force.
+result.ooc=Closing or canceling this conversation will automatically pick the first option.\
+  <p>This situation was caused by low <a href=''GLOSSARY:PRISONER_CAPACITY''>Prisoner Capacity</a>. Consider hiring\
+  \ infantry units and assigning them to a <b>Security</b> force.</p>
 
 successful.button=Understood
 failure.button=Unfortunate

--- a/MekHQ/src/mekhq/gui/baseComponents/MHQDialogImmersive.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/MHQDialogImmersive.java
@@ -27,6 +27,29 @@
  */
 package mekhq.gui.baseComponents;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static megamek.client.ui.WrapLayout.wordWrap;
+import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
+import static mekhq.campaign.force.Force.FORCE_NONE;
+import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Toolkit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkEvent.EventType;
+
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
@@ -37,22 +60,6 @@ import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.GlossaryDialog;
-
-import javax.swing.*;
-import javax.swing.event.HyperlinkEvent;
-import javax.swing.event.HyperlinkEvent.EventType;
-import java.awt.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
-import static java.lang.Math.max;
-import static java.lang.Math.min;
-import static megamek.client.ui.WrapLayout.wordWrap;
-import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
-import static mekhq.campaign.force.Force.FORCE_NONE;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * An immersive dialog used in MekHQ to display interactions between speakers,
@@ -85,7 +92,7 @@ public class MHQDialogImmersive extends JDialog {
     private JSpinner spinner;
     private int spinnerValue;
 
-    private int dialogChoice;
+    private int dialogChoice = 0;
 
     private static final MMLogger logger = MMLogger.create(MHQDialogImmersive.class);
 
@@ -124,17 +131,18 @@ public class MHQDialogImmersive extends JDialog {
 
     /**
      * Constructs and initializes an immersive dialog with configurable layouts, speakers, actions, and messages.
-     * <p>
-     * This dialog is designed to provide a rich, immersive interface featuring optional speakers on the
+     *
+     * <p>This dialog is designed to provide a rich, immersive interface featuring optional speakers on the
      * left and right, a central message panel with configurable width, a spinner panel, and a list of actionable buttons.
-     * An optional out-of-character message can also be displayed below the buttons.
+     * An optional out-of-character message can also be displayed below the buttons.</p>
      *
      * @param campaign The {@link Campaign} instance tied to the dialog, providing contextual information.
      * @param leftSpeaker Optional left-side {@link Person}; use {@code null} if no left speaker is present.
      * @param rightSpeaker Optional right-side {@link Person}; use {@code null} if no right speaker is present.
      * @param centerMessage The main {@link String} message displayed in the center panel of the dialog.
      * @param buttons A {@link List} of {@link ButtonLabelTooltipPair} instances representing actions available
-     *                in the dialog (displayed as buttons).
+     *                in the dialog (displayed as buttons). The default option is used if the user closes or cancels
+     *                the dialog.
      * @param outOfCharacterMessage An optional {@link String} message displayed below the buttons;
      *                               use {@code null} if not applicable.
      * @param centerWidth An optional width for the center panel; uses the default value if {@code null}.
@@ -222,7 +230,7 @@ public class MHQDialogImmersive extends JDialog {
         int screenWidth = screenSize.width;
         setSize(min(screenWidth, getWidth()), (int) min(getHeight(), screenHeight * 0.8));
 
-        setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
         setModal(isModal);
         setLocationRelativeTo(null); // Needs to be after pack
         setResizable(false);

--- a/MekHQ/src/mekhq/gui/dialog/MercenaryAuctionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MercenaryAuctionDialog.java
@@ -27,6 +27,19 @@
  */
 package mekhq.gui.dialog;
 
+import static mekhq.campaign.Campaign.AdministratorSpecialization.TRANSPORT;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.FlowLayout;
+import java.util.List;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkEvent.EventType;
+
 import megamek.client.ui.swing.MekViewPanel;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
@@ -35,15 +48,6 @@ import megamek.common.annotations.Nullable;
 import megamek.common.templates.TROView;
 import mekhq.campaign.Campaign;
 import mekhq.gui.baseComponents.MHQDialogImmersive;
-
-import javax.swing.*;
-import javax.swing.event.HyperlinkEvent;
-import javax.swing.event.HyperlinkEvent.EventType;
-import java.awt.*;
-import java.util.List;
-
-import static mekhq.campaign.Campaign.AdministratorSpecialization.TRANSPORT;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * A dialog for handling mercenary unit auctions in the campaign.
@@ -123,12 +127,12 @@ public class MercenaryAuctionDialog extends MHQDialogImmersive {
      * @return A {@link List} of {@link ButtonLabelTooltipPair} objects for the dialog.
      */
     private static List<ButtonLabelTooltipPair> createButtons() {
-        ButtonLabelTooltipPair btnConfirm = new ButtonLabelTooltipPair(
-              getFormattedTextAt(RESOURCE_BUNDLE, "confirm.button"), null);
         ButtonLabelTooltipPair btnCancel = new ButtonLabelTooltipPair(
               getFormattedTextAt(RESOURCE_BUNDLE, "cancel.button"), null);
+        ButtonLabelTooltipPair btnConfirm = new ButtonLabelTooltipPair(
+              getFormattedTextAt(RESOURCE_BUNDLE, "confirm.button"), null);
 
-        return List.of(btnConfirm, btnCancel);
+        return List.of(btnCancel, btnConfirm);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/MissionEndPrisonerDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MissionEndPrisonerDialog.java
@@ -27,18 +27,18 @@
  */
 package mekhq.gui.dialog;
 
+import static megamek.common.Compute.randomInt;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.baseComponents.MHQDialogImmersive;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static megamek.common.Compute.randomInt;
-import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 public class MissionEndPrisonerDialog extends MHQDialogImmersive {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.PrisonerEvents";
@@ -84,15 +84,15 @@ public class MissionEndPrisonerDialog extends MHQDialogImmersive {
                 || (isAllied && !isSuccess && isGoodEvent);
 
         if (isRansom) {
+            if (isAllied) {
+                ButtonLabelTooltipPair btnDecline = new ButtonLabelTooltipPair(getFormattedTextAt(RESOURCE_BUNDLE,
+                      "decline.button"), null);
+                buttons.add(btnDecline);
+            }
+
             ButtonLabelTooltipPair btnAccept = new ButtonLabelTooltipPair(getFormattedTextAt(RESOURCE_BUNDLE,
                 "accept.button"), null);
             buttons.add(btnAccept);
-
-            if (isAllied) {
-                ButtonLabelTooltipPair btnDecline = new ButtonLabelTooltipPair(getFormattedTextAt(RESOURCE_BUNDLE,
-                    "decline.button"), null);
-                buttons.add(btnDecline);
-            }
         }
 
         if (!isAllied) {


### PR DESCRIPTION
- Enhanced `MHQDialogImmersive` to define a default button option when dialog is closed or canceled.
- Adjusted the order of buttons in `MercenaryAuctionDialog` and `MissionEndPrisonerDialog` to align with this new functionality.
- Updated `PrisonerEvents.properties` to clarify 'cancel dialog' results.

### Dev Notes
Previously we disallowed users from canceling Immersive Dialogs. That made sense, from a developmental standpoint, but it created a poor play experience. I've gone through and confirmed all existing Immersive Dialogs will have expected behavior when the dialog is canceled. With this feature in place my next move will be to replace the nag dialogs with Immersive Dialogs.