### PR TITLE
Restored Campaign Options to Apply Skill Level Modifiers When Creating Characters

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1877,6 +1877,8 @@ lblSecondarySkillBonus.text=Modifier
 lblSecondarySkillBonus.tooltip=The skill level modifier applied to the skill (if present).
 ## Recruitment Bonuses Tab
 lblRecruitmentBonusesTab.text=Recruitment Modifiers
+lblRecruitmentBonusesTabBody.text=When a character is generated, a 2d6 is rolled to determine their experience level (Green,\
+  \ Regular, etc.). These options allow you to apply a modifier to those rolls, specific to each profession.
 lblRecruitmentBonusesCombatPanel.text=Combat Roles
 lblRecruitmentBonusesSupportPanel.text=Support Roles
 ## Advancement Tab

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -8,7 +8,6 @@ lblLoadPreset.text=Load Preset
 lblLoadPreset.tooltip=Load an existing preset.
 lblCancel.text=Cancel Changes
 lblCancel.tooltip=Cancel all changes and close the dialog.
-
 ## SelectPresetDialog Class
 # SelectPresetDialog
 presetDialog.title=Select a Campaign Preset
@@ -20,7 +19,6 @@ lblPresetDialogCustomize.text=Customize
 lblPresetDialogCustomize.tooltip=Select a preset, then open the campaign options menu.
 lblPresetDialogCancel.text=Cancel
 lblPresetDialogCancel.tooltip=Return to the prior screen.
-
 ## Campaign Options Pane
 campaignOptions.title=Campaign Options
 generalPanel.title=General
@@ -28,7 +26,6 @@ humanResourcesParentTab.title=Human Resources
 advancementParentTab.title=Advancement
 logisticsAndMaintenanceParentTab.title=Logistics
 strategicOperationsParentTab.title=Operations
-
 ## General Tab Class
 # createGeneralTab
 lblGeneral.text=Welcome, Commander
@@ -94,7 +91,6 @@ lblCamo.tooltip=Pick a camouflage scheme for the units in your campaign.
 lblIcon.text=Unit Insignia
 lblIcon.tooltip=Pick an insignia for your campaign. Or leave blank to use an image based on your\
   \ campaign faction.
-
 # createFurtherReadingPanel
 lblFurtherReadingPanel.text=Suggested Reading
 lblBMMPanel.text=BATTLEMECH MANUAL (BMM)
@@ -112,20 +108,16 @@ lblCampaignOperationsPanelBody.text=Campaign Operations offers rules for creatin
   \ book's final sections introduce diverse options for campaign play, enabling players to run\
   \ thrilling campaigns of virtually any type with their newly created forces. Campaign Operations\
   \ serves as the foundational rulebook for modern MekHQ.
-
 ## RepairAndMaintenanceTab
 repairsAndMaintenanceContentTabs.title=Maintenance & Repairs
-
 repairTab.title=Repairs
 repairTab.border="Victory depends upon the proper use of combined arms \u2014 light, medium, heavy,\
   \ assault, air, infantry, and the rest. Variety is the spice of battle."\
   <br><i>Captain Natasha Kerensky, Wolf's Dragoons</i>
-
 maintenanceTab.title=Maintenance
 maintenanceTab.border="One 'Mek lance can beat one mob, large or small, any time."\
   <br><i>Dr. Shindu Banzai, Fundamentals of Military Science\
   <br>Lecture at the New Avalon Institute of Science, 3017</i>
-
 # createRepairTab
 lblRepairTab.text=Repair Options
 lblUseEraModsCheckBox.text=Use Era Modifiers for Repair Rolls
@@ -150,10 +142,8 @@ lblDamageMargin.tooltip=Determines how bad a failure must be before an item is d
 lblDestroyPartTarget.text=Equipment Survival Target Number
 lblDestroyPartTarget.tooltip=Equipment hit in battle will survive if this target number is beat on\
   \ 2d6.
-
 # createMaintenanceTab
 lblMaintenanceTab.text=Maintenance Options
-
 lblCheckMaintenance.text=Enable Unit Maintenance
 lblCheckMaintenance.tooltip=If checked, each unit will make a parts-specific maintenance check at\
   \ the end of each maintenance cycle
@@ -195,30 +185,24 @@ lblUseUnofficialMaintenance.tooltip=Determines whether parts should only be dama
 lblLogMaintenance.text=Log Maintenance Results
 lblLogMaintenance.tooltip=Determines whether the results of each maintenance check should be added\
   \ to 'mekhq.log'
-
 ## SuppliesAndAcquisitionTab
 suppliesAndAcquisitionContentTabs.title=Supplies and Acquisition
-
 acquisitionTab.title=Acquisitions & Deliveries
 acquisitionTab.border="Forget the casualties. How much did we make?"\
   <br><i>From the comedy holoplay Minor Major\
   <br>Andurien Broadcasting Corporation</i>
-
 planetaryAcquisitionTab.title=Planetary Acquisitions
 planetaryAcquisitionTab.border="The lowest, dirtiest, nastiest kind of assignment a hard-luck\
   \ bastard merc can draw... is whatever mission he's on at the moment."\
   <br><i>Major Fran Delmarre\
   <br>12th Star Guards</i>
-
 techLimitsTab.title=Tech Limits
 techLimitsTab.border="In a universe where we fight with the ghosts of a golden age, technology is a\
   \ reminder: we are bound by history, but not defined by it."\
   <br><i>Engineer Talia "Patch" Kessler\
   <br>Noble's Faulty Firepower</i>
-
 # createAcquisitionTab
 lblAcquisitionTab.text=Acquisition & Delivery Options
-
 # createAcquisitionPanel
 lblAcquisitionPanel.text=Acquisitions
 lblChoiceAcquireSkill.text=Acquisitions Skill
@@ -236,7 +220,6 @@ lblAcquireWaitingPeriod.text=Acquisition Roll Period Frequency
 lblAcquireWaitingPeriod.tooltip=How many days should pass between acquisition attempts being refreshed?
 lblMaxAcquisitions.text=Max Acquisition Rolls per Period
 lblMaxAcquisitions.tooltip=How many times can a character make an acquisition check per period?
-
 # createAutoLogisticsPanel
 lblAutoLogisticsPanel.text=AutoLogistics
 lblAutoLogisticsMekHead.text='Mek Head Restock Percent
@@ -272,7 +255,6 @@ lblAutoLogisticsOther.text=Other Restock Percent
 lblAutoLogisticsOther.tooltip=autoLogistics counts each part in use, that is not covered by one of\
   \ the other options, and automatically orders replacement spares equal to the percentage set in\
   \ this options.
-
 # createDeliveryPanel
 lblDeliveryPanel.text=Deliveries
 lblTransitTimeUnits.text=Delivery Scale
@@ -281,10 +263,8 @@ lblTransitTimeUnits.tooltip=Should deliveries be scaled using days, weeks, or mo
 transitUnitNamesDays.text=Days
 transitUnitNamesWeeks.text=Weeks
 transitUnitNamesMonths.text=Months
-
 # createPlanetaryAcquisitionTab
 lblPlanetaryAcquisitionTab.text=Planetary Acquisition Options \u270E
-
 # createOptionsPanel
 lblUsePlanetaryAcquisitions.text=Use Planetary Acquisitions \u26A0 \u2714
 lblUsePlanetaryAcquisitions.tooltip=Supplies will be searched for on specific planets up to a\
@@ -324,7 +304,6 @@ lblUsePlanetaryAcquisitionsVerbose.tooltip=This shows all the details of the pla
   <br>\
   <br><b>Warning:</b> This option can lead to a huge daily report, which will create a saved file\
   \ that takes a significant amount of time to load.
-
 # createModifiersPanel
 lblModifiersPanel.text=Modifiers
 lblTechLabel.text=Tech
@@ -333,7 +312,6 @@ lblIndustryLabel.text=Industry
 lblIndustryLabel.tooltip=The planet's industrial rating.
 lblOutputLabel.text=Output
 lblOutputLabel.tooltip=The planet's technological output rating.
-
 # createTechLimitsTab
 lblTechLimitsTab.text=Tech Limit Options
 lblLimitByYearBox.text=Limit Tech Purchases by Game Year
@@ -361,46 +339,37 @@ lblVariableTechLevelBox.tooltip=If checked, the tech level for a part or unit wi
 lblUseAmmoByTypeBox.text=Use Ammo Cross-Weapon Compatibility \u270E
 lblUseAmmoByTypeBox.tooltip=In the warehouse, LRM, SRM, MRM, and MML launchers can mix ammo between\
   \ sizes. For example, an LRM-10 can use LRM-20 ammo.
-
 ## Human Resources Tab
 personnelContentTabs.title=Personnel
-
 # Personnel Tab
 personnelGeneralTab.title=General
 personnelGeneralTab.border="The merc's worst enemy is usually the employer's High Command."\
   <br><i>Colonel Jaime Wolf\
   <br>Commander of Wolf's Dragoons</i>
-
 personnelInformationTab.title=Personnel Information
 personnelInformationTab.border="Why continue a wasteful campaign from an untenable position?"\
   <br><i>From a letter written by Takashi Kurita to his son Theodore, Prince of Luthien\
   <br>Part of the Military Precepts of House Kurita\
   <br>Printed and circulated privately by the Prince in 3020 A.D.</i>
-
 awardsTab.title=Awards
 awardsTab.border="They'll get you somehow. One way or another, there'll be an employer who teaches\
   \ you the true meaning of paranoia..."\
   <br><i>Major Fran Delmare\
   <br>12th Star Guards</i>
-
 prisonersAndDependentsTab.title=Prisoners \u0026 Dependents
 prisonersAndDependentsTab.border="One thing\u2014whose side are we on this week?"\
   <br><i>From the comedy holoplay Minor Major\
   <br>Andurien Broadcasting Corporation</i>
-
 medicalTab.title=Medical
 medicalTab.border="Justice? Justice died with Richard Cameron. The best thing we can ask for is an\
   \ occasional lapse in injustice."\
   <br><i>Katrina Steiner's address to the Estates General</i>
-
 salariesTab.title=Salaries
 salariesTab.border="No job too small...no fee too high."\
   <br><i>Unknown Mercenacy\
   <br>Terran Alliance</i>
-
 # createGeneralTab
 lblPersonnelGeneralTab.text=General Options
-
 lblUseTactics.text=Use Commander Initiative Bonus \u26A0
 lblUseTactics.tooltip=All initiative rolls are modified by the commander's Tactics skill.\
   <br>\
@@ -431,7 +400,6 @@ lblUseImplants.tooltip=Allows personnel to have implants (e.g., Manei Domini)
 lblUseAlternativeQualityAveraging.text=Use Higher-Precision Skill Averaging \u270E
 lblUseAlternativeQualityAveraging.tooltip=Where two skills determine experience level, attempt to\
   \ average by number (e.g., 8/4), rather than product (e.g., Regular/Green), for greater precision.
-
 # createPersonnelCleanUpPanel
 lblPersonnelCleanUpPanel.text=Personnel Cleanup \u270E
 lblUsePersonnelRemoval.text=Enable Personnel Cleanup
@@ -441,7 +409,6 @@ lblUseRemovalExemptCemetery.text=Exempt Dead Personnel
 lblUseRemovalExemptCemetery.tooltip=Data from dead personnel is exempt from being cleaned up.
 lblUseRemovalExemptRetirees.text=Exempt Retirees
 lblUseRemovalExemptRetirees.tooltip=Data from retired personnel is exempt from being cleaned up.
-
 # createPersonnelLogsTab
 lblPersonnelLogsPanel.text=Personnel Logs
 lblUseTransfers.text=Use Reassign for Logging \u2714
@@ -470,7 +437,6 @@ lblDisplayScenarioLog.text=Expand Scenario Log by Default
 lblDisplayScenarioLog.tooltip=Determines whether the scenario log will be expanded by default
 lblDisplayKillRecord.text=Expand Kill Log by Default
 lblDisplayKillRecord.tooltip=Determines whether the kill log will be expanded by default
-
 # createPersonnelInformationTab
 lblPersonnelInformation.text=Personnel Information Options \u270E
 lblUseTimeInService.text=Track Time in Service
@@ -496,7 +462,6 @@ lblTrackTotalXPEarnings.tooltip=This tracks the total amount of experience earne
   \ tracking is only done when this option is enabled, and it is not backfilled.
 lblShowOriginFaction.text=Display Origin Faction
 lblShowOriginFaction.tooltip=Display the origin faction of a person in the personnel table.
-
 # createAdministratorsTab
 lblAdministratorsPanel.text=Administrators \u270E
 lblAdminsHaveNegotiation.text=Admins Have Negotiation
@@ -509,10 +474,8 @@ lblAdminsHaveScrounge.tooltip=Generate all admin personnel with ranks in the Scr
 lblAdminExperienceLevelIncludeScrounge.text=Scrounge Factored into Experience Level
 lblAdminExperienceLevelIncludeScrounge.tooltip=All admin personnel will factor the Scrounge skill\
   \ into their experience level calculations (green, regular, etc.).
-
 # createAwardsTab
 lblAwardsTab.text=Awards Options \u270E \u2318
-
 lblAwardBonusStyle.text=Bonuses
 lblAwardBonusStyle.tooltip=Toggle XP and/or Edge bonuses from awards.
 lblAwardTierSize.text=Tier Size
@@ -535,7 +498,6 @@ lblAwardSetFilterList.tooltip=Include the name of any award sets you don't want 
   <br><b>Warning:</b> The spelling and capitalization must be exact, and each award set must be\
   \ separated by a comma. While spaces can appear in the award set name, the comma shouldn't be\
   \ followed by a space.
-
 # createAutoAwardsFilterPanel
 lblAutoAwardsFilterPanel.text=Award Tracking
 lblEnableContractAwards.text=Contract
@@ -580,16 +542,13 @@ lblEnableTrainingAwards.tooltip=These are awards issued for graduating from acad
   <br><b>Requirement:</b> the Education module must also be enabled for this option to function.
 lblEnableMiscAwards.text=Misc
 lblEnableMiscAwards.tooltip=These awards aren't covered by the other categories.
-
 # createPrisonersAndDependentsTab
 lblPrisonersAndDependentsTab.text=Dependent & Prisoner Options \u270E \u2318
-
 # createPrisonersPanel
 lblPrisonersPanel.text=Prisoners
 lblPrisonerCaptureStyle.text=Capture Style
 lblPrisonerCaptureStyle.tooltip=This is the ruleset to use when determining if a person has been\
   \ captured by the force following a scenario.
-
 # createDependentsPanel
 lblDependentsPanel.text=Dependents
 lblUseRandomDependentAddition.text=Random Addition
@@ -598,7 +557,6 @@ lblUseRandomDependentAddition.tooltip=This enables the monthly addition of rando
 lblUseRandomDependentRemoval.text=Random Removal
 lblUseRandomDependentRemoval.tooltip=This enables the monthly removal of random dependents from the\
   \ campaign.
-
 # createMedicalTab
 lblMedicalTab.text=Medical Options
 lblUseAdvancedMedical.text=Use Advanced Medical \u270E \u2318
@@ -619,13 +577,11 @@ lblUseTougherHealing.text=Use Tougher Healing \u270E
 lblUseTougherHealing.tooltip=The healing check will be penalized for every additional hit above 2.
 lblMaximumPatients.text=Beds per Doctor
 lblMaximumPatients.tooltip=This is the maximum number of patients that can be treated per doctor.
-
 # createSalariesTab
 lblSalariesTab.text=Salary Options
 lblDisableSecondaryRoleSalary.text=Disable Secondary Role Salaries \u270E
 lblDisableSecondaryRoleSalary.tooltip=Determines whether personnel will have their salaries\
   \ increased by their secondary role (if any).
-
 # createSalaryMultipliersPanel
 lblSalaryMultipliersPanel.text=Role Multipliers
 lblAntiMekSalary.text=Anti-Mek
@@ -634,7 +590,6 @@ lblAntiMekSalary.tooltip=Anti-Mek trained soldiers and battle armor/elemental pe
 lblSpecialistInfantrySalary.text=Specialist Infantry
 lblSpecialistInfantrySalary.tooltip=Soldiers assigned to specialist infantry units have their\
   \ salaries multiplied by this.
-
 # createExperienceMultipliersPanel
 lblExperienceMultipliersPanel.text=Experience Multipliers
 lblSkillLevelNone.text=None
@@ -647,13 +602,10 @@ lblSkillLevelVeteran.text=Veteran
 lblSkillLevelElite.text=Elite
 lblSkillLevelHeroic.text=Heroic
 lblSkillLevelLegendary.text=Legendary
-
 # createBaseSalariesPanel
 lblBaseSalariesPanel.text=Base Salaries
-
 # Biography Tab
 biographyContentTabs.title=Biography
-
 biographyGeneralTab.title=General
 biographyGeneralTab.border="With warfare an accepted part of everyday life and competition rife\
   \ between Great Houses, Minor Houses, Periphery warlords, Bandit Kings, mercantile combines, and\
@@ -665,7 +617,6 @@ biographyGeneralTab.border="With warfare an accepted part of everyday life and c
   \ staple of the Successor States?"\
   <br><i>Major Charlene Fellowes\
   <br>From Under Four Flags: My Life as a Mercenary, New Avalon Press, 3023</i>
-
 backgroundsTab.title=Backgrounds
 backgroundsTab.border="Now, Krieger and Farber are two of the best Techs in the sphere, and two of\
   \ the best scroungers. They got some facing off a wrecked building to cover us. That stuff works,\
@@ -688,29 +639,24 @@ backgroundsTab.border="Now, Krieger and Farber are two of the best Techs in the 
   \ it read 'Processed Chicken.'"\
   <br><i>Unknown MechWarrior\
   <br>3rd Succession War</i>
-
 deathTab.title=Death
 deathTab.border="School didn't teach me how to explode; I just learn fast."\
   <br><i>Sergeant Pete "Wildfire" Watson\
   <br>The Shenanigans Squadron</i>
-
 educationTab.title=Education
 educationTab.border="It's a sad comment on urban living when you see a Battle Master mug a Phoenix\
   \ Hawk in a blind alley."\
   <br><i>Unknown MechWarrior\
   <br>3rd Succession War</i>
-
 nameAndPortraitGenerationTab.title=Name & Portraits
 nameAndPortraitGenerationTab.border="Look at the bright side, kid. You get to keep all the money."\
   <br><i>Unknown MechWarrior\
   <br>2nd Succession War</i>
-
 rankTab.title=Rank Systems
 rankTab.border="Rank isn't about authority \u2014 it's about responsibility. Every step up means you're\
   \ carrying more than your own survival."\
   <br><i>Kommandant Clara "Demo" Bertsimas\
   <br>Herc's Jerks</i>
-
 # createGeneralTab
 lblBiographyGeneralTab.text=General Options \u270E
 lblUseDylansRandomXP.text=Use Random XP
@@ -731,7 +677,6 @@ lblFamilyDisplayLevel.tooltip=This setting is the relation to the selected chara
   \ display up to, including the previous levels.\
   <br>\
   <br><b>Warning:</b> Higher levels require more processing when loading a character.
-
 # createAnniversariesPanel
 lblAnniversariesPanel.text=Anniversaries
 lblAnnounceBirthdays.text=Announce Birthdays
@@ -746,10 +691,8 @@ lblAnnounceChildBirthdays.text=Always Announce 18th Birthdays \u26A0
 lblAnnounceChildBirthdays.tooltip=If enabled, 18th birthdays will always be announced.\
   <br>\
   <br><b>Warning:</b> Enabling this option will override any other settings.
-
 # createBackgroundsTab
 lblBackgroundsTab.text=Background Options \u270E
-
 # createRandomBackgroundsPanel
 lblRandomBackgroundsPanel.text=Random Backgrounds
 lblUseRandomPersonalities.text=Assign Random Personalities \u2318
@@ -776,7 +719,6 @@ lblUseSimulatedRelationships.tooltip=Personnel are generated with a random relat
   \ used to determine whether any marriages have ended in divorce.\
   <br>\
   <br>Any children and current spouses will travel alongside the unit.
-
 # createRandomOriginOptionsPanel
 lblRandomOriginOptionsPanel.text=Origins
 lblRandomizeOrigin.text=Randomize Origin
@@ -814,7 +756,6 @@ lblAllowClanOrigins.tooltip=Generate Clan origin factions for factions that aren
 lblExtraRandomOrigin.text=Extra Random Origins
 lblExtraRandomOrigin.tooltip=Random origin is randomized to the planetary level when selected,\
   \ rather than just randomizing to the system level (with the planet being the primary planet).
-
 # createDeathTab
 lblDeathTab.text=Death Options \u270E
 lblUseRandomDeathSuicideCause.text=Enable Cause of Death: Suicide
@@ -825,10 +766,8 @@ lblRandomDeathMultiplier.tooltip=This multiplier is applied directly to a charac
   <br>\
   <br><b>Warning:</b> Setting this to 0 disables Random Death. The default value of 1.0 gives an\
   \ average life expectancy of 84 for men and 89 for women.
-
 # createDeathAgeGroupsPanel
 lblDeathAgeGroupsPanel.text=Death by Age Group
-
 # createEducationTab
 lblEducationTab.text=Education Options \u270E \u2318
 lblUseEducationModule.text=Enable Education Module
@@ -852,7 +791,6 @@ lblEntranceExamBaseTargetNumber.tooltip=The base target number for Prestigious A
   <br>\
   <br>The final TN is this value minus Faculty Skill, opposed by 2d6 + Intelligence/4 or just 2d6\
   \ (if personalities are disabled)
-
 # createEnableStandardSetsPanel
 lblEnableStandardSetsPanel.text=Enable Academy Sets
 lblEnableLocalAcademies.text=Local Academies
@@ -862,7 +800,6 @@ lblEnablePrestigiousAcademies.tooltip=Allows personnel to enroll in named, canon
 lblEnableUnitEducation.text=Unit Education
 lblEnableUnitEducation.tooltip=Allows personnel to enroll in education and training conducted by\
   \ the unit. These are generally inferior to prestigious or local academies.
-
 # createXpAndSkillBonusesPanel
 lblXpAndSkillBonusesPanel.text=Faculty XP & Skill Bonuses
 lblEnableBonuses.text=Enable Graduation Bonuses
@@ -872,7 +809,6 @@ lblFacultyXpMultiplier.tooltip=This value multiplies the number of XP gained whe
   \ partially completing) a qualification.\
   <br>\
   <br>Setting this to zero disables faculty XP.
-
 # createDropoutChancePanel
 lblDropoutChancePanel.text=Weekly Dropout Chances
 lblAdultDropoutChance.text=Adult Dropout Chance: 1 in
@@ -885,7 +821,6 @@ lblChildrenDropoutChance.tooltip=The number of sides on the die used to determin
   \ dropouts. A dropout occurs on a roll of 1.\
   <br>\
   <br>Setting this to 0 disables random dropouts.
-
 # createAccidentsAndEventsPanel
 lblAccidentsAndEventsPanel.text=Weekly Accidents & Events
 lblAllAges.text=All Ages Affected
@@ -896,7 +831,6 @@ lblMilitaryAcademyAccidents.tooltip=The number of sides on the die used to deter
   \ (potentially fatal) accidents. An accident occurs on a roll of 1.\
   <br>\
   <br>Setting this to 0 disables random accidents.
-
 # createNameAndPortraitGenerationTab
 lblNameAndPortraitGenerationTab.text=Name and Portrait Generation Options \u270E \u2318
 lblUseOriginFactionForNames.text=Assign Names Based on Origin Faction
@@ -910,14 +844,12 @@ lblAssignPortraitOnRoleChange.tooltip=With this enabled, a person without a port
 lblAllowDuplicatePortraits.text=Allow Duplicate Portraits
 lblAllowDuplicatePortraits.tooltip=With this enabled, random portraits are no longer unique\
   \ and several different people can have the same portrait.
-
 # createRandomPortraitPanel
 lblRandomPortraitPanel.text=Portrait Assignment
 lblEnableAllPortraits.text=Enable All
 lblEnableAllPortraits.tooltip=Enable all portrait assignment options
 lblDisableAllPortraits.text=Disable All
 lblDisableAllPortraits.tooltip=Disable all portrait assignment options
-
 # createRankTab
 lblRankTab.text=Rank Systems \u2318
 lblRankTabBody.text=<p>You can use the table below to assign ranks for your campaign. Choose one of\
@@ -961,29 +893,23 @@ lblRankTabBody.text=<p>You can use the table below to assign ranks for your camp
           </ul>\
       </li>\
   </ol>
-
-
 # Turnover and Rention Tab
 turnoverAndRetentionContentTabs.title=Turnover & Retention
-
 turnoverTab.title=Turnover
 turnoverTab.border="For a MekWarrior, retirement is a strange thing. We spend our lives in battle,\
   \ and when the guns go silent, we find out who we are without them."\
   <br><i>Colonel Sofia "Whisper" Talon\
   <br>Ark's Bonked Battalion</i>
-
 fatigueTab.title=Fatigue
 fatigueTab.border="I say to Hell with Information! Ammunition is Ammunition!"\
   <br><i>Unknown Mercenary\
   <br>Clan Invasion</i>
-
 # createTurnoverTab
 lblTurnoverTab.text=Turnover Options \u270E \u2318
 lblTurnoverTabBody.text=Turnover is a reasonably complex system. It is highly recommended that you\
   \ read through the documentation: <i>MekHQ/docs/Personnel Modules/Turnover and Retention.pdf</i>
 lblUseRandomRetirement.text=Enable Random Turnover
 lblUseRandomRetirement.tooltip=Determines whether personnel will randomly leave the unit.
-
 # createSettingsPanel
 lblSettingsPanel.text=Settings
 lblTurnoverFixedTargetNumber.text=Target Number
@@ -1020,7 +946,6 @@ lblPayBonusDefault.tooltip=Personnel with a turnover target number equal (or exc
 lblPayBonusDefaultThreshold.text=Bonus Threshold
 lblPayBonusDefaultThreshold.tooltip=This option sets the threshold for default bonus payouts (if\
   \ the above option is enabled).
-
 # createModifiersPanel
 lblTurnoverModifiersPanel.text=Modifiers
 lblUseCustomRetirementModifiers.text=Custom
@@ -1054,7 +979,6 @@ lblUseLoyaltyModifiers.tooltip=If enabled, personnel have a random loyalty ratin
   \ their Turnover target number.
 lblUseHideLoyalty.text=Hide Loyalty
 lblUseHideLoyalty.tooltip=If enabled, loyalty modifiers will be hidden.
-
 # createPayoutsPanel
 lblPayoutsPanel.text=Payouts
 lblPayoutRateOfficer.text=Officer Rate
@@ -1071,7 +995,6 @@ lblUsePayoutServiceBonus.tooltip=If enabled, personnel increase their payouts ba
 lblPayoutServiceBonusRate.text=Bonus %
 lblPayoutServiceBonusRate.tooltip=This sets the payout percentage increase per year of service,\
   \ applied when personnel resign or retire.
-
 # createUnitCohesionPanel
 lblUnitCohesionPanel.text=Unit Cohesion
 lblUseAdministrativeStrain.text=Enable Administrative Strain
@@ -1080,7 +1003,6 @@ lblUseAdministrativeStrain.tooltip=This option limits the number of personnel th
 lblUseManagementSkill.text=Enable Management Skill
 lblUseManagementSkill.tooltip=This option applies a modifier to turnover checks based on the\
   \ Leadership of commanding personnel.
-
 # createAdministrativeStrainPanel
 lblAdministrativeStrain.text=Administrative Strain
 lblAdministrativeCapacity.text=Administrative Capacity
@@ -1089,7 +1011,6 @@ lblAdministrativeCapacity.tooltip=How many personnel can be supported per combin
 lblMultiCrewStrainDivider.text=Multi-Crew Strain Divider
 lblMultiCrewStrainDivider.tooltip=For multi-crew units (and ProtoMeks) divide crew size by this\
   \ value. This value is doubled for civilians and prisoners.
-
 # createManagementSkill
 lblManagementSkill.text=Management Skill
 lblUseCommanderLeadershipOnly.text=Use Commander's Leadership Only
@@ -1099,7 +1020,6 @@ lblUseCommanderLeadershipOnly.tooltip=Personnel only use the Leadership skill of
 lblManagementSkillPenalty.text=Unskilled Penalty
 lblManagementSkillPenalty.tooltip=The unskilled modifier to turnover target numbers. Each rank in\
   \ Leadership reduces this number by 1.
-
 # createFatigueTab
 lblFatigueTab.text=Fatigue Options
 lblFatigueTabBody.text=The rules for Fatigue can be found in Campaign Operations. With our\
@@ -1129,24 +1049,19 @@ lblFatigueLeaveThreshold.tooltip=Automatically assign personnel to Leave status 
   \ duty once their fatigue has returned to 0.\
   <br>\
   <br>Set to 0 to disable.
-
 ## Relationships Tab
 relationshipsContentTabs.title=Relationships
-
 marriageTab.title=Marriage
 marriageTab.border="My love, I give you the Capellan Confederation!"\
   <br><i>Hanse Davion to Melissa Steiner-Davion at their wedding reception on Terra\
   <br>August 20, 3028</i>
-
 divorceTab.title=Divorce
 divorceTab.border="Whoever said 'never shoot a man in the back' never saw the front a Hunchback."\
   <br><i>Unknown Mercenary\
   <br>First Succession War</i>
-
 procreationTab.title=Procreation
 procreationTab.border="They've requested LRMs. I'm pretty sure they mean Living Room Modules."\
   <br><i>Unknown Logistics Tech</i>
-
 # createMarriageTab
 lblMarriageTab.text=Marriage Options \u270E
 lblUseManualMarriages.text=Enable Manual Marriages
@@ -1171,7 +1086,6 @@ lblCheckMutualAncestorsDepth.tooltip=This is the depth to which the ancestry of 
 lblLogMarriageNameChanges.text=Log Name Changes
 lblLogMarriageNameChanges.tooltip=This enables the addition of a personnel log entry whenever a\
   \ name is changed during marriage.
-
 # createRandomMarriagePanel
 lblRandomMarriages.text=Random Marriages
 lblRandomMarriageMethod.text=Random Marriage Method
@@ -1186,7 +1100,6 @@ lblUseRandomPrisonerMarriages.tooltip=Allow random divorce when one or both of t
 lblRandomMarriageAgeRange.text=Random Marriage Age Band
 lblRandomMarriageAgeRange.tooltip=This plus/minus age forms the possible range of ages for spouses\
   \ in the forming of a random marriage.
-
 # createPercentageRandomMarriagePanel
 lblPercentageRandomMarriagePanel.text=Marriage Dice
 lblRandomMarriageOppositeSexDiceSize.text=Opposite Sex Marriage Chance: 1 in
@@ -1205,7 +1118,6 @@ lblRandomNewDependentMarriage.tooltip=This determines the number of sides on the
   \ occurs on a roll of 1.\
   <br>\
   <br>Set this value to 0 to disable inter-unit marriages.
-
 # createDivorceTab
 lblDivorceTab.text=Divorce Options \u270E
 lblUseManualDivorce.text=Enable Manual Divorce
@@ -1217,7 +1129,6 @@ lblUsePrisonerDivorce.text=Enable Manual Prisoner Divorce
 lblUsePrisonerDivorce.tooltip=Allow divorce when one or both of the couple are currently prisoners.\
   \ Bondsmen are treated as free personnel when it comes to this option, and are thus not affected\
   \ by it.
-
 # createRandomDivorcePanel
 lblRandomDivorcePanel.text=Random Divorce
 lblRandomDivorceMethod.text=Random Divorce Method
@@ -1241,10 +1152,8 @@ lblRandomDivorceDiceSize.tooltip=This is the number of sides featured on the wee
   \ see whether a marriage ends in divorce. Divorce occurs on a roll of 1.\
   <br>\
   <br>Set to 0 to disable random divorces for all personnel.
-
 # createProcreationTab
 lblProcreationTab.text=Procreation Options \u270E
-
 # createProcreationGeneralOptionsPanel
 lblUseManualProcreation.text=Enable Manual Procreation
 lblUseManualProcreation.tooltip=This allows you to disable the Add/Remove Pregnancy options in the\
@@ -1293,7 +1202,6 @@ lblUseMaternityLeave.tooltip=If enabled, pregnant personnel will be placed on ma
   \ birth.
 lblLogProcreation.text=Log Procreation
 lblLogProcreation.tooltip=This enables logging the date of conception and birth in a person's logs.
-
 # createRandomProcreationPanel
 lblRandomProcreationPanel.text=Random Procreation
 lblRandomProcreationMethod.text=Random Procreation Method
@@ -1315,24 +1223,19 @@ lblRandomProcreationRelationshiplessDiceSize.text=Relationshipless Procreation C
 lblRandomProcreationRelationshiplessDiceSize.tooltip=This is the number of sides on the dice rolled\
   \ weekly to determine whether a woman not in a relationship will fall pregnant. A roll of 1\
   \ results in a pregnancy.
-
 # Finances Tab
 financesContentTabs.title=Finances
-
 financesGeneralTab.title=General
 financesGeneralTab.border="War is expensive. If the enemy doesn't kill you, the repair bills might."\
   <br><i>Sergeant Tara "Grease" Hall\
   <br>Vogel's Fumble Force
-
 priceMultipliersTab.title=Price Multipliers
 priceMultipliersTab.border="The used parts market is where dreams are built \u2014 and nightmares are patched\
   \ together. Just make sure the part you're buying doesn't come with someone else's curse."\
   <br><i>Captain Nia "Jackal" Thorne\
   <br>The Stormbringer Jägers</i>
-
 # createFinancesGeneralOptionsTab
 lblFinancesGeneralTab.text=General Options
-
 # createPaymentsPanel
 lblPaymentsPanel.text=Payments
 lblPayForPartsBox.text=Pay For Parts
@@ -1354,7 +1257,6 @@ lblPayForTransportBox.text=Transport
 lblPayForTransportBox.tooltip=Pay for excess transportation needs.
 lblPayForRecruitmentBox.text=Recruitment (FM:Mr)
 lblPayForRecruitmentBox.tooltip=Pay a two-month salary to new recruits.
-
 # createGeneralOptionsPanel
 lblUseLoanLimitsBox.text=Available Loans Based on Unit Reputation \u270E
 lblUseLoanLimitsBox.tooltip=Put limits on interest, collateral, and length.
@@ -1378,14 +1280,12 @@ lblNewFinancialYearFinancesToCSVExportBox.tooltip=This writes the finance table 
   \ the first day of a new financial term, right before the table is carried over to the next period.
 lblSimulateGrayMonday.text=Simulate Gray Monday
 lblSimulateGrayMonday.tooltip=Simulate the economic and social upheaval of Gray Monday.
-
 # createSalesPanel
 lblSalesPanel.text=Sales
 lblSellUnitsBox.text=Enable the Sale of Units
 lblSellUnitsBox.tooltip=Units can be sold.
 lblSellPartsBox.text=Enable the Sale of Parts
 lblSellPartsBox.tooltip=Parts can be sold.
-
 # createTaxesPanel
 lblTaxesPanel.text=Taxes \u270E
 lblUseTaxesBox.text=Enable Taxes
@@ -1397,7 +1297,6 @@ lblUseTaxesBox.tooltip=If enabled, taxes will be paid at the end of each financi
   <brStarting Capital and End of Term Carryover sums are excluded from profit calculations.
 lblTaxesPercentage.text=Tax Percentage
 lblTaxesPercentage.tooltip=The percentage of profits paid as taxes.
-
 # createSharesPanel
 lblSharesPanel.text=Shares \u270E
 lblUseShareSystem.text=Enable Shares
@@ -1405,14 +1304,12 @@ lblUseShareSystem.tooltip=Gives personnel a stake in the unit. This system lower
   \ increase retention.
 lblSharesForAll.text=All Personnel Have Shares
 lblSharesForAll.tooltip=All combat and support personnel have shares rather than just MekWarriors.
-
 # createFinancesGeneralOptionsTab
 lblPriceMultipliersTab.text=Price Multiplier Options
 lblPriceMultipliersTabBody.text=It's important to remember that the qualities (A-F) under <b>Used\
   \ Parts</b> do not update based on whether you have <b>Reverse Quality Names</b> enabled.\
   <br>\
   <br>This means <b>A</b> is the worst quality and <b>F</b> is the best.
-
 # createGeneralMultipliersPanel
 lblGeneralMultipliersPanel.text=General
 lblCommonPartPriceMultiplier.text=Common Parts
@@ -1433,10 +1330,8 @@ lblClanPartPriceMultiplier.tooltip=Multiplies the buy/sell price of Clan tech pa
 lblMixedTechUnitPriceMultiplier.text=Mixed Units
 lblMixedTechUnitPriceMultiplier.tooltip=Multiplies the buy/sell price of Mixed Tech units by the\
   \ specified value.
-
 # createUsedPartsMultiplierPanel
 lblUsedPartsMultiplierPanel.text=Used Parts
-
 # createOtherMultipliersPanel
 lblOtherMultipliersPanel.text=Other
 lblDamagedPartsValueMultiplier.text=Damaged Parts
@@ -1448,10 +1343,8 @@ lblUnrepairablePartsValueMultiplier.tooltip=Multiplies the value and thus the se
 lblCancelledOrderRefundMultiplier.text=Cancelled Order Refund
 lblCancelledOrderRefundMultiplier.tooltip=The decimal percentage of the original purchase price\
   \ that is refunded when an order is canceled.
-
 # Markets Tab
 marketsContentTabs.title=Markets
-
 personnelMarketTab.title=Personnel
 personnelMarketTab.border=\u2014 Toilet Paper 22 Tons\
   <br>\u2014 Soap 1.2 Tons\
@@ -1464,22 +1357,18 @@ personnelMarketTab.border=\u2014 Toilet Paper 22 Tons\
   <br>\u2014 Morale Package (Hunky Hanse and Bellissima Melissa Dolls) 1 crate\
   <br><i>Unknown Resupply Shipment\
   <br>Fourth Succession War</i>
-
 unitMarketTab.title=Units
 unitMarketTab.border="Buying a new 'Mek is exciting \u2014 right up until you see the repair bill after\
   \ your first mission. Then it's just another hole in your wallet."\
   <br><i>Sergeant Kyle "Scrapheap" Carter\
   <br>The Blacksmiths</i>
-
 contractMarketTab.title=Contracts
 contractMarketTab.border="So there I was, between rock and a hard place, when suddenly I thought,\
   \ 'What am I doing on this side of the rock?'"\
   <br><i>Star Commander Karra\
   <br>Clan Ghost Bear, Constance, Apr 3050</i>
-
 # createPersonnelMarketTab
 lblPersonnelMarketTab.text=Personnel Market Options
-
 # createPersonnelMarketGeneralOptionsPanel
 lblPersonnelMarketType.text=Market Method
 lblPersonnelMarketType.tooltip=This is the type of personnel market used to generate and remove new\
@@ -1494,10 +1383,8 @@ lblPersonnelMarketReportRefresh.tooltip=Adds a report to the daily log when the 
 lblUsePersonnelHireHiringHallOnly.text=Hiring Halls & Capitals Only \u270E
 lblUsePersonnelHireHiringHallOnly.tooltip=Enabling this option disables the personnel market\
   \ outside of hiring halls or capital planets.
-
 # createPersonnelMarketRemovalOptionsPanel
 lblPersonnelMarketRemovalOptionsPanel.text=Removal Target Numbers
-
 # createUnitMarketTab
 lblUnitMarketTab.text=Unit Market Options \u270E
 lblUnitMarketMethod.text=Market Method
@@ -1523,10 +1410,8 @@ lblMothballUnitMarketDeliveries.tooltip=Units bought from the unit market will a
   \ mothballed state.
 lblUnitMarketReportRefresh.text=Post Report on Market Refresh
 lblUnitMarketReportRefresh.tooltip=Adds a report to the daily log when the unit market refreshes.
-
 # createContractMarketTab
 lblContractMarketTab.text=Contract Market Options
-
 # createContractMarketGeneralOptionsPanel
 lblContractMarketMethod.text=Market Method
 lblContractMarketMethod.tooltip=This is the method of contract market used to generate new\
@@ -1547,7 +1432,6 @@ lblCoontractMaxSalvagePercentage.tooltip=Used to limit the salvage roll when cre
 lblDropShipBonusPercentage.text=DropShip Bonus Percent
 lblDropShipBonusPercentage.tooltip=It is not possible to salvage DropShips from ground maps.\
   \ Setting this option above 0 will instead pay a percentage of the DropShip's value as a 'bounty.'
-
 # createMercenaryPanel
 lblContractPayPanel.text=Contract Pay
 lblContractEquipment.text=TO&E Value Influences Pay (CamOps)
@@ -1578,22 +1462,18 @@ lblOverageRepaymentInFinalPayment.text=Repay Salvage Overages on Contract End
 lblOverageRepaymentInFinalPayment.tooltip=This is an unofficial addition that has you repay any\
   \ overages from your salvage percent as part of the final payment, which may take that into a\
   \ debit.
-
 # Markets Tab
 rulesetsContentTabs.title=Custom Rulesets
-
 stratConGeneralTab.title=General
 stratConGeneralTab.border="Strategy is just a fancy way of saying, 'I'm going to send you in first\
   \ and see what happens.'"\
   <br><i>Sergeant Milo "Wildcard" Trent\
   <br>The Tridents</i>
-
 legacyTab.title=Legacy Options
 legacyTab.border="You know, for 5-tons, I'd expect more than 256 colors!"\
   <br><i>Colonel Elias "Warhound" Drake\
   <br>Impetus Alliance\
   <br>Comments made following a Targeting Computer retrofit</i>
-
 # substantializeUniversalOptions
 lblSkillLevel.text=Difficulty \u2714
 lblSkillLevel.tooltip=<html>This is the difficulty level for generated scenarios.\
@@ -1668,25 +1548,18 @@ lblAdjustPaymentForStrategy.text=Adjust Contract Pay by Maximum Force Count
 lblAdjustPaymentForStrategy.tooltip=If the number of lances required to be deployed exceeds the\
   \ current commander's strategy skill, reduce the number when calculating new contracts and reduce\
   \ the payment proportionally.
-
 # createUniversalScenarioGenerationPanel
 lblUniversalScenarioGenerationPanel.text=Scenario Generation
-
 # createUniversalUnitRatioPanel
 lblUniversalUnitRatioPanel.text=Unit Ratios
-
 # createUniversalModifiersPanel
 lblUniversalModifiersPanel.text=Random Modifiers
-
 # createUniversalMapGenerationPanel
 lblUniversalMapGenerationPanel.text=Map Generation
-
 # createUniversalPartsPanel
 lblUniversalPartsPanel.text=Parts Availability
-
 # createUniversalLancePanel
 lblUniversalLancePanel.text=Force Organization
-
 # createStratConTab
 lblStratConTab.text=General Options \u270E
 lblUseStratCon.text=Enable StratCon (Digital GM) \u2318 \u26A0
@@ -1705,7 +1578,6 @@ lblUseGenericBattleValue.tooltip=Bot forces are balanced used Generic Battle Val
 lblUseVerboseBidding.text=Enable Verbose Clan Bidding
 lblUseVerboseBidding.tooltip=When Generic BV is in use, Clan OpFors will engage in bidding prior\
   \ to the scenario. If this option is enabled, a list of all units bid away will be provided.
-
 # initializeLegacyTab
 lblLegacyTab.text=Legacy Options \u270E
 lblLegacyTabBody.text=This tab includes options for <b>Legacy AtB: Against the Bot</b>. All options\
@@ -1716,7 +1588,6 @@ lblUseAtB.tooltip=AtB was MekHQ's first attempt at a Digital GM. It creates rand
   \ Support for Legacy AtB ended in 2025 with v50.02.\
   <br>\
   <br><b>Warning:</b> If StratCon is enabled, all Legacy options are ignored.
-
 # createAutoResolvePanel
 lblAutoResolvePanel.text=AutoResolve \u270E \u2318
 lblAutoResolveMethod.text=AutoResolve Method \u26A0
@@ -1737,10 +1608,8 @@ lblAutoResolveVictoryChanceEnabled.tooltip=Determines whether MekHQ should tell 
 lblAutoResolveExperimentalPacarGuiEnabled.text=Experimental Commander's Interface for PACAR \u26A0
 lblAutoResolveExperimentalPacarGuiEnabled.tooltip=A lightweight graphical interface for PACAR.\
   \ <b>Warning:</b> This is an experimental feature and may not work as expected. It's intended for solo play only.
-
 lblMinimapTheme.text=Strategic View Theme \u26A0
 lblMinimapTheme.tooltip=Select a theme for the strategic view screen on the Commander's Interface
-
 # createLegacyOpForGenerationPanel
 lblLegacyOpForGenerationPanel.text=Force Generation
 lblUseVehicles.text=Enable NPC Vehicles
@@ -1759,7 +1628,6 @@ lblOpForUsesLocalForces.tooltip=The bot may introduce turrets, infantry and batt
 lblAdjustPlayerVehicles.text=Treat Player Vehicles as Half Weight
 lblAdjustPlayerVehicles.tooltip=Vehicles deployed by the player only count half their weight to the\
   \ lance weight class to compensate for enemy force generation designed to oppose player Meks.
-
 # createLegacyScenarioGenerationPanel
 lblLegacyScenarioGenerationPanel.text=Scenario Generation
 lblGenerateChases.text=Generate Chase Scenarios
@@ -1769,22 +1637,23 @@ lblAtBBattleIntensity.text=Battle Frequency
 lblAtBBattleIntensity.tooltip=How intense should contracts be? Lower these values for easier contracts.
 lblIntensityUpdate.text=Update Intensity
 lblIntensityUpdate.tooltip=Update intensity based on the current battle chance values.
-
 ## Advancement Tab
 awardsAndRandomizationContentTabs.title=Awards & Randomization
-
-xpAwardsTab.title=Experience Awards
-xpAwardsTab.border="It is possible to commit no mistakes and still lose. That is not a weakness;\
+1xpAwardsTab.title=Experience Awards
+1xpAwardsTab.border="It is possible to commit no mistakes and still lose. That is not a weakness;\
   \ that is life."\
   <br><i>Captain Jean Stuart, The Voyagers\
   <br>Date Unknown</i>
-
-randomizationTab.title=Randomization
-randomizationTab.border="Every skill has its moment. What seems trivial today may save lives tomorrow,\
+0randomizationTab.title=Randomization
+0randomizationTab.border="Every skill has its moment. What seems trivial today may save lives tomorrow,\
   \ because out in the stars, survival favors the adaptable."\
   <br><i>Colonel Drake "Ironjaw" Valen\
   <br>The Missed Connection Militia</i>
-
+2recruitmentBonusesTab.title=Recruitment Bonuses
+2recruitmentBonusesTab.border="You don't own a 'Mek. You inherit it, you bleed for it, and if you're lucky, you die in it\
+  \ before someone strips you for parts."\
+  <br><i>MekWarrior David\
+  <br>Jade Solahma Cluster</i>
 # xpAwardsTab
 lblXpAwardsTab.text=Experience Award Options
 lblXpCostMultiplier.text=Advancement Multiplier \u26A0
@@ -1792,7 +1661,6 @@ lblXpCostMultiplier.tooltip=This value multiplies the XP costs of all SPAs, Edge
   \ Skill Levels.\
   <br>\
   <br><b>Warning:</b> This option updates costs while you play and not the options shown here.
-
 # createTasksPanel
 lblTasksPanel.text=Tasks (Deprecated)
 lblTaskXP.text=XP per
@@ -1825,7 +1693,6 @@ lblMistakeXP.tooltip=How much experience should be awarded whenever an unsuccess
   \ checks. Usually Admin characters, or those making acquisition checks.\
   <br>\
   <br><b>Recommended:</b> Keep this disabled.
-
 # createScenariosPanel
 lblScenariosPanel.text=Scenarios \u270E
 lblScenarioXP.text=XP per Scenario \u26A0 \u2714
@@ -1854,7 +1721,6 @@ lblKills.tooltip=How many kills need to be scored before experience is awarded?\
   \ at once, such as bomb equipped aircraft pilots.\
   <br>\
   <br><b>Recommended:</b> Keep this disabled.
-
 # createMissionsPanel
 lblMissionsPanel.text=Missions
 lblVocationalXP.text=Vocational XP per \u26A0
@@ -1876,7 +1742,6 @@ lblMissionXpSuccess.tooltip=How much experience is awarded for a successful cont
 lblMissionXpOutstandingSuccess.text=Outstanding Success (StratCon Only)
 lblMissionXpOutstandingSuccess.tooltip=Experience points awarded when successfully concluding a\
   \ mission with 3+ campaign victory points.
-
 # createAdministratorsPanel
 lblAdministratorsXpPanel.text=Administrators (Deprecated) \u270E \u26A0 \u2714
 lblAdminWeeklyXP.text=XP per
@@ -1901,7 +1766,6 @@ lblContractNegotiationXP.tooltip=How much experience does a contract negotiator 
   \ gains of admin personnel.\
   <br>\
   <br><b>Recommended:</b> Keep this disabled.
-
 # skillRandomizationTab
 lblSkillRandomizationTab.text=Skill Randomization Options \u270E
 lblExtraRandomness.text=Extra Randomness \u26A0
@@ -1910,7 +1774,6 @@ lblExtraRandomness.tooltip=If checked, an additional 1d6 will be rolled per skil
   <br>\
   <br><b>Warning:</b> Due to the way experience levels are calculated, enabling this option will\
   \ more frequently have characters created with slightly lower than normal experience levels.
-
 lblPhenotypesPanel.text=Clan Trueborn Percentages
 lblMekWarrior.text=MekWarrior
 lblMekWarrior.tooltip=What percentage of Clan MekWarriors should have a Trueborn phenotype?
@@ -1924,7 +1787,6 @@ lblProtoMek.text=ProtoMek
 lblProtoMek.tooltip=What percentage of ProtoMek pilots should have a Trueborn phenotype?
 lblNaval.text=Naval
 lblNaval.tooltip=What percentage of Naval crew should have a Trueborn phenotype?
-
 lblAbilityPanel.text=Random SPA Chances
 lblAbilityGreen.text=Green \u26A0
 lblAbilityGreen.tooltip=Modifier to the 2d6 roll used to determine whether a character is created\
@@ -1954,7 +1816,6 @@ lblAbilityElite.tooltip=Modifier to the 2d6 roll used to determine whether a cha
   <br><b><9:</b> 0 SPAs\
   <br><b>10-11:</b> 1 SPA\
   <br><b>12+:</b> 2 SPAs
-
 lblCommandSkillsPanel.text=Command Skills
 lblCommandSkillsGreen.text=Green \u26A0
 lblCommandSkillsGreen.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
@@ -1992,7 +1853,6 @@ lblCommandSkillsElite.tooltip=Modifier made to the 2d6 roll used to determine wh
   <br><b>6-9:</b> Regular\
   <br><b>10-11:</b> Veteran\
   <br><b>12+:</b> Elite
-
 lblSmallArmsPanel.text=Small Arms
 lblCombatSmallArms.text=Combatants
 lblCombatSmallArms.tooltip=The skill level modifier applied to the Small Arms skill of\
@@ -2000,14 +1860,12 @@ lblCombatSmallArms.tooltip=The skill level modifier applied to the Small Arms sk
 lblNonCombatSmallArms.text=Non-Combatants
 lblNonCombatSmallArms.tooltip=The skill level modifier applied to the Small Arms skill of\
   \ newly created characters with a non-combat role.
-
 lblArtilleryPanel.text=Artillery
 lblArtilleryChance.text=Percent
 lblArtilleryChance.tooltip=The percentage chance a MekWarrior, Vehicle Crew, or Conventional\
   \ Infantry character has of being created with the Artillery skill (if that option is enabled).
 lblArtilleryBonus.text=Modifier
 lblArtilleryBonus.tooltip=The skill level modifier applied to the skill (if present).
-
 lblSecondarySkillPanel.text=Secondary Skills
 lblAntiMekChance.text=Anti-Mek Percent
 lblAntiMekChance.tooltip=The percentage chance a conventional infantry character has of being\
@@ -2017,32 +1875,30 @@ lblSecondarySkillChance.tooltip=The percentage chance a conventional infantry ch
   \ created with a random secondary skill.
 lblSecondarySkillBonus.text=Modifier
 lblSecondarySkillBonus.tooltip=The skill level modifier applied to the skill (if present).
-
+## Recruitment Bonuses Tab
+lblRecruitmentBonusesTab.text=Recruitment Modifiers
+lblRecruitmentBonusesCombatPanel.text=Combat Roles
+lblRecruitmentBonusesSupportPanel.text=Support Roles
 ## Advancement Tab
 skillsContentTabs.title=Skills
-
 combatSkillsTab.title=Combat Skills
 combatSkillsTab.border="Every skill you master is another weapon in your arsenal. Out here, the\
   \ better you fight, the longer you live."\
   <br><i>Sergeant Mick "Crash" Lannister\
   <br>The Enforcers</i>
-
 supportSkillsTab.title=Support Skills
 supportSkillsTab.border="Support staff are like the coolant system in a 'Mek \u2014 nobody notices them\
   \ until they're gone, and then everyone's screaming."\
   <br><i>Sergeant Leo "Gears" Malone\
   <br>The Panther Corsairs</i>
-
 btnToggle.text=Toggle Advanced Options
 btnHideAll.text=Hide All Advanced Options
 btnDisplayAll.text=Display All Advanced Options
 btnCopy.text=Copy
 btnPaste.text=Paste
-
 lblSkillPanelTargetNumber.text=Base Target Number
 lblSkillPanelTargetNumber.tooltip=The base target number used by this skill. All target numbers,\
   \ for uses of this skill are derived from this value.
-
 lblSkillLevel0.text=0
 lblSkillLevel1.text=1
 lblSkillLevel2.text=2
@@ -2054,10 +1910,8 @@ lblSkillLevel7.text=7
 lblSkillLevel8.text=8
 lblSkillLevel9.text=9
 lblSkillLevel10.text=10
-
 # Combat Skills Tab
 lblCombatSkillsTab.text=Combat Skill Options
-
 lblSkillPanelPiloting/Mek.text=Piloting/Mek
 lblSkillPanelPiloting/Aerospace.text=Piloting/Aerospace
 lblSkillPanelPiloting/Aircraft.text=Piloting/Aircraft
@@ -2075,9 +1929,7 @@ lblSkillPanelGunnery/ProtoMek.text=Gunnery/ProtoMek
 lblSkillPanelArtillery.text=Artillery
 lblSkillPanelSmallArms.text=Small Arms
 lblSkillPanelAnti-Mek.text=Anti-Mek
-
 lblSupportSkillsTab.text=Support Skill Options
-
 lblSkillPanelTech/Mek.text=Tech/Mek
 lblSkillPanelTech/Mechanic.text=Tech/Mechanic
 lblSkillPanelTech/Aero.text=Tech/Aero
@@ -2093,31 +1945,24 @@ lblSkillPanelLeadership.text=Leadership
 lblSkillPanelScrounge.text=Scrounge
 lblSkillPanelStrategy.text=Strategy
 lblSkillPanelTactics.text=Tactics
-
 ## Advancement Tab
 abilityContentTabs.title=Abilities
-
 combatAbilitiesTab.title=Combat Abilities
 combatAbilitiesTab.border="Abilities only matter if you know how to use them. A sharp blade is\
   \ useless in the hands of someone who doesn't know how to wield it."\
   <br><i>Captain Elena "Ironshadow" Kane\
   <br>Problem, Meet Solution</i>
-
 maneuveringAbilitiesTab.title=Maneuvering Abilities
 maneuveringAbilitiesTab.border="Talent without discipline is like a fusion engine without a 'Mek\
   \ \u2014 powerful, but going nowhere."\
   <br><i>Colonel Liana "Shadow" Voss\
   <br>Axis Innovations</i>
-
 utilityAbilitiesTab.title=Utility Abilities
 utilityAbilitiesTab.border="Unique abilities? Yeah, I've got one: breaking everything I touch."\
   <br><i>Technician Cole "Scrapheap" Drayton\
   <br>The Bulwarks</i>
-
 lblCombatAbilitiesTab.text=Combat Ability Options \u2318
-
 lblManeuveringAbilitiesTab.text=Maneuvering Ability Options \u2318
-
 lblUtilityAbilitiesTab.text=Utility Ability Options \u2318
 lblEdgeCostPanel.text=Edge Cost
 lblEdgeCost.text=Cost
@@ -2134,7 +1979,6 @@ removes.text=<b>Removes</b><br>
 lblCustomizeAbility.text=Customize Ability
 lblCustomizeAbility.tooltip=Launch the 'customize SPA' dialog, allowing you to change cost,\
   \ requirements, and other options.
-
 ## StratCon Notice
 stratConPromo.title=++INCOMING TRANSMISSION++
 stratConPromo.message=<html><body style='width: 500px'><br><div style='text-align: center;'>\

--- a/MekHQ/src/mekhq/campaign/RandomSkillPreferences.java
+++ b/MekHQ/src/mekhq/campaign/RandomSkillPreferences.java
@@ -85,11 +85,17 @@ public class RandomSkillPreferences {
         overallRecruitBonus = b;
     }
 
+    /**
+     * @deprecated Use {@link #getRecruitmentBonus(PersonnelRole)} instead.
+     */
     @Deprecated(since = "0.50.05", forRemoval = true)
     public int getRecruitBonus(PersonnelRole role) {
         return getRecruitmentBonus(role);
     }
 
+    /**
+     * @deprecated Use {@link #addRecruitmentBonus(PersonnelRole, int)}.
+     */
     @Deprecated(since = "0.50.05", forRemoval = true)
     public void setRecruitBonus(int index, int bonus) {
         PersonnelRole[] personnelRoles = PersonnelRole.values();
@@ -97,6 +103,9 @@ public class RandomSkillPreferences {
         addRecruitmentBonus(role, bonus);
     }
 
+    /**
+     * @deprecated Use {@link #getRecruitmentBonuses()}.
+     */
     @Deprecated(since = "0.50.05", forRemoval = true)
     public int[] getRecruitBonuses() {
         List<PersonnelRole> personnelRoles = List.of(PersonnelRole.values());

--- a/MekHQ/src/mekhq/campaign/RandomSkillPreferences.java
+++ b/MekHQ/src/mekhq/campaign/RandomSkillPreferences.java
@@ -30,6 +30,7 @@ package mekhq.campaign;
 
 import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -82,6 +83,31 @@ public class RandomSkillPreferences {
 
     public void setOverallRecruitBonus(int b) {
         overallRecruitBonus = b;
+    }
+
+    @Deprecated(since = "0.50.05", forRemoval = true)
+    public int getRecruitBonus(PersonnelRole role) {
+        return getRecruitmentBonus(role);
+    }
+
+    @Deprecated(since = "0.50.05", forRemoval = true)
+    public void setRecruitBonus(int index, int bonus) {
+        PersonnelRole[] personnelRoles = PersonnelRole.values();
+        PersonnelRole role = personnelRoles[index];
+        addRecruitmentBonus(role, bonus);
+    }
+
+    @Deprecated(since = "0.50.05", forRemoval = true)
+    public int[] getRecruitBonuses() {
+        List<PersonnelRole> personnelRoles = List.of(PersonnelRole.values());
+        int[] bonuses = new int[personnelRoles.size()];
+
+        for (PersonnelRole personnelRole : personnelRoles) {
+            int index = personnelRoles.indexOf(personnelRole);
+            bonuses[index] = getRecruitmentBonus(personnelRole);
+        }
+
+        return bonuses;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/RandomSkillPreferences.java
+++ b/MekHQ/src/mekhq/campaign/RandomSkillPreferences.java
@@ -28,14 +28,17 @@
  */
 package mekhq.campaign;
 
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import megamek.Version;
 import megamek.logging.MMLogger;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import java.io.PrintWriter;
 
 /**
  * @author Jay Lawson
@@ -44,7 +47,7 @@ public class RandomSkillPreferences {
     private static final MMLogger logger = MMLogger.create(CampaignOptions.class);
 
     private int overallRecruitBonus;
-    private int[] recruitBonuses;
+    Map<PersonnelRole, Integer> recruitmentBonuses;
     private boolean randomizeSkill;
     private boolean useClanBonuses;
     private int antiMekProb;
@@ -59,7 +62,7 @@ public class RandomSkillPreferences {
 
     public RandomSkillPreferences() {
         overallRecruitBonus = 0;
-        recruitBonuses = new int[PersonnelRole.values().length];
+        recruitmentBonuses = new HashMap<>();
         randomizeSkill = true;
         useClanBonuses = true;
         antiMekProb = 10;
@@ -81,16 +84,36 @@ public class RandomSkillPreferences {
         overallRecruitBonus = b;
     }
 
-    public int[] getRecruitBonuses() {
-        return recruitBonuses;
+    /**
+     * Retrieves the current recruitment bonus values for different personnel roles.
+     *
+     * @return A map containing personnel roles as keys and their associated recruitment bonus values as integers
+     */
+    public Map<PersonnelRole, Integer> getRecruitmentBonuses() {
+        return recruitmentBonuses;
     }
 
-    public int getRecruitBonus(PersonnelRole role) {
-        return getRecruitBonuses()[role.ordinal()];
+    /**
+     * Adds or updates a recruitment bonus for a specific personnel role.
+     *
+     * @param role  The personnel role to set a bonus for
+     * @param bonus The integer value representing the recruitment bonus
+     */
+    public void addRecruitmentBonus(final PersonnelRole role, final int bonus) {
+        recruitmentBonuses.put(role, bonus);
     }
 
-    public void setRecruitBonus(int index, int bonus) {
-        recruitBonuses[index] = bonus;
+    /**
+     * Retrieves the recruitment bonus value for a specific personnel role.
+     *
+     * <p>If no bonus has been defined for the requested role, this method returns 0.</p>
+     *
+     * @param role The personnel role to get the recruitment bonus for
+     *
+     * @return The integer bonus value for the specified role, or 0 if no bonus is defined
+     */
+    public int getRecruitmentBonus(final PersonnelRole role) {
+        return recruitmentBonuses.getOrDefault(role, 0);
     }
 
     public int getSpecialAbilityBonus(int type) {
@@ -188,7 +211,11 @@ public class RandomSkillPreferences {
     public void writeToXML(final PrintWriter pw, int indent) {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "randomSkillPreferences");
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "overallRecruitBonus", overallRecruitBonus);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "recruitBonuses", recruitBonuses);
+        MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "recruitmentBonuses");
+        for (final Entry<PersonnelRole, Integer> entry : recruitmentBonuses.entrySet()) {
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, entry.getKey().name(), entry.getValue());
+        }
+        MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "recruitmentBonuses");
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "specialAbilityBonus", specialAbilityBonus);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "commandSkillsModifier", commandSkillsModifier);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "randomizeSkill", randomizeSkill);
@@ -242,14 +269,11 @@ public class RandomSkillPreferences {
                     retVal.secondSkillProb = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("secondSkillBonus")) {
                     retVal.secondSkillBonus = Integer.parseInt(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("recruitBonuses")) {
-                    String[] values = wn2.getTextContent().split(",");
-                    for (int i = 0; i < values.length; i++) {
-                        retVal.recruitBonuses[i] = Integer.parseInt(values[i]);
-                    }
+                } else if (wn2.getNodeName().equalsIgnoreCase("recruitmentBonuses")) {
+                    processRecruitmentBonusNodes(wn2, retVal);
                 } else if (wn2.getNodeName().equalsIgnoreCase("commandSkillsModifier")
-                      // <50.04 compatibility handler
-                      || wn2.getNodeName().equalsIgnoreCase("tacticsMod")) {
+                                 // <50.04 compatibility handler
+                                 || wn2.getNodeName().equalsIgnoreCase("tacticsMod")) {
                     String[] values = wn2.getTextContent().split(",");
                     for (int i = 0; i < values.length; i++) {
                         retVal.commandSkillsModifier[i] = Integer.parseInt(values[i]);
@@ -268,5 +292,38 @@ public class RandomSkillPreferences {
         logger.debug("Load Random Skill Preferences Complete!");
 
         return retVal;
+    }
+
+    /**
+     * Processes XML nodes containing recruitment bonus information and populates the random skill preferences.
+     *
+     * <p>This method parses child nodes where each node name represents a {@link PersonnelRole} enum value and
+     * the node's text content represents the bonus value as an integer. Each parsed role-bonus pair is added into the
+     * specified {@link RandomSkillPreferences} object. If parsing fails for any node, an error is logged.</p>
+     *
+     * @param node             The parent XML node containing recruitment bonus child nodes
+     * @param skillPreferences The {@link RandomSkillPreferences} object to populate with recruitment bonuses
+     */
+    private static void processRecruitmentBonusNodes(Node node, RandomSkillPreferences skillPreferences) {
+        if (!node.hasChildNodes()) {
+            return;
+        }
+
+        final NodeList nodes = node.getChildNodes();
+        for (int j = 0; j < nodes.getLength(); j++) {
+            final Node workingNode = nodes.item(j);
+            if (workingNode.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+
+            String nodeName = workingNode.getNodeName().trim();
+            String nodeValue = workingNode.getTextContent().trim();
+
+            try {
+                skillPreferences.addRecruitmentBonus(PersonnelRole.valueOf(nodeName), Integer.parseInt(nodeValue));
+            } catch (Exception ex) {
+                logger.error(ex, "Failed to process recruitment bonus node: {}, {}", nodeName, nodeValue);
+            }
+        }
     }
 }

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarketFMMr.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarketFMMr.java
@@ -27,6 +27,9 @@
  */
 package mekhq.campaign.market;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import megamek.common.Compute;
 import megamek.common.Entity;
 import mekhq.campaign.Campaign;
@@ -34,9 +37,6 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.rating.IUnitRating;
 import mekhq.module.api.PersonnelMarketMethod;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Generation method for personnel market based on Field Manual: Mercenaries (Revised)
@@ -59,10 +59,13 @@ public class PersonnelMarketFMMr implements PersonnelMarketMethod {
         int q = 0;
         long mft = PersonnelMarket.getUnitMainForceType(c);
         int mftMod = 0;
-        if (mft == Entity.ETYPE_MEK || mft == Entity.ETYPE_TANK || mft == Entity.ETYPE_INFANTRY || mft == Entity.ETYPE_BATTLEARMOR) {
+        if (mft == Entity.ETYPE_MEK ||
+                  mft == Entity.ETYPE_TANK ||
+                  mft == Entity.ETYPE_INFANTRY ||
+                  mft == Entity.ETYPE_BATTLEARMOR) {
             mftMod = 1;
         }
-        for (PersonnelRole role : PersonnelRole.getMilitaryRoles()) {
+        for (PersonnelRole role : PersonnelRole.getMarketableRoles()) {
             int roll = Compute.d6(2);
             // TODO: Modifiers for hiring hall, but first needs to track the hiring hall
             switch (c.getAtBUnitRatingMod()) {

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -494,6 +494,10 @@ public enum PersonnelRole {
     // endregion Boolean Comparison Methods
 
     // region Static Methods
+
+    /**
+     * @deprecated Use {@link #getMarketableRoles()}.
+     */
     @Deprecated(since = "0.50.05", forRemoval = true)
     public static List<PersonnelRole> getMilitaryRoles() {
         return getMarketableRoles();

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -28,6 +28,7 @@
 package mekhq.campaign.personnel.enums;
 
 import java.awt.event.KeyEvent;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
@@ -80,7 +81,7 @@ public enum PersonnelRole {
     // region Variable Declarations
     private final String name;
     private final String clanName;
-    private final int    mnemonic; // Unused: J, K, Q, X, Z
+    private final int mnemonic; // Unused: J, K, Q, X, Z
     // endregion Variable Declarations
 
     // region Constructors
@@ -106,7 +107,7 @@ public enum PersonnelRole {
     PersonnelRole(final String name, @Nullable final String clanName, final int mnemonic) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
               MekHQ.getMHQOptions().getLocale());
-        this.name     = resources.getString(name);
+        this.name = resources.getString(name);
         this.clanName = (clanName == null) ? this.name : resources.getString(clanName);
         this.mnemonic = mnemonic;
     }
@@ -479,9 +480,9 @@ public enum PersonnelRole {
      */
     public boolean isAdministrator() {
         return isAdministratorCommand() ||
-               isAdministratorLogistics() ||
-               isAdministratorTransport() ||
-               isAdministratorHR();
+                     isAdministratorLogistics() ||
+                     isAdministratorTransport() ||
+                     isAdministratorHR();
     }
 
     /**
@@ -497,8 +498,34 @@ public enum PersonnelRole {
     /**
      * @return a list of roles that can be included in the personnel market
      */
-    public static List<PersonnelRole> getMilitaryRoles() {
+    public static List<PersonnelRole> getMarketableRoles() {
         return Stream.of(values()).filter(personnelRole -> !personnelRole.isCivilian()).collect(Collectors.toList());
+    }
+
+    /**
+     * @return a list of personnel roles classified as combat roles.
+     */
+    public static List<PersonnelRole> getCombatRoles() {
+        List<PersonnelRole> combatRoles = new ArrayList<>();
+        for (PersonnelRole personnelRole : PersonnelRole.values()) {
+            if (personnelRole.isCombat()) {
+                combatRoles.add(personnelRole);
+            }
+        }
+        return combatRoles;
+    }
+
+    /**
+     * @return a list of personnel roles classified as support (non-combat) roles.
+     */
+    public static List<PersonnelRole> getSupportRoles() {
+        List<PersonnelRole> supportRoles = new ArrayList<>();
+        for (PersonnelRole personnelRole : PersonnelRole.values()) {
+            if (!personnelRole.isCombat()) {
+                supportRoles.add(personnelRole);
+            }
+        }
+        return supportRoles;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -494,6 +494,10 @@ public enum PersonnelRole {
     // endregion Boolean Comparison Methods
 
     // region Static Methods
+    @Deprecated(since = "0.50.05", forRemoval = true)
+    public static List<PersonnelRole> getMilitaryRoles() {
+        return getMarketableRoles();
+    }
 
     /**
      * @return a list of roles that can be included in the personnel market

--- a/MekHQ/src/mekhq/campaign/personnel/generator/AbstractPersonnelGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/AbstractPersonnelGenerator.java
@@ -27,6 +27,9 @@
  */
 package mekhq.campaign.personnel.generator;
 
+import java.time.LocalDate;
+import java.util.Objects;
+
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.common.Compute;
@@ -39,12 +42,8 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.Phenotype;
 
-import java.time.LocalDate;
-import java.util.Objects;
-
 /**
- * Represents a class which can generate new {@link Person} objects
- * for a {@link Campaign}.
+ * Represents a class which can generate new {@link Person} objects for a {@link Campaign}.
  */
 public abstract class AbstractPersonnelGenerator {
     private RandomNameGenerator randomNameGenerator = RandomNameGenerator.getInstance();
@@ -53,6 +52,7 @@ public abstract class AbstractPersonnelGenerator {
 
     /**
      * Gets the {@link RandomNameGenerator}.
+     *
      * @return The {@link RandomNameGenerator} to use.
      */
     public RandomNameGenerator getNameGenerator() {
@@ -61,6 +61,7 @@ public abstract class AbstractPersonnelGenerator {
 
     /**
      * Sets the {@link RandomNameGenerator}.
+     *
      * @param rng A {@link RandomNameGenerator} to use.
      */
     public void setNameGenerator(RandomNameGenerator rng) {
@@ -69,6 +70,7 @@ public abstract class AbstractPersonnelGenerator {
 
     /**
      * Gets the {@link RandomSkillPreferences}.
+     *
      * @return The {@link RandomSkillPreferences} to use.
      */
     public RandomSkillPreferences getSkillPreferences() {
@@ -77,6 +79,7 @@ public abstract class AbstractPersonnelGenerator {
 
     /**
      * Sets the {@link RandomSkillPreferences}.
+     *
      * @param skillPreferences A {@link RandomSkillPreferences} to use.
      */
     public void setSkillPreferences(RandomSkillPreferences skillPreferences) {
@@ -85,17 +88,21 @@ public abstract class AbstractPersonnelGenerator {
 
     /**
      * Generates a new {@link Person}.
-     * @param campaign The {@link Campaign} which tracks the person.
-     * @param primaryRole The primary role of the person.
+     *
+     * @param campaign      The {@link Campaign} which tracks the person.
+     * @param primaryRole   The primary role of the person.
      * @param secondaryRole The secondary role of the person.
-     * @param gender The person's gender, or a randomize value
+     * @param gender        The person's gender, or a randomize value
+     *
      * @return A new {@link Person}.
      */
     public abstract Person generate(Campaign campaign, PersonnelRole primaryRole, PersonnelRole secondaryRole, Gender gender);
 
     /**
      * Creates a {@link Person} object for the given {@link Campaign}.
+     *
      * @param campaign The {@link Campaign} to create the person within.
+     *
      * @return A new {@link Person} object for the given campaign.
      */
     protected Person createPerson(Campaign campaign) {
@@ -104,12 +111,15 @@ public abstract class AbstractPersonnelGenerator {
 
     /**
      * Generates an experience level for a {@link Person}.
+     *
      * @param person The {@link Person} being generated.
+     *
      * @return An integer value between {@link SkillType#EXP_ULTRA_GREEN} and {@link SkillType#EXP_ELITE}.
      */
     public int generateExperienceLevel(Person person) {
-        int bonus = getSkillPreferences().getOverallRecruitBonus()
-                + getSkillPreferences().getRecruitBonus(person.getPrimaryRole());
+
+
+        int bonus = rSkillPrefs.getOverallRecruitBonus() + rSkillPrefs.getRecruitmentBonus(person.getPrimaryRole());
 
         // LAM pilots get +3 to random experience roll
         if (person.getPrimaryRole().isLAMPilot()) {
@@ -123,8 +133,9 @@ public abstract class AbstractPersonnelGenerator {
      * Generates and sets the name and gender of a person.
      *
      * @param campaign the campaign the person belongs to
-     * @param person the person whose name and gender is being generated
-     * @param gender the gender of the person. Can be Gender.MALE, Gender.FEMALE, Gender.NON_BINARY, or Gender.RANDOMIZE
+     * @param person   the person whose name and gender is being generated
+     * @param gender   the gender of the person. Can be Gender.MALE, Gender.FEMALE, Gender.NON_BINARY, or
+     *                 Gender.RANDOMIZE
      */
     protected void generateNameAndGender(Campaign campaign, Person person, Gender gender) {
         int nonBinaryDiceSize = campaign.getCampaignOptions().getNonBinaryDiceSize();
@@ -135,20 +146,22 @@ public abstract class AbstractPersonnelGenerator {
             person.setGender(RandomGenderGenerator.generate());
         }
 
-        String factionCode = campaign.getCampaignOptions().isUseOriginFactionForNames()
-                ? person.getOriginFaction().getShortName()
-                : RandomNameGenerator.getInstance().getChosenFaction();
+        String factionCode = campaign.getCampaignOptions().isUseOriginFactionForNames() ?
+                                   person.getOriginFaction().getShortName() :
+                                   RandomNameGenerator.getInstance().getChosenFaction();
 
-        String[] name = getNameGenerator().generateGivenNameSurnameSplit(person.getGender(), person.isClanPersonnel(),
-                factionCode);
+        String[] name = getNameGenerator().generateGivenNameSurnameSplit(person.getGender(),
+              person.isClanPersonnel(),
+              factionCode);
         person.setGivenName(name[0]);
         person.setSurname(name[1]);
     }
 
     /**
      * Generates the starting XP for a {@link Person}.
+     *
      * @param campaign The {@link Campaign} which tracks the person.
-     * @param person The {@link Person} being generated.
+     * @param person   The {@link Person} being generated.
      */
     protected void generateXp(Campaign campaign, Person person) {
         if (campaign.getCampaignOptions().isUseDylansRandomXP()) {
@@ -158,8 +171,9 @@ public abstract class AbstractPersonnelGenerator {
 
     /**
      * Generates the clan phenotype, if applicable, for a {@link Person}.
+     *
      * @param campaign The {@link Campaign} which tracks the person.
-     * @param person The {@link Person} being generated.
+     * @param person   The {@link Person} being generated.
      */
     protected void generatePhenotype(Campaign campaign, Person person) {
         //check for clan phenotypes
@@ -167,7 +181,8 @@ public abstract class AbstractPersonnelGenerator {
             switch (person.getPrimaryRole()) {
                 case MEKWARRIOR:
                 case LAM_PILOT:
-                    if (Utilities.rollProbability(campaign.getCampaignOptions().getPhenotypeProbability(Phenotype.MEKWARRIOR))) {
+                    if (Utilities.rollProbability(campaign.getCampaignOptions()
+                                                        .getPhenotypeProbability(Phenotype.MEKWARRIOR))) {
                         person.setPhenotype(Phenotype.MEKWARRIOR);
                     }
                     break;
@@ -176,26 +191,30 @@ public abstract class AbstractPersonnelGenerator {
                 case VTOL_PILOT:
                 case VEHICLE_GUNNER:
                 case VEHICLE_CREW:
-                    if (person.getOriginFaction().getShortName().equalsIgnoreCase("CHH")
-                            && (campaign.getGameYear() >= 3100)
-                            && Utilities.rollProbability(campaign.getCampaignOptions().getPhenotypeProbability(Phenotype.VEHICLE))) {
+                    if (person.getOriginFaction().getShortName().equalsIgnoreCase("CHH") &&
+                              (campaign.getGameYear() >= 3100) &&
+                              Utilities.rollProbability(campaign.getCampaignOptions()
+                                                              .getPhenotypeProbability(Phenotype.VEHICLE))) {
                         person.setPhenotype(Phenotype.VEHICLE);
                     }
                     break;
                 case AEROSPACE_PILOT:
                 case CONVENTIONAL_AIRCRAFT_PILOT:
-                    if (Utilities.rollProbability(campaign.getCampaignOptions().getPhenotypeProbability(Phenotype.AEROSPACE))) {
+                    if (Utilities.rollProbability(campaign.getCampaignOptions()
+                                                        .getPhenotypeProbability(Phenotype.AEROSPACE))) {
                         person.setPhenotype(Phenotype.AEROSPACE);
                     }
                     break;
                 case PROTOMEK_PILOT:
-                    if ((campaign.getGameYear() > 3060)
-                            && Utilities.rollProbability(campaign.getCampaignOptions().getPhenotypeProbability(Phenotype.PROTOMEK))) {
+                    if ((campaign.getGameYear() > 3060) &&
+                              Utilities.rollProbability(campaign.getCampaignOptions()
+                                                              .getPhenotypeProbability(Phenotype.PROTOMEK))) {
                         person.setPhenotype(Phenotype.PROTOMEK);
                     }
                     break;
                 case BATTLE_ARMOUR:
-                    if (Utilities.rollProbability(campaign.getCampaignOptions().getPhenotypeProbability(Phenotype.ELEMENTAL))) {
+                    if (Utilities.rollProbability(campaign.getCampaignOptions()
+                                                        .getPhenotypeProbability(Phenotype.ELEMENTAL))) {
                         person.setPhenotype(Phenotype.ELEMENTAL);
                     }
                     break;
@@ -203,9 +222,10 @@ public abstract class AbstractPersonnelGenerator {
                 case VESSEL_GUNNER:
                 case VESSEL_CREW:
                 case VESSEL_NAVIGATOR:
-                    if ((person.getOriginFaction().getShortName().equalsIgnoreCase("CSR")
-                            || person.getOriginFaction().getShortName().equalsIgnoreCase("RA"))
-                            && Utilities.rollProbability(campaign.getCampaignOptions().getPhenotypeProbability(Phenotype.NAVAL))) {
+                    if ((person.getOriginFaction().getShortName().equalsIgnoreCase("CSR") ||
+                               person.getOriginFaction().getShortName().equalsIgnoreCase("RA")) &&
+                              Utilities.rollProbability(campaign.getCampaignOptions()
+                                                              .getPhenotypeProbability(Phenotype.NAVAL))) {
                         person.setPhenotype(Phenotype.NAVAL);
                     }
                     break;
@@ -218,17 +238,17 @@ public abstract class AbstractPersonnelGenerator {
     /**
      * Generates the birthday for a {@link Person} based on their experience level and affiliation.
      * <p>
-     * The method calculates the person's age using {@link Utilities#getAgeByExpLevel(int, boolean)}
-     * and subtracts it from the current campaign date to determine their year of birth.
-     * A random day within that year is then selected, ensuring the generated birthday is
-     * always on or before the current campaign date, so the person's age is accurate.
+     * The method calculates the person's age using {@link Utilities#getAgeByExpLevel(int, boolean)} and subtracts it
+     * from the current campaign date to determine their year of birth. A random day within that year is then selected,
+     * ensuring the generated birthday is always on or before the current campaign date, so the person's age is
+     * accurate.
      * </p>
      *
      * @param campaign        The {@link Campaign} containing metadata such as the current local date.
      * @param person          The {@link Person} whose birthday is being generated.
      * @param expLvl          The experience level of the {@code person}, which determines their age.
-     * @param isClanPersonnel Indicates whether the {@code person} belongs to the Clans,
-     *                        which affects the calculated age.
+     * @param isClanPersonnel Indicates whether the {@code person} belongs to the Clans, which affects the calculated
+     *                        age.
      */
     protected void generateBirthday(Campaign campaign, Person person, int expLvl, boolean isClanPersonnel) {
         LocalDate currentDate = campaign.getLocalDate();

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -56,16 +56,14 @@ import mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode
 import mekhq.gui.campaignOptions.contents.*;
 
 /**
- * The {@code CampaignOptionsPane} class represents a tabbed pane used for displaying
- * and managing various campaign options in MekHQ. It organizes these options
- * into tabs and sub-tabs, enabling users to configure different aspects of a campaign.
- * This component serves as the central UI for campaign settings management.
+ * The {@code CampaignOptionsPane} class represents a tabbed pane used for displaying and managing various campaign
+ * options in MekHQ. It organizes these options into tabs and sub-tabs, enabling users to configure different aspects of
+ * a campaign. This component serves as the central UI for campaign settings management.
  *
  * <p>
- * The pane is initialized with a {@link Campaign} instance, which provides the campaign's
- * data and allows options to be applied directly to the active campaign.
- * The dialog supports multiple modes, such as {@code NORMAL}, {@code ABRIDGED},
- * and {@code STARTUP}, to determine the level of detail and features shown.
+ * The pane is initialized with a {@link Campaign} instance, which provides the campaign's data and allows options to be
+ * applied directly to the active campaign. The dialog supports multiple modes, such as {@code NORMAL},
+ * {@code ABRIDGED}, and {@code STARTUP}, to determine the level of detail and features shown.
  * </p>
  *
  * <strong>Key Features:</strong>
@@ -103,9 +101,8 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private RulesetsTab rulesetsTab;
 
     /**
-     * Constructs a {@code CampaignOptionsPane} for managing campaign settings.
-     * This initializes the tabbed pane and populates it with categories and sub-tabs
-     * based on the provided {@link Campaign} instance and dialog mode.
+     * Constructs a {@code CampaignOptionsPane} for managing campaign settings. This initializes the tabbed pane and
+     * populates it with categories and sub-tabs based on the provided {@link Campaign} instance and dialog mode.
      *
      * @param frame    the parent {@link JFrame} for this pane
      * @param campaign the {@link Campaign} object representing the current campaign
@@ -121,19 +118,20 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     }
 
     /**
-     * Initializes the campaign options pane by creating all parent tabs and adding
-     * sub-tabs for various campaign settings categories. Dynamically adjusts tab fonts
-     * and layout based on UI scaling settings.
+     * Initializes the campaign options pane by creating all parent tabs and adding sub-tabs for various campaign
+     * settings categories. Dynamically adjusts tab fonts and layout based on UI scaling settings.
      */
     @Override
     protected void initialize() {
         double uiScale = 1;
         try {
             uiScale = Double.parseDouble(System.getProperty("flatlaf.uiScale"));
-        } catch (Exception ignored) {}
+        } catch (Exception ignored) {
+        }
 
-        addTab(String.format("<html><font size=%s><b>%s</b></font></html>", round(HEADER_FONT_SIZE * uiScale),
-            resources.getString("generalPanel.title")), createGeneralTab(mode));
+        addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              round(HEADER_FONT_SIZE * uiScale),
+              resources.getString("generalPanel.title")), createGeneralTab(mode));
 
         JTabbedPane humanResourcesParentTab = createHumanResourcesParentTab();
         createTab("humanResourcesParentTab", humanResourcesParentTab);
@@ -149,9 +147,8 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     }
 
     /**
-     * Adds a new tab to the pane. Wrapper method for adding a resource-labeled tab
-     * containing a {@link JScrollPane} to the campaign options pane. Dynamically adjusts font size
-     * for consistent scaling across all UI elements.
+     * Adds a new tab to the pane. Wrapper method for adding a resource-labeled tab containing a {@link JScrollPane} to
+     * the campaign options pane. Dynamically adjusts font size for consistent scaling across all UI elements.
      *
      * @param resourceName the resource string key to locate the tab title
      * @param tab          the {@link JTabbedPane} to add as content for the tab
@@ -167,19 +164,19 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         double uiScale = 1;
         try {
             uiScale = Double.parseDouble(System.getProperty("flatlaf.uiScale"));
-        } catch (Exception ignored) {}
+        } catch (Exception ignored) {
+        }
 
         if (mode != ABRIDGED && mode != STARTUP_ABRIDGED) {
             addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
-                round(HEADER_FONT_SIZE * uiScale),
-                resources.getString(resourceName + ".title")),
-                tabScrollPane);
+                  round(HEADER_FONT_SIZE * uiScale),
+                  resources.getString(resourceName + ".title")), tabScrollPane);
         }
     }
 
     /**
-     * Creates the panel for general campaign options. Loads settings for general preferences
-     * and initializes it with current campaign options.
+     * Creates the panel for general campaign options. Loads settings for general preferences and initializes it with
+     * current campaign options.
      *
      * @param mode the state in which the dialog was triggered.
      *
@@ -194,8 +191,8 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     }
 
     /**
-     * Creates the "Human Resources" parent tab. This tab organizes related sub-tabs concerning
-     * personnel management, relationships, turnover, and biography options.
+     * Creates the "Human Resources" parent tab. This tab organizes related sub-tabs concerning personnel management,
+     * relationships, turnover, and biography options.
      *
      * @return a {@link JTabbedPane} containing sub-tabs for the human resources category
      */
@@ -206,63 +203,81 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         // Personnel
         personnelTab = new PersonnelTab(campaignOptions);
 
-        JTabbedPane personnelContentTabs = createSubTabs(Map.of(
-            "personnelGeneralTab", personnelTab.createGeneralTab(),
-            "personnelInformationTab", personnelTab.createPersonnelInformationTab(),
-            "awardsTab", personnelTab.createAwardsTab(),
-            "prisonersAndDependentsTab", personnelTab.createPrisonersAndDependentsTab(),
-            "medicalTab", personnelTab.createMedicalTab(),
-            "salariesTab", personnelTab.createSalariesTab()));
+        JTabbedPane personnelContentTabs = createSubTabs(Map.of("personnelGeneralTab",
+              personnelTab.createGeneralTab(),
+              "personnelInformationTab",
+              personnelTab.createPersonnelInformationTab(),
+              "awardsTab",
+              personnelTab.createAwardsTab(),
+              "prisonersAndDependentsTab",
+              personnelTab.createPrisonersAndDependentsTab(),
+              "medicalTab",
+              personnelTab.createMedicalTab(),
+              "salariesTab",
+              personnelTab.createSalariesTab()));
         personnelTab.loadValuesFromCampaignOptions();
 
         // Biography
         biographyTab = new BiographyTab(campaign, generalTab);
 
-        JTabbedPane biographyContentTabs = createSubTabs(Map.of(
-            "biographyGeneralTab", biographyTab.createGeneralTab(),
-            "backgroundsTab", biographyTab.createBackgroundsTab(),
-            "deathTab", biographyTab.createDeathTab(),
-            "educationTab", biographyTab.createEducationTab(),
-            "nameAndPortraitGenerationTab", biographyTab.createNameAndPortraitGenerationTab(),
-            "rankTab", biographyTab.createRankTab()));
+        JTabbedPane biographyContentTabs = createSubTabs(Map.of("biographyGeneralTab",
+              biographyTab.createGeneralTab(),
+              "backgroundsTab",
+              biographyTab.createBackgroundsTab(),
+              "deathTab",
+              biographyTab.createDeathTab(),
+              "educationTab",
+              biographyTab.createEducationTab(),
+              "nameAndPortraitGenerationTab",
+              biographyTab.createNameAndPortraitGenerationTab(),
+              "rankTab",
+              biographyTab.createRankTab()));
         biographyTab.loadValuesFromCampaignOptions();
 
         // Relationships
         relationshipsTab = new RelationshipsTab(campaignOptions);
 
-        JTabbedPane relationshipsContentTabs = createSubTabs(Map.of(
-            "marriageTab", relationshipsTab.createMarriageTab(),
-            "divorceTab", relationshipsTab.createDivorceTab(),
-            "procreationTab", relationshipsTab.createProcreationTab()));
+        JTabbedPane relationshipsContentTabs = createSubTabs(Map.of("marriageTab",
+              relationshipsTab.createMarriageTab(),
+              "divorceTab",
+              relationshipsTab.createDivorceTab(),
+              "procreationTab",
+              relationshipsTab.createProcreationTab()));
         relationshipsTab.loadValuesFromCampaignOptions();
 
         // Turnover and Retention
         turnoverAndRetentionTab = new TurnoverAndRetentionTab(campaignOptions);
 
-        JTabbedPane turnoverAndRetentionContentTabs = createSubTabs(Map.of(
-            "turnoverTab", turnoverAndRetentionTab.createTurnoverTab(),
-            "fatigueTab", turnoverAndRetentionTab.createFatigueTab()));
+        JTabbedPane turnoverAndRetentionContentTabs = createSubTabs(Map.of("turnoverTab",
+              turnoverAndRetentionTab.createTurnoverTab(),
+              "fatigueTab",
+              turnoverAndRetentionTab.createFatigueTab()));
         turnoverAndRetentionTab.loadValuesFromCampaignOptions();
 
         // Add Tabs
-        humanResourcesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("personnelContentTabs.title")), personnelContentTabs);
-        humanResourcesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("biographyContentTabs.title")), biographyContentTabs);
-        humanResourcesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("relationshipsContentTabs.title")), relationshipsContentTabs);
-        humanResourcesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("turnoverAndRetentionContentTabs.title")), turnoverAndRetentionContentTabs);
+        humanResourcesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("personnelContentTabs.title")), personnelContentTabs);
+        humanResourcesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("biographyContentTabs.title")), biographyContentTabs);
+        humanResourcesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("relationshipsContentTabs.title")), relationshipsContentTabs);
+        humanResourcesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("turnoverAndRetentionContentTabs.title")), turnoverAndRetentionContentTabs);
 
-        addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("humanResourcesParentTab.title")), humanResourcesParentTab);
+        addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("humanResourcesParentTab.title")), humanResourcesParentTab);
 
         return humanResourcesParentTab;
     }
 
     /**
-     * Creates the "Advancement" parent tab. This tab organizes related sub-tabs for awards,
-     * skill randomization, general skill management, and special pilot abilities (SPAs).
+     * Creates the "Advancement" parent tab. This tab organizes related sub-tabs for awards, skill randomization,
+     * general skill management, and special pilot abilities (SPAs).
      *
      * @return a {@link JTabbedPane} containing sub-tabs for the advancement category
      */
@@ -273,45 +288,55 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         // Advancement
         advancementTab = new AdvancementTab(campaign);
 
-        JTabbedPane awardsAndRandomizationContentTabs = createSubTabs(Map.of(
-            "xpAwardsTab", advancementTab.xpAwardsTab(),
-            "randomizationTab", advancementTab.skillRandomizationTab()));
+        JTabbedPane awardsAndRandomizationContentTabs = createSubTabs(Map.of("1xpAwardsTab",
+              advancementTab.xpAwardsTab(),
+              "0randomizationTab",
+              advancementTab.skillRandomizationTab(),
+              "2recruitmentBonusesTab",
+              advancementTab.recruitmentBonusesTab()));
         advancementTab.loadValuesFromCampaignOptions();
 
         // Skills
         skillsTab = new SkillsTab(campaignOptions);
 
-        JTabbedPane skillsContentTabs = createSubTabs(Map.of(
-            "combatSkillsTab", skillsTab.createSkillsTab(true),
-            "supportSkillsTab", skillsTab.createSkillsTab(false)));
+        JTabbedPane skillsContentTabs = createSubTabs(Map.of("combatSkillsTab",
+              skillsTab.createSkillsTab(true),
+              "supportSkillsTab",
+              skillsTab.createSkillsTab(false)));
         skillsTab.loadValuesFromCampaignOptions();
 
         // SPAs
         abilitiesTab = new AbilitiesTab();
 
-        JTabbedPane abilityContentTabs = createSubTabs(Map.of(
-            "combatAbilitiesTab", abilitiesTab.createAbilitiesTab(AbilityCategory.COMBAT_ABILITY),
-            "maneuveringAbilitiesTab", abilitiesTab.createAbilitiesTab(AbilityCategory.MANEUVERING_ABILITY),
-            "utilityAbilitiesTab", abilitiesTab.createAbilitiesTab(AbilityCategory.UTILITY_ABILITY)));
+        JTabbedPane abilityContentTabs = createSubTabs(Map.of("combatAbilitiesTab",
+              abilitiesTab.createAbilitiesTab(AbilityCategory.COMBAT_ABILITY),
+              "maneuveringAbilitiesTab",
+              abilitiesTab.createAbilitiesTab(AbilityCategory.MANEUVERING_ABILITY),
+              "utilityAbilitiesTab",
+              abilitiesTab.createAbilitiesTab(AbilityCategory.UTILITY_ABILITY)));
         // the loading of values from the campaign is built into the AbilitiesTab class so not called here.
 
         // Add Tabs
-        advancementParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("awardsAndRandomizationContentTabs.title")), awardsAndRandomizationContentTabs);
-        advancementParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("skillsContentTabs.title")), skillsContentTabs);
-        advancementParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("abilityContentTabs.title")), abilityContentTabs);
+        advancementParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("awardsAndRandomizationContentTabs.title")), awardsAndRandomizationContentTabs);
+        advancementParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("skillsContentTabs.title")), skillsContentTabs);
+        advancementParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("abilityContentTabs.title")), abilityContentTabs);
 
-        addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("advancementParentTab.title")), advancementParentTab);
+        addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("advancementParentTab.title")), advancementParentTab);
 
         return advancementParentTab;
     }
 
     /**
-     * Creates the "Logistics and Maintenance" parent tab. This tab organizes related sub-tabs
-     * for equipment acquisition, repair, maintenance, and supply management options.
+     * Creates the "Logistics and Maintenance" parent tab. This tab organizes related sub-tabs for equipment
+     * acquisition, repair, maintenance, and supply management options.
      *
      * @return a {@link JTabbedPane} containing sub-tabs for the logistics and maintenance category
      */
@@ -322,35 +347,41 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         // Repair and Maintenance
         repairAndMaintenanceTab = new RepairAndMaintenanceTab(campaignOptions);
 
-        JTabbedPane repairsAndMaintenanceContentTabs = createSubTabs(Map.of(
-            "repairTab", repairAndMaintenanceTab.createRepairTab(),
-            "maintenanceTab", repairAndMaintenanceTab.createMaintenanceTab()));
+        JTabbedPane repairsAndMaintenanceContentTabs = createSubTabs(Map.of("repairTab",
+              repairAndMaintenanceTab.createRepairTab(),
+              "maintenanceTab",
+              repairAndMaintenanceTab.createMaintenanceTab()));
         repairAndMaintenanceTab.loadValuesFromCampaignOptions();
 
         // Supplies and Acquisition
         equipmentAndSuppliesTab = new EquipmentAndSuppliesTab(campaignOptions);
 
-        JTabbedPane suppliesAndAcquisitionContentTabs = createSubTabs(Map.of(
-            "acquisitionTab", equipmentAndSuppliesTab.createAcquisitionTab(),
-            "planetaryAcquisitionTab", equipmentAndSuppliesTab.createPlanetaryAcquisitionTab(),
-            "techLimitsTab", equipmentAndSuppliesTab.createTechLimitsTab()));
+        JTabbedPane suppliesAndAcquisitionContentTabs = createSubTabs(Map.of("acquisitionTab",
+              equipmentAndSuppliesTab.createAcquisitionTab(),
+              "planetaryAcquisitionTab",
+              equipmentAndSuppliesTab.createPlanetaryAcquisitionTab(),
+              "techLimitsTab",
+              equipmentAndSuppliesTab.createTechLimitsTab()));
         equipmentAndSuppliesTab.loadValuesFromCampaignOptions();
 
         // Add tabs
-        equipmentAndSuppliesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("suppliesAndAcquisitionContentTabs.title")), suppliesAndAcquisitionContentTabs);
-        equipmentAndSuppliesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("repairsAndMaintenanceContentTabs.title")), repairsAndMaintenanceContentTabs);
+        equipmentAndSuppliesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("suppliesAndAcquisitionContentTabs.title")), suppliesAndAcquisitionContentTabs);
+        equipmentAndSuppliesParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("repairsAndMaintenanceContentTabs.title")), repairsAndMaintenanceContentTabs);
 
-        addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("logisticsAndMaintenanceParentTab.title")), equipmentAndSuppliesParentTab);
+        addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("logisticsAndMaintenanceParentTab.title")), equipmentAndSuppliesParentTab);
 
         return equipmentAndSuppliesParentTab;
     }
 
     /**
-     * Creates the "Strategic Operations" parent tab. This tab organizes related sub-tabs for
-     * finances, market management (personnel, units, and contracts), and ruleset configuration.
+     * Creates the "Strategic Operations" parent tab. This tab organizes related sub-tabs for finances, market
+     * management (personnel, units, and contracts), and ruleset configuration.
      *
      * @return a {@link JTabbedPane} containing sub-tabs for the strategic operations category
      */
@@ -361,53 +392,60 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         // Finances
         financesTab = new FinancesTab(campaign);
 
-        JTabbedPane financesContentTabs = createSubTabs(Map.of(
-            "financesGeneralTab", financesTab.createFinancesGeneralOptionsTab(),
-            "priceMultipliersTab", financesTab.createPriceMultipliersTab()));
+        JTabbedPane financesContentTabs = createSubTabs(Map.of("financesGeneralTab",
+              financesTab.createFinancesGeneralOptionsTab(),
+              "priceMultipliersTab",
+              financesTab.createPriceMultipliersTab()));
         financesTab.loadValuesFromCampaignOptions();
 
         // Markets
         marketsTab = new MarketsTab(campaign);
 
-        JTabbedPane marketsContentTabs = createSubTabs(Map.of(
-            "personnelMarketTab", marketsTab.createPersonnelMarketTab(),
-            "unitMarketTab", marketsTab.createUnitMarketTab(),
-            "contractMarketTab", marketsTab.createContractMarketTab()));
+        JTabbedPane marketsContentTabs = createSubTabs(Map.of("personnelMarketTab",
+              marketsTab.createPersonnelMarketTab(),
+              "unitMarketTab",
+              marketsTab.createUnitMarketTab(),
+              "contractMarketTab",
+              marketsTab.createContractMarketTab()));
         marketsTab.loadValuesFromCampaignOptions();
 
         // Rulesets
         rulesetsTab = new RulesetsTab(campaignOptions);
 
-        JTabbedPane rulesetsContentTabs = createSubTabs(Map.of(
-            "stratConGeneralTab", rulesetsTab.createStratConTab(),
-            "legacyTab", rulesetsTab.createLegacyTab()));
+        JTabbedPane rulesetsContentTabs = createSubTabs(Map.of("stratConGeneralTab",
+              rulesetsTab.createStratConTab(),
+              "legacyTab",
+              rulesetsTab.createLegacyTab()));
         rulesetsTab.loadValuesFromCampaignOptions();
 
         // Add tabs
-        strategicOperationsParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("financesContentTabs.title")), financesContentTabs);
-        strategicOperationsParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("marketsContentTabs.title")), marketsContentTabs);
-        strategicOperationsParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("rulesetsContentTabs.title")), rulesetsContentTabs);
+        strategicOperationsParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("financesContentTabs.title")), financesContentTabs);
+        strategicOperationsParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("marketsContentTabs.title")), marketsContentTabs);
+        strategicOperationsParentTab.addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("rulesetsContentTabs.title")), rulesetsContentTabs);
 
-        addTab(String.format("<html><font size=%s><b>%s</b></font></html>", 4,
-            resources.getString("strategicOperationsParentTab.title")), strategicOperationsParentTab);
+        addTab(String.format("<html><font size=%s><b>%s</b></font></html>",
+              4,
+              resources.getString("strategicOperationsParentTab.title")), strategicOperationsParentTab);
 
         return strategicOperationsParentTab;
     }
 
     /**
-     * Applies the currently configured campaign options to the active {@link Campaign}.
-     * This method processes all tabs in the dialog, applying the options to the campaign
-     * in logical order (e.g., "General" first, followed by other categories).
+     * Applies the currently configured campaign options to the active {@link Campaign}. This method processes all tabs
+     * in the dialog, applying the options to the campaign in logical order (e.g., "General" first, followed by other
+     * categories).
      *
-     * @param preset      an optional {@link CampaignPreset} used to override campaign options
-     * @param isStartUp   specifies whether this is run as part of a startup initialization
+     * @param preset       an optional {@link CampaignPreset} used to override campaign options
+     * @param isStartUp    specifies whether this is run as part of a startup initialization
      * @param isSaveAction determines if this action is saving options to a preset
      */
-    public void applyCampaignOptionsToCampaign(@Nullable CampaignPreset preset, boolean isStartUp,
-                                               boolean isSaveAction) {
+    public void applyCampaignOptionsToCampaign(@Nullable CampaignPreset preset, boolean isStartUp, boolean isSaveAction) {
         CampaignOptions options = this.campaignOptions;
         RandomSkillPreferences presetRandomSkillPreferences = null;
         Map<String, SkillType> presetSkills = null;
@@ -455,9 +493,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     }
 
     /**
-     * Applies the values from a {@link CampaignPreset} to all tabs in the dialog. This propagates
-     * preset-specific configuration to all associated components and sub-tabs, including
-     * campaign-related properties such as dates, factions, and skills.
+     * Applies the values from a {@link CampaignPreset} to all tabs in the dialog. This propagates preset-specific
+     * configuration to all associated components and sub-tabs, including campaign-related properties such as dates,
+     * factions, and skills.
      *
      * @param campaignPreset the {@link CampaignPreset} containing the preset options to apply
      */
@@ -475,13 +513,13 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         // Human Resources
         personnelTab.loadValuesFromCampaignOptions(presetCampaignOptions);
         biographyTab.loadValuesFromCampaignOptions(presetCampaignOptions,
-            presetCampaignOptions.getRandomOriginOptions(), campaignPreset.getRankSystem());
+              presetCampaignOptions.getRandomOriginOptions(),
+              campaignPreset.getRankSystem());
         relationshipsTab.loadValuesFromCampaignOptions(presetCampaignOptions);
         turnoverAndRetentionTab.loadValuesFromCampaignOptions(presetCampaignOptions);
 
         // Advancement
-        advancementTab.loadValuesFromCampaignOptions(presetCampaignOptions,
-            campaignPreset.getRandomSkillPreferences());
+        advancementTab.loadValuesFromCampaignOptions(presetCampaignOptions, campaignPreset.getRandomSkillPreferences());
         skillsTab.loadValuesFromCampaignOptions(presetCampaignOptions, campaignPreset.getSkills());
         // The ability tab is a special case, so handled differently to other tabs
         abilitiesTab.buildAllAbilityInfo(campaignPreset.getSpecialAbilities());

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
@@ -27,26 +27,36 @@
  */
 package mekhq.gui.campaignOptions.contents;
 
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createParentPanel;
+import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
+
+import java.awt.GridBagConstraints;
+import java.util.List;
+import java.util.Map;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.RandomSkillPreferences;
 import mekhq.campaign.personnel.SkillType;
+import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.Phenotype;
-import mekhq.gui.campaignOptions.components.*;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.List;
-
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createParentPanel;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
+import mekhq.gui.campaignOptions.components.CampaignOptionsCheckBox;
+import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
+import mekhq.gui.campaignOptions.components.CampaignOptionsHeaderPanel;
+import mekhq.gui.campaignOptions.components.CampaignOptionsLabel;
+import mekhq.gui.campaignOptions.components.CampaignOptionsSpinner;
+import mekhq.gui.campaignOptions.components.CampaignOptionsStandardPanel;
 
 /**
- * The {@code AdvancementTab} class is responsible for rendering and managing two primary tabs
- * in the campaign options interface: the Experience Awards (XP Awards) tab and the Skill
- * Randomization tab. These tabs allow for customization of experience point distribution,
- * randomization preferences, and skill probabilities in the campaign.
+ * The {@code AdvancementTab} class is responsible for rendering and managing two primary tabs in the campaign options
+ * interface: the Experience Awards (XP Awards) tab and the Skill Randomization tab. These tabs allow for customization
+ * of experience point distribution, randomization preferences, and skill probabilities in the campaign.
  *
  * <p>This class provides methods to initialize the UI components, load current settings
  * from the campaign options, and update the options based on user input.</p>
@@ -151,12 +161,21 @@ public class AdvancementTab {
     private JSpinner spnSecondBonus;
     //end Skill Randomization Tab
 
+    //start Recruitment Bonus Tab
+    private JPanel pnlRecruitmentBonusesCombat;
+    private JLabel[] lblRecruitmentBonusCombat;
+    private JSpinner[] spnRecruitmentBonusCombat;
+
+    private JPanel pnlRecruitmentBonusesSupport;
+    private JLabel[] lblRecruitmentBonusSupport;
+    private JSpinner[] spnRecruitmentBonusSupport;
+    //end Recruitment Bonus Tab
+
     /**
-     * Constructs an {@code AdvancementTab} object for rendering and managing campaign advancement
-     * configurations.
+     * Constructs an {@code AdvancementTab} object for rendering and managing campaign advancement configurations.
      *
-     * @param campaign The {@code Campaign} instance from which the campaign options and random
-     *                skill preferences are retrieved.
+     * @param campaign The {@code Campaign} instance from which the campaign options and random skill preferences are
+     *                 retrieved.
      */
     public AdvancementTab(Campaign campaign) {
         this.campaign = campaign;
@@ -168,8 +187,8 @@ public class AdvancementTab {
     }
 
     /**
-     * Initializes the UI components for the XP Awards and Skill Randomization tabs. This includes
-     * setting up the labels, panels, and spinners for each of the categories within the respective tabs.
+     * Initializes the UI components for the XP Awards and Skill Randomization tabs. This includes setting up the
+     * labels, panels, and spinners for each of the categories within the respective tabs.
      */
     private void initialize() {
         initializeXPAwardsTab();
@@ -177,8 +196,8 @@ public class AdvancementTab {
     }
 
     /**
-     * Initializes the XP Awards tab by setting up the UI components, such as labels,
-     * panels, and spinners, for various experience-related options within the campaign.
+     * Initializes the XP Awards tab by setting up the UI components, such as labels, panels, and spinners, for various
+     * experience-related options within the campaign.
      */
     private void initializeXPAwardsTab() {
         lblXpCostMultiplier = new JLabel();
@@ -226,21 +245,19 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Experience Awards (XP Awards) tab panel. This tab allows users to
-     * configure experience awards for tasks, scenarios, missions, and administrators, as well
-     * as set the overall XP cost multiplier.
+     * Creates and returns the Experience Awards (XP Awards) tab panel. This tab allows users to configure experience
+     * awards for tasks, scenarios, missions, and administrators, as well as set the overall XP cost multiplier.
      *
      * @return A {@code JPanel} containing the configuration options for XP Awards in the campaign.
      */
     public JPanel xpAwardsTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("XpAwardsTab",
-            getImageDirectory() + "logo_clan_steel_viper.png");
+              getImageDirectory() + "logo_clan_steel_viper.png");
 
         // Contents
         lblXpCostMultiplier = new CampaignOptionsLabel("XpCostMultiplier");
-        spnXpCostMultiplier = new CampaignOptionsSpinner("XpCostMultiplier",
-            1, 0, 5, 0.05);
+        spnXpCostMultiplier = new CampaignOptionsSpinner("XpCostMultiplier", 1, 0, 5, 0.05);
 
         pnlTasks = createTasksPanel();
         pnlScenarios = createScenariosPanel();
@@ -282,32 +299,27 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Tasks panel, which allows users to configure settings
-     * for task-related experience awards, such as successful task completions or mistakes.
+     * Creates and returns the Tasks panel, which allows users to configure settings for task-related experience awards,
+     * such as successful task completions or mistakes.
      *
      * @return A {@code JPanel} containing configuration options for task-related experience awards.
      */
     private JPanel createTasksPanel() {
         // Contents
         lblTaskXP = new CampaignOptionsLabel("TaskXP");
-        spnTaskXP = new CampaignOptionsSpinner("TaskXP",
-            0, 0, 20, 1);
+        spnTaskXP = new CampaignOptionsSpinner("TaskXP", 0, 0, 20, 1);
 
         lblNTasksXP = new CampaignOptionsLabel("NTasksXP");
-        spnNTasksXP = new CampaignOptionsSpinner("NTasksXP",
-            0, 0, 100, 1);
+        spnNTasksXP = new CampaignOptionsSpinner("NTasksXP", 0, 0, 100, 1);
 
         lblSuccessXP = new CampaignOptionsLabel("SuccessXP");
-        spnSuccessXP = new CampaignOptionsSpinner("SuccessXP",
-            0, 0, 20, 1);
+        spnSuccessXP = new CampaignOptionsSpinner("SuccessXP", 0, 0, 20, 1);
 
         lblMistakeXP = new CampaignOptionsLabel("MistakeXP");
-        spnMistakeXP = new CampaignOptionsSpinner("MistakeXP",
-            0, 0, 20, 1);
+        spnMistakeXP = new CampaignOptionsSpinner("MistakeXP", 0, 0, 20, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("TasksPanel", true,
-            "TasksPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("TasksPanel", true, "TasksPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = 0;
@@ -339,27 +351,23 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Scenarios panel, which allows users to configure settings
-     * for experience awards related to scenarios, kills, and kill thresholds.
+     * Creates and returns the Scenarios panel, which allows users to configure settings for experience awards related
+     * to scenarios, kills, and kill thresholds.
      *
      * @return A {@code JPanel} containing configuration options for scenario-related experience awards.
      */
     private JPanel createScenariosPanel() {
         // Contents
         lblScenarioXP = new CampaignOptionsLabel("ScenarioXP");
-        spnScenarioXP = new CampaignOptionsSpinner("ScenarioXP",
-            0, 0, 20, 1);
+        spnScenarioXP = new CampaignOptionsSpinner("ScenarioXP", 0, 0, 20, 1);
         lblKillXP = new CampaignOptionsLabel("KillXP");
-        spnKillXP = new CampaignOptionsSpinner("KillXP",
-            0, 0, 20, 1);
+        spnKillXP = new CampaignOptionsSpinner("KillXP", 0, 0, 20, 1);
 
         lblKills = new CampaignOptionsLabel("Kills");
-        spnKills = new CampaignOptionsSpinner("Kills",
-            0, 0, 100, 1);
+        spnKills = new CampaignOptionsSpinner("Kills", 0, 0, 100, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("ScenariosPanel", true,
-            "ScenariosPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("ScenariosPanel", true, "ScenariosPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = 0;
@@ -384,38 +392,31 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Missions panel, which allows users to configure settings
-     * related to mission performance and idle time experience bonuses in the campaign.
+     * Creates and returns the Missions panel, which allows users to configure settings related to mission performance
+     * and idle time experience bonuses in the campaign.
      *
      * @return A {@code JPanel} containing configuration options for mission-related experience settings.
      */
     private JPanel createMissionsPanel() {
         // Contents
         lblVocationalXP = new CampaignOptionsLabel("VocationalXP");
-        spnVocationalXP = new CampaignOptionsSpinner("VocationalXP",
-            0, 0, 20, 1);
+        spnVocationalXP = new CampaignOptionsSpinner("VocationalXP", 0, 0, 20, 1);
         lblVocationalXPFrequency = new CampaignOptionsLabel("VocationalXPFrequency");
-        spnVocationalXPFrequency = new CampaignOptionsSpinner("VocationalXPFrequency",
-            0, 0, 12, 1);
+        spnVocationalXPFrequency = new CampaignOptionsSpinner("VocationalXPFrequency", 0, 0, 12, 1);
         lblVocationalXPTargetNumber = new CampaignOptionsLabel("VocationalXPTargetNumber");
-        spnVocationalXPTargetNumber = new CampaignOptionsSpinner("VocationalXPTargetNumber",
-            2, 0, 12, 1);
+        spnVocationalXPTargetNumber = new CampaignOptionsSpinner("VocationalXPTargetNumber", 2, 0, 12, 1);
 
         lblMissionXpFail = new CampaignOptionsLabel("MissionXpFail");
-        spnMissionXpFail = new CampaignOptionsSpinner("MissionXpFail",
-            1, 0, 20, 1);
+        spnMissionXpFail = new CampaignOptionsSpinner("MissionXpFail", 1, 0, 20, 1);
 
         lblMissionXpSuccess = new CampaignOptionsLabel("MissionXpSuccess");
-        spnMissionXpSuccess = new CampaignOptionsSpinner("MissionXpSuccess",
-            1, 0, 20, 1);
+        spnMissionXpSuccess = new CampaignOptionsSpinner("MissionXpSuccess", 1, 0, 20, 1);
 
         lblMissionXpOutstandingSuccess = new CampaignOptionsLabel("MissionXpOutstandingSuccess");
-        spnMissionXpOutstandingSuccess = new CampaignOptionsSpinner("MissionXpOutstandingSuccess",
-            1, 0, 20, 1);
+        spnMissionXpOutstandingSuccess = new CampaignOptionsSpinner("MissionXpOutstandingSuccess", 1, 0, 20, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("MissionsPanel", true,
-            "MissionsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("MissionsPanel", true, "MissionsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = 0;
@@ -459,27 +460,23 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Administrators panel, which allows users to configure settings
-     * for contract negotiation experience points and weekly experience points for administrators.
+     * Creates and returns the Administrators panel, which allows users to configure settings for contract negotiation
+     * experience points and weekly experience points for administrators.
      *
      * @return A {@code JPanel} containing configuration options for administrator experience settings.
      */
     private JPanel createAdministratorsPanel() {
         // Contents
         lblAdminWeeklyXP = new CampaignOptionsLabel("AdminWeeklyXP");
-        spnAdminWeeklyXP = new CampaignOptionsSpinner("AdminWeeklyXP",
-            0, 0, 20, 1);
+        spnAdminWeeklyXP = new CampaignOptionsSpinner("AdminWeeklyXP", 0, 0, 20, 1);
         lblAdminWeeklyXPPeriod = new CampaignOptionsLabel("AdminWeeklyXPPeriod");
-        spnAdminWeeklyXPPeriod = new CampaignOptionsSpinner("AdminWeeklyXPPeriod",
-            1, 1, 52, 1);
+        spnAdminWeeklyXPPeriod = new CampaignOptionsSpinner("AdminWeeklyXPPeriod", 1, 1, 52, 1);
 
         lblContractNegotiationXP = new CampaignOptionsLabel("ContractNegotiationXP");
-        spnContractNegotiationXP = new CampaignOptionsSpinner("ContractNegotiationXP",
-            0, 0, 20, 1);
+        spnContractNegotiationXP = new CampaignOptionsSpinner("ContractNegotiationXP", 0, 0, 20, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("AdministratorsXpPanel", true,
-            "AdministratorsXpPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("AdministratorsXpPanel", true, "AdministratorsXpPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = 0;
@@ -503,9 +500,8 @@ public class AdvancementTab {
     }
 
     /**
-     * Initializes the Skill Randomization tab by setting up the UI components,
-     * including phenotype configurations, random abilities, skill groups, and other
-     * randomization settings.
+     * Initializes the Skill Randomization tab by setting up the UI components, including phenotype configurations,
+     * random abilities, skill groups, and other randomization settings.
      */
     private void initializeSkillRandomizationTab() {
         chkExtraRandomness = new JCheckBox();
@@ -555,19 +551,27 @@ public class AdvancementTab {
         spnAbilityVet = new JSpinner();
         lblAbilityElite = new JLabel();
         spnAbilityElite = new JSpinner();
+
+        pnlRecruitmentBonusesCombat = new JPanel();
+        lblRecruitmentBonusCombat = new JLabel[] {}; // This will be initialized properly later
+        spnRecruitmentBonusCombat = new JSpinner[] {}; // This will be initialized properly later
+
+        pnlRecruitmentBonusesSupport = new JPanel();
+        lblRecruitmentBonusSupport = new JLabel[] {}; // This will be initialized properly later
+        spnRecruitmentBonusSupport = new JSpinner[] {}; // This will be initialized properly later
     }
 
     /**
-     * Creates and returns the Skill Randomization tab panel. This tab allows users to configure
-     * settings related to skill randomization, including phenotype probabilities and skill bonuses
-     * for different experience levels and skill groups.
+     * Creates and returns the Skill Randomization tab panel. This tab allows users to configure settings related to
+     * skill randomization, including phenotype probabilities and skill bonuses for different experience levels and
+     * skill groups.
      *
      * @return A {@code JPanel} containing the configuration options for skill randomization.
      */
     public JPanel skillRandomizationTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("SkillRandomizationTab",
-            getImageDirectory() + "logo_republic_of_the_sphere.png");
+              getImageDirectory() + "logo_republic_of_the_sphere.png");
 
         // Contents
         chkExtraRandomness = new CampaignOptionsCheckBox("ExtraRandomness");
@@ -604,9 +608,8 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Phenotype panel, which allows users to configure settings
-     * for phenotype probabilities in the campaign. Each phenotype is assigned a spinner
-     * to adjust its probability.
+     * Creates and returns the Phenotype panel, which allows users to configure settings for phenotype probabilities in
+     * the campaign. Each phenotype is assigned a spinner to adjust its probability.
      *
      * @return A {@code JPanel} containing configuration options for phenotype probabilities.
      */
@@ -616,8 +619,7 @@ public class AdvancementTab {
         phenotypeLabels = new JLabel[phenotypes.size()];
         phenotypeSpinners = new JSpinner[phenotypes.size()];
 
-        final JPanel panel = new CampaignOptionsStandardPanel("PhenotypesPanel", true,
-            "PhenotypesPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("PhenotypesPanel", true, "PhenotypesPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = -1;
@@ -625,8 +627,7 @@ public class AdvancementTab {
 
         for (int i = 0; i < phenotypes.size(); i++) {
             phenotypeLabels[i] = new CampaignOptionsLabel(phenotypes.get(i).getName());
-            phenotypeSpinners[i] = new CampaignOptionsSpinner(phenotypes.get(i).getName(),
-                0, 0, 100, 1);
+            phenotypeSpinners[i] = new CampaignOptionsSpinner(phenotypes.get(i).getName(), 0, 0, 100, 1);
 
             layout.gridx++;
             panel.add(phenotypeLabels[i], layout);
@@ -643,32 +644,26 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Ability panel, which allows users to configure settings
-     * for bonuses to special abilities at different experience levels, such as green,
-     * regular, veteran, and elite.
+     * Creates and returns the Ability panel, which allows users to configure settings for bonuses to special abilities
+     * at different experience levels, such as green, regular, veteran, and elite.
      *
      * @return A {@code JPanel} containing configuration options for special ability bonuses.
      */
     private JPanel createAbilityPanel() {
         // Contents
         lblAbilityGreen = new CampaignOptionsLabel("AbilityGreen");
-        spnAbilityGreen = new CampaignOptionsSpinner("AbilityGreen",
-            0, -10, 10, 1);
+        spnAbilityGreen = new CampaignOptionsSpinner("AbilityGreen", 0, -10, 10, 1);
         lblAbilityReg = new CampaignOptionsLabel("AbilityRegular");
-        spnAbilityReg = new CampaignOptionsSpinner("AbilityRegular",
-            0, -10, 10, 1);
+        spnAbilityReg = new CampaignOptionsSpinner("AbilityRegular", 0, -10, 10, 1);
 
         lblAbilityVet = new CampaignOptionsLabel("AbilityVeteran");
-        spnAbilityVet = new CampaignOptionsSpinner("AbilityVeteran",
-            0, -10, 10, 1);
+        spnAbilityVet = new CampaignOptionsSpinner("AbilityVeteran", 0, -10, 10, 1);
 
         lblAbilityElite = new CampaignOptionsLabel("AbilityElite");
-        spnAbilityElite = new CampaignOptionsSpinner("AbilityElite",
-            0, -10, 10, 1);
+        spnAbilityElite = new CampaignOptionsSpinner("AbilityElite", 0, -10, 10, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("AbilityPanel", true,
-            "AbilityPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("AbilityPanel", true, "AbilityPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = 0;
@@ -695,9 +690,8 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Skill Groups panel, which groups together related panels
-     * for configuring various skill-related options, including tactics, small arms,
-     * secondary skills, and artillery.
+     * Creates and returns the Skill Groups panel, which groups together related panels for configuring various
+     * skill-related options, including tactics, small arms, secondary skills, and artillery.
      *
      * @return A {@code JPanel} containing grouped configuration options for skills.
      */
@@ -731,32 +725,27 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Tactics panel, which allows users to configure settings
-     * for Tactics modifiers for different skill levels, such as green, regular, veteran, and elite.
+     * Creates and returns the Tactics panel, which allows users to configure settings for Tactics modifiers for
+     * different skill levels, such as green, regular, veteran, and elite.
      *
      * @return A {@code JPanel} containing configuration options for Tactics modifiers.
      */
     private JPanel createTacticsPanel() {
         // Contents
         lblCommandSkillsGreen = new CampaignOptionsLabel("CommandSkillsGreen");
-        spnCommandSkillsGreen = new CampaignOptionsSpinner("CommandSkillsGreen",
-            0, -10, 10, 1);
+        spnCommandSkillsGreen = new CampaignOptionsSpinner("CommandSkillsGreen", 0, -10, 10, 1);
 
         lblCommandSkillsReg = new CampaignOptionsLabel("CommandSkillsRegular");
-        spnCommandSkillsReg = new CampaignOptionsSpinner("CommandSkillsRegular",
-            0, -10, 10, 1);
+        spnCommandSkillsReg = new CampaignOptionsSpinner("CommandSkillsRegular", 0, -10, 10, 1);
 
         lblCommandSkillsVet = new CampaignOptionsLabel("CommandSkillsVeteran");
-        spnCommandSkillsVet = new CampaignOptionsSpinner("CommandSkillsVeteran",
-            0, -10, 10, 1);
+        spnCommandSkillsVet = new CampaignOptionsSpinner("CommandSkillsVeteran", 0, -10, 10, 1);
 
         lblCommandSkillsElite = new CampaignOptionsLabel("CommandSkillsElite");
-        spnCommandSkillsElite = new CampaignOptionsSpinner("CommandSkillsElite",
-            0, -10, 10, 1);
+        spnCommandSkillsElite = new CampaignOptionsSpinner("CommandSkillsElite", 0, -10, 10, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("CommandSkillsPanel", true,
-            "CommandSkillsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("CommandSkillsPanel", true, "CommandSkillsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = 0;
@@ -783,24 +772,21 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Small Arms panel, which allows users to configure settings
-     * for combat and non-combat small arms bonuses.
+     * Creates and returns the Small Arms panel, which allows users to configure settings for combat and non-combat
+     * small arms bonuses.
      *
      * @return A {@code JPanel} containing configuration options for small arms skill bonuses.
      */
     private JPanel createSmallArmsPanel() {
         // Contents
         lblCombatSA = new CampaignOptionsLabel("CombatSmallArms");
-        spnCombatSA = new CampaignOptionsSpinner("CombatSmallArms",
-            0, -10, 10, 1);
+        spnCombatSA = new CampaignOptionsSpinner("CombatSmallArms", 0, -10, 10, 1);
 
         lblSupportSA = new CampaignOptionsLabel("NonCombatSmallArms");
-        spnSupportSA = new CampaignOptionsSpinner("NonCombatSmallArms",
-            0, -10, 10, 1);
+        spnSupportSA = new CampaignOptionsSpinner("NonCombatSmallArms", 0, -10, 10, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("SmallArmsPanel",
-            true, "SmallArmsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("SmallArmsPanel", true, "SmallArmsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = 0;
@@ -817,25 +803,21 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Artillery panel, which allows users to configure settings
-     * for artillery-specific skills, including the chance for an artillery skill and
-     * the bonus associated with it.
+     * Creates and returns the Artillery panel, which allows users to configure settings for artillery-specific skills,
+     * including the chance for an artillery skill and the bonus associated with it.
      *
      * @return A {@code JPanel} containing configuration options for artillery-related skills.
      */
     private JPanel createArtilleryPanel() {
         // Contents
         lblArtyProb = new CampaignOptionsLabel("ArtilleryChance");
-        spnArtyProb = new CampaignOptionsSpinner("ArtilleryChance",
-            0, 0, 100, 1);
+        spnArtyProb = new CampaignOptionsSpinner("ArtilleryChance", 0, 0, 100, 1);
 
         lblArtyBonus = new CampaignOptionsLabel("ArtilleryBonus");
-        spnArtyBonus = new CampaignOptionsSpinner("ArtilleryBonus",
-            0, -10, 10, 1);
+        spnArtyBonus = new CampaignOptionsSpinner("ArtilleryBonus", 0, -10, 10, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("ArtilleryPanel",
-            true, "ArtilleryPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("ArtilleryPanel", true, "ArtilleryPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = 0;
@@ -852,29 +834,24 @@ public class AdvancementTab {
     }
 
     /**
-     * Creates and returns the Secondary Skill panel, which allows users to configure settings
-     * related to special secondary skills such as Anti-Mek, secondary skill probability,
-     * and secondary skill bonuses.
+     * Creates and returns the Secondary Skill panel, which allows users to configure settings related to special
+     * secondary skills such as Anti-Mek, secondary skill probability, and secondary skill bonuses.
      *
      * @return A {@code JPanel} containing configuration options for secondary skills.
      */
     private JPanel createSecondarySkillPanel() {
         // Contents
         lblAntiMekSkill = new CampaignOptionsLabel("AntiMekChance");
-        spnAntiMekSkill = new CampaignOptionsSpinner("AntiMekChance",
-            0, 0, 100, 1);
+        spnAntiMekSkill = new CampaignOptionsSpinner("AntiMekChance", 0, 0, 100, 1);
 
         lblSecondProb = new CampaignOptionsLabel("SecondarySkillChance");
-        spnSecondProb = new CampaignOptionsSpinner("SecondarySkillChance",
-            0, 0, 100, 1);
+        spnSecondProb = new CampaignOptionsSpinner("SecondarySkillChance", 0, 0, 100, 1);
 
         lblSecondBonus = new CampaignOptionsLabel("SecondarySkillBonus");
-        spnSecondBonus = new CampaignOptionsSpinner("SecondarySkillBonus",
-            0, -10, 10, 1);
+        spnSecondBonus = new CampaignOptionsSpinner("SecondarySkillBonus", 0, -10, 10, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("SecondarySkillPanel",
-            true, "SecondarySkillPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("SecondarySkillPanel", true, "SecondarySkillPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 1;
         layout.gridx = 0;
@@ -897,24 +874,141 @@ public class AdvancementTab {
     }
 
     /**
-     * Loads the current values for XP Awards and Skill Randomization settings into the UI components
-     * from the campaign options and random skill preferences.
+     * Constructs and returns the panel containing recruitment bonus controls grouped by combat and support roles.
+     *
+     * <p>Includes the header and separately laid-out subpanels for combat and support personnel roles.</p>
+     *
+     * @return the fully configured {@link JPanel} for recruitment bonus settings
+     */
+    public JPanel recruitmentBonusesTab() {
+        // Header
+        JPanel headerPanel = new CampaignOptionsHeaderPanel("RecruitmentBonusesTab",
+              getImageDirectory() + "logo_calderon_protectorate.png");
+
+        // Contents
+        pnlRecruitmentBonusesCombat = createRecruitmentBonusesCombatPanel();
+        pnlRecruitmentBonusesSupport = createRecruitmentBonusesSupportPanel();
+
+        // Layout the Panel
+        final JPanel panel = new CampaignOptionsStandardPanel("RecruitmentBonusesTab", true);
+        final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
+        layout.gridwidth = 5;
+        layout.gridx = 0;
+        layout.gridy = 0;
+        panel.add(headerPanel, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(pnlRecruitmentBonusesCombat, layout);
+        layout.gridy++;
+        panel.add(pnlRecruitmentBonusesSupport, layout);
+
+        // Create Parent Panel and return
+        return createParentPanel(panel, "RecruitmentBonusesTab");
+    }
+
+    /**
+     * Creates and initializes a panel for setting recruitment bonuses for combat personnel roles.
+     *
+     * <p>This method arranges labels and spinner controls for all combat-specific personnel roles
+     * in a grid layout. Each row contains up to four roles, where each role is represented by a label and a
+     * corresponding numeric spinner control for input.</p>
+     *
+     * @return a configured {@link JPanel} specifically for defining recruitment bonuses for combat roles
+     */
+    private JPanel createRecruitmentBonusesCombatPanel() {
+        // Contents
+        List<PersonnelRole> roles = PersonnelRole.getCombatRoles();
+        lblRecruitmentBonusCombat = new JLabel[roles.size()];
+        spnRecruitmentBonusCombat = new JSpinner[roles.size()];
+
+        final JPanel panel = new CampaignOptionsStandardPanel("RecruitmentBonusesCombatPanel",
+              true,
+              "RecruitmentBonusesCombatPanel");
+        final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
+        layout.gridwidth = 1;
+
+        int columnsPerRow = 4;
+
+        for (int i = 0; i < roles.size(); i++) {
+            int currentColumn = i % columnsPerRow;
+            int currentRow = i / columnsPerRow;
+
+            layout.gridx = currentColumn * 2;
+            layout.gridy = currentRow;
+
+            lblRecruitmentBonusCombat[i] = new JLabel(roles.get(i).getName(false));
+            spnRecruitmentBonusCombat[i] = new JSpinner(new SpinnerNumberModel(0, -12, 12, 1));
+
+            panel.add(lblRecruitmentBonusCombat[i], layout);
+
+            layout.gridx = currentColumn * 2 + 1;
+            panel.add(spnRecruitmentBonusCombat[i], layout);
+        }
+
+        return panel;
+    }
+
+    /**
+     * Creates and initializes a panel for setting recruitment bonuses for support (non-combat) personnel roles.
+     *
+     * <p>This method arranges labels and spinner controls for all support-specific personnel roles
+     * in a grid layout. Each row contains up to four roles, where each role is represented by a label and a
+     * corresponding numeric spinner control for input.</p>
+     *
+     * @return a configured {@link JPanel} specifically for defining recruitment bonuses for support roles
+     */
+    private JPanel createRecruitmentBonusesSupportPanel() {
+        // Contents
+        List<PersonnelRole> roles = PersonnelRole.getSupportRoles();
+        lblRecruitmentBonusSupport = new JLabel[roles.size()];
+        spnRecruitmentBonusSupport = new JSpinner[roles.size()];
+
+        final JPanel panel = new CampaignOptionsStandardPanel("RecruitmentBonusesSupportPanel",
+              true,
+              "RecruitmentBonusesSupportPanel");
+        final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
+        layout.gridwidth = 1;
+
+        int columnsPerRow = 4;
+
+        for (int i = 0; i < roles.size(); i++) {
+            int currentColumn = i % columnsPerRow;
+            int currentRow = i / columnsPerRow;
+
+            layout.gridx = currentColumn * 2;
+            layout.gridy = currentRow;
+
+            lblRecruitmentBonusSupport[i] = new JLabel(roles.get(i).getName(false));
+            spnRecruitmentBonusSupport[i] = new JSpinner(new SpinnerNumberModel(0, -12, 12, 1));
+
+            panel.add(lblRecruitmentBonusSupport[i], layout);
+
+            layout.gridx = currentColumn * 2 + 1;
+            panel.add(spnRecruitmentBonusSupport[i], layout);
+        }
+
+        return panel;
+    }
+
+    /**
+     * Loads the current values for XP Awards and Skill Randomization settings into the UI components from the campaign
+     * options and random skill preferences.
      */
     public void loadValuesFromCampaignOptions() {
         loadValuesFromCampaignOptions(null, null);
     }
 
     /**
-     * Loads the current values for XP Awards and Skill Randomization settings into the UI components
-     * from the given {@code CampaignOptions} and {@code RandomSkillPreferences} objects.
+     * Loads the current values for XP Awards and Skill Randomization settings into the UI components from the given
+     * {@code CampaignOptions} and {@code RandomSkillPreferences} objects.
      *
-     * @param presetCampaignOptions    Optional {@code CampaignOptions} object to load values from;
-     *                                 if {@code null}, values are loaded from the current campaign options.
-     * @param presetRandomSkillPreferences Optional {@code RandomSkillPreferences} object to load values
-     *                                 from; if {@code null}, values are loaded from the current skill preferences.
+     * @param presetCampaignOptions        Optional {@code CampaignOptions} object to load values from; if {@code null},
+     *                                     values are loaded from the current campaign options.
+     * @param presetRandomSkillPreferences Optional {@code RandomSkillPreferences} object to load values from; if
+     *                                     {@code null}, values are loaded from the current skill preferences.
      */
-    public void loadValuesFromCampaignOptions(@Nullable CampaignOptions presetCampaignOptions,
-                                              @Nullable RandomSkillPreferences presetRandomSkillPreferences) {
+    public void loadValuesFromCampaignOptions(@Nullable CampaignOptions presetCampaignOptions, @Nullable RandomSkillPreferences presetRandomSkillPreferences) {
         CampaignOptions options = presetCampaignOptions;
         if (presetCampaignOptions == null) {
             options = this.campaignOptions;
@@ -965,19 +1059,33 @@ public class AdvancementTab {
         spnAntiMekSkill.setValue(skillPreferences.getAntiMekProb());
         spnSecondProb.setValue(skillPreferences.getSecondSkillProb());
         spnSecondBonus.setValue(skillPreferences.getSecondSkillBonus());
+
+        //start Recruitment Bonuses Tab
+        final Map<PersonnelRole, Integer> recruitmentBonuses = skillPreferences.getRecruitmentBonuses();
+
+        final List<PersonnelRole> combatRoles = PersonnelRole.getCombatRoles();
+        for (int i = 0; i < spnRecruitmentBonusCombat.length; i++) {
+            PersonnelRole role = combatRoles.get(i);
+            spnRecruitmentBonusCombat[i].setValue(recruitmentBonuses.getOrDefault(role, 0));
+        }
+
+        final List<PersonnelRole> supportRoles = PersonnelRole.getSupportRoles();
+        for (int i = 0; i < spnRecruitmentBonusSupport.length; i++) {
+            PersonnelRole role = supportRoles.get(i);
+            spnRecruitmentBonusSupport[i].setValue(recruitmentBonuses.getOrDefault(role, 0));
+        }
     }
 
     /**
-     * Applies the current values from the XP Awards and Skill Randomization tabs
-     * to the specified {@code CampaignOptions} and {@code RandomSkillPreferences}.
+     * Applies the current values from the XP Awards and Skill Randomization tabs to the specified
+     * {@code CampaignOptions} and {@code RandomSkillPreferences}.
      *
-     * @param presetCampaignOptions    Optional {@code CampaignOptions} object to set values to;
-     *                                 if {@code null}, values are applied to the current campaign options.
-     * @param presetRandomSkillPreferences Optional {@code RandomSkillPreferences} object to set values
-     *                                 to; if {@code null}, values are applied to the current skill preferences.
+     * @param presetCampaignOptions        Optional {@code CampaignOptions} object to set values to; if {@code null},
+     *                                     values are applied to the current campaign options.
+     * @param presetRandomSkillPreferences Optional {@code RandomSkillPreferences} object to set values to; if
+     *                                     {@code null}, values are applied to the current skill preferences.
      */
-    public void applyCampaignOptionsToCampaign(@Nullable CampaignOptions presetCampaignOptions,
-                                               @Nullable RandomSkillPreferences presetRandomSkillPreferences) {
+    public void applyCampaignOptionsToCampaign(@Nullable CampaignOptions presetCampaignOptions, @Nullable RandomSkillPreferences presetRandomSkillPreferences) {
         CampaignOptions options = presetCampaignOptions;
         if (presetCampaignOptions == null) {
             options = this.campaignOptions;
@@ -1029,6 +1137,22 @@ public class AdvancementTab {
         skillPreferences.setSpecialAbilityBonus(SkillType.EXP_VETERAN, (int) spnAbilityVet.getValue());
         skillPreferences.setSpecialAbilityBonus(SkillType.EXP_ELITE, (int) spnAbilityElite.getValue());
 
+        //start Recruitment Bonuses
+        final List<PersonnelRole> supportRoles = PersonnelRole.getSupportRoles();
+        final List<PersonnelRole> combatRoles = PersonnelRole.getCombatRoles();
+
+        for (int i = 0; i < spnRecruitmentBonusCombat.length; i++) {
+            PersonnelRole role = combatRoles.get(i);
+            skillPreferences.addRecruitmentBonus(role, (int) spnRecruitmentBonusCombat[i].getValue());
+        }
+
+        for (int i = 0; i < spnRecruitmentBonusSupport.length; i++) {
+            PersonnelRole role = supportRoles.get(i);
+            skillPreferences.addRecruitmentBonus(role, (int) spnRecruitmentBonusSupport[i].getValue());
+        }
+
+        // Finishing Touches
+        // This must be the last item, after all other tabs, no matter what.
         if (presetRandomSkillPreferences == null) {
             campaign.setRandomSkillPreferences(randomSkillPreferences);
         }

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
@@ -883,7 +883,8 @@ public class AdvancementTab {
     public JPanel recruitmentBonusesTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("RecruitmentBonusesTab",
-              getImageDirectory() + "logo_calderon_protectorate.png");
+              getImageDirectory() + "logo_calderon_protectorate.png",
+              true);
 
         // Contents
         pnlRecruitmentBonusesCombat = createRecruitmentBonusesCombatPanel();

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelRoleTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelRoleTest.java
@@ -38,31 +38,28 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
 
-import org.junit.jupiter.api.Test;
-
 import mekhq.MekHQ;
+import org.junit.jupiter.api.Test;
 
 class PersonnelRoleTest {
     // region Variable Declarations
     private static final PersonnelRole[] roles = PersonnelRole.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale());
+          MekHQ.getMHQOptions().getLocale());
     // endregion Variable Declarations
 
     // region Getters
     @Test
     void testGetName() {
-        assertEquals(resources.getString("PersonnelRole.MEKWARRIOR.text"),
-                PersonnelRole.MEKWARRIOR.getName(false));
-        assertEquals(resources.getString("PersonnelRole.MEKWARRIOR.text"),
-                PersonnelRole.MEKWARRIOR.getName(true));
+        assertEquals(resources.getString("PersonnelRole.MEKWARRIOR.text"), PersonnelRole.MEKWARRIOR.getName(false));
+        assertEquals(resources.getString("PersonnelRole.MEKWARRIOR.text"), PersonnelRole.MEKWARRIOR.getName(true));
         assertEquals(resources.getString("PersonnelRole.BATTLE_ARMOUR.text"),
-                PersonnelRole.BATTLE_ARMOUR.getName(false));
+              PersonnelRole.BATTLE_ARMOUR.getName(false));
         assertEquals(resources.getString("PersonnelRole.BATTLE_ARMOUR.clan.text"),
-                PersonnelRole.BATTLE_ARMOUR.getName(true));
+              PersonnelRole.BATTLE_ARMOUR.getName(true));
         assertEquals(resources.getString("PersonnelRole.ADMINISTRATOR_LOGISTICS.text"),
-                PersonnelRole.ADMINISTRATOR_LOGISTICS.getName(false));
+              PersonnelRole.ADMINISTRATOR_LOGISTICS.getName(false));
     }
 
     @Test
@@ -74,7 +71,7 @@ class PersonnelRoleTest {
                 continue;
             }
             assertFalse(usedMnemonics.contains(role.getMnemonic()),
-                    String.format("%s: Using duplicate mnemonic of %d", role.name(), role.getMnemonic()));
+                  String.format("%s: Using duplicate mnemonic of %d", role.name(), role.getMnemonic()));
             usedMnemonics.add(role.getMnemonic());
         }
     }
@@ -432,8 +429,7 @@ class PersonnelRoleTest {
     @Test
     void testIsMekWarriorGrouping() {
         for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.MEKWARRIOR)
-                    || (personnelRole == PersonnelRole.LAM_PILOT)) {
+            if ((personnelRole == PersonnelRole.MEKWARRIOR) || (personnelRole == PersonnelRole.LAM_PILOT)) {
                 assertTrue(personnelRole.isMekWarriorGrouping());
             } else {
                 assertFalse(personnelRole.isMekWarriorGrouping());
@@ -444,8 +440,7 @@ class PersonnelRoleTest {
     @Test
     void testIsAerospaceGrouping() {
         for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.LAM_PILOT)
-                    || (personnelRole == PersonnelRole.AEROSPACE_PILOT)) {
+            if ((personnelRole == PersonnelRole.LAM_PILOT) || (personnelRole == PersonnelRole.AEROSPACE_PILOT)) {
                 assertTrue(personnelRole.isAerospaceGrouping());
             } else {
                 assertFalse(personnelRole.isAerospaceGrouping());
@@ -467,9 +462,9 @@ class PersonnelRoleTest {
     @Test
     void testIsGroundVehicleCrew() {
         for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.GROUND_VEHICLE_DRIVER)
-                    || (personnelRole == PersonnelRole.VEHICLE_GUNNER)
-                    || (personnelRole == PersonnelRole.VEHICLE_CREW)) {
+            if ((personnelRole == PersonnelRole.GROUND_VEHICLE_DRIVER) ||
+                      (personnelRole == PersonnelRole.VEHICLE_GUNNER) ||
+                      (personnelRole == PersonnelRole.VEHICLE_CREW)) {
                 assertTrue(personnelRole.isGroundVehicleCrew());
             } else {
                 assertFalse(personnelRole.isGroundVehicleCrew());
@@ -480,9 +475,9 @@ class PersonnelRoleTest {
     @Test
     void testIsNavalVehicleCrew() {
         for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.NAVAL_VEHICLE_DRIVER)
-                    || (personnelRole == PersonnelRole.VEHICLE_GUNNER)
-                    || (personnelRole == PersonnelRole.VEHICLE_CREW)) {
+            if ((personnelRole == PersonnelRole.NAVAL_VEHICLE_DRIVER) ||
+                      (personnelRole == PersonnelRole.VEHICLE_GUNNER) ||
+                      (personnelRole == PersonnelRole.VEHICLE_CREW)) {
                 assertTrue(personnelRole.isNavalVehicleCrew());
             } else {
                 assertFalse(personnelRole.isNavalVehicleCrew());
@@ -493,9 +488,9 @@ class PersonnelRoleTest {
     @Test
     void testIsVTOLCrew() {
         for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.VTOL_PILOT)
-                    || (personnelRole == PersonnelRole.VEHICLE_GUNNER)
-                    || (personnelRole == PersonnelRole.VEHICLE_CREW)) {
+            if ((personnelRole == PersonnelRole.VTOL_PILOT) ||
+                      (personnelRole == PersonnelRole.VEHICLE_GUNNER) ||
+                      (personnelRole == PersonnelRole.VEHICLE_CREW)) {
                 assertTrue(personnelRole.isVTOLCrew());
             } else {
                 assertFalse(personnelRole.isVTOLCrew());
@@ -524,8 +519,7 @@ class PersonnelRoleTest {
     @Test
     void testIsSoldierOrBattleArmour() {
         for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.SOLDIER)
-                    || (personnelRole == PersonnelRole.BATTLE_ARMOUR)) {
+            if ((personnelRole == PersonnelRole.SOLDIER) || (personnelRole == PersonnelRole.BATTLE_ARMOUR)) {
                 assertTrue(personnelRole.isSoldierOrBattleArmour());
             } else {
                 assertFalse(personnelRole.isSoldierOrBattleArmour());
@@ -606,8 +600,7 @@ class PersonnelRoleTest {
     @Test
     void testIsMedicalStaff() {
         for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.DOCTOR)
-                    || (personnelRole == PersonnelRole.MEDIC)) {
+            if ((personnelRole == PersonnelRole.DOCTOR) || (personnelRole == PersonnelRole.MEDIC)) {
                 assertTrue(personnelRole.isMedicalStaff());
             } else {
                 assertFalse(personnelRole.isMedicalStaff());
@@ -635,8 +628,7 @@ class PersonnelRoleTest {
     @Test
     void testIsCivilian() {
         for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.DEPENDENT)
-                    || (personnelRole == PersonnelRole.NONE)) {
+            if ((personnelRole == PersonnelRole.DEPENDENT) || (personnelRole == PersonnelRole.NONE)) {
                 assertTrue(personnelRole.isCivilian());
             } else {
                 assertFalse(personnelRole.isCivilian());
@@ -647,8 +639,8 @@ class PersonnelRoleTest {
 
     // region Static Methods
     @Test
-    void testGetMilitaryRoles() {
-        final List<PersonnelRole> militaryRoles = PersonnelRole.getMilitaryRoles();
+    void testGetMarketableRoles() {
+        final List<PersonnelRole> militaryRoles = PersonnelRole.getMarketableRoles();
         assertEquals(roles.length - 2, militaryRoles.size());
         assertFalse(militaryRoles.contains(PersonnelRole.DEPENDENT));
         assertFalse(militaryRoles.contains(PersonnelRole.NONE));
@@ -716,9 +708,8 @@ class PersonnelRoleTest {
 
     @Test
     void testToStringOverride() {
-        assertEquals(resources.getString("PersonnelRole.MEKWARRIOR.text"),
-                PersonnelRole.MEKWARRIOR.toString());
+        assertEquals(resources.getString("PersonnelRole.MEKWARRIOR.text"), PersonnelRole.MEKWARRIOR.toString());
         assertEquals(resources.getString("PersonnelRole.ADMINISTRATOR_LOGISTICS.text"),
-                PersonnelRole.ADMINISTRATOR_LOGISTICS.toString());
+              PersonnelRole.ADMINISTRATOR_LOGISTICS.toString());
     }
 }


### PR DESCRIPTION
### Reviewer Note
There are a lot of automatic format changes in this PR, I've commented the functional changes. There rest is chaff and can probably be ignored.

### Dev Notes
When CO IIC was created we dropped the various options that allowed players to specify modifiers to the dice rolls made to determine a characters' experience level. This PR modernizes the implementation of these options and makes them available in CO IIC.


<img width="893" alt="image" src="https://github.com/user-attachments/assets/00d0864e-9ee4-4747-b6bc-6d34a5b72515" />