### PR TITLE
Expanded Prisoner End of Contract Events to Missions

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
@@ -70,9 +70,9 @@ import mekhq.gui.dialog.randomEvents.prisonerDialogs.PrisonerWarningResultsDialo
  * Manages prisoner-related events and warnings during a campaign.
  *
  * <p>Handles both weekly and monthly events associated with prisoners in the campaign, including
- * ransom opportunities, warnings for prisoner overflow, and random events that affect the campaign
- * state. It also calculates prisoner capacity, processes executions, and dynamically generates
- * prisoner-related scenarios based on campaign conditions.</p>
+ * ransom opportunities, warnings for prisoner overflow, and random events that affect the campaign state. It also
+ * calculates prisoner capacity, processes executions, and dynamically generates prisoner-related scenarios based on
+ * campaign conditions.</p>
  *
  * <p>The manager adjusts campaign parameters such as temporary prisoner capacity and handles
  * interactions with the player via dialogs, providing options to resolve prisoner-related issues.</p>
@@ -108,8 +108,7 @@ public class PrisonerEventManager {
     private final int CHOICE_EXECUTE = 2;
 
     /**
-     * Constructs a new {@link PrisonerEventManager} and handles the initialization of
-     * prisoner-related events.
+     * Constructs a new {@link PrisonerEventManager} and handles the initialization of prisoner-related events.
      *
      * <p>Performs the following during initialization:</p>
      * <ul>
@@ -118,8 +117,7 @@ public class PrisonerEventManager {
      *     <li>Handles weekly events related to prisoner overflow or random events.</li>
      * </ul>
      *
-     * @param campaign The current campaign instance, providing context and state for prisoner
-     *                management.
+     * @param campaign The current campaign instance, providing context and state for prisoner management.
      */
     public PrisonerEventManager(Campaign campaign) {
         this.campaign = campaign;
@@ -144,7 +142,7 @@ public class PrisonerEventManager {
             return;
         }
 
-        if (!campaign.hasActiveContract()) {
+        if (campaign.getActiveMissions(false).isEmpty()) {
             return;
         }
 
@@ -163,9 +161,8 @@ public class PrisonerEventManager {
      * Adjusts the temporary prisoner capacity for the given campaign by degrading it.
      *
      * <p>This method modifies the campaign's temporary prisoner capacity based on a percentage of
-     * the current value. It ensures that the capacity moves closer to a default value, either
-     * increasing or decreasing depending on the current capacity modifier's position relative to
-     * the default.</p>
+     * the current value. It ensures that the capacity moves closer to a default value, either increasing or decreasing
+     * depending on the current capacity modifier's position relative to the default.</p>
      *
      * @return The updated temporary capacity modifier after the adjustment has been applied.
      */
@@ -193,11 +190,11 @@ public class PrisonerEventManager {
     }
 
     /**
-     * Checks for ransom-related events in the given campaign. This method determines if a ransom
-     * event is triggered and whether friendly prisoners of war (POWs) are involved.
+     * Checks for ransom-related events in the given campaign. This method determines if a ransom event is triggered and
+     * whether friendly prisoners of war (POWs) are involved.
      *
-     * @return A list of two boolean values where the first element indicates if an event
-     *         was triggered, and the second element specifies if the event involves friendly POWs.
+     * @return A list of two boolean values where the first element indicates if an event was triggered, and the second
+     *       element specifies if the event involves friendly POWs.
      */
     List<Boolean> checkForRansomEvents() {
         boolean eventTriggered = false;
@@ -225,13 +222,13 @@ public class PrisonerEventManager {
      * Checks for events related to prisoner overflow in the campaign.
      *
      * <p>This method determines whether a minor or major prisoner-related event occurs based on
-     * the current prisoner capacity, usage, and overflow. If there is no event, a warning may be
-     * processed.
+     * the current prisoner capacity, usage, and overflow. If there is no event, a warning may be processed.
      *
-     * @param isHeadless A boolean value indicating whether the process is running without a user
-     *                  interface. Allows Unit Tests to bypass the GUI prompts created by this method.
-     * @return A list of two boolean values: The first element indicates whether a minor event
-     * occurred. The second element indicates whether a major event occurred.
+     * @param isHeadless A boolean value indicating whether the process is running without a user interface. Allows Unit
+     *                   Tests to bypass the GUI prompts created by this method.
+     *
+     * @return A list of two boolean values: The first element indicates whether a minor event occurred. The second
+     *       element indicates whether a major event occurred.
      */
     List<Boolean> checkForPrisonerEvents(boolean isHeadless) {
         int totalPrisoners = campaign.getCurrentPrisoners().size();
@@ -254,9 +251,9 @@ public class PrisonerEventManager {
 
         // Does the minor event escalate into a major event?
         eventRoll = randomInt(100);
-        boolean majorEvent = minorEvent
-            && (totalPrisoners > MINIMUM_PRISONER_COUNT)
-            && (eventRoll < overflow || eventRoll == 0);
+        boolean majorEvent = minorEvent &&
+                                   (totalPrisoners > MINIMUM_PRISONER_COUNT) &&
+                                   (eventRoll < overflow || eventRoll == 0);
 
         // If there is no event, throw up a warning and give the player an opportunity to do
         // something about the situation.
@@ -278,11 +275,10 @@ public class PrisonerEventManager {
      * Processes a random event involving prisoners.
      *
      * <p>Handles both minor and major prisoner events. A dialog is presented to the player,
-     * allowing them to decide how to respond. Based on the outcome, the event's effects are
-     * applied, which may include generating escapee scenarios or other consequences.</p>
+     * allowing them to decide how to respond. Based on the outcome, the event's effects are applied, which may include
+     * generating escapee scenarios or other consequences.</p>
      *
-     * @param majorEvent {@code true} if the event is classified as a major event, {@code false}
-     *                              for a minor event.
+     * @param majorEvent {@code true} if the event is classified as a major event, {@code false} for a minor event.
      */
     private void processRandomEvent(boolean majorEvent) {
         PrisonerEventData eventData;
@@ -293,8 +289,7 @@ public class PrisonerEventManager {
         }
         PrisonerEvent event = eventData.prisonerEvent();
 
-        PrisonerEventDialog eventDialog =
-            new PrisonerEventDialog(campaign, speaker, event);
+        PrisonerEventDialog eventDialog = new PrisonerEventDialog(campaign, speaker, event);
 
         int choiceIndex = eventDialog.getDialogChoice();
 
@@ -321,8 +316,8 @@ public class PrisonerEventManager {
      * Processes a warning event when the prisoner overflow exceeds acceptable limits.
      *
      * <p>Presents a dialog to the player, allowing them to take corrective actions by choosing to
-     * either release or execute prisoners to address the overflow. Results in the removal or
-     * execution of prisoners based on the player's choice.</p>
+     * either release or execute prisoners to address the overflow. Results in the removal or execution of prisoners
+     * based on the player's choice.</p>
      *
      * @param overflow The calculated overflow value indicating prisoners exceeding capacity.
      */
@@ -359,6 +354,7 @@ public class PrisonerEventManager {
      * Selects a random event from the available prisoner events.
      *
      * @param isMajor {@code true} to select a major event, {@code false} to select a minor event.
+     *
      * @return A randomly selected {@link PrisonerEventData} object representing the event.
      */
     private PrisonerEventData pickEvent(boolean isMajor) {
@@ -375,13 +371,17 @@ public class PrisonerEventManager {
      *
      * @param eventData   The data for the prisoner event being processed.
      * @param choiceIndex The index of the choice made by the player in the event dialog.
+     *
      * @return {@code true} if the player's response is deemed successful, {@code false} otherwise.
      */
     private boolean makeEventCheck(PrisonerEventData eventData, int choiceIndex) {
         int responseModifier = 0;
         if (speaker != null) {
             responseModifier = getPersonalityValue(campaign.getCampaignOptions().isUseRandomPersonalities(),
-                speaker.getAggression(), speaker.getAmbition(), speaker.getGreed(), speaker.getSocial());
+                  speaker.getAggression(),
+                  speaker.getAmbition(),
+                  speaker.getGreed(),
+                  speaker.getSocial());
         }
 
         if (speaker == null) {
@@ -390,7 +390,8 @@ public class PrisonerEventManager {
 
         ResponseQuality responseQuality = eventData.responseEntries().get(choiceIndex).quality();
         switch (responseQuality) {
-            case RESPONSE_NEUTRAL -> {} // No modifier
+            case RESPONSE_NEUTRAL -> {
+            } // No modifier
             case RESPONSE_POSITIVE -> responseModifier += 3;
             case RESPONSE_NEGATIVE -> responseModifier -= 3;
         }
@@ -404,8 +405,8 @@ public class PrisonerEventManager {
      * Processes the execution of a given number of prisoners.
      *
      * <p>Removes prisoners from the campaign while generating appropriate reports of their
-     * execution. Triggers additional logic to handle campaign state updates, such as potential
-     * backfires or penalties from the executions.</p>
+     * execution. Triggers additional logic to handle campaign state updates, such as potential backfires or penalties
+     * from the executions.</p>
      *
      * @param executions The number of prisoners to be executed.
      * @param prisoners  The list of prisoners involved in the execution.
@@ -413,8 +414,7 @@ public class PrisonerEventManager {
     private void processExecutions(int executions, List<Person> prisoners) {
         for (int i = 0; i < executions; i++) {
             Person prisoner = prisoners.get(i);
-            campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE, "execute.report",
-                    prisoner.getFullName()));
+            campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE, "execute.report", prisoner.getFullName()));
             campaign.removePerson(prisoner, false);
         }
 
@@ -454,23 +454,27 @@ public class PrisonerEventManager {
         // Build the report
         String key = getFormattedTextAt(RESOURCE_BUNDLE, hasBackfired ? "execute.backfired" : "execute.successful");
 
-        String messageColor = hasBackfired
-            ? spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor())
-            : spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor());
+        String messageColor = hasBackfired ?
+                                    spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()) :
+                                    spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor());
 
-        String crimeColor = crimeNoticed
-            ? spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor())
-            : spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor());
+        String crimeColor = crimeNoticed ?
+                                  spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()) :
+                                  spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor());
 
-        String crimeMessage = crimeNoticed
-            ? getFormattedTextAt(RESOURCE_BUNDLE, "execute.crimeNoticed",
-                crimeColor, CLOSING_SPAN_TAG, penalty)
-            : getFormattedTextAt(RESOURCE_BUNDLE, "execute.crimeUnnoticed",
-                crimeColor, CLOSING_SPAN_TAG);
+        String crimeMessage = crimeNoticed ?
+                                    getFormattedTextAt(RESOURCE_BUNDLE,
+                                          "execute.crimeNoticed",
+                                          crimeColor,
+                                          CLOSING_SPAN_TAG,
+                                          penalty) :
+                                    getFormattedTextAt(RESOURCE_BUNDLE,
+                                          "execute.crimeUnnoticed",
+                                          crimeColor,
+                                          CLOSING_SPAN_TAG);
 
         // Add the report
-        campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE, key), messageColor, CLOSING_SPAN_TAG,
-                crimeMessage);
+        campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE, key), messageColor, CLOSING_SPAN_TAG, crimeMessage);
     }
 
     /**
@@ -480,6 +484,7 @@ public class PrisonerEventManager {
      * This value represents the total number of prisoners consuming capacity resources.</p>
      *
      * @param campaign The current campaign instance.
+     *
      * @return The total prisoner capacity usage.
      */
     public static int calculatePrisonerCapacityUsage(Campaign campaign) {
@@ -507,10 +512,10 @@ public class PrisonerEventManager {
      * Calculates the total available capacity for holding prisoners in the campaign.
      *
      * <p>This calculation accounts for forces capable of handling prisoners, such as security
-     * units, and factors in adjustments based on the MekHQ capture style and temporary capacity
-     * modifiers.</p>
+     * units, and factors in adjustments based on the MekHQ capture style and temporary capacity modifiers.</p>
      *
      * @param campaign The current campaign instance.
+     *
      * @return The total prisoner capacity.
      */
     public static int calculatePrisonerCapacity(Campaign campaign) {
@@ -543,9 +548,10 @@ public class PrisonerEventManager {
                     int crewSize = unit.getCrew().size();
                     for (int trooper = 0; trooper < crewSize; trooper++) {
                         if (unit.isBattleArmorSuitOperable(trooper)) {
-                            prisonerCapacity += isMekHQCaptureStyle
-                                ? PRISONER_CAPACITY_BATTLE_ARMOR
-                                : PRISONER_CAPACITY_BATTLE_ARMOR * PRISONER_CAPACITY_CAM_OPS_MULTIPLIER;
+                            prisonerCapacity += isMekHQCaptureStyle ?
+                                                      PRISONER_CAPACITY_BATTLE_ARMOR :
+                                                      PRISONER_CAPACITY_BATTLE_ARMOR *
+                                                            PRISONER_CAPACITY_CAM_OPS_MULTIPLIER;
                         }
                     }
 
@@ -555,9 +561,10 @@ public class PrisonerEventManager {
                 if (unit.isConventionalInfantry()) {
                     for (Person soldier : unit.getCrew()) {
                         if (!soldier.needsFixing()) {
-                            prisonerCapacity += isMekHQCaptureStyle
-                                ? PRISONER_CAPACITY_CONVENTIONAL_INFANTRY
-                                : PRISONER_CAPACITY_CONVENTIONAL_INFANTRY * PRISONER_CAPACITY_CAM_OPS_MULTIPLIER;
+                            prisonerCapacity += isMekHQCaptureStyle ?
+                                                      PRISONER_CAPACITY_CONVENTIONAL_INFANTRY :
+                                                      PRISONER_CAPACITY_CONVENTIONAL_INFANTRY *
+                                                            PRISONER_CAPACITY_CAM_OPS_MULTIPLIER;
                         }
                     }
                     continue;
@@ -579,10 +586,11 @@ public class PrisonerEventManager {
     }
 
     /**
-     * Determines whether the specified unit is of a prohibited type. A unit is considered
-     * prohibited if its associated entity is an aerospace entity.
+     * Determines whether the specified unit is of a prohibited type. A unit is considered prohibited if its associated
+     * entity is an aerospace entity.
      *
      * @param unit The unit to be checked for prohibition. Must not be null.
+     *
      * @return true if the unit's entity is an aerospace entity, false otherwise.
      */
     private static boolean isProhibitedUnitType(Unit unit) {
@@ -599,8 +607,7 @@ public class PrisonerEventManager {
      * Retrieves the speaker for a prisoner-related dialog or event.
      *
      * <p>The speaker is typically selected from security forces within the campaign. If no suitable
-     * speaker is found, a senior administrator with the transport specialization is returned as a
-     * fallback.</p>
+     * speaker is found, a senior administrator with the transport specialization is returned as a fallback.</p>
      *
      * @return The selected {@link Person} who acts as the speaker, or {@code null} if none is found.
      */
@@ -638,6 +645,7 @@ public class PrisonerEventManager {
      * value.</p>
      *
      * @param maxValue The upper bound (exclusive) for the random integer. Must be greater than 0.
+     *
      * @return A randomly generated integer in the range [0, (maxValue - 1)].
      */
     protected int randomInt(int maxValue) {
@@ -651,6 +659,7 @@ public class PrisonerEventManager {
      * value.</p>
      *
      * @param dice The number of six-sided dice to roll. Must be a non-negative integer.
+     *
      * @return The total result of the rolled dice.
      */
     protected int d6(int dice) {

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerMissionEndEvent.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerMissionEndEvent.java
@@ -46,6 +46,8 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.mission.Contract;
+import mekhq.campaign.mission.Mission;
+import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.gui.dialog.MissionEndPrisonerDefectorDialog;
@@ -55,15 +57,15 @@ import mekhq.gui.dialog.MissionEndPrisonerDialog;
  * Handles events involving prisoners at the end of a mission.
  *
  * <p>This class manages the outcomes for prisoners of war (POWs) at the conclusion
- * of a mission. These outcomes can include release, execution, ransom, or other status updates
- * based on mission success, alliances, and player choices. It also handles financial transactions
- * related to ransoms and updates the campaign state accordingly.</p>
+ * of a mission. These outcomes can include release, execution, ransom, or other status updates based on mission
+ * success, alliances, and player choices. It also handles financial transactions related to ransoms and updates the
+ * campaign state accordingly.</p>
  */
 public class PrisonerMissionEndEvent {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.PrisonerEvents";
 
     private final Campaign campaign;
-    private final Contract contract;
+    private final Mission contract;
     private boolean isSuccess;
     private boolean isAllied;
 
@@ -76,11 +78,10 @@ public class PrisonerMissionEndEvent {
     /**
      * Creates a new instance of `PrisonerMissionEndEvent` to handle mission-end prisoner events.
      *
-     * @param campaign The current campaign instance, providing context and data about prisoners
-     *                and finances.
+     * @param campaign The current campaign instance, providing context and data about prisoners and finances.
      * @param contract The current mission contract related to this event.
      */
-    public PrisonerMissionEndEvent(Campaign campaign, Contract contract) {
+    public PrisonerMissionEndEvent(Campaign campaign, Mission contract) {
         this.campaign = campaign;
         this.contract = contract;
     }
@@ -101,13 +102,12 @@ public class PrisonerMissionEndEvent {
      * Processes the handling of prisoners after a mission ends.
      *
      * <p>This method determines the list of prisoners involved, calculates ransom amounts if
-     * applicable, determines the likelihood of a positive ("good") event, and presents the player
-     * with a dialog for managing prisoners. Outcomes depend on whether the player succeeds in the
-     * mission, prisoner allegiance, and good/bad events.</p>
+     * applicable, determines the likelihood of a positive ("good") event, and presents the player with a dialog for
+     * managing prisoners. Outcomes depend on whether the player succeeds in the mission, prisoner allegiance, and
+     * good/bad events.</p>
      *
      * @param isSuccess {@code true} if the mission was a success, {@code false} otherwise.
-     * @param isAllied  {@code true} if the prisoners are allied POWs, {@code false} if they belong
-     *                             to the enemy.
+     * @param isAllied  {@code true} if the prisoners are allied POWs, {@code false} if they belong to the enemy.
      */
     public void handlePrisoners(boolean isSuccess, boolean isAllied) {
         this.isAllied = isAllied;
@@ -119,25 +119,38 @@ public class PrisonerMissionEndEvent {
         int goodEventChance = determineGoodEventChance(isAllied);
         boolean isGoodEvent = randomInt(goodEventChance) > 0;
 
-        MissionEndPrisonerDialog dialog = new MissionEndPrisonerDialog(campaign, ransom, isAllied,
-            isSuccess, isGoodEvent);
+        MissionEndPrisonerDialog dialog = new MissionEndPrisonerDialog(campaign,
+              ransom,
+              isAllied,
+              isSuccess,
+              isGoodEvent);
 
         processPlayerResponse(ransom, isGoodEvent, dialog.getDialogChoice(), prisoners);
     }
 
     /**
-     * Determines if the event progresses into a "good event" based on mission success, prisoner
-     * allegiance, and other contextual factors such as recent crimes.
+     * Determines the likelihood of an end of contract event being classified as a "good event" based on mission
+     * success, prisoner allegiance, and contextual factors such as recent crimes.
+     *
+     * <p>If the prisoners are allied POWs, the method evaluates whether recent crimes have occurred after the start
+     * of the current contract or mission. If such crimes exist, the chance of a "good event" is adjusted downward based
+     * on the crime rating. For non-allied prisoners or situations without recent crimes, a default chance value is
+     * used.</p>
      *
      * @param isAllied {@code true} if the prisoners are allied POWs, {@code false} otherwise.
-     * @return {@code true} if the event is classified as a "good event," {@code false} otherwise.
+     *
+     * @return the likelihood of a "good event" as an integer value, where higher values indicate a greater chance.
      */
     int determineGoodEventChance(boolean isAllied) {
         if (isAllied) {
             LocalDate lastCrime = campaign.getDateOfLastCrime();
-            if (lastCrime != null && lastCrime.isAfter(contract.getStartDate().minusDays(1))) {
-                // Adjust the chance of a good event based on crime rating
-                return max(1, GOOD_EVENT_CHANCE - campaign.getAdjustedCrimeRating());
+            LocalDate startDate = getContractOrMissionStartDate();
+
+            if ((startDate != null) && (lastCrime != null)) {
+                if (lastCrime.isAfter(startDate)) {
+                    // Adjust the chance of a good event based on crime rating
+                    return max(1, GOOD_EVENT_CHANCE - campaign.getAdjustedCrimeRating());
+                }
             }
         }
         // Default chance for goodEvent (used for both non-allied and no recent crimes in allied)
@@ -145,9 +158,46 @@ public class PrisonerMissionEndEvent {
     }
 
     /**
+     * Retrieves the earliest starting date from either the active contract or completed mission scenarios.
+     *
+     * <p>The method determines the start date of the current contract or mission by examining the contract's
+     * start date or the earliest date among completed scenarios. Each start date is adjusted slightly earlier by one
+     * day.</p>
+     *
+     * @return the start date of the contract or mission as a {@link LocalDate}, or {@code null} if no valid date is
+     *       found.
+     */
+    private LocalDate getContractOrMissionStartDate() {
+        LocalDate startDate = null;
+        if (contract instanceof Contract) {
+            startDate = ((Contract) contract).getStartDate();
+        } else {
+            for (Scenario scenario : contract.getCompletedScenarios()) {
+                LocalDate scenarioDate = scenario.getDate();
+
+                if (startDate == null) {
+                    startDate = scenarioDate;
+                    continue;
+                }
+
+                if (scenarioDate.isBefore(startDate)) {
+                    startDate = scenarioDate;
+                }
+            }
+        }
+
+        if (startDate == null) {
+            return null;
+        }
+
+        return startDate.minusDays(1);
+    }
+
+    /**
      * Calculates the total ransom amount for a list of prisoners.
      *
      * @param alliedPoWs The list of prisoners for whom the ransom is calculated.
+     *
      * @return The total ransom as {@link Money}.
      */
     Money getRansom(List<Person> alliedPoWs) {
@@ -165,16 +215,15 @@ public class PrisonerMissionEndEvent {
      * Processes the player's response from the prisoner-handling dialog.
      *
      * <p>Based on the player's choice, this method applies appropriate actions, including
-     * releasing, executing, or ransoming prisoners. It also modifies prisoner status and manages
-     * any associated financial transactions.</p>
+     * releasing, executing, or ransoming prisoners. It also modifies prisoner status and manages any associated
+     * financial transactions.</p>
      *
      * @param ransom      The calculated ransom amount.
      * @param isGoodEvent {@code true} if the event is classified as positive, {@code false} otherwise.
      * @param choiceIndex The player's choice index from the dialog.
      * @param prisoners   The list of prisoners involved in the event.
      */
-    private void processPlayerResponse(Money ransom, boolean isGoodEvent, int choiceIndex,
-                                       List<Person> prisoners) {
+    private void processPlayerResponse(Money ransom, boolean isGoodEvent, int choiceIndex, List<Person> prisoners) {
         if (choiceIndex == CHOICE_RELEASE_THEM) {
             removeAllPrisoners(prisoners);
         }
@@ -260,21 +309,21 @@ public class PrisonerMissionEndEvent {
     /**
      * Performs a financial transaction for a ransom, either crediting or debiting funds.
      *
-     * @param isCredit {@code true} if the ransom results in funds being credited to the player,
-     * {@code false} if debited.
+     * @param isCredit {@code true} if the ransom results in funds being credited to the player, {@code false} if
+     *                 debited.
      * @param ransom   The ransom amount being transacted.
      * @param today    The current campaign date for the transaction record.
      */
     private void performRansom(boolean isCredit, Money ransom, LocalDate today) {
         if (isCredit) {
-            campaign.getFinances().credit(RANSOM, today, ransom, getFormattedTextAt(RESOURCE_BUNDLE,
-                "transaction.ransom"));
+            campaign.getFinances()
+                  .credit(RANSOM, today, ransom, getFormattedTextAt(RESOURCE_BUNDLE, "transaction.ransom"));
         } else {
             // That this can take a player into negative is a deliberate decision. As this dialog
             // is only presented after the point of no return, we don't want the player left in a
             // situation where 1 C-Bill locks them out of ransoming back their people.
-            campaign.getFinances().debit(RANSOM, today, ransom, getFormattedTextAt(RESOURCE_BUNDLE,
-                "transaction.ransom"));
+            campaign.getFinances()
+                  .debit(RANSOM, today, ransom, getFormattedTextAt(RESOURCE_BUNDLE, "transaction.ransom"));
         }
     }
 
@@ -293,8 +342,7 @@ public class PrisonerMissionEndEvent {
      * Executes prisoners involved in the event and applies related penalties or notifications.
      *
      * <p>Depending on the severity of the execution, this method adjusts the campaign's crime
-     * rating, generates reports, and determines whether the crime was noticed based on a random
-     * roll.</p>
+     * rating, generates reports, and determines whether the crime was noticed based on a random roll.</p>
      *
      * @param prisoners The list of prisoners to be executed.
      */
@@ -310,15 +358,20 @@ public class PrisonerMissionEndEvent {
         }
 
         // Build the report
-        String crimeColor = crimeNoticed
-            ? spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor())
-            : spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor());
+        String crimeColor = crimeNoticed ?
+                                  spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()) :
+                                  spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor());
 
-        String crimeMessage = crimeNoticed
-            ? getFormattedTextAt(RESOURCE_BUNDLE, "execute.crimeNoticed",
-            crimeColor, CLOSING_SPAN_TAG, penalty)
-            : getFormattedTextAt(RESOURCE_BUNDLE, "execute.crimeUnnoticed",
-            crimeColor, CLOSING_SPAN_TAG);
+        String crimeMessage = crimeNoticed ?
+                                    getFormattedTextAt(RESOURCE_BUNDLE,
+                                          "execute.crimeNoticed",
+                                          crimeColor,
+                                          CLOSING_SPAN_TAG,
+                                          penalty) :
+                                    getFormattedTextAt(RESOURCE_BUNDLE,
+                                          "execute.crimeUnnoticed",
+                                          crimeColor,
+                                          CLOSING_SPAN_TAG);
 
         // Add the report
         campaign.addReport(crimeMessage);

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerMissionEndEvent.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerMissionEndEvent.java
@@ -65,7 +65,7 @@ public class PrisonerMissionEndEvent {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.PrisonerEvents";
 
     private final Campaign campaign;
-    private final Mission contract;
+    private final Mission mission;
     private boolean isSuccess;
     private boolean isAllied;
 
@@ -79,11 +79,11 @@ public class PrisonerMissionEndEvent {
      * Creates a new instance of `PrisonerMissionEndEvent` to handle mission-end prisoner events.
      *
      * @param campaign The current campaign instance, providing context and data about prisoners and finances.
-     * @param contract The current mission contract related to this event.
+     * @param mission  The current mission related to this event.
      */
-    public PrisonerMissionEndEvent(Campaign campaign, Mission contract) {
+    public PrisonerMissionEndEvent(Campaign campaign, Mission mission) {
         this.campaign = campaign;
-        this.contract = contract;
+        this.mission = mission;
     }
 
     /**
@@ -169,10 +169,10 @@ public class PrisonerMissionEndEvent {
      */
     private LocalDate getContractOrMissionStartDate() {
         LocalDate startDate = null;
-        if (contract instanceof Contract) {
-            startDate = ((Contract) contract).getStartDate();
+        if (mission instanceof Contract) {
+            startDate = ((Contract) mission).getStartDate();
         } else {
-            for (Scenario scenario : contract.getCompletedScenarios()) {
+            for (Scenario scenario : mission.getCompletedScenarios()) {
                 LocalDate scenarioDate = scenario.getDate();
 
                 if (startDate == null) {

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -445,18 +445,15 @@ public final class BriefingTab extends CampaignGuiTab {
             }
         }
 
-        if (mission instanceof AtBContract) {
-            boolean wasOverallSuccess = cmd.getStatus() == SUCCESS || cmd.getStatus() == PARTIAL;
+        // Prisoners
+        boolean wasOverallSuccess = cmd.getStatus() == SUCCESS || cmd.getStatus() == PARTIAL;
 
-            if (prisoners != null) { // IDEA says we don't need the null check; I left it for insurance
-                if (!getCampaign().getFriendlyPrisoners().isEmpty()) {
-                    prisoners.handlePrisoners(wasOverallSuccess, true);
-                }
+        if (!getCampaign().getFriendlyPrisoners().isEmpty()) {
+            prisoners.handlePrisoners(wasOverallSuccess, true);
+        }
 
-                if (!getCampaign().getCurrentPrisoners().isEmpty()) {
-                    prisoners.handlePrisoners(wasOverallSuccess, false);
-                }
-            }
+        if (!getCampaign().getCurrentPrisoners().isEmpty()) {
+            prisoners.handlePrisoners(wasOverallSuccess, false);
         }
 
         // resolve turnover

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -78,7 +78,6 @@ import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.BotForce;
-import mekhq.campaign.mission.Contract;
 import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
@@ -412,14 +411,11 @@ public final class BriefingTab extends CampaignGuiTab {
             return;
         }
 
-        PrisonerMissionEndEvent prisoners = null;
-        if (mission instanceof Contract) {
-            prisoners = new PrisonerMissionEndEvent(getCampaign(), mission);
+        PrisonerMissionEndEvent prisoners = new PrisonerMissionEndEvent(getCampaign(), mission);
 
-            if (!getCampaign().getPrisonerDefectors().isEmpty() &&
-                      prisoners.handlePrisonerDefectors() == 0) { // This is the cancel choice index
-                return;
-            }
+        if (!getCampaign().getPrisonerDefectors().isEmpty() &&
+                  prisoners.handlePrisonerDefectors() == 0) { // This is the cancel choice index
+            return;
         }
 
         if (getCampaign().getCampaignOptions().isUseAtB() && (mission instanceof AtBContract)) {

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -162,7 +162,7 @@ public final class BriefingTab extends CampaignGuiTab {
     @Override
     public void initTab() {
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CampaignGUI",
-                MekHQ.getMHQOptions().getLocale());
+              MekHQ.getMHQOptions().getLocale());
 
         JPanel panMission = new JPanel(new GridBagLayout());
 
@@ -336,8 +336,7 @@ public final class BriefingTab extends CampaignGuiTab {
         paneLanceDeployment.setMinimumSize(new Dimension(200, 300));
         paneLanceDeployment.setPreferredSize(new Dimension(200, 300));
         paneLanceDeployment.setVisible(getCampaign().getCampaignOptions().isUseAtB());
-        splitScenario = new JSplitPane(JSplitPane.VERTICAL_SPLIT, panScenario,
-                paneLanceDeployment);
+        splitScenario = new JSplitPane(JSplitPane.VERTICAL_SPLIT, panScenario, paneLanceDeployment);
         splitScenario.setOneTouchExpandable(true);
         splitScenario.setResizeWeight(1.0);
 
@@ -354,13 +353,13 @@ public final class BriefingTab extends CampaignGuiTab {
         MissionTypeDialog mtd = new MissionTypeDialog(getFrame(), true);
         mtd.setVisible(true);
         if (mtd.isContract()) {
-            NewContractDialog ncd = getCampaignOptions().isUseAtB()
-                    ? new NewAtBContractDialog(getFrame(), true, getCampaign())
-                    : new NewContractDialog(getFrame(), true, getCampaign());
+            NewContractDialog ncd = getCampaignOptions().isUseAtB() ?
+                                          new NewAtBContractDialog(getFrame(), true, getCampaign()) :
+                                          new NewContractDialog(getFrame(), true, getCampaign());
             ncd.setVisible(true);
             comboMission.setSelectedItem(ncd.getContract());
         }
-         if (mtd.isMission()) {
+        if (mtd.isMission()) {
             CustomizeMissionDialog cmd = new CustomizeMissionDialog(getFrame(), true, null, getCampaign());
             cmd.setVisible(true);
             comboMission.setSelectedItem(cmd.getMission());
@@ -374,8 +373,10 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         if (getCampaign().getCampaignOptions().isUseAtB() && (mission instanceof AtBContract)) {
-            CustomizeAtBContractDialog cmd = new CustomizeAtBContractDialog(getFrame(), true,
-                    (AtBContract) mission, getCampaign());
+            CustomizeAtBContractDialog cmd = new CustomizeAtBContractDialog(getFrame(),
+                  true,
+                  (AtBContract) mission,
+                  getCampaign());
             cmd.setVisible(true);
             comboMission.setSelectedItem(cmd.getAtBContract());
         } else {
@@ -387,16 +388,17 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     private void completeMission() {
-        ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-                MekHQ.getMHQOptions().getLocale());
+        ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI", MekHQ.getMHQOptions().getLocale());
 
         final Mission mission = comboMission.getSelectedItem();
 
         if (mission == null) {
             return;
         } else if (mission.hasPendingScenarios()) {
-            JOptionPane.showMessageDialog(getFrame(), "You cannot complete a mission that has pending scenarios",
-                    "Pending Scenarios", JOptionPane.WARNING_MESSAGE);
+            JOptionPane.showMessageDialog(getFrame(),
+                  "You cannot complete a mission that has pending scenarios",
+                  "Pending Scenarios",
+                  JOptionPane.WARNING_MESSAGE);
             return;
         }
 
@@ -412,9 +414,10 @@ public final class BriefingTab extends CampaignGuiTab {
 
         PrisonerMissionEndEvent prisoners = null;
         if (mission instanceof Contract) {
-            prisoners = new PrisonerMissionEndEvent(getCampaign(), (AtBContract) mission);
+            prisoners = new PrisonerMissionEndEvent(getCampaign(), mission);
 
-            if (!getCampaign().getPrisonerDefectors().isEmpty() && prisoners.handlePrisonerDefectors() == 0) { // This is the cancel choice index
+            if (!getCampaign().getPrisonerDefectors().isEmpty() &&
+                      prisoners.handlePrisonerDefectors() == 0) { // This is the cancel choice index
                 return;
             }
         }
@@ -461,8 +464,8 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         // resolve turnover
-        if ((getCampaign().getCampaignOptions().isUseRandomRetirement())
-                && (getCampaign().getCampaignOptions().isUseContractCompletionRandomRetirement())) {
+        if ((getCampaign().getCampaignOptions().isUseRandomRetirement()) &&
+                  (getCampaign().getCampaignOptions().isUseContractCompletionRandomRetirement())) {
             RetirementDefectionDialog rdd = new RetirementDefectionDialog(getCampaignGui(), mission, true);
 
             if (rdd.wasAborted()) {
@@ -477,8 +480,8 @@ public final class BriefingTab extends CampaignGuiTab {
                     return;
                 }
             } else {
-                if ((getCampaign().getRetirementDefectionTracker().getRetirees(mission) != null)
-                        && getCampaign().getFinances().getBalance().isGreaterOrEqualThan(rdd.totalPayout())) {
+                if ((getCampaign().getRetirementDefectionTracker().getRetirees(mission) != null) &&
+                          getCampaign().getFinances().getBalance().isGreaterOrEqualThan(rdd.totalPayout())) {
                     for (PersonnelRole role : PersonnelRole.getAdministratorRoles()) {
                         Person admin = getCampaign().findBestInRole(role, SkillType.S_ADMIN);
                         if (admin != null) {
@@ -504,8 +507,9 @@ public final class BriefingTab extends CampaignGuiTab {
 
             // for the purposes of Mission Accomplished awards, we do not count partial
             // Successes as Success
-            autoAwardsController.PostMissionController(getCampaign(), mission,
-                    Objects.equals(String.valueOf(cmd.getStatus()), "Success"));
+            autoAwardsController.PostMissionController(getCampaign(),
+                  mission,
+                  Objects.equals(String.valueOf(cmd.getStatus()), "Success"));
         }
 
         final List<Mission> missions = getCampaign().getSortedMissions();
@@ -513,37 +517,31 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     /**
-     * Displays a prompt asking the user if they want to ransom their prisoners or
-     * defectors.
+     * Displays a prompt asking the user if they want to ransom their prisoners or defectors.
      *
      * @param prisoners    The list of prisoners to be ransomed.
-     * @param resourceName The name of the resource bundle key for the prompt
-     *                     message.
+     * @param resourceName The name of the resource bundle key for the prompt message.
      * @param resources    The resource bundle containing the string resources.
+     *
      * @return true if the user selects the "Cancel" option, false otherwise.
      */
     private boolean prisonerPrompt(List<Person> prisoners, String resourceName, ResourceBundle resources) {
         Money total = Money.zero();
         total = total.plus(prisoners.stream()
-                .map(person -> person.getRansomValue(getCampaign()))
-                .collect(Collectors.toList()));
+                                 .map(person -> person.getRansomValue(getCampaign()))
+                                 .collect(Collectors.toList()));
 
-        int optionSelected = JOptionPane.showConfirmDialog(
-                null,
-                String.format(resources.getString(resourceName),
-                        prisoners.size(),
-                        total.toAmountAndSymbolString()),
-                resources.getString("ransom.text"),
-                JOptionPane.YES_NO_CANCEL_OPTION);
+        int optionSelected = JOptionPane.showConfirmDialog(null,
+              String.format(resources.getString(resourceName), prisoners.size(), total.toAmountAndSymbolString()),
+              resources.getString("ransom.text"),
+              JOptionPane.YES_NO_CANCEL_OPTION);
 
         switch (optionSelected) {
             case JOptionPane.YES_OPTION -> {
                 getCampaign().addReport(String.format(resources.getString("ransomReport.format"),
-                        prisoners.size(),
-                        total.toAmountAndSymbolString()));
-                getCampaign().addFunds(TransactionType.RANSOM,
-                        total,
-                        resources.getString("ransom.text"));
+                      prisoners.size(),
+                      total.toAmountAndSymbolString()));
+                getCampaign().addFunds(TransactionType.RANSOM, total, resources.getString("ransom.text"));
                 prisoners.forEach(prisoner -> getCampaign().removePerson(prisoner, false));
             }
             case JOptionPane.NO_OPTION -> {
@@ -560,15 +558,16 @@ public final class BriefingTab extends CampaignGuiTab {
      *
      * @param missionStatus The status of the mission as a MissionStatus enum.
      * @param mission       The Mission object representing the completed mission.
+     *
      * @return The XP award for completing the mission.
      */
     private int getMissionXpAward(MissionStatus missionStatus, Mission mission) {
         return switch (missionStatus) {
             case FAILED, BREACH -> getCampaign().getCampaignOptions().getMissionXpFail();
             case SUCCESS, PARTIAL -> {
-                if ((getCampaign().getCampaignOptions().isUseStratCon())
-                        && (mission instanceof AtBContract)
-                        && (((AtBContract) mission).getStratconCampaignState().getVictoryPoints() >= 3)) {
+                if ((getCampaign().getCampaignOptions().isUseStratCon()) &&
+                          (mission instanceof AtBContract) &&
+                          (((AtBContract) mission).getStratconCampaignState().getVictoryPoints() >= 3)) {
                     yield getCampaign().getCampaignOptions().getMissionXpOutstandingSuccess();
                 } else {
                     yield getCampaign().getCampaignOptions().getMissionXpSuccess();
@@ -585,8 +584,11 @@ public final class BriefingTab extends CampaignGuiTab {
             return;
         }
         logger.debug("Attempting to Delete Mission, Mission ID: {}", mission.getId());
-        if (0 != JOptionPane.showConfirmDialog(null, "Are you sure you want to delete this mission?", "Delete mission?",
-                JOptionPane.YES_NO_OPTION)) {
+        if (0 !=
+                  JOptionPane.showConfirmDialog(null,
+                        "Are you sure you want to delete this mission?",
+                        "Delete mission?",
+                        JOptionPane.YES_NO_OPTION)) {
             return;
         }
         getCampaign().removeMission(mission);
@@ -597,15 +599,15 @@ public final class BriefingTab extends CampaignGuiTab {
 
     private void gmGenerateScenarios() {
         if (!getCampaign().isGM()) {
-            JOptionPane.showMessageDialog(this,
-                    "Only allowed for GM players",
-                    "Not GM", JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(this, "Only allowed for GM players", "Not GM", JOptionPane.ERROR_MESSAGE);
             return;
         }
 
-        if (0 != JOptionPane.showConfirmDialog(null, "Are you sure you want to generate a new set of scenarios?",
-                "Generate scenarios?",
-                JOptionPane.YES_NO_OPTION)) {
+        if (0 !=
+                  JOptionPane.showConfirmDialog(null,
+                        "Are you sure you want to generate a new set of scenarios?",
+                        "Generate scenarios?",
+                        JOptionPane.YES_NO_OPTION)) {
             return;
         }
 
@@ -627,9 +629,11 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     private void clearAssignedUnits() {
-        if (0 == JOptionPane.showConfirmDialog(null,
-            "Do you really want to remove all units from this scenario?",
-                "Clear Units?", JOptionPane.YES_NO_OPTION)) {
+        if (0 ==
+                  JOptionPane.showConfirmDialog(null,
+                        "Do you really want to remove all units from this scenario?",
+                        "Clear Units?",
+                        JOptionPane.YES_NO_OPTION)) {
             int row = scenarioTable.getSelectedRow();
             Scenario scenario = scenarioModel.getScenario(scenarioTable.convertRowIndexToModel(row));
 
@@ -641,7 +645,7 @@ public final class BriefingTab extends CampaignGuiTab {
             if (scenario instanceof AtBScenario) {
                 AtBContract contract = ((AtBScenario) scenario).getContract(getCampaign());
                 StratconScenario stratConScenario = ((AtBScenario) scenario).getStratconScenario(contract,
-                    (AtBScenario) scenario);
+                      (AtBScenario) scenario);
 
                 if (stratConScenario != null) {
                     stratConScenario.resetScenario(getCampaign());
@@ -671,9 +675,9 @@ public final class BriefingTab extends CampaignGuiTab {
         // null and
         // any units with null entities
         final List<Unit> units = unitIds.stream()
-                .map(unitId -> getCampaign().getUnit(unitId))
-                .filter(unit -> (unit != null) && (unit.getEntity() != null))
-                .toList();
+                                       .map(unitId -> getCampaign().getUnit(unitId))
+                                       .filter(unit -> (unit != null) && (unit.getEntity() != null))
+                                       .toList();
 
         final List<Entity> chosen = new ArrayList<>();
         final StringBuilder undeployed = new StringBuilder();
@@ -690,9 +694,13 @@ public final class BriefingTab extends CampaignGuiTab {
         if (!undeployed.isEmpty()) {
             final Object[] options = { "Continue", "Cancel" };
             if (JOptionPane.showOptionDialog(getFrame(),
-                    "The following units could not be deployed:" + undeployed,
-                    "Could not deploy some units", JOptionPane.OK_CANCEL_OPTION,
-                    JOptionPane.WARNING_MESSAGE, null, options, options[1]) == JOptionPane.NO_OPTION) {
+                  "The following units could not be deployed:" + undeployed,
+                  "Could not deploy some units",
+                  JOptionPane.OK_CANCEL_OPTION,
+                  JOptionPane.WARNING_MESSAGE,
+                  null,
+                  options,
+                  options[1]) == JOptionPane.NO_OPTION) {
                 return;
             }
         }
@@ -703,9 +711,10 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         // add bot forces
-        chosen.addAll(scenario.getBotForces().stream()
-                .flatMap(botForce -> botForce.getFullEntityList(getCampaign()).stream())
-                .toList());
+        chosen.addAll(scenario.getBotForces()
+                            .stream()
+                            .flatMap(botForce -> botForce.getFullEntityList(getCampaign()).stream())
+                            .toList());
 
         if (!chosen.isEmpty()) {
             UnitPrintManager.printAllUnits(chosen, true);
@@ -740,8 +749,7 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     /**
-     * Auto-resolve the selected scenario.
-     * Can run both the auto resolve using princess or using the ACS engine
+     * Auto-resolve the selected scenario. Can run both the auto resolve using princess or using the ACS engine
      */
     private void autoResolveScenario() {
         Scenario scenario = getSelectedScenario();
@@ -766,18 +774,19 @@ public final class BriefingTab extends CampaignGuiTab {
     private void promptAutoResolve(Scenario scenario) {
         // the options for the auto resolve method follow a predefined order, which is the same as the order in the enum
         // and it uses that to preselect the option that is currently set in the campaign options
-        Object[] options = new Object[]{
-            MHQInternationalization.getText("AutoResolveMethod.PRINCESS.text"),
-            MHQInternationalization.getText("AutoResolveMethod.ABSTRACT_COMBAT.text"),
-        };
+        Object[] options = new Object[] { MHQInternationalization.getText("AutoResolveMethod.PRINCESS.text"),
+                                          MHQInternationalization.getText("AutoResolveMethod.ABSTRACT_COMBAT.text"), };
 
         var preSelectedOptionIndex = getCampaignOptions().getAutoResolveMethod().ordinal();
 
         var selectedOption = JOptionPane.showOptionDialog(getFrame(),
-            MHQInternationalization.getText("AutoResolveMethod.promptForAutoResolveMethod.text"),
-            MHQInternationalization.getText("AutoResolveMethod.promptForAutoResolveMethod.title"),
-            JOptionPane.YES_NO_OPTION,
-            JOptionPane.QUESTION_MESSAGE, null, options, options[preSelectedOptionIndex]);
+              MHQInternationalization.getText("AutoResolveMethod.promptForAutoResolveMethod.text"),
+              MHQInternationalization.getText("AutoResolveMethod.promptForAutoResolveMethod.title"),
+              JOptionPane.YES_NO_OPTION,
+              JOptionPane.QUESTION_MESSAGE,
+              null,
+              options,
+              options[preSelectedOptionIndex]);
 
         if (selectedOption == JOptionPane.CLOSED_OPTION) {
             return;
@@ -865,8 +874,13 @@ public final class BriefingTab extends CampaignGuiTab {
         if (!undeployed.isEmpty()) {
             Object[] options = { "Continue", "Cancel" };
             int n = JOptionPane.showOptionDialog(getFrame(),
-                    "The following units could not be deployed:" + undeployed, "Could not deploy some units",
-                    JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, options, options[1]);
+                  "The following units could not be deployed:" + undeployed,
+                  "Could not deploy some units",
+                  JOptionPane.OK_CANCEL_OPTION,
+                  JOptionPane.WARNING_MESSAGE,
+                  null,
+                  options,
+                  options[1]);
 
             if (n == 1) {
                 return;
@@ -876,8 +890,7 @@ public final class BriefingTab extends CampaignGuiTab {
         // Ensure that the MegaMek year GameOption matches the campaign year
         // this is being set early on so that when setting up the autoconfig munitions
         // the correct year is used
-        getCampaign().getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR)
-            .setValue(getCampaign().getGameYear());
+        getCampaign().getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(getCampaign().getGameYear());
 
         // code to support deployment of reinforcements for legacy ATB scenarios.
         if ((scenario instanceof AtBScenario atBScenario) && !(scenario instanceof AtBDynamicScenario)) {
@@ -899,7 +912,9 @@ public final class BriefingTab extends CampaignGuiTab {
                 }
 
                 AtBDynamicScenarioFactory.setDeploymentTurnsForReinforcements(getCampaign().getHangar(),
-                      scenario, reinforcementEntities, cmdrStrategy);
+                      scenario,
+                      reinforcementEntities,
+                      cmdrStrategy);
             }
         }
 
@@ -924,8 +939,7 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         if (!chosen.isEmpty()) {
-            getCampaignGui().getApplication()
-                .startHost(scenario, false, chosen, autoResolveBehaviorSettings);
+            getCampaignGui().getApplication().startHost(scenario, false, chosen, autoResolveBehaviorSettings);
         }
     }
 
@@ -939,7 +953,9 @@ public final class BriefingTab extends CampaignGuiTab {
 
     /**
      * Get the enemy faction from the Mission from the scenario
+     *
      * @param scenario the scenario to get the enemy faction from
+     *
      * @return the enemy faction
      */
     private Faction getEnemyFactionFromScenario(Scenario scenario) {
@@ -964,9 +980,8 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     /**
-     * Designed to fully kit out all non-player-controlled forces prior to battle.
-     * Does not do any checks for supplies, only for availability to each faction
-     * during the current timeframe.
+     * Designed to fully kit out all non-player-controlled forces prior to battle. Does not do any checks for supplies,
+     * only for availability to each faction during the current timeframe.
      *
      * @param scenario
      * @param chosen
@@ -1029,15 +1044,14 @@ public final class BriefingTab extends CampaignGuiTab {
         for (ArrayList<Entity> entityList : botTeamMappings.values()) {
             // bin fill ratio will be adjusted by the loadout generator based on piracy and
             // quality
-            ReconfigurationParameters rp = TeamLoadOutGenerator.generateParameters(
-                    cGame,
-                    cGame.getOptions(),
-                    entityList,
-                    opforFactionCode,
-                    playerEntities,
-                    allyFactionCodes,
-                    opforQuality,
-                    ((isPirate) ? TeamLoadOutGenerator.UNSET_FILL_RATIO : 1.0f));
+            ReconfigurationParameters rp = TeamLoadOutGenerator.generateParameters(cGame,
+                  cGame.getOptions(),
+                  entityList,
+                  opforFactionCode,
+                  playerEntities,
+                  allyFactionCodes,
+                  opforQuality,
+                  ((isPirate) ? TeamLoadOutGenerator.UNSET_FILL_RATIO : 1.0f));
             rp.isPirate = isPirate;
             rp.groundMap = groundMap;
             rp.spaceEnvironment = spaceMap;
@@ -1048,15 +1062,14 @@ public final class BriefingTab extends CampaignGuiTab {
         // Finally, reconfigure all allies (but not player entities) as one organization
         ArrayList<Entity> allEnemyEntities = new ArrayList<>();
         botTeamMappings.values().stream().forEach(x -> allEnemyEntities.addAll(x));
-        ReconfigurationParameters rp = TeamLoadOutGenerator.generateParameters(
-                cGame,
-                cGame.getOptions(),
-                alliedEntities,
-                allyFactionCodes.get(0),
-                allEnemyEntities,
-                opforFactionCodes,
-                opforQuality,
-                (getCampaign().getFaction().isPirate()) ? TeamLoadOutGenerator.UNSET_FILL_RATIO : 1.0f);
+        ReconfigurationParameters rp = TeamLoadOutGenerator.generateParameters(cGame,
+              cGame.getOptions(),
+              alliedEntities,
+              allyFactionCodes.get(0),
+              allEnemyEntities,
+              opforFactionCodes,
+              opforQuality,
+              (getCampaign().getFaction().isPirate()) ? TeamLoadOutGenerator.UNSET_FILL_RATIO : 1.0f);
         rp.isPirate = getCampaign().getFaction().isPirate();
         rp.groundMap = groundMap;
         rp.spaceEnvironment = spaceMap;
@@ -1101,8 +1114,13 @@ public final class BriefingTab extends CampaignGuiTab {
         if (!undeployed.isEmpty()) {
             Object[] options = { "Continue", "Cancel" };
             int n = JOptionPane.showOptionDialog(getFrame(),
-                    "The following units could not be deployed:" + undeployed, "Could not deploy some units",
-                    JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, options, options[1]);
+                  "The following units could not be deployed:" + undeployed,
+                  "Could not deploy some units",
+                  JOptionPane.OK_CANCEL_OPTION,
+                  JOptionPane.WARNING_MESSAGE,
+                  null,
+                  options,
+                  options[1]);
             if (n == 1) {
                 return;
             }
@@ -1130,9 +1148,9 @@ public final class BriefingTab extends CampaignGuiTab {
         // null and
         // any units with null entities
         final List<Unit> units = unitIds.stream()
-                .map(unitId -> getCampaign().getUnit(unitId))
-                .filter(unit -> (unit != null) && (unit.getEntity() != null))
-                .toList();
+                                       .map(unitId -> getCampaign().getUnit(unitId))
+                                       .filter(unit -> (unit != null) && (unit.getEntity() != null))
+                                       .toList();
 
         final ArrayList<Entity> chosen = new ArrayList<>();
         final StringBuilder undeployed = new StringBuilder();
@@ -1149,9 +1167,13 @@ public final class BriefingTab extends CampaignGuiTab {
         if (!undeployed.isEmpty()) {
             final Object[] options = { "Continue", "Cancel" };
             if (JOptionPane.showOptionDialog(getFrame(),
-                    "The following units could not be deployed:" + undeployed,
-                    "Could not deploy some units", JOptionPane.OK_CANCEL_OPTION,
-                    JOptionPane.WARNING_MESSAGE, null, options, options[1]) == JOptionPane.NO_OPTION) {
+                  "The following units could not be deployed:" + undeployed,
+                  "Could not deploy some units",
+                  JOptionPane.OK_CANCEL_OPTION,
+                  JOptionPane.WARNING_MESSAGE,
+                  null,
+                  options,
+                  options[1]) == JOptionPane.NO_OPTION) {
                 return;
             }
         }
@@ -1169,8 +1191,9 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         final Mission mission = comboMission.getSelectedItem();
-        if ((mission instanceof AtBContract) && (scenario instanceof AtBScenario)
-                && !((AtBScenario) scenario).getAlliesPlayer().isEmpty()) {
+        if ((mission instanceof AtBContract) &&
+                  (scenario instanceof AtBScenario) &&
+                  !((AtBScenario) scenario).getAlliesPlayer().isEmpty()) {
             // Export allies
             chosen.clear();
             chosen.addAll(((AtBScenario) scenario).getAlliesPlayer());
@@ -1211,14 +1234,13 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     /**
-     * Calculates the total generic battle value of the entities chosen.
-     * If the use of generic battle value option is enabled in the campaign options, the generic battle
-     * value of each entity in the list is summed up and returned as the total generic battle value.
-     * If the said option is disabled, the method returns 0.
+     * Calculates the total generic battle value of the entities chosen. If the use of generic battle value option is
+     * enabled in the campaign options, the generic battle value of each entity in the list is summed up and returned as
+     * the total generic battle value. If the said option is disabled, the method returns 0.
      *
      * @param chosen the list of entities for which the generic battle value is to be calculated.
-     * @return the total generic battle value or 0 if the generic battle value usage is turned off in
-     * campaign options.
+     *
+     * @return the total generic battle value or 0 if the generic battle value usage is turned off in campaign options.
      */
     private int calculateGenericBattleValue(ArrayList<Entity> chosen) {
         int genericBattleValue = 0;
@@ -1285,8 +1307,9 @@ public final class BriefingTab extends CampaignGuiTab {
         }
         selectedScenario = scenario.getId();
         if (getCampaign().getCampaignOptions().isUseAtB() && (scenario instanceof AtBScenario)) {
-            scrollScenarioView.setViewportView(
-                    new AtBScenarioViewPanel((AtBScenario) scenario, getCampaign(), getFrame()));
+            scrollScenarioView.setViewportView(new AtBScenarioViewPanel((AtBScenario) scenario,
+                  getCampaign(),
+                  getFrame()));
         } else {
             scrollScenarioView.setViewportView(new ScenarioViewPanel(getFrame(), getCampaign(), scenario));
         }
@@ -1295,9 +1318,8 @@ public final class BriefingTab extends CampaignGuiTab {
         // later
         SwingUtilities.invokeLater(() -> scrollScenarioView.getVerticalScrollBar().setValue(0));
 
-        final boolean canStartGame = (
-            (!getCampaign().checkLinkedScenario(scenario.getId())) && (scenario.canStartScenario(getCampaign()))
-            );
+        final boolean canStartGame = ((!getCampaign().checkLinkedScenario(scenario.getId())) &&
+                                            (scenario.canStartScenario(getCampaign())));
 
         btnStartGame.setEnabled(canStartGame);
         btnJoinGame.setEnabled(canStartGame);
@@ -1378,8 +1400,8 @@ public final class BriefingTab extends CampaignGuiTab {
     @Subscribe
     public void handle(ScenarioChangedEvent evt) {
         final Mission mission = comboMission.getSelectedItem();
-        if ((evt.getScenario() != null)
-                && (evt.getScenario().getMissionId() == (mission == null ? -1 : mission.getId()))) {
+        if ((evt.getScenario() != null) &&
+                  (evt.getScenario().getMissionId() == (mission == null ? -1 : mission.getId()))) {
             scenarioTable.repaint();
             if (evt.getScenario().getId() == selectedScenario) {
                 scenarioViewScheduler.schedule();


### PR DESCRIPTION
- Updated `PrisonerMissionEndEvent` to use the `Mission` class instead of `Contract` for better accuracy and flexibility in handling mission data.
- Added a new method `getContractOrMissionStartDate` to retrieve the effective start date from either a contract or completed mission scenarios.
- Replaced `hasActiveContract` with `getActiveMissions(false)` for active mission checks.

### Dev Notes
_Missions_ (as opposed to _Contracts_) were in a weird position where they would not get end of 'contract' events, because they were not a contract. This was because Missions don't have start dates. I did a little sorcery and inferred the mission's start date based on its' completed scenarios.