### PR TITLE
Removed Unused Nag Dialog Strings From GUI Properties

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -297,6 +297,8 @@ StandardForceIconDialog.title=Select Force Icon
 ### UnitIconDialog Class
 UnitIconDialog.title=Select Unit Icon
 UnitIconDialog.btnNone.toolTipText=The unit doesn't have a unit icon. This will hide all displays of the unit icon outside Campaign Options.
+#### Dialogs
+incomingTransmission.title=++INCOMING TRANSMISSION++
 #### Report Dialogs
 ### CargoReportDialog Class
 CargoReportDialog.title=Cargo Report

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -297,11 +297,6 @@ StandardForceIconDialog.title=Select Force Icon
 ### UnitIconDialog Class
 UnitIconDialog.title=Select Unit Icon
 UnitIconDialog.btnNone.toolTipText=The unit doesn't have a unit icon. This will hide all displays of the unit icon outside Campaign Options.
-#### Nag Dialogs
-incomingTransmission.title=++INCOMING TRANSMISSION++
-ignoreFutureNags.checkbox=Don't show this again
-button.advanceDay=Advance Day
-button.cancel=Cancel
 #### Report Dialogs
 ### CargoReportDialog Class
 CargoReportDialog.title=Cargo Report


### PR DESCRIPTION
- Deleted remaining unused Nag Dialog-related strings from `GUI.properties`, including titles and button texts.