### PR TITLE
Updated Date and Faction Handling in Campaign Options IIC

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -789,8 +789,10 @@ lblRandomizeAroundSpecifiedPlanet.text=Randomize Around Specific Planet
 lblRandomizeAroundSpecifiedPlanet.tooltip=Dependents have their origins randomized so that they do\
   \ not come from the current planet and the campaign's faction but instead have origins randomized\
   \ in the same way as standard personnel.
-lblSpecifiedSystemFactionSpecific.text=Faction Specific
-lblSpecifiedSystemFactionSpecific.tooltip=Limit the system options based on faction.
+lblSpecifiedSystemFactionSpecific.text=Faction Specific \u26A0
+lblSpecifiedSystemFactionSpecific.tooltip=Limit the system options based on faction.\
+  <br>\
+  <br><b>Warning:</b> Must be toggled off-and-on again if you change faction after enabling this option.
 lblSpecifiedSystem.text=System
 lblSpecifiedSystem.tooltip=This is the system from which to select the specified planet around\
   \ which origin planet and faction are randomized.

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -27,6 +27,20 @@
  */
 package mekhq.gui.campaignOptions;
 
+import static java.lang.Math.round;
+import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
+import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.ABRIDGED;
+import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP_ABRIDGED;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createSubTabs;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.ResourceBundle;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTabbedPane;
+
 import megamek.common.annotations.Nullable;
 import mekhq.CampaignPreset;
 import mekhq.MekHQ;
@@ -40,17 +54,6 @@ import mekhq.gui.baseComponents.AbstractMHQTabbedPane;
 import mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory;
 import mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode;
 import mekhq.gui.campaignOptions.contents.*;
-
-import javax.swing.*;
-import java.time.LocalDate;
-import java.util.Map;
-import java.util.ResourceBundle;
-
-import static java.lang.Math.round;
-import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
-import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.ABRIDGED;
-import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP_ABRIDGED;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createSubTabs;
 
 /**
  * The {@code CampaignOptionsPane} class represents a tabbed pane used for displaying
@@ -213,7 +216,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         personnelTab.loadValuesFromCampaignOptions();
 
         // Biography
-        biographyTab = new BiographyTab(campaign);
+        biographyTab = new BiographyTab(campaign, generalTab);
 
         JTabbedPane biographyContentTabs = createSubTabs(Map.of(
             "biographyGeneralTab", biographyTab.createGeneralTab(),

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -27,6 +27,21 @@
  */
 package mekhq.gui.campaignOptions.contents;
 
+import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
+import static megamek.common.options.OptionsConstants.ALLOWED_YEAR;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createGroupLayout;
+import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.time.LocalDate;
+import java.util.ResourceBundle;
+import javax.swing.*;
+import javax.swing.GroupLayout.Alignment;
+
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.dialogs.CamoChooserDialog;
 import megamek.client.ui.swing.util.UIUtil;
@@ -44,22 +59,17 @@ import mekhq.gui.baseComponents.AbstractMHQScrollablePanel;
 import mekhq.gui.baseComponents.AbstractMHQTabbedPane;
 import mekhq.gui.baseComponents.DefaultMHQScrollablePanel;
 import mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode;
-import mekhq.gui.campaignOptions.components.*;
+import mekhq.gui.campaignOptions.components.CampaignOptionsButton;
+import mekhq.gui.campaignOptions.components.CampaignOptionsCheckBox;
+import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
+import mekhq.gui.campaignOptions.components.CampaignOptionsHeaderPanel;
+import mekhq.gui.campaignOptions.components.CampaignOptionsLabel;
+import mekhq.gui.campaignOptions.components.CampaignOptionsSpinner;
+import mekhq.gui.campaignOptions.components.CampaignOptionsStandardPanel;
+import mekhq.gui.campaignOptions.components.CampaignOptionsTextField;
 import mekhq.gui.dialog.DateChooser;
 import mekhq.gui.dialog.iconDialogs.UnitIconDialog;
 import mekhq.gui.displayWrappers.FactionDisplay;
-
-import javax.swing.*;
-import javax.swing.GroupLayout.Alignment;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.time.LocalDate;
-import java.util.ResourceBundle;
-
-import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
-import static megamek.common.options.OptionsConstants.ALLOWED_YEAR;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createGroupLayout;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
 
 /**
  * Represents a tab within the campaign options UI that allows the user to configure
@@ -124,6 +134,29 @@ public class GeneralTab {
         this.mode = mode;
 
         initialize();
+    }
+
+    /**
+     * @return the currently selected date
+     */
+    public LocalDate getDate() {
+        return date;
+    }
+
+    /**
+     * Retrieves the currently selected faction.
+     *
+     * <p>If no faction is selected, the method defaults to returning the "MERC" faction.</p>
+     *
+     * @return the {@link Faction} object representing the selected faction, or the "MERC" faction if no selection is
+     * made.
+     */
+    public Faction getFaction() {
+        if (comboFaction.getSelectedItem() == null) {
+            return Factions.getInstance().getFaction("MERC");
+        } else {
+            return comboFaction.getSelectedItem().getFaction();
+        }
     }
 
     /**
@@ -371,7 +404,7 @@ public class GeneralTab {
         DefaultComboBoxModel<FactionDisplay> factionModel = new DefaultComboBoxModel<>();
 
         factionModel.addAll(FactionDisplay.getSortedValidFactionDisplays(
-            Factions.getInstance().getChoosableFactions(), campaign.getLocalDate()));
+            Factions.getInstance().getChoosableFactions(), date));
 
         return factionModel;
     }


### PR DESCRIPTION
- Added date and faction retrieval methods (`getDate` and `getFaction`) to `GeneralTab`.
- Updated `BiographyTab` to accept `GeneralTab` as a parameter for accessing campaign configurations.
- Replaced direct `campaign` date and faction references in `BiographyTab` with `GeneralTab` methods to ensure we're fetching the right data.
- Updated tooltip and label in Campaign Options to include a warning about faction-specific system toggling.
- Improved default behavior for `SpecifiedPlanet` when no selection is made by setting it to Terra.

### Dev Notes
Purely out of force of habit I made the mistake of fetching faction and date information from `campaign`, however this becomes an issue if CO IIC is being triggered during campaign creation, as it would cause CO IIC to pull the default values from the nascent `campaign` class.