### PR TITLE
Removed Player Deployment Zone "ANY" From Scenario Templates

### DIFF
--- a/MekHQ/data/scenariotemplates/Annihilation.xml
+++ b/MekHQ/data/scenariotemplates/Annihilation.xml
@@ -30,7 +30,6 @@ The victor controls the field, and we will be the ones standing when the dust se
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Assassination.xml
+++ b/MekHQ/data/scenariotemplates/Assassination.xml
@@ -30,7 +30,6 @@ We expect a fierce but contained battle. Your forces will be operating behind en
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Base Defense.xml
+++ b/MekHQ/data/scenariotemplates/Base Defense.xml
@@ -69,7 +69,6 @@ The victor will control the field when this is over. Ensure that it is us.</deta
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Chasing a Rumor.xml
+++ b/MekHQ/data/scenariotemplates/Chasing a Rumor.xml
@@ -31,7 +31,6 @@
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Covert Strike.xml
+++ b/MekHQ/data/scenariotemplates/Covert Strike.xml
@@ -32,7 +32,6 @@ Be advised, the enemy will control the field at the end of the engagement. You w
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Decoy Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Engagement.xml
@@ -34,7 +34,6 @@ Hold the line, weather the storm, and outlast them. If they break, the field is 
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Decoy Interception.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Interception.xml
@@ -34,7 +34,6 @@ Stand firm, draw them in, and ensure they never reach their goal. If they break,
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Engagement.xml
@@ -32,7 +32,6 @@ Strike hard, eliminate the opposition, and take control. Victory is absolute, or
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Frontier Assassination.xml
+++ b/MekHQ/data/scenariotemplates/Frontier Assassination.xml
@@ -32,7 +32,6 @@ The victor will control the battlefield at the end of the engagement, securing a
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Frontline Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Engagement.xml
@@ -32,7 +32,6 @@ The victor will control the battlefield at the end of the engagement, securing s
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -34,7 +34,6 @@ The enemy will control the field at the end of the engagement, meaning there wil
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
@@ -32,7 +32,6 @@ The victor will control the battlefield at the end of the engagement, securing d
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
@@ -32,7 +32,6 @@ There will be no time to secure the battlefield at the end of the engagement, me
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Minor Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Minor Engagement.xml
@@ -32,7 +32,6 @@ The victor will control the battlefield at the end of the engagement, securing t
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Pivotal Battle.xml
+++ b/MekHQ/data/scenariotemplates/Pivotal Battle.xml
@@ -32,7 +32,6 @@ The victor will control the battlefield at the end of the engagement, ensuring w
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Recon Evasion.xml
@@ -34,7 +34,6 @@ The enemy will control the field at the end of the engagement, meaning there wil
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
@@ -34,7 +34,6 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
@@ -32,7 +32,6 @@ There is no time to secure the battlefield at the end of the engagement, meaning
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Space Aerospace Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space Aerospace Intercept.xml
@@ -34,7 +34,6 @@ The victor will control the battlefield at the end of the engagement, securing d
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
@@ -34,7 +34,6 @@ There will be no time to secure the battlefield after the engagement, meaning an
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/VIP Ambush.xml
+++ b/MekHQ/data/scenariotemplates/VIP Ambush.xml
@@ -32,7 +32,6 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>

--- a/MekHQ/data/scenariotemplates/VIP Defense.xml
+++ b/MekHQ/data/scenariotemplates/VIP Defense.xml
@@ -32,7 +32,6 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>0</deploymentZone>
                     <deploymentZone>1</deploymentZone>
                     <deploymentZone>2</deploymentZone>
                     <deploymentZone>3</deploymentZone>


### PR DESCRIPTION
- Cleaned up scenario template XML files to remove `<deploymentZone>0</deploymentZone>` entries.
- Affected 22 scenario templates to ensure consistent deployment zone configuration.

### Dev Notes
This change stops player forces from getting the 'any' deployment zone. Now they will always be deployed to one of the edge zones (including 'any edge'), or 'center'