### PR TITLE
Updated Untreated Injuries Nag Dialog to Account for AutoInfirmary

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -98,9 +98,11 @@ public class NagController {
         }
 
         final List<Person> activePersonnel = campaign.getActivePersonnel(false);
+        final CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        final int doctorCapacity = campaignOptions.getMaximumPatients();
 
         // Untreated personnel
-        if (UntreatedPersonnelNagDialog.checkNag(activePersonnel)) {
+        if (UntreatedPersonnelNagDialog.checkNag(activePersonnel, doctorCapacity)) {
             UntreatedPersonnelNagDialog untreatedPersonnelNagDialog = new UntreatedPersonnelNagDialog(campaign);
             if (untreatedPersonnelNagDialog.wasAdvanceDayCanceled()) {
                 return true;
@@ -135,7 +137,6 @@ public class NagController {
 
         // Unmaintained Units
         final Collection<Unit> units = campaign.getUnits();
-        final CampaignOptions campaignOptions = campaign.getCampaignOptions();
         final boolean isCheckMaintenance = campaignOptions.isCheckMaintenance();
 
         if (UnmaintainedUnitsNagDialog.checkNag(units, isCheckMaintenance)) {

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
@@ -27,15 +27,15 @@
  */
 package mekhq.gui.dialog.nagDialogs;
 
+import static mekhq.gui.dialog.nagDialogs.nagLogic.UntreatedPersonnelNagLogic.campaignHasUntreatedInjuries;
+
+import java.util.List;
+
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.baseComponents.AbstractMHQNagDialog;
-
-import java.util.List;
-
-import static mekhq.gui.dialog.nagDialogs.nagLogic.UntreatedPersonnelNagLogic.campaignHasUntreatedInjuries;
 
 /**
  * A nag dialog that alerts the user about untreated injuries within the campaign's personnel.
@@ -76,13 +76,14 @@ public class UntreatedPersonnelNagDialog extends AbstractMHQNagDialog {
      * </ul>
      *
      * @param activePersonnel A {@link List} of active personnel in the campaign.
-     * @return {@code true} if the nag dialog should be displayed due to untreated injuries,
-     *         {@code false} otherwise.
+     * @param doctorCapacity The maximum number of patients each doctor can medicate.
+     *
+     * @return {@code true} if the nag dialog should be displayed due to untreated injuries, {@code false} otherwise.
      */
-    public static boolean checkNag(List<Person> activePersonnel) {
+    public static boolean checkNag(List<Person> activePersonnel, int doctorCapacity) {
         final String NAG_KEY = MHQConstants.NAG_UNTREATED_PERSONNEL;
 
         return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && campaignHasUntreatedInjuries(activePersonnel);
+            && campaignHasUntreatedInjuries(activePersonnel, doctorCapacity);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/UntreatedPersonnelNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/UntreatedPersonnelNagLogic.java
@@ -27,9 +27,10 @@
  */
 package mekhq.gui.dialog.nagDialogs.nagLogic;
 
-import mekhq.campaign.personnel.Person;
-
 import java.util.List;
+
+import mekhq.MekHQ;
+import mekhq.campaign.personnel.Person;
 
 public class UntreatedPersonnelNagLogic {
     /**
@@ -46,12 +47,51 @@ public class UntreatedPersonnelNagLogic {
      * @param activePersonnel A {@link List} of active personnel in the campaign.
      * @return {@code true} if there are untreated injuries among the personnel, {@code false} otherwise.
      */
-    public static boolean campaignHasUntreatedInjuries(List<Person> activePersonnel) {
+    public static boolean campaignHasUntreatedInjuries(List<Person> activePersonnel, int doctorCapacity) {
+        // if we're automatically optimizing medical assignments, we only want to advance day if there are more
+        // patients than doctor capacity
+        if (MekHQ.getMHQOptions().getNewDayOptimizeMedicalAssignments()) {
+            return checkDoctorCapacity(activePersonnel, doctorCapacity);
+        }
+
+        // Otherwise, we only need to find the first unassigned patient.
         for (Person person : activePersonnel) {
             if (person.needsFixing() && person.getDoctorId() == null) {
                 return true;
             }
         }
+
         return false;
+    }
+
+    /**
+     * Checks if the current doctor capacity is sufficient to handle the patients needing attention.
+     *
+     * <p>This method iterates through a list of active personnel to count the number of patients
+     * (individuals who need fixing) and available doctor capacity. The available doctor capacity
+     * is calculated by multiplying the number of doctors by their individual capacity. The method
+     * returns whether the number of patients exceeds the calculated doctor capacity.</p>
+     *
+     * @param activePersonnel a list of {@link Person} objects representing the active personnel,
+     *                        including both patients and doctors.
+     * @param doctorCapacity the number of patients a single doctor can handle.
+     * @return {@code true} if the number of patients exceeds the total doctor capacity,
+     *         {@code false} otherwise.
+     */
+    private static boolean checkDoctorCapacity(List<Person> activePersonnel, int doctorCapacity) {
+        int patients = 0;
+        int doctors = 0;
+
+        for (Person person : activePersonnel) {
+            if (person.needsFixing()) {
+                patients++;
+            }
+
+            if (person.isDoctor()) {
+                doctors += doctorCapacity;
+            }
+        }
+
+        return patients > doctors;
     }
 }

--- a/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/UntreatedPersonnelNagLogicTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/UntreatedPersonnelNagLogicTest.java
@@ -27,8 +27,18 @@
  */
 package mekhq.gui.dialog.nagDialogs.nagLogic;
 
+import static mekhq.campaign.personnel.SkillType.S_DOCTOR;
+import static mekhq.campaign.personnel.enums.PersonnelRole.DOCTOR;
+import static mekhq.gui.dialog.nagDialogs.nagLogic.UntreatedPersonnelNagLogic.campaignHasUntreatedInjuries;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
 import megamek.common.EquipmentType;
 import megamek.logging.MMLogger;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
@@ -39,13 +49,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static mekhq.gui.dialog.nagDialogs.nagLogic.UntreatedPersonnelNagLogic.campaignHasUntreatedInjuries;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-
 /**
  * This class contains test methods for the {@link UntreatedPersonnelNagDialog} class.
  * It tests the different combinations of untreated personnel and verifies the behavior of the
@@ -55,6 +58,7 @@ class UntreatedPersonnelNagLogicTest {
     Campaign campaign;
     Person injuredPerson;
     Person uninjuredPerson;
+    Person doctor;
 
     /**
      * Sets up the necessary dependencies and configurations before running the test methods.
@@ -81,6 +85,9 @@ class UntreatedPersonnelNagLogicTest {
         injuredPerson = new Person(campaign);
         injuredPerson.setHits(1);
         uninjuredPerson = new Person(campaign);
+        doctor = new Person(campaign);
+        doctor.addSkill(S_DOCTOR, 5, 0);
+        doctor.setPrimaryRole(campaign, DOCTOR);
     }
 
     // In the following tests the isUntreatedInjury() method is called, and its response is checked
@@ -88,11 +95,23 @@ class UntreatedPersonnelNagLogicTest {
 
     @Test
     public void isUntreatedInjuryTest() {
-        assertTrue(campaignHasUntreatedInjuries(List.of(injuredPerson)));
+        assertTrue(campaignHasUntreatedInjuries(List.of(injuredPerson), 0));
     }
 
     @Test
     public void isNoUntreatedInjuryTest() {
-        assertFalse(campaignHasUntreatedInjuries(List.of(uninjuredPerson)));
+        assertFalse(campaignHasUntreatedInjuries(List.of(uninjuredPerson), 0));
+    }
+
+    @Test
+    public void isAboveDoctorThresholdTest() {
+        MekHQ.getMHQOptions().setNewDayOptimizeMedicalAssignments(true);
+        assertTrue(campaignHasUntreatedInjuries(List.of(injuredPerson), 0));
+    }
+
+    @Test
+    public void isBelowDoctorThresholdTest() {
+        MekHQ.getMHQOptions().setNewDayOptimizeMedicalAssignments(true);
+        assertFalse(campaignHasUntreatedInjuries(List.of(injuredPerson, doctor), 25));
     }
 }


### PR DESCRIPTION
- Integrated a check to determine if patients exceed available doctor capacity when automatic medical assignment optimization is enabled.
- Updated unit tests to cover scenarios for doctor capacity and optimized assignment logic.

Fix #6353

### Dev Notes
Nags are triggered prior to the new day action - so the player can interrupt new day advancement. However autoInfirmary runs _after_ the new day processes have started. This means the infirmary nag will trigger, to advise the player they have untended patients, but then the whole situation will be solved automatically if the player proceeds.

Now, if the player has autoInfirmary enabled they will only get the infirmary nag if the total number of patients exceeds the total capacity of the campaign's doctors.

**Note:** this nag still will **not** trigger if the outstanding patients are active prisoners. That behavior remains unchanged.