### PR TITLE
Marked `AbstractMHQNagDialog` as Deprecated

### DIFF
--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQNagDialog.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQNagDialog.java
@@ -74,6 +74,7 @@ import mekhq.campaign.personnel.Person;
  *   <li>Localized using resource bundles.</li>
  * </ul>
  */
+@Deprecated(since = "0.50.05", forRemoval = true)
 public abstract class AbstractMHQNagDialog extends JDialog {
     /**
      * Unique key for this nag dialog, used to track if the dialog has been ignored by the user in the campaign


### PR DESCRIPTION
- Added `@Deprecated` annotation to `AbstractMHQNagDialog`, specifying version `0.50.05` and indicating it is marked for removal.