### PR TITLE
Created `ImmersiveDialogNag` Base Class; Rolled Out Base Class to Previously Edited Nags

### DIFF
--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogNag.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogNag.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.gui.baseComponents.immersiveDialogs;
+
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import megamek.common.annotations.Nullable;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.Campaign.AdministratorSpecialization;
+import mekhq.campaign.personnel.Person;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.ButtonLabelTooltipPair;
+
+/**
+ * Handles the display and processing of immersive nag dialogs.
+ *
+ * <p>The {@code ImmersiveDialogNag} class provides functionality to show an immersive dialog for specific nag
+ * notifications, allowing users to either acknowledge, suppress, or cancel advancing the day. The class integrates with
+ * MekHQ Options to handle suppression preferences and dialog messaging mechanisms.</p>
+ *
+ * <p>This class also supports the creation of both in-character and out-of-character messages, formatted using a
+ * resource bundle, and provides fallback mechanisms to ensure a valid speaker is always presented in the dialog.</p>
+ *
+ * <p>Key features include:</p>
+ * <ul>
+ *   <li>Processing user dialog choices to determine campaign behavior (e.g., cancel advancing the day).</li>
+ *   <li>Allowing users to suppress future dialogs for specific nag constants.</li>
+ *   <li>Providing localized and formatted message content for immersive dialogs.</li>
+ * </ul>
+ */
+public class ImmersiveDialogNag {
+    /**
+     * Represents the available user choices for the nag dialog.
+     */
+    private enum DialogChoice {
+        CHOICE_CANCEL(0), CHOICE_CONTINUE(1), CHOICE_SUPPRESS(2);
+
+        private final int choiceIndex;
+
+        DialogChoice(int choiceIndex) {
+            this.choiceIndex = choiceIndex;
+        }
+
+        /**
+         * Retrieves the enum value corresponding to the given choice index.
+         *
+         * @param choiceIndex The index of the choice.
+         *
+         * @return The corresponding {@link DialogChoice}.
+         *
+         * @throws IllegalArgumentException If no matching choice is found.
+         */
+        public static DialogChoice fromIndex(int choiceIndex) {
+            for (DialogChoice choice : DialogChoice.values()) {
+                if (choice.choiceIndex == choiceIndex) {
+                    return choice;
+                }
+            }
+            throw new IllegalArgumentException("Invalid choice index in ImmersiveDialogNag/DialogChoice/fromIndex: " +
+                                                     choiceIndex);
+        }
+    }
+
+    private final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
+
+    private boolean cancelAdvanceDay;
+
+    /**
+     * Constructs an {@code ImmersiveDialogNag} instance to display a nag dialog.
+     *
+     * <p>This constructor initializes the nag dialog with in-character and out-of-character messages, dialog
+     * buttons, and a speaker determined by the given {@code specialization}. If the {@code specialization} parameter is
+     * {@code null}, a fallback speaker with the {@code "COMMAND"} specialization is used. It also processes the user's
+     * dialog choice to update campaign state or suppression settings as necessary.</p>
+     *
+     * @param campaign       The {@link Campaign} instance associated with this nag dialog. Used to fetch relevant
+     *                       campaign data and update settings.
+     * @param specialization The {@link AdministratorSpecialization} specifying the desired type of administrator to act
+     *                       as the speaker. If {@code null}, the fallback speaker with the {@code "COMMAND"}
+     *                       specialization will be used.
+     * @param nagConstant    A {@code String} identifying the nag constant associated with the dialog. Used to manage
+     *                       whether future dialogs with this constant should be suppressed.
+     * @param messageKey     A {@code String} key to retrieve localized text for the in-character and out-of-character
+     *                       messages from the resource bundle.
+     */
+    public ImmersiveDialogNag(final Campaign campaign, final @Nullable AdministratorSpecialization specialization, final String nagConstant, final String messageKey) {
+        ImmersiveDialogCore dialog = constructDialog(campaign, specialization, messageKey);
+        processDialogChoice(dialog.getDialogChoice(), nagConstant);
+    }
+
+    /**
+     * Constructs an {@link ImmersiveDialogSimple} instance for the nag dialog.
+     *
+     * <p>This method creates an immersive dialog, setting the speaker based on the provided {@code specialization},
+     * and populates it with in-character and out-of-character messages along with dialog button labels.</p>
+     *
+     * @param campaign       The {@link Campaign} instance to associate with the dialog. Used to fetch relevant campaign
+     *                       data, such as the commander's address.
+     * @param specialization The {@link AdministratorSpecialization} specifying the desired administrator to act as the
+     *                       speaker.
+     * @param messageKey     A {@code String} key used to retrieve localized text for the dialog's in-character and
+     *                       out-of-character messages.
+     *
+     * @return The constructed {@link ImmersiveDialogSimple} instance containing the specified speaker, messages, and
+     *       button labels.
+     */
+    protected ImmersiveDialogCore constructDialog(Campaign campaign, AdministratorSpecialization specialization, String messageKey) {
+        return new ImmersiveDialogCore(campaign,
+              getSpeaker(campaign, specialization),
+              null,
+              getInCharacterMessage(campaign, messageKey, campaign.getCommanderAddress(false)),
+              createButtons(),
+              getOutOfCharacterMessage(messageKey),
+              null,
+              true,
+              null,
+              true);
+    }
+
+    /**
+     * Retrieves an in-character message formatted with the provided commander address.
+     *
+     * <p>This method fetches the text associated with an in-character message key from the
+     * resource bundle and formats it using the provided address of the commander.</p>
+     *
+     * @param campaign         The campaign context.
+     * @param key              The reference bundle key.
+     * @param commanderAddress The address of the commander to be inserted into the formatted message.
+     *
+     * @return A formatted in-character message as a {@code String}.
+     */
+    protected String getInCharacterMessage(Campaign campaign, String key, String commanderAddress) {
+        return getFormattedTextAt(RESOURCE_BUNDLE, key + ".ic", commanderAddress);
+    }
+
+    /**
+     * Retrieves an out-of-character message.
+     *
+     * <p>This method fetches the text associated with the out-of-character message key
+     * from the resource bundle without requiring any additional parameters for formatting.</p>
+     *
+     * @param key The reference bundle key.
+     *
+     * @return An out-of-character message as a {@code String}.
+     */
+    protected String getOutOfCharacterMessage(String key) {
+        return getFormattedTextAt(RESOURCE_BUNDLE, key + ".ooc");
+    }
+
+    /**
+     * Handles the processing of a dialog choice based on the given index and updates related settings or state.
+     *
+     * <p>This method performs different actions depending on the value of the {@code choiceIndex}:</p>
+     * <ul>
+     *   <li>If {@code CHOICE_CANCEL} is selected, it sets the operation to cancel advancing the day.</li>
+     *   <li>If {@code CHOICE_CONTINUE} is selected, it allows advancing the day.</li>
+     *   <li>If {@code CHOICE_SUPPRESS} is selected, it suppresses future dialog prompts associated with the
+     *       given nag constant and allows advancing the day.</li>
+     *   <li>Throws an exception if the {@code choiceIndex} does not match any expected value.</li>
+     * </ul>
+     *
+     * @param choiceIndex An {@code int} representing the user's dialog choice. Must match one of the predefined
+     *                    constants (e.g., {@code CHOICE_CANCEL}, {@code CHOICE_CONTINUE}, or {@code CHOICE_SUPPRESS}).
+     * @param nagConstant A {@code String} identifying the nag constant associated with the dialog choice. Used to
+     *                    manage whether future prompts with this constant should be suppressed.
+     *
+     * @throws IllegalStateException If the {@code choiceIndex} does not match any of the expected constants.
+     */
+    private void processDialogChoice(int choiceIndex, String nagConstant) {
+        DialogChoice choice = DialogChoice.fromIndex(choiceIndex);
+
+        switch (choice) {
+            case CHOICE_CANCEL -> cancelAdvanceDay = true;
+            case CHOICE_CONTINUE -> cancelAdvanceDay = false;
+            case CHOICE_SUPPRESS -> {
+                MekHQ.getMHQOptions().setNagDialogIgnore(nagConstant, true);
+                cancelAdvanceDay = false;
+            }
+            default -> throw new IllegalStateException("Unexpected value in ImmersiveDialogNag/processDialogChoice: " +
+                                                             choiceIndex);
+        }
+    }
+
+    /**
+     * Builds the list of buttons displayed in the dialog.
+     *
+     * <p>
+     * This method creates buttons allowing the player to either cancel the mission conclusion or continue.
+     * </p>
+     *
+     * @return A list of button-label and tooltip pairs for this dialog.
+     */
+    private List<ButtonLabelTooltipPair> createButtons() {
+        List<ButtonLabelTooltipPair> buttons = new ArrayList<>();
+
+        ButtonLabelTooltipPair btnCancel = new ButtonLabelTooltipPair(getFormattedTextAt(RESOURCE_BUNDLE,
+              "button.cancel"), null);
+        buttons.add(btnCancel);
+
+        ButtonLabelTooltipPair btnContinue = new ButtonLabelTooltipPair(getFormattedTextAt(RESOURCE_BUNDLE,
+              "button.continue"), null);
+        buttons.add(btnContinue);
+
+        ButtonLabelTooltipPair btnSuppress = new ButtonLabelTooltipPair(getFormattedTextAt(RESOURCE_BUNDLE,
+              "button.suppress"), null);
+        buttons.add(btnSuppress);
+
+        return buttons;
+    }
+
+    /**
+     * Retrieves the senior administrator assigned as the speaker for the given specialization.
+     *
+     * <p>This method attempts to fetch the senior administrator associated with the specified
+     * {@code specialization}. If the {@code specialization} is {@code null}, it defaults to retrieving the senior
+     * administrator with the {@code "COMMAND"} specialization. If no administrator is found for the provided
+     * specialization, it also falls back to the {@code "COMMAND"} specialization.</p>
+     *
+     * @param campaign       The campaign context.
+     * @param specialization The {@link AdministratorSpecialization} specifying the required type of administrator. Can
+     *                       be {@code null}, in which case the fallback to the {@code "COMMAND"} specialization is
+     *                       applied directly.
+     *
+     * @return The {@link Person} assigned as the speaker. This will either be the person matching the given
+     *       specialization or, if unavailable, the one assigned to the {@code "COMMAND"} specialization.
+     */
+    protected @Nullable Person getSpeaker(Campaign campaign, @Nullable AdministratorSpecialization specialization) {
+        if (specialization == null) {
+            return campaign.getSeniorAdminPerson(COMMAND);
+        }
+
+        Person speaker = campaign.getSeniorAdminPerson(specialization);
+
+        if (speaker == null && specialization != COMMAND) {
+            speaker = campaign.getSeniorAdminPerson(COMMAND);
+        }
+
+        return speaker;
+    }
+
+    /**
+     * Determines whether the advance day operation should be canceled.
+     *
+     * @return {@code true} if advancing the day should be canceled, {@code false} otherwise.
+     */
+    public boolean shouldCancelAdvanceDay() {
+        return cancelAdvanceDay;
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/AdminStrainNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/AdminStrainNagDialog.java
@@ -28,112 +28,36 @@
 package mekhq.gui.dialog.nagDialogs;
 
 import static mekhq.MHQConstants.NAG_ADMIN_STRAIN;
-import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
 import static mekhq.gui.dialog.nagDialogs.nagLogic.AdminStrainNagLogic.hasAdminStrain;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.Person;
-import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNag;
 
 /**
- * Represents a nag dialog that warns the user about administrative strain in a campaign.
+ * A dialog class used to notify players about administrative strain in their campaign.
  *
- * <p>This dialog is triggered when the campaign has a positive administrative strain. The purpose
- * of the dialog is to notify the user about the issue, allowing them to take any corrective action as necessary.</p>
+ * <p>The {@code AdminStrainNagDialog} extends {@link ImmersiveDialogNag} and provides a specialized
+ * nag dialog specifically intended to alert players when administrative strain occurs. It utilizes predefined
+ * parameters such as the "HR" specialization, the "NAG_ADMIN_STRAIN" constant, and a specific message key to display
+ * relevant information to the player.</p>
  */
-public class AdminStrainNagDialog {
-    private final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
-
-    private final int CHOICE_CANCEL = 0;
-    private final int CHOICE_CONTINUE = 1;
-    private final int CHOICE_SUPPRESS = 2;
-
-    private final Campaign campaign;
-    private boolean cancelAdvanceDay;
+public class AdminStrainNagDialog extends ImmersiveDialogNag {
 
     /**
-     * Constructs the administrative strain nag dialog for the given campaign.
+     * Constructs a new {@code AdminStrainNagDialog} instance to display the administrative strain nag dialog.
      *
-     * <p>This dialog displays a detailed message describing the administrative strain
-     * issue in the campaign.</p>
+     * <p>This constructor sets up the nag dialog using predefined parameters specific to administrative
+     * strain scenarios. It passes the {@code HR} specialization to highlight administrators relevant to human resources
+     * and uses the {@code NAG_ADMIN_STRAIN} constant for suppression control. The {@code "AdminStrainNagDialog"}
+     * message key is used to retrieve localized message content.</p>
      *
-     * @param campaign The {@link Campaign} for which the administrative strain nag dialog is to be displayed.
+     * @param campaign The {@link Campaign} instance associated with this dialog. Provides access to campaign data and
+     *                 settings required for dialog construction.
      */
     public AdminStrainNagDialog(final Campaign campaign) {
-        this.campaign = campaign;
-
-        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
-              getSpeaker(),
-              null,
-              getFormattedTextAt(RESOURCE_BUNDLE, "AdminStrainNagDialog.ic", campaign.getCommanderAddress(false)),
-              getButtonLabels(),
-              getFormattedTextAt(RESOURCE_BUNDLE, "AdminStrainNagDialog.ooc"),
-              true);
-
-        int choiceIndex = dialog.getDialogChoice();
-
-        switch (choiceIndex) {
-            case CHOICE_CANCEL -> cancelAdvanceDay = true;
-            case CHOICE_CONTINUE -> cancelAdvanceDay = false;
-            case CHOICE_SUPPRESS -> {
-                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_ADMIN_STRAIN, true);
-                cancelAdvanceDay = false;
-            }
-            default -> throw new IllegalStateException("Unexpected value in AdminStrainNagDialog: " + choiceIndex);
-        }
-    }
-
-    /**
-     * Retrieves a list of button labels from the resource bundle.
-     *
-     * <p>The method collects and returns button labels such as "Cancel", "Continue", and "Suppress" after
-     * formatting them using the provided resource bundle.</p>
-     *
-     * @return a {@link List} of formatted button labels as {@link String}.
-     */
-    private List<String> getButtonLabels() {
-        List<String> buttonLabels = new ArrayList<>();
-
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.cancel"));
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"));
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.suppress"));
-
-        return buttonLabels;
-    }
-
-    /**
-     * Retrieves the speaker based on the given administrator specialization.
-     *
-     * <p>This method first attempts to fetch the senior administrator person for the specified specialization. If no
-     * person is found, it defaults to retrieving the senior administrator person with the "COMMAND"
-     * specialization.</p>
-     *
-     * @return the {@link Person} assigned as the speaker, either the one matching the given specialization or the one
-     *       with the "COMMAND" specialization if no specialized person is available.
-     */
-    private Person getSpeaker() {
-        Person speaker = campaign.getSeniorAdminPerson(HR);
-
-        if (speaker == null) {
-            speaker = campaign.getSeniorAdminPerson(COMMAND);
-        }
-
-        return speaker;
-    }
-
-    /**
-     * Determines whether the advance day operation should be canceled.
-     *
-     * @return {@code true} if advancing the day should be canceled, {@code false} otherwise.
-     */
-    public boolean shouldCancelAdvanceDay() {
-        return cancelAdvanceDay;
+        super(campaign, HR, NAG_ADMIN_STRAIN, "AdminStrainNagDialog");
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/DeploymentShortfallNagDialog.java
@@ -28,95 +28,34 @@
 package mekhq.gui.dialog.nagDialogs;
 
 import static mekhq.MHQConstants.NAG_SHORT_DEPLOYMENT;
-import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
 import static mekhq.gui.dialog.nagDialogs.nagLogic.DeploymentShortfallNagLogic.hasDeploymentShortfall;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
-import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNag;
 
 /**
- * A nag dialog that alerts the user if short deployments are detected in the campaign's active contracts.
+ * A dialog class used to notify players about deployment shortfalls in their campaign.
  *
- * <p>
- * This dialog checks whether any active AtB (Against the Bot) contracts have a deployment deficit and alerts the player
- * to address the issue. The check is performed weekly (on Sundays) and only when the campaign is currently located on a
- * planet. If deployment requirements are not met, the dialog is displayed to prompt the user to correct the situation.
- * </p>
+ * <p>The {@code DeploymentShortfallNagDialog} extends {@link ImmersiveDialogNag} and provides
+ * a specialized nag dialog designed to alert players when deployment shortfalls occur. It uses predefined parameters,
+ * such as the {@code NAG_SHORT_DEPLOYMENT} constant, and no specific specialization for its speaker, allowing for a
+ * default fallback during dialog creation.</p>
  */
-public class DeploymentShortfallNagDialog {
-    private final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
-
-    private final int CHOICE_CANCEL = 0;
-    private final int CHOICE_CONTINUE = 1;
-    private final int CHOICE_SUPPRESS = 2;
-
-    private boolean cancelAdvanceDay;
-
+public class DeploymentShortfallNagDialog extends ImmersiveDialogNag {
     /**
-     * Constructs the shortfall deployment nag dialog for a given campaign.
+     * Constructs a new {@code DeploymentShortfallNagDialog} instance to display the deployment shortfall nag dialog.
      *
-     * <p>
-     * This constructor initializes the dialog with the specified campaign and formats the resource message to display
-     * information about deployment shortfalls.
-     * </p>
+     * <p>This constructor initializes the nag dialog without a specific specialization, allowing the fallback
+     * mechanism to determine the appropriate speaker. The {@code NAG_SHORT_DEPLOYMENT} constant is used to manage
+     * dialog suppression, and the {@code "DeploymentShortfallNagDialog"} message key is utilized to retrieve localized
+     * content.</p>
      *
-     * @param campaign The {@link Campaign} object representing the current campaign.
+     * @param campaign The {@link Campaign} instance associated with this dialog. Provides access to campaign data and
+     *                 settings required for dialog construction.
      */
     public DeploymentShortfallNagDialog(final Campaign campaign) {
-        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
-              campaign.getSeniorAdminPerson(COMMAND),
-              null,
-              getFormattedTextAt(RESOURCE_BUNDLE,
-                    "DeploymentShortfallNagDialog.ic",
-                    campaign.getCommanderAddress(false)),
-              getButtonLabels(),
-              getFormattedTextAt(RESOURCE_BUNDLE, "DeploymentShortfallNagDialog.ooc"),
-              true);
-
-        int choiceIndex = dialog.getDialogChoice();
-
-        switch (choiceIndex) {
-            case CHOICE_CANCEL -> cancelAdvanceDay = true;
-            case CHOICE_CONTINUE -> cancelAdvanceDay = false;
-            case CHOICE_SUPPRESS -> {
-                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_SHORT_DEPLOYMENT, true);
-                cancelAdvanceDay = false;
-            }
-            default ->
-                  throw new IllegalStateException("Unexpected value in DeploymentShortfallNagDialog: " + choiceIndex);
-        }
-    }
-
-    /**
-     * Retrieves a list of button labels from the resource bundle.
-     *
-     * <p>The method collects and returns button labels such as "Cancel", "Continue", and "Suppress" after
-     * formatting them using the provided resource bundle.</p>
-     *
-     * @return a {@link List} of formatted button labels as {@link String}.
-     */
-    private List<String> getButtonLabels() {
-        List<String> buttonLabels = new ArrayList<>();
-
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.cancel"));
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"));
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.suppress"));
-
-        return buttonLabels;
-    }
-
-    /**
-     * Determines whether the advance day operation should be canceled.
-     *
-     * @return {@code true} if advancing the day should be canceled, {@code false} otherwise.
-     */
-    public boolean shouldCancelAdvanceDay() {
-        return cancelAdvanceDay;
+        super(campaign, null, NAG_SHORT_DEPLOYMENT, "DeploymentShortfallNagDialog");
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/EndContractNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/EndContractNagDialog.java
@@ -28,106 +28,39 @@
 package mekhq.gui.dialog.nagDialogs;
 
 import static mekhq.MHQConstants.NAG_CONTRACT_ENDED;
-import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
 import static mekhq.gui.dialog.nagDialogs.nagLogic.EndContractNagLogic.isContractEnded;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
-import mekhq.gui.baseComponents.AbstractMHQNagDialog;
-import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNag;
 
 /**
- * A dialog used to notify the user about the end date of a contract in the campaign.
+ * A dialog class used to notify players when a contract has ended in their campaign.
  *
- * <p>
- * This nag dialog is triggered when a contract in the campaign is flagged as ending on the current date and the user
- * has not opted to ignore such notifications. It shows relevant details about the situation and allows the user to take
- * action or dismiss the dialog.
- * </p>
- *
- * <strong>Features:</strong>
- * <ul>
- *   <li>Handles notifications for contract end dates in the campaign.</li>
- *   <li>Uses a localized message with context-specific details from the campaign.</li>
- *   <li>Extends the {@link AbstractMHQNagDialog} to reuse base nag dialog functionality.</li>
- * </ul>
+ * <p>The {@code EndContractNagDialog} extends {@link ImmersiveDialogNag} and provides
+ * a specialized nag dialog to alert players about the conclusion of a contract. It leverages predefined parameters,
+ * such as the {@code NAG_CONTRACT_ENDED} constant, and uses no specific specialization, relying on a fallback
+ * speaker.</p>
  */
-public class EndContractNagDialog {
-    private final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
-
-    private final int CHOICE_CANCEL = 0;
-    private final int CHOICE_CONTINUE = 1;
-    private final int CHOICE_SUPPRESS = 2;
-
-    private boolean cancelAdvanceDay;
+public class EndContractNagDialog extends ImmersiveDialogNag {
 
     /**
-     * Constructs an {@code EndContractNagDialog} for the given campaign.
+     * Constructs a new {@code EndContractNagDialog} instance to display the end-of-contract nag dialog.
      *
-     * <p>
-     * This dialog uses the localization key {@code "EndContractNagDialog.text"} to provide a message that includes
-     * additional information, such as the commander's address. It is specifically tailored to show when a contract is
-     * reaching its end date.
-     * </p>
+     * <p>This constructor initializes the nag dialog without a specific specialization, enabling
+     * the fallback mechanism to determine the appropriate speaker. The {@code NAG_CONTRACT_ENDED} constant is used to
+     * manage dialog suppression, and the {@code "EndContractNagDialog"} message key is utilized to fetch localized
+     * message content.</p>
      *
-     * @param campaign The {@link Campaign} that the nag dialog is tied to.
+     * @param campaign The {@link Campaign} instance associated with this dialog. Provides access to campaign data and
+     *                 settings required for dialog construction.
      */
     public EndContractNagDialog(final Campaign campaign) {
-        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
-              campaign.getSeniorAdminPerson(COMMAND),
-              null,
-              getFormattedTextAt(RESOURCE_BUNDLE, "EndContractNagDialog.ic", campaign.getCommanderAddress(false)),
-              getButtonLabels(),
-              getFormattedTextAt(RESOURCE_BUNDLE, "EndContractNagDialog.ooc"),
-              true);
-
-        int choiceIndex = dialog.getDialogChoice();
-
-        switch (choiceIndex) {
-            case CHOICE_CANCEL -> cancelAdvanceDay = true;
-            case CHOICE_CONTINUE -> cancelAdvanceDay = false;
-            case CHOICE_SUPPRESS -> {
-                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_CONTRACT_ENDED, true);
-                cancelAdvanceDay = false;
-            }
-            default -> throw new IllegalStateException("Unexpected value in " +
-                                                             getClass().getSimpleName() +
-                                                             ": " +
-                                                             choiceIndex);
-        }
-    }
-
-    /**
-     * Retrieves a list of button labels from the resource bundle.
-     *
-     * <p>The method collects and returns button labels such as "Cancel", "Continue", and "Suppress" after
-     * formatting them using the provided resource bundle.</p>
-     *
-     * @return a {@link List} of formatted button labels as {@link String}.
-     */
-    private List<String> getButtonLabels() {
-        List<String> buttonLabels = new ArrayList<>();
-
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.cancel"));
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"));
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.suppress"));
-
-        return buttonLabels;
-    }
-
-    /**
-     * Determines whether the advance day operation should be canceled.
-     *
-     * @return {@code true} if advancing the day should be canceled, {@code false} otherwise.
-     */
-    public boolean shouldCancelAdvanceDay() {
-        return cancelAdvanceDay;
+        super(campaign, null, NAG_CONTRACT_ENDED, "EndContractNagDialog");
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InvalidFactionNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InvalidFactionNagDialog.java
@@ -28,101 +28,38 @@
 package mekhq.gui.dialog.nagDialogs;
 
 import static mekhq.MHQConstants.NAG_INVALID_FACTION;
-import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
 import static mekhq.gui.dialog.nagDialogs.nagLogic.InvalidFactionNagLogic.isFactionInvalid;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.universe.Faction;
-import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNag;
 
 /**
- * A dialog used to notify the user about an invalid faction in the current campaign.
+ * A dialog class used to notify players about an invalid faction in their campaign.
  *
- * <p>
- * This nag dialog is triggered when the campaign's selected faction is determined to be invalid for the current
- * campaign date. It evaluates the validity of the faction based on the campaign date and displays a localized message
- * warning the user about the issue.
- * </p>
- *
- * <strong>Features:</strong>
- * <ul>
- *   <li>Checks whether the campaign's faction is valid based on the current in-game date.</li>
- *   <li>Displays a warning dialog to alert the user when an invalid faction is detected.</li>
- * </ul>
+ * <p>The {@code InvalidFactionNagDialog} extends {@link ImmersiveDialogNag} and provides a specialized dialog
+ * designed to alert players when an invalid or unexpected faction is encountered during campaign operations. It uses
+ * predefined values, including the {@code NAG_INVALID_FACTION} constant, and does not include a specific speaker
+ * specialization, relying on a default fallback mechanism instead.</p>
  */
-public class InvalidFactionNagDialog {
-    private final String RESOURCE_BUNDLE = "mekhq.resources.NagDialogs";
-
-    private final int CHOICE_CANCEL = 0;
-    private final int CHOICE_CONTINUE = 1;
-    private final int CHOICE_SUPPRESS = 2;
-
-    private boolean cancelAdvanceDay;
+public class InvalidFactionNagDialog extends ImmersiveDialogNag {
 
     /**
-     * Constructs an {@code InvalidFactionNagDialog} for the given campaign.
+     * Constructs a new {@code InvalidFactionNagDialog} instance to display the invalid faction nag dialog.
      *
-     * <p>
-     * This dialog initializes with the campaign information and sets a localized message to notify the user about the
-     * potential issue involving an invalid faction. The message includes the commander's address for better clarity.
-     * </p>
+     * <p>This constructor initializes the dialog with preconfigured parameters, such as the
+     * {@code NAG_INVALID_FACTION} constant for managing dialog suppression and the {@code "InvalidFactionNagDialog"}
+     * message key for retrieving localized dialog content. No specific speaker is provided, triggering fallback logic
+     * to determine a suitable speaker for the dialog.</p>
      *
-     * @param campaign The {@link Campaign} associated with this nag dialog. The campaign provides the faction and other
-     *                 details for evaluation.
+     * @param campaign The {@link Campaign} instance associated with this dialog. Provides access to campaign data and
+     *                 settings required for constructing the dialog.
      */
     public InvalidFactionNagDialog(final Campaign campaign) {
-        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
-              campaign.getSeniorAdminPerson(COMMAND),
-              null,
-              getFormattedTextAt(RESOURCE_BUNDLE, "InvalidFactionNagDialog.ic", campaign.getCommanderAddress(false)),
-              getButtonLabels(),
-              getFormattedTextAt(RESOURCE_BUNDLE, "InvalidFactionNagDialog.ooc"),
-              true);
-
-        int choiceIndex = dialog.getDialogChoice();
-
-        switch (choiceIndex) {
-            case CHOICE_CANCEL -> cancelAdvanceDay = true;
-            case CHOICE_CONTINUE -> cancelAdvanceDay = false;
-            case CHOICE_SUPPRESS -> {
-                MekHQ.getMHQOptions().setNagDialogIgnore(NAG_INVALID_FACTION, true);
-                cancelAdvanceDay = false;
-            }
-            default -> throw new IllegalStateException("Unexpected value in InvalidFactionNagDialog: " + choiceIndex);
-        }
-    }
-
-    /**
-     * Retrieves a list of button labels from the resource bundle.
-     *
-     * <p>The method collects and returns button labels such as "Cancel", "Continue", and "Suppress" after
-     * formatting them using the provided resource bundle.</p>
-     *
-     * @return a {@link List} of formatted button labels as {@link String}.
-     */
-    private List<String> getButtonLabels() {
-        List<String> buttonLabels = new ArrayList<>();
-
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.cancel"));
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"));
-        buttonLabels.add(getFormattedTextAt(RESOURCE_BUNDLE, "button.suppress"));
-
-        return buttonLabels;
-    }
-
-    /**
-     * Determines whether the advance day operation should be canceled.
-     *
-     * @return {@code true} if advancing the day should be canceled, {@code false} otherwise.
-     */
-    public boolean shouldCancelAdvanceDay() {
-        return cancelAdvanceDay;
+        super(campaign, null, NAG_INVALID_FACTION, "InvalidFactionNagDialog");
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -174,11 +174,7 @@ public class NagController {
               isOvertimeAllowed,
               possibleAstechPoolOvertime)) {
             InsufficientAstechTimeNagDialog insufficientAstechTimeNagDialog = new InsufficientAstechTimeNagDialog(
-                  campaign,
-                  units,
-                  possibleAstechPoolMinutes,
-                  isOvertimeAllowed,
-                  possibleAstechPoolOvertime);
+                  campaign);
             if (insufficientAstechTimeNagDialog.shouldCancelAdvanceDay()) {
                 return true;
             }


### PR DESCRIPTION
- Consolidated the common nag dialog logic into a newly created `ImmersiveDialogNag` base class to reduce code duplication.
- Updated `AdminStrainNagDialog`, `EndContractNagDialog`, and `InsufficientAstechsNagDialog` to extend `ImmersiveDialogNag`.

### Dev Notes
Nothing super fancy here, just some consolidation of code so we don't have so much duplication.