### PR TITLE
Adjusted Glossary Dialog Dimensions

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/GlossaryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GlossaryDialog.java
@@ -65,8 +65,8 @@ public class GlossaryDialog extends JDialog {
     private final JDialog parent;
     private final Campaign campaign;
 
-    private int CENTER_WIDTH = UIUtil.scaleForGUI(400);
-    private int CENTER_HEIGHT = UIUtil.scaleForGUI(300);
+    private int CENTER_WIDTH = UIUtil.scaleForGUI(800);
+    private int CENTER_HEIGHT = UIUtil.scaleForGUI(400);
     private int PADDING = UIUtil.scaleForGUI(10);
 
     private final String GLOSSARY_BUNDLE = "mekhq.resources.Glossary";


### PR DESCRIPTION
- Increased `CENTER_WIDTH` from 400 to 800 for improved usability and readability.
- Increased `CENTER_HEIGHT` from 300 to 400 for better display of glossary content.

### Dev Notes
Some of the glossary entries are quite large, so I opted to increase the dialog size to better accommodate them.