### PR TITLE
Updated Contract End Nag To Use Immersive Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -309,12 +309,6 @@ NoCommanderNagDialog.text=Please be advised that no commanding officer is curren
   <br>\
   <br><i>You can assign one of your personnel as the campaign commander by right-clicking on that\
   \ character, navigating to Flags and selecting the Commander flag.</i>
-EndContractNagDialog.text=%s, a contract has reached its conclusion and requires your attention for\
-  \ final resolution. While you may advance the day, I recommend addressing this to avoid delays in\
-  \ resource allocation and payment. Confirm your decision to proceed.\
-  <br>\
-  <br><i>You can resolve a contract by selecting the contract in the Briefing Room, followed by\
-  \ Complete Mission.</i>
 InsufficientAstechsNagDialog.text=%s, a shortage of %d Astech%s is affecting the productivity of\
   \ your tech teams. For optimal performance, consider recruiting additional personnel. Confirm\
   \ your intent to advance the day under these conditions.\

--- a/MekHQ/resources/mekhq/resources/NagDialogs.properties
+++ b/MekHQ/resources/mekhq/resources/NagDialogs.properties
@@ -8,3 +8,9 @@ AdminStrainNagDialog.ooc=Excess <a href=''GLOSSARY:ADMIN_STRAIN''>Administrative
   \ Admin/HR personnel. If that isn''t viable, consider assigning your current Admin personnel to multiple roles.</p>\
   <p>For more information, please see <i>MekHQ/docs/Personnel Modules/Turnover & Retention Module (feat. Fatigue).pdf</i></p>\
   <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Options.</p>
+# End Contract Nag
+EndContractNagDialog.ic={0}, a contract has reached its conclusion and requires your attention for\
+  \ final resolution. While you may advance the day, I recommend addressing this to avoid delays in\
+  \ resource allocation and payment. Confirm your decision to proceed.
+EndContractNagDialog.ooc=You can resolve a contract by selecting the contract in the Briefing Room,\
+  \ followed by 'Complete Mission'.</i>

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/EndContractNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/EndContractNagDialog.java
@@ -27,24 +27,28 @@
  */
 package mekhq.gui.dialog.nagDialogs;
 
-import mekhq.MHQConstants;
+import static mekhq.MHQConstants.NAG_CONTRACT_ENDED;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.gui.dialog.nagDialogs.nagLogic.EndContractNagLogic.isContractEnded;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.gui.baseComponents.AbstractMHQNagDialog;
-
-import java.time.LocalDate;
-import java.util.List;
-
-import static mekhq.gui.dialog.nagDialogs.nagLogic.EndContractNagLogic.isContractEnded;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 
 /**
  * A dialog used to notify the user about the end date of a contract in the campaign.
  *
  * <p>
- * This nag dialog is triggered when a contract in the campaign is flagged as ending on the current date
- * and the user has not opted to ignore such notifications. It shows relevant details about the situation
- * and allows the user to take action or dismiss the dialog.
+ * This nag dialog is triggered when a contract in the campaign is flagged as ending on the current date and the user
+ * has not opted to ignore such notifications. It shows relevant details about the situation and allows the user to take
+ * action or dismiss the dialog.
  * </p>
  *
  * <strong>Features:</strong>
@@ -54,25 +58,79 @@ import static mekhq.gui.dialog.nagDialogs.nagLogic.EndContractNagLogic.isContrac
  *   <li>Extends the {@link AbstractMHQNagDialog} to reuse base nag dialog functionality.</li>
  * </ul>
  */
-public class EndContractNagDialog extends AbstractMHQNagDialog {
+public class EndContractNagDialog {
+    private final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
+
+    private final int CHOICE_CANCEL = 0;
+    private final int CHOICE_CONTINUE = 1;
+    private final int CHOICE_SUPPRESS = 2;
+
+    private final Campaign campaign;
+    private boolean cancelAdvanceDay;
+
     /**
      * Constructs an {@code EndContractNagDialog} for the given campaign.
      *
      * <p>
-     * This dialog uses the localization key {@code "EndContractNagDialog.text"} to provide
-     * a message that includes additional information, such as the commander's address.
-     * It is specifically tailored to show when a contract is reaching its end date.
+     * This dialog uses the localization key {@code "EndContractNagDialog.text"} to provide a message that includes
+     * additional information, such as the commander's address. It is specifically tailored to show when a contract is
+     * reaching its end date.
      * </p>
      *
      * @param campaign The {@link Campaign} that the nag dialog is tied to.
      */
     public EndContractNagDialog(final Campaign campaign) {
-        super(campaign, MHQConstants.NAG_CONTRACT_ENDED);
+        this.campaign = campaign;
 
-        final String DIALOG_BODY = "EndContractNagDialog.text";
-        setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
-            campaign.getCommanderAddress(false)));
-        showDialog();
+        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
+              campaign.getSeniorAdminPerson(COMMAND),
+              null,
+              getFormattedTextAt(RESOURCE_BUNDLE, "EndContractNagDialog.ic", campaign.getCommanderAddress(false)),
+              getButtonLabels(),
+              getFormattedTextAt(RESOURCE_BUNDLE, "EndContractNagDialog.ooc"),
+              true);
+
+        int choiceIndex = dialog.getDialogChoice();
+
+        switch (choiceIndex) {
+            case CHOICE_CANCEL -> cancelAdvanceDay = true;
+            case CHOICE_CONTINUE -> cancelAdvanceDay = false;
+            case CHOICE_SUPPRESS -> {
+                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_CONTRACT_ENDED, true);
+                cancelAdvanceDay = false;
+            }
+            default -> throw new IllegalStateException("Unexpected value in " +
+                                                             getClass().getSimpleName() +
+                                                             ": " +
+                                                             choiceIndex);
+        }
+    }
+
+    /**
+     * Retrieves a list of button labels from the resource bundle.
+     *
+     * <p>The method collects and returns button labels such as "Cancel", "Continue", and "Suppress" after
+     * formatting them using the provided resource bundle.</p>
+     *
+     * @return a {@link List} of formatted button labels as {@link String}.
+     */
+    private List<String> getButtonLabels() {
+        List<String> buttonLabels = new ArrayList<>();
+
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.cancel"));
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"));
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.suppress"));
+
+        return buttonLabels;
+    }
+
+    /**
+     * Determines whether the advance day operation should be canceled.
+     *
+     * @return {@code true} if advancing the day should be canceled, {@code false} otherwise.
+     */
+    public boolean shouldCancelAdvanceDay() {
+        return cancelAdvanceDay;
     }
 
     /**
@@ -84,15 +142,14 @@ public class EndContractNagDialog extends AbstractMHQNagDialog {
      *     <li>A contract in the campaign has ended, as determined by {@code #isContractEnded}.</li>
      * </ul>
      *
-     * @param today The current local date used to check against the contracts' ending dates.
+     * @param today           The current local date used to check against the contracts' ending dates.
      * @param activeContracts A list of {@link AtBContract} objects representing the campaign's active contracts.
      *
      * @return {@code true} if the nag dialog should be displayed; {@code false} otherwise.
      */
     public static boolean checkNag(LocalDate today, List<AtBContract> activeContracts) {
-        final String NAG_KEY = MHQConstants.NAG_CONTRACT_ENDED;
+        final String NAG_KEY = NAG_CONTRACT_ENDED;
 
-        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-              && isContractEnded(today, activeContracts);
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY) && isContractEnded(today, activeContracts);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -242,7 +242,7 @@ public class NagController {
         // Contract Ended
         if (EndContractNagDialog.checkNag(today, activeContracts)) {
             EndContractNagDialog endContractNagDialog = new EndContractNagDialog(campaign);
-            if (endContractNagDialog.wasAdvanceDayCanceled()) {
+            if (endContractNagDialog.shouldCancelAdvanceDay()) {
                 return true;
             }
         }


### PR DESCRIPTION
- Refactored `EndContractNagDialog` to utilize `ImmersiveDialogSimple` for improved modularity and customization.
- Replaced inheritance from `AbstractMHQNagDialog` with a standalone class to simplify and streamline the implementation.
- Updated NagController logic to replace `wasAdvanceDayCanceled()` with `shouldCancelAdvanceDay()` to reflect the updated behavior.

<img width="584" alt="image" src="https://github.com/user-attachments/assets/c388eac9-6089-4998-95ec-46005b87f2bc" />
