### PR TITLE
Updated BV Display in TO&E to Account for C3

### DIFF
--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -27,6 +27,21 @@
  */
 package mekhq.gui.view;
 
+import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffectiveFatigue;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.ResourceBundle;
+import java.util.UUID;
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextPane;
+
 import megamek.client.ui.Messages;
 import megamek.common.Entity;
 import megamek.common.UnitType;
@@ -42,15 +57,6 @@ import mekhq.campaign.unit.Unit;
 import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.utilities.MarkdownRenderer;
 import mekhq.utilities.ReportingUtilities;
-
-import javax.swing.*;
-import java.awt.*;
-import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.ResourceBundle;
-import java.util.UUID;
-
-import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffectiveFatigue;
 
 /**
  * A custom panel that gets filled in with goodies from a Force record
@@ -176,9 +182,10 @@ public class ForceViewPanel extends JScrollablePanel {
         }
 
         for (UUID uid : force.getAllUnits(false)) {
+            bv = force.getTotalBV(campaign, true);
+
             Unit u = campaign.getUnit(uid);
             if (null != u) {
-                bv += u.getEntity().calculateBattleValue(true, !u.hasPilot());
                 cost = cost.plus(u.getEntity().getCost(true));
                 ton += u.getEntity().getWeight();
                 String utype = UnitType.getTypeDisplayableName(u.getEntity().getUnitType());
@@ -548,7 +555,7 @@ public class ForceViewPanel extends JScrollablePanel {
 
     public String getForceSummary(Unit unit) {
         String toReturn = "<html><font size='4'><b>" + unit.getName() + "</b></font><br/>";
-        toReturn += "<font><b>BV:</b> " + unit.getEntity().calculateBattleValue(true, null == unit.getEntity().getCrew()) + "<br/>";
+        toReturn += "<font><b>BV:</b> " + unit.getEntity().calculateBattleValue() + "<br/>";
         toReturn += unit.getStatus();
         Entity entity = unit.getEntity();
         if (entity.hasNavalC3()) {


### PR DESCRIPTION
- Corrected the method used to calculate the Battle Value in the `ForceViewPanel` to replace redundant per-unit BV calculations with a single call to `force.getTotalBV()`.
- Updated BV calculation in the unit summary to account for C3.

Fix #6351

### Dev Notes
The original issue report stated that the deploy force dialog displayed the wrong BV, in fact it was actually force view. Force view wasn't factoring in C3, now it does.