### PR TITLE
Updated Insufficient Astech Time Nag To Use Immersive Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -323,15 +323,6 @@ InsufficientAstechsNagDialog.text=%s, a shortage of %d Astech%s is affecting the
   \ then selecting the option to bring all teams up to full strength. If this does not resolve the\
   \ issue, you have likely spread your techs too thinly by assigning them to too many units.\
   \ Consider hiring more techs.</i>
-InsufficientAstechTimeNagDialog.text=%s, current maintenance requires an additional %d Astech%s.\
-  \ Proceeding without resolving this will prevent some units from being maintained. Confirm your\
-  \ decision to advance the day.\
-  <br>\
-  <br><i>You can resolve this issue by selecting 'Marketplace' in the taskbar, then 'Astech Pool,'\
-  \ then selecting the option to bring all teams up to full strength. If this does not resolve the\
-  \ issue, you have likely spread your techs too thinly by assigning them to too many units.\
-  \ Consider hiring more techs. Alternatively, you may enable overtime, though this has its own\
-  \ downsides.</i>
 InsufficientMedicsNagDialog.text=%s, our medical teams are short by %d medic%s. This may lead to\
   \ delays in treatment or personnel remaining untreated. Confirm if you wish to advance the day\
   \ regardless.\

--- a/MekHQ/resources/mekhq/resources/NagDialogs.properties
+++ b/MekHQ/resources/mekhq/resources/NagDialogs.properties
@@ -19,3 +19,14 @@ DeploymentShortfallNagDialog.ooc=You should head to the Briefing Room and addres
   \ Reserve roles do not count towards deployment levels. Nor do Combat Teams assigned to the\
   \ Training role, unless the contract is Cadre Duty.\
   <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Options.</p>
+# Insufficient Astech Time
+InsufficientAstechTimeNagDialog.ic={0}, current maintenance requires an additional {1}\
+  \ {1, choice, 0#Astechs|1#Astech|2#Astechs}. Proceeding without resolving this will prevent some\
+  \ units from being maintained. Confirm your decision to advance the day.
+InsufficientAstechTimeNagDialog.ooc=You can resolve this issue by selecting 'Marketplace' in the\
+  \ toolbar, then 'Astech Pool,' then selecting the option to bring all teams up to full strength.\
+  \ If this does not resolve the issue, you have likely spread your techs too thinly by assigning\
+  \ them to too many units. Consider hiring more techs.\
+  <p>Alternatively, you may enable overtime, though this will significantly increase the Target\
+  \ Numbers of Tech and Medical tasks.</p>\
+  <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Options.</p>

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechTimeNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechTimeNagDialog.java
@@ -27,60 +27,174 @@
  */
 package mekhq.gui.dialog.nagDialogs;
 
-import mekhq.MHQConstants;
-import mekhq.MekHQ;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.unit.Unit;
-import mekhq.gui.baseComponents.AbstractMHQNagDialog;
-
-import java.util.Collection;
-
+import static mekhq.MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
 import static mekhq.gui.dialog.nagDialogs.nagLogic.InsufficientAstechTimeNagLogic.getAsTechTimeDeficit;
 import static mekhq.gui.dialog.nagDialogs.nagLogic.InsufficientAstechTimeNagLogic.hasAsTechTimeDeficit;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.unit.Unit;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 
 /**
- * A dialog used to notify the user about insufficient available time for astechs to complete the
- * required maintenance tasks. Not to be confused with {@link InsufficientAstechsNagDialog}.
+ * A dialog used to notify the user about insufficient available time for astechs to complete the required maintenance
+ * tasks. Not to be confused with {@link InsufficientAstechsNagDialog}.
  *
  * <p>
- * This nag dialog is triggered when the available work time for the astech pool is inadequate to meet
- * the maintenance time requirements for the current campaign's hangar units. It provides a localized
- * message detailing the time deficit and allows the user to take necessary action or dismiss the dialog.
+ * This nag dialog is triggered when the available work time for the astech pool is inadequate to meet the maintenance
+ * time requirements for the current campaign's hangar units. It provides a localized message detailing the time deficit
+ * and allows the user to take necessary action or dismiss the dialog.
  * </p>
  *
  * <strong>Features:</strong>
  * <ul>
  *   <li>Calculates the time deficit for the astech pool based on hangar unit maintenance requirements.</li>
  *   <li>Notifies the user when there is inadequate time available to maintain all units.</li>
- *   <li>Extends {@link AbstractMHQNagDialog} for consistent nag dialog behavior.</li>
  * </ul>
  */
-public class InsufficientAstechTimeNagDialog extends AbstractMHQNagDialog {
+public class InsufficientAstechTimeNagDialog {
+    private final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
+
+    private final int CHOICE_CANCEL = 0;
+    private final int CHOICE_CONTINUE = 1;
+    private final int CHOICE_SUPPRESS = 2;
+
+    private final Campaign campaign;
+    private boolean cancelAdvanceDay;
+
     /**
      * Constructs an {@code InsufficientAstechTimeNagDialog} for the given campaign.
      *
      * <p>
-     * This dialog calculates the astech time deficit and uses a localized message
-     * to notify the user about the shortage of available time. The message provides
-     * the commander's address, the time deficit, and a pluralized suffix for correctness.
+     * This dialog calculates the astech time deficit and uses a localized message to notify the user about the shortage
+     * of available time. The message provides the commander's address, the time deficit, and a pluralized suffix for
+     * correctness.
      * </p>
      *
-     * @param campaign The {@link Campaign} tied to this nag dialog.
-     *                 The campaign provides data about hangar units and astech availability.
+     * @param campaign                   The {@link Campaign} tied to this nag dialog. The campaign provides data about
+     *                                   hangar units and astech availability.
+     * @param units                      A collection of {@link Unit} objects to evaluate for maintenance needs.
+     * @param possibleAstechPoolMinutes  The total available AsTech work minutes without considering overtime.
+     * @param isOvertimeAllowed          A flag indicating whether overtime is allowed, which adds to the available
+     *                                   AsTech work time.
+     * @param possibleAstechPoolOvertime The additional AsTech work minutes available if overtime is allowed.
      */
-    public InsufficientAstechTimeNagDialog(final Campaign campaign) {
-        super(campaign, MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME);
+    public InsufficientAstechTimeNagDialog(final Campaign campaign, Collection<Unit> units, int possibleAstechPoolMinutes, boolean isOvertimeAllowed, int possibleAstechPoolOvertime) {
+        this.campaign = campaign;
 
-        int asTechsTimeDeficit = getAsTechTimeDeficit(campaign.getUnits(), campaign.getPossibleAstechPoolMinutes(),
-              campaign.isOvertimeAllowed(), campaign.getPossibleAstechPoolOvertime());
+        int asTechsTimeDeficit = getAsTechTimeDeficit(units,
+              possibleAstechPoolMinutes,
+              isOvertimeAllowed,
+              possibleAstechPoolOvertime);
 
-        String pluralizer = (asTechsTimeDeficit > 1) ? "s" : "";
+        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
+              getSpeaker(),
+              null,
+              getFormattedTextAt(RESOURCE_BUNDLE,
+                    "InsufficientAstechTimeNagDialog.ic",
+                    campaign.getCommanderAddress(false),
+                    asTechsTimeDeficit),
+              getButtonLabels(),
+              getFormattedTextAt(RESOURCE_BUNDLE, "InsufficientAstechTimeNagDialog.ooc"),
+              true);
 
-        final String DIALOG_BODY = "InsufficientAstechTimeNagDialog.text";
-        setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
-            campaign.getCommanderAddress(false), asTechsTimeDeficit, pluralizer));
-        showDialog();
+        int choiceIndex = dialog.getDialogChoice();
+
+        switch (choiceIndex) {
+            case CHOICE_CANCEL -> cancelAdvanceDay = true;
+            case CHOICE_CONTINUE -> cancelAdvanceDay = false;
+            case CHOICE_SUPPRESS -> {
+                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_INSUFFICIENT_ASTECH_TIME, true);
+                cancelAdvanceDay = false;
+            }
+            default ->
+                  throw new IllegalStateException("Unexpected value in InsufficientAstechTimeNagDialog" + choiceIndex);
+        }
     }
+
+    /**
+     * Retrieves a list of button labels from the resource bundle.
+     *
+     * <p>The method collects and returns button labels such as "Cancel", "Continue", and "Suppress" after
+     * formatting them using the provided resource bundle.</p>
+     *
+     * @return a {@link List} of formatted button labels as {@link String}.
+     */
+    private List<String> getButtonLabels() {
+        List<String> buttonLabels = new ArrayList<>();
+
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.cancel"));
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"));
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.suppress"));
+
+        return buttonLabels;
+    }
+
+    /**
+     * Retrieves the speaker based on the active personnel.
+     *
+     * <p>This method iterates through the active personnel within the campaign and attempts to identify a speaker who
+     * meets the criteria. It prioritizes selecting a person with technical specialization, using a tie-breaking
+     * mechanism based on rank and skills. If no suitable speaker is found, it defaults to the senior administrator
+     * person with the "COMMAND" specialization.</p>
+     *
+     * @return the {@link Person} designated as the speaker, either the highest-ranking technical specialist or the
+     *       senior administrator with the "COMMAND" specialization if no other suitable speaker is found.
+     */
+    private Person getSpeaker() {
+        List<Person> activePersonnel = campaign.getActivePersonnel(false);
+
+        Person speaker = null;
+
+        for (Person person : activePersonnel) {
+            if (!person.isTech()) {
+                continue;
+            }
+
+            if (speaker == null) {
+                speaker = person;
+                continue;
+            }
+
+            if (person.outRanksUsingSkillTiebreaker(campaign, speaker)) {
+                speaker = person;
+            }
+        }
+
+        // First fallback
+        if (speaker == null) {
+            speaker = campaign.getSeniorAdminPerson(HR);
+        } else {
+            return speaker;
+        }
+
+        // Second fallback
+        if (speaker == null) {
+            speaker = campaign.getSeniorAdminPerson(COMMAND);
+        } else {
+            return speaker;
+        }
+
+        return speaker;
+    }
+
+    /**
+     * Determines whether the advance day operation should be canceled.
+     *
+     * @return {@code true} if advancing the day should be canceled, {@code false} otherwise.
+     */
+    public boolean shouldCancelAdvanceDay() {
+        return cancelAdvanceDay;
+    }
+
 
     /**
      * Determines whether a nag dialog should be displayed due to insufficient AsTech time in the campaign.
@@ -91,19 +205,22 @@ public class InsufficientAstechTimeNagDialog extends AbstractMHQNagDialog {
      *     <li>There is a positive deficit in the available AsTech time for maintaining the campaign's units.</li>
      * </ul>
      *
-     * @param units A collection of {@link Unit} objects to evaluate for maintenance needs.
-     * @param possibleAstechPoolMinutes The total available AsTech work minutes without considering overtime.
-     * @param isOvertimeAllowed A flag indicating whether overtime is allowed, which adds to the available AsTech work time.
+     * @param units                      A collection of {@link Unit} objects to evaluate for maintenance needs.
+     * @param possibleAstechPoolMinutes  The total available AsTech work minutes without considering overtime.
+     * @param isOvertimeAllowed          A flag indicating whether overtime is allowed, which adds to the available
+     *                                   AsTech work time.
      * @param possibleAstechPoolOvertime The additional AsTech work minutes available if overtime is allowed.
      *
-     * @return {@code true} if the nag dialog should be displayed due to insufficient AsTech time,
-     *         {@code false} otherwise.
+     * @return {@code true} if the nag dialog should be displayed due to insufficient AsTech time, {@code false}
+     *       otherwise.
      */
-    public static boolean checkNag(Collection<Unit> units, int possibleAstechPoolMinutes,
-                                   boolean isOvertimeAllowed, int possibleAstechPoolOvertime) {
-        final String NAG_KEY = MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME;
+    public static boolean checkNag(Collection<Unit> units, int possibleAstechPoolMinutes, boolean isOvertimeAllowed, int possibleAstechPoolOvertime) {
+        final String NAG_KEY = NAG_INSUFFICIENT_ASTECH_TIME;
 
-        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-              && hasAsTechTimeDeficit(units, possibleAstechPoolMinutes, isOvertimeAllowed, possibleAstechPoolOvertime);
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY) &&
+                     hasAsTechTimeDeficit(units,
+                           possibleAstechPoolMinutes,
+                           isOvertimeAllowed,
+                           possibleAstechPoolOvertime);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -174,8 +174,12 @@ public class NagController {
               isOvertimeAllowed,
               possibleAstechPoolOvertime)) {
             InsufficientAstechTimeNagDialog insufficientAstechTimeNagDialog = new InsufficientAstechTimeNagDialog(
-                  campaign);
-            if (insufficientAstechTimeNagDialog.wasAdvanceDayCanceled()) {
+                  campaign,
+                  units,
+                  possibleAstechPoolMinutes,
+                  isOvertimeAllowed,
+                  possibleAstechPoolOvertime);
+            if (insufficientAstechTimeNagDialog.shouldCancelAdvanceDay()) {
                 return true;
             }
         }


### PR DESCRIPTION
- Refactored `InsufficientAstechTimeNagDialog` to utilize `ImmersiveDialogSimple` for improved modularity and customization.
- Replaced inheritance from `AbstractMHQNagDialog` with a standalone class to simplify and streamline the implementation.
- Updated NagController logic to replace `wasAdvanceDayCanceled()` with `shouldCancelAdvanceDay()` to reflect the updated behavior.

<img width="586" alt="image" src="https://github.com/user-attachments/assets/729afb62-9958-4fb4-bbd2-74950e2e61ef" />
