### PR TITLE
Updated Deployment Shortfall Nag To Use Immersive Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -354,13 +354,6 @@ OutstandingScenariosNagDialog.stratCon=<br>\
 PregnantCombatantNagDialog.text=%s, pregnant personnel have been identified in our TO&E, putting\
   \ them at risk of harm. Reassignment is advised. Do you wish to advance the day without\
   \ addressing this concern?
-DeploymentShortfallNagDialog.text=%s, deployment levels fall below requirements for one or more active\
-  \ contracts. While advancing the day is an option, it may strain relations with our employer. Do\
-  \ you wish to continue without addressing this?\
-  <br>\
-  <br><i>You should head to the Briefing Room and address this shortfall. Remember, Combat Teams\
-  \ assigned to the Auxiliary or Reserve roles do not count towards deployment levels. Nor do\
-  \ Combat Teams assigned to the Training role, unless the contract is Cadre Duty.</i>
 PrisonersNagDialog.text=%s, our forces are still holding prisoners of war. It is important to\
   \ consider their status before advancing the day. Do you wish to continue without resolving this?\
   <br>\

--- a/MekHQ/resources/mekhq/resources/NagDialogs.properties
+++ b/MekHQ/resources/mekhq/resources/NagDialogs.properties
@@ -1,10 +1,21 @@
+# Buttons
 button.cancel=I better take a look.
 button.continue=Continue as ordered.
 button.suppress=Continue and don''t bother me with future issues of this type.
+# Admin Strain
 AdminStrainNagDialog.ic={0}, my team is buckling under the strain. Memos are going unanswered. We''ve got people queuing\
   \ up outside with complaints. We''ve even got reports of unpaid salaries. People are getting angry, and if we don''t\
   \ solve the problem soon, they''re liable to quit.
 AdminStrainNagDialog.ooc=Excess <a href=''GLOSSARY:ADMIN_STRAIN''>Administrative Strain</a> is addressed by hiring more\
   \ Admin/HR personnel. If that isn''t viable, consider assigning your current Admin personnel to multiple roles.</p>\
   <p>For more information, please see <i>MekHQ/docs/Personnel Modules/Turnover & Retention Module (feat. Fatigue).pdf</i></p>\
+  <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Options.</p>
+# Deployment Shortfall
+DeploymentShortfallNagDialog.ic={0}, deployment levels fall below contractual requirements for one\
+  \ or more contracts. While advancing the day is an option, it may strain relations with our\
+  \ employer. Do you wish to continue without addressing this?
+DeploymentShortfallNagDialog.ooc=You should head to the Briefing Room and address this shortfall.\
+  \ Remember, <a href=''GLOSSARY:COMBAT_TEAMS''>Combat Teams</a> assigned to the Auxiliary or\
+  \ Reserve roles do not count towards deployment levels. Nor do Combat Teams assigned to the\
+  \ Training role, unless the contract is Cadre Duty.\
   <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Options.</p>

--- a/MekHQ/resources/mekhq/resources/NagDialogs.properties
+++ b/MekHQ/resources/mekhq/resources/NagDialogs.properties
@@ -11,9 +11,9 @@ AdminStrainNagDialog.ooc=Excess <a href=''GLOSSARY:ADMIN_STRAIN''>Administrative
   <p>For more information, please see <i>MekHQ/docs/Personnel Modules/Turnover & Retention Module (feat. Fatigue).pdf</i></p>\
   <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Options.</p>
 # Deployment Shortfall
-DeploymentShortfallNagDialog.ic={0}, deployment levels fall below contractual requirements for one\
-  \ or more contracts. While advancing the day is an option, it may strain relations with our\
-  \ employer. Do you wish to continue without addressing this?
+DeploymentShortfallNagDialog.ic={0}, deployment levels have fallen below contractual requirements\
+  \ for one or more contracts. While advancing the day is an option, it may strain relations with\
+  \ our employer. Do you wish to continue without addressing this?
 DeploymentShortfallNagDialog.ooc=You should head to the Briefing Room and address this shortfall.\
   \ Remember, <a href=''GLOSSARY:COMBAT_TEAMS''>Combat Teams</a> assigned to the Auxiliary or\
   \ Reserve roles do not count towards deployment levels. Nor do Combat Teams assigned to the\

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/AdminStrainNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/AdminStrainNagDialog.java
@@ -85,7 +85,10 @@ public class AdminStrainNagDialog {
                 MekHQ.getMHQOptions().setNagDialogIgnore(NAG_ADMIN_STRAIN, true);
                 cancelAdvanceDay = false;
             }
-            default -> throw new IllegalStateException("Unexpected value in AdminStrainNagDialog: " + choiceIndex);
+            default -> throw new IllegalStateException("Unexpected value in " +
+                                                             getClass().getSimpleName() +
+                                                             ": " +
+                                                             choiceIndex);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
@@ -27,41 +27,99 @@
  */
 package mekhq.gui.dialog.nagDialogs;
 
+import static mekhq.MHQConstants.NAG_ADMIN_STRAIN;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.gui.dialog.nagDialogs.nagLogic.DeploymentShortfallNagLogic.hasDeploymentShortfall;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.gui.baseComponents.AbstractMHQNagDialog;
-
-import static mekhq.gui.dialog.nagDialogs.nagLogic.DeploymentShortfallNagLogic.hasDeploymentShortfall;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 
 /**
  * A nag dialog that alerts the user if short deployments are detected in the campaign's active contracts.
  *
  * <p>
- * This dialog checks whether any active AtB (Against the Bot) contracts have a deployment deficit
- * and alerts the player to address the issue. The check is performed weekly (on Sundays) and only
- * when the campaign is currently located on a planet. If deployment requirements are not met,
- * the dialog is displayed to prompt the user to correct the situation.
+ * This dialog checks whether any active AtB (Against the Bot) contracts have a deployment deficit and alerts the player
+ * to address the issue. The check is performed weekly (on Sundays) and only when the campaign is currently located on a
+ * planet. If deployment requirements are not met, the dialog is displayed to prompt the user to correct the situation.
  * </p>
  */
-public class DeploymentShortfallNagDialog extends AbstractMHQNagDialog {
+public class DeploymentShortfallNagDialog {
+    private final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
+
+    private final int CHOICE_CANCEL = 0;
+    private final int CHOICE_CONTINUE = 1;
+    private final int CHOICE_SUPPRESS = 2;
+
+    private final Campaign campaign;
+    private boolean cancelAdvanceDay;
+
     /**
      * Constructs the shortfall deployment nag dialog for a given campaign.
      *
      * <p>
-     * This constructor initializes the dialog with the specified campaign and
-     * formats the resource message to display information about deployment shortfalls.
+     * This constructor initializes the dialog with the specified campaign and formats the resource message to display
+     * information about deployment shortfalls.
      * </p>
      *
      * @param campaign The {@link Campaign} object representing the current campaign.
      */
     public DeploymentShortfallNagDialog(final Campaign campaign) {
-        super(campaign, MHQConstants.NAG_SHORT_DEPLOYMENT);
+        this.campaign = campaign;
 
-        final String DIALOG_BODY = "DeploymentShortfallNagDialog.text";
-        setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
-            campaign.getCommanderAddress(false)));
-        showDialog();
+        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
+              campaign.getSeniorAdminPerson(COMMAND),
+              null,
+              getFormattedTextAt(RESOURCE_BUNDLE,
+                    "DeploymentShortfallNagDialog.ic",
+                    campaign.getCommanderAddress(false)),
+              getButtonLabels(),
+              getFormattedTextAt(RESOURCE_BUNDLE, "DeploymentShortfallNagDialog.ooc"),
+              true);
+
+        int choiceIndex = dialog.getDialogChoice();
+
+        switch (choiceIndex) {
+            case CHOICE_CANCEL -> cancelAdvanceDay = true;
+            case CHOICE_CONTINUE -> cancelAdvanceDay = false;
+            case CHOICE_SUPPRESS -> {
+                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_ADMIN_STRAIN, true);
+                cancelAdvanceDay = false;
+            }
+            default -> throw new IllegalStateException("Unexpected value in AdminStrainNagDialog: " + choiceIndex);
+        }
+    }
+
+    /**
+     * Retrieves a list of button labels from the resource bundle.
+     *
+     * <p>The method collects and returns button labels such as "Cancel", "Continue", and "Suppress" after
+     * formatting them using the provided resource bundle.</p>
+     *
+     * @return a {@link List} of formatted button labels as {@link String}.
+     */
+    private List<String> getButtonLabels() {
+        List<String> buttonLabels = new ArrayList<>();
+
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.cancel"));
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"));
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.suppress"));
+
+        return buttonLabels;
+    }
+
+    /**
+     * Determines whether the advance day operation should be canceled.
+     *
+     * @return {@code true} if advancing the day should be canceled, {@code false} otherwise.
+     */
+    public boolean shouldCancelAdvanceDay() {
+        return cancelAdvanceDay;
     }
 
     /**
@@ -82,8 +140,6 @@ public class DeploymentShortfallNagDialog extends AbstractMHQNagDialog {
     public static boolean checkNag(boolean isUseAtB, Campaign campaign) {
         final String NAG_KEY = MHQConstants.NAG_SHORT_DEPLOYMENT;
 
-        return isUseAtB
-              && !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-              && hasDeploymentShortfall(campaign);
+        return isUseAtB && !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY) && hasDeploymentShortfall(campaign);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
@@ -90,7 +90,10 @@ public class DeploymentShortfallNagDialog {
                 MekHQ.getMHQOptions().setNagDialogIgnore(NAG_SHORT_DEPLOYMENT, true);
                 cancelAdvanceDay = false;
             }
-            default -> throw new IllegalStateException("Unexpected value in AdminStrainNagDialog: " + choiceIndex);
+            default -> throw new IllegalStateException("Unexpected value in " +
+                                                             getClass().getSimpleName() +
+                                                             ": " +
+                                                             choiceIndex);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
@@ -27,7 +27,7 @@
  */
 package mekhq.gui.dialog.nagDialogs;
 
-import static mekhq.MHQConstants.NAG_ADMIN_STRAIN;
+import static mekhq.MHQConstants.NAG_SHORT_DEPLOYMENT;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
 import static mekhq.gui.dialog.nagDialogs.nagLogic.DeploymentShortfallNagLogic.hasDeploymentShortfall;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
@@ -35,7 +35,6 @@ import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import java.util.ArrayList;
 import java.util.List;
 
-import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
@@ -88,7 +87,7 @@ public class DeploymentShortfallNagDialog {
             case CHOICE_CANCEL -> cancelAdvanceDay = true;
             case CHOICE_CONTINUE -> cancelAdvanceDay = false;
             case CHOICE_SUPPRESS -> {
-                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_ADMIN_STRAIN, true);
+                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_SHORT_DEPLOYMENT, true);
                 cancelAdvanceDay = false;
             }
             default -> throw new IllegalStateException("Unexpected value in AdminStrainNagDialog: " + choiceIndex);
@@ -138,7 +137,7 @@ public class DeploymentShortfallNagDialog {
      * @return {@code true} if the nag dialog should be displayed due to deployment shortfalls; {@code false} otherwise.
      */
     public static boolean checkNag(boolean isUseAtB, Campaign campaign) {
-        final String NAG_KEY = MHQConstants.NAG_SHORT_DEPLOYMENT;
+        final String NAG_KEY = NAG_SHORT_DEPLOYMENT;
 
         return isUseAtB && !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY) && hasDeploymentShortfall(campaign);
     }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -205,7 +205,7 @@ public class NagController {
 
         if (DeploymentShortfallNagDialog.checkNag(isUseAtB, campaign)) {
             DeploymentShortfallNagDialog deploymentShortfallNagDialog = new DeploymentShortfallNagDialog(campaign);
-            if (deploymentShortfallNagDialog.wasAdvanceDayCanceled()) {
+            if (deploymentShortfallNagDialog.shouldCancelAdvanceDay()) {
                 return true;
             }
         }


### PR DESCRIPTION
- Refactored `DeploymentShortfallNagDialog` to utilize `ImmersiveDialogSimple` for improved modularity and customization.
- Replaced inheritance from `AbstractMHQNagDialog` with a standalone class to simplify and streamline the implementation.
- Updated NagController logic to replace `wasAdvanceDayCanceled()` with `shouldCancelAdvanceDay()` to reflect the updated behavior.

<img width="587" alt="image" src="https://github.com/user-attachments/assets/321c6db1-bc53-47c0-94f4-90bd16f3e9c1" />
