### PR TITLE
Added Skill Deprecation Tool For Managing Deprecated Skills; Deprecated the 'Scrounge' Skill

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -8,7 +8,6 @@ lblLoadPreset.text=Load Preset
 lblLoadPreset.tooltip=Load an existing preset.
 lblCancel.text=Cancel Changes
 lblCancel.tooltip=Cancel all changes and close the dialog.
-
 ## SelectPresetDialog Class
 # SelectPresetDialog
 presetDialog.title=Select a Campaign Preset
@@ -20,7 +19,6 @@ lblPresetDialogCustomize.text=Customize
 lblPresetDialogCustomize.tooltip=Select a preset, then open the campaign options menu.
 lblPresetDialogCancel.text=Cancel
 lblPresetDialogCancel.tooltip=Return to the prior screen.
-
 ## Campaign Options Pane
 campaignOptions.title=Campaign Options
 generalPanel.title=General
@@ -28,7 +26,6 @@ humanResourcesParentTab.title=Human Resources
 advancementParentTab.title=Advancement
 logisticsAndMaintenanceParentTab.title=Logistics
 strategicOperationsParentTab.title=Operations
-
 ## General Tab Class
 # createGeneralTab
 lblGeneral.text=Welcome, Commander
@@ -94,7 +91,6 @@ lblCamo.tooltip=Pick a camouflage scheme for the units in your campaign.
 lblIcon.text=Unit Insignia
 lblIcon.tooltip=Pick an insignia for your campaign. Or leave blank to use an image based on your\
   \ campaign faction.
-
 # createFurtherReadingPanel
 lblFurtherReadingPanel.text=Suggested Reading
 lblBMMPanel.text=BATTLEMECH MANUAL (BMM)
@@ -112,20 +108,16 @@ lblCampaignOperationsPanelBody.text=Campaign Operations offers rules for creatin
   \ book's final sections introduce diverse options for campaign play, enabling players to run\
   \ thrilling campaigns of virtually any type with their newly created forces. Campaign Operations\
   \ serves as the foundational rulebook for modern MekHQ.
-
 ## RepairAndMaintenanceTab
 repairsAndMaintenanceContentTabs.title=Maintenance & Repairs
-
 repairTab.title=Repairs
 repairTab.border="Victory depends upon the proper use of combined arms \u2014 light, medium, heavy,\
   \ assault, air, infantry, and the rest. Variety is the spice of battle."\
   <br><i>Captain Natasha Kerensky, Wolf's Dragoons</i>
-
 maintenanceTab.title=Maintenance
 maintenanceTab.border="One 'Mek lance can beat one mob, large or small, any time."\
   <br><i>Dr. Shindu Banzai, Fundamentals of Military Science\
   <br>Lecture at the New Avalon Institute of Science, 3017</i>
-
 # createRepairTab
 lblRepairTab.text=Repair Options
 lblUseEraModsCheckBox.text=Use Era Modifiers for Repair Rolls
@@ -150,10 +142,8 @@ lblDamageMargin.tooltip=Determines how bad a failure must be before an item is d
 lblDestroyPartTarget.text=Equipment Survival Target Number
 lblDestroyPartTarget.tooltip=Equipment hit in battle will survive if this target number is beat on\
   \ 2d6.
-
 # createMaintenanceTab
 lblMaintenanceTab.text=Maintenance Options
-
 lblCheckMaintenance.text=Enable Unit Maintenance
 lblCheckMaintenance.tooltip=If checked, each unit will make a parts-specific maintenance check at\
   \ the end of each maintenance cycle
@@ -195,30 +185,24 @@ lblUseUnofficialMaintenance.tooltip=Determines whether parts should only be dama
 lblLogMaintenance.text=Log Maintenance Results
 lblLogMaintenance.tooltip=Determines whether the results of each maintenance check should be added\
   \ to 'mekhq.log'
-
 ## SuppliesAndAcquisitionTab
 suppliesAndAcquisitionContentTabs.title=Supplies and Acquisition
-
 acquisitionTab.title=Acquisitions & Deliveries
 acquisitionTab.border="Forget the casualties. How much did we make?"\
   <br><i>From the comedy holoplay Minor Major\
   <br>Andurien Broadcasting Corporation</i>
-
 planetaryAcquisitionTab.title=Planetary Acquisitions
 planetaryAcquisitionTab.border="The lowest, dirtiest, nastiest kind of assignment a hard-luck\
   \ bastard merc can draw... is whatever mission he's on at the moment."\
   <br><i>Major Fran Delmarre\
   <br>12th Star Guards</i>
-
 techLimitsTab.title=Tech Limits
 techLimitsTab.border="In a universe where we fight with the ghosts of a golden age, technology is a\
   \ reminder: we are bound by history, but not defined by it."\
   <br><i>Engineer Talia "Patch" Kessler\
   <br>Noble's Faulty Firepower</i>
-
 # createAcquisitionTab
 lblAcquisitionTab.text=Acquisition & Delivery Options
-
 # createAcquisitionPanel
 lblAcquisitionPanel.text=Acquisitions
 lblChoiceAcquireSkill.text=Acquisitions Skill
@@ -236,7 +220,6 @@ lblAcquireWaitingPeriod.text=Acquisition Roll Period Frequency
 lblAcquireWaitingPeriod.tooltip=How many days should pass between acquisition attempts being refreshed?
 lblMaxAcquisitions.text=Max Acquisition Rolls per Period
 lblMaxAcquisitions.tooltip=How many times can a character make an acquisition check per period?
-
 # createAutoLogisticsPanel
 lblAutoLogisticsPanel.text=AutoLogistics
 lblAutoLogisticsMekHead.text='Mek Head Restock Percent
@@ -272,7 +255,6 @@ lblAutoLogisticsOther.text=Other Restock Percent
 lblAutoLogisticsOther.tooltip=autoLogistics counts each part in use, that is not covered by one of\
   \ the other options, and automatically orders replacement spares equal to the percentage set in\
   \ this options.
-
 # createDeliveryPanel
 lblDeliveryPanel.text=Deliveries
 lblTransitTimeUnits.text=Delivery Scale
@@ -281,10 +263,8 @@ lblTransitTimeUnits.tooltip=Should deliveries be scaled using days, weeks, or mo
 transitUnitNamesDays.text=Days
 transitUnitNamesWeeks.text=Weeks
 transitUnitNamesMonths.text=Months
-
 # createPlanetaryAcquisitionTab
 lblPlanetaryAcquisitionTab.text=Planetary Acquisition Options \u270E
-
 # createOptionsPanel
 lblUsePlanetaryAcquisitions.text=Use Planetary Acquisitions \u26A0 \u2714
 lblUsePlanetaryAcquisitions.tooltip=Supplies will be searched for on specific planets up to a\
@@ -324,7 +304,6 @@ lblUsePlanetaryAcquisitionsVerbose.tooltip=This shows all the details of the pla
   <br>\
   <br><b>Warning:</b> This option can lead to a huge daily report, which will create a saved file\
   \ that takes a significant amount of time to load.
-
 # createModifiersPanel
 lblModifiersPanel.text=Modifiers
 lblTechLabel.text=Tech
@@ -333,7 +312,6 @@ lblIndustryLabel.text=Industry
 lblIndustryLabel.tooltip=The planet's industrial rating.
 lblOutputLabel.text=Output
 lblOutputLabel.tooltip=The planet's technological output rating.
-
 # createTechLimitsTab
 lblTechLimitsTab.text=Tech Limit Options
 lblLimitByYearBox.text=Limit Tech Purchases by Game Year
@@ -361,46 +339,37 @@ lblVariableTechLevelBox.tooltip=If checked, the tech level for a part or unit wi
 lblUseAmmoByTypeBox.text=Use Ammo Cross-Weapon Compatibility \u270E
 lblUseAmmoByTypeBox.tooltip=In the warehouse, LRM, SRM, MRM, and MML launchers can mix ammo between\
   \ sizes. For example, an LRM-10 can use LRM-20 ammo.
-
 ## Human Resources Tab
 personnelContentTabs.title=Personnel
-
 # Personnel Tab
 personnelGeneralTab.title=General
 personnelGeneralTab.border="The merc's worst enemy is usually the employer's High Command."\
   <br><i>Colonel Jaime Wolf\
   <br>Commander of Wolf's Dragoons</i>
-
 personnelInformationTab.title=Personnel Information
 personnelInformationTab.border="Why continue a wasteful campaign from an untenable position?"\
   <br><i>From a letter written by Takashi Kurita to his son Theodore, Prince of Luthien\
   <br>Part of the Military Precepts of House Kurita\
   <br>Printed and circulated privately by the Prince in 3020 A.D.</i>
-
 awardsTab.title=Awards
 awardsTab.border="They'll get you somehow. One way or another, there'll be an employer who teaches\
   \ you the true meaning of paranoia..."\
   <br><i>Major Fran Delmare\
   <br>12th Star Guards</i>
-
 prisonersAndDependentsTab.title=Prisoners \u0026 Dependents
 prisonersAndDependentsTab.border="One thing\u2014whose side are we on this week?"\
   <br><i>From the comedy holoplay Minor Major\
   <br>Andurien Broadcasting Corporation</i>
-
 medicalTab.title=Medical
 medicalTab.border="Justice? Justice died with Richard Cameron. The best thing we can ask for is an\
   \ occasional lapse in injustice."\
   <br><i>Katrina Steiner's address to the Estates General</i>
-
 salariesTab.title=Salaries
 salariesTab.border="No job too small...no fee too high."\
   <br><i>Unknown Mercenacy\
   <br>Terran Alliance</i>
-
 # createGeneralTab
 lblPersonnelGeneralTab.text=General Options
-
 lblUseTactics.text=Use Commander Initiative Bonus \u26A0
 lblUseTactics.tooltip=All initiative rolls are modified by the commander's Tactics skill.\
   <br>\
@@ -431,7 +400,6 @@ lblUseImplants.tooltip=Allows personnel to have implants (e.g., Manei Domini)
 lblUseAlternativeQualityAveraging.text=Use Higher-Precision Skill Averaging \u270E
 lblUseAlternativeQualityAveraging.tooltip=Where two skills determine experience level, attempt to\
   \ average by number (e.g., 8/4), rather than product (e.g., Regular/Green), for greater precision.
-
 # createPersonnelCleanUpPanel
 lblPersonnelCleanUpPanel.text=Personnel Cleanup \u270E
 lblUsePersonnelRemoval.text=Enable Personnel Cleanup
@@ -441,7 +409,6 @@ lblUseRemovalExemptCemetery.text=Exempt Dead Personnel
 lblUseRemovalExemptCemetery.tooltip=Data from dead personnel is exempt from being cleaned up.
 lblUseRemovalExemptRetirees.text=Exempt Retirees
 lblUseRemovalExemptRetirees.tooltip=Data from retired personnel is exempt from being cleaned up.
-
 # createPersonnelLogsTab
 lblPersonnelLogsPanel.text=Personnel Logs
 lblUseTransfers.text=Use Reassign for Logging \u2714
@@ -470,7 +437,6 @@ lblDisplayScenarioLog.text=Expand Scenario Log by Default
 lblDisplayScenarioLog.tooltip=Determines whether the scenario log will be expanded by default
 lblDisplayKillRecord.text=Expand Kill Log by Default
 lblDisplayKillRecord.tooltip=Determines whether the kill log will be expanded by default
-
 # createPersonnelInformationTab
 lblPersonnelInformation.text=Personnel Information Options \u270E
 lblUseTimeInService.text=Track Time in Service
@@ -496,7 +462,6 @@ lblTrackTotalXPEarnings.tooltip=This tracks the total amount of experience earne
   \ tracking is only done when this option is enabled, and it is not backfilled.
 lblShowOriginFaction.text=Display Origin Faction
 lblShowOriginFaction.tooltip=Display the origin faction of a person in the personnel table.
-
 # createAdministratorsTab
 lblAdministratorsPanel.text=Administrators \u270E
 lblAdminsHaveNegotiation.text=Admins Have Negotiation
@@ -504,15 +469,13 @@ lblAdminsHaveNegotiation.tooltip=Generate all admin personnel with ranks in the 
 lblAdminExperienceLevelIncludeNegotiation.text=Negotiation Factored into Experience Level
 lblAdminExperienceLevelIncludeNegotiation.tooltip=All admin personnel will factor the Negotiation\
   \ skill into their experience level calculations (green, regular, etc.).
-lblAdminsHaveScrounge.text=Admins Have Scrounge
+lblAdminsHaveScrounge.text=Admins Have Scrounge (Deprecated)
 lblAdminsHaveScrounge.tooltip=Generate all admin personnel with ranks in the Scrounge skill.
-lblAdminExperienceLevelIncludeScrounge.text=Scrounge Factored into Experience Level
+lblAdminExperienceLevelIncludeScrounge.text=Scrounge Factored into Experience Level (Deprecated)
 lblAdminExperienceLevelIncludeScrounge.tooltip=All admin personnel will factor the Scrounge skill\
   \ into their experience level calculations (green, regular, etc.).
-
 # createAwardsTab
 lblAwardsTab.text=Awards Options \u270E \u2318
-
 lblAwardBonusStyle.text=Bonuses
 lblAwardBonusStyle.tooltip=Toggle XP and/or Edge bonuses from awards.
 lblAwardTierSize.text=Tier Size
@@ -535,7 +498,6 @@ lblAwardSetFilterList.tooltip=Include the name of any award sets you don't want 
   <br><b>Warning:</b> The spelling and capitalization must be exact, and each award set must be\
   \ separated by a comma. While spaces can appear in the award set name, the comma shouldn't be\
   \ followed by a space.
-
 # createAutoAwardsFilterPanel
 lblAutoAwardsFilterPanel.text=Award Tracking
 lblEnableContractAwards.text=Contract
@@ -580,16 +542,13 @@ lblEnableTrainingAwards.tooltip=These are awards issued for graduating from acad
   <br><b>Requirement:</b> the Education module must also be enabled for this option to function.
 lblEnableMiscAwards.text=Misc
 lblEnableMiscAwards.tooltip=These awards aren't covered by the other categories.
-
 # createPrisonersAndDependentsTab
 lblPrisonersAndDependentsTab.text=Dependent & Prisoner Options \u270E \u2318
-
 # createPrisonersPanel
 lblPrisonersPanel.text=Prisoners
 lblPrisonerCaptureStyle.text=Capture Style
 lblPrisonerCaptureStyle.tooltip=This is the ruleset to use when determining if a person has been\
   \ captured by the force following a scenario.
-
 # createDependentsPanel
 lblDependentsPanel.text=Dependents
 lblUseRandomDependentAddition.text=Random Addition
@@ -598,7 +557,6 @@ lblUseRandomDependentAddition.tooltip=This enables the monthly addition of rando
 lblUseRandomDependentRemoval.text=Random Removal
 lblUseRandomDependentRemoval.tooltip=This enables the monthly removal of random dependents from the\
   \ campaign.
-
 # createMedicalTab
 lblMedicalTab.text=Medical Options
 lblUseAdvancedMedical.text=Use Advanced Medical \u270E \u2318
@@ -619,13 +577,11 @@ lblUseTougherHealing.text=Use Tougher Healing \u270E
 lblUseTougherHealing.tooltip=The healing check will be penalized for every additional hit above 2.
 lblMaximumPatients.text=Beds per Doctor
 lblMaximumPatients.tooltip=This is the maximum number of patients that can be treated per doctor.
-
 # createSalariesTab
 lblSalariesTab.text=Salary Options
 lblDisableSecondaryRoleSalary.text=Disable Secondary Role Salaries \u270E
 lblDisableSecondaryRoleSalary.tooltip=Determines whether personnel will have their salaries\
   \ increased by their secondary role (if any).
-
 # createSalaryMultipliersPanel
 lblSalaryMultipliersPanel.text=Role Multipliers
 lblAntiMekSalary.text=Anti-Mek
@@ -634,7 +590,6 @@ lblAntiMekSalary.tooltip=Anti-Mek trained soldiers and battle armor/elemental pe
 lblSpecialistInfantrySalary.text=Specialist Infantry
 lblSpecialistInfantrySalary.tooltip=Soldiers assigned to specialist infantry units have their\
   \ salaries multiplied by this.
-
 # createExperienceMultipliersPanel
 lblExperienceMultipliersPanel.text=Experience Multipliers
 lblSkillLevelNone.text=None
@@ -647,13 +602,10 @@ lblSkillLevelVeteran.text=Veteran
 lblSkillLevelElite.text=Elite
 lblSkillLevelHeroic.text=Heroic
 lblSkillLevelLegendary.text=Legendary
-
 # createBaseSalariesPanel
 lblBaseSalariesPanel.text=Base Salaries
-
 # Biography Tab
 biographyContentTabs.title=Biography
-
 biographyGeneralTab.title=General
 biographyGeneralTab.border="With warfare an accepted part of everyday life and competition rife\
   \ between Great Houses, Minor Houses, Periphery warlords, Bandit Kings, mercantile combines, and\
@@ -665,7 +617,6 @@ biographyGeneralTab.border="With warfare an accepted part of everyday life and c
   \ staple of the Successor States?"\
   <br><i>Major Charlene Fellowes\
   <br>From Under Four Flags: My Life as a Mercenary, New Avalon Press, 3023</i>
-
 backgroundsTab.title=Backgrounds
 backgroundsTab.border="Now, Krieger and Farber are two of the best Techs in the sphere, and two of\
   \ the best scroungers. They got some facing off a wrecked building to cover us. That stuff works,\
@@ -688,29 +639,24 @@ backgroundsTab.border="Now, Krieger and Farber are two of the best Techs in the 
   \ it read 'Processed Chicken.'"\
   <br><i>Unknown MechWarrior\
   <br>3rd Succession War</i>
-
 deathTab.title=Death
 deathTab.border="School didn't teach me how to explode; I just learn fast."\
   <br><i>Sergeant Pete "Wildfire" Watson\
   <br>The Shenanigans Squadron</i>
-
 educationTab.title=Education
 educationTab.border="It's a sad comment on urban living when you see a Battle Master mug a Phoenix\
   \ Hawk in a blind alley."\
   <br><i>Unknown MechWarrior\
   <br>3rd Succession War</i>
-
 nameAndPortraitGenerationTab.title=Name & Portraits
 nameAndPortraitGenerationTab.border="Look at the bright side, kid. You get to keep all the money."\
   <br><i>Unknown MechWarrior\
   <br>2nd Succession War</i>
-
 rankTab.title=Rank Systems
 rankTab.border="Rank isn't about authority \u2014 it's about responsibility. Every step up means you're\
   \ carrying more than your own survival."\
   <br><i>Kommandant Clara "Demo" Bertsimas\
   <br>Herc's Jerks</i>
-
 # createGeneralTab
 lblBiographyGeneralTab.text=General Options \u270E
 lblUseDylansRandomXP.text=Use Random XP
@@ -731,7 +677,6 @@ lblFamilyDisplayLevel.tooltip=This setting is the relation to the selected chara
   \ display up to, including the previous levels.\
   <br>\
   <br><b>Warning:</b> Higher levels require more processing when loading a character.
-
 # createAnniversariesPanel
 lblAnniversariesPanel.text=Anniversaries
 lblAnnounceBirthdays.text=Announce Birthdays
@@ -746,10 +691,8 @@ lblAnnounceChildBirthdays.text=Always Announce 18th Birthdays \u26A0
 lblAnnounceChildBirthdays.tooltip=If enabled, 18th birthdays will always be announced.\
   <br>\
   <br><b>Warning:</b> Enabling this option will override any other settings.
-
 # createBackgroundsTab
 lblBackgroundsTab.text=Background Options \u270E
-
 # createRandomBackgroundsPanel
 lblRandomBackgroundsPanel.text=Random Backgrounds
 lblUseRandomPersonalities.text=Assign Random Personalities \u2318
@@ -776,7 +719,6 @@ lblUseSimulatedRelationships.tooltip=Personnel are generated with a random relat
   \ used to determine whether any marriages have ended in divorce.\
   <br>\
   <br>Any children and current spouses will travel alongside the unit.
-
 # createRandomOriginOptionsPanel
 lblRandomOriginOptionsPanel.text=Origins
 lblRandomizeOrigin.text=Randomize Origin
@@ -814,7 +756,6 @@ lblAllowClanOrigins.tooltip=Generate Clan origin factions for factions that aren
 lblExtraRandomOrigin.text=Extra Random Origins
 lblExtraRandomOrigin.tooltip=Random origin is randomized to the planetary level when selected,\
   \ rather than just randomizing to the system level (with the planet being the primary planet).
-
 # createDeathTab
 lblDeathTab.text=Death Options \u270E
 lblUseRandomDeathSuicideCause.text=Enable Cause of Death: Suicide
@@ -825,10 +766,8 @@ lblRandomDeathMultiplier.tooltip=This multiplier is applied directly to a charac
   <br>\
   <br><b>Warning:</b> Setting this to 0 disables Random Death. The default value of 1.0 gives an\
   \ average life expectancy of 84 for men and 89 for women.
-
 # createDeathAgeGroupsPanel
 lblDeathAgeGroupsPanel.text=Death by Age Group
-
 # createEducationTab
 lblEducationTab.text=Education Options \u270E \u2318
 lblUseEducationModule.text=Enable Education Module
@@ -852,7 +791,6 @@ lblEntranceExamBaseTargetNumber.tooltip=The base target number for Prestigious A
   <br>\
   <br>The final TN is this value minus Faculty Skill, opposed by 2d6 + Intelligence/4 or just 2d6\
   \ (if personalities are disabled)
-
 # createEnableStandardSetsPanel
 lblEnableStandardSetsPanel.text=Enable Academy Sets
 lblEnableLocalAcademies.text=Local Academies
@@ -862,7 +800,6 @@ lblEnablePrestigiousAcademies.tooltip=Allows personnel to enroll in named, canon
 lblEnableUnitEducation.text=Unit Education
 lblEnableUnitEducation.tooltip=Allows personnel to enroll in education and training conducted by\
   \ the unit. These are generally inferior to prestigious or local academies.
-
 # createXpAndSkillBonusesPanel
 lblXpAndSkillBonusesPanel.text=Faculty XP & Skill Bonuses
 lblEnableBonuses.text=Enable Graduation Bonuses
@@ -872,7 +809,6 @@ lblFacultyXpMultiplier.tooltip=This value multiplies the number of XP gained whe
   \ partially completing) a qualification.\
   <br>\
   <br>Setting this to zero disables faculty XP.
-
 # createDropoutChancePanel
 lblDropoutChancePanel.text=Weekly Dropout Chances
 lblAdultDropoutChance.text=Adult Dropout Chance: 1 in
@@ -885,7 +821,6 @@ lblChildrenDropoutChance.tooltip=The number of sides on the die used to determin
   \ dropouts. A dropout occurs on a roll of 1.\
   <br>\
   <br>Setting this to 0 disables random dropouts.
-
 # createAccidentsAndEventsPanel
 lblAccidentsAndEventsPanel.text=Weekly Accidents & Events
 lblAllAges.text=All Ages Affected
@@ -896,7 +831,6 @@ lblMilitaryAcademyAccidents.tooltip=The number of sides on the die used to deter
   \ (potentially fatal) accidents. An accident occurs on a roll of 1.\
   <br>\
   <br>Setting this to 0 disables random accidents.
-
 # createNameAndPortraitGenerationTab
 lblNameAndPortraitGenerationTab.text=Name and Portrait Generation Options \u270E \u2318
 lblUseOriginFactionForNames.text=Assign Names Based on Origin Faction
@@ -910,14 +844,12 @@ lblAssignPortraitOnRoleChange.tooltip=With this enabled, a person without a port
 lblAllowDuplicatePortraits.text=Allow Duplicate Portraits
 lblAllowDuplicatePortraits.tooltip=With this enabled, random portraits are no longer unique\
   \ and several different people can have the same portrait.
-
 # createRandomPortraitPanel
 lblRandomPortraitPanel.text=Portrait Assignment
 lblEnableAllPortraits.text=Enable All
 lblEnableAllPortraits.tooltip=Enable all portrait assignment options
 lblDisableAllPortraits.text=Disable All
 lblDisableAllPortraits.tooltip=Disable all portrait assignment options
-
 # createRankTab
 lblRankTab.text=Rank Systems \u2318
 lblRankTabBody.text=<p>You can use the table below to assign ranks for your campaign. Choose one of\
@@ -961,29 +893,23 @@ lblRankTabBody.text=<p>You can use the table below to assign ranks for your camp
           </ul>\
       </li>\
   </ol>
-
-
 # Turnover and Rention Tab
 turnoverAndRetentionContentTabs.title=Turnover & Retention
-
 turnoverTab.title=Turnover
 turnoverTab.border="For a MekWarrior, retirement is a strange thing. We spend our lives in battle,\
   \ and when the guns go silent, we find out who we are without them."\
   <br><i>Colonel Sofia "Whisper" Talon\
   <br>Ark's Bonked Battalion</i>
-
 fatigueTab.title=Fatigue
 fatigueTab.border="I say to Hell with Information! Ammunition is Ammunition!"\
   <br><i>Unknown Mercenary\
   <br>Clan Invasion</i>
-
 # createTurnoverTab
 lblTurnoverTab.text=Turnover Options \u270E \u2318
 lblTurnoverTabBody.text=Turnover is a reasonably complex system. It is highly recommended that you\
   \ read through the documentation: <i>MekHQ/docs/Personnel Modules/Turnover and Retention.pdf</i>
 lblUseRandomRetirement.text=Enable Random Turnover
 lblUseRandomRetirement.tooltip=Determines whether personnel will randomly leave the unit.
-
 # createSettingsPanel
 lblSettingsPanel.text=Settings
 lblTurnoverFixedTargetNumber.text=Target Number
@@ -1020,7 +946,6 @@ lblPayBonusDefault.tooltip=Personnel with a turnover target number equal (or exc
 lblPayBonusDefaultThreshold.text=Bonus Threshold
 lblPayBonusDefaultThreshold.tooltip=This option sets the threshold for default bonus payouts (if\
   \ the above option is enabled).
-
 # createModifiersPanel
 lblTurnoverModifiersPanel.text=Modifiers
 lblUseCustomRetirementModifiers.text=Custom
@@ -1054,7 +979,6 @@ lblUseLoyaltyModifiers.tooltip=If enabled, personnel have a random loyalty ratin
   \ their Turnover target number.
 lblUseHideLoyalty.text=Hide Loyalty
 lblUseHideLoyalty.tooltip=If enabled, loyalty modifiers will be hidden.
-
 # createPayoutsPanel
 lblPayoutsPanel.text=Payouts
 lblPayoutRateOfficer.text=Officer Rate
@@ -1071,7 +995,6 @@ lblUsePayoutServiceBonus.tooltip=If enabled, personnel increase their payouts ba
 lblPayoutServiceBonusRate.text=Bonus %
 lblPayoutServiceBonusRate.tooltip=This sets the payout percentage increase per year of service,\
   \ applied when personnel resign or retire.
-
 # createUnitCohesionPanel
 lblUnitCohesionPanel.text=Unit Cohesion
 lblUseAdministrativeStrain.text=Enable Administrative Strain
@@ -1080,7 +1003,6 @@ lblUseAdministrativeStrain.tooltip=This option limits the number of personnel th
 lblUseManagementSkill.text=Enable Management Skill
 lblUseManagementSkill.tooltip=This option applies a modifier to turnover checks based on the\
   \ Leadership of commanding personnel.
-
 # createAdministrativeStrainPanel
 lblAdministrativeStrain.text=Administrative Strain
 lblAdministrativeCapacity.text=Administrative Capacity
@@ -1089,7 +1011,6 @@ lblAdministrativeCapacity.tooltip=How many personnel can be supported per combin
 lblMultiCrewStrainDivider.text=Multi-Crew Strain Divider
 lblMultiCrewStrainDivider.tooltip=For multi-crew units (and ProtoMeks) divide crew size by this\
   \ value. This value is doubled for civilians and prisoners.
-
 # createManagementSkill
 lblManagementSkill.text=Management Skill
 lblUseCommanderLeadershipOnly.text=Use Commander's Leadership Only
@@ -1099,7 +1020,6 @@ lblUseCommanderLeadershipOnly.tooltip=Personnel only use the Leadership skill of
 lblManagementSkillPenalty.text=Unskilled Penalty
 lblManagementSkillPenalty.tooltip=The unskilled modifier to turnover target numbers. Each rank in\
   \ Leadership reduces this number by 1.
-
 # createFatigueTab
 lblFatigueTab.text=Fatigue Options
 lblFatigueTabBody.text=The rules for Fatigue can be found in Campaign Operations. With our\
@@ -1129,24 +1049,19 @@ lblFatigueLeaveThreshold.tooltip=Automatically assign personnel to Leave status 
   \ duty once their fatigue has returned to 0.\
   <br>\
   <br>Set to 0 to disable.
-
 ## Relationships Tab
 relationshipsContentTabs.title=Relationships
-
 marriageTab.title=Marriage
 marriageTab.border="My love, I give you the Capellan Confederation!"\
   <br><i>Hanse Davion to Melissa Steiner-Davion at their wedding reception on Terra\
   <br>August 20, 3028</i>
-
 divorceTab.title=Divorce
 divorceTab.border="Whoever said 'never shoot a man in the back' never saw the front a Hunchback."\
   <br><i>Unknown Mercenary\
   <br>First Succession War</i>
-
 procreationTab.title=Procreation
 procreationTab.border="They've requested LRMs. I'm pretty sure they mean Living Room Modules."\
   <br><i>Unknown Logistics Tech</i>
-
 # createMarriageTab
 lblMarriageTab.text=Marriage Options \u270E
 lblUseManualMarriages.text=Enable Manual Marriages
@@ -1171,7 +1086,6 @@ lblCheckMutualAncestorsDepth.tooltip=This is the depth to which the ancestry of 
 lblLogMarriageNameChanges.text=Log Name Changes
 lblLogMarriageNameChanges.tooltip=This enables the addition of a personnel log entry whenever a\
   \ name is changed during marriage.
-
 # createRandomMarriagePanel
 lblRandomMarriages.text=Random Marriages
 lblRandomMarriageMethod.text=Random Marriage Method
@@ -1186,7 +1100,6 @@ lblUseRandomPrisonerMarriages.tooltip=Allow random divorce when one or both of t
 lblRandomMarriageAgeRange.text=Random Marriage Age Band
 lblRandomMarriageAgeRange.tooltip=This plus/minus age forms the possible range of ages for spouses\
   \ in the forming of a random marriage.
-
 # createPercentageRandomMarriagePanel
 lblPercentageRandomMarriagePanel.text=Marriage Dice
 lblRandomMarriageOppositeSexDiceSize.text=Opposite Sex Marriage Chance: 1 in
@@ -1205,7 +1118,6 @@ lblRandomNewDependentMarriage.tooltip=This determines the number of sides on the
   \ occurs on a roll of 1.\
   <br>\
   <br>Set this value to 0 to disable inter-unit marriages.
-
 # createDivorceTab
 lblDivorceTab.text=Divorce Options \u270E
 lblUseManualDivorce.text=Enable Manual Divorce
@@ -1217,7 +1129,6 @@ lblUsePrisonerDivorce.text=Enable Manual Prisoner Divorce
 lblUsePrisonerDivorce.tooltip=Allow divorce when one or both of the couple are currently prisoners.\
   \ Bondsmen are treated as free personnel when it comes to this option, and are thus not affected\
   \ by it.
-
 # createRandomDivorcePanel
 lblRandomDivorcePanel.text=Random Divorce
 lblRandomDivorceMethod.text=Random Divorce Method
@@ -1241,10 +1152,8 @@ lblRandomDivorceDiceSize.tooltip=This is the number of sides featured on the wee
   \ see whether a marriage ends in divorce. Divorce occurs on a roll of 1.\
   <br>\
   <br>Set to 0 to disable random divorces for all personnel.
-
 # createProcreationTab
 lblProcreationTab.text=Procreation Options \u270E
-
 # createProcreationGeneralOptionsPanel
 lblUseManualProcreation.text=Enable Manual Procreation
 lblUseManualProcreation.tooltip=This allows you to disable the Add/Remove Pregnancy options in the\
@@ -1293,7 +1202,6 @@ lblUseMaternityLeave.tooltip=If enabled, pregnant personnel will be placed on ma
   \ birth.
 lblLogProcreation.text=Log Procreation
 lblLogProcreation.tooltip=This enables logging the date of conception and birth in a person's logs.
-
 # createRandomProcreationPanel
 lblRandomProcreationPanel.text=Random Procreation
 lblRandomProcreationMethod.text=Random Procreation Method
@@ -1315,24 +1223,19 @@ lblRandomProcreationRelationshiplessDiceSize.text=Relationshipless Procreation C
 lblRandomProcreationRelationshiplessDiceSize.tooltip=This is the number of sides on the dice rolled\
   \ weekly to determine whether a woman not in a relationship will fall pregnant. A roll of 1\
   \ results in a pregnancy.
-
 # Finances Tab
 financesContentTabs.title=Finances
-
 financesGeneralTab.title=General
 financesGeneralTab.border="War is expensive. If the enemy doesn't kill you, the repair bills might."\
   <br><i>Sergeant Tara "Grease" Hall\
   <br>Vogel's Fumble Force
-
 priceMultipliersTab.title=Price Multipliers
 priceMultipliersTab.border="The used parts market is where dreams are built \u2014 and nightmares are patched\
   \ together. Just make sure the part you're buying doesn't come with someone else's curse."\
   <br><i>Captain Nia "Jackal" Thorne\
   <br>The Stormbringer Jägers</i>
-
 # createFinancesGeneralOptionsTab
 lblFinancesGeneralTab.text=General Options
-
 # createPaymentsPanel
 lblPaymentsPanel.text=Payments
 lblPayForPartsBox.text=Pay For Parts
@@ -1354,7 +1257,6 @@ lblPayForTransportBox.text=Transport
 lblPayForTransportBox.tooltip=Pay for excess transportation needs.
 lblPayForRecruitmentBox.text=Recruitment (FM:Mr)
 lblPayForRecruitmentBox.tooltip=Pay a two-month salary to new recruits.
-
 # createGeneralOptionsPanel
 lblUseLoanLimitsBox.text=Available Loans Based on Unit Reputation \u270E
 lblUseLoanLimitsBox.tooltip=Put limits on interest, collateral, and length.
@@ -1378,14 +1280,12 @@ lblNewFinancialYearFinancesToCSVExportBox.tooltip=This writes the finance table 
   \ the first day of a new financial term, right before the table is carried over to the next period.
 lblSimulateGrayMonday.text=Simulate Gray Monday
 lblSimulateGrayMonday.tooltip=Simulate the economic and social upheaval of Gray Monday.
-
 # createSalesPanel
 lblSalesPanel.text=Sales
 lblSellUnitsBox.text=Enable the Sale of Units
 lblSellUnitsBox.tooltip=Units can be sold.
 lblSellPartsBox.text=Enable the Sale of Parts
 lblSellPartsBox.tooltip=Parts can be sold.
-
 # createTaxesPanel
 lblTaxesPanel.text=Taxes \u270E
 lblUseTaxesBox.text=Enable Taxes
@@ -1397,7 +1297,6 @@ lblUseTaxesBox.tooltip=If enabled, taxes will be paid at the end of each financi
   <brStarting Capital and End of Term Carryover sums are excluded from profit calculations.
 lblTaxesPercentage.text=Tax Percentage
 lblTaxesPercentage.tooltip=The percentage of profits paid as taxes.
-
 # createSharesPanel
 lblSharesPanel.text=Shares \u270E
 lblUseShareSystem.text=Enable Shares
@@ -1405,14 +1304,12 @@ lblUseShareSystem.tooltip=Gives personnel a stake in the unit. This system lower
   \ increase retention.
 lblSharesForAll.text=All Personnel Have Shares
 lblSharesForAll.tooltip=All combat and support personnel have shares rather than just MekWarriors.
-
 # createFinancesGeneralOptionsTab
 lblPriceMultipliersTab.text=Price Multiplier Options
 lblPriceMultipliersTabBody.text=It's important to remember that the qualities (A-F) under <b>Used\
   \ Parts</b> do not update based on whether you have <b>Reverse Quality Names</b> enabled.\
   <br>\
   <br>This means <b>A</b> is the worst quality and <b>F</b> is the best.
-
 # createGeneralMultipliersPanel
 lblGeneralMultipliersPanel.text=General
 lblCommonPartPriceMultiplier.text=Common Parts
@@ -1433,10 +1330,8 @@ lblClanPartPriceMultiplier.tooltip=Multiplies the buy/sell price of Clan tech pa
 lblMixedTechUnitPriceMultiplier.text=Mixed Units
 lblMixedTechUnitPriceMultiplier.tooltip=Multiplies the buy/sell price of Mixed Tech units by the\
   \ specified value.
-
 # createUsedPartsMultiplierPanel
 lblUsedPartsMultiplierPanel.text=Used Parts
-
 # createOtherMultipliersPanel
 lblOtherMultipliersPanel.text=Other
 lblDamagedPartsValueMultiplier.text=Damaged Parts
@@ -1448,10 +1343,8 @@ lblUnrepairablePartsValueMultiplier.tooltip=Multiplies the value and thus the se
 lblCancelledOrderRefundMultiplier.text=Cancelled Order Refund
 lblCancelledOrderRefundMultiplier.tooltip=The decimal percentage of the original purchase price\
   \ that is refunded when an order is canceled.
-
 # Markets Tab
 marketsContentTabs.title=Markets
-
 personnelMarketTab.title=Personnel
 personnelMarketTab.border=\u2014 Toilet Paper 22 Tons\
   <br>\u2014 Soap 1.2 Tons\
@@ -1464,22 +1357,18 @@ personnelMarketTab.border=\u2014 Toilet Paper 22 Tons\
   <br>\u2014 Morale Package (Hunky Hanse and Bellissima Melissa Dolls) 1 crate\
   <br><i>Unknown Resupply Shipment\
   <br>Fourth Succession War</i>
-
 unitMarketTab.title=Units
 unitMarketTab.border="Buying a new 'Mek is exciting \u2014 right up until you see the repair bill after\
   \ your first mission. Then it's just another hole in your wallet."\
   <br><i>Sergeant Kyle "Scrapheap" Carter\
   <br>The Blacksmiths</i>
-
 contractMarketTab.title=Contracts
 contractMarketTab.border="So there I was, between rock and a hard place, when suddenly I thought,\
   \ 'What am I doing on this side of the rock?'"\
   <br><i>Star Commander Karra\
   <br>Clan Ghost Bear, Constance, Apr 3050</i>
-
 # createPersonnelMarketTab
 lblPersonnelMarketTab.text=Personnel Market Options
-
 # createPersonnelMarketGeneralOptionsPanel
 lblPersonnelMarketType.text=Market Method
 lblPersonnelMarketType.tooltip=This is the type of personnel market used to generate and remove new\
@@ -1494,10 +1383,8 @@ lblPersonnelMarketReportRefresh.tooltip=Adds a report to the daily log when the 
 lblUsePersonnelHireHiringHallOnly.text=Hiring Halls & Capitals Only \u270E
 lblUsePersonnelHireHiringHallOnly.tooltip=Enabling this option disables the personnel market\
   \ outside of hiring halls or capital planets.
-
 # createPersonnelMarketRemovalOptionsPanel
 lblPersonnelMarketRemovalOptionsPanel.text=Removal Target Numbers
-
 # createUnitMarketTab
 lblUnitMarketTab.text=Unit Market Options \u270E
 lblUnitMarketMethod.text=Market Method
@@ -1523,10 +1410,8 @@ lblMothballUnitMarketDeliveries.tooltip=Units bought from the unit market will a
   \ mothballed state.
 lblUnitMarketReportRefresh.text=Post Report on Market Refresh
 lblUnitMarketReportRefresh.tooltip=Adds a report to the daily log when the unit market refreshes.
-
 # createContractMarketTab
 lblContractMarketTab.text=Contract Market Options
-
 # createContractMarketGeneralOptionsPanel
 lblContractMarketMethod.text=Market Method
 lblContractMarketMethod.tooltip=This is the method of contract market used to generate new\
@@ -1547,7 +1432,6 @@ lblCoontractMaxSalvagePercentage.tooltip=Used to limit the salvage roll when cre
 lblDropShipBonusPercentage.text=DropShip Bonus Percent
 lblDropShipBonusPercentage.tooltip=It is not possible to salvage DropShips from ground maps.\
   \ Setting this option above 0 will instead pay a percentage of the DropShip's value as a 'bounty.'
-
 # createMercenaryPanel
 lblContractPayPanel.text=Contract Pay
 lblContractEquipment.text=TO&E Value Influences Pay (CamOps)
@@ -1578,22 +1462,18 @@ lblOverageRepaymentInFinalPayment.text=Repay Salvage Overages on Contract End
 lblOverageRepaymentInFinalPayment.tooltip=This is an unofficial addition that has you repay any\
   \ overages from your salvage percent as part of the final payment, which may take that into a\
   \ debit.
-
 # Markets Tab
 rulesetsContentTabs.title=Custom Rulesets
-
 stratConGeneralTab.title=General
 stratConGeneralTab.border="Strategy is just a fancy way of saying, 'I'm going to send you in first\
   \ and see what happens.'"\
   <br><i>Sergeant Milo "Wildcard" Trent\
   <br>The Tridents</i>
-
 legacyTab.title=Legacy Options
 legacyTab.border="You know, for 5-tons, I'd expect more than 256 colors!"\
   <br><i>Colonel Elias "Warhound" Drake\
   <br>Impetus Alliance\
   <br>Comments made following a Targeting Computer retrofit</i>
-
 # substantializeUniversalOptions
 lblSkillLevel.text=Difficulty \u2714
 lblSkillLevel.tooltip=<html>This is the difficulty level for generated scenarios.\
@@ -1668,25 +1548,18 @@ lblAdjustPaymentForStrategy.text=Adjust Contract Pay by Maximum Force Count
 lblAdjustPaymentForStrategy.tooltip=If the number of lances required to be deployed exceeds the\
   \ current commander's strategy skill, reduce the number when calculating new contracts and reduce\
   \ the payment proportionally.
-
 # createUniversalScenarioGenerationPanel
 lblUniversalScenarioGenerationPanel.text=Scenario Generation
-
 # createUniversalUnitRatioPanel
 lblUniversalUnitRatioPanel.text=Unit Ratios
-
 # createUniversalModifiersPanel
 lblUniversalModifiersPanel.text=Random Modifiers
-
 # createUniversalMapGenerationPanel
 lblUniversalMapGenerationPanel.text=Map Generation
-
 # createUniversalPartsPanel
 lblUniversalPartsPanel.text=Parts Availability
-
 # createUniversalLancePanel
 lblUniversalLancePanel.text=Force Organization
-
 # createStratConTab
 lblStratConTab.text=General Options \u270E
 lblUseStratCon.text=Enable StratCon (Digital GM) \u2318 \u26A0
@@ -1705,7 +1578,6 @@ lblUseGenericBattleValue.tooltip=Bot forces are balanced used Generic Battle Val
 lblUseVerboseBidding.text=Enable Verbose Clan Bidding
 lblUseVerboseBidding.tooltip=When Generic BV is in use, Clan OpFors will engage in bidding prior\
   \ to the scenario. If this option is enabled, a list of all units bid away will be provided.
-
 # initializeLegacyTab
 lblLegacyTab.text=Legacy Options \u270E
 lblLegacyTabBody.text=This tab includes options for <b>Legacy AtB: Against the Bot</b>. All options\
@@ -1716,7 +1588,6 @@ lblUseAtB.tooltip=AtB was MekHQ's first attempt at a Digital GM. It creates rand
   \ Support for Legacy AtB ended in 2025 with v50.02.\
   <br>\
   <br><b>Warning:</b> If StratCon is enabled, all Legacy options are ignored.
-
 # createAutoResolvePanel
 lblAutoResolvePanel.text=AutoResolve \u270E \u2318
 lblAutoResolveMethod.text=AutoResolve Method \u26A0
@@ -1737,10 +1608,8 @@ lblAutoResolveVictoryChanceEnabled.tooltip=Determines whether MekHQ should tell 
 lblAutoResolveExperimentalPacarGuiEnabled.text=Experimental Commander's Interface for PACAR \u26A0
 lblAutoResolveExperimentalPacarGuiEnabled.tooltip=A lightweight graphical interface for PACAR.\
   \ <b>Warning:</b> This is an experimental feature and may not work as expected. It's intended for solo play only.
-
 lblMinimapTheme.text=Strategic View Theme \u26A0
 lblMinimapTheme.tooltip=Select a theme for the strategic view screen on the Commander's Interface
-
 # createLegacyOpForGenerationPanel
 lblLegacyOpForGenerationPanel.text=Force Generation
 lblUseVehicles.text=Enable NPC Vehicles
@@ -1759,7 +1628,6 @@ lblOpForUsesLocalForces.tooltip=The bot may introduce turrets, infantry and batt
 lblAdjustPlayerVehicles.text=Treat Player Vehicles as Half Weight
 lblAdjustPlayerVehicles.tooltip=Vehicles deployed by the player only count half their weight to the\
   \ lance weight class to compensate for enemy force generation designed to oppose player Meks.
-
 # createLegacyScenarioGenerationPanel
 lblLegacyScenarioGenerationPanel.text=Scenario Generation
 lblGenerateChases.text=Generate Chase Scenarios
@@ -1769,22 +1637,18 @@ lblAtBBattleIntensity.text=Battle Frequency
 lblAtBBattleIntensity.tooltip=How intense should contracts be? Lower these values for easier contracts.
 lblIntensityUpdate.text=Update Intensity
 lblIntensityUpdate.tooltip=Update intensity based on the current battle chance values.
-
 ## Advancement Tab
 awardsAndRandomizationContentTabs.title=Awards & Randomization
-
 xpAwardsTab.title=Experience Awards
 xpAwardsTab.border="It is possible to commit no mistakes and still lose. That is not a weakness;\
   \ that is life."\
   <br><i>Captain Jean Stuart, The Voyagers\
   <br>Date Unknown</i>
-
 randomizationTab.title=Randomization
 randomizationTab.border="Every skill has its moment. What seems trivial today may save lives tomorrow,\
   \ because out in the stars, survival favors the adaptable."\
   <br><i>Colonel Drake "Ironjaw" Valen\
   <br>The Missed Connection Militia</i>
-
 # xpAwardsTab
 lblXpAwardsTab.text=Experience Award Options
 lblXpCostMultiplier.text=Advancement Multiplier \u26A0
@@ -1792,7 +1656,6 @@ lblXpCostMultiplier.tooltip=This value multiplies the XP costs of all SPAs, Edge
   \ Skill Levels.\
   <br>\
   <br><b>Warning:</b> This option updates costs while you play and not the options shown here.
-
 # createTasksPanel
 lblTasksPanel.text=Tasks (Deprecated)
 lblTaskXP.text=XP per
@@ -1825,7 +1688,6 @@ lblMistakeXP.tooltip=How much experience should be awarded whenever an unsuccess
   \ checks. Usually Admin characters, or those making acquisition checks.\
   <br>\
   <br><b>Recommended:</b> Keep this disabled.
-
 # createScenariosPanel
 lblScenariosPanel.text=Scenarios \u270E
 lblScenarioXP.text=XP per Scenario \u26A0 \u2714
@@ -1854,7 +1716,6 @@ lblKills.tooltip=How many kills need to be scored before experience is awarded?\
   \ at once, such as bomb equipped aircraft pilots.\
   <br>\
   <br><b>Recommended:</b> Keep this disabled.
-
 # createMissionsPanel
 lblMissionsPanel.text=Missions
 lblVocationalXP.text=Vocational XP per \u26A0
@@ -1876,7 +1737,6 @@ lblMissionXpSuccess.tooltip=How much experience is awarded for a successful cont
 lblMissionXpOutstandingSuccess.text=Outstanding Success (StratCon Only)
 lblMissionXpOutstandingSuccess.tooltip=Experience points awarded when successfully concluding a\
   \ mission with 3+ campaign victory points.
-
 # createAdministratorsPanel
 lblAdministratorsXpPanel.text=Administrators (Deprecated) \u270E \u26A0 \u2714
 lblAdminWeeklyXP.text=XP per
@@ -1901,7 +1761,6 @@ lblContractNegotiationXP.tooltip=How much experience does a contract negotiator 
   \ gains of admin personnel.\
   <br>\
   <br><b>Recommended:</b> Keep this disabled.
-
 # skillRandomizationTab
 lblSkillRandomizationTab.text=Skill Randomization Options \u270E
 lblExtraRandomness.text=Extra Randomness \u26A0
@@ -1910,7 +1769,6 @@ lblExtraRandomness.tooltip=If checked, an additional 1d6 will be rolled per skil
   <br>\
   <br><b>Warning:</b> Due to the way experience levels are calculated, enabling this option will\
   \ more frequently have characters created with slightly lower than normal experience levels.
-
 lblPhenotypesPanel.text=Clan Trueborn Percentages
 lblMekWarrior.text=MekWarrior
 lblMekWarrior.tooltip=What percentage of Clan MekWarriors should have a Trueborn phenotype?
@@ -1924,7 +1782,6 @@ lblProtoMek.text=ProtoMek
 lblProtoMek.tooltip=What percentage of ProtoMek pilots should have a Trueborn phenotype?
 lblNaval.text=Naval
 lblNaval.tooltip=What percentage of Naval crew should have a Trueborn phenotype?
-
 lblAbilityPanel.text=Random SPA Chances
 lblAbilityGreen.text=Green \u26A0
 lblAbilityGreen.tooltip=Modifier to the 2d6 roll used to determine whether a character is created\
@@ -1954,7 +1811,6 @@ lblAbilityElite.tooltip=Modifier to the 2d6 roll used to determine whether a cha
   <br><b><9:</b> 0 SPAs\
   <br><b>10-11:</b> 1 SPA\
   <br><b>12+:</b> 2 SPAs
-
 lblCommandSkillsPanel.text=Command Skills
 lblCommandSkillsGreen.text=Green \u26A0
 lblCommandSkillsGreen.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
@@ -1992,7 +1848,6 @@ lblCommandSkillsElite.tooltip=Modifier made to the 2d6 roll used to determine wh
   <br><b>6-9:</b> Regular\
   <br><b>10-11:</b> Veteran\
   <br><b>12+:</b> Elite
-
 lblSmallArmsPanel.text=Small Arms
 lblCombatSmallArms.text=Combatants
 lblCombatSmallArms.tooltip=The skill level modifier applied to the Small Arms skill of\
@@ -2000,14 +1855,12 @@ lblCombatSmallArms.tooltip=The skill level modifier applied to the Small Arms sk
 lblNonCombatSmallArms.text=Non-Combatants
 lblNonCombatSmallArms.tooltip=The skill level modifier applied to the Small Arms skill of\
   \ newly created characters with a non-combat role.
-
 lblArtilleryPanel.text=Artillery
 lblArtilleryChance.text=Percent
 lblArtilleryChance.tooltip=The percentage chance a MekWarrior, Vehicle Crew, or Conventional\
   \ Infantry character has of being created with the Artillery skill (if that option is enabled).
 lblArtilleryBonus.text=Modifier
 lblArtilleryBonus.tooltip=The skill level modifier applied to the skill (if present).
-
 lblSecondarySkillPanel.text=Secondary Skills
 lblAntiMekChance.text=Anti-Mek Percent
 lblAntiMekChance.tooltip=The percentage chance a conventional infantry character has of being\
@@ -2017,32 +1870,26 @@ lblSecondarySkillChance.tooltip=The percentage chance a conventional infantry ch
   \ created with a random secondary skill.
 lblSecondarySkillBonus.text=Modifier
 lblSecondarySkillBonus.tooltip=The skill level modifier applied to the skill (if present).
-
 ## Advancement Tab
 skillsContentTabs.title=Skills
-
 combatSkillsTab.title=Combat Skills
 combatSkillsTab.border="Every skill you master is another weapon in your arsenal. Out here, the\
   \ better you fight, the longer you live."\
   <br><i>Sergeant Mick "Crash" Lannister\
   <br>The Enforcers</i>
-
 supportSkillsTab.title=Support Skills
 supportSkillsTab.border="Support staff are like the coolant system in a 'Mek \u2014 nobody notices them\
   \ until they're gone, and then everyone's screaming."\
   <br><i>Sergeant Leo "Gears" Malone\
   <br>The Panther Corsairs</i>
-
 btnToggle.text=Toggle Advanced Options
 btnHideAll.text=Hide All Advanced Options
 btnDisplayAll.text=Display All Advanced Options
 btnCopy.text=Copy
 btnPaste.text=Paste
-
 lblSkillPanelTargetNumber.text=Base Target Number
 lblSkillPanelTargetNumber.tooltip=The base target number used by this skill. All target numbers,\
   \ for uses of this skill are derived from this value.
-
 lblSkillLevel0.text=0
 lblSkillLevel1.text=1
 lblSkillLevel2.text=2
@@ -2054,10 +1901,8 @@ lblSkillLevel7.text=7
 lblSkillLevel8.text=8
 lblSkillLevel9.text=9
 lblSkillLevel10.text=10
-
 # Combat Skills Tab
 lblCombatSkillsTab.text=Combat Skill Options
-
 lblSkillPanelPiloting/Mek.text=Piloting/Mek
 lblSkillPanelPiloting/Aerospace.text=Piloting/Aerospace
 lblSkillPanelPiloting/Aircraft.text=Piloting/Aircraft
@@ -2075,9 +1920,7 @@ lblSkillPanelGunnery/ProtoMek.text=Gunnery/ProtoMek
 lblSkillPanelArtillery.text=Artillery
 lblSkillPanelSmallArms.text=Small Arms
 lblSkillPanelAnti-Mek.text=Anti-Mek
-
 lblSupportSkillsTab.text=Support Skill Options
-
 lblSkillPanelTech/Mek.text=Tech/Mek
 lblSkillPanelTech/Mechanic.text=Tech/Mechanic
 lblSkillPanelTech/Aero.text=Tech/Aero
@@ -2090,34 +1933,27 @@ lblSkillPanelHyperspaceNavigation.text=Hyperspace Navigation
 lblSkillPanelAdministration.text=Administration
 lblSkillPanelNegotiation.text=Negotiation
 lblSkillPanelLeadership.text=Leadership
-lblSkillPanelScrounge.text=Scrounge
+lblSkillPanelScrounge.text=Scrounge (Deprecated)
 lblSkillPanelStrategy.text=Strategy
 lblSkillPanelTactics.text=Tactics
-
 ## Advancement Tab
 abilityContentTabs.title=Abilities
-
 combatAbilitiesTab.title=Combat Abilities
 combatAbilitiesTab.border="Abilities only matter if you know how to use them. A sharp blade is\
   \ useless in the hands of someone who doesn't know how to wield it."\
   <br><i>Captain Elena "Ironshadow" Kane\
   <br>Problem, Meet Solution</i>
-
 maneuveringAbilitiesTab.title=Maneuvering Abilities
 maneuveringAbilitiesTab.border="Talent without discipline is like a fusion engine without a 'Mek\
   \ \u2014 powerful, but going nowhere."\
   <br><i>Colonel Liana "Shadow" Voss\
   <br>Axis Innovations</i>
-
 utilityAbilitiesTab.title=Utility Abilities
 utilityAbilitiesTab.border="Unique abilities? Yeah, I've got one: breaking everything I touch."\
   <br><i>Technician Cole "Scrapheap" Drayton\
   <br>The Bulwarks</i>
-
 lblCombatAbilitiesTab.text=Combat Ability Options \u2318
-
 lblManeuveringAbilitiesTab.text=Maneuvering Ability Options \u2318
-
 lblUtilityAbilitiesTab.text=Utility Ability Options \u2318
 lblEdgeCostPanel.text=Edge Cost
 lblEdgeCost.text=Cost
@@ -2134,7 +1970,6 @@ removes.text=<b>Removes</b><br>
 lblCustomizeAbility.text=Customize Ability
 lblCustomizeAbility.tooltip=Launch the 'customize SPA' dialog, allowing you to change cost,\
   \ requirements, and other options.
-
 ## StratCon Notice
 stratConPromo.title=++INCOMING TRANSMISSION++
 stratConPromo.message=<html><body style='width: 500px'><br><div style='text-align: center;'>\

--- a/MekHQ/resources/mekhq/resources/SkillDeprecationTool.properties
+++ b/MekHQ/resources/mekhq/resources/SkillDeprecationTool.properties
@@ -1,0 +1,9 @@
+button.continue=Continue Without Refunding
+button.refund=Refund the Skill
+message.ic={0}, HR told me I''m scheduled for retraining.\
+  <p>Apparently, my skills in ''<b>{1}</b>'' are no longer recognized by the personnel database. Something about a\
+  \ ''software update.''</p>\
+  <p>Want me to sign up for a class, or should I wait a bit?</p>
+message.ooc=The {0} skill is <b>Deprecated</b> and scheduled for removal. While you do not need to refund the skill now,\
+  \ the opportunity will be lost when the skill is removed from MekHQ.\
+  <p>Choosing to refund this skill will grant {1} <b>{2}</b> xp.</p>

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1661,10 +1661,23 @@ public class Person {
     // endregion Pregnancy
 
     // region Experience
+
+    /**
+     * @return the current experience points (XP) of the character.
+     */
     public int getXP() {
         return xp;
     }
 
+    /**
+     * Awards experience points (XP) to the character and optionally tracks the total XP earnings if enabled.
+     *
+     * <p>This method increments the current XP by the specified amount and, if the campaign
+     * option for tracking total XP earnings is enabled, updates the total XP earnings as well.</p>
+     *
+     * @param campaign the {@link Campaign} instance providing the campaign options
+     * @param xp       the amount of XP to be awarded
+     */
     public void awardXP(final Campaign campaign, final int xp) {
         this.xp += xp;
         if (campaign.getCampaignOptions().isTrackTotalXPEarnings()) {
@@ -1672,10 +1685,28 @@ public class Person {
         }
     }
 
+    /**
+     * Spends (deducts) experience points (XP) from the character's current XP total.
+     *
+     * <p>This method decrements the current XP by the specified amount.</p>
+     *
+     * @param xp the amount of XP to deduct
+     */
     public void spendXP(final int xp) {
         this.xp -= xp;
     }
 
+    /**
+     * Sets the current experience points (XP) for the character and optionally tracks the adjustment in total XP
+     * earnings if enabled.
+     *
+     * <p>This method updates the current XP to the specified value. If the campaign option for tracking total XP
+     * earnings is enabled, it also calculates and updates the total XP earnings based on the difference between the new
+     * and current XP values.</p>
+     *
+     * @param campaign the {@link Campaign} instance providing the campaign options
+     * @param xp       the new XP value to set
+     */
     public void setXP(final Campaign campaign, final int xp) {
         if (campaign.getCampaignOptions().isTrackTotalXPEarnings()) {
             changeTotalXPEarnings(xp - getXP());
@@ -1683,7 +1714,17 @@ public class Person {
         setXPDirect(xp);
     }
 
-    private void setXPDirect(final int xp) {
+    /**
+     * Directly sets the experience points (XP) for the entity without adjusting total XP earnings tracking.
+     *
+     * <p>This method updates the XP value directly, bypassing any optional campaign-related tracking logic.</p>
+     *
+     * <p><b>Usage:</b> Generally this should only be used in special circumstances, as it bypasses the tracking of
+     * experience point gains. For most use cases {@code #awardXP()} or {@code #setXP()} are preferred.</p>
+     *
+     * @param xp the new XP value to set
+     */
+    public void setXPDirect(final int xp) {
         this.xp = xp;
     }
 
@@ -2454,8 +2495,8 @@ public class Person {
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "person");
     }
 
-    public static Person generateInstanceFromXML(Node wn, Campaign c, Version version) {
-        Person retVal = new Person(c);
+    public static Person generateInstanceFromXML(Node wn, Campaign campaign, Version version) {
+        Person person = new Person(campaign);
 
         try {
             // Okay, now load Person-specific fields!
@@ -2469,153 +2510,153 @@ public class Person {
                 Node wn2 = nl.item(x);
 
                 if (wn2.getNodeName().equalsIgnoreCase("preNominal")) {
-                    retVal.setPreNominalDirect(wn2.getTextContent().trim());
+                    person.setPreNominalDirect(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("givenName")) {
-                    retVal.setGivenNameDirect(wn2.getTextContent().trim());
+                    person.setGivenNameDirect(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("surname")) {
-                    retVal.setSurnameDirect(wn2.getTextContent().trim());
+                    person.setSurnameDirect(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("postNominal")) {
-                    retVal.setPostNominalDirect(wn2.getTextContent().trim());
+                    person.setPostNominalDirect(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("maidenName")) {
-                    retVal.setMaidenName(wn2.getTextContent().trim());
+                    person.setMaidenName(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("callsign")) {
-                    retVal.setCallsignDirect(wn2.getTextContent().trim());
+                    person.setCallsignDirect(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("faction")) {
-                    retVal.setOriginFaction(Factions.getInstance().getFaction(wn2.getTextContent().trim()));
+                    person.setOriginFaction(Factions.getInstance().getFaction(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("planetId")) {
                     String systemId = "", planetId = "";
                     try {
                         systemId = wn2.getAttributes().getNamedItem("systemId").getTextContent().trim();
                         planetId = wn2.getTextContent().trim();
-                        PlanetarySystem ps = c.getSystemById(systemId);
+                        PlanetarySystem ps = campaign.getSystemById(systemId);
                         Planet p = null;
                         if (ps == null) {
-                            ps = c.getSystemByName(systemId);
+                            ps = campaign.getSystemByName(systemId);
                         }
                         if (ps != null) {
                             p = ps.getPlanetById(planetId);
                         }
-                        retVal.originPlanet = p;
+                        person.originPlanet = p;
                     } catch (NullPointerException e) {
                         logger.error("Error loading originPlanet for {}, {}", systemId, planetId, e);
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("becomingBondsmanEndDate")) {
-                    retVal.becomingBondsmanEndDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
+                    person.becomingBondsmanEndDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("phenotype")) {
-                    retVal.phenotype = Phenotype.parseFromString(wn2.getTextContent().trim());
+                    person.phenotype = Phenotype.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("bloodname")) {
-                    retVal.bloodname = wn2.getTextContent();
+                    person.bloodname = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("biography")) {
-                    retVal.biography = wn2.getTextContent();
+                    person.biography = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("primaryRole")) {
                     final PersonnelRole primaryRole = PersonnelRole.parseFromString(wn2.getTextContent().trim());
-                    retVal.setPrimaryRoleDirect(primaryRole);
+                    person.setPrimaryRoleDirect(primaryRole);
                 } else if (wn2.getNodeName().equalsIgnoreCase("secondaryRole")) {
-                    retVal.setSecondaryRoleDirect(PersonnelRole.parseFromString(wn2.getTextContent().trim()));
+                    person.setSecondaryRoleDirect(PersonnelRole.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("acquisitions")) {
-                    retVal.acquisitions = Integer.parseInt(wn2.getTextContent());
+                    person.acquisitions = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("primaryDesignator")) {
-                    retVal.primaryDesignator = ROMDesignation.parseFromString(wn2.getTextContent().trim());
+                    person.primaryDesignator = ROMDesignation.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("secondaryDesignator")) {
-                    retVal.secondaryDesignator = ROMDesignation.parseFromString(wn2.getTextContent().trim());
+                    person.secondaryDesignator = ROMDesignation.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("daysToWaitForHealing")) {
-                    retVal.daysToWaitForHealing = Integer.parseInt(wn2.getTextContent());
+                    person.daysToWaitForHealing = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("vocationalXPTimer")
                                  // <50.03 compatibility handler
                                  || wn2.getNodeName().equalsIgnoreCase("idleMonths")) {
-                    retVal.vocationalXPTimer = Integer.parseInt(wn2.getTextContent());
+                    person.vocationalXPTimer = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("id")) {
-                    retVal.id = UUID.fromString(wn2.getTextContent());
+                    person.id = UUID.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("genealogy")) {
-                    retVal.getGenealogy().fillFromXML(wn2.getChildNodes());
+                    person.getGenealogy().fillFromXML(wn2.getChildNodes());
                 } else if (wn2.getNodeName().equalsIgnoreCase("dueDate")) {
-                    retVal.dueDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
+                    person.dueDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("expectedDueDate")) {
-                    retVal.expectedDueDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
+                    person.expectedDueDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase(Portrait.XML_TAG)) {
-                    retVal.setPortrait(Portrait.parseFromXML(wn2));
+                    person.setPortrait(Portrait.parseFromXML(wn2));
                 } else if (wn2.getNodeName().equalsIgnoreCase("xp")) {
-                    retVal.setXPDirect(Integer.parseInt(wn2.getTextContent().trim()));
+                    person.setXPDirect(Integer.parseInt(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("totalXPEarnings")) {
-                    retVal.setTotalXPEarnings(Integer.parseInt(wn2.getTextContent().trim()));
+                    person.setTotalXPEarnings(Integer.parseInt(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("nTasks")) {
-                    retVal.nTasks = Integer.parseInt(wn2.getTextContent());
+                    person.nTasks = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("hits")) {
-                    retVal.hits = Integer.parseInt(wn2.getTextContent());
+                    person.hits = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("hitsPrior")) {
-                    retVal.hitsPrior = Integer.parseInt(wn2.getTextContent());
+                    person.hitsPrior = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("gender")) {
-                    retVal.setGender(Gender.parseFromString(wn2.getTextContent().trim()));
+                    person.setGender(Gender.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("rankSystem")) {
                     final RankSystem rankSystem = Ranks.getRankSystemFromCode(wn2.getTextContent().trim());
 
                     if (rankSystem != null) {
-                        retVal.setRankSystemDirect(rankSystem);
+                        person.setRankSystemDirect(rankSystem);
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("rank")) {
-                    retVal.setRank(Integer.parseInt(wn2.getTextContent().trim()));
+                    person.setRank(Integer.parseInt(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("rankLevel")) {
-                    retVal.setRankLevel(Integer.parseInt(wn2.getTextContent().trim()));
+                    person.setRankLevel(Integer.parseInt(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("maneiDominiClass")) {
-                    retVal.setManeiDominiClassDirect(ManeiDominiClass.parseFromString(wn2.getTextContent().trim()));
+                    person.setManeiDominiClassDirect(ManeiDominiClass.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("maneiDominiRank")) {
-                    retVal.setManeiDominiRankDirect(ManeiDominiRank.parseFromString(wn2.getTextContent().trim()));
+                    person.setManeiDominiRankDirect(ManeiDominiRank.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("doctorId")) {
                     if (!wn2.getTextContent().equals("null")) {
-                        retVal.doctorId = UUID.fromString(wn2.getTextContent());
+                        person.doctorId = UUID.fromString(wn2.getTextContent());
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("unitId")) {
                     if (!wn2.getTextContent().equals("null")) {
-                        retVal.unit = new PersonUnitRef(UUID.fromString(wn2.getTextContent()));
+                        person.unit = new PersonUnitRef(UUID.fromString(wn2.getTextContent()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("status")) {
-                    retVal.setStatus(PersonnelStatus.fromString(wn2.getTextContent().trim()));
+                    person.setStatus(PersonnelStatus.fromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("prisonerStatus")) {
-                    retVal.prisonerStatus = PrisonerStatus.parseFromString(wn2.getTextContent().trim());
+                    person.prisonerStatus = PrisonerStatus.parseFromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("salary")) {
-                    retVal.salary = Money.fromXmlString(wn2.getTextContent().trim());
+                    person.salary = Money.fromXmlString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("totalEarnings")) {
-                    retVal.totalEarnings = Money.fromXmlString(wn2.getTextContent().trim());
+                    person.totalEarnings = Money.fromXmlString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("minutesLeft")) {
-                    retVal.minutesLeft = Integer.parseInt(wn2.getTextContent());
+                    person.minutesLeft = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("overtimeLeft")) {
-                    retVal.overtimeLeft = Integer.parseInt(wn2.getTextContent());
+                    person.overtimeLeft = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("birthday")) {
-                    retVal.birthday = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
+                    person.birthday = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("deathday")) {
-                    retVal.dateOfDeath = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
+                    person.dateOfDeath = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("recruitment")) {
-                    retVal.recruitment = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
+                    person.recruitment = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("joinedCampaign")) {
-                    retVal.joinedCampaign = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
+                    person.joinedCampaign = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("lastRankChangeDate")) {
-                    retVal.lastRankChangeDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
+                    person.lastRankChangeDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("autoAwardSupportPoints")) {
-                    retVal.setAutoAwardSupportPoints(Integer.parseInt(wn2.getTextContent().trim()));
+                    person.setAutoAwardSupportPoints(Integer.parseInt(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("retirement")) {
-                    retVal.setRetirement(MHQXMLUtility.parseDate(wn2.getTextContent().trim()));
+                    person.setRetirement(MHQXMLUtility.parseDate(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("loyalty")) {
-                    retVal.loyalty = Integer.parseInt(wn2.getTextContent());
+                    person.loyalty = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("fatigue")) {
-                    retVal.fatigue = Integer.parseInt(wn2.getTextContent());
+                    person.fatigue = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("isRecoveringFromFatigue")) {
-                    retVal.isRecoveringFromFatigue = Boolean.parseBoolean(wn2.getTextContent().trim());
+                    person.isRecoveringFromFatigue = Boolean.parseBoolean(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("advantages")) {
                     advantages = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("edge")) {
                     edge = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("edgeAvailable")) {
-                    retVal.currentEdge = Integer.parseInt(wn2.getTextContent());
+                    person.currentEdge = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("implants")) {
                     implants = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("toughness")) {
-                    retVal.toughness = Integer.parseInt(wn2.getTextContent());
+                    person.toughness = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("pilotHits")) {
-                    retVal.hits = Integer.parseInt(wn2.getTextContent());
+                    person.hits = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("skill")) {
                     Skill s = Skill.generateInstanceFromXML(wn2);
                     if ((s != null) && (s.getType() != null)) {
-                        retVal.skills.addSkill(s.getType().getName(), s);
+                        person.skills.addSkill(s.getType().getName(), s);
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("techUnitIds")) {
                     NodeList nl2 = wn2.getChildNodes();
@@ -2630,7 +2671,7 @@ public class Person {
                             logger.error("Unknown node type not loaded in techUnitIds nodes: {}", wn3.getNodeName());
                             continue;
                         }
-                        retVal.addTechUnit(new PersonUnitRef(UUID.fromString(wn3.getTextContent())));
+                        person.addTechUnit(new PersonUnitRef(UUID.fromString(wn3.getTextContent())));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("personnelLog")) {
                     NodeList nl2 = wn2.getChildNodes();
@@ -2649,7 +2690,7 @@ public class Person {
 
                         final LogEntry logEntry = LogEntryFactory.getInstance().generateInstanceFromXML(wn3);
                         if (logEntry != null) {
-                            retVal.addLogEntry(logEntry);
+                            person.addLogEntry(logEntry);
                         }
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("scenarioLog")) {
@@ -2669,7 +2710,7 @@ public class Person {
 
                         final LogEntry logEntry = LogEntryFactory.getInstance().generateInstanceFromXML(wn3);
                         if (logEntry != null) {
-                            retVal.addScenarioLogEntry(logEntry);
+                            person.addScenarioLogEntry(logEntry);
                         }
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("awards")) {
@@ -2686,7 +2727,7 @@ public class Person {
                             continue;
                         }
 
-                        retVal.getAwardController()
+                        person.getAwardController()
                               .addAwardFromXml(AwardsFactory.getInstance().generateNewFromXML(wn3));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("injuries")) {
@@ -2702,24 +2743,24 @@ public class Person {
                             logger.error("Unknown node type not loaded in injury nodes: {}", wn3.getNodeName());
                             continue;
                         }
-                        retVal.injuries.add(Injury.generateInstanceFromXML(wn3));
+                        person.injuries.add(Injury.generateInstanceFromXML(wn3));
                     }
-                    LocalDate now = c.getLocalDate();
-                    retVal.injuries.stream()
+                    LocalDate now = campaign.getLocalDate();
+                    person.injuries.stream()
                           .filter(inj -> (null == inj.getStart()))
                           .forEach(inj -> inj.setStart(now.minusDays(inj.getOriginalTime() - inj.getTime())));
                 } else if (wn2.getNodeName().equalsIgnoreCase("originalUnitWeight")) {
-                    retVal.originalUnitWeight = Integer.parseInt(wn2.getTextContent());
+                    person.originalUnitWeight = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("originalUnitTech")) {
-                    retVal.originalUnitTech = Integer.parseInt(wn2.getTextContent());
+                    person.originalUnitTech = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("originalUnitId")) {
-                    retVal.originalUnitId = UUID.fromString(wn2.getTextContent());
+                    person.originalUnitId = UUID.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduHighestEducation")) {
-                    retVal.eduHighestEducation = EducationLevel.parseFromString(wn2.getTextContent());
+                    person.eduHighestEducation = EducationLevel.parseFromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduJourneyTime")) {
-                    retVal.eduJourneyTime = Integer.parseInt(wn2.getTextContent());
+                    person.eduJourneyTime = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduDaysOfTravel")) {
-                    retVal.eduDaysOfTravel = Integer.parseInt(wn2.getTextContent());
+                    person.eduDaysOfTravel = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduTagAlongs")) {
                     if (wn2.getNodeName().equalsIgnoreCase("eduTagAlongs")) {
                         NodeList uuidNodes = wn2.getChildNodes();
@@ -2732,7 +2773,7 @@ public class Person {
 
                                 UUID uuid = UUID.fromString(uuidString);
 
-                                retVal.eduTagAlongs.add(uuid);
+                                person.eduTagAlongs.add(uuid);
                             }
                         }
                     }
@@ -2744,72 +2785,72 @@ public class Person {
                             Node node = nodes.item(j);
 
                             if (node.getNodeName().equalsIgnoreCase("eduFailedApplication")) {
-                                retVal.eduFailedApplications.add(node.getTextContent());
+                                person.eduFailedApplications.add(node.getTextContent());
                             }
                         }
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduAcademySystem")) {
-                    retVal.eduAcademySystem = String.valueOf(wn2.getTextContent());
+                    person.eduAcademySystem = String.valueOf(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduAcademyName")) {
-                    retVal.eduAcademyName = String.valueOf(wn2.getTextContent());
+                    person.eduAcademyName = String.valueOf(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduAcademySet")) {
-                    retVal.eduAcademySet = String.valueOf(wn2.getTextContent());
+                    person.eduAcademySet = String.valueOf(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduAcademyNameInSet")) {
-                    retVal.eduAcademyNameInSet = String.valueOf(wn2.getTextContent());
+                    person.eduAcademyNameInSet = String.valueOf(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduAcademyFaction")) {
-                    retVal.eduAcademyFaction = String.valueOf(wn2.getTextContent());
+                    person.eduAcademyFaction = String.valueOf(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduCourseIndex")) {
-                    retVal.eduCourseIndex = Integer.parseInt(wn2.getTextContent());
+                    person.eduCourseIndex = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduEducationStage")) {
-                    retVal.eduEducationStage = EducationStage.parseFromString(wn2.getTextContent());
+                    person.eduEducationStage = EducationStage.parseFromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("eduEducationTime")) {
-                    retVal.eduEducationTime = Integer.parseInt(wn2.getTextContent());
+                    person.eduEducationTime = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("aggression")) {
-                    retVal.aggression = Aggression.fromString(wn2.getTextContent());
+                    person.aggression = Aggression.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("aggressionDescriptionIndex")) {
-                    retVal.aggressionDescriptionIndex = Integer.parseInt(wn2.getTextContent());
+                    person.aggressionDescriptionIndex = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("ambition")) {
-                    retVal.ambition = Ambition.fromString(wn2.getTextContent());
+                    person.ambition = Ambition.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("ambitionDescriptionIndex")) {
-                    retVal.ambitionDescriptionIndex = Integer.parseInt(wn2.getTextContent());
+                    person.ambitionDescriptionIndex = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("greed")) {
-                    retVal.greed = Greed.fromString(wn2.getTextContent());
+                    person.greed = Greed.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("greedDescriptionIndex")) {
-                    retVal.greedDescriptionIndex = Integer.parseInt(wn2.getTextContent());
+                    person.greedDescriptionIndex = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("social")) {
-                    retVal.social = Social.fromString(wn2.getTextContent());
+                    person.social = Social.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("socialDescriptionIndex")) {
-                    retVal.socialDescriptionIndex = Integer.parseInt(wn2.getTextContent());
+                    person.socialDescriptionIndex = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("personalityQuirk")) {
-                    retVal.personalityQuirk = PersonalityQuirk.fromString(wn2.getTextContent());
+                    person.personalityQuirk = PersonalityQuirk.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("personalityQuirkDescriptionIndex")) {
-                    retVal.personalityQuirkDescriptionIndex = Integer.parseInt(wn2.getTextContent());
+                    person.personalityQuirkDescriptionIndex = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("intelligence")) {
-                    retVal.intelligence = Intelligence.fromString(wn2.getTextContent());
+                    person.intelligence = Intelligence.fromString(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("intelligenceDescriptionIndex")) {
-                    retVal.intelligenceDescriptionIndex = Integer.parseInt(wn2.getTextContent());
+                    person.intelligenceDescriptionIndex = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("personalityDescription")) {
-                    retVal.personalityDescription = wn2.getTextContent();
+                    person.personalityDescription = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("clanPersonnel")) {
-                    retVal.setClanPersonnel(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                    person.setClanPersonnel(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("commander")) {
-                    retVal.setCommander(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                    person.setCommander(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("divorceable")) {
-                    retVal.setDivorceable(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                    person.setDivorceable(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("founder")) {
-                    retVal.setFounder(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                    person.setFounder(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("immortal")) {
-                    retVal.setImmortal(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                    person.setImmortal(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("marriageable")) {
-                    retVal.setMarriageable(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                    person.setMarriageable(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("tryingToConceive")) {
-                    retVal.setTryingToConceive(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                    person.setTryingToConceive(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("extraData")) {
-                    retVal.extraData = ExtraData.createFromXml(wn2);
+                    person.extraData = ExtraData.createFromXml(wn2);
                 }
             }
 
-            retVal.setFullName(); // this sets the name based on the loaded values
+            person.setFullName(); // this sets the name based on the loaded values
 
             if ((advantages != null) && !advantages.isBlank()) {
                 StringTokenizer st = new StringTokenizer(advantages, "::");
@@ -2819,7 +2860,7 @@ public class Person {
                     Object value = Crew.parseAdvantageValue(adv);
 
                     try {
-                        retVal.getOptions().getOption(advName).setValue(value);
+                        person.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
                         logger.warn("Error restoring advantage: {}", adv);
                     }
@@ -2832,8 +2873,8 @@ public class Person {
                 // list of options for that group
                 edgeOptionList.remove(0);
 
-                updateOptions(edge, retVal, edgeOptionList);
-                removeUnusedEdgeTriggers(retVal, edgeOptionList);
+                updateOptions(edge, person, edgeOptionList);
+                removeUnusedEdgeTriggers(person, edgeOptionList);
             }
 
             if ((implants != null) && !implants.isBlank()) {
@@ -2844,7 +2885,7 @@ public class Person {
                     Object value = Crew.parseAdvantageValue(adv);
 
                     try {
-                        retVal.getOptions().getOption(advName).setValue(value);
+                        person.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
                         logger.error("Error restoring implants: {}", adv);
                     }
@@ -2852,35 +2893,35 @@ public class Person {
             }
 
             // Fixing Prisoner Ranks - 0.47.X Fix
-            if (retVal.getRankNumeric() < 0) {
-                retVal.setRank(0);
+            if (person.getRankNumeric() < 0) {
+                person.setRank(0);
             }
 
             // Fixing recruitment dates
             // I don't know when this metric was added, so we check all versions
-            if (retVal.getRecruitment() == null) {
-                retVal.setRecruitment(c.getLocalDate());
+            if (person.getRecruitment() == null) {
+                person.setRecruitment(campaign.getLocalDate());
             }
 
             // This resolves a bug squashed in 2025 (50.03) but lurked in our codebase
             // potentially as far back as 2014. The next two handlers should never be removed.
-            if (!retVal.canPerformRole(c.getLocalDate(), retVal.getPrimaryRole(), true)) {
-                retVal.setPrimaryRole(c, PersonnelRole.NONE);
+            if (!person.canPerformRole(campaign.getLocalDate(), person.getPrimaryRole(), true)) {
+                person.setPrimaryRole(campaign, PersonnelRole.NONE);
                 logger.info("{} was found to be ineligible for their primary role. That role has been removed and " +
-                                  "they were assigned the NONE role.", retVal.getFullTitle());
+                                  "they were assigned the NONE role.", person.getFullTitle());
             }
 
-            if (!retVal.canPerformRole(c.getLocalDate(), retVal.getSecondaryRole(), false)) {
-                retVal.setSecondaryRole(PersonnelRole.NONE);
+            if (!person.canPerformRole(campaign.getLocalDate(), person.getSecondaryRole(), false)) {
+                person.setSecondaryRole(PersonnelRole.NONE);
                 logger.info("{} was found to be ineligible for their secondary role. That role has been removed and " +
-                                  "they were assigned the NONE role.", retVal.getFullTitle());
+                                  "they were assigned the NONE role.", person.getFullTitle());
             }
         } catch (Exception e) {
-            logger.error(e, "Failed to read person {} from file", retVal.getFullName());
-            retVal = null;
+            logger.error(e, "Failed to read person {} from file", person.getFullName());
+            person = null;
         }
 
-        return retVal;
+        return person;
     }
     // endregion File I/O
 

--- a/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.campaign.personnel;
+
+import static java.lang.Math.ceil;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.List;
+
+import mekhq.campaign.Campaign;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+
+/**
+ * The {@code SkillDeprecationTool} class checks and manages deprecated skills for a {@link Person}.
+ *
+ * <p>It identifies deprecated skills from the person's current skill set and allows the user to remove them while
+ * refunding the appropriate amount of XP. This process involves calculating XP refunds using the skill's cost and
+ * intelligence multiplier, and providing a dialog for managing the refund.
+ *
+ * <p>The class is initialized with a {@link Campaign} and a {@link Person}, and directly modifies the person's
+ * skills and XP as necessary.
+ *
+ * <p>Resources such as messages and button labels are loaded from a localized resource bundle.</p>
+ */
+public class SkillDeprecationTool {
+    private final String RESOURCE_BUNDLE = "mekhq.resources." + getClass().getSimpleName();
+
+    /**
+     * A list of deprecated skills.
+     *
+     * <p>These are skills that have been scheduled for removal.</p>
+     *
+     * <p>Once the skill is removed from this list, players will no longer be able to benefit from skill refund.
+     * This list should be updated following each Milestone release. If there are no skills in the list an empty array
+     * MUST be left; otherwise we will run into NPEs during campaign loading.</p>
+     */
+    public static final List<SkillType> DEPRECATED_SKILLS = List.of(SkillType.getType(SkillType.S_SCROUNGE));
+
+    private final Campaign campaign;
+    private final Person person;
+
+    /**
+     * Constructs a new {@code SkillDeprecationTool} for the specified campaign and person.
+     *
+     * <p>Upon initialization, this constructor immediately checks the person's skills for any deprecated skills and
+     * handles them if necessary.
+     *
+     * @param campaign the {@link Campaign} instance that provides context for the operation
+     * @param person   the {@link Person} whose skills will be checked for deprecation
+     */
+    public SkillDeprecationTool(Campaign campaign, Person person) {
+        this.campaign = campaign;
+        this.person = person;
+
+        checkForDeprecatedSkills(person);
+    }
+
+    /**
+     * Checks the specified person's skills for any deprecated skills.
+     *
+     * <p>If a deprecated skill is found, calculates the XP refund based on the skill's level and the person's
+     * intelligence multiplier. It then triggers a dialog to allow the user to refund or retain the skill.
+     *
+     * @param person the {@link Person} to check for deprecated skills
+     */
+    private void checkForDeprecatedSkills(Person person) {
+        final Skills skills = person.getSkills();
+
+        for (SkillType skillType : DEPRECATED_SKILLS) {
+            final String skillName = skillType.getName();
+            if (skills.hasSkill(skillName)) {
+                int refundValue = getRefundValue(skills, skillType, skillName);
+                double intelligenceMultiplier = person.getIntelligenceXpCostMultiplier(campaign.getCampaignOptions());
+                refundValue = (int) ceil(refundValue * intelligenceMultiplier);
+
+                triggerDialog(skills, skillName, refundValue);
+            }
+        }
+    }
+
+    /**
+     * Calculates the total XP refund value for a deprecated skill by summing the XP required to reach the current level
+     * of the skill.
+     *
+     * @param skills    the {@link Skills} object containing details about the person's skills
+     * @param skillType the {@link SkillType} of the deprecated skill
+     * @param skillName the name of the deprecated skill
+     *
+     * @return the total XP refund value for the deprecated skill
+     */
+    public int getRefundValue(Skills skills, SkillType skillType, String skillName) {
+        Skill skill = skills.getSkill(skillName);
+        int level = skill.getLevel();
+
+        // Sum the XP cost to reach the current level
+        int totalCost = 0;
+        for (int i = 1; i <= level; i++) {
+            totalCost += skillType.getCost(i);
+        }
+
+        return totalCost;
+    }
+
+    /**
+     * Triggers a dialog to inform the user of a deprecated skill and provides options to either refund the skill or
+     * retain it.
+     *
+     * <p>If the user chooses to refund the skill, it will be removed from the person's skill set, and the XP refund
+     * will be added directly to the person's current XP.
+     *
+     * @param skills      the {@link Skills} object associated with the person
+     * @param skillName   the name of the deprecated skill
+     * @param refundValue the XP refund value for the skill
+     */
+    private void triggerDialog(final Skills skills, final String skillName, final int refundValue) {
+        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
+              person,
+              null,
+              getInCharacterMessage(skillName),
+              getButtonLabels(),
+              getOutOfCharacterMessage(skillName, refundValue),
+              false);
+
+        final int REFUND_DIALOG_OPTION_INDEX = 1;
+        if (dialog.getDialogChoice() == REFUND_DIALOG_OPTION_INDEX) {
+            skills.removeSkill(skillName);
+            int currentXp = person.getXP();
+            // We use 'setXPDirect' here as the xp gain has already been factored into the tracking of xp gain, so we
+            // don't want to double-dip.
+            person.setXPDirect(currentXp + refundValue);
+        }
+    }
+
+    /**
+     * Retrieves the in-character message for the deprecated skill dialog.
+     *
+     * <p>The message is formatted using the localized resource bundle and includes skill-specific context, such as
+     * the commander address.
+     *
+     * @param skillName the name of the deprecated skill
+     *
+     * @return the formatted in-character message
+     */
+    private String getInCharacterMessage(String skillName) {
+        return getFormattedTextAt(RESOURCE_BUNDLE, "message.ic", campaign.getCommanderAddress(false), skillName);
+    }
+
+    /**
+     * Retrieves the button labels for the deprecated skill dialog.
+     *
+     * <p>These labels are localized and include options such as "Continue" and "Refund".
+     *
+     * @return a {@link List} of button label strings
+     */
+    private List<String> getButtonLabels() {
+        return List.of(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"),
+              getFormattedTextAt(RESOURCE_BUNDLE, "button.refund"));
+    }
+
+    /**
+     * Retrieves the out-of-character message for the deprecated skill dialog.
+     *
+     * <p>The message is formatted using the localized resource bundle and includes context about the skill being
+     * refunded, the person's name, and the refund value.
+     *
+     * @param skillName   the name of the deprecated skill
+     * @param refundValue the XP refund value for the skill
+     *
+     * @return the formatted out-of-character message
+     */
+    private String getOutOfCharacterMessage(String skillName, int refundValue) {
+        return getFormattedTextAt(RESOURCE_BUNDLE, "message.ooc", skillName, person.getFullTitle(), refundValue);
+    }
+}

--- a/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
@@ -58,6 +58,8 @@ public class SkillDeprecationTool {
      * <p>Once the skill is removed from this list, players will no longer be able to benefit from skill refund.
      * This list should be updated following each Milestone release. If there are no skills in the list an empty array
      * MUST be left; otherwise we will run into NPEs during campaign loading.</p>
+     *
+     * <p><b>Last Updated:</b> 50.05</p>
      */
     public static final List<SkillType> DEPRECATED_SKILLS = List.of(SkillType.getType(SkillType.S_SCROUNGE));
 

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -27,6 +27,15 @@
  */
 package mekhq.gui.enums;
 
+import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffectiveFatigue;
+
+import java.util.Comparator;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+import javax.swing.JTable;
+import javax.swing.SortOrder;
+import javax.swing.SwingConstants;
+
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.Entity;
@@ -43,18 +52,20 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.GenderDescriptors;
-import mekhq.campaign.randomEvents.personalities.enums.*;
+import mekhq.campaign.randomEvents.personalities.enums.Aggression;
+import mekhq.campaign.randomEvents.personalities.enums.Ambition;
+import mekhq.campaign.randomEvents.personalities.enums.Greed;
+import mekhq.campaign.randomEvents.personalities.enums.Intelligence;
+import mekhq.campaign.randomEvents.personalities.enums.Social;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Planet;
-import mekhq.gui.sorter.*;
+import mekhq.gui.sorter.BonusSorter;
+import mekhq.gui.sorter.DateStringComparator;
+import mekhq.gui.sorter.FormattedNumberSorter;
+import mekhq.gui.sorter.IntegerStringSorter;
+import mekhq.gui.sorter.LevelSorter;
+import mekhq.gui.sorter.PersonRankStringSorter;
 import mekhq.utilities.ReportingUtilities;
-
-import javax.swing.*;
-import java.util.Comparator;
-import java.util.ResourceBundle;
-import java.util.stream.Collectors;
-
-import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffectiveFatigue;
 
 public enum PersonnelTableModelColumn {
     // region Enum Declarations
@@ -98,7 +109,7 @@ public enum PersonnelTableModelColumn {
     MEDICAL("PersonnelTableModelColumn.MEDICAL.text"),
     ADMINISTRATION("PersonnelTableModelColumn.ADMINISTRATION.text"),
     NEGOTIATION("PersonnelTableModelColumn.NEGOTIATION.text"),
-    SCROUNGE("PersonnelTableModelColumn.SCROUNGE.text"),
+    @Deprecated(since = "0.50.05", forRemoval = true) SCROUNGE("PersonnelTableModelColumn.SCROUNGE.text"),
     INJURIES("PersonnelTableModelColumn.INJURIES.text"),
     KILLS("PersonnelTableModelColumn.KILLS.text"),
     SALARY("PersonnelTableModelColumn.SALARY.text"),
@@ -137,7 +148,7 @@ public enum PersonnelTableModelColumn {
     private final String name;
 
     private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale());
+          MekHQ.getMHQOptions().getLocale());
     // endregion Variable Declarations
 
     // region Constructors
@@ -441,9 +452,7 @@ public enum PersonnelTableModelColumn {
     }
     // endregion Boolean Comparison Methods
 
-    public String getCellValue(final Campaign campaign, final PersonnelMarket personnelMarket,
-            final Person person, final boolean loadAssignmentFromMarket,
-            final boolean groupByUnit) {
+    public String getCellValue(final Campaign campaign, final PersonnelMarket personnelMarket, final Person person, final boolean loadAssignmentFromMarket, final boolean groupByUnit) {
         String sign;
 
         switch (this) {
@@ -483,9 +492,12 @@ public enum PersonnelTableModelColumn {
                         return surname;
                     }
 
-                    return surname + " (+" + crewSize + resources.getString(unit.usesSoldiers()
-                            ? "PersonnelTableModelColumn.SURNAME.Soldiers.text"
-                            : "PersonnelTableModelColumn.SURNAME.Crew.text");
+                    return surname +
+                                 " (+" +
+                                 crewSize +
+                                 resources.getString(unit.usesSoldiers() ?
+                                                           "PersonnelTableModelColumn.SURNAME.Soldiers.text" :
+                                                           "PersonnelTableModelColumn.SURNAME.Crew.text");
                 }
             }
             case BLOODNAME:
@@ -503,8 +515,9 @@ public enum PersonnelTableModelColumn {
             case GENDER:
                 return GenderDescriptors.MALE_FEMALE_OTHER.getDescriptorCapitalized(person.getGender());
             case SKILL_LEVEL:
-                return "<html>" + SkillType.getColoredExperienceLevelName(
-                    person.getSkillLevel(campaign, false)) + "</html>";
+                return "<html>" +
+                             SkillType.getColoredExperienceLevelName(person.getSkillLevel(campaign, false)) +
+                             "</html>";
             case PERSONNEL_ROLE:
                 return person.getRoleDesc();
             case UNIT_ASSIGNMENT: {
@@ -521,8 +534,7 @@ public enum PersonnelTableModelColumn {
                             } else {
                                 name = name + " [Gunner]";
                             }
-                        } else if ((unit.getEntity() instanceof SmallCraft)
-                                || (unit.getEntity() instanceof Jumpship)) {
+                        } else if ((unit.getEntity() instanceof SmallCraft) || (unit.getEntity() instanceof Jumpship)) {
                             if (unit.isNavigator(person)) {
                                 name = name + " [Navigator]";
                             } else if (unit.isDriver(person)) {
@@ -539,21 +551,30 @@ public enum PersonnelTableModelColumn {
 
                     // Check for tech units
                     if (!person.getTechUnits().isEmpty()) {
-                        Unit refitUnit = person.getTechUnits().stream()
-                            .filter(u -> u.isRefitting() && u.getRefit().getTech() == person)
-                            .findFirst().orElse(null);
-                        String refitString = null != refitUnit ?
-                                "<b>Refitting</b> " + refitUnit.getName() : "";
+                        Unit refitUnit = person.getTechUnits()
+                                               .stream()
+                                               .filter(u -> u.isRefitting() && u.getRefit().getTech() == person)
+                                               .findFirst()
+                                               .orElse(null);
+                        String refitString = null != refitUnit ? "<b>Refitting</b> " + refitUnit.getName() : "";
                         if (person.getTechUnits().size() == 1) {
                             unit = person.getTechUnits().get(0);
                             if (unit != null) {
-                                return "<html>" + ReportingUtilities.separateIf(refitString, ", ",
-                                        unit.getName() + " (" + person.getMaintenanceTimeUsing() + "m)") + "</html>";
+                                return "<html>" +
+                                             ReportingUtilities.separateIf(refitString,
+                                                   ", ",
+                                                   unit.getName() + " (" + person.getMaintenanceTimeUsing() + "m)") +
+                                             "</html>";
                             }
                         } else {
-                            return "<html>" + ReportingUtilities.separateIf(refitString, ", ",
-                                    person.getTechUnits().size() + " units (" + person.getMaintenanceTimeUsing() + "m)")
-                                    + "</html>";
+                            return "<html>" +
+                                         ReportingUtilities.separateIf(refitString,
+                                               ", ",
+                                               person.getTechUnits().size() +
+                                                     " units (" +
+                                                     person.getMaintenanceTimeUsing() +
+                                                     "m)") +
+                                         "</html>";
                         }
                     }
                 }
@@ -566,128 +587,129 @@ public enum PersonnelTableModelColumn {
                 return (force == null) ? "-" : force.getName();
             case DEPLOYED:
                 final Unit unit = person.getUnit();
-                return ((unit == null) || !unit.isDeployed()) ? "-"
-                        : campaign.getScenario(unit.getScenarioId()).getName();
+                return ((unit == null) || !unit.isDeployed()) ?
+                             "-" :
+                             campaign.getScenario(unit.getScenarioId()).getName();
             case MEK:
-                return (person.hasSkill(SkillType.S_GUN_MEK)
-                        ? Integer.toString(person.getSkill(SkillType.S_GUN_MEK).getFinalSkillValue())
-                        : "-")
-                        + '/'
-                        + (person.hasSkill(SkillType.S_PILOT_MEK)
-                                ? Integer.toString(person.getSkill(SkillType.S_PILOT_MEK).getFinalSkillValue())
-                                : "-");
+                return (person.hasSkill(SkillType.S_GUN_MEK) ?
+                              Integer.toString(person.getSkill(SkillType.S_GUN_MEK).getFinalSkillValue()) :
+                              "-") +
+                             '/' +
+                             (person.hasSkill(SkillType.S_PILOT_MEK) ?
+                                    Integer.toString(person.getSkill(SkillType.S_PILOT_MEK).getFinalSkillValue()) :
+                                    "-");
             case GROUND_VEHICLE:
-                return (person.hasSkill(SkillType.S_GUN_VEE)
-                        ? Integer.toString(person.getSkill(SkillType.S_GUN_VEE).getFinalSkillValue())
-                        : "-")
-                        + '/'
-                        + (person.hasSkill(SkillType.S_PILOT_GVEE)
-                                ? Integer.toString(person.getSkill(SkillType.S_PILOT_GVEE).getFinalSkillValue())
-                                : "-");
+                return (person.hasSkill(SkillType.S_GUN_VEE) ?
+                              Integer.toString(person.getSkill(SkillType.S_GUN_VEE).getFinalSkillValue()) :
+                              "-") +
+                             '/' +
+                             (person.hasSkill(SkillType.S_PILOT_GVEE) ?
+                                    Integer.toString(person.getSkill(SkillType.S_PILOT_GVEE).getFinalSkillValue()) :
+                                    "-");
             case NAVAL_VEHICLE:
-                return (person.hasSkill(SkillType.S_GUN_VEE)
-                        ? Integer.toString(person.getSkill(SkillType.S_GUN_VEE).getFinalSkillValue())
-                        : "-")
-                        + '/'
-                        + (person.hasSkill(SkillType.S_PILOT_NVEE)
-                                ? Integer.toString(person.getSkill(SkillType.S_PILOT_NVEE).getFinalSkillValue())
-                                : "-");
+                return (person.hasSkill(SkillType.S_GUN_VEE) ?
+                              Integer.toString(person.getSkill(SkillType.S_GUN_VEE).getFinalSkillValue()) :
+                              "-") +
+                             '/' +
+                             (person.hasSkill(SkillType.S_PILOT_NVEE) ?
+                                    Integer.toString(person.getSkill(SkillType.S_PILOT_NVEE).getFinalSkillValue()) :
+                                    "-");
             case VTOL:
-                return (person.hasSkill(SkillType.S_GUN_VEE)
-                        ? Integer.toString(person.getSkill(SkillType.S_GUN_VEE).getFinalSkillValue())
-                        : "-")
-                        + '/'
-                        + (person.hasSkill(SkillType.S_PILOT_VTOL)
-                                ? Integer.toString(person.getSkill(SkillType.S_PILOT_VTOL).getFinalSkillValue())
-                                : "-");
+                return (person.hasSkill(SkillType.S_GUN_VEE) ?
+                              Integer.toString(person.getSkill(SkillType.S_GUN_VEE).getFinalSkillValue()) :
+                              "-") +
+                             '/' +
+                             (person.hasSkill(SkillType.S_PILOT_VTOL) ?
+                                    Integer.toString(person.getSkill(SkillType.S_PILOT_VTOL).getFinalSkillValue()) :
+                                    "-");
             case AEROSPACE:
-                return (person.hasSkill(SkillType.S_GUN_AERO)
-                        ? Integer.toString(person.getSkill(SkillType.S_GUN_AERO).getFinalSkillValue())
-                        : "-")
-                        + '/'
-                        + (person.hasSkill(SkillType.S_PILOT_AERO)
-                                ? Integer.toString(person.getSkill(SkillType.S_PILOT_AERO).getFinalSkillValue())
-                                : "-");
+                return (person.hasSkill(SkillType.S_GUN_AERO) ?
+                              Integer.toString(person.getSkill(SkillType.S_GUN_AERO).getFinalSkillValue()) :
+                              "-") +
+                             '/' +
+                             (person.hasSkill(SkillType.S_PILOT_AERO) ?
+                                    Integer.toString(person.getSkill(SkillType.S_PILOT_AERO).getFinalSkillValue()) :
+                                    "-");
             case CONVENTIONAL_AIRCRAFT:
-                return (person.hasSkill(SkillType.S_GUN_JET)
-                        ? Integer.toString(person.getSkill(SkillType.S_GUN_JET).getFinalSkillValue())
-                        : "-")
-                        + '/'
-                        + (person.hasSkill(SkillType.S_PILOT_JET)
-                                ? Integer.toString(person.getSkill(SkillType.S_PILOT_JET).getFinalSkillValue())
-                                : "-");
+                return (person.hasSkill(SkillType.S_GUN_JET) ?
+                              Integer.toString(person.getSkill(SkillType.S_GUN_JET).getFinalSkillValue()) :
+                              "-") +
+                             '/' +
+                             (person.hasSkill(SkillType.S_PILOT_JET) ?
+                                    Integer.toString(person.getSkill(SkillType.S_PILOT_JET).getFinalSkillValue()) :
+                                    "-");
             case VESSEL:
-                return (person.hasSkill(SkillType.S_GUN_SPACE)
-                        ? Integer.toString(person.getSkill(SkillType.S_GUN_SPACE).getFinalSkillValue())
-                        : "-")
-                        + '/'
-                        + (person.hasSkill(SkillType.S_PILOT_SPACE)
-                                ? Integer.toString(person.getSkill(SkillType.S_PILOT_SPACE).getFinalSkillValue())
-                                : "-");
+                return (person.hasSkill(SkillType.S_GUN_SPACE) ?
+                              Integer.toString(person.getSkill(SkillType.S_GUN_SPACE).getFinalSkillValue()) :
+                              "-") +
+                             '/' +
+                             (person.hasSkill(SkillType.S_PILOT_SPACE) ?
+                                    Integer.toString(person.getSkill(SkillType.S_PILOT_SPACE).getFinalSkillValue()) :
+                                    "-");
             case BATTLE_ARMOUR:
-                return person.hasSkill(SkillType.S_GUN_BA)
-                        ? Integer.toString(person.getSkill(SkillType.S_GUN_BA).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_GUN_BA) ?
+                             Integer.toString(person.getSkill(SkillType.S_GUN_BA).getFinalSkillValue()) :
+                             "-";
             case ANTI_MEK:
-                return person.hasSkill(SkillType.S_ANTI_MEK)
-                        ? Integer.toString(person.getSkill(SkillType.S_ANTI_MEK).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_ANTI_MEK) ?
+                             Integer.toString(person.getSkill(SkillType.S_ANTI_MEK).getFinalSkillValue()) :
+                             "-";
             case SMALL_ARMS:
-                return person.hasSkill(SkillType.S_SMALL_ARMS)
-                        ? Integer.toString(person.getSkill(SkillType.S_SMALL_ARMS).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_SMALL_ARMS) ?
+                             Integer.toString(person.getSkill(SkillType.S_SMALL_ARMS).getFinalSkillValue()) :
+                             "-";
             case ARTILLERY:
-                return person.hasSkill(SkillType.S_ARTILLERY)
-                        ? Integer.toString(person.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_ARTILLERY) ?
+                             Integer.toString(person.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue()) :
+                             "-";
             case TACTICS:
-                return person.hasSkill(SkillType.S_TACTICS)
-                        ? Integer.toString(person.getSkill(SkillType.S_TACTICS).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_TACTICS) ?
+                             Integer.toString(person.getSkill(SkillType.S_TACTICS).getFinalSkillValue()) :
+                             "-";
             case STRATEGY:
-                return person.hasSkill(SkillType.S_STRATEGY)
-                        ? Integer.toString(person.getSkill(SkillType.S_STRATEGY).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_STRATEGY) ?
+                             Integer.toString(person.getSkill(SkillType.S_STRATEGY).getFinalSkillValue()) :
+                             "-";
             case LEADERSHIP:
-                return person.hasSkill(SkillType.S_LEADER)
-                        ? Integer.toString(person.getSkill(SkillType.S_LEADER).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_LEADER) ?
+                             Integer.toString(person.getSkill(SkillType.S_LEADER).getFinalSkillValue()) :
+                             "-";
             case TECH_MEK:
-                return person.hasSkill(SkillType.S_TECH_MEK)
-                        ? Integer.toString(person.getSkill(SkillType.S_TECH_MEK).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_TECH_MEK) ?
+                             Integer.toString(person.getSkill(SkillType.S_TECH_MEK).getFinalSkillValue()) :
+                             "-";
             case TECH_AERO:
-                return person.hasSkill(SkillType.S_TECH_AERO)
-                        ? Integer.toString(person.getSkill(SkillType.S_TECH_AERO).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_TECH_AERO) ?
+                             Integer.toString(person.getSkill(SkillType.S_TECH_AERO).getFinalSkillValue()) :
+                             "-";
             case TECH_MECHANIC:
-                return person.hasSkill(SkillType.S_TECH_MECHANIC)
-                        ? Integer.toString(person.getSkill(SkillType.S_TECH_MECHANIC).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_TECH_MECHANIC) ?
+                             Integer.toString(person.getSkill(SkillType.S_TECH_MECHANIC).getFinalSkillValue()) :
+                             "-";
             case TECH_BA:
-                return person.hasSkill(SkillType.S_TECH_BA)
-                        ? Integer.toString(person.getSkill(SkillType.S_TECH_BA).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_TECH_BA) ?
+                             Integer.toString(person.getSkill(SkillType.S_TECH_BA).getFinalSkillValue()) :
+                             "-";
             case TECH_VESSEL:
-                return person.hasSkill(SkillType.S_TECH_VESSEL)
-                        ? Integer.toString(person.getSkill(SkillType.S_TECH_VESSEL).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_TECH_VESSEL) ?
+                             Integer.toString(person.getSkill(SkillType.S_TECH_VESSEL).getFinalSkillValue()) :
+                             "-";
             case MEDICAL:
-                return person.hasSkill(SkillType.S_DOCTOR)
-                        ? Integer.toString(person.getSkill(SkillType.S_DOCTOR).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_DOCTOR) ?
+                             Integer.toString(person.getSkill(SkillType.S_DOCTOR).getFinalSkillValue()) :
+                             "-";
             case ADMINISTRATION:
-                return person.hasSkill(SkillType.S_ADMIN)
-                        ? Integer.toString(person.getSkill(SkillType.S_ADMIN).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_ADMIN) ?
+                             Integer.toString(person.getSkill(SkillType.S_ADMIN).getFinalSkillValue()) :
+                             "-";
             case NEGOTIATION:
-                return person.hasSkill(SkillType.S_NEG)
-                        ? Integer.toString(person.getSkill(SkillType.S_NEG).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_NEG) ?
+                             Integer.toString(person.getSkill(SkillType.S_NEG).getFinalSkillValue()) :
+                             "-";
             case SCROUNGE:
-                return person.hasSkill(SkillType.S_SCROUNGE)
-                        ? Integer.toString(person.getSkill(SkillType.S_SCROUNGE).getFinalSkillValue())
-                        : "-";
+                return person.hasSkill(SkillType.S_SCROUNGE) ?
+                             Integer.toString(person.getSkill(SkillType.S_SCROUNGE).getFinalSkillValue()) :
+                             "-";
             case INJURIES:
                 if (campaign.getCampaignOptions().isUseAdvancedMedical()) {
                     return Integer.toString(person.getInjuries().size());
@@ -722,24 +744,28 @@ public enum PersonnelTableModelColumn {
             case CLAN_PERSONNEL:
                 return resources.getString(person.isClanPersonnel() ? "Yes.text" : "No.text");
             case MARRIAGEABLE:
-                return resources.getString(person.getGenealogy().hasSpouse() ? "NA.text"
-                        : (person.isMarriageable() ? "Yes.text" : "No.text"));
+                return resources.getString(person.getGenealogy().hasSpouse() ?
+                                                 "NA.text" :
+                                                 (person.isMarriageable() ? "Yes.text" : "No.text"));
             case DIVORCEABLE:
-                return resources
-                        .getString(person.getGenealogy().hasSpouse() ? (person.isDivorceable() ? "Yes.text" : "No.text")
-                                : "NA.text");
+                return resources.getString(person.getGenealogy().hasSpouse() ?
+                                                 (person.isDivorceable() ? "Yes.text" : "No.text") :
+                                                 "NA.text");
             case TRYING_TO_CONCEIVE:
-                return resources.getString(
-                        person.getGender().isFemale() ? (person.isTryingToConceive() ? "Yes.text" : "No.text")
-                                : "NA.text");
+                return resources.getString(person.getGender().isFemale() ?
+                                                 (person.isTryingToConceive() ? "Yes.text" : "No.text") :
+                                                 "NA.text");
             case IMMORTAL:
-                return resources.getString(
-                        person.getStatus().isDead() ? "NA.text" : (person.isImmortal() ? "Yes.text" : "No.text"));
+                return resources.getString(person.getStatus().isDead() ?
+                                                 "NA.text" :
+                                                 (person.isImmortal() ? "Yes.text" : "No.text"));
             case TOUGHNESS:
                 return Integer.toString(person.getToughness());
             case FATIGUE:
-                return Integer.toString(getEffectiveFatigue(person.getFatigue(), person.isClanPersonnel(),
-                      person.getSkillLevel(campaign, false), campaign.getFieldKitchenWithinCapacity()));
+                return Integer.toString(getEffectiveFatigue(person.getFatigue(),
+                      person.isClanPersonnel(),
+                      person.getSkillLevel(campaign, false),
+                      campaign.getFieldKitchenWithinCapacity()));
             case EDGE:
                 return Integer.toString(person.getEdge());
             case SPA_COUNT:
@@ -759,7 +785,7 @@ public enum PersonnelTableModelColumn {
                 Ambition ambition = person.getAmbition();
                 sign = ambition.isTraitPositive() ? "+" : "-";
 
-                return  ambition + " (" + (ambition.isTraitMajor() ? sign + sign : sign) + ')';
+                return ambition + " (" + (ambition.isTraitMajor() ? sign + sign : sign) + ')';
             case GREED:
                 Greed greed = person.getGreed();
                 sign = greed.isTraitPositive() ? "+" : "-";
@@ -786,16 +812,16 @@ public enum PersonnelTableModelColumn {
         return null;
     }
 
-    public @Nullable String getToolTipText(final Person person,
-            final boolean loadAssignmentFromMarket) {
+    public @Nullable String getToolTipText(final Person person, final boolean loadAssignmentFromMarket) {
         switch (this) {
             case PERSONNEL_STATUS:
                 return person.getStatus().getToolTipText();
             case UNIT_ASSIGNMENT: {
                 if ((person.getTechUnits().size() > 1) && !loadAssignmentFromMarket) {
-                    return person.getTechUnits().stream()
-                            .map(u1 -> u1.getName() + "<br>")
-                            .collect(Collectors.joining("", "<html>", "</html>"));
+                    return person.getTechUnits()
+                                 .stream()
+                                 .map(u1 -> u1.getName() + "<br>")
+                                 .collect(Collectors.joining("", "<html>", "</html>"));
                 } else {
                     return null;
                 }
@@ -821,17 +847,28 @@ public enum PersonnelTableModelColumn {
 
     public int getAlignment() {
         return switch (this) {
-            case PERSON, RANK, FIRST_NAME, LAST_NAME, PRE_NOMINAL, GIVEN_NAME, SURNAME, BLOODNAME, POST_NOMINAL,
-                    CALLSIGN, GENDER,
-                    SKILL_LEVEL, PERSONNEL_ROLE, UNIT_ASSIGNMENT, FORCE, DEPLOYED ->
-                SwingConstants.LEFT;
+            case PERSON,
+                 RANK,
+                 FIRST_NAME,
+                 LAST_NAME,
+                 PRE_NOMINAL,
+                 GIVEN_NAME,
+                 SURNAME,
+                 BLOODNAME,
+                 POST_NOMINAL,
+                 CALLSIGN,
+                 GENDER,
+                 SKILL_LEVEL,
+                 PERSONNEL_ROLE,
+                 UNIT_ASSIGNMENT,
+                 FORCE,
+                 DEPLOYED -> SwingConstants.LEFT;
             case SALARY -> SwingConstants.RIGHT;
             default -> SwingConstants.CENTER;
         };
     }
 
-    public boolean isVisible(final Campaign campaign, final PersonnelTabView view,
-            final JTable table) {
+    public boolean isVisible(final Campaign campaign, final PersonnelTabView view, final JTable table) {
         return switch (view) {
             case GRAPHIC -> {
                 table.setRowHeight(UIUtil.scaleForGUI(60));
@@ -841,16 +878,32 @@ public enum PersonnelTableModelColumn {
                 };
             }
             case GENERAL -> switch (this) {
-                case RANK, FIRST_NAME, LAST_NAME, SKILL_LEVEL, PERSONNEL_ROLE, UNIT_ASSIGNMENT, FORCE, DEPLOYED,
-                        INJURIES, XP ->
-                    true;
+                case RANK,
+                     FIRST_NAME,
+                     LAST_NAME,
+                     SKILL_LEVEL,
+                     PERSONNEL_ROLE,
+                     UNIT_ASSIGNMENT,
+                     FORCE,
+                     DEPLOYED,
+                     INJURIES,
+                     XP -> true;
                 case SALARY -> campaign.getCampaignOptions().isPayForSalaries();
                 default -> false;
             };
             case PILOT_GUNNERY_SKILLS -> switch (this) {
-                case RANK, FIRST_NAME, LAST_NAME, PERSONNEL_ROLE, MEK, GROUND_VEHICLE, NAVAL_VEHICLE, VTOL, AEROSPACE,
-                        CONVENTIONAL_AIRCRAFT, VESSEL, ARTILLERY ->
-                    true;
+                case RANK,
+                     FIRST_NAME,
+                     LAST_NAME,
+                     PERSONNEL_ROLE,
+                     MEK,
+                     GROUND_VEHICLE,
+                     NAVAL_VEHICLE,
+                     VTOL,
+                     AEROSPACE,
+                     CONVENTIONAL_AIRCRAFT,
+                     VESSEL,
+                     ARTILLERY -> true;
                 default -> false;
             };
             case INFANTRY_SKILLS -> switch (this) {
@@ -862,9 +915,16 @@ public enum PersonnelTableModelColumn {
                 default -> false;
             };
             case TECHNICAL_SKILLS -> switch (this) {
-                case RANK, FIRST_NAME, LAST_NAME, PERSONNEL_ROLE, TECH_MEK, TECH_AERO, TECH_MECHANIC, TECH_BA,
-                        TECH_VESSEL, MEDICAL ->
-                    true;
+                case RANK,
+                     FIRST_NAME,
+                     LAST_NAME,
+                     PERSONNEL_ROLE,
+                     TECH_MEK,
+                     TECH_AERO,
+                     TECH_MECHANIC,
+                     TECH_BA,
+                     TECH_VESSEL,
+                     MEDICAL -> true;
                 default -> false;
             };
             case ADMINISTRATIVE_SKILLS -> switch (this) {
@@ -877,31 +937,43 @@ public enum PersonnelTableModelColumn {
                 default -> false;
             };
             case FLUFF -> switch (this) {
-                case RANK, PRE_NOMINAL, GIVEN_NAME, SURNAME, BLOODNAME, POST_NOMINAL, CALLSIGN, GENDER, PERSONNEL_ROLE,
-                        KILLS ->
-                    true;
+                case RANK,
+                     PRE_NOMINAL,
+                     GIVEN_NAME,
+                     SURNAME,
+                     BLOODNAME,
+                     POST_NOMINAL,
+                     CALLSIGN,
+                     GENDER,
+                     PERSONNEL_ROLE,
+                     KILLS -> true;
                 default -> false;
             };
             case DATES -> switch (this) {
                 case RANK, FIRST_NAME, LAST_NAME, BIRTHDAY, DEATH_DATE, RETIREMENT_DATE -> true;
                 case RECRUITMENT_DATE -> campaign.getCampaignOptions().isUseTimeInService();
                 case LAST_RANK_CHANGE_DATE -> campaign.getCampaignOptions().isUseTimeInRank();
-                case DUE_DATE ->
-                    campaign.getCampaignOptions().isUseManualProcreation()
-                            || !campaign.getCampaignOptions().getRandomProcreationMethod().isNone();
+                case DUE_DATE -> campaign.getCampaignOptions().isUseManualProcreation() ||
+                                       !campaign.getCampaignOptions().getRandomProcreationMethod().isNone();
                 default -> false;
             };
             case FLAGS -> switch (this) {
-                case RANK, FIRST_NAME, LAST_NAME, COMMANDER, FOUNDER, CLAN_PERSONNEL, MARRIAGEABLE, DIVORCEABLE,
-                        TRYING_TO_CONCEIVE,
-                        IMMORTAL ->
-                    true;
+                case RANK,
+                     FIRST_NAME,
+                     LAST_NAME,
+                     COMMANDER,
+                     FOUNDER,
+                     CLAN_PERSONNEL,
+                     MARRIAGEABLE,
+                     DIVORCEABLE,
+                     TRYING_TO_CONCEIVE,
+                     IMMORTAL -> true;
                 default -> false;
             };
             case PERSONALITY -> switch (this) {
                 case RANK, FIRST_NAME, LAST_NAME -> true;
                 case AGGRESSION, AMBITION, GREED, SOCIAL, INTELLIGENCE ->
-                    campaign.getCampaignOptions().isUseRandomPersonalities();
+                      campaign.getCampaignOptions().isUseRandomPersonalities();
                 default -> false;
             };
             case OTHER -> switch (this) {
@@ -911,8 +983,8 @@ public enum PersonnelTableModelColumn {
                 case EDGE -> campaign.getCampaignOptions().isUseEdge();
                 case SPA_COUNT -> campaign.getCampaignOptions().isUseAbilities();
                 case IMPLANT_COUNT -> campaign.getCampaignOptions().isUseImplants();
-                case LOYALTY -> campaign.getCampaignOptions().isUseLoyaltyModifiers()
-                        && !campaign.getCampaignOptions().isUseHideLoyalty();
+                case LOYALTY -> campaign.getCampaignOptions().isUseLoyaltyModifiers() &&
+                                      !campaign.getCampaignOptions().isUseHideLoyalty();
                 default -> false;
             };
         };
@@ -922,15 +994,33 @@ public enum PersonnelTableModelColumn {
         return switch (this) {
             case RANK -> new PersonRankStringSorter(campaign);
             case AGE, BIRTHDAY, RECRUITMENT_DATE, LAST_RANK_CHANGE_DATE, DUE_DATE, RETIREMENT_DATE, DEATH_DATE ->
-                new DateStringComparator();
+                  new DateStringComparator();
             case SKILL_LEVEL -> new LevelSorter();
-            case MEK, GROUND_VEHICLE, NAVAL_VEHICLE, VTOL, AEROSPACE, CONVENTIONAL_AIRCRAFT, VESSEL, BATTLE_ARMOUR,
-                    SMALL_ARMS, ANTI_MEK,
-                    ARTILLERY, TACTICS, STRATEGY, LEADERSHIP, TECH_MEK, TECH_AERO, TECH_MECHANIC, TECH_BA, TECH_VESSEL,
-                    MEDICAL,
-                    ADMINISTRATION, NEGOTIATION, SCROUNGE ->
-                new BonusSorter();
-            case INJURIES, KILLS, XP, TOUGHNESS, EDGE, SPA_COUNT, IMPLANT_COUNT, LOYALTY, INTELLIGENCE -> new IntegerStringSorter();
+            case MEK,
+                 GROUND_VEHICLE,
+                 NAVAL_VEHICLE,
+                 VTOL,
+                 AEROSPACE,
+                 CONVENTIONAL_AIRCRAFT,
+                 VESSEL,
+                 BATTLE_ARMOUR,
+                 SMALL_ARMS,
+                 ANTI_MEK,
+                 ARTILLERY,
+                 TACTICS,
+                 STRATEGY,
+                 LEADERSHIP,
+                 TECH_MEK,
+                 TECH_AERO,
+                 TECH_MECHANIC,
+                 TECH_BA,
+                 TECH_VESSEL,
+                 MEDICAL,
+                 ADMINISTRATION,
+                 NEGOTIATION,
+                 SCROUNGE -> new BonusSorter();
+            case INJURIES, KILLS, XP, TOUGHNESS, EDGE, SPA_COUNT, IMPLANT_COUNT, LOYALTY, INTELLIGENCE ->
+                  new IntegerStringSorter();
             case SALARY -> new FormattedNumberSorter();
             default -> new NaturalOrderComparator();
         };


### PR DESCRIPTION
- Introduced `SkillDeprecationTool` to handle deprecated skills for personnel in campaigns.
- Added functionality for identifying deprecated skills, providing XP refunds, and managing skill removal.
- Implemented Immersive Dialogs to alert user to skill deprecation.
- Deprecated the "Scrounge" skill.

### Dev Notes
Around 50.02 we removed the Clan Tech Knowledge SPA. This was in response to official errata. At the time I noted that the way we handled the removal wasn't great. As SPAs are expensive, and that was potentially a lot of XP we just poof'd away. Not a great user experience.

<img width="581" alt="image" src="https://github.com/user-attachments/assets/b0446ec6-0d42-4ce0-aa03-10a27286b49d" />

Following a poll on Discord (see above) we decided to officially deprecate the 'Scrounge' skill. Not wanting to repeat the mistakes of the past I have created the `SkillDeprecationTool` to handle skill deprecations. Now, whenever we want to Deprecate a skill we just add it to the `DEPRECATED_SKILLS` list. Users loading campaigns containing characters with a deprecated skill are then prompted to refund any xp spent on the deprecated skill.

<img width="599" alt="image" src="https://github.com/user-attachments/assets/2e80cd90-b4aa-4221-8f5b-4eb06eaae210" />

Originally, the intent was to refund Scrounge when the skill was removed, however that created an order of operations issue. How can we refund a skill that has been completely removed? In short, we can't. At least not easily.