### PR TITLE
Updated Prisoner Handling to Remove Reliance on `AtBContract`

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
@@ -27,6 +27,25 @@
  */
 package mekhq.campaign.randomEvents.prisoners;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.Math.round;
+import static java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.TRANSPORT;
+import static mekhq.campaign.force.ForceType.SECURITY;
+import static mekhq.campaign.randomEvents.personalities.PersonalityController.getPersonalityValue;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
 import megamek.codeUtilities.ObjectUtility;
 import megamek.common.Compute;
 import megamek.common.Entity;
@@ -46,21 +65,6 @@ import mekhq.gui.dialog.randomEvents.prisonerDialogs.PrisonerEventDialog;
 import mekhq.gui.dialog.randomEvents.prisonerDialogs.PrisonerEventResultsDialog;
 import mekhq.gui.dialog.randomEvents.prisonerDialogs.PrisonerWarningDialog;
 import mekhq.gui.dialog.randomEvents.prisonerDialogs.PrisonerWarningResultsDialog;
-
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.util.*;
-
-import static java.lang.Math.max;
-import static java.lang.Math.min;
-import static java.lang.Math.round;
-import static java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR;
-import static mekhq.campaign.Campaign.AdministratorSpecialization.TRANSPORT;
-import static mekhq.campaign.force.ForceType.SECURITY;
-import static mekhq.campaign.randomEvents.personalities.PersonalityController.getPersonalityValue;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
-import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
-import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 /**
  * Manages prisoner-related events and warnings during a campaign.
@@ -140,7 +144,7 @@ public class PrisonerEventManager {
             return;
         }
 
-        if (!campaign.hasActiveAtBContract(false)) {
+        if (!campaign.hasActiveContract()) {
             return;
         }
 

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerMissionEndEvent.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerMissionEndEvent.java
@@ -27,18 +27,6 @@
  */
 package mekhq.campaign.randomEvents.prisoners;
 
-import mekhq.MekHQ;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.enums.PersonnelStatus;
-import mekhq.gui.dialog.MissionEndPrisonerDefectorDialog;
-import mekhq.gui.dialog.MissionEndPrisonerDialog;
-
-import java.time.LocalDate;
-import java.util.List;
-
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static megamek.common.Compute.randomInt;
@@ -50,6 +38,18 @@ import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.MAX_CRI
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.mission.Contract;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelStatus;
+import mekhq.gui.dialog.MissionEndPrisonerDefectorDialog;
+import mekhq.gui.dialog.MissionEndPrisonerDialog;
 
 /**
  * Handles events involving prisoners at the end of a mission.
@@ -63,7 +63,7 @@ public class PrisonerMissionEndEvent {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.PrisonerEvents";
 
     private final Campaign campaign;
-    private final AtBContract contract;
+    private final Contract contract;
     private boolean isSuccess;
     private boolean isAllied;
 
@@ -80,7 +80,7 @@ public class PrisonerMissionEndEvent {
      *                and finances.
      * @param contract The current mission contract related to this event.
      */
-    public PrisonerMissionEndEvent(Campaign campaign, AtBContract contract) {
+    public PrisonerMissionEndEvent(Campaign campaign, Contract contract) {
         this.campaign = campaign;
         this.contract = contract;
     }

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -27,6 +27,31 @@
  */
 package mekhq.gui;
 
+import static megamek.client.ratgenerator.ForceDescriptor.RATING_5;
+import static mekhq.campaign.mission.enums.MissionStatus.PARTIAL;
+import static mekhq.campaign.mission.enums.MissionStatus.SUCCESS;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+import java.io.File;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.UUID;
+import java.util.Vector;
+import java.util.stream.Collectors;
+import javax.swing.*;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.PrincessException;
 import megamek.client.generator.ReconfigurationParameters;
@@ -48,7 +73,14 @@ import mekhq.campaign.event.*;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.force.CombatTeam;
-import mekhq.campaign.mission.*;
+import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.mission.AtBDynamicScenario;
+import mekhq.campaign.mission.AtBDynamicScenarioFactory;
+import mekhq.campaign.mission.AtBScenario;
+import mekhq.campaign.mission.BotForce;
+import mekhq.campaign.mission.Contract;
+import mekhq.campaign.mission.Mission;
+import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
 import mekhq.campaign.mission.enums.MissionStatus;
 import mekhq.campaign.personnel.Person;
@@ -61,7 +93,14 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.gui.adapter.ScenarioTableMouseAdapter;
-import mekhq.gui.dialog.*;
+import mekhq.gui.dialog.CompleteMissionDialog;
+import mekhq.gui.dialog.CustomizeAtBContractDialog;
+import mekhq.gui.dialog.CustomizeMissionDialog;
+import mekhq.gui.dialog.CustomizeScenarioDialog;
+import mekhq.gui.dialog.MissionTypeDialog;
+import mekhq.gui.dialog.NewAtBContractDialog;
+import mekhq.gui.dialog.NewContractDialog;
+import mekhq.gui.dialog.RetirementDefectionDialog;
 import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.model.ScenarioTableModel;
 import mekhq.gui.sorter.DateStringComparator;
@@ -71,20 +110,6 @@ import mekhq.gui.view.LanceAssignmentView;
 import mekhq.gui.view.MissionViewPanel;
 import mekhq.gui.view.ScenarioViewPanel;
 import mekhq.utilities.MHQInternationalization;
-
-import javax.swing.*;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-import java.awt.*;
-import java.io.File;
-import java.time.LocalDate;
-import java.util.*;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static megamek.client.ratgenerator.ForceDescriptor.RATING_5;
-import static mekhq.campaign.mission.enums.MissionStatus.PARTIAL;
-import static mekhq.campaign.mission.enums.MissionStatus.SUCCESS;
 
 /**
  * Displays Mission/Contract and Scenario details.
@@ -386,7 +411,7 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         PrisonerMissionEndEvent prisoners = null;
-        if (mission instanceof AtBContract) {
+        if (mission instanceof Contract) {
             prisoners = new PrisonerMissionEndEvent(getCampaign(), (AtBContract) mission);
 
             if (!getCampaign().getPrisonerDefectors().isEmpty() && prisoners.handlePrisonerDefectors() == 0) { // This is the cancel choice index


### PR DESCRIPTION
- Replaced `AtBContract` references with the more generic `Contract` class for improved flexibility.
- Updated `PrisonerEventManager`, `BriefingTab`, and `PrisonerMissionEndEvent` to align with this change.

### Dev Notes
This allows non-AtB Users to use MekHQ prisoners, instead of just Campaign Operations prisoners.