### PR TITLE
MHQ side of fix for 6373: Increase random off-board distance range

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -4314,7 +4314,11 @@ public class AtBDynamicScenarioFactory {
      */
     private static void deployArtilleryOffBoard(List<Entity> entityList) {
         OffBoardDirection direction = OffBoardDirection.getDirection(randomInt(4));
-        int distance = (randomInt(2) + 1) * 17;
+
+        // Set distance to max of 1/2 the 1-turn flight time distance in boards so that Counter-Battery
+        // duels don't require interminable waiting.
+        // TODO: add logic for own ranges, strategic targets, and enemy off-board artillery assets.
+        int distance = (randomInt(4) + 1) * 17;
 
         for (Entity entity : entityList) {
             entity.setOffBoard(distance, direction);


### PR DESCRIPTION
In #6373 we discovered that Player and OpFor off-board artillery units could be deployed to the same distance and direction, causing them to silently fail all Counter-Battery Fire attempts.
I've put a stopgap fix in MM to prevent these auto-fail CBF shots from being taken, but we'd also like to minimize this sort of overlap if possible.

By doubling the range of possible off-board map distances, we should reduce the chance of identical off-board artillery positions from 1/8th chance to 1/16th chance.  There will be a slightly higher chance that any two off-board artillery forces will have a flight time of 2 or more against each other, but this should only occur on very large maps.

At a future date, perhaps when battlefield intelligence is more fully fleshed out (or rolling boards are added) we should implement more intelligent off-board asset placement, taking into account:
- Shortest max range for the off-board force,
- Need to have turn-1 artillery support for the mission objectives,
- Possibility of overrun by enemy forces, or need to reach enemy artillery with counter-battery fire

Testing:
- Confirmed new ranges used when regenerating OpFor in the campaign from #6373 
- Ran all three projects' unit tests

Close #6373 