### PR TITLE
Added Invalid Faction Validation During Day Advancement

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -223,11 +223,17 @@ lblTransportCapacity.text=<html><nobr><b>Transport Capacity:</b></nobr></html>;
 lblCargoSummary.text=<html><nobr><b>Cargo Summary:</b></nobr></html>;
 lblFacilityCapacities.text=<html><nobr><b>Facility Capacities:</b></nobr></html>;
 panLog.title=Daily Activity Log
+# New Day Blockers
+# Overdue Loans
 dialogOverdueLoans.title=Overdue loans
 dialogOverdueLoans.text=You must resolve overdue loans before advancing the day.
-dialogInvalidFaction.title=Invalid Faction
-dialogInvalidFaction.text=Your chosen campaign faction is not valid for the current in-game date.\
-  \n\
-  \nBefore you can proceed, you must choose a new faction in Campaign Options.
+# Invalid Faction
+dialogInvalidFaction.ic={0}, our parent faction has gone dark. All attempts at communication have failed, and we have\
+  \ received no orders, updates, or logistical support. This is a serious situation that requires immediate attention.\
+  <p>Without direction or resupply from High Command, the unit will be unable to proceed with operations.</p>\
+  <p>I recommend initiating contingency protocols and establishing temporary local command authority until we can\
+  \ determine the status of the faction or secure an alternative support structure. Please advise on next steps.</p>
+dialogInvalidFaction.ooc=Your chosen campaign faction is not valid for the current in-game date.\
+  <p>Before you can proceed, you must choose a new faction in Campaign Options.</p>
 dialogCheckDueScenarios.title=Scenarios Must Be Completed
 dialogCheckDueScenarios.text=You must complete scenarios with a date of today or earlier before advancing the day.

--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -1,8 +1,7 @@
 # Resources for the CampaignGUI class
-
 # Menu Resources
 # File Menu
-fileMenu.text = File
+fileMenu.text=File
 menuLoad.text=Load Campaign...
 menuSave.text=Save Campaign...
 menuNew.text=New Campaign...
@@ -17,11 +16,11 @@ miImportParts.text=Parts from a 'parts' file...
 miLoadForces.text=Forces from a MUL File...
 # Menu Export
 menuExport.text=Export
-menuExportCSV.text = CSV File
+menuExportCSV.text=CSV File
 miExportPersonnel.text=Personnel...
 miExportUnit.text=Units...
 miExportFinances.text=Finances...
-menuExportXML.text = XML File
+menuExportXML.text=XML File
 miExportCampaignPreset.text=Campaign Preset...
 miExportRankSystems.text=Rank Systems...
 miExportIndividualRankSystem.text=Campaign Rank System...
@@ -50,7 +49,6 @@ menuExit.text=Exit
 mekSelectorDialog.unsupported.gunEmplacement=Gun Emplacements are %s<b>not supported</b>%s by MekHQ.
 mekSelectorDialog.unsupported.droneOs=Drone units are %s<b>not supported</b>%s by MekHQ.
 mekSelectorDialog.unsupported.null=Unit does not have an entity.
-
 # Marketplace Menu
 menuMarket.text=Marketplace
 miPersonnelMarket.text=Personnel Market
@@ -77,7 +75,6 @@ miFireMedics.text=Release Medics
 popupFireMedicsNum.text=Release How Many Medics?
 miFullStrengthMedics.text=Bring All Medical Teams to Full Strength
 miFireAllMedics.text=Release All Medics from Pool
-
 # Reports Menu
 menuReports.text=Reports
 miDragoonsRating.text=Unit Rating...
@@ -85,13 +82,11 @@ miPersonnelReport.text=Personnel Report...
 miHangarBreakdown.text=Hangar Breakdown...
 miTransportReport.text=Transport Capacity Report...
 miCargoReport.text=Cargo Report...
-
 # View Menu
 menuView.text=View
 miShowHistoricalReportLog.text=Historical Daily Report Log
 miRetirementDefectionDialog.text=Employee Turnover Dialog
 miAwardEligibilityDialog.text=Award Eligibility Dialog
-
 # Manage Campaign Menu
 menuManageCampaign.text=Manage Campaign
 miGMToolsDialog.text=GM Tools Dialog...
@@ -102,16 +97,13 @@ miMassPersonnelTraining.toolTipText=This launches the Mass Personnel Training Di
 miScenarioEditor.text=Scenario Template Editor...
 miCompanyGenerator.text=Company Generator...
 miAutoResolveBehaviorSettings.text=Auto Resolve Behavior Settings
-
 # Help Menu
 menuHelp.text=Help
 menuAbout.text=About...
 #End Menu Resources
-
 # In-App New Campaign
 savePrompt.title=Save First?
 savePrompt.text=Do you want to save the game before starting a new campaign?
-
 ## Unsorted Resources
 btnAdvanceDay.text=Advance Day
 btnAdvanceDay.toolTipText=Advance forward one day.
@@ -197,10 +189,8 @@ btnBeginTransit.text=Begin Transit
 lblFindPlanet.text=Find Planet:
 panAssignedPatient.title=Assigned Patients
 panUnassignedPatient.title=Unassigned Patients
-
 customizeMenu.individualCamo.text=Individual camouflage...
 customizeMenu.removeIndividualCamo.text=Remove individual camo
-
 btnGetUnit.text=Find Units
 btnGetUnit.toolTipText=Search for unit(s) to procure
 btnGetParts.text=Find Parts
@@ -233,9 +223,11 @@ lblTransportCapacity.text=<html><nobr><b>Transport Capacity:</b></nobr></html>;
 lblCargoSummary.text=<html><nobr><b>Cargo Summary:</b></nobr></html>;
 lblFacilityCapacities.text=<html><nobr><b>Facility Capacities:</b></nobr></html>;
 panLog.title=Daily Activity Log
-
 dialogOverdueLoans.title=Overdue loans
 dialogOverdueLoans.text=You must resolve overdue loans before advancing the day.
-
+dialogInvalidFaction.title=Invalid Faction
+dialogInvalidFaction.text=Your chosen campaign faction is not valid for the current in-game date.\
+  \n\
+  \nBefore you can proceed, you must choose a new faction in Campaign Options.
 dialogCheckDueScenarios.title=Scenarios Must Be Completed
 dialogCheckDueScenarios.text=You must complete scenarios with a date of today or earlier before advancing the day.

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -39,6 +39,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.List;
@@ -105,6 +106,7 @@ import mekhq.campaign.report.HangarReport;
 import mekhq.campaign.report.PersonnelReport;
 import mekhq.campaign.report.TransportReport;
 import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.NewsItem;
 import mekhq.gui.campaignOptions.CampaignOptionsDialog;
 import mekhq.gui.dialog.*;
@@ -131,12 +133,12 @@ public class CampaignGUI extends JPanel {
     private static final MMLogger logger = MMLogger.create(CampaignGUI.class);
 
     @Serial
-    private static final long serialVersionUID     = 3126634639249129512L;
+    private static final long serialVersionUID = 3126634639249129512L;
     // region Variable Declarations
-    public static final  int  MAX_START_WIDTH      = 1400;
-    public static final  int  MAX_START_HEIGHT     = 900;
+    public static final int MAX_START_WIDTH = 1400;
+    public static final int MAX_START_HEIGHT = 900;
     // the max quantity when mass purchasing parts, hiring, etc. using the JSpinner
-    public static final  int  MAX_QUANTITY_SPINNER = 10000;
+    public static final int MAX_QUANTITY_SPINNER = 10000;
 
     private JFrame frame;
 
@@ -149,8 +151,8 @@ public class CampaignGUI extends JPanel {
     private JTabbedPane tabMain;
 
     /* For the menu bar */
-    private JMenuBar  menuBar;
-    private JMenu     menuThemes;
+    private JMenuBar menuBar;
+    private JMenu menuThemes;
     private JMenuItem miPersonnelMarket;
     private JMenuItem miContractMarket;
     private JMenuItem miUnitMarket;
@@ -170,8 +172,8 @@ public class CampaignGUI extends JPanel {
     private JLabel lblPartsAvailabilityRating;
 
     /* for the top button panel */
-    private       JPanel        btnPanel;
-    private final JToggleButton btnGMMode   = new MMToggleButton(resourceMap.getString("btnGMMode.text"));
+    private JPanel btnPanel;
+    private final JToggleButton btnGMMode = new MMToggleButton(resourceMap.getString("btnGMMode.text"));
     private final JToggleButton btnOvertime = new MMToggleButton(resourceMap.getString("btnOvertime.text"));
 
     ReportHyperlinkListener reportHLL;
@@ -183,8 +185,8 @@ public class CampaignGUI extends JPanel {
 
     // region Constructors
     public CampaignGUI(MekHQ app) {
-        this.app     = app;
-        reportHLL    = new ReportHyperlinkListener(this);
+        this.app = app;
+        reportHLL = new ReportHyperlinkListener(this);
         standardTabs = new EnumMap<>(MHQTabType.class);
         initComponents();
         MekHQ.registerHandler(this);
@@ -462,10 +464,10 @@ public class CampaignGUI extends JPanel {
                 exportUnits(FileType.CSV,
                       resourceMap.getString("dlgSaveUnitsCSV.text"),
                       getCampaign().getName() +
-                      getCampaign().getLocalDate()
-                            .format(DateTimeFormatter.ofPattern(MHQConstants.FILENAME_DATE_FORMAT)
-                                          .withLocale(MekHQ.getMHQOptions().getDateLocale())) +
-                      "_ExportedUnits");
+                            getCampaign().getLocalDate()
+                                  .format(DateTimeFormatter.ofPattern(MHQConstants.FILENAME_DATE_FORMAT)
+                                                .withLocale(MekHQ.getMHQOptions().getDateLocale())) +
+                            "_ExportedUnits");
             } catch (Exception ex) {
                 logger.error("", ex);
             }
@@ -480,10 +482,10 @@ public class CampaignGUI extends JPanel {
                 exportFinances(FileType.CSV,
                       resourceMap.getString("dlgSaveFinancesCSV.text"),
                       getCampaign().getName() +
-                      getCampaign().getLocalDate()
-                            .format(DateTimeFormatter.ofPattern(MHQConstants.FILENAME_DATE_FORMAT)
-                                          .withLocale(MekHQ.getMHQOptions().getDateLocale())) +
-                      "_ExportedFinances");
+                            getCampaign().getLocalDate()
+                                  .format(DateTimeFormatter.ofPattern(MHQConstants.FILENAME_DATE_FORMAT)
+                                                .withLocale(MekHQ.getMHQOptions().getDateLocale())) +
+                            "_ExportedFinances");
             } catch (Exception ex) {
                 logger.error("", ex);
             }
@@ -525,10 +527,10 @@ public class CampaignGUI extends JPanel {
                 exportPlanets(FileType.XML,
                       resourceMap.getString("dlgSavePlanetsXML.text"),
                       getCampaign().getName() +
-                      getCampaign().getLocalDate()
-                            .format(DateTimeFormatter.ofPattern(MHQConstants.FILENAME_DATE_FORMAT)
-                                          .withLocale(MekHQ.getMHQOptions().getDateLocale())) +
-                      "_ExportedPlanets");
+                            getCampaign().getLocalDate()
+                                  .format(DateTimeFormatter.ofPattern(MHQConstants.FILENAME_DATE_FORMAT)
+                                                .withLocale(MekHQ.getMHQOptions().getDateLocale())) +
+                            "_ExportedPlanets");
             } catch (Exception ex) {
                 logger.error("", ex);
             }
@@ -1072,8 +1074,8 @@ public class CampaignGUI extends JPanel {
 
         // Abort if the user cancels, closes the dialog, or fails to save
         if (savePrompt == JOptionPane.CANCEL_OPTION ||
-            savePrompt == JOptionPane.CLOSED_OPTION ||
-            (savePrompt == JOptionPane.YES_OPTION && !app.getCampaigngui().saveCampaign(null))) {
+                  savePrompt == JOptionPane.CLOSED_OPTION ||
+                  (savePrompt == JOptionPane.YES_OPTION && !app.getCampaigngui().saveCampaign(null))) {
             return;
         }
 
@@ -1100,9 +1102,9 @@ public class CampaignGUI extends JPanel {
         statusPanel = new JPanel(new FlowLayout(FlowLayout.LEADING, 20, 4));
         statusPanel.getAccessibleContext().setAccessibleName("Status Bar");
 
-        lblFunds                   = new JLabel();
-        lblTempAstechs             = new JLabel();
-        lblTempMedics              = new JLabel();
+        lblFunds = new JLabel();
+        lblTempAstechs = new JLabel();
+        lblTempMedics = new JLabel();
         lblPartsAvailabilityRating = new JLabel();
 
         statusPanel.add(lblFunds);
@@ -1118,43 +1120,43 @@ public class CampaignGUI extends JPanel {
         btnPanel.getAccessibleContext().setAccessibleName("Campaign Actions");
 
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx      = 0;
-        gridBagConstraints.gridy      = 0;
-        gridBagConstraints.fill       = GridBagConstraints.NONE;
-        gridBagConstraints.weightx    = 1;
-        gridBagConstraints.weighty    = 0.0;
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.weightx = 1;
+        gridBagConstraints.weighty = 0.0;
         gridBagConstraints.gridheight = 2;
-        gridBagConstraints.anchor     = GridBagConstraints.WEST;
-        gridBagConstraints.insets     = new Insets(3, 10, 3, 3);
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(3, 10, 3, 3);
         btnPanel.add(lblLocation, gridBagConstraints);
 
         btnGMMode.setToolTipText(resourceMap.getString("btnGMMode.toolTipText"));
         btnGMMode.setSelected(getCampaign().isGM());
         btnGMMode.addActionListener(e -> getCampaign().setGMMode(btnGMMode.isSelected()));
-        gridBagConstraints         = new GridBagConstraints();
-        gridBagConstraints.gridx   = 1;
-        gridBagConstraints.gridy   = 0;
-        gridBagConstraints.fill    = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.weightx = 0;
         gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor  = GridBagConstraints.EAST;
-        gridBagConstraints.insets  = new Insets(3, 3, 3, 3);
+        gridBagConstraints.anchor = GridBagConstraints.EAST;
+        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
         btnPanel.add(btnGMMode, gridBagConstraints);
 
         btnOvertime.setToolTipText(resourceMap.getString("btnOvertime.toolTipText"));
         btnOvertime.addActionListener(evt -> getCampaign().setOvertime(btnOvertime.isSelected()));
-        gridBagConstraints         = new GridBagConstraints();
-        gridBagConstraints.gridx   = 1;
-        gridBagConstraints.gridy   = 1;
-        gridBagConstraints.fill    = GridBagConstraints.HORIZONTAL;
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.weightx = 0;
         gridBagConstraints.weighty = 0.0;
-        gridBagConstraints.anchor  = GridBagConstraints.EAST;
-        gridBagConstraints.insets  = new Insets(3, 3, 3, 3);
+        gridBagConstraints.anchor = GridBagConstraints.EAST;
+        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
         btnPanel.add(btnOvertime, gridBagConstraints);
 
         // This button uses a mnemonic that is unique and listed in the initMenu JavaDoc
-        String  padding       = "       ";
+        String padding = "       ";
         JButton btnAdvanceDay = new JButton(padding + resourceMap.getString("btnAdvanceDay.text") + padding);
         btnAdvanceDay.setToolTipText(resourceMap.getString("btnAdvanceDay.toolTipText"));
         btnAdvanceDay.addActionListener(evt -> {
@@ -1174,15 +1176,15 @@ public class CampaignGUI extends JPanel {
             });
         });
         btnAdvanceDay.setMnemonic(KeyEvent.VK_A);
-        gridBagConstraints            = new GridBagConstraints();
-        gridBagConstraints.gridx      = 2;
-        gridBagConstraints.gridy      = 0;
-        gridBagConstraints.fill       = GridBagConstraints.VERTICAL;
-        gridBagConstraints.weightx    = 0.0;
-        gridBagConstraints.weighty    = 0.0;
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = GridBagConstraints.VERTICAL;
+        gridBagConstraints.weightx = 0.0;
+        gridBagConstraints.weighty = 0.0;
         gridBagConstraints.gridheight = 2;
-        gridBagConstraints.anchor     = GridBagConstraints.NORTHEAST;
-        gridBagConstraints.insets     = new Insets(3, 3, 3, 15);
+        gridBagConstraints.anchor = GridBagConstraints.NORTHEAST;
+        gridBagConstraints.insets = new Insets(3, 3, 3, 15);
         btnPanel.add(btnAdvanceDay, gridBagConstraints);
     }
     // endregion Initialization
@@ -1242,7 +1244,7 @@ public class CampaignGUI extends JPanel {
                 standardTabs.put(tab, t);
                 int index = IntStream.range(0, tabMain.getTabCount())
                                   .filter(i -> ((CampaignGuiTab) tabMain.getComponentAt(i)).tabType().ordinal() >
-                                               tab.ordinal())
+                                                     tab.ordinal())
                                   .findFirst()
                                   .orElse(tabMain.getTabCount());
                 tabMain.insertTab(t.getTabName(), null, t, null, index);
@@ -1294,8 +1296,8 @@ public class CampaignGUI extends JPanel {
          * present the retirement view to give the player a chance to follow a
          * custom schedule
          */
-        boolean                   doRetirement = getCampaign().getRetirementDefectionTracker().getRetirees().isEmpty();
-        RetirementDefectionDialog dialog       = new RetirementDefectionDialog(this, null, doRetirement);
+        boolean doRetirement = getCampaign().getRetirementDefectionTracker().getRetirees().isEmpty();
+        RetirementDefectionDialog dialog = new RetirementDefectionDialog(this, null, doRetirement);
 
         if (!dialog.wasAborted()) {
             getCampaign().applyRetirement(dialog.totalPayout(), dialog.getUnitAssignments());
@@ -1434,8 +1436,8 @@ public class CampaignGUI extends JPanel {
         }
 
         // check for existing file and make a back-up if found
-        String path2      = path + "_backup";
-        File   backupFile = new File(path2);
+        String path2 = path + "_backup";
+        File backupFile = new File(path2);
         if (file.exists()) {
             Utilities.copyfile(file, backupFile);
         }
@@ -1458,10 +1460,10 @@ public class CampaignGUI extends JPanel {
         } catch (Exception ex) {
             logger.error("", ex);
             JOptionPane.showMessageDialog(frame, """
-                                                 Oh no! The program was unable to correctly save your game. We know this
-                                                 is annoying and apologize. Please help us out and submit a bug with the
-                                                 mekhq.log file from this game so we can prevent this from happening in
-                                                 the future.""", "Could not save game", JOptionPane.ERROR_MESSAGE);
+                  Oh no! The program was unable to correctly save your game. We know this
+                  is annoying and apologize. Please help us out and submit a bug with the
+                  mekhq.log file from this game so we can prevent this from happening in
+                  the future.""", "Could not save game", JOptionPane.ERROR_MESSAGE);
 
             // restore the backup file
             if (file.delete()) {
@@ -1470,13 +1472,13 @@ public class CampaignGUI extends JPanel {
                     if (!backupFile.delete()) {
                         logger.error(
                               "Backup file deletion failure after restoring the original file. This means that the " +
-                              "backup file of {} will be retained instead of being properly deleted.",
+                                    "backup file of {} will be retained instead of being properly deleted.",
                               backupFile.getPath());
                     }
                 }
             } else {
                 logger.error("File deletion failure. This means that the file at {} will be retained instead of being " +
-                             "properly deleted, with any backup at {} not being restored nor deleted.",
+                                   "properly deleted, with any backup at {} not being restored nor deleted.",
                       file.getPath(),
                       backupFile.getPath());
             }
@@ -1494,13 +1496,13 @@ public class CampaignGUI extends JPanel {
         final CampaignOptions oldOptions = getCampaign().getCampaignOptions();
         // We need to handle it like this for now, as the options above get written to
         // currently
-        boolean                       atb                     = oldOptions.isUseAtB();
-        boolean                       timeIn                  = oldOptions.isUseTimeInService();
-        boolean                       rankIn                  = oldOptions.isUseTimeInRank();
-        boolean                       staticRATs              = oldOptions.isUseStaticRATs();
-        boolean                       factionIntroDate        = oldOptions.isFactionIntroDate();
-        final RandomDivorceMethod     randomDivorceMethod     = oldOptions.getRandomDivorceMethod();
-        final RandomMarriageMethod    randomMarriageMethod    = oldOptions.getRandomMarriageMethod();
+        boolean atb = oldOptions.isUseAtB();
+        boolean timeIn = oldOptions.isUseTimeInService();
+        boolean rankIn = oldOptions.isUseTimeInRank();
+        boolean staticRATs = oldOptions.isUseStaticRATs();
+        boolean factionIntroDate = oldOptions.isFactionIntroDate();
+        final RandomDivorceMethod randomDivorceMethod = oldOptions.getRandomDivorceMethod();
+        final RandomMarriageMethod randomMarriageMethod = oldOptions.getRandomMarriageMethod();
         final RandomProcreationMethod randomProcreationMethod = oldOptions.getRandomProcreationMethod();
 
         CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(getFrame(), getCampaign());
@@ -1643,12 +1645,12 @@ public class CampaignGUI extends JPanel {
             }
             r.setTech(engineer);
         } else if (getCampaign().getActivePersonnel(true).stream().anyMatch(Person::isTech)) {
-            String              name;
+            String name;
             Map<String, Person> techHash = new HashMap<>();
-            List<String>        techList = new ArrayList<>();
+            List<String> techList = new ArrayList<>();
 
-            List<Person> techs         = getCampaign().getTechs(false, true);
-            int          lastRightTech = 0;
+            List<Person> techs = getCampaign().getTechs(false, true);
+            int lastRightTech = 0;
 
             for (Person tech : techs) {
                 if (getCampaign().isWorkingOnRefit(tech) || tech.isEngineer()) {
@@ -1656,18 +1658,18 @@ public class CampaignGUI extends JPanel {
                 }
 
                 name = "<html>" +
-                       tech.getFullName() +
-                       ", <b>" +
-                       SkillType.getColoredExperienceLevelName(tech.getSkillLevel(getCampaign(), false)) +
-                       "</b> " +
-                       tech.getPrimaryRoleDesc() +
-                       " (" +
-                       getCampaign().getTargetFor(r, tech).getValueAsString() +
-                       "+), " +
-                       tech.getMinutesLeft() +
-                       '/' +
-                       tech.getDailyAvailableTechTime() +
-                       " minutes</html>";
+                             tech.getFullName() +
+                             ", <b>" +
+                             SkillType.getColoredExperienceLevelName(tech.getSkillLevel(getCampaign(), false)) +
+                             "</b> " +
+                             tech.getPrimaryRoleDesc() +
+                             " (" +
+                             getCampaign().getTargetFor(r, tech).getValueAsString() +
+                             "+), " +
+                             tech.getMinutesLeft() +
+                             '/' +
+                             tech.getDailyAvailableTechTime() +
+                             " minutes</html>";
                 techHash.put(name, tech);
                 if (tech.isRightTechTypeFor(r)) {
                     techList.add(lastRightTech++, name);
@@ -1694,10 +1696,10 @@ public class CampaignGUI extends JPanel {
 
             if (!selectedTech.isRightTechTypeFor(r)) {
                 if (JOptionPane.NO_OPTION ==
-                    JOptionPane.showConfirmDialog(null,
-                          "This tech is not appropriate for this unit. Would you like to continue?",
-                          "Incorrect Tech Type",
-                          JOptionPane.YES_NO_OPTION)) {
+                          JOptionPane.showConfirmDialog(null,
+                                "This tech is not appropriate for this unit. Would you like to continue?",
+                                "Incorrect Tech Type",
+                                JOptionPane.YES_NO_OPTION)) {
                     return;
                 }
             }
@@ -1728,17 +1730,17 @@ public class CampaignGUI extends JPanel {
         String RefitRefurbish;
         if (r.isBeingRefurbished()) {
             RefitRefurbish = "Refurbishment is a " +
-                             r.getRefitClassName() +
-                             " refit and must be done at a factory and costs 10% of the purchase price" +
-                             ".\n Are you sure you want to refurbish ";
+                                   r.getRefitClassName() +
+                                   " refit and must be done at a factory and costs 10% of the purchase price" +
+                                   ".\n Are you sure you want to refurbish ";
         } else {
             RefitRefurbish = "This is a " + r.getRefitClassName() + " refit. Are you sure you want to refit ";
         }
         if (0 !=
-            JOptionPane.showConfirmDialog(null,
-                  RefitRefurbish + r.getUnit().getName() + '?',
-                  "Proceed?",
-                  JOptionPane.YES_NO_OPTION)) {
+                  JOptionPane.showConfirmDialog(null,
+                        RefitRefurbish + r.getUnit().getName() + '?',
+                        "Proceed?",
+                        JOptionPane.YES_NO_OPTION)) {
             return;
         }
         try {
@@ -1770,7 +1772,7 @@ public class CampaignGUI extends JPanel {
      * @return The ID of the selected tech, or null if none is selected.
      */
     public @Nullable UUID selectTech(Unit u, String desc, boolean ignoreMaintenance) {
-        String              name;
+        String name;
         Map<String, Person> techHash = new LinkedHashMap<>();
         for (Person tech : getCampaign().getTechsExpanded()) {
             if (!tech.isMothballing() && tech.canTech(u.getEntity())) {
@@ -1779,11 +1781,11 @@ public class CampaignGUI extends JPanel {
                     time -= Math.max(0, tech.getMaintenanceTimeUsing());
                 }
                 name = tech.getFullTitle() +
-                       ", " +
-                       SkillType.getExperienceLevelName(tech.getSkillForWorkingOn(u).getExperienceLevel()) +
-                       " (" +
-                       time +
-                       "min)";
+                             ", " +
+                             SkillType.getExperienceLevelName(tech.getSkillForWorkingOn(u).getExperienceLevel()) +
+                             " (" +
+                             time +
+                             "min)";
                 techHash.put(name, tech);
             }
         }
@@ -1949,8 +1951,8 @@ public class CampaignGUI extends JPanel {
      */
     private void checkToBackupFile(File file, String path) {
         // check for existing file and make a back-up if found
-        String path2      = path + "_backup";
-        File   backupFile = new File(path2);
+        String path2 = path + "_backup";
+        File backupFile = new File(path2);
         if (file.exists()) {
             Utilities.copyfile(file, backupFile);
         }
@@ -2013,8 +2015,8 @@ public class CampaignGUI extends JPanel {
                 return; // otherwise we NPE out in the next line
             }
 
-            Element  personnelEle = xmlDoc.getDocumentElement();
-            NodeList nl           = personnelEle.getChildNodes();
+            Element personnelEle = xmlDoc.getDocumentElement();
+            NodeList nl = personnelEle.getChildNodes();
 
             // Get rid of empty text nodes and adjacent text nodes...
             // Stupid weird parsing of XML. At least this cleans it up.
@@ -2061,7 +2063,7 @@ public class CampaignGUI extends JPanel {
             // TODO : make it so that exports will automatically include both spouses
             for (Person p : getCampaign().getActivePersonnel(true)) {
                 if (p.getGenealogy().hasSpouse() &&
-                    !getCampaign().getPersonnel().contains(p.getGenealogy().getSpouse())) {
+                          !getCampaign().getPersonnel().contains(p.getGenealogy().getSpouse())) {
                     // If this happens, we need to clear the spouse
                     if (p.getMaidenName() != null) {
                         p.setSurname(p.getMaidenName());
@@ -2072,9 +2074,9 @@ public class CampaignGUI extends JPanel {
 
                 if (p.isPregnant()) {
                     String fatherIdString = p.getExtraData().get(AbstractProcreation.PREGNANCY_FATHER_DATA);
-                    UUID   fatherId       = (fatherIdString != null) ? UUID.fromString(fatherIdString) : null;
+                    UUID fatherId = (fatherIdString != null) ? UUID.fromString(fatherIdString) : null;
                     if ((fatherId != null) &&
-                        !getCampaign().getPersonnel().contains(getCampaign().getPerson(fatherId))) {
+                              !getCampaign().getPersonnel().contains(getCampaign().getPerson(fatherId))) {
                         p.getExtraData().set(AbstractProcreation.PREGNANCY_FATHER_DATA, null);
                     }
                 }
@@ -2097,8 +2099,8 @@ public class CampaignGUI extends JPanel {
         }
 
         // check for existing file and make a back-up if found
-        String path2      = path + "_backup";
-        File   backupFile = new File(path2);
+        String path2 = path + "_backup";
+        File backupFile = new File(path2);
         if (file.exists()) {
             Utilities.copyfile(file, backupFile);
         }
@@ -2114,7 +2116,7 @@ public class CampaignGUI extends JPanel {
             return;
         }
         Person selectedPerson = pt.getPersonModel().getPerson(pt.getPersonnelTable().convertRowIndexToModel(row));
-        int[]  rows           = pt.getPersonnelTable().getSelectedRows();
+        int[] rows = pt.getPersonnelTable().getSelectedRows();
         Person[] people = Arrays.stream(rows)
                                 .mapToObj(j -> pt.getPersonModel()
                                                      .getPerson(pt.getPersonnelTable().convertRowIndexToModel(j)))
@@ -2148,14 +2150,11 @@ public class CampaignGUI extends JPanel {
             logger.info("Personnel saved to {}", file);
         } catch (Exception ex) {
             logger.error("", ex);
-            JOptionPane.showMessageDialog(getFrame(),
-                  """
+            JOptionPane.showMessageDialog(getFrame(), """
                   Oh no! The program was unable to correctly export your personnel. We know this
                   is annoying and apologize. Please help us out and submit a bug with the
                   mekhq.log file from this game so we can prevent this from happening in
-                  the future.""",
-                  "Could not export personnel",
-                  JOptionPane.ERROR_MESSAGE);
+                  the future.""", "Could not export personnel", JOptionPane.ERROR_MESSAGE);
             // restore the backup file
             file.delete();
             if (backupFile.exists()) {
@@ -2190,8 +2189,8 @@ public class CampaignGUI extends JPanel {
             return;
         }
 
-        Element  partsEle = xmlDoc.getDocumentElement();
-        NodeList nl       = partsEle.getChildNodes();
+        Element partsEle = xmlDoc.getDocumentElement();
+        NodeList nl = partsEle.getChildNodes();
 
         // Get rid of empty text nodes and adjacent text nodes...
         // Stupid weird parsing of XML. At least this cleans it up.
@@ -2241,8 +2240,8 @@ public class CampaignGUI extends JPanel {
         }
 
         // check for existing file and make a back-up if found
-        String path2      = file.getAbsolutePath() + "_backup";
-        File   backupFile = new File(path2);
+        String path2 = file.getAbsolutePath() + "_backup";
+        File backupFile = new File(path2);
         if (file.exists()) {
             Utilities.copyfile(file, backupFile);
         }
@@ -2254,15 +2253,15 @@ public class CampaignGUI extends JPanel {
             return;
         }
 
-        JTable          partsTable = warehouseTab.getPartsTable();
+        JTable partsTable = warehouseTab.getPartsTable();
         PartsTableModel partsModel = warehouseTab.getPartsModel();
-        int             row        = partsTable.getSelectedRow();
+        int row = partsTable.getSelectedRow();
         if (row < 0) {
             logger.warn("Cannot export parts if none are selected! Ignoring.");
             return;
         }
-        Part  selectedPart = partsModel.getPartAt(partsTable.convertRowIndexToModel(row));
-        int[] rows         = partsTable.getSelectedRows();
+        Part selectedPart = partsModel.getPartAt(partsTable.convertRowIndexToModel(row));
+        int[] rows = partsTable.getSelectedRows();
         Part[] parts = Arrays.stream(rows)
                              .mapToObj(j -> partsModel.getPartAt(partsTable.convertRowIndexToModel(j)))
                              .toArray(Part[]::new);
@@ -2295,14 +2294,11 @@ public class CampaignGUI extends JPanel {
             logger.info("Parts saved to {}", file);
         } catch (Exception ex) {
             logger.error("", ex);
-            JOptionPane.showMessageDialog(getFrame(),
-                  """
+            JOptionPane.showMessageDialog(getFrame(), """
                   Oh no! The program was unable to correctly export your parts. We know this
                   is annoying and apologize. Please help us out and submit a bug with the
                   mekhq.log file from this game so we can prevent this from happening in
-                  the future.""",
-                  "Could not export parts",
-                  JOptionPane.ERROR_MESSAGE);
+                  the future.""", "Could not export parts", JOptionPane.ERROR_MESSAGE);
             // restore the backup file
             file.delete();
             if (backupFile.exists()) {
@@ -2362,7 +2358,7 @@ public class CampaignGUI extends JPanel {
      * Refreshes the 'funds' display on the GUI.
      */
     private void refreshFunds() {
-        Money  funds  = getCampaign().getFunds();
+        Money funds = getCampaign().getFunds();
         String inDebt = "";
         if (getCampaign().getFinances().isInDebt()) {
             // FIXME : Localize
@@ -2387,7 +2383,7 @@ public class CampaignGUI extends JPanel {
 
     private void refreshPartsAvailability() {
         if (!getCampaign().getCampaignOptions().isUseAtB() ||
-            CampaignOptions.S_AUTO.equals(getCampaign().getCampaignOptions().getAcquisitionSkill())) {
+                  CampaignOptions.S_AUTO.equals(getCampaign().getCampaignOptions().getAcquisitionSkill())) {
             lblPartsAvailabilityRating.setText("");
         } else {
             int partsAvailability = getCampaign().findAtBPartsAvailabilityLevel();
@@ -2442,7 +2438,7 @@ public class CampaignGUI extends JPanel {
     }
 
     public void undeployForce(Force f, boolean killSubs) {
-        int      sid      = f.getScenarioId();
+        int sid = f.getScenarioId();
         Scenario scenario = getCampaign().getScenario(sid);
         if (null != scenario) {
             f.clearScenarioIds(getCampaign(), killSubs);
@@ -2459,7 +2455,7 @@ public class CampaignGUI extends JPanel {
 
             // We have to clear out the parents as well.
             Force parent = f;
-            int   prevId = f.getId();
+            int prevId = f.getId();
             while ((parent = parent.getParentForce()) != null) {
                 if (parent.getScenarioId() == NO_ASSIGNED_SCENARIO) {
                     break;
@@ -2501,6 +2497,10 @@ public class CampaignGUI extends JPanel {
             return;
         }
 
+        if (checkForInvalidFaction(dayEndingEvent)) {
+            return;
+        }
+
         if (checkForDueScenarios(dayEndingEvent)) {
             return;
         }
@@ -2528,7 +2528,7 @@ public class CampaignGUI extends JPanel {
                     return;
                 default:
                     throw new IllegalStateException("Unexpected value in mekhq/gui/CampaignGUI.java/handleDayEnding: " +
-                                                    turnoverPrompt);
+                                                          turnoverPrompt);
             }
         }
     }
@@ -2572,6 +2572,32 @@ public class CampaignGUI extends JPanel {
             JOptionPane.showMessageDialog(null,
                   getResourceMap().getString("dialogOverdueLoans.text"),
                   getResourceMap().getString("dialogOverdueLoans.title"),
+                  JOptionPane.WARNING_MESSAGE);
+
+            dayEndingEvent.cancel();
+
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the faction associated with the campaign is invalid for the current date and takes appropriate action
+     * if so.
+     *
+     * @param dayEndingEvent the event that signals the ending of the day's activities in the campaign
+     *
+     * @return {@code true} if the faction is invalid, {@code false} otherwise.
+     */
+    private boolean checkForInvalidFaction(DayEndingEvent dayEndingEvent) {
+        Campaign campaign = getCampaign();
+        Faction campaignFaction = campaign.getFaction();
+        LocalDate currentDate = campaign.getLocalDate();
+
+        if (!campaignFaction.validIn(currentDate)) {
+            JOptionPane.showMessageDialog(null,
+                  getResourceMap().getString("dialogInvalidFaction.text"),
+                  getResourceMap().getString("dialogInvalidFaction.title"),
                   JOptionPane.WARNING_MESSAGE);
 
             dayEndingEvent.cancel();


### PR DESCRIPTION
- Implemented a check to validate the campaign's faction for the current in-game date during day advancement.
- Displayed a warning dialog and halted advancement if the faction is invalid.
- Updated related resource strings in `CampaignGUI.properties` for the faction validation dialog.

### Order of Merging
Must be merged **BEFORE** #6421

### Reviewer Note
There are a lot of automatic format changes in this PR, I've commented the functional changes. There rest is chaff and can probably be ignored.

### Dev Notes
While this might seem draconian, advancing beyond the date when a faction ceases to exist causes MekHQ to explode. This was evident when my log jumped to several megabytes large because my faction didn't have Era Mods for the era in which I was testing. There are likely innumerable less obvious problems being caused by invalid factions.

As accidentally ending up with an invalid faction is so easy - if the player isn't paying attention to their nags, or has the invalid faction nag disabled. I opted to block day advancement if the player has an invalid faction.

<img width="586" alt="image" src="https://github.com/user-attachments/assets/a4579b7e-9caa-4aa8-b493-24b83f65779b" />
