### PR TITLE
Fixed Logic Error In Prisoners Nag Yet Again

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/PrisonersNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/PrisonersNagLogic.java
@@ -44,7 +44,7 @@ public class PrisonersNagLogic {
      * @return {@code true} if there are prisoners in the campaign and no active contract; {@code false} otherwise.
      */
     public static boolean hasPrisoners(boolean hasActiveContract, boolean hasPrisoners) {
-        if (!hasActiveContract) {
+        if (hasActiveContract) {
             return false;
         }
 

--- a/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/PrisonersNagLogicTest.java
+++ b/MekHQ/unittests/mekhq/gui/dialog/nagDialogs/nagLogic/PrisonersNagLogicTest.java
@@ -27,15 +27,15 @@
  */
 package mekhq.gui.dialog.nagDialogs.nagLogic;
 
-import mekhq.campaign.Campaign;
-import mekhq.gui.dialog.nagDialogs.PrisonersNagDialog;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import static mekhq.gui.dialog.nagDialogs.nagLogic.PrisonersNagLogic.hasPrisoners;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+
+import mekhq.campaign.Campaign;
+import mekhq.gui.dialog.nagDialogs.PrisonersNagDialog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class is a test class for the {@link PrisonersNagDialog} class.
@@ -57,7 +57,7 @@ class PrisonersNagLogicTest {
 
     @Test
     void activeContract() {
-        assertTrue(hasPrisoners(true, true));
+        assertFalse(hasPrisoners(true, true));
     }
 
     @Test
@@ -67,6 +67,6 @@ class PrisonersNagLogicTest {
 
     @Test
     void noActiveContractPrisoners() {
-        assertFalse(hasPrisoners(false, true));
+        assertTrue(hasPrisoners(false, true));
     }
 }


### PR DESCRIPTION
- Corrected logic in `PrisonersNagLogic.hasPrisoners` to properly handle cases with and without active contracts.
- Updated related unit tests in `PrisonersNagLogicTest` to align with the corrected logic.

### Dev Notes
This basically undoes the 'fix' that was implemented in 50.04's dev cycle that ultimately led us to the constant nagging bug in release. Between this and the logic fix I added yesterday this nag should be working as intended.

What a mess...