### PR TITLE
Updated Invalid Faction Nag To Use Immersive Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -315,11 +315,6 @@ InsufficientMedicsNagDialog.text=%s, our medical teams are short by %d medic%s. 
   <br>\
   <br><i>You can resolve this issue by selecting 'Marketplace' in the taskbar, then 'Medic Pool,'\
   \ then selecting the option to bring all teams up to full strength.</i>
-InvalidFactionNagDialog.text=%s, reports indicate our parent faction is invalid. Possibly\
-  \ destroyed. Confirm your intent to advance the day under these circumstances.\
-  <br>\
-  <br><i>You will need to select a new faction in the campaign options. Failure to do will result\
-  \ in contracts no longer being generated.
 OutstandingScenariosNagDialog.text=%s, our forces are positioned for combat but await your commands to\
   \ proceed. Alternatively, you may order a tactical withdrawal by advancing the day. Do you wish\
   \ to proceed without addressing these engagements?\

--- a/MekHQ/resources/mekhq/resources/NagDialogs.properties
+++ b/MekHQ/resources/mekhq/resources/NagDialogs.properties
@@ -45,3 +45,10 @@ InsufficientAstechsNagDialog.ooc=You can resolve this issue by selecting 'Market
   \ does not resolve the issue, you have likely spread your techs too thinly by assigning them to too\
   \ many units. Consider hiring more techs.</i>\
   <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Options.</p>
+# Invalid Faction
+InvalidFactionNagDialog.ic={0}, reports indicate our parent faction is invalid. Possibly\
+  \ destroyed. Confirm your intent to advance the day under these circumstances.
+InvalidFactionNagDialog.ooc=You will need to select a new faction in the campaign options. Failure\
+  \ to do this while using <a href=''GLOSSARY:STRATCON''>StratCon</a> will prevent contracts from\
+  \ being generated.\
+  <p>If you accidentally suppress this warning, you can re-enable it in MekHQ Options.</p>

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
@@ -55,7 +55,6 @@ public class DeploymentShortfallNagDialog {
     private final int CHOICE_CONTINUE = 1;
     private final int CHOICE_SUPPRESS = 2;
 
-    private final Campaign campaign;
     private boolean cancelAdvanceDay;
 
     /**
@@ -69,8 +68,6 @@ public class DeploymentShortfallNagDialog {
      * @param campaign The {@link Campaign} object representing the current campaign.
      */
     public DeploymentShortfallNagDialog(final Campaign campaign) {
-        this.campaign = campaign;
-
         ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
               campaign.getSeniorAdminPerson(COMMAND),
               null,

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/EndContractNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/EndContractNagDialog.java
@@ -65,7 +65,6 @@ public class EndContractNagDialog {
     private final int CHOICE_CONTINUE = 1;
     private final int CHOICE_SUPPRESS = 2;
 
-    private final Campaign campaign;
     private boolean cancelAdvanceDay;
 
     /**
@@ -80,8 +79,6 @@ public class EndContractNagDialog {
      * @param campaign The {@link Campaign} that the nag dialog is tied to.
      */
     public EndContractNagDialog(final Campaign campaign) {
-        this.campaign = campaign;
-
         ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
               campaign.getSeniorAdminPerson(COMMAND),
               null,

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InvalidFactionNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InvalidFactionNagDialog.java
@@ -27,52 +27,102 @@
  */
 package mekhq.gui.dialog.nagDialogs;
 
-import mekhq.MHQConstants;
+import static mekhq.MHQConstants.NAG_INVALID_FACTION;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.gui.dialog.nagDialogs.nagLogic.InvalidFactionNagLogic.isFactionInvalid;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.universe.Faction;
-import mekhq.gui.baseComponents.AbstractMHQNagDialog;
-
-import java.time.LocalDate;
-
-import static mekhq.gui.dialog.nagDialogs.nagLogic.InvalidFactionNagLogic.isFactionInvalid;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 
 /**
  * A dialog used to notify the user about an invalid faction in the current campaign.
  *
  * <p>
- * This nag dialog is triggered when the campaign's selected faction is determined to be invalid
- * for the current campaign date. It evaluates the validity of the faction based on the campaign
- * date and displays a localized message warning the user about the issue.
+ * This nag dialog is triggered when the campaign's selected faction is determined to be invalid for the current
+ * campaign date. It evaluates the validity of the faction based on the campaign date and displays a localized message
+ * warning the user about the issue.
  * </p>
  *
  * <strong>Features:</strong>
  * <ul>
  *   <li>Checks whether the campaign's faction is valid based on the current in-game date.</li>
  *   <li>Displays a warning dialog to alert the user when an invalid faction is detected.</li>
- *   <li>Extends {@link AbstractMHQNagDialog} to ensure consistent behavior with other nag dialogs.</li>
  * </ul>
  */
-public class InvalidFactionNagDialog extends AbstractMHQNagDialog {
+public class InvalidFactionNagDialog {
+    private final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
+
+    private final int CHOICE_CANCEL = 0;
+    private final int CHOICE_CONTINUE = 1;
+    private final int CHOICE_SUPPRESS = 2;
+
+    private boolean cancelAdvanceDay;
+
     /**
      * Constructs an {@code InvalidFactionNagDialog} for the given campaign.
      *
      * <p>
-     * This dialog initializes with the campaign information and sets a localized
-     * message to notify the user about the potential issue involving an invalid faction.
-     * The message includes the commander's address for better clarity.
+     * This dialog initializes with the campaign information and sets a localized message to notify the user about the
+     * potential issue involving an invalid faction. The message includes the commander's address for better clarity.
      * </p>
      *
-     * @param campaign The {@link Campaign} associated with this nag dialog.
-     *                 The campaign provides the faction and other details for evaluation.
+     * @param campaign The {@link Campaign} associated with this nag dialog. The campaign provides the faction and other
+     *                 details for evaluation.
      */
     public InvalidFactionNagDialog(final Campaign campaign) {
-        super(campaign, MHQConstants.NAG_INVALID_FACTION);
+        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
+              campaign.getSeniorAdminPerson(COMMAND),
+              null,
+              getFormattedTextAt(RESOURCE_BUNDLE, "InvalidFactionNagDialog.ic", campaign.getCommanderAddress(false)),
+              getButtonLabels(),
+              getFormattedTextAt(RESOURCE_BUNDLE, "InvalidFactionNagDialog.ooc"),
+              true);
 
-        final String DIALOG_BODY = "InvalidFactionNagDialog.text";
-        setRightDescriptionMessage(String.format(resources.getString(DIALOG_BODY),
-            campaign.getCommanderAddress(false)));
-        showDialog();
+        int choiceIndex = dialog.getDialogChoice();
+
+        switch (choiceIndex) {
+            case CHOICE_CANCEL -> cancelAdvanceDay = true;
+            case CHOICE_CONTINUE -> cancelAdvanceDay = false;
+            case CHOICE_SUPPRESS -> {
+                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_INVALID_FACTION, true);
+                cancelAdvanceDay = false;
+            }
+            default -> throw new IllegalStateException("Unexpected value in InvalidFactionNagDialog: " + choiceIndex);
+        }
+    }
+
+    /**
+     * Retrieves a list of button labels from the resource bundle.
+     *
+     * <p>The method collects and returns button labels such as "Cancel", "Continue", and "Suppress" after
+     * formatting them using the provided resource bundle.</p>
+     *
+     * @return a {@link List} of formatted button labels as {@link String}.
+     */
+    private List<String> getButtonLabels() {
+        List<String> buttonLabels = new ArrayList<>();
+
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.cancel"));
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"));
+        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.suppress"));
+
+        return buttonLabels;
+    }
+
+    /**
+     * Determines whether the advance day operation should be canceled.
+     *
+     * @return {@code true} if advancing the day should be canceled, {@code false} otherwise.
+     */
+    public boolean shouldCancelAdvanceDay() {
+        return cancelAdvanceDay;
     }
 
     /**
@@ -86,12 +136,12 @@ public class InvalidFactionNagDialog extends AbstractMHQNagDialog {
      *
      * @param campaignFaction The {@link Faction} associated with the campaign to be checked.
      * @param today           The {@link LocalDate} representing the current in-game date.
+     *
      * @return {@code true} if the nag dialog should be displayed, {@code false} otherwise.
      */
     public static boolean checkNag(Faction campaignFaction, LocalDate today) {
-        final String NAG_KEY = MHQConstants.NAG_INVALID_FACTION;
+        final String NAG_KEY = NAG_INVALID_FACTION;
 
-        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY)
-            && (isFactionInvalid(campaignFaction, today));
+        return !MekHQ.getMHQOptions().getNagDialogIgnore(NAG_KEY) && (isFactionInvalid(campaignFaction, today));
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -84,7 +84,7 @@ public class NagController {
 
         if (InvalidFactionNagDialog.checkNag(campaign.getFaction(), today)) {
             InvalidFactionNagDialog invalidFactionNagDialog = new InvalidFactionNagDialog(campaign);
-            if (invalidFactionNagDialog.wasAdvanceDayCanceled()) {
+            if (invalidFactionNagDialog.shouldCancelAdvanceDay()) {
                 return true;
             }
         }


### PR DESCRIPTION
- Refactored `InvalidFactionNagDialog` to utilize `ImmersiveDialogSimple` for improved modularity and customization.
- Replaced inheritance from `AbstractMHQNagDialog` with a standalone class to simplify and streamline the implementation.
- Updated NagController logic to replace `wasAdvanceDayCanceled()` with `shouldCancelAdvanceDay()` to reflect the updated behavior.

<img width="587" alt="image" src="https://github.com/user-attachments/assets/a1d1aa05-c87c-4994-ba09-df4fac49b424" />