### PR TITLE
Sorted Personality Quirks Alphabetically in Quirk Picker

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/PersonalityQuirk.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/PersonalityQuirk.java
@@ -27,16 +27,20 @@
  */
 package mekhq.campaign.randomEvents.personalities.enums;
 
+import static megamek.codeUtilities.MathUtility.clamp;
+import static mekhq.campaign.personnel.enums.PersonnelRole.BATTLE_ARMOUR;
+import static mekhq.campaign.personnel.enums.PersonnelRole.SOLDIER;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
 import megamek.common.enums.Gender;
 import megamek.logging.MMLogger;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.randomEvents.personalities.PersonalityController.PronounData;
 import mekhq.campaign.universe.Faction;
-
-import static megamek.codeUtilities.MathUtility.clamp;
-import static mekhq.campaign.personnel.enums.PersonnelRole.BATTLE_ARMOUR;
-import static mekhq.campaign.personnel.enums.PersonnelRole.SOLDIER;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * Represents various personality quirks that can define an individual's behavior or habits.
@@ -405,10 +409,20 @@ public enum PersonalityQuirk {
             pronounData.possessivePronoun(), pronounData.possessivePronounLowerCase(), lanceLabelUppercase,
             lanceLabelLowercase, pronounData.pluralizer());
     }
+
+    /**
+     * Returns a list of Personality Quirks sorted alphabetically by their label.
+     *
+     * @return a sorted {@link List} of {@link PersonalityQuirk} objects by their label.
+     */
+    public static List<PersonalityQuirk> personalityQuirksSortedAlphabetically() {
+        List<PersonalityQuirk> quirks = new ArrayList<>(List.of(PersonalityQuirk.values()));
+        quirks.sort(Comparator.comparing(PersonalityQuirk::getLabel));
+        return quirks;
+    }
     // endregion Getters
 
     // region Boolean Comparison Methods
-
     public boolean isNone() {
         return this == NONE;
     }

--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -27,6 +27,33 @@
  */
 package mekhq.gui.dialog;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static mekhq.campaign.personnel.Skill.getCountDownMaxValue;
+import static mekhq.campaign.personnel.Skill.getCountUpMaxValue;
+import static mekhq.campaign.randomEvents.personalities.enums.PersonalityQuirk.personalityQuirksSortedAlphabetically;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.ResourceBundle;
+import javax.swing.*;
+
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.ui.baseComponents.MMComboBox;
@@ -45,11 +72,20 @@ import megamek.common.options.Option;
 import megamek.common.options.OptionsConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.*;
+import mekhq.campaign.personnel.Bloodname;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
+import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.enums.Phenotype;
 import mekhq.campaign.personnel.enums.education.EducationLevel;
 import mekhq.campaign.randomEvents.personalities.PersonalityController;
-import mekhq.campaign.randomEvents.personalities.enums.*;
+import mekhq.campaign.randomEvents.personalities.enums.Aggression;
+import mekhq.campaign.randomEvents.personalities.enums.Ambition;
+import mekhq.campaign.randomEvents.personalities.enums.Greed;
+import mekhq.campaign.randomEvents.personalities.enums.Intelligence;
+import mekhq.campaign.randomEvents.personalities.enums.PersonalityQuirk;
+import mekhq.campaign.randomEvents.personalities.enums.Social;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Faction.Tag;
 import mekhq.campaign.universe.Factions;
@@ -58,20 +94,6 @@ import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
 import mekhq.gui.utilities.MarkdownEditorPanel;
 import mekhq.gui.utilities.MarkdownRenderer;
-
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.time.LocalDate;
-import java.time.Period;
-import java.util.*;
-import java.util.List;
-import java.util.Map.Entry;
-
-import static java.lang.Math.max;
-import static java.lang.Math.min;
-import static mekhq.campaign.personnel.Skill.getCountDownMaxValue;
-import static mekhq.campaign.personnel.Skill.getCountUpMaxValue;
 
 /**
  * This dialog is used to create a character in story arcs from a pool of XP
@@ -789,7 +811,7 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
             gridBagConstraints.insets = new Insets(0, 5, 0, 0);
             demogPanel.add(labelPersonalityQuirk, gridBagConstraints);
 
-            comboPersonalityQuirk = new MMComboBox<>("comboPersonalityQuirk", PersonalityQuirk.values());
+            comboPersonalityQuirk = new MMComboBox<>("comboPersonalityQuirk", personalityQuirksSortedAlphabetically());
             comboPersonalityQuirk.setSelectedItem(person.getPersonalityQuirk());
 
             gridBagConstraints.gridx = 1;

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -31,6 +31,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static mekhq.campaign.personnel.Skill.getCountDownMaxValue;
 import static mekhq.campaign.personnel.Skill.getCountUpMaxValue;
+import static mekhq.campaign.randomEvents.personalities.enums.PersonalityQuirk.personalityQuirksSortedAlphabetically;
 
 import java.awt.Component;
 import java.awt.Dimension;
@@ -954,7 +955,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             gridBagConstraints.insets = new Insets(0, 5, 0, 0);
             panDemog.add(labelPersonalityQuirk, gridBagConstraints);
 
-            comboPersonalityQuirk = new MMComboBox<>("comboPersonalityQuirk", PersonalityQuirk.values());
+            comboPersonalityQuirk = new MMComboBox<>("comboPersonalityQuirk", personalityQuirksSortedAlphabetically());
             comboPersonalityQuirk.setSelectedItem(person.getPersonalityQuirk());
 
             gridBagConstraints.gridx     = 1;


### PR DESCRIPTION
- Added a new utility method `personalityQuirksSortedAlphabetically` in the `PersonalityQuirk` enum to provide a list of quirks sorted alphabetically by label.
- Updated `CustomizePersonDialog` and `CreateCharacterDialog` to use the new sorted quirks list for the personality quirk selection combo box.
- Improved user experience by ensuring personality quirks are displayed in a logical, alphabetical order.

Fix #6367