### PR TITLE
Updated Insufficient Astechs Nag To Use Immersive Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -315,14 +315,6 @@ EndContractNagDialog.text=%s, a contract has reached its conclusion and requires
   <br>\
   <br><i>You can resolve a contract by selecting the contract in the Briefing Room, followed by\
   \ Complete Mission.</i>
-InsufficientAstechsNagDialog.text=%s, a shortage of %d Astech%s is affecting the productivity of\
-  \ your tech teams. For optimal performance, consider recruiting additional personnel. Confirm\
-  \ your intent to advance the day under these conditions.\
-  <br>\
-  <br><i>You can resolve this issue by selecting 'Marketplace' in the taskbar, then 'Astech Pool,'\
-  \ then selecting the option to bring all teams up to full strength. If this does not resolve the\
-  \ issue, you have likely spread your techs too thinly by assigning them to too many units.\
-  \ Consider hiring more techs.</i>
 InsufficientAstechTimeNagDialog.text=%s, current maintenance requires an additional %d Astech%s.\
   \ Proceeding without resolving this will prevent some units from being maintained. Confirm your\
   \ decision to advance the day.\

--- a/MekHQ/resources/mekhq/resources/NagDialogs.properties
+++ b/MekHQ/resources/mekhq/resources/NagDialogs.properties
@@ -19,3 +19,12 @@ DeploymentShortfallNagDialog.ooc=You should head to the Briefing Room and addres
   \ Reserve roles do not count towards deployment levels. Nor do Combat Teams assigned to the\
   \ Training role, unless the contract is Cadre Duty.\
   <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Options.</p>
+# Insufficient Astechs
+InsufficientAstechsNagDialog.ic={0}, a shortage of {1} {1, choice, 0#Astechs|1#Astech|2#Astechs} is\
+  \ affecting the productivity of our tech teams. For optimal performance, we should consider\
+  \ recruiting additional personnel. Confirm your intent to advance the day under these conditions.
+InsufficientAstechsNagDialog.ooc=You can resolve this issue by selecting 'Marketplace' in the toolbar,\
+  \ then 'Astech Pool,' then selecting the option to bring all teams up to full strength. If this\
+  \ does not resolve the issue, you have likely spread your techs too thinly by assigning them to too\
+  \ many units. Consider hiring more techs.</i>\
+  <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Options.</p>

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/AdminStrainNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/AdminStrainNagDialog.java
@@ -85,10 +85,7 @@ public class AdminStrainNagDialog {
                 MekHQ.getMHQOptions().setNagDialogIgnore(NAG_ADMIN_STRAIN, true);
                 cancelAdvanceDay = false;
             }
-            default -> throw new IllegalStateException("Unexpected value in " +
-                                                             getClass().getSimpleName() +
-                                                             ": " +
-                                                             choiceIndex);
+            default -> throw new IllegalStateException("Unexpected value in AdminStrainNagDialog: " + choiceIndex);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
@@ -90,10 +90,8 @@ public class DeploymentShortfallNagDialog {
                 MekHQ.getMHQOptions().setNagDialogIgnore(NAG_SHORT_DEPLOYMENT, true);
                 cancelAdvanceDay = false;
             }
-            default -> throw new IllegalStateException("Unexpected value in " +
-                                                             getClass().getSimpleName() +
-                                                             ": " +
-                                                             choiceIndex);
+            default ->
+                  throw new IllegalStateException("Unexpected value in DeploymentShortfallNagDialog: " + choiceIndex);
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechsNagDialog.java
@@ -27,52 +27,159 @@
  */
 package mekhq.gui.dialog.nagDialogs;
 
+import static mekhq.MHQConstants.NAG_ADMIN_STRAIN;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
+import static mekhq.gui.dialog.nagDialogs.nagLogic.InsufficientAstechsNagLogic.hasAsTechsNeeded;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.gui.baseComponents.AbstractMHQNagDialog;
-
-import static mekhq.gui.dialog.nagDialogs.nagLogic.InsufficientAstechsNagLogic.hasAsTechsNeeded;
+import mekhq.campaign.personnel.Person;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 
 /**
- * A dialog used to notify the user that their campaign has insufficient astechs. Not to be
- * confused with {@link InsufficientAstechTimeNagDialog}.
+ * A dialog used to notify the user that their campaign has insufficient astechs. Not to be confused with
+ * {@link InsufficientAstechTimeNagDialog}.
  *
  * <p>
- * This nag dialog is triggered when the campaign does not have enough astechs to handle
- * the current maintenance and repair workload. Users are notified via a localized
- * message that provides relevant details about the issue.
+ * This nag dialog is triggered when the campaign does not have enough astechs to handle the current maintenance and
+ * repair workload. Users are notified via a localized message that provides relevant details about the issue.
  * </p>
  *
  * <strong>Features:</strong>
  * <ul>
  *   <li>Notifies users about the shortage of astechs in the current campaign.</li>
  *   <li>Allows users to address the issue or dismiss the dialog while optionally ignoring future warnings.</li>
- *   <li>Extends {@link AbstractMHQNagDialog} for consistent functionality with other nag dialogs.</li>
  * </ul>
  */
-public class InsufficientAstechsNagDialog extends AbstractMHQNagDialog {
+public class InsufficientAstechsNagDialog {
+    private final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
+
+    private final int CHOICE_CANCEL = 0;
+    private final int CHOICE_CONTINUE = 1;
+    private final int CHOICE_SUPPRESS = 2;
+
+    private final Campaign campaign;
+    private boolean cancelAdvanceDay;
+
     /**
      * Constructs an {@code InsufficientAstechsNagDialog} for the given campaign.
      *
      * <p>
-     * This dialog uses a localized message identified by the key
-     * {@code "InsufficientAstechsNagDialog.text"} to inform the user of the insufficient
-     * astechs in their campaign.
+     * This dialog uses a localized message identified by the key {@code "InsufficientAstechsNagDialog.text"} to inform
+     * the user of the insufficient astechs in their campaign.
      * </p>
      *
      * @param campaign The {@link Campaign} associated with this nag dialog.
      */
     public InsufficientAstechsNagDialog(final Campaign campaign) {
-        super(campaign, MHQConstants.NAG_INSUFFICIENT_ASTECHS);
+        this.campaign = campaign;
+
         int asTechsNeeded = campaign.getAstechNeed();
 
-        String pluralizer = (asTechsNeeded > 1) ? "s" : "";
+        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
+              getSpeaker(),
+              null,
+              getFormattedTextAt(RESOURCE_BUNDLE,
+                    "InsufficientAstechsNagDialog.ic",
+                    campaign.getCommanderAddress(false),
+                    asTechsNeeded),
+              getButtonLabels(),
+              getFormattedTextAt(RESOURCE_BUNDLE, "InsufficientAstechsNagDialog.ooc"),
+              true);
 
-        final String DIALOG_BODY = "InsufficientAstechsNagDialog.text";
-        setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
-            campaign.getCommanderAddress(false), asTechsNeeded, pluralizer));
-        showDialog();
+        int choiceIndex = dialog.getDialogChoice();
+
+        switch (choiceIndex) {
+            case CHOICE_CANCEL -> cancelAdvanceDay = true;
+            case CHOICE_CONTINUE -> cancelAdvanceDay = false;
+            case CHOICE_SUPPRESS -> {
+                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_ADMIN_STRAIN, true);
+                cancelAdvanceDay = false;
+            }
+            default ->
+                  throw new IllegalStateException("Unexpected value in InsufficientAstechsNagDialog: " + choiceIndex);
+        }
+    }
+
+    /**
+     * Retrieves a list of button labels from the resource bundle.
+     *
+     * <p>The method collects and returns button labels such as "Cancel", "Continue", and "Suppress" after
+     * formatting them using the provided resource bundle.</p>
+     *
+     * @return a {@link List} of formatted button labels as {@link String}.
+     */
+    private List<String> getButtonLabels() {
+        List<String> buttonLabels = new ArrayList<>();
+
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.cancel"));
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"));
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.suppress"));
+
+        return buttonLabels;
+    }
+
+    /**
+     * Retrieves the speaker based on the active personnel.
+     *
+     * <p>This method iterates through the active personnel within the campaign and attempts to identify a speaker who
+     * meets the criteria. It prioritizes selecting a person with technical specialization, using a tie-breaking
+     * mechanism based on rank and skills. If no suitable speaker is found, it defaults to the senior administrator
+     * person with the "COMMAND" specialization.</p>
+     *
+     * @return the {@link Person} designated as the speaker, either the highest-ranking technical specialist or the
+     *       senior administrator with the "COMMAND" specialization if no other suitable speaker is found.
+     */
+    private Person getSpeaker() {
+        List<Person> activePersonnel = campaign.getActivePersonnel(false);
+
+        Person speaker = null;
+
+        for (Person person : activePersonnel) {
+            if (!person.isTech()) {
+                continue;
+            }
+
+            if (speaker == null) {
+                speaker = person;
+                continue;
+            }
+
+            if (person.outRanksUsingSkillTiebreaker(campaign, speaker)) {
+                speaker = person;
+            }
+        }
+
+        // First fallback
+        if (speaker == null) {
+            speaker = campaign.getSeniorAdminPerson(HR);
+        } else {
+            return speaker;
+        }
+
+        // Second fallback
+        if (speaker == null) {
+            speaker = campaign.getSeniorAdminPerson(COMMAND);
+        } else {
+            return speaker;
+        }
+
+        return speaker;
+    }
+
+    /**
+     * Determines whether the advance day operation should be canceled.
+     *
+     * @return {@code true} if advancing the day should be canceled, {@code false} otherwise.
+     */
+    public boolean shouldCancelAdvanceDay() {
+        return cancelAdvanceDay;
     }
 
     /**
@@ -85,13 +192,12 @@ public class InsufficientAstechsNagDialog extends AbstractMHQNagDialog {
      * </ul>
      *
      * @param asTechsNeeded The number of additional AsTechs required to meet the campaign's needs.
-     * @return {@code true} if the nag dialog should be displayed due to insufficient AsTechs,
-     *         {@code false} otherwise.
+     *
+     * @return {@code true} if the nag dialog should be displayed due to insufficient AsTechs, {@code false} otherwise.
      */
     public static boolean checkNag(int asTechsNeeded) {
         final String NAG_KEY = MHQConstants.NAG_INSUFFICIENT_ASTECHS;
 
-        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-              && hasAsTechsNeeded(asTechsNeeded);
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY) && hasAsTechsNeeded(asTechsNeeded);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechsNagDialog.java
@@ -27,7 +27,7 @@
  */
 package mekhq.gui.dialog.nagDialogs;
 
-import static mekhq.MHQConstants.NAG_ADMIN_STRAIN;
+import static mekhq.MHQConstants.NAG_INSUFFICIENT_ASTECHS;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
 import static mekhq.gui.dialog.nagDialogs.nagLogic.InsufficientAstechsNagLogic.hasAsTechsNeeded;
@@ -36,7 +36,6 @@ import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import java.util.ArrayList;
 import java.util.List;
 
-import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
@@ -99,7 +98,7 @@ public class InsufficientAstechsNagDialog {
             case CHOICE_CANCEL -> cancelAdvanceDay = true;
             case CHOICE_CONTINUE -> cancelAdvanceDay = false;
             case CHOICE_SUPPRESS -> {
-                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_ADMIN_STRAIN, true);
+                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_INSUFFICIENT_ASTECHS, true);
                 cancelAdvanceDay = false;
             }
             default ->
@@ -196,7 +195,7 @@ public class InsufficientAstechsNagDialog {
      * @return {@code true} if the nag dialog should be displayed due to insufficient AsTechs, {@code false} otherwise.
      */
     public static boolean checkNag(int asTechsNeeded) {
-        final String NAG_KEY = MHQConstants.NAG_INSUFFICIENT_ASTECHS;
+        final String NAG_KEY = NAG_INSUFFICIENT_ASTECHS;
 
         return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY) && hasAsTechsNeeded(asTechsNeeded);
     }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -159,7 +159,7 @@ public class NagController {
         // Insufficient AsTechs
         if (InsufficientAstechsNagDialog.checkNag(campaign.getAstechNeed())) {
             InsufficientAstechsNagDialog insufficientAstechsNagDialog = new InsufficientAstechsNagDialog(campaign);
-            if (insufficientAstechsNagDialog.wasAdvanceDayCanceled()) {
+            if (insufficientAstechsNagDialog.shouldCancelAdvanceDay()) {
                 return true;
             }
         }


### PR DESCRIPTION
- Refactored `InsufficientAstechsNagDialog` to utilize `ImmersiveDialogSimple` for improved modularity and customization.
- Replaced inheritance from `AbstractMHQNagDialog` with a standalone class to simplify and streamline the implementation.
- Updated NagController logic to replace `wasAdvanceDayCanceled()` with `shouldCancelAdvanceDay()` to reflect the updated behavior.

<img width="588" alt="image" src="https://github.com/user-attachments/assets/b27e06e8-038d-4562-a05b-7c8830e852f9" />
