### PR TITLE
Replaced Scrounge With Negotiation or Removed It Across Academy Curricula

### DIFF
--- a/MekHQ/data/universe/academies/Local Academies.xml
+++ b/MekHQ/data/universe/academies/Local Academies.xml
@@ -3,9 +3,7 @@
     <academy>
         <name>Military Creche</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>Housed in a secure buildings reinforced against the skirmishes that frequent the Inner Sphere,
-            military creches provide a safe and nurturing environment.
-        </description>
+        <description>Housed in a secure buildings reinforced against the skirmishes that frequent the Inner Sphere, military creches provide a safe and nurturing environment.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -23,11 +21,7 @@
     <academy>
         <name>Boarding School</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>A prestigious, well-guarded institution where children of nobility and influential families receive
-            a comprehensive education in subjects ranging from advanced sciences and history to political strategy. The
-            curriculum is designed to groom future leaders and warriors, incorporating rigorous academic coursework,
-            physical training, and simulated combat exercises to prepare students for future leadership roles.
-        </description>
+        <description>A prestigious, well-guarded institution where children of nobility and influential families receive a comprehensive education in subjects ranging from advanced sciences and history to political strategy. The curriculum is designed to groom future leaders and warriors, incorporating rigorous academic coursework, physical training, and simulated combat exercises to prepare students for future leadership roles.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -45,10 +39,7 @@
     <academy>
         <name>Junior School</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>Junior schools provide foundational education for children, preparing them for the future. These
-            schools are adapted to the needs of their respective regions, reflecting the culture and priorities of each
-            faction.
-        </description>
+        <description>Junior schools provide foundational education for children, preparing them for the future. These schools are adapted to the needs of their respective regions, reflecting the culture and priorities of each faction.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -67,10 +58,7 @@
         <name>High School</name>
         <type>High School</type>
         <isPrepSchool>true</isPrepSchool>
-        <description>A technologically advanced facility where students balance traditional academic subjects with a
-            basic education in technical fields such as modern electronics, and computer science. The school fosters a
-            competitive environment to prepare students for potential military service.
-        </description>
+        <description>A technologically advanced facility where students balance traditional academic subjects with a basic education in technical fields such as modern electronics, and computer science. The school fosters a competitive environment to prepare students for potential military service.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -87,12 +75,7 @@
         <name>Preparatory School</name>
         <type>High School</type>
         <isPrepSchool>true</isPrepSchool>
-        <description>A prestigious institution catering to the elite of the Inner Sphere. Nestled within secure
-            compounds, these schools provide a comprehensive education emphasizing not only academic excellence but also
-            etiquette, and political maneuvering. Students, typically from noble or affluent families, are groomed for
-            leadership roles, learning the intricacies of diplomacy. The curriculum is rigorous, preparing graduates to
-            navigate the complex power dynamics of the Inner Sphere with grace and skill.
-        </description>
+        <description>A prestigious institution catering to the elite of the Inner Sphere. Nestled within secure compounds, these schools provide a comprehensive education emphasizing not only academic excellence but also etiquette, and political maneuvering. Students, typically from noble or affluent families, are groomed for leadership roles, learning the intricacies of diplomacy. The curriculum is rigorous, preparing graduates to navigate the complex power dynamics of the Inner Sphere with grace and skill.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -110,10 +93,7 @@
         <type>High School</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>A disciplined institution focused on cultivating the skills necessary for future soldiers and
-            officers. Cadets undergo rigorous physical training, tactical simulations, and academic studies in subjects
-            like military history, strategy, and technology.
-        </description>
+        <description>A disciplined institution focused on cultivating the skills necessary for future soldiers and officers. Cadets undergo rigorous physical training, tactical simulations, and academic studies in subjects like military history, strategy, and technology.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -129,11 +109,7 @@
     <academy>
         <name>Tech Apprenticeship</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>A tech apprenticeship involves hands-on training under the guidance of experienced technicians and
-            engineers. Apprentices learn the intricacies of repairing, maintaining, and upgrading advanced military
-            technology. They gain practical experience in workshops and repair bays, mastering skills in diagnostics,
-            fabrication, and the integration of cutting-edge weaponry and equipment.
-        </description>
+        <description>A tech apprenticeship involves hands-on training under the guidance of experienced technicians and engineers. Apprentices learn the intricacies of repairing, maintaining, and upgrading advanced military technology. They gain practical experience in workshops and repair bays, mastering skills in diagnostics, fabrication, and the integration of cutting-edge weaponry and equipment.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -162,12 +138,7 @@
     <academy>
         <name>Adult High School</name>
         <type>High School</type>
-        <description>An institution that caters to individuals who, for various reasons, didn't complete their high
-            school education. These institutions offer flexible schedules and tailored programs to accommodate the
-            diverse backgrounds and goals of adult learners. The environment encourages personal growth and provides
-            opportunities for individuals to acquire the skills necessary for advancement in both civilian and military
-            careers.
-        </description>
+        <description>An institution that caters to individuals who, for various reasons, didn't complete their high school education. These institutions offer flexible schedules and tailored programs to accommodate the diverse backgrounds and goals of adult learners. The environment encourages personal growth and provides opportunities for individuals to acquire the skills necessary for advancement in both civilian and military careers.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -182,10 +153,7 @@
     <academy>
         <name>College</name>
         <type>College</type>
-        <description>Colleges play a crucial role in shaping the minds and skills of those who will go on to become
-            productive citizens of the Inner Sphere. Each institution reflects the culture, priorities, and
-            technological advancements of its respective faction.
-        </description>
+        <description>Colleges play a crucial role in shaping the minds and skills of those who will go on to become productive citizens of the Inner Sphere. Each institution reflects the culture, priorities, and technological advancements of its respective faction.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -196,8 +164,7 @@
         <ageMin>16</ageMin>
         <qualification>General Studies</qualification>
         <curriculum>XP</curriculum>
-        <qualificationStartYear>2300</qualificationStartYear>Sure, here are the elements sorted alphabetically, keeping
-        the tags in the same order:
+        <qualificationStartYear>2300</qualificationStartYear>Sure, here are the elements sorted alphabetically, keeping the tags in the same order:
         <qualification>Biology</qualification>
         <curriculum>XP</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
@@ -241,12 +208,7 @@
     <academy>
         <name>Technical College</name>
         <type>College</type>
-        <description>A technical college serves as a hub for specialized education in fields crucial to the advancement
-            of technology and warfare. Students enrolled in technical colleges undergo rigorous training in disciplines
-            such as aerospace engineering, robotics, computer science, and weapon systems development. The curriculum
-            combines theoretical knowledge with practical hands-on experience, utilizing state-of-the-art laboratories
-            and workshops to foster innovation and skill acquisition.
-        </description>
+        <description>A technical college serves as a hub for specialized education in fields crucial to the advancement of technology and warfare. Students enrolled in technical colleges undergo rigorous training in disciplines such as aerospace engineering, robotics, computer science, and weapon systems development. The curriculum combines theoretical knowledge with practical hands-on experience, utilizing state-of-the-art laboratories and workshops to foster innovation and skill acquisition.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -273,10 +235,7 @@
     </academy>
     <academy>
         <name>Trade School</name>
-        <description>A trade school provides specialized training in practical skills essential for supporting the
-            military-industrial complex. These schools offer courses in areas such as medicine, administration,
-            electronics, metallurgy, and logistics.
-        </description>
+        <description>A trade school provides specialized training in practical skills essential for supporting the military-industrial complex. These schools offer courses in areas such as medicine, administration, electronics, metallurgy, and logistics.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -289,7 +248,7 @@
         <curriculum>Administration, Negotiation</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Vocational Logistician</qualification>
-        <curriculum>Administration, Negotiation</curriculum>
+        <curriculum>Administration</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Nursing School</qualification>
         <curriculum>MedTech</curriculum>
@@ -298,11 +257,7 @@
     <academy>
         <name>University</name>
         <type>University</type>
-        <description>A university stands as a beacon of knowledge and innovation amidst the turmoil of interstellar
-            conflict. These institutions offer a wide array of academic disciplines, ranging from the humanities and
-            social sciences to advanced engineering and military strategy. Professors and researchers engage in
-            cutting-edge studies, pushing the boundaries of technology and exploring the depths of history and culture.
-        </description>
+        <description>A university stands as a beacon of knowledge and innovation amidst the turmoil of interstellar conflict. These institutions offer a wide array of academic disciplines, ranging from the humanities and social sciences to advanced engineering and military strategy. Professors and researchers engage in cutting-edge studies, pushing the boundaries of technology and exploring the depths of history and culture.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -331,7 +286,7 @@
         <curriculum>Administration, Negotiation</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Applied Economics</qualification>
-        <curriculum>Administration, Negotiation</curriculum>
+        <curriculum>Administration</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Advanced Medicine</qualification>
         <curriculum>Doctor</curriculum>
@@ -342,10 +297,7 @@
     </academy>
     <academy>
         <name>Police Academy</name>
-        <description>A fortified urban complex where cadets undergo rigorous training in urban warfare, crowd control,
-            and investigative techniques. Cadets train with advanced surveillance equipment, non-lethal and lethal
-            weaponry, and are educated in interstellar law, and faction-specific protocols.
-        </description>
+        <description>A fortified urban complex where cadets undergo rigorous training in urban warfare, crowd control, and investigative techniques. Cadets train with advanced surveillance equipment, non-lethal and lethal weaponry, and are educated in interstellar law, and faction-specific protocols.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -363,11 +315,7 @@
     </academy>
     <academy>
         <name>Reeducation Camp</name>
-        <description>A secluded, heavily guarded facility where students undergo intense psychological conditioning and
-            reprogramming to erase loyalty to their original faction and instill unwavering allegiance to their new
-            home. Students are subjected to a regimen of sensory deprivation, propaganda broadcasts, and neural
-            reconditioning to ensure their complete mental and emotional transformation.
-        </description>
+        <description>A secluded, heavily guarded facility where students undergo intense psychological conditioning and reprogramming to erase loyalty to their original faction and instill unwavering allegiance to their new home. Students are subjected to a regimen of sensory deprivation, propaganda broadcasts, and neural reconditioning to ensure their complete mental and emotional transformation.</description>
         <isReeducationCamp>true</isReeducationCamp>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
@@ -385,11 +333,7 @@
         <name>Boot Camp</name>
         <type>Basic Training</type>
         <isMilitary>true</isMilitary>
-        <description>A sprawling, high-security installation where recruits endure intense physical conditioning,
-            drills, and live-fire exercises with both personal and vehicle-scale weaponry. The training regimen
-            emphasizes discipline, loyalty to one's faction, and the strategic use of cutting-edge technology in
-            combined arms warfare.
-        </description>
+        <description>A sprawling, high-security installation where recruits endure intense physical conditioning, drills, and live-fire exercises with both personal and vehicle-scale weaponry. The training regimen emphasizes discipline, loyalty to one's faction, and the strategic use of cutting-edge technology in combined arms warfare.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -419,11 +363,7 @@
         <name>Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>A prestigious institution dedicated to training the warriors of the Inner Sphere. Situated within
-            heavily fortified compounds, these academies offer a comprehensive education that blends rigorous physical
-            training, tactical instruction, and academic study. Cadets undergo intensive combat simulations, and study
-            military history, strategy, and ethics.
-        </description>
+        <description>A prestigious institution dedicated to training the warriors of the Inner Sphere. Situated within heavily fortified compounds, these academies offer a comprehensive education that blends rigorous physical training, tactical instruction, and academic study. Cadets undergo intensive combat simulations, and study military history, strategy, and ethics.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -461,12 +401,7 @@
         <name>NCO Candidate Bootcamp</name>
         <type>NCO Academy</type>
         <isMilitary>true</isMilitary>
-        <description>A specialized training program designed to prepare enlisted personnel for leadership roles within
-            their respective military units. Held within secure facilities, the bootcamp emphasizes the development of
-            tactical proficiency, effective communication, and leadership skills essential for leading personnel in
-            combat. Cadets undergo intensive physical conditioning, weapons training, and tactical simulations, with a
-            focus on fostering teamwork and initiative.
-        </description>
+        <description>A specialized training program designed to prepare enlisted personnel for leadership roles within their respective military units. Held within secure facilities, the bootcamp emphasizes the development of tactical proficiency, effective communication, and leadership skills essential for leading personnel in combat. Cadets undergo intensive physical conditioning, weapons training, and tactical simulations, with a focus on fostering teamwork and initiative.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -484,12 +419,7 @@
         <name>Warrant Officer Candidate School</name>
         <type>Warrant Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>A specialized institution tasked with training promising enlisted personnel for positions of
-            leadership and technical expertise as Warrant Officers. Held in secure military installations, these schools
-            combine intensive academic study with practical training in areas such as engineering, logistics, and
-            advanced tactics. Candidates undergo rigorous evaluations and assessments to demonstrate their aptitude for
-            assuming roles of responsibility within their units.
-        </description>
+        <description>A specialized institution tasked with training promising enlisted personnel for positions of leadership and technical expertise as Warrant Officers. Held in secure military installations, these schools combine intensive academic study with practical training in areas such as engineering, logistics, and advanced tactics. Candidates undergo rigorous evaluations and assessments to demonstrate their aptitude for assuming roles of responsibility within their units.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -506,14 +436,7 @@
         <name>Officer Candidate School</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>A prestigious institution dedicated to training and grooming promising individuals for leadership
-            roles within the military. Held in secure and strategically located facilities, these schools provide a
-            comprehensive curriculum that encompasses both theoretical and practical aspects of warfare, leadership, and
-            strategy. Candidates undergo rigorous physical training, tactical simulations, and academic studies in
-            subjects such as military history, and tactics. The program is designed to identify and cultivate
-            individuals with the potential to command units effectively and uphold the honor and integrity of their
-            respective factions.
-        </description>
+        <description>A prestigious institution dedicated to training and grooming promising individuals for leadership roles within the military. Held in secure and strategically located facilities, these schools provide a comprehensive curriculum that encompasses both theoretical and practical aspects of warfare, leadership, and strategy. Candidates undergo rigorous physical training, tactical simulations, and academic studies in subjects such as military history, and tactics. The program is designed to identify and cultivate individuals with the potential to command units effectively and uphold the honor and integrity of their respective factions.</description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>

--- a/MekHQ/data/universe/academies/Local Academies.xml
+++ b/MekHQ/data/universe/academies/Local Academies.xml
@@ -3,7 +3,9 @@
     <academy>
         <name>Military Creche</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>Housed in a secure buildings reinforced against the skirmishes that frequent the Inner Sphere, military creches provide a safe and nurturing environment.</description>
+        <description>Housed in a secure buildings reinforced against the skirmishes that frequent the Inner Sphere,
+            military creches provide a safe and nurturing environment.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -21,7 +23,11 @@
     <academy>
         <name>Boarding School</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>A prestigious, well-guarded institution where children of nobility and influential families receive a comprehensive education in subjects ranging from advanced sciences and history to political strategy. The curriculum is designed to groom future leaders and warriors, incorporating rigorous academic coursework, physical training, and simulated combat exercises to prepare students for future leadership roles.</description>
+        <description>A prestigious, well-guarded institution where children of nobility and influential families receive
+            a comprehensive education in subjects ranging from advanced sciences and history to political strategy. The
+            curriculum is designed to groom future leaders and warriors, incorporating rigorous academic coursework,
+            physical training, and simulated combat exercises to prepare students for future leadership roles.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -39,7 +45,10 @@
     <academy>
         <name>Junior School</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>Junior schools provide foundational education for children, preparing them for the future. These schools are adapted to the needs of their respective regions, reflecting the culture and priorities of each faction.</description>
+        <description>Junior schools provide foundational education for children, preparing them for the future. These
+            schools are adapted to the needs of their respective regions, reflecting the culture and priorities of each
+            faction.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -58,7 +67,10 @@
         <name>High School</name>
         <type>High School</type>
         <isPrepSchool>true</isPrepSchool>
-        <description>A technologically advanced facility where students balance traditional academic subjects with a basic education in technical fields such as modern electronics, and computer science. The school fosters a competitive environment to prepare students for potential military service.</description>
+        <description>A technologically advanced facility where students balance traditional academic subjects with a
+            basic education in technical fields such as modern electronics, and computer science. The school fosters a
+            competitive environment to prepare students for potential military service.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -75,7 +87,12 @@
         <name>Preparatory School</name>
         <type>High School</type>
         <isPrepSchool>true</isPrepSchool>
-        <description>A prestigious institution catering to the elite of the Inner Sphere. Nestled within secure compounds, these schools provide a comprehensive education emphasizing not only academic excellence but also etiquette, and political maneuvering. Students, typically from noble or affluent families, are groomed for leadership roles, learning the intricacies of diplomacy. The curriculum is rigorous, preparing graduates to navigate the complex power dynamics of the Inner Sphere with grace and skill.</description>
+        <description>A prestigious institution catering to the elite of the Inner Sphere. Nestled within secure
+            compounds, these schools provide a comprehensive education emphasizing not only academic excellence but also
+            etiquette, and political maneuvering. Students, typically from noble or affluent families, are groomed for
+            leadership roles, learning the intricacies of diplomacy. The curriculum is rigorous, preparing graduates to
+            navigate the complex power dynamics of the Inner Sphere with grace and skill.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -93,7 +110,10 @@
         <type>High School</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>A disciplined institution focused on cultivating the skills necessary for future soldiers and officers. Cadets undergo rigorous physical training, tactical simulations, and academic studies in subjects like military history, strategy, and technology.</description>
+        <description>A disciplined institution focused on cultivating the skills necessary for future soldiers and
+            officers. Cadets undergo rigorous physical training, tactical simulations, and academic studies in subjects
+            like military history, strategy, and technology.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -109,7 +129,11 @@
     <academy>
         <name>Tech Apprenticeship</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>A tech apprenticeship involves hands-on training under the guidance of experienced technicians and engineers. Apprentices learn the intricacies of repairing, maintaining, and upgrading advanced military technology. They gain practical experience in workshops and repair bays, mastering skills in diagnostics, fabrication, and the integration of cutting-edge weaponry and equipment.</description>
+        <description>A tech apprenticeship involves hands-on training under the guidance of experienced technicians and
+            engineers. Apprentices learn the intricacies of repairing, maintaining, and upgrading advanced military
+            technology. They gain practical experience in workshops and repair bays, mastering skills in diagnostics,
+            fabrication, and the integration of cutting-edge weaponry and equipment.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -138,7 +162,12 @@
     <academy>
         <name>Adult High School</name>
         <type>High School</type>
-        <description>An institution that caters to individuals who, for various reasons, didn't complete their high school education. These institutions offer flexible schedules and tailored programs to accommodate the diverse backgrounds and goals of adult learners. The environment encourages personal growth and provides opportunities for individuals to acquire the skills necessary for advancement in both civilian and military careers.</description>
+        <description>An institution that caters to individuals who, for various reasons, didn't complete their high
+            school education. These institutions offer flexible schedules and tailored programs to accommodate the
+            diverse backgrounds and goals of adult learners. The environment encourages personal growth and provides
+            opportunities for individuals to acquire the skills necessary for advancement in both civilian and military
+            careers.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -153,7 +182,10 @@
     <academy>
         <name>College</name>
         <type>College</type>
-        <description>Colleges play a crucial role in shaping the minds and skills of those who will go on to become productive citizens of the Inner Sphere. Each institution reflects the culture, priorities, and technological advancements of its respective faction.</description>
+        <description>Colleges play a crucial role in shaping the minds and skills of those who will go on to become
+            productive citizens of the Inner Sphere. Each institution reflects the culture, priorities, and
+            technological advancements of its respective faction.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -164,7 +196,8 @@
         <ageMin>16</ageMin>
         <qualification>General Studies</qualification>
         <curriculum>XP</curriculum>
-        <qualificationStartYear>2300</qualificationStartYear>Sure, here are the elements sorted alphabetically, keeping the tags in the same order:
+        <qualificationStartYear>2300</qualificationStartYear>Sure, here are the elements sorted alphabetically, keeping
+        the tags in the same order:
         <qualification>Biology</qualification>
         <curriculum>XP</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
@@ -208,7 +241,12 @@
     <academy>
         <name>Technical College</name>
         <type>College</type>
-        <description>A technical college serves as a hub for specialized education in fields crucial to the advancement of technology and warfare. Students enrolled in technical colleges undergo rigorous training in disciplines such as aerospace engineering, robotics, computer science, and weapon systems development. The curriculum combines theoretical knowledge with practical hands-on experience, utilizing state-of-the-art laboratories and workshops to foster innovation and skill acquisition.</description>
+        <description>A technical college serves as a hub for specialized education in fields crucial to the advancement
+            of technology and warfare. Students enrolled in technical colleges undergo rigorous training in disciplines
+            such as aerospace engineering, robotics, computer science, and weapon systems development. The curriculum
+            combines theoretical knowledge with practical hands-on experience, utilizing state-of-the-art laboratories
+            and workshops to foster innovation and skill acquisition.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -235,7 +273,10 @@
     </academy>
     <academy>
         <name>Trade School</name>
-        <description>A trade school provides specialized training in practical skills essential for supporting the military-industrial complex. These schools offer courses in areas such as medicine, administration, electronics, metallurgy, and logistics.</description>
+        <description>A trade school provides specialized training in practical skills essential for supporting the
+            military-industrial complex. These schools offer courses in areas such as medicine, administration,
+            electronics, metallurgy, and logistics.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -248,7 +289,7 @@
         <curriculum>Administration, Negotiation</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Vocational Logistician</qualification>
-        <curriculum>Administration, Scrounge</curriculum>
+        <curriculum>Administration, Negotiation</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Nursing School</qualification>
         <curriculum>MedTech</curriculum>
@@ -257,7 +298,11 @@
     <academy>
         <name>University</name>
         <type>University</type>
-        <description>A university stands as a beacon of knowledge and innovation amidst the turmoil of interstellar conflict. These institutions offer a wide array of academic disciplines, ranging from the humanities and social sciences to advanced engineering and military strategy. Professors and researchers engage in cutting-edge studies, pushing the boundaries of technology and exploring the depths of history and culture.</description>
+        <description>A university stands as a beacon of knowledge and innovation amidst the turmoil of interstellar
+            conflict. These institutions offer a wide array of academic disciplines, ranging from the humanities and
+            social sciences to advanced engineering and military strategy. Professors and researchers engage in
+            cutting-edge studies, pushing the boundaries of technology and exploring the depths of history and culture.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -286,7 +331,7 @@
         <curriculum>Administration, Negotiation</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Applied Economics</qualification>
-        <curriculum>Administration, Scrounge</curriculum>
+        <curriculum>Administration, Negotiation</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Advanced Medicine</qualification>
         <curriculum>Doctor</curriculum>
@@ -297,7 +342,10 @@
     </academy>
     <academy>
         <name>Police Academy</name>
-        <description>A fortified urban complex where cadets undergo rigorous training in urban warfare, crowd control, and investigative techniques. Cadets train with advanced surveillance equipment, non-lethal and lethal weaponry, and are educated in interstellar law, and faction-specific protocols.</description>
+        <description>A fortified urban complex where cadets undergo rigorous training in urban warfare, crowd control,
+            and investigative techniques. Cadets train with advanced surveillance equipment, non-lethal and lethal
+            weaponry, and are educated in interstellar law, and faction-specific protocols.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -315,7 +363,11 @@
     </academy>
     <academy>
         <name>Reeducation Camp</name>
-        <description>A secluded, heavily guarded facility where students undergo intense psychological conditioning and reprogramming to erase loyalty to their original faction and instill unwavering allegiance to their new home. Students are subjected to a regimen of sensory deprivation, propaganda broadcasts, and neural reconditioning to ensure their complete mental and emotional transformation.</description>
+        <description>A secluded, heavily guarded facility where students undergo intense psychological conditioning and
+            reprogramming to erase loyalty to their original faction and instill unwavering allegiance to their new
+            home. Students are subjected to a regimen of sensory deprivation, propaganda broadcasts, and neural
+            reconditioning to ensure their complete mental and emotional transformation.
+        </description>
         <isReeducationCamp>true</isReeducationCamp>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
@@ -333,7 +385,11 @@
         <name>Boot Camp</name>
         <type>Basic Training</type>
         <isMilitary>true</isMilitary>
-        <description>A sprawling, high-security installation where recruits endure intense physical conditioning, drills, and live-fire exercises with both personal and vehicle-scale weaponry. The training regimen emphasizes discipline, loyalty to one's faction, and the strategic use of cutting-edge technology in combined arms warfare.</description>
+        <description>A sprawling, high-security installation where recruits endure intense physical conditioning,
+            drills, and live-fire exercises with both personal and vehicle-scale weaponry. The training regimen
+            emphasizes discipline, loyalty to one's faction, and the strategic use of cutting-edge technology in
+            combined arms warfare.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -363,7 +419,11 @@
         <name>Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>A prestigious institution dedicated to training the warriors of the Inner Sphere. Situated within heavily fortified compounds, these academies offer a comprehensive education that blends rigorous physical training, tactical instruction, and academic study. Cadets undergo intensive combat simulations, and study military history, strategy, and ethics.</description>
+        <description>A prestigious institution dedicated to training the warriors of the Inner Sphere. Situated within
+            heavily fortified compounds, these academies offer a comprehensive education that blends rigorous physical
+            training, tactical instruction, and academic study. Cadets undergo intensive combat simulations, and study
+            military history, strategy, and ethics.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -401,7 +461,12 @@
         <name>NCO Candidate Bootcamp</name>
         <type>NCO Academy</type>
         <isMilitary>true</isMilitary>
-        <description>A specialized training program designed to prepare enlisted personnel for leadership roles within their respective military units. Held within secure facilities, the bootcamp emphasizes the development of tactical proficiency, effective communication, and leadership skills essential for leading personnel in combat. Cadets undergo intensive physical conditioning, weapons training, and tactical simulations, with a focus on fostering teamwork and initiative.</description>
+        <description>A specialized training program designed to prepare enlisted personnel for leadership roles within
+            their respective military units. Held within secure facilities, the bootcamp emphasizes the development of
+            tactical proficiency, effective communication, and leadership skills essential for leading personnel in
+            combat. Cadets undergo intensive physical conditioning, weapons training, and tactical simulations, with a
+            focus on fostering teamwork and initiative.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -419,7 +484,12 @@
         <name>Warrant Officer Candidate School</name>
         <type>Warrant Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>A specialized institution tasked with training promising enlisted personnel for positions of leadership and technical expertise as Warrant Officers. Held in secure military installations, these schools combine intensive academic study with practical training in areas such as engineering, logistics, and advanced tactics. Candidates undergo rigorous evaluations and assessments to demonstrate their aptitude for assuming roles of responsibility within their units.</description>
+        <description>A specialized institution tasked with training promising enlisted personnel for positions of
+            leadership and technical expertise as Warrant Officers. Held in secure military installations, these schools
+            combine intensive academic study with practical training in areas such as engineering, logistics, and
+            advanced tactics. Candidates undergo rigorous evaluations and assessments to demonstrate their aptitude for
+            assuming roles of responsibility within their units.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -436,7 +506,14 @@
         <name>Officer Candidate School</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>A prestigious institution dedicated to training and grooming promising individuals for leadership roles within the military. Held in secure and strategically located facilities, these schools provide a comprehensive curriculum that encompasses both theoretical and practical aspects of warfare, leadership, and strategy. Candidates undergo rigorous physical training, tactical simulations, and academic studies in subjects such as military history, and tactics. The program is designed to identify and cultivate individuals with the potential to command units effectively and uphold the honor and integrity of their respective factions.</description>
+        <description>A prestigious institution dedicated to training and grooming promising individuals for leadership
+            roles within the military. Held in secure and strategically located facilities, these schools provide a
+            comprehensive curriculum that encompasses both theoretical and practical aspects of warfare, leadership, and
+            strategy. Candidates undergo rigorous physical training, tactical simulations, and academic studies in
+            subjects such as military history, and tactics. The program is designed to identify and cultivate
+            individuals with the potential to command units effectively and uphold the honor and integrity of their
+            respective factions.
+        </description>
         <isLocal>true</isLocal>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>

--- a/MekHQ/data/universe/academies/Prestigious Academies.xml
+++ b/MekHQ/data/universe/academies/Prestigious Academies.xml
@@ -3,9 +3,7 @@
     <academy>
         <name>Academies of Keid</name>
         <type>College</type>
-        <description>The Academies of Kied consist of three distinct colleges dedicated to metallurgy, diplomatic
-            studies, and economics, each renowned for training future leaders and staff officers.
-        </description>
+        <description>The Academies of Kied consist of three distinct colleges dedicated to metallurgy, diplomatic studies, and economics, each renowned for training future leaders and staff officers.</description>
         <locationSystem>Keid</locationSystem>
         <tuition>7500</tuition>
         <durationDays>1200</durationDays>
@@ -24,10 +22,7 @@
     <academy>
         <name>Addicks University</name>
         <type>University</type>
-        <description>Located in the heart of the Inner Sphere, Addicks University is celebrated for its progressive
-            liberal arts education, particularly in teacher training. The institution uniquely integrates its academic
-            programs with community schools, allowing student teachers to gain invaluable hands-on experience.
-        </description>
+        <description>Located in the heart of the Inner Sphere, Addicks University is celebrated for its progressive liberal arts education, particularly in teacher training. The institution uniquely integrates its academic programs with community schools, allowing student teachers to gain invaluable hands-on experience.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Addicks</locationSystem>
@@ -51,10 +46,7 @@
         <name>Aerospace and Interstellar Institute [Dover] (Year One)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Staffed by veteran officers from Operation SCOUR, the school instructs experienced crew members in
-            fleet combat subtleties. This initiative adapts to evolving military needs, enhancing future fleet
-            commanders' and high-ranking personnel's capabilities in complex operational environments.
-        </description>
+        <description>Staffed by veteran officers from Operation SCOUR, the school instructs experienced crew members in fleet combat subtleties. This initiative adapts to evolving military needs, enhancing future fleet commanders' and high-ranking personnel's capabilities in complex operational environments.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dover</locationSystem>
@@ -74,10 +66,7 @@
         <name>Aerospace and Interstellar Institute [Dover]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Staffed by veteran officers from Operation SCOUR, the school instructs experienced crew members in
-            fleet combat subtleties. This initiative adapts to evolving military needs, enhancing future fleet
-            commanders' and high-ranking personnel's capabilities in complex operational environments.
-        </description>
+        <description>Staffed by veteran officers from Operation SCOUR, the school instructs experienced crew members in fleet combat subtleties. This initiative adapts to evolving military needs, enhancing future fleet commanders' and high-ranking personnel's capabilities in complex operational environments.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dover</locationSystem>
@@ -103,11 +92,7 @@
         <name>Aerospace and Interstellar Institute [Midway] (Year One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Aerospace and Interstellar Institute specializes in training aerospace personnel, including
-            DropShip and JumpShip crews. The curriculum spans covers small arms, first aid, and specialized aerospace
-            roles. Limited crewing opportunities, especially for JumpShips, create fierce competition, pushing most
-            cadets to train as aerospace fighter pilots.
-        </description>
+        <description>The Aerospace and Interstellar Institute specializes in training aerospace personnel, including DropShip and JumpShip crews. The curriculum spans covers small arms, first aid, and specialized aerospace roles. Limited crewing opportunities, especially for JumpShips, create fierce competition, pushing most cadets to train as aerospace fighter pilots.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Midway</locationSystem>
@@ -127,11 +112,7 @@
         <name>Aerospace and Interstellar Institute [Midway]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Aerospace and Interstellar Institute specializes in training aerospace personnel, including
-            DropShip and JumpShip crews. The curriculum spans covers small arms, first aid, and specialized aerospace
-            roles. Limited crewing opportunities, especially for JumpShips, create fierce competition, pushing most
-            cadets to train as aerospace fighter pilots.
-        </description>
+        <description>The Aerospace and Interstellar Institute specializes in training aerospace personnel, including DropShip and JumpShip crews. The curriculum spans covers small arms, first aid, and specialized aerospace roles. Limited crewing opportunities, especially for JumpShips, create fierce competition, pushing most cadets to train as aerospace fighter pilots.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Midway</locationSystem>
@@ -160,11 +141,7 @@
         <name>Aitutaki Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik
-            sentiment. The academy emphasizes physical training and survival skills in the first year, followed by
-            advanced MekWarriorand Cavalry training. The aerospace program was discontinued after fatal accidents.
-            Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.
-        </description>
+        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik sentiment. The academy emphasizes physical training and survival skills in the first year, followed by advanced MekWarriorand Cavalry training. The aerospace program was discontinued after fatal accidents. Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aitutaki</locationSystem>
@@ -193,11 +170,7 @@
         <name>Aitutaki Academy (Year One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik
-            sentiment. The academy emphasizes physical training and survival skills in the first year, followed by
-            advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents.
-            Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.
-        </description>
+        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik sentiment. The academy emphasizes physical training and survival skills in the first year, followed by advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents. Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aitutaki</locationSystem>
@@ -217,11 +190,7 @@
         <name>Aitutaki Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik
-            sentiment. The academy emphasizes physical training and survival skills in the first year, followed by
-            advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents.
-            Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.
-        </description>
+        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik sentiment. The academy emphasizes physical training and survival skills in the first year, followed by advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents. Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aitutaki</locationSystem>
@@ -250,11 +219,7 @@
         <name>Aitutaki Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik
-            sentiment. The academy emphasizes physical training and survival skills in the first year, followed by
-            advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents.
-            Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.
-        </description>
+        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik sentiment. The academy emphasizes physical training and survival skills in the first year, followed by advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents. Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aitutaki</locationSystem>
@@ -283,11 +248,7 @@
         <name>Alarion Naval Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Alarion Naval Academy, established to meet the Lyran Alliance's need for WarShip crew training,
-            complements existing aerospace academies. It quickly became crucial for naval training in the Inner Sphere,
-            offering rigorous programs for DropShip, JumpShip, and WarShip crews, incorporating both basic and
-            specialized studies.
-        </description>
+        <description>The Alarion Naval Academy, established to meet the Lyran Alliance's need for WarShip crew training, complements existing aerospace academies. It quickly became crucial for naval training in the Inner Sphere, offering rigorous programs for DropShip, JumpShip, and WarShip crews, incorporating both basic and specialized studies.</description>
         <locationSystem>Alarion</locationSystem>
         <constructionYear>3060</constructionYear>
         <destructionYear>3069</destructionYear>
@@ -321,12 +282,7 @@
         <name>Albion Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Albion Military Academy quickly became the Federated Suns' premier institution. Traditionally,
-            it allows graduates a unique buyout option to serve directly with the Federated Suns, bypassing service
-            requirements. Located near Avalon City, the AMA is pivotal in training various military disciplines and
-            continues to produce highly decorated officers. Despite intense academic and physical demands resulting in a
-            high dropout rate, its graduates often ascend to senior AFFS leadership roles.
-        </description>
+        <description>The Albion Military Academy quickly became the Federated Suns' premier institution. Traditionally, it allows graduates a unique buyout option to serve directly with the Federated Suns, bypassing service requirements. Located near Avalon City, the AMA is pivotal in training various military disciplines and continues to produce highly decorated officers. Despite intense academic and physical demands resulting in a high dropout rate, its graduates often ascend to senior AFFS leadership roles.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Albion (LC)</locationSystem>
@@ -388,12 +344,7 @@
         <name>Albion Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Albion Military Academy quickly became the Federated Suns' premier institution. Traditionally,
-            it allows graduates a unique buyout option to serve directly with the Federated Suns, bypassing service
-            requirements. Located near Avalon City, the AMA is pivotal in training various military disciplines and
-            continues to produce highly decorated officers. Despite intense academic and physical demands resulting in a
-            high dropout rate, its graduates often ascend to senior AFFS leadership roles.
-        </description>
+        <description>The Albion Military Academy quickly became the Federated Suns' premier institution. Traditionally, it allows graduates a unique buyout option to serve directly with the Federated Suns, bypassing service requirements. Located near Avalon City, the AMA is pivotal in training various military disciplines and continues to produce highly decorated officers. Despite intense academic and physical demands resulting in a high dropout rate, its graduates often ascend to senior AFFS leadership roles.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Albion (LC)</locationSystem>
@@ -455,12 +406,7 @@
         <name>Algedi War College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Algedi War College is particularly recognized for its mobile warfare division. This development
-            aligns with the production of military vehicles on the Arkab worlds. The college primarily admits candidates
-            with an Azami background, reflecting its unique cultural focus. The AWC has seen immense popularity, with
-            its first class contributing roughly ten percent of graduates as volunteers to DCMS line units,
-            demonstrating goodwill to the Coordinator and strengthening military ties.
-        </description>
+        <description>The Algedi War College is particularly recognized for its mobile warfare division. This development aligns with the production of military vehicles on the Arkab worlds. The college primarily admits candidates with an Azami background, reflecting its unique cultural focus. The AWC has seen immense popularity, with its first class contributing roughly ten percent of graduates as volunteers to DCMS line units, demonstrating goodwill to the Coordinator and strengthening military ties.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Algedi</locationSystem>
@@ -495,13 +441,7 @@
         <name>Allison MechWarrior Institute</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent
-            to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute
-            fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks
-            that occasionally escalate into conflicts. Admission is highly competitive, influenced by political
-            considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold
-            loyalty.
-        </description>
+        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold loyalty.</description>
         <locationSystem>New Olympia</locationSystem>
         <constructionYear>2465</constructionYear>
         <tuition>5250</tuition>
@@ -519,13 +459,7 @@
         <name>Allison MechWarrior Institute (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent
-            to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute
-            fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks
-            that occasionally escalate into conflicts. Admission is highly competitive, influenced by political
-            considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold
-            loyalty.
-        </description>
+        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold loyalty.</description>
         <locationSystem>New Olympia</locationSystem>
         <constructionYear>2465</constructionYear>
         <tuition>13125</tuition>
@@ -543,10 +477,7 @@
         <name>An Ting University</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The An Ting University is a renowned military academy historically dedicated to training
-            MekWarriors. ATU, enjoying support from the DCMS and local government, provides rigorous training with a
-            commitment to military reforms and a focus on loyalty and excellence.
-        </description>
+        <description>The An Ting University is a renowned military academy historically dedicated to training MekWarriors. ATU, enjoying support from the DCMS and local government, provides rigorous training with a commitment to military reforms and a focus on loyalty and excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>An Ting</locationSystem>
@@ -573,10 +504,7 @@
         <name>An Ting University (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The An Ting University is a renowned military academy historically dedicated to training
-            MekWarriors. ATU, enjoying support from the DCMS and local government, provides rigorous training with a
-            commitment to military reforms and a focus on loyalty and excellence.
-        </description>
+        <description>The An Ting University is a renowned military academy historically dedicated to training MekWarriors. ATU, enjoying support from the DCMS and local government, provides rigorous training with a commitment to military reforms and a focus on loyalty and excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>An Ting</locationSystem>
@@ -603,13 +531,7 @@
         <name>An Ting University [3055]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The An Ting University, a renowned military academy historically dedicated to training MekWarriors,
-            faced significant damage from both external attacks and internal strife in 3015 from Sun Zhang Cadre alumni.
-            The academy remained shuttered until 3055 when it reopened with advancements from the Helm Memory Core. ATU,
-            enjoying support from the DCMS and local government, provides rigorous training with a commitment to
-            military reforms and a focus on loyalty and excellence. Despite past conflicts, it now produces capable
-            graduates, reaffirming its status alongside prestigious institutions like the Sun Zhang MekWarrior Academy.
-        </description>
+        <description>The An Ting University, a renowned military academy historically dedicated to training MekWarriors, faced significant damage from both external attacks and internal strife in 3015 from Sun Zhang Cadre alumni. The academy remained shuttered until 3055 when it reopened with advancements from the Helm Memory Core. ATU, enjoying support from the DCMS and local government, provides rigorous training with a commitment to military reforms and a focus on loyalty and excellence. Despite past conflicts, it now produces capable graduates, reaffirming its status alongside prestigious institutions like the Sun Zhang MekWarrior Academy.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>An Ting</locationSystem>
@@ -635,13 +557,7 @@
         <name>An Ting University (Officer) [3055]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The An Ting University, a renowned military academy historically dedicated to training MekWarriors,
-            faced significant damage from both external attacks and internal strife in 3015 from Sun Zhang Cadre alumni.
-            The academy remained shuttered until 3055 when it reopened with advancements from the Helm Memory Core. ATU,
-            enjoying support from the DCMS and local government, provides rigorous training with a commitment to
-            military reforms and a focus on loyalty and excellence. Despite past conflicts, it now produces capable
-            graduates, reaffirming its status alongside prestigious institutions like the Sun Zhang MekWarrior Academy.
-        </description>
+        <description>The An Ting University, a renowned military academy historically dedicated to training MekWarriors, faced significant damage from both external attacks and internal strife in 3015 from Sun Zhang Cadre alumni. The academy remained shuttered until 3055 when it reopened with advancements from the Helm Memory Core. ATU, enjoying support from the DCMS and local government, provides rigorous training with a commitment to military reforms and a focus on loyalty and excellence. Despite past conflicts, it now produces capable graduates, reaffirming its status alongside prestigious institutions like the Sun Zhang MekWarrior Academy.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>An Ting</locationSystem>
@@ -667,12 +583,7 @@
         <name>Annapolis Naval Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted
-            for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command
-            within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to
-            mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled
-            in the Inner Sphere.
-        </description>
+        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled in the Inner Sphere.</description>
         <locationSystem>Terra</locationSystem>
         <closureYear>2779</closureYear>
         <tuition>7350</tuition>
@@ -702,12 +613,7 @@
         <name>Annapolis Naval Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted
-            for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command
-            within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to
-            mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled
-            in the Inner Sphere.
-        </description>
+        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled in the Inner Sphere.</description>
         <locationSystem>Terra</locationSystem>
         <closureYear>2779</closureYear>
         <tuition>12600</tuition>
@@ -737,12 +643,7 @@
         <name>Annapolis Naval Academy (Officer) [ComStar]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted
-            for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command
-            within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to
-            mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled
-            in the Inner Sphere.
-        </description>
+        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled in the Inner Sphere.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -774,12 +675,7 @@
         <name>Annapolis Naval Academy [ComStar]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted
-            for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command
-            within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to
-            mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled
-            in the Inner Sphere.
-        </description>
+        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled in the Inner Sphere.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -811,11 +707,7 @@
         <name>Apollo Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Esteemed as the premier military institution of the Rim Worlds Republic, the Apollo Military
-            Academy is located on the capital world of the Republic. Known for its rigorous standards and distinguished
-            graduates, AMA excels in producing MekWarriors of superior leadership and combat skills, rivaling those from
-            the most prestigious academies in the Inner Sphere.
-        </description>
+        <description>Esteemed as the premier military institution of the Rim Worlds Republic, the Apollo Military Academy is located on the capital world of the Republic. Known for its rigorous standards and distinguished graduates, AMA excels in producing MekWarriors of superior leadership and combat skills, rivaling those from the most prestigious academies in the Inner Sphere.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Apollo</locationSystem>
@@ -854,11 +746,7 @@
         <name>Apollo Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Esteemed as the premier military institution of the Rim Worlds Republic, the Apollo Military
-            Academy is located on the capital world of the Republic. Known for its rigorous standards and distinguished
-            graduates, AMA excels in producing MekWarriors of superior leadership and combat skills, rivaling those from
-            the most prestigious academies in the Inner Sphere.
-        </description>
+        <description>Esteemed as the premier military institution of the Rim Worlds Republic, the Apollo Military Academy is located on the capital world of the Republic. Known for its rigorous standards and distinguished graduates, AMA excels in producing MekWarriors of superior leadership and combat skills, rivaling those from the most prestigious academies in the Inner Sphere.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Apollo</locationSystem>
@@ -897,11 +785,7 @@
         <name>Arc Royal War College of Tamar</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Tamar was renowned for producing adept tacticians, strategists, and outstanding
-            administrators. After Clan Wolf's initial efforts to rebuild the original college yielded poor results,
-            hostilities with Clan Jade Falcon prompted Clan Wolf to collaborate with House Steiner, resulting in the
-            establishment of a new War College of Tamar on the planet Arc Royal.
-        </description>
+        <description>The War College of Tamar was renowned for producing adept tacticians, strategists, and outstanding administrators. After Clan Wolf's initial efforts to rebuild the original college yielded poor results, hostilities with Clan Jade Falcon prompted Clan Wolf to collaborate with House Steiner, resulting in the establishment of a new War College of Tamar on the planet Arc Royal.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tamar</locationSystem>
@@ -928,12 +812,7 @@
         <name>Armstrong Flight Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The premier flight school of the Federated Suns and a leading institution in the Inner Sphere,
-            Galax Flight Academy strategically co-located near Federated-Boeing Interstellar, the largest spacecraft
-            manufacturer in the region. This proximity fosters close interactions with leading engineers and test
-            pilots, enhancing practical training. The academy concentrates on high-level piloting and technician skills,
-            benefiting from this collaborative relationship.
-        </description>
+        <description>The premier flight school of the Federated Suns and a leading institution in the Inner Sphere, Galax Flight Academy strategically co-located near Federated-Boeing Interstellar, the largest spacecraft manufacturer in the region. This proximity fosters close interactions with leading engineers and test pilots, enhancing practical training. The academy concentrates on high-level piloting and technician skills, benefiting from this collaborative relationship.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Galax</locationSystem>
@@ -969,12 +848,7 @@
         <name>Armstrong Phoenix Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally the premier flight school of the Federated Suns and a leading institution in the Inner
-            Sphere, the academy underwent significant changes during the Word of Blake Jihad. It was relocated and
-            renamed Armstrong Phoenix Academy due to severe disruptions. Despite this, it maintains rigorous standards,
-            with intense physical screenings and high skill requirements, resulting in over half of the applicants being
-            rejected pre-examination.
-        </description>
+        <description>Originally the premier flight school of the Federated Suns and a leading institution in the Inner Sphere, the academy underwent significant changes during the Word of Blake Jihad. It was relocated and renamed Armstrong Phoenix Academy due to severe disruptions. Despite this, it maintains rigorous standards, with intense physical screenings and high skill requirements, resulting in over half of the applicants being rejected pre-examination.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Delavan</locationSystem>
@@ -1008,11 +882,7 @@
         <name>Athene Combat School</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Athene Combat School was established during a period of high recruitment within the Free Worlds
-            League, as part of efforts by the Dormuth Council to expand military education. Unique among its
-            contemporaries, ACS focused exclusively on infantry training, addressing a demand for specialized infantry
-            forces.
-        </description>
+        <description>The Athene Combat School was established during a period of high recruitment within the Free Worlds League, as part of efforts by the Dormuth Council to expand military education. Unique among its contemporaries, ACS focused exclusively on infantry training, addressing a demand for specialized infantry forces.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Atreus (FWL)</locationSystem>
@@ -1035,12 +905,7 @@
         <name>Atreus Officer Training College</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Officer Training College offers a unique year-long course focused on developing leadership and
-            command skills, the only one of its kind in the League. Enrollment is open to all soldiers yet to undergo
-            officer training, though only 5% of applicants pass on their first try. The curriculum emphasizes practical
-            skills over theoretical knowledge, preparing officers for the complexities of daily bureaucratic
-            responsibilities with a strong focus on delegation and time management.
-        </description>
+        <description>The Officer Training College offers a unique year-long course focused on developing leadership and command skills, the only one of its kind in the League. Enrollment is open to all soldiers yet to undergo officer training, though only 5% of applicants pass on their first try. The curriculum emphasizes practical skills over theoretical knowledge, preparing officers for the complexities of daily bureaucratic responsibilities with a strong focus on delegation and time management.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Atreus (FWL)</locationSystem>
@@ -1060,10 +925,7 @@
         <name>Blackjack School of Conflict</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Blackjack School of Conflict is a private military academy within the Lyran Commonwealth known
-            for its unorthodox curriculum. Founded by tutors who failed entrance exams at other academies, it offers
-            courses that include unofficial lessons on the shadier aspects of military life.
-        </description>
+        <description>The Blackjack School of Conflict is a private military academy within the Lyran Commonwealth known for its unorthodox curriculum. Founded by tutors who failed entrance exams at other academies, it offers courses that include unofficial lessons on the shadier aspects of military life.</description>
         <locationSystem>Blackjack</locationSystem>
         <constructionYear>2714</constructionYear>
         <destructionYear>3050</destructionYear>
@@ -1109,13 +971,7 @@
         <name>Brotherhood Monastery</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Located in Hope City, the Brotherhood Monastery serves as the training ground for the Brotherhood
-            of Randis, a group reminiscent of the legendary Templar Knights in their stringent adherence to moral and
-            physical disciplines. Entry into this elite unit is highly selective, focusing on candidates who demonstrate
-            a commitment to the Christian faith and moral integrity. The initiation process is rigorous, featuring four
-            perilous trials testing endurance, strength, dexterity, and courage—culminating in an elaborate ceremony
-            where successful initiates receive a distinctive uniform of red and black silk, steel mesh, and a sword.
-        </description>
+        <description>Located in Hope City, the Brotherhood Monastery serves as the training ground for the Brotherhood of Randis, a group reminiscent of the legendary Templar Knights in their stringent adherence to moral and physical disciplines. Entry into this elite unit is highly selective, focusing on candidates who demonstrate a commitment to the Christian faith and moral integrity. The initiation process is rigorous, featuring four perilous trials testing endurance, strength, dexterity, and courage—culminating in an elaborate ceremony where successful initiates receive a distinctive uniform of red and black silk, steel mesh, and a sword.</description>
         <locationSystem>Randis IV (Hope IV 2988-)</locationSystem>
         <constructionYear>2988</constructionYear>
         <tuition>5250</tuition>
@@ -1133,10 +989,7 @@
         <name>Calloway Martial College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Calloway Martial College was established to address the surge in military recruitment within
-            the Free Worlds League. As the first of three new schools created by the Dormuth Council, the academy
-            quickly became operational, featuring its own Calloway Training Battalion.
-        </description>
+        <description>The Calloway Martial College was established to address the surge in military recruitment within the Free Worlds League. As the first of three new schools created by the Dormuth Council, the academy quickly became operational, featuring its own Calloway Training Battalion.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Calloway VI</locationSystem>
@@ -1157,12 +1010,7 @@
         <name>Canopian Institute of War</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of
-            War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic
-            training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates,
-            distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal
-            Guards or pursue further training at the Victoria Academy of Arms and Technology.
-        </description>
+        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards or pursue further training at the Victoria Academy of Arms and Technology.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1186,12 +1034,7 @@
         <name>Canopian Institute of War (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of
-            War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic
-            training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates,
-            distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal
-            Guards or pursue further training at the Victoria Academy of Arms and Technology.
-        </description>
+        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards or pursue further training at the Victoria Academy of Arms and Technology.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1214,12 +1057,7 @@
         <name>Canopian Institute of War [3080]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of
-            War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic
-            training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates,
-            distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal
-            Guards or pursue further training at the Victoria Academy of Arms and Technology.
-        </description>
+        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards or pursue further training at the Victoria Academy of Arms and Technology.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1242,12 +1080,7 @@
         <name>Canopian Institute of War (Officer) [3080]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of
-            War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic
-            training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates,
-            distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal
-            Guards or pursue further training at the Victoria Academy of Arms and Technology.
-        </description>
+        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards or pursue further training at the Victoria Academy of Arms and Technology.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1270,10 +1103,7 @@
         <name>Capella War College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established concurrently with the Capellan Hegemony, the Capella War College stands as the oldest
-            military academy in the Capellan Confederation. Training emphasizes combined-arms tactics and includes
-            cross-training with the local Duchy RTC.
-        </description>
+        <description>Established concurrently with the Capellan Hegemony, the Capella War College stands as the oldest military academy in the Capellan Confederation. Training emphasizes combined-arms tactics and includes cross-training with the local Duchy RTC.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Capella</locationSystem>
@@ -1338,10 +1168,7 @@
         <name>Capella War College (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established concurrently with the Capellan Hegemony, the Capella War College stands as the oldest
-            military academy in the Capellan Confederation. Training emphasizes combined-arms tactics and includes
-            cross-training with the local Duchy RTC.
-        </description>
+        <description>Established concurrently with the Capellan Hegemony, the Capella War College stands as the oldest military academy in the Capellan Confederation. Training emphasizes combined-arms tactics and includes cross-training with the local Duchy RTC.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Capella</locationSystem>
@@ -1405,10 +1232,7 @@
     <academy>
         <name>Caph Institute of Technology</name>
         <type>Military Academy</type>
-        <description>Perched on a high hill and protected by electronic barriers against native lizards, the Caph
-            Institute of Technology specializes in natural sciences, notably paleontology and chemistry. The institute
-            is known for inventing the Jamerson-Ulikov Water Purifier.
-        </description>
+        <description>Perched on a high hill and protected by electronic barriers against native lizards, the Caph Institute of Technology specializes in natural sciences, notably paleontology and chemistry. The institute is known for inventing the Jamerson-Ulikov Water Purifier.</description>
         <locationSystem>Caph</locationSystem>
         <destructionYear>2768</destructionYear>
         <tuition>7500</tuition>
@@ -1425,10 +1249,7 @@
     <academy>
         <name>College of Talitha</name>
         <type>Military Academy</type>
-        <description>The College of Talitha, one of the Golden Ten Universities of the Terran Hegemony, specializes in
-            design studies for civilian and military products, closely collaborating with the Hegemony Research and
-            Development Centers.
-        </description>
+        <description>The College of Talitha, one of the Golden Ten Universities of the Terran Hegemony, specializes in design studies for civilian and military products, closely collaborating with the Hegemony Research and Development Centers.</description>
         <locationSystem>Talitha</locationSystem>
         <destructionYear>2770</destructionYear>
         <tuition>7500</tuition>
@@ -1449,10 +1270,7 @@
         <name>Combat College of New Earth</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Built in 2331, the Combat College was the first military academy on a foreign world. It prided
-            itself on being equal to any academy on Terra. To prove their worth, the graduating warrior and pilot class
-            always challenged the Sandhurst graduates to a military contest.
-        </description>
+        <description>Built in 2331, the Combat College was the first military academy on a foreign world. It prided itself on being equal to any academy on Terra. To prove their worth, the graduating warrior and pilot class always challenged the Sandhurst graduates to a military contest.</description>
         <locationSystem>New Earth (Tau Ceti 2116-)</locationSystem>
         <constructionYear>2331</constructionYear>
         <tuition>9625</tuition>
@@ -1485,10 +1303,7 @@
         <name>Combat College of New Earth (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Built in 2331, the Combat College was the first military academy on a foreign world. It prided
-            itself on being equal to any academy on Terra. To prove their worth, the graduating warrior and pilot class
-            always challenged the Sandhurst graduates to a military contest.
-        </description>
+        <description>Built in 2331, the Combat College was the first military academy on a foreign world. It prided itself on being equal to any academy on Terra. To prove their worth, the graduating warrior and pilot class always challenged the Sandhurst graduates to a military contest.</description>
         <locationSystem>New Earth (Tau Ceti 2116-)</locationSystem>
         <constructionYear>2331</constructionYear>
         <tuition>17500</tuition>
@@ -1521,11 +1336,7 @@
         <name>Concordat Aerospace Flight School</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Operated by seasoned instructors from the Outworlds Alliance, this academy boasts a reputation for
-            excellence. Though it produces fewer graduates than the École Militaire, its focus on quality ensures each
-            cadet emerges as a skilled and disciplined pilot. The school plays a vital role in shaping the aerospace
-            forces of the Taurian Concordat, fostering a legacy of proficiency and valor among its graduates.
-        </description>
+        <description>Operated by seasoned instructors from the Outworlds Alliance, this academy boasts a reputation for excellence. Though it produces fewer graduates than the École Militaire, its focus on quality ensures each cadet emerges as a skilled and disciplined pilot. The school plays a vital role in shaping the aerospace forces of the Taurian Concordat, fostering a legacy of proficiency and valor among its graduates.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Samantha</locationSystem>
@@ -1557,11 +1368,7 @@
         <name>Coventry Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Coventry Academy, located in Dunnigan near Port Lawrence on Coventry, is a military academy
-            close to the Coventry Metal Works plant. Many professors at the Academy also work at the CMW plant. Due to
-            its close ties to CMW, it has been described as a glorified cadre for the manufacturer, with graduates often
-            requiring additional training on equipment from other manufacturers.
-        </description>
+        <description>The Coventry Academy, located in Dunnigan near Port Lawrence on Coventry, is a military academy close to the Coventry Metal Works plant. Many professors at the Academy also work at the CMW plant. Due to its close ties to CMW, it has been described as a glorified cadre for the manufacturer, with graduates often requiring additional training on equipment from other manufacturers.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Coventry</locationSystem>
@@ -1584,11 +1391,7 @@
         <name>Coventry Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Coventry Academy, located in Dunnigan near Port Lawrence on Coventry, is a military academy
-            close to the Coventry Metal Works plant. Many professors at the Academy also work at the CMW plant. Due to
-            its close ties to CMW, it has been described as a glorified cadre for the manufacturer, with graduates often
-            requiring additional training on equipment from other manufacturers.
-        </description>
+        <description>The Coventry Academy, located in Dunnigan near Port Lawrence on Coventry, is a military academy close to the Coventry Metal Works plant. Many professors at the Academy also work at the CMW plant. Due to its close ties to CMW, it has been described as a glorified cadre for the manufacturer, with graduates often requiring additional training on equipment from other manufacturers.</description>
         <locationSystem>Coventry</locationSystem>
         <constructionYear>2700</constructionYear>
         <destructionYear>3058</destructionYear>
@@ -1609,12 +1412,7 @@
         <name>Coventry Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally focused solely on training MekWarriors, its ties to Coventry Metal Works drew criticism,
-            but it persisted as a crucial training ground. During the Clan Invasion, cadets and instructors valiantly
-            defended against Clan Jade Falcon, sacrificing parts of the academy to protect Coventry. Reborn as the
-            Coventry Military Academy in 3060 under Lyran Alliance patronage, it flourishes with modern facilities and
-            OmniMech training.
-        </description>
+        <description>Originally focused solely on training MekWarriors, its ties to Coventry Metal Works drew criticism, but it persisted as a crucial training ground. During the Clan Invasion, cadets and instructors valiantly defended against Clan Jade Falcon, sacrificing parts of the academy to protect Coventry. Reborn as the Coventry Military Academy in 3060 under Lyran Alliance patronage, it flourishes with modern facilities and OmniMech training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Coventry</locationSystem>
@@ -1637,12 +1435,7 @@
         <name>Coventry Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally focused solely on training MekWarriors, its ties to Coventry Metal Works drew criticism,
-            but it persisted as a crucial training ground. During the Clan Invasion, cadets and instructors valiantly
-            defended against Clan Jade Falcon, sacrificing parts of the academy to protect Coventry. Reborn as the
-            Coventry Military Academy in 3060 under Lyran Alliance patronage, it flourishes with modern facilities and
-            OmniMech training.
-        </description>
+        <description>Originally focused solely on training MekWarriors, its ties to Coventry Metal Works drew criticism, but it persisted as a crucial training ground. During the Clan Invasion, cadets and instructors valiantly defended against Clan Jade Falcon, sacrificing parts of the academy to protect Coventry. Reborn as the Coventry Military Academy in 3060 under Lyran Alliance patronage, it flourishes with modern facilities and OmniMech training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Coventry</locationSystem>
@@ -1665,11 +1458,7 @@
         <name>Dieron District Gymnasium</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness
-            over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training,
-            accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the
-            Dieron Military District.
-        </description>
+        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training, accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the Dieron Military District.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieron</locationSystem>
@@ -1693,11 +1482,7 @@
         <name>Dieron District Gymnasium (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness
-            over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training,
-            accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the
-            Dieron Military District.
-        </description>
+        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training, accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the Dieron Military District.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieron</locationSystem>
@@ -1721,12 +1506,7 @@
         <name>Dieron District Gymnasium [3078]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness
-            over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training,
-            accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the
-            Dieron Military District. Briefly closed in 3068; it reopened in 3078, attracting attention with its first
-            class of battlesuit trainees, including a notable presence of ISF agents.
-        </description>
+        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training, accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the Dieron Military District. Briefly closed in 3068; it reopened in 3078, attracting attention with its first class of battlesuit trainees, including a notable presence of ISF agents.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieron</locationSystem>
@@ -1752,12 +1532,7 @@
         <name>Dieron District Gymnasium (Officer) [3078]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness
-            over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training,
-            accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the
-            Dieron Military District. Briefly closed in 3068; it reopened in 3078, attracting attention with its first
-            class of battlesuit trainees, including a notable presence of ISF agents.
-        </description>
+        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training, accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the Dieron Military District. Briefly closed in 3068; it reopened in 3078, attracting attention with its first class of battlesuit trainees, including a notable presence of ISF agents.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieron</locationSystem>
@@ -1783,11 +1558,7 @@
         <name>Dieron Warriors' Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron Warriors Academy on Shimonita annually produces skilled MekWarriors. Graduates are
-            favored for recruitment into the renowned Dieron Regulars, showcasing the academy's pivotal role in regional
-            military development. All five BattleMek regiment commanders have roots in both the Dieron draft and Sun
-            Zhang MekWarrior Academy, highlighting the DWA's lasting influence.
-        </description>
+        <description>The Dieron Warriors Academy on Shimonita annually produces skilled MekWarriors. Graduates are favored for recruitment into the renowned Dieron Regulars, showcasing the academy's pivotal role in regional military development. All five BattleMek regiment commanders have roots in both the Dieron draft and Sun Zhang MekWarrior Academy, highlighting the DWA's lasting influence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Shimonita</locationSystem>
@@ -1808,12 +1579,7 @@
         <name>Dover Institute for Higher Learning</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dover Institute for Higher Learning rose from the ashes of the People's Reconstruction Effort
-            University of Ashio, destroyed during the Shadow War of 2865. Established in 2910 under Coordinator Shinjiro
-            Kurita's patronage, it prioritizes scientific, technical education, and MekWarrior training. Enrollment is
-            open to all meeting basic criteria, with a rigorous five-month basic training followed by a four-year
-            curriculum exposing cadets to diverse combat scenarios.
-        </description>
+        <description>The Dover Institute for Higher Learning rose from the ashes of the People's Reconstruction Effort University of Ashio, destroyed during the Shadow War of 2865. Established in 2910 under Coordinator Shinjiro Kurita's patronage, it prioritizes scientific, technical education, and MekWarrior training. Enrollment is open to all meeting basic criteria, with a rigorous five-month basic training followed by a four-year curriculum exposing cadets to diverse combat scenarios.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dover</locationSystem>
@@ -1839,10 +1605,7 @@
         <name>Ecole Militaire</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The École Militaire stands as the most renowned academy in the Taurian Concordat, offering courses
-            covering almost every form of modern warfare. Renowned for producing elite MekWarriors, armor, and infantry
-            units, the academy admits foreign applicants with a preference for Taurians.
-        </description>
+        <description>The École Militaire stands as the most renowned academy in the Taurian Concordat, offering courses covering almost every form of modern warfare. Renowned for producing elite MekWarriors, armor, and infantry units, the academy admits foreign applicants with a preference for Taurians. </description>
         <locationSystem>Taurus</locationSystem>
         <constructionYear>2500</constructionYear>
         <destructionYear>3078</destructionYear>
@@ -1879,12 +1642,7 @@
         <name>Ecole Militaire [3130]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Devastated during the Jihad, the Ecole Militaire now relies on wounded troops as temporary
-            instructors, reminding cadets of its loss. Renowned for producing elite MekWarriors, armor, and infantry
-            units, the academy admits foreign applicants with a preference for Taurians. Rigorous basic training
-            precedes specialization in armor, infantry, or MekWarrior tracks, emphasizing leadership and offering
-            Officer Candidate School slots upon graduation.
-        </description>
+        <description>Devastated during the Jihad, the Ecole Militaire now relies on wounded troops as temporary instructors, reminding cadets of its loss. Renowned for producing elite MekWarriors, armor, and infantry units, the academy admits foreign applicants with a preference for Taurians. Rigorous basic training precedes specialization in armor, infantry, or MekWarrior tracks, emphasizing leadership and offering Officer Candidate School slots upon graduation.</description>
         <locationSystem>Taurus</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>9625</tuition>
@@ -1919,10 +1677,7 @@
         <name>Emma Centrella Martial Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Emma Centrella Martial Academy succeeds the Canopian Institute of War, nestled in Astarte on
-            Salonika's continent. Graduating its inaugural class in 3083, murmurs of discontent regarding instructional
-            quality have surfaced, despite the MAF's efforts to secure top-tier instructors.
-        </description>
+        <description>The Emma Centrella Martial Academy succeeds the Canopian Institute of War, nestled in Astarte on Salonika's continent. Graduating its inaugural class in 3083, murmurs of discontent regarding instructional quality have surfaced, despite the MAF's efforts to secure top-tier instructors.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1960,10 +1715,7 @@
         <name>Emma Centrella Martial Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Emma Centrella Martial Academy succeeds the Canopian Institute of War, nestled in Astarte on
-            Salonika's continent. Graduating its inaugural class in 3083, murmurs of discontent regarding instructional
-            quality have surfaced, despite the MAF's efforts to secure top-tier instructors.
-        </description>
+        <description>The Emma Centrella Martial Academy succeeds the Canopian Institute of War, nestled in Astarte on Salonika's continent. Graduating its inaugural class in 3083, murmurs of discontent regarding instructional quality have surfaced, despite the MAF's efforts to secure top-tier instructors.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -2001,13 +1753,7 @@
         <name>Emporia Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Following the cataclysmic events of 3150, the Emporia Military Academy rose from the ashes of the
-            Ritza Academy, embodying resilience and fortitude in the face of adversity. Led by a dedicated faculty and
-            staff, it prepares cadets for the challenges of modern warfare, instilling in them the values of courage,
-            discipline, and honor. Despite the scars of past conflicts, the academy remains steadfast in its commitment
-            to shaping future generations of warriors, ensuring that Emporia's legacy of valor endures for generations
-            to come.
-        </description>
+        <description>Following the cataclysmic events of 3150, the Emporia Military Academy rose from the ashes of the Ritza Academy, embodying resilience and fortitude in the face of adversity. Led by a dedicated faculty and staff, it prepares cadets for the challenges of modern warfare, instilling in them the values of courage, discipline, and honor. Despite the scars of past conflicts, the academy remains steadfast in its commitment to shaping future generations of warriors, ensuring that Emporia's legacy of valor endures for generations to come.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Emporia</locationSystem>
@@ -2045,13 +1791,7 @@
         <name>Filtvelt Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Filtvelt Military Academy, initially serving the Federated Suns' Outback region and later the
-            Filtvelt Coalition, is built during the late Third Succession War near Undredal's capital. Similar to
-            Kilbourne Academy, FMA offers educational opportunities to civilians in a region scarce in options. Despite
-            lacking advanced resources like simulators, FMA excels by providing intensive practical training, producing
-            graduates well-prepared for real combat situations, though they are often underestimated by larger military
-            entities.
-        </description>
+        <description>Filtvelt Military Academy, initially serving the Federated Suns' Outback region and later the Filtvelt Coalition, is built during the late Third Succession War near Undredal's capital. Similar to Kilbourne Academy, FMA offers educational opportunities to civilians in a region scarce in options. Despite lacking advanced resources like simulators, FMA excels by providing intensive practical training, producing graduates well-prepared for real combat situations, though they are often underestimated by larger military entities.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Filtvelt</locationSystem>
@@ -2092,11 +1832,7 @@
         <name>Finmark Air and Space Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Finmark Air and Space Academy serves as a vital training ground for the naval officer corps of
-            the Rim Worlds Republic. Positioned in high orbit above Finmark, the administrative hub of the Finmark
-            Province, FASA boasts a substantial annual output of new officers. Offering a comprehensive WarShip program
-            among its military courses, FASA plays a crucial role in shaping Republic naval personnel.
-        </description>
+        <description>The Finmark Air and Space Academy serves as a vital training ground for the naval officer corps of the Rim Worlds Republic. Positioned in high orbit above Finmark, the administrative hub of the Finmark Province, FASA boasts a substantial annual output of new officers. Offering a comprehensive WarShip program among its military courses, FASA plays a crucial role in shaping Republic naval personnel.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Finmark</locationSystem>
@@ -2132,11 +1868,7 @@
         <name>Finmark Air and Space Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Finmark Air and Space Academy serves as a vital training ground for the naval officer corps of
-            the Rim Worlds Republic. Positioned in high orbit above Finmark, the administrative hub of the Finmark
-            Province, FASA boasts a substantial annual output of new officers. Offering a comprehensive WarShip program
-            among its military courses, FASA plays a crucial role in shaping Republic naval personnel.
-        </description>
+        <description>The Finmark Air and Space Academy serves as a vital training ground for the naval officer corps of the Rim Worlds Republic. Positioned in high orbit above Finmark, the administrative hub of the Finmark Province, FASA boasts a substantial annual output of new officers. Offering a comprehensive WarShip program among its military courses, FASA plays a crucial role in shaping Republic naval personnel.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Finmark</locationSystem>
@@ -2172,10 +1904,7 @@
         <name>Fleet School of Keid</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Next to the Annapolis and Kure Naval Academies, the Fleet School of Keid is the largest training
-            facility for naval personnel in the Inner Sphere. Each school has several WarShips and JumpShips for crew
-            training.
-        </description>
+        <description>Next to the Annapolis and Kure Naval Academies, the Fleet School of Keid is the largest training facility for naval personnel in the Inner Sphere. Each school has several WarShips and JumpShips for crew training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Keid</locationSystem>
@@ -2210,10 +1939,7 @@
         <name>Fleet School of Keid (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Next to the Annapolis and Kure Naval Academies, the Fleet School of Keid is the largest training
-            facility for naval personnel in the Inner Sphere. Each school has several WarShips and JumpShips for crew
-            training.
-        </description>
+        <description>Next to the Annapolis and Kure Naval Academies, the Fleet School of Keid is the largest training facility for naval personnel in the Inner Sphere. Each school has several WarShips and JumpShips for crew training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Keid</locationSystem>
@@ -2248,9 +1974,7 @@
         <name>Flight Academy of Graham</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Flight Academy of Graham is one of the few schools dedicated solely to training aerospace
-            pilots and one of the few orbiting space academies. Over 2,000 pilots graduate from the academy every year.
-        </description>
+        <description>The Flight Academy of Graham is one of the few schools dedicated solely to training aerospace pilots and one of the few orbiting space academies. Over 2,000 pilots graduate from the academy every year.</description>
         <locationSystem>Graham IV</locationSystem>
         <destructionYear>2767</destructionYear>
         <tuition>8750</tuition>
@@ -2274,9 +1998,7 @@
         <name>Flight Academy of Graham (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Flight Academy of Graham is one of the few schools dedicated solely to training aerospace
-            pilots and one of the few orbiting space academies. Over 2,000 pilots graduate from the academy every year.
-        </description>
+        <description>The Flight Academy of Graham is one of the few schools dedicated solely to training aerospace pilots and one of the few orbiting space academies. Over 2,000 pilots graduate from the academy every year.</description>
         <locationSystem>Graham IV</locationSystem>
         <destructionYear>2767</destructionYear>
         <tuition>14875</tuition>
@@ -2300,9 +2022,7 @@
         <name>Flight Academy of Thorin</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Flight Academy of Thorin excels in training aerospace personnel for the Lyran Commonwealth
-            Armed Forces. Graduates, distinguished by gray-red 'school rags,' reflect Thorin's Star League legacy.
-        </description>
+        <description>The Flight Academy of Thorin excels in training aerospace personnel for the Lyran Commonwealth Armed Forces. Graduates, distinguished by gray-red 'school rags,' reflect Thorin's Star League legacy.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Thorin</locationSystem>
@@ -2338,10 +2058,7 @@
         <name>Focht War College [Kentares IV]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Following the Jihad and the destruction of the original Focht War College on Tukayyid, Kentares IV
-            becomes the new location for the college. With significant financial backing from the Federated Suns, the
-            college focuses on training a new generation of leaders for various military roles.
-        </description>
+        <description>Following the Jihad and the destruction of the original Focht War College on Tukayyid, Kentares IV becomes the new location for the college. With significant financial backing from the Federated Suns, the college focuses on training a new generation of leaders for various military roles.</description>
         <locationSystem>Kentares IV</locationSystem>
         <constructionYear>3085</constructionYear>
         <tuition>7500</tuition>
@@ -2377,10 +2094,7 @@
         <name>Focht War College (Officer) [Kentares IV]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Following the Jihad and the destruction of the original Focht War College on Tukayyid, Kentares IV
-            becomes the new location for the college. With significant financial backing from the Federated Suns, the
-            college focuses on training a new generation of leaders for various military roles.
-        </description>
+        <description>Following the Jihad and the destruction of the original Focht War College on Tukayyid, Kentares IV becomes the new location for the college. With significant financial backing from the Federated Suns, the college focuses on training a new generation of leaders for various military roles.</description>
         <locationSystem>Kentares IV</locationSystem>
         <constructionYear>3085</constructionYear>
         <tuition>14063</tuition>
@@ -2416,10 +2130,7 @@
         <name>Focht War College [Tukayyid]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Focht War College is pivotal in training the elite ComGuards and later, the forces of the
-            Second Star League. Tukayyid's sparse civilian presence and rugged terrain made it ideal for rigorous
-            military exercises.
-        </description>
+        <description>The Focht War College is pivotal in training the elite ComGuards and later, the forces of the Second Star League. Tukayyid's sparse civilian presence and rugged terrain made it ideal for rigorous military exercises.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tukayyid</locationSystem>
@@ -2458,10 +2169,7 @@
         <name>Focht War College (Officer) [Tukayyid]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Focht War College is pivotal in training the elite ComGuards and later, the forces of the
-            Second Star League. Tukayyid's sparse civilian presence and rugged terrain made it ideal for rigorous
-            military exercises.
-        </description>
+        <description>The Focht War College is pivotal in training the elite ComGuards and later, the forces of the Second Star League. Tukayyid's sparse civilian presence and rugged terrain made it ideal for rigorous military exercises.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tukayyid</locationSystem>
@@ -2500,9 +2208,7 @@
         <name>Frihet Training Facility (Semester One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 3055 after the loss of the Radstadt Academy during the Clan Invasion, the Frihet
-            Training Facility became a cornerstone of the Free Rasalhague Republic's military growth efforts.
-        </description>
+        <description>Established in 3055 after the loss of the Radstadt Academy during the Clan Invasion, the Frihet Training Facility became a cornerstone of the Free Rasalhague Republic's military growth efforts.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Grumium</locationSystem>
@@ -2522,9 +2228,7 @@
         <name>Frihet Training Facility</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 3055 after the loss of the Radstadt Academy during the Clan Invasion, the Frihet
-            Training Facility became a cornerstone of the Free Rasalhague Republic's military growth efforts.
-        </description>
+        <description>Established in 3055 after the loss of the Radstadt Academy during the Clan Invasion, the Frihet Training Facility became a cornerstone of the Free Rasalhague Republic's military growth efforts.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Grumium</locationSystem>
@@ -2562,10 +2266,7 @@
         <name>Frunze Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Frunze Military Academy is a renowned institution, central in the development of military
-            theory and practice in the former Soviet Union. Frunze's graduates are esteemed for their deep tactical
-            acumen and unwavering discipline, preparing them for multifaceted warfare among the stars.
-        </description>
+        <description>The Frunze Military Academy is a renowned institution, central in the development of military theory and practice in the former Soviet Union. Frunze's graduates are esteemed for their deep tactical acumen and unwavering discipline, preparing them for multifaceted warfare among the stars.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -2602,10 +2303,7 @@
         <name>Frunze Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Frunze Military Academy is a renowned institution, central in the development of military
-            theory and practice in the former Soviet Union. Frunze's graduates are esteemed for their deep tactical
-            acumen and unwavering discipline, preparing them for multifaceted warfare among the stars.
-        </description>
+        <description>The Frunze Military Academy is a renowned institution, central in the development of military theory and practice in the former Soviet Union. Frunze's graduates are esteemed for their deep tactical acumen and unwavering discipline, preparing them for multifaceted warfare among the stars.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -2642,11 +2340,7 @@
         <name>Galedon Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established on Galedon V before the formation of the Draconis Combine, the Galedon Military Academy
-            is renowned as one of the oldest institutions of its kind. Exclusive to graduates of Galedon Military
-            District primary schools, GMA offers comprehensive training across all DCMS branches, with a focus on
-            rigorous physical conditioning unmatched by other academies.
-        </description>
+        <description>Established on Galedon V before the formation of the Draconis Combine, the Galedon Military Academy is renowned as one of the oldest institutions of its kind. Exclusive to graduates of Galedon Military District primary schools, GMA offers comprehensive training across all DCMS branches, with a focus on rigorous physical conditioning unmatched by other academies.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Galedon V</locationSystem>
@@ -2715,11 +2409,7 @@
         <name>Galedon Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established on Galedon V before the formation of the Draconis Combine, the Galedon Military Academy
-            is renowned as one of the oldest institutions of its kind. Exclusive to graduates of Galedon Military
-            District primary schools, GMA offers comprehensive training across all DCMS branches, with a focus on
-            rigorous physical conditioning unmatched by other academies.
-        </description>
+        <description>Established on Galedon V before the formation of the Draconis Combine, the Galedon Military Academy is renowned as one of the oldest institutions of its kind. Exclusive to graduates of Galedon Military District primary schools, GMA offers comprehensive training across all DCMS branches, with a focus on rigorous physical conditioning unmatched by other academies.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Galedon V</locationSystem>
@@ -2788,11 +2478,7 @@
         <name>Gershwin Academy of Combat</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The esteemed Gershwin Academy of Combat, a private institution founded by the Gershwin Mining
-            Collective, specializes in honing the skills of MekWarrior and armored cavalry. Graduates emerge
-            well-equipped for diverse combat scenarios, instilled with discipline and strategic prowess. Aspiring
-            warriors flock to GAC for its distinguished legacy and commitment to producing elite combat personnel.
-        </description>
+        <description>The esteemed Gershwin Academy of Combat, a private institution founded by the Gershwin Mining Collective, specializes in honing the skills of MekWarrior and armored cavalry. Graduates emerge well-equipped for diverse combat scenarios, instilled with discipline and strategic prowess. Aspiring warriors flock to GAC for its distinguished legacy and commitment to producing elite combat personnel.</description>
         <locationSystem>Zollikofen</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>15750</tuition>
@@ -2821,11 +2507,7 @@
     <academy>
         <name>Gogh-Bukowski University of New Avalon</name>
         <type>University</type>
-        <description>Located on New Avalon, Gogh-Bukowski University stands as a leading arts institution in the Inner
-            Sphere, housing schools for Written Arts, Visual Arts, and Musical Arts. With a reputation for its liberal
-            and anti-government stance, the university has historically experienced tensions with the New Avalon
-            Institute of Science.
-        </description>
+        <description>Located on New Avalon, Gogh-Bukowski University stands as a leading arts institution in the Inner Sphere, housing schools for Written Arts, Visual Arts, and Musical Arts. With a reputation for its liberal and anti-government stance, the university has historically experienced tensions with the New Avalon Institute of Science.</description>
         <locationSystem>New Avalon</locationSystem>
         <constructionYear>2600</constructionYear>
         <tuition>6250</tuition>
@@ -2846,9 +2528,7 @@
         <name>Goshen BattleMek Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Goshen, founded by Generals Alexander and Truscott, is a renowned private
-            military academy in the Federated Suns, celebrated for its production of capable combat leaders.
-        </description>
+        <description>The War College of Goshen, founded by Generals Alexander and Truscott, is a renowned private military academy in the Federated Suns, celebrated for its production of capable combat leaders.</description>
         <locationSystem>Goshen</locationSystem>
         <constructionYear>2950</constructionYear>
         <closureYear>2960</closureYear>
@@ -2867,10 +2547,7 @@
         <name>Gunslinger Program</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Gunslinger Program, originally known as the Advanced Combat and Maneuvering Skills Project, was
-            initiated by the Star League Defense Force in response to the First Hidden War. It blends ancient martial
-            philosophies with cutting-edge technology, producing skilled duelists.
-        </description>
+        <description>The Gunslinger Program, originally known as the Advanced Combat and Maneuvering Skills Project, was initiated by the Star League Defense Force in response to the First Hidden War. It blends ancient martial philosophies with cutting-edge technology, producing skilled duelists.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -2891,13 +2568,7 @@
         <name>Gunslinger Program [3062]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Gunslinger Program, originally known as the Advanced Combat and Maneuvering Skills Project, was
-            initiated by the Star League Defense Force in response to the First Hidden War. It blends ancient martial
-            philosophies with cutting-edge technology, producing skilled duelists. Though the original program ceased
-            with the fall of the Star League in 2781, its revival by the Second Star League in 3062 at the Focht War
-            College on Tukayyid. This iteration focuses on teaching the one-on-one combat style favored by the Clans,
-            accepting troops from any member state.
-        </description>
+        <description>The Gunslinger Program, originally known as the Advanced Combat and Maneuvering Skills Project, was initiated by the Star League Defense Force in response to the First Hidden War. It blends ancient martial philosophies with cutting-edge technology, producing skilled duelists. Though the original program ceased with the fall of the Star League in 2781, its revival by the Second Star League in 3062 at the Focht War College on Tukayyid. This iteration focuses on teaching the one-on-one combat style favored by the Clans, accepting troops from any member state.</description>
         <locationSystem>Tukayyid</locationSystem>
         <constructionYear>3062</constructionYear>
         <tuition>36750</tuition>
@@ -2915,10 +2586,7 @@
         <name>Hachiman Technical Institute</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Hachiman Technical Institute specializes in battlefield repair and technical training, focusing
-            on maintaining BattleMeks, aerospace fighters, and DropShips. It admits candidates rejected by other
-            Draconis Combine military academies, as well as select trade school graduates.
-        </description>
+        <description>The Hachiman Technical Institute specializes in battlefield repair and technical training, focusing on maintaining BattleMeks, aerospace fighters, and DropShips. It admits candidates rejected by other Draconis Combine military academies, as well as select trade school graduates.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Hachiman</locationSystem>
@@ -2947,9 +2615,7 @@
         <name>Hero Training Institute [Cap Rouge]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Situated on Sillery's continent, the Hero Training Institute - Cap Rouge provides training programs
-            for aspiring BattleMek and aerospace fighter pilots.
-        </description>
+        <description>Situated on Sillery's continent, the Hero Training Institute - Cap Rouge provides training programs for aspiring BattleMek and aerospace fighter pilots.</description>
         <locationSystem>Cap Rouge</locationSystem>
         <constructionYear>3072</constructionYear>
         <tuition>35000</tuition>
@@ -2970,11 +2636,7 @@
         <name>Hero Training Institute [Maxwell]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Hero Training Institute offers an unconventional route to becoming a MekWarrior, bypassing
-            traditional credentials. Known for its high fees and extensive advertising, HTI provides subpar training
-            with limited hands-on experience. Nonetheless, it allows graduates to enter mercenary units or
-            non-commissioned positions in the Free Worlds League Military.
-        </description>
+        <description>The Hero Training Institute offers an unconventional route to becoming a MekWarrior, bypassing traditional credentials. Known for its high fees and extensive advertising, HTI provides subpar training with limited hands-on experience. Nonetheless, it allows graduates to enter mercenary units or non-commissioned positions in the Free Worlds League Military.</description>
         <locationSystem>Maxwell</locationSystem>
         <constructionYear>2989</constructionYear>
         <tuition>52500</tuition>
@@ -3001,10 +2663,7 @@
         <name>Hero Training Institute [Payvand]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The second-oldest Hero Training Institute, the Payvand campus, is located in Pejman on the Gooya
-            continent. Despite significant investment in the Maxwell campus, Payvand remains decrepit, with aging
-            simulators reflecting the corporation's neglect in updating its facilities.
-        </description>
+        <description>The second-oldest Hero Training Institute, the Payvand campus, is located in Pejman on the Gooya continent. Despite significant investment in the Maxwell campus, Payvand remains decrepit, with aging simulators reflecting the corporation's neglect in updating its facilities.</description>
         <locationSystem>Payvand</locationSystem>
         <constructionYear>3010</constructionYear>
         <tuition>35000</tuition>
@@ -3025,11 +2684,7 @@
         <name>Hero Training Institute [Sorunda]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Hero Training Institute's Sorunda campus sits on the predominantly pacifist Buddhist planet of
-            Serenity, nestled in the Modesty Grasslands. Constructed away from population centers to minimize
-            disruption, the academy faced initial resistance from locals. However, concerns over defense eventually led
-            to the community's approval of its establishment.
-        </description>
+        <description>The Hero Training Institute's Sorunda campus sits on the predominantly pacifist Buddhist planet of Serenity, nestled in the Modesty Grasslands. Constructed away from population centers to minimize disruption, the academy faced initial resistance from locals. However, concerns over defense eventually led to the community's approval of its establishment.</description>
         <locationSystem>Sorunda</locationSystem>
         <constructionYear>3073</constructionYear>
         <tuition>35000</tuition>
@@ -3050,10 +2705,7 @@
         <name>Hero Training Institute [Sterling]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Hero Training Institute's Sterling campus sits near Starlight on the Graham continent, offering
-            training for BattleMek and aerospace fighter pilots. Sterling is among several new HTI campuses established
-            to meet the heightened demand for military training.
-        </description>
+        <description>The Hero Training Institute's Sterling campus sits near Starlight on the Graham continent, offering training for BattleMek and aerospace fighter pilots. Sterling is among several new HTI campuses established to meet the heightened demand for military training.</description>
         <locationSystem>Sterling</locationSystem>
         <constructionYear>3074</constructionYear>
         <tuition>35000</tuition>
@@ -3074,12 +2726,7 @@
         <name>Hero Training Institute [Trinidad]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Trinidad, the newest Hero Training Institute campus as of 3079, sits in the Arawak Marshlands on
-            the Arawak continent. Founded by ex-SAFE veterans, it offers the Inner Sphere's first private Special
-            Operations training. Its "logistics studies" course, though not officially listed, commands the highest fees
-            and the best equipment. Enrollment entails heavy screening and dean's permission, with most applicants
-            relying on referrals.
-        </description>
+        <description>Trinidad, the newest Hero Training Institute campus as of 3079, sits in the Arawak Marshlands on the Arawak continent. Founded by ex-SAFE veterans, it offers the Inner Sphere's first private Special Operations training. Its "logistics studies" course, though not officially listed, commands the highest fees and the best equipment. Enrollment entails heavy screening and dean's permission, with most applicants relying on referrals.</description>
         <locationSystem>Trinidad</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>192500</tuition>
@@ -3099,10 +2746,7 @@
         <name>Humphreys School of Warfare</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established on Kanata in late 2762, the Humphreys School of Warfare (HSW) is one of three major
-            military academies created by the Dormuth Council to manage high recruitment numbers in the Free Worlds
-            League. It primarily recruits cadets from the Duchy of Andurien and nearby independent worlds.
-        </description>
+        <description>Established on Kanata in late 2762, the Humphreys School of Warfare (HSW) is one of three major military academies created by the Dormuth Council to manage high recruitment numbers in the Free Worlds League. It primarily recruits cadets from the Duchy of Andurien and nearby independent worlds.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kanata</locationSystem>
@@ -3134,9 +2778,7 @@
         <name>Humphreys Training Academy (Semester One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors,
-            providing comprehensive classes instructed by experienced lecturers.
-        </description>
+        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors, providing comprehensive classes instructed by experienced lecturers.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
@@ -3157,9 +2799,7 @@
         <name>Humphreys Training Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors,
-            providing comprehensive classes instructed by experienced lecturers.
-        </description>
+        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors, providing comprehensive classes instructed by experienced lecturers.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
@@ -3180,12 +2820,7 @@
         <name>Humphreys Training Academy (Semester One) [3079]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>After the Andurien Secession, the Humphreys Training Academy was rebranded as the Legionary
-            Training Academy. Upon the Free Worlds League's dissolution, the Duchy of Andurien restored its original
-            name. Despite production challenges, the Anduriens have expanded training for battle armor and aerospace,
-            hiring experienced Andurien Rangers as instructors. Enrollment is limited to low-risk students passing
-            mental and physical tests.
-        </description>
+        <description>After the Andurien Secession, the Humphreys Training Academy was rebranded as the Legionary Training Academy. Upon the Free Worlds League's dissolution, the Duchy of Andurien restored its original name. Despite production challenges, the Anduriens have expanded training for battle armor and aerospace, hiring experienced Andurien Rangers as instructors. Enrollment is limited to low-risk students passing mental and physical tests.</description>
         <locationSystem>Andurien</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>4375</tuition>
@@ -3203,12 +2838,7 @@
         <name>Humphreys Training Academy [3079]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>After the Andurien Secession, the Humphreys Training Academy was rebranded as the Legionary
-            Training Academy. Upon the Free Worlds League's dissolution, the Duchy of Andurien restored its original
-            name. Despite production challenges, the Anduriens have expanded training for battle armor and aerospace,
-            hiring experienced Andurien Rangers as instructors. Enrollment is limited to low-risk students passing
-            mental and physical tests.
-        </description>
+        <description>After the Andurien Secession, the Humphreys Training Academy was rebranded as the Legionary Training Academy. Upon the Free Worlds League's dissolution, the Duchy of Andurien restored its original name. Despite production challenges, the Anduriens have expanded training for battle armor and aerospace, hiring experienced Andurien Rangers as instructors. Enrollment is limited to low-risk students passing mental and physical tests.</description>
         <locationSystem>Andurien</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>4375</tuition>
@@ -3232,9 +2862,7 @@
         <name>Illiushin Taurian Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Illiushin Taurian Academy is a small academy within the Taurian Concordat that trains
-            conventional troops, alongside a program of IndustrialMek training.
-        </description>
+        <description>The Illiushin Taurian Academy is a small academy within the Taurian Concordat that trains conventional troops, alongside a program of IndustrialMek training.</description>
         <locationSystem>Illiushin</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>8750</tuition>
@@ -3263,10 +2891,7 @@
     <academy>
         <name>Imperial Institute of Technology</name>
         <type>University</type>
-        <description>The Imperial Institute of Technology stands as the Draconis Combine's top-tier university for
-            technology studies. It admits only the most talented students in science and mathematics, with some cadets
-            from other academies attending for a year after passing stringent tests.
-        </description>
+        <description>The Imperial Institute of Technology stands as the Draconis Combine's top-tier university for technology studies. It admits only the most talented students in science and mathematics, with some cadets from other academies attending for a year after passing stringent tests.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Xinyang</locationSystem>
@@ -3289,12 +2914,7 @@
         <name>Internal Security College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Internal Security College is where the Draconis Combine's Internal Security Force receives
-            training. The facility is heavily fortified, surrounded by 60 kilometers of diacetylsillicate, a corrosive
-            sand, and strictly enforces a no-fly zone within 200 km, shooting down any unauthorized aircraft. Admission
-            to the ISC is through a classified recruitment process, and students' identities are kept secret. The ISC
-            provides rigorous training in psychology, anatomy, and zero-g martial arts.
-        </description>
+        <description>The Internal Security College is where the Draconis Combine's Internal Security Force receives training. The facility is heavily fortified, surrounded by 60 kilometers of diacetylsillicate, a corrosive sand, and strictly enforces a no-fly zone within 200 km, shooting down any unauthorized aircraft. Admission to the ISC is through a classified recruitment process, and students' identities are kept secret. The ISC provides rigorous training in psychology, anatomy, and zero-g martial arts.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Samarkand</locationSystem>
@@ -3317,9 +2937,7 @@
         <name>Irian Academy of Combative Science</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Irian Academy trains MekWarriors and is highly regarded among schools. Students undergo
-            instruction in history and combat, including live fire training in the Radner Proving Grounds.
-        </description>
+        <description>The Irian Academy trains MekWarriors and is highly regarded among schools. Students undergo instruction in history and combat, including live fire training in the Radner Proving Grounds.</description>
         <locationSystem>Irian</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>4375</tuition>
@@ -3336,10 +2954,7 @@
     <academy>
         <name>James McKenna University</name>
         <type>University</type>
-        <description>Situated in Glasgow on Terra, James McKenna University, named after the founder of the Terran
-            Hegemony, specializes in foreign relations. Its distinguished program prepares graduates for prestigious
-            roles within the Star League's diplomatic corps.
-        </description>
+        <description>Situated in Glasgow on Terra, James McKenna University, named after the founder of the Terran Hegemony, specializes in foreign relations. Its distinguished program prepares graduates for prestigious roles within the Star League's diplomatic corps.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3362,9 +2977,7 @@
         <name>Jarvis Military Proving and Training Grounds</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Jarvis Military Proving and Training Grounds serves as a key training facility for infantry and
-            armor crews in the Free Worlds League Military.
-        </description>
+        <description>The Jarvis Military Proving and Training Grounds serves as a key training facility for infantry and armor crews in the Free Worlds League Military.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieudonné</locationSystem>
@@ -3396,10 +3009,7 @@
     <academy>
         <name>Jefferson University</name>
         <type>University</type>
-        <description>Jefferson University, a prominent Federated Suns institution, is renowned for its science and
-            research programs, particularly in physics. The campus features an underground particle accelerator with
-            extensive tunnels for cutting-edge research.
-        </description>
+        <description>Jefferson University, a prominent Federated Suns institution, is renowned for its science and research programs, particularly in physics. The campus features an underground particle accelerator with extensive tunnels for cutting-edge research.</description>
         <locationSystem>New Syrtis</locationSystem>
         <constructionYear>2600</constructionYear>
         <tuition>7500</tuition>
@@ -3420,10 +3030,7 @@
         <name>Kensai Kami [Aix-la-Chapelle]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered
-            Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against
-            instructors and peers to reach new heights of excellence.
-        </description>
+        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against instructors and peers to reach new heights of excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aix-la-Chapelle</locationSystem>
@@ -3443,10 +3050,7 @@
         <name>Kensai Kami [Luthien]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered
-            Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against
-            instructors and peers to reach new heights of excellence.
-        </description>
+        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against instructors and peers to reach new heights of excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Luthien</locationSystem>
@@ -3466,10 +3070,7 @@
         <name>Kensai Kami [McAlister]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered
-            Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against
-            instructors and peers to reach new heights of excellence.
-        </description>
+        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against instructors and peers to reach new heights of excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>McAlister</locationSystem>
@@ -3489,10 +3090,7 @@
         <name>Kilbourne Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Kilbourne Academy, located on Kilbourne's Colorado continent near the Rio Grande, has long been a
-            key military training institution in the Federated Suns. Renowned for producing high-quality officers for
-            conventional forces, its graduates are as esteemed as those from more prominent academies.
-        </description>
+        <description>Kilbourne Academy, located on Kilbourne's Colorado continent near the Rio Grande, has long been a key military training institution in the Federated Suns. Renowned for producing high-quality officers for conventional forces, its graduates are as esteemed as those from more prominent academies.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kilbourne</locationSystem>
@@ -3530,10 +3128,7 @@
         <name>Kilbourne Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Kilbourne Academy, located on Kilbourne's Colorado continent near the Rio Grande, has long been a
-            key military training institution in the Federated Suns. Renowned for producing high-quality officers for
-            conventional forces, its graduates are as esteemed as those from more prominent academies.
-        </description>
+        <description>Kilbourne Academy, located on Kilbourne's Colorado continent near the Rio Grande, has long been a key military training institution in the Federated Suns. Renowned for producing high-quality officers for conventional forces, its graduates are as esteemed as those from more prominent academies.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kilbourne</locationSystem>
@@ -3571,11 +3166,7 @@
         <name>Krieg Universital</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Rooted in Prussian military traditions, the Kriegsakademie, known in the Star League as Krieg
-            Universital, epitomizes strategic and operational excellence. Distinguished by its rigorous approach to
-            military science and integration of technological innovation, the academy prepares officers adept in
-            commanding both space fleets and ground operations.
-        </description>
+        <description>Rooted in Prussian military traditions, the Kriegsakademie, known in the Star League as Krieg Universital, epitomizes strategic and operational excellence. Distinguished by its rigorous approach to military science and integration of technological innovation, the academy prepares officers adept in commanding both space fleets and ground operations.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3624,10 +3215,7 @@
         <name>Kure Naval Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originating from Kure, Japan, the Kure Naval Academy exemplifies Earth's enduring martial spirit.
-            Graduates are proficient in naval command and adept in JumpShip and DropShip operations, making them
-            indispensable to the League's celestial might.
-        </description>
+        <description>Originating from Kure, Japan, the Kure Naval Academy exemplifies Earth's enduring martial spirit. Graduates are proficient in naval command and adept in JumpShip and DropShip operations, making them indispensable to the League's celestial might.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3655,10 +3243,7 @@
         <name>Kure Naval Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originating from Kure, Japan, the Kure Naval Academy exemplifies Earth's enduring martial spirit.
-            Graduates are proficient in naval command and adept in JumpShip and DropShip operations, making them
-            indispensable to the League's celestial might.
-        </description>
+        <description>Originating from Kure, Japan, the Kure Naval Academy exemplifies Earth's enduring martial spirit. Graduates are proficient in naval command and adept in JumpShip and DropShip operations, making them indispensable to the League's celestial might.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3686,10 +3271,7 @@
         <name>Legionary Training Academy (Semester One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors,
-            providing comprehensive classes instructed by experienced lecturers. Following the Andurien Secession, the
-            Humphreys Training Academy became the Legionary Training Academy under the Free Worlds League.
-        </description>
+        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors, providing comprehensive classes instructed by experienced lecturers. Following the Andurien Secession, the Humphreys Training Academy became the Legionary Training Academy under the Free Worlds League.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
@@ -3710,10 +3292,7 @@
         <name>Legionary Training Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors,
-            providing comprehensive classes instructed by experienced lecturers. Following the Andurien Secession, the
-            Humphreys Training Academy became the Legionary Training Academy under the Free Worlds League.
-        </description>
+        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors, providing comprehensive classes instructed by experienced lecturers. Following the Andurien Secession, the Humphreys Training Academy became the Legionary Training Academy under the Free Worlds League.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
@@ -3734,10 +3313,7 @@
         <name>Liao Conservatory of Military Arts</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to
-            train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields,
-            with the expectation of joining veteran or elite commands upon graduation.
-        </description>
+        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields, with the expectation of joining veteran or elite commands upon graduation.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -3779,10 +3355,7 @@
         <name>Liao Conservatory of Military Arts (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to
-            train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields,
-            with the expectation of joining veteran or elite commands upon graduation.
-        </description>
+        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields, with the expectation of joining veteran or elite commands upon graduation.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -3824,11 +3397,7 @@
         <name>Liao Conservatory of Military Arts [3135]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to
-            train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields,
-            with the expectation of joining veteran or elite commands upon graduation. Briefly renamed the Republic
-            Conservatory, it became a focal point during the Capellan Confederation's 3134 invasion.
-        </description>
+        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields, with the expectation of joining veteran or elite commands upon graduation. Briefly renamed the Republic Conservatory, it became a focal point during the Capellan Confederation's 3134 invasion. </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -3869,11 +3438,7 @@
         <name>Liao Conservatory of Military Arts [3135] (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to
-            train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields,
-            with the expectation of joining veteran or elite commands upon graduation. Briefly renamed the Republic
-            Conservatory, it became a focal point during the Capellan Confederation's 3134 invasion.
-        </description>
+        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields, with the expectation of joining veteran or elite commands upon graduation. Briefly renamed the Republic Conservatory, it became a focal point during the Capellan Confederation's 3134 invasion. </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -3914,11 +3479,7 @@
         <name>Lloyd Marik-Stanley Aerospace School (Year One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>For over five centuries, the Lloyd Marik-Stanley Aerospace School has been the primary training
-            ground for essential naval personnel in the Free Worlds League. Each year, the school admits 1,000 students
-            into a rigorous three-year basic training program. Selection is made by the Captain-General, with aptitude
-            testing ensuring suitability for aerospace roles.
-        </description>
+        <description>For over five centuries, the Lloyd Marik-Stanley Aerospace School has been the primary training ground for essential naval personnel in the Free Worlds League. Each year, the school admits 1,000 students into a rigorous three-year basic training program. Selection is made by the Captain-General, with aptitude testing ensuring suitability for aerospace roles.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Marik</locationSystem>
@@ -3938,11 +3499,7 @@
         <name>Lloyd Marik-Stanley Aerospace School</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>For over five centuries, the Lloyd Marik-Stanley Aerospace School has been the primary training
-            ground for essential naval personnel in the Free Worlds League. Each year, the school admits 1,000 students
-            into a rigorous three-year basic training program. Selection is made by the Captain-General, with aptitude
-            testing ensuring suitability for aerospace roles.
-        </description>
+        <description>For over five centuries, the Lloyd Marik-Stanley Aerospace School has been the primary training ground for essential naval personnel in the Free Worlds League. Each year, the school admits 1,000 students into a rigorous three-year basic training program. Selection is made by the Captain-General, with aptitude testing ensuring suitability for aerospace roles.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Marik</locationSystem>
@@ -3970,11 +3527,7 @@
     <academy>
         <name>Luthien University</name>
         <type>University</type>
-        <description>Situated on Luthien, this university provides a conventional educational range aimed at equipping
-            students for civil or diplomatic roles. The curriculum encompasses history, astrography, languages, and art
-            history, prioritizing the development of students' communicative abilities rather than technical
-            proficiency. Graduates typically embark on careers as bureaucrats or in junior diplomatic positions.
-        </description>
+        <description>Situated on Luthien, this university provides a conventional educational range aimed at equipping students for civil or diplomatic roles. The curriculum encompasses history, astrography, languages, and art history, prioritizing the development of students' communicative abilities rather than technical proficiency. Graduates typically embark on careers as bureaucrats or in junior diplomatic positions.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Luthien</locationSystem>
@@ -3994,9 +3547,7 @@
         <name>Lyons School of Combat Preparedness</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Lyons School of Combat Preparedness is a publicly funded training institution renowned for its
-            diverse student body, hailing from the Draconis Combine, Free Worlds League, and beyond.
-        </description>
+        <description>The Lyons School of Combat Preparedness is a publicly funded training institution renowned for its diverse student body, hailing from the Draconis Combine, Free Worlds League, and beyond.</description>
         <locationSystem>Lyons</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>14583</tuition>
@@ -4029,11 +3580,7 @@
         <name>Magistracy Aerospace Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Magistracy Aerospace Academy stands as one of two aerospace academies inaugurated by the
-            Magistracy of Canopus during the Star League era. The selection of the Marantha system was deliberate, given
-            its flourishing civilian spacecraft industry and expansive asteroid belt, which serves as an ideal locale
-            for avoidance training and is home to a significant Belter population.
-        </description>
+        <description>The Magistracy Aerospace Academy stands as one of two aerospace academies inaugurated by the Magistracy of Canopus during the Star League era. The selection of the Marantha system was deliberate, given its flourishing civilian spacecraft industry and expansive asteroid belt, which serves as an ideal locale for avoidance training and is home to a significant Belter population.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Marantha</locationSystem>
@@ -4066,11 +3613,7 @@
         <name>Magistracy Institute for Strategic Studies</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Magistracy Institute for Strategic Studies stands as one of two aerospace academies founded by
-            the Magistracy of Canopus during the Star League era, with a distinct focus on WarShip training. MISS
-            operates from two facilities enabling thorough WarShip operations training, with an extensive and
-            specialized program designed to prepare cadets for service in the Magistracy's naval forces.
-        </description>
+        <description>The Magistracy Institute for Strategic Studies stands as one of two aerospace academies founded by the Magistracy of Canopus during the Star League era, with a distinct focus on WarShip training. MISS operates from two facilities enabling thorough WarShip operations training, with an extensive and specialized program designed to prepare cadets for service in the Magistracy's naval forces.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -4100,12 +3643,7 @@
         <name>Magistracy Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Magistracy Military Academy came into being following the separation of the Magistracy Armed
-            Forces from the Star League Defense Force. The MMA's primary emphasis lies in MekWarrior training, serving
-            both fresh recruits and existing MAF personnel. While it doesn't function as a combined arms academy, the
-            MMA occasionally hosts seminars covering other branches of service, thereby offering a more comprehensive
-            military education.
-        </description>
+        <description>The Magistracy Military Academy came into being following the separation of the Magistracy Armed Forces from the Star League Defense Force. The MMA's primary emphasis lies in MekWarrior training, serving both fresh recruits and existing MAF personnel. While it doesn't function as a combined arms academy, the MMA occasionally hosts seminars covering other branches of service, thereby offering a more comprehensive military education.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -4125,11 +3663,7 @@
         <name>Malinovsky BattleMek and Tank Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Specializing in armored warfare, the Malinovsky Academy is a formidable institution that combines
-            the proud heritage of Russian military engineering with the advanced technology of BattleMeks. Its cadets
-            are rigorously trained in both theoretical knowledge and practical application, making them highly sought
-            after for their expertise in handling the heavy metal titans on the battlefield.
-        </description>
+        <description>Specializing in armored warfare, the Malinovsky Academy is a formidable institution that combines the proud heritage of Russian military engineering with the advanced technology of BattleMeks. Its cadets are rigorously trained in both theoretical knowledge and practical application, making them highly sought after for their expertise in handling the heavy metal titans on the battlefield.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -4160,11 +3694,7 @@
         <name>Malinovsky BattleMek and Tank Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Specializing in armored warfare, the Malinovsky Academy is a formidable institution that combines
-            the proud heritage of Russian military engineering with the advanced technology of BattleMeks. Its cadets
-            are rigorously trained in both theoretical knowledge and practical application, making them highly sought
-            after for their expertise in handling the heavy metal titans on the battlefield.
-        </description>
+        <description>Specializing in armored warfare, the Malinovsky Academy is a formidable institution that combines the proud heritage of Russian military engineering with the advanced technology of BattleMeks. Its cadets are rigorously trained in both theoretical knowledge and practical application, making them highly sought after for their expertise in handling the heavy metal titans on the battlefield.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -4195,11 +3725,7 @@
         <name>Marshalry Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Marshalry Academy trains Marshals in the Fronc Reaches. Since 3075, instruction has taken place
-            in Freedom's Ring, with equal emphasis on law enforcement and combat training. Due to a lack of simulators,
-            cadets learn using the BattleMeks of the instructing Marshals. This hands-on approach ensures that graduates
-            are well-versed in both maintaining order and engaging in combat within the Reaches.
-        </description>
+        <description>The Marshalry Academy trains Marshals in the Fronc Reaches. Since 3075, instruction has taken place in Freedom's Ring, with equal emphasis on law enforcement and combat training. Due to a lack of simulators, cadets learn using the BattleMeks of the instructing Marshals. This hands-on approach ensures that graduates are well-versed in both maintaining order and engaging in combat within the Reaches.</description>
         <locationSystem>Fronc</locationSystem>
         <constructionYear>3075</constructionYear>
         <tuition>13125</tuition>
@@ -4217,11 +3743,7 @@
         <name>Marshalry Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Marshalry Academy trains Marshals in the Fronc Reaches. Since 3075, instruction has taken place
-            in Freedom's Ring, with equal emphasis on law enforcement and combat training. Due to a lack of simulators,
-            cadets learn using the BattleMeks of the instructing Marshals. This hands-on approach ensures that graduates
-            are well-versed in both maintaining order and engaging in combat within the Reaches.
-        </description>
+        <description>The Marshalry Academy trains Marshals in the Fronc Reaches. Since 3075, instruction has taken place in Freedom's Ring, with equal emphasis on law enforcement and combat training. Due to a lack of simulators, cadets learn using the BattleMeks of the instructing Marshals. This hands-on approach ensures that graduates are well-versed in both maintaining order and engaging in combat within the Reaches.</description>
         <locationSystem>Fronc</locationSystem>
         <constructionYear>3075</constructionYear>
         <tuition>13125</tuition>
@@ -4239,11 +3761,7 @@
         <name>Martial College of Donegal</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>As the oldest military academy in the Lyran Commonwealth, the Martial College of Donegal stands out
-            for its specialized training for WarShip and spacecraft crews, although its equipment and facilities are
-            less modern compared to other Lyran academies. Despite its rich tradition, the MCD faces challenges due to
-            outdated facilities.
-        </description>
+        <description>As the oldest military academy in the Lyran Commonwealth, the Martial College of Donegal stands out for its specialized training for WarShip and spacecraft crews, although its equipment and facilities are less modern compared to other Lyran academies. Despite its rich tradition, the MCD faces challenges due to outdated facilities.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Donegal</locationSystem>
@@ -4287,9 +3805,7 @@
         <name>Meistmorn Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Meistmorn Academy is a renowned military academy known for training MekWarriors for the Armed
-            Forces of the Federated Suns.
-        </description>
+        <description>Meistmorn Academy is a renowned military academy known for training MekWarriors for the Armed Forces of the Federated Suns.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Doneval II</locationSystem>
@@ -4309,11 +3825,7 @@
         <name>Melissa Steiner Martial Academy of Bolan</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally established as a Lyran Commonwealth militia training facility on Bolan, the Melissa
-            Steiner Martial Academy of Bolan underwent upgrades to become a full academy in 3054 following the loss of
-            the Tamar War College. Regarded as a "commoner" academy, the MSMA welcomes candidates from all backgrounds
-            within the Lyran Department of Military Education.
-        </description>
+        <description>Originally established as a Lyran Commonwealth militia training facility on Bolan, the Melissa Steiner Martial Academy of Bolan underwent upgrades to become a full academy in 3054 following the loss of the Tamar War College. Regarded as a "commoner" academy, the MSMA welcomes candidates from all backgrounds within the Lyran Department of Military Education.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Bolan</locationSystem>
@@ -4351,10 +3863,7 @@
         <name>Military Academy of Aphros</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>As a component of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
-            located on Venus, stands as a premier training institution, particularly renowned for hosting the SLDF's
-            prestigious Gunslinger Program.
-        </description>
+        <description>As a component of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, stands as a premier training institution, particularly renowned for hosting the SLDF's prestigious Gunslinger Program.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -4387,10 +3896,7 @@
         <name>Military Academy of Aphros (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>As a component of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
-            located on Venus, stood as a premier training institution, particularly renowned for hosting the SLDF's
-            prestigious Gunslinger Program.
-        </description>
+        <description>As a component of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, stood as a premier training institution, particularly renowned for hosting the SLDF's prestigious Gunslinger Program.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -4423,11 +3929,7 @@
         <name>Military Academy of Aphros [3061]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
-            located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake
-            in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh
-            environment.
-        </description>
+        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh environment.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -4457,11 +3959,7 @@
         <name>Military Academy of Aphros (Officer) [3061]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
-            located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake
-            in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh
-            environment.
-        </description>
+        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh environment.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -4491,12 +3989,7 @@
         <name>Military Academy of Aphros [3085]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
-            located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake
-            in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh
-            environment. By 3085, the Republic of the Sphere took over, transforming it into their primary naval
-            training facility.
-        </description>
+        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh environment. By 3085, the Republic of the Sphere took over, transforming it into their primary naval training facility.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -4525,12 +4018,7 @@
         <name>Military Academy of Aphros (Officer) [3085]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
-            located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake
-            in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh
-            environment. By 3085, the Republic of the Sphere took over, transforming it into their primary naval
-            training facility.
-        </description>
+        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh environment. By 3085, the Republic of the Sphere took over, transforming it into their primary naval training facility.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -4559,9 +4047,7 @@
         <name>Military Academy of Somerset</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Military Academy of Somerset, a small institution focused on BattleMek and aerospace fighter
-            training.
-        </description>
+        <description>The Military Academy of Somerset, a small institution focused on BattleMek and aerospace fighter training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Somerset</locationSystem>
@@ -4609,9 +4095,7 @@
         <name>Military Academy of Somerset (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Military Academy of Somerset, a small institution focused on BattleMek and aerospace fighter
-            training.
-        </description>
+        <description>The Military Academy of Somerset, a small institution focused on BattleMek and aerospace fighter training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Somerset</locationSystem>
@@ -4659,10 +4143,7 @@
         <name>Minoru Kurita University</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Minoru Kurita University is an infantry training center established by Coordinator Minoru
-            Kurita to ensure the Draconis Combine Mustered Soldiery has sufficient trained infantry. Focused on
-            graduating large numbers of troopers quickly, MKU's training program lasts just six months.
-        </description>
+        <description>The Minoru Kurita University is an infantry training center established by Coordinator Minoru Kurita to ensure the Draconis Combine Mustered Soldiery has sufficient trained infantry. Focused on graduating large numbers of troopers quickly, MKU's training program lasts just six months.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Luthien</locationSystem>
@@ -4685,10 +4166,7 @@
         <name>NAIS College of Military Science</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2614, the New Avalon Military Academy emerged to train officers for the Armed Forces of
-            the Federated Suns after the Albion Military Academy became exclusive to the Star League Defense Force. NAMA
-            swiftly rivaled AMA in training quality, emphasizing political loyalty to the First Prince.
-        </description>
+        <description>Founded in 2614, the New Avalon Military Academy emerged to train officers for the Armed Forces of the Federated Suns after the Albion Military Academy became exclusive to the Star League Defense Force. NAMA swiftly rivaled AMA in training quality, emphasizing political loyalty to the First Prince.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Avalon</locationSystem>
@@ -4754,12 +4232,7 @@
         <name>NAIS College of Military Science [3079]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2614, the New Avalon Military Academy emerged to train officers for the Armed Forces of
-            the Federated Suns after the Albion Military Academy became exclusive to the Star League Defense Force. NAMA
-            swiftly rivaled AMA in training quality, emphasizing political loyalty to the First Prince. Despite
-            challenges, NAIS persists in producing top MekWarriors and officers, with graduates often joining mercenary
-            units or returning to their home nations.
-        </description>
+        <description>Founded in 2614, the New Avalon Military Academy emerged to train officers for the Armed Forces of the Federated Suns after the Albion Military Academy became exclusive to the Star League Defense Force. NAMA swiftly rivaled AMA in training quality, emphasizing political loyalty to the First Prince. Despite challenges, NAIS persists in producing top MekWarriors and officers, with graduates often joining mercenary units or returning to their home nations.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Avalon</locationSystem>
@@ -4824,11 +4297,7 @@
         <name>Nellus Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Nellus Academy is a small institution providing four years of combined academic and military
-            instruction, readying students for enlistment in the Free Worlds League Military. Additionally, the academy
-            imparts a unique nonverbal cant rooted in gestures, enabling graduates to communicate silently across
-            generations.
-        </description>
+        <description>Nellus Academy is a small institution providing four years of combined academic and military instruction, readying students for enlistment in the Free Worlds League Military. Additionally, the academy imparts a unique nonverbal cant rooted in gestures, enabling graduates to communicate silently across generations.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Nestor</locationSystem>
@@ -4859,10 +4328,7 @@
     <academy>
         <name>New Cambridge University of Wessex</name>
         <type>University</type>
-        <description>Located near the city of Wessex, this Lyran Commonwealth institution boasts a sprawling campus. New
-            Cambridge University specializes in electronics, robotics, and metallurgy, setting itself apart with its
-            relatively high tuition fees. However, numerous students offset these costs through corporate scholarships.
-        </description>
+        <description>Located near the city of Wessex, this Lyran Commonwealth institution boasts a sprawling campus. New Cambridge University specializes in electronics, robotics, and metallurgy, setting itself apart with its relatively high tuition fees. However, numerous students offset these costs through corporate scholarships.</description>
         <locationSystem>Coventry</locationSystem>
         <constructionYear>2600</constructionYear>
         <tuition>7500</tuition>
@@ -4879,10 +4345,7 @@
     <academy>
         <name>New Earth University</name>
         <type>University</type>
-        <description>Specializing in the operation and maintenance of commercial spacecraft, New Earth University
-            featured a dual-campus system—one on the planet’s surface and another within a massive space station that
-            served as a training center for JumpShips and DropShips.
-        </description>
+        <description>Specializing in the operation and maintenance of commercial spacecraft, New Earth University featured a dual-campus system—one on the planet’s surface and another within a massive space station that served as a training center for JumpShips and DropShips.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Earth (Tau Ceti 2116-)</locationSystem>
@@ -4920,11 +4383,7 @@
         <name>New Galedon Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3070, the closure of the Galedon Military Academy dealt a significant blow to the DCMS' training
-            infrastructure. Acknowledging the necessity for a successor, the New Galedon Military Academy was
-            established. This new institution, named in honor of its predecessor, serves as a tribute to the courageous
-            cadets who sacrificed their lives defending the original academy.
-        </description>
+        <description>In 3070, the closure of the Galedon Military Academy dealt a significant blow to the DCMS' training infrastructure. Acknowledging the necessity for a successor, the New Galedon Military Academy was established. This new institution, named in honor of its predecessor, serves as a tribute to the courageous cadets who sacrificed their lives defending the original academy.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Matsuida</locationSystem>
@@ -4992,11 +4451,7 @@
         <name>New Galedon Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3070, the closure of the Galedon Military Academy dealt a significant blow to the DCMS' training
-            infrastructure. Acknowledging the necessity for a successor, the New Galedon Military Academy was
-            established. This new institution, named in honor of its predecessor, serves as a tribute to the courageous
-            cadets who sacrificed their lives defending the original academy.
-        </description>
+        <description>In 3070, the closure of the Galedon Military Academy dealt a significant blow to the DCMS' training infrastructure. Acknowledging the necessity for a successor, the New Galedon Military Academy was established. This new institution, named in honor of its predecessor, serves as a tribute to the courageous cadets who sacrificed their lives defending the original academy.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Matsuida</locationSystem>
@@ -5064,11 +4519,7 @@
         <name>New Hope Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The New Hope Military Academy specializes in training conventional forces while also providing
-            MekWarrior and aerospace pilot programs. The curriculum, developed by senior commanders of the First Taurian
-            Pride, includes practical 'Mek instruction, even in the absence of simulators, and places a strong emphasis
-            on tactical classroom instruction.
-        </description>
+        <description>The New Hope Military Academy specializes in training conventional forces while also providing MekWarrior and aerospace pilot programs. The curriculum, developed by senior commanders of the First Taurian Pride, includes practical 'Mek instruction, even in the absence of simulators, and places a strong emphasis on tactical classroom instruction.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Erod's Escape</locationSystem>
@@ -5108,12 +4559,7 @@
     <academy>
         <name>New Avalon Institute of Science</name>
         <type>University</type>
-        <description>Following his successful raid on the Draconis Combine's Halstead Station and the subsequent capture
-            of a treasure trove of Star League era knowledge, Prince Ian Davion allocated extensive resources into the
-            founding of a new university dedicated towards studying and developing the reclaimed data. In 3016, this
-            initiative resulted in the opening of the New Avalon Institute of Science, a premier center of learning and
-            leader of the effort to revive LosTech innovations.
-        </description>
+        <description>Following his successful raid on the Draconis Combine's Halstead Station and the subsequent capture of a treasure trove of Star League era knowledge, Prince Ian Davion allocated extensive resources into the founding of a new university dedicated towards studying and developing the reclaimed data. In 3016, this initiative resulted in the opening of the New Avalon Institute of Science, a premier center of learning and leader of the effort to revive LosTech innovations.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Avalon</locationSystem>
@@ -5151,10 +4597,7 @@
     <academy>
         <name>New Avalon Institute of Science [3079]</name>
         <type>University</type>
-        <description>Founded in 3016 by Prince Ian Davion, the NAIS reached prominence as a leading institute of
-            learning and developer of LosTech. As the technological renaissance of the Inner Sphere continued, NAIS
-            continued its mission to remain at the cutting edge of innovation and research.
-        </description>
+        <description>Founded in 3016 by Prince Ian Davion, the NAIS reached prominence as a leading institute of learning and developer of LosTech. As the technological renaissance of the Inner Sphere continued, NAIS continued its mission to remain at the cutting edge of innovation and research.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Avalon</locationSystem>
@@ -5192,12 +4635,7 @@
         <name>New Vandenberg Taurian Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The New Vandenberg Taurian Academy is a crucial institution focused on training conventional
-            troops. Renowned for its demanding curriculum, the academy specializes in defensive operations, ensuring
-            cadets are equipped with the skills necessary to safeguard the Concordat's interests. The training
-            encompasses advanced tactics and strategies tailored for holding defensive positions and repelling
-            invasions.
-        </description>
+        <description>The New Vandenberg Taurian Academy is a crucial institution focused on training conventional troops. Renowned for its demanding curriculum, the academy specializes in defensive operations, ensuring cadets are equipped with the skills necessary to safeguard the Concordat's interests. The training encompasses advanced tactics and strategies tailored for holding defensive positions and repelling invasions.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Vandenburg</locationSystem>
@@ -5228,11 +4666,7 @@
     <academy>
         <name>Noius Archipelagus Institute of Science</name>
         <type>University</type>
-        <description>The Noius Archipelagus Institute of Science prioritizes military science and technology, aiming to
-            compete with the prestigious New Avalon Institute of Science. It primarily admits students not accepted into
-            more esteemed institutions, often serving as a last option for those seeking to avoid standard citizenship
-            roles.
-        </description>
+        <description>The Noius Archipelagus Institute of Science prioritizes military science and technology, aiming to compete with the prestigious New Avalon Institute of Science. It primarily admits students not accepted into more esteemed institutions, often serving as a last option for those seeking to avoid standard citizenship roles.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kaznejoy</locationSystem>
@@ -5255,11 +4689,7 @@
         <name>Northwind Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 2365, the Northwind Military Academy (NMA) was created to train troops specifically
-            for the Northwind Highlanders. Endorsed by the Clan Elders of Northwind, the academy traditionally operated
-            without the latest technology. However, it consistently produced highly skilled cadets. Admission was
-            exclusive to individuals from Northwind or descendants of the Highlanders.
-        </description>
+        <description>Established in 2365, the Northwind Military Academy (NMA) was created to train troops specifically for the Northwind Highlanders. Endorsed by the Clan Elders of Northwind, the academy traditionally operated without the latest technology. However, it consistently produced highly skilled cadets. Admission was exclusive to individuals from Northwind or descendants of the Highlanders.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Northwind</locationSystem>
@@ -5312,11 +4742,7 @@
         <name>Northwind Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 2365, the Northwind Military Academy (NMA) was created to train troops specifically
-            for the Northwind Highlanders. Endorsed by the Clan Elders of Northwind, the academy traditionally operated
-            without the latest technology. However, it consistently produced highly skilled cadets. Admission was
-            exclusive to individuals from Northwind or descendants of the Highlanders.
-        </description>
+        <description>Established in 2365, the Northwind Military Academy (NMA) was created to train troops specifically for the Northwind Highlanders. Endorsed by the Clan Elders of Northwind, the academy traditionally operated without the latest technology. However, it consistently produced highly skilled cadets. Admission was exclusive to individuals from Northwind or descendants of the Highlanders.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Northwind</locationSystem>
@@ -5369,10 +4795,7 @@
         <name>Organo Taurian Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Organo Taurian Academy specializes in training aerospace fighters, cavalry, and both armored
-            and unarmored infantry. Despite its modest size, the academy plays a crucial role in shaping well-rounded
-            military personnel for the Concordat's defense forces.
-        </description>
+        <description>The Organo Taurian Academy specializes in training aerospace fighters, cavalry, and both armored and unarmored infantry. Despite its modest size, the academy plays a crucial role in shaping well-rounded military personnel for the Concordat's defense forces.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Organo</locationSystem>
@@ -5411,10 +4834,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Orloff Military Academy initiates student training at the age of twelve. Admission, except for
-            Orloff family members, is exclusively by invitation. The academy's small scale guarantees an exceptional
-            teacher-student ratio, enabling personalized and intensive training.
-        </description>
+        <description>The Orloff Military Academy initiates student training at the age of twelve. Admission, except for Orloff family members, is exclusively by invitation. The academy's small scale guarantees an exceptional teacher-student ratio, enabling personalized and intensive training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kievanur</locationSystem>
@@ -5435,10 +4855,7 @@
         <name>Orloff Military Academy (Advanced Training)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Orloff Military Academy initiates student training at the age of twelve. Admission, except for
-            Orloff family members, is exclusively by invitation. The academy's small scale guarantees an exceptional
-            teacher-student ratio, enabling personalized and intensive training.
-        </description>
+        <description>The Orloff Military Academy initiates student training at the age of twelve. Admission, except for Orloff family members, is exclusively by invitation. The academy's small scale guarantees an exceptional teacher-student ratio, enabling personalized and intensive training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kievanur</locationSystem>
@@ -5458,11 +4875,7 @@
         <name>Osaka Fields Proving Grounds</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Osaka Fields Proving Grounds stands as the largest of its kind in the Draconis Combine. Spread
-            across every district and prefecture capital, these facilities offer entry into the DCMS for individuals
-            beyond the noble classes. Osaka Fields encompasses an abandoned military base from the Succession Wars era,
-            untamed wilderness, and three live-fire ranges tailored for BattleMek training.
-        </description>
+        <description>The Osaka Fields Proving Grounds stands as the largest of its kind in the Draconis Combine. Spread across every district and prefecture capital, these facilities offer entry into the DCMS for individuals beyond the noble classes. Osaka Fields encompasses an abandoned military base from the Succession Wars era, untamed wilderness, and three live-fire ranges tailored for BattleMek training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Benjamin</locationSystem>
@@ -5500,10 +4913,7 @@
         <name>Outreach Mercenary Training Command (100-Grade)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military
-            training outside traditional state institutions. Its programs span from fundamental academic subjects to
-            advanced military courses. The academy is open to anyone able to afford its fees.
-        </description>
+        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military training outside traditional state institutions. Its programs span from fundamental academic subjects to advanced military courses. The academy is open to anyone able to afford its fees.</description>
         <locationSystem>Outreach</locationSystem>
         <constructionYear>3056</constructionYear>
         <destructionYear>3067</destructionYear>
@@ -5522,10 +4932,7 @@
         <name>Outreach Mercenary Training Command (200-Grade)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military
-            training outside traditional state institutions. Its programs span from fundamental academic subjects to
-            advanced military courses. The academy is open to anyone able to afford its fees.
-        </description>
+        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military training outside traditional state institutions. Its programs span from fundamental academic subjects to advanced military courses. The academy is open to anyone able to afford its fees.</description>
         <locationSystem>Outreach</locationSystem>
         <constructionYear>3056</constructionYear>
         <destructionYear>3067</destructionYear>
@@ -5544,10 +4951,7 @@
         <name>Outreach Mercenary Training Command (300-Grade)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military
-            training outside traditional state institutions. Its programs span from fundamental academic subjects to
-            advanced military courses. The academy is open to anyone able to afford its fees.
-        </description>
+        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military training outside traditional state institutions. Its programs span from fundamental academic subjects to advanced military courses. The academy is open to anyone able to afford its fees.</description>
         <locationSystem>Outreach</locationSystem>
         <constructionYear>3056</constructionYear>
         <destructionYear>3067</destructionYear>
@@ -5617,10 +5021,7 @@
         <name>Outreach Mercenary Training Command (400-Grade)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military
-            training outside traditional state institutions. Its programs span from fundamental academic subjects to
-            advanced military courses. The academy is open to anyone able to afford its fees.
-        </description>
+        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military training outside traditional state institutions. Its programs span from fundamental academic subjects to advanced military courses. The academy is open to anyone able to afford its fees.</description>
         <locationSystem>Outreach</locationSystem>
         <constructionYear>3056</constructionYear>
         <destructionYear>3067</destructionYear>
@@ -5690,11 +5091,7 @@
         <name>Pacifica Training School</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Pacifica Training School stands as one of the Lyran Commonwealth’s foremost MekWarrior training
-            centers. Cadets engage in a series of solo cockpit missions, with each mission increasing in difficulty.
-            They pilot full-size, fully operational BattleMeks within a specially designed arena, which replicates
-            genuine battlefield conditions.
-        </description>
+        <description>Pacifica Training School stands as one of the Lyran Commonwealth’s foremost MekWarrior training centers. Cadets engage in a series of solo cockpit missions, with each mission increasing in difficulty. They pilot full-size, fully operational BattleMeks within a specially designed arena, which replicates genuine battlefield conditions.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Chara (Pacifica)</locationSystem>
@@ -5714,11 +5111,7 @@
         <name>Pagoda for Luthien Officers</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Pagoda for Luthien Officers, situated on Luthien, is a prestigious military academy. Often
-            referred to as the "Pampered Luthien Officers," it exclusively admits nobility who successfully navigates a
-            demanding application process. The academy prioritizes courtly life over combat training. Nearly all
-            students graduate, with only those deemed truly inept facing dismissal.
-        </description>
+        <description>The Pagoda for Luthien Officers, situated on Luthien, is a prestigious military academy. Often referred to as the "Pampered Luthien Officers," it exclusively admits nobility who successfully navigates a demanding application process. The academy prioritizes courtly life over combat training. Nearly all students graduate, with only those deemed truly inept facing dismissal.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Luthien</locationSystem>
@@ -5738,11 +5131,7 @@
         <name>Pandora College of Military Sciences</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Renowned for its distinctive "blood band" red school rag, the Pandora College of Military Sciences
-            prioritizes practical training and rigorous physical education to ensure cadets are combat-ready. Situated
-            within Pandora's military and intelligence command center, PCMS provides real-world training opportunities,
-            closely monitored by the Lyran Intelligence Corps.
-        </description>
+        <description>Renowned for its distinctive "blood band" red school rag, the Pandora College of Military Sciences prioritizes practical training and rigorous physical education to ensure cadets are combat-ready. Situated within Pandora's military and intelligence command center, PCMS provides real-world training opportunities, closely monitored by the Lyran Intelligence Corps.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Pandora</locationSystem>
@@ -5791,10 +5180,7 @@
     <academy>
         <name>People's Reconstruction Effort University of Ashio</name>
         <type>University</type>
-        <description>The University of Ashio aims to employ war-displaced educators and factory experts, creating a vast
-            library and consultation group for post-war rebuilding. However, it faced opposition from the military and
-            the ISF even before opening.
-        </description>
+        <description>The University of Ashio aims to employ war-displaced educators and factory experts, creating a vast library and consultation group for post-war rebuilding. However, it faced opposition from the military and the ISF even before opening.</description>
         <locationSystem>Dover</locationSystem>
         <constructionYear>2821</constructionYear>
         <destructionYear>2910</destructionYear>
@@ -5816,9 +5202,7 @@
         <name>Perdition Taurian Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Perdition Taurian Academy, located within the Taurian Concordat, is a small institution focused
-            on training cavalry and infantry, encompassing both armored and unarmored units.
-        </description>
+        <description>The Perdition Taurian Academy, located within the Taurian Concordat, is a small institution focused on training cavalry and infantry, encompassing both armored and unarmored units.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Perdition</locationSystem>
@@ -5853,9 +5237,7 @@
         <name>Pesht University of Military Science</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Pesht University of Military Science, situated on Pesht, is a leading institution specializing
-            in the training of elite staff officers for complex military operations.
-        </description>
+        <description>The Pesht University of Military Science, situated on Pesht, is a leading institution specializing in the training of elite staff officers for complex military operations.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Pesht</locationSystem>
@@ -5890,10 +5272,7 @@
         <name>Point Barrow Military Academy</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Point Barrow Military Academy has played a crucial role in training officers for the Armed
-            Forces of the Federated Suns, particularly in conventional forces roles. While initially overshadowed, its
-            graduates are highly regarded for their competence in infantry and cavalry positions.
-        </description>
+        <description>The Point Barrow Military Academy has played a crucial role in training officers for the Armed Forces of the Federated Suns, particularly in conventional forces roles. While initially overshadowed, its graduates are highly regarded for their competence in infantry and cavalry positions.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Point Barrow</locationSystem>
@@ -5937,10 +5316,7 @@
         <name>Princefield Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Regarded as one of the most prestigious academies in the Free Worlds League, the Princefield
-            Military Academy functions as a finishing school for young nobles. Admission to the academy is typically
-            reserved for cadets with political connections or sufficient funding.
-        </description>
+        <description>Regarded as one of the most prestigious academies in the Free Worlds League, the Princefield Military Academy functions as a finishing school for young nobles. Admission to the academy is typically reserved for cadets with political connections or sufficient funding.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Oriente</locationSystem>
@@ -5981,10 +5357,7 @@
         <name>Princefield Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Regarded as one of the most prestigious academies in the Free Worlds League, the Princefield
-            Military Academy functions as a finishing school for young nobles. Admission to the academy is typically
-            reserved for cadets with political connections or sufficient funding.
-        </description>
+        <description>Regarded as one of the most prestigious academies in the Free Worlds League, the Princefield Military Academy functions as a finishing school for young nobles. Admission to the academy is typically reserved for cadets with political connections or sufficient funding.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Oriente</locationSystem>
@@ -5999,8 +5372,7 @@
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Small Arms, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
-        <curriculum>Piloting/Ground Vehicle, Gunnery/Vehicle, Tactics, Strategy, Leadership, Small Arms, Artillery
-        </curriculum>
+        <curriculum>Piloting/Ground Vehicle, Gunnery/Vehicle, Tactics, Strategy, Leadership, Small Arms, Artillery</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Air Cavalry Command Graduate</qualification>
         <curriculum>Piloting/VTOL, Gunnery/Vehicle, Tactics, Strategy, Leadership, Small Arms, Artillery</curriculum>
@@ -6026,11 +5398,7 @@
         <name>Radstadt Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Radstadt Academy is renowned for producing elite soldiers. Cadets undergo rigorous training
-            programs, beginning with three months of basic military discipline and advancing through specialized courses
-            in their chosen service. The academy is famous for its demanding physical and tactical training, fostering a
-            strong esprit de corps among cadets.
-        </description>
+        <description>The Radstadt Academy is renowned for producing elite soldiers. Cadets undergo rigorous training programs, beginning with three months of basic military discipline and advancing through specialized courses in their chosen service. The academy is famous for its demanding physical and tactical training, fostering a strong esprit de corps among cadets.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Radstadt</locationSystem>
@@ -6072,11 +5440,7 @@
         <name>Radstadt Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Radstadt Academy is renowned for producing elite soldiers. Cadets undergo rigorous training
-            programs, beginning with three months of basic military discipline and advancing through specialized courses
-            in their chosen service. The academy is famous for its demanding physical and tactical training, fostering a
-            strong esprit de corps among cadets.
-        </description>
+        <description>The Radstadt Academy is renowned for producing elite soldiers. Cadets undergo rigorous training programs, beginning with three months of basic military discipline and advancing through specialized courses in their chosen service. The academy is famous for its demanding physical and tactical training, fostering a strong esprit de corps among cadets.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Radstadt</locationSystem>
@@ -6118,8 +5482,7 @@
         <name>Raina University on Skye</name>
         <type>University</type>
         <isMilitary>true</isMilitary>
-        <description>Raina University is renowned for its research and development in aeronautics and aerospace.
-        </description>
+        <description>Raina University is renowned for its research and development in aeronautics and aerospace.</description>
         <locationSystem>Skye</locationSystem>
         <constructionYear>2500</constructionYear>
         <tuition>12600</tuition>
@@ -6149,12 +5512,7 @@
         <name>Republic Conservatory</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 3062, the Liao Conservatory of Military Arts is dedicated to training elite
-            soldiers. Students oversee their own studies, balancing learning, practice, and specialized fields,
-            preparing to join veteran or elite commands upon graduation. Despite being briefly renamed the Republic
-            Conservatory, the academy remains steadfast in its mission, emphasizing the cultivation of individual
-            motivation and excellence.
-        </description>
+        <description>Established in 3062, the Liao Conservatory of Military Arts is dedicated to training elite soldiers. Students oversee their own studies, balancing learning, practice, and specialized fields, preparing to join veteran or elite commands upon graduation. Despite being briefly renamed the Republic Conservatory, the academy remains steadfast in its mission, emphasizing the cultivation of individual motivation and excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -6196,12 +5554,7 @@
         <name>Republic Conservatory (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 3062, the Liao Conservatory of Military Arts is dedicated to training elite
-            soldiers. Students oversee their own studies, balancing learning, practice, and specialized fields,
-            preparing to join veteran or elite commands upon graduation. Despite being briefly renamed the Republic
-            Conservatory, the academy remains steadfast in its mission, emphasizing the cultivation of individual
-            motivation and excellence.
-        </description>
+        <description>Established in 3062, the Liao Conservatory of Military Arts is dedicated to training elite soldiers. Students oversee their own studies, balancing learning, practice, and specialized fields, preparing to join veteran or elite commands upon graduation. Despite being briefly renamed the Republic Conservatory, the academy remains steadfast in its mission, emphasizing the cultivation of individual motivation and excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -6243,10 +5596,7 @@
         <name>Ritza Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Ritza Academy stands as a bastion of martial education on Emporia, nurturing generations of
-            warriors. Renowned for its rigorous training programs and esteemed faculty, it prepares cadets for combat
-            across various disciplines.
-        </description>
+        <description>The Ritza Academy stands as a bastion of martial education on Emporia, nurturing generations of warriors. Renowned for its rigorous training programs and esteemed faculty, it prepares cadets for combat across various disciplines.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Emporia</locationSystem>
@@ -6282,10 +5632,7 @@
         <name>Robinson Battle Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the
-            NAIS, producing loyal troops with a strong animosity towards the Draconis Combine. The curriculum emphasizes
-            practical training and political indoctrination.
-        </description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the NAIS, producing loyal troops with a strong animosity towards the Draconis Combine. The curriculum emphasizes practical training and political indoctrination.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>2780</constructionYear>
         <closureYear>2781</closureYear>
@@ -6337,10 +5684,7 @@
         <name>Robinson Battle Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the
-            NAIS, producing loyal troops with a strong animosity towards the Draconis Combine. The curriculum emphasizes
-            practical training and political indoctrination.
-        </description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the NAIS, producing loyal troops with a strong animosity towards the Draconis Combine. The curriculum emphasizes practical training and political indoctrination.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>2780</constructionYear>
         <closureYear>2781</closureYear>
@@ -6392,11 +5736,7 @@
         <name>Robinson Battle Academy (Officer) [2814]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the
-            NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum
-            emphasizes practical training and political indoctrination. The academy was dismantled by Kurita forces in
-            2781 and has only recently been rebuilt.
-        </description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. The academy was dismantled by Kurita forces in 2781 and has only recently been rebuilt.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>2814</constructionYear>
         <destructionYear>2854</destructionYear>
@@ -6448,11 +5788,7 @@
         <name>Robinson Battle Academy (Officer) [3020]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
-            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
-            Its curriculum emphasizes practical training and political indoctrination. The academy was rebuilt after
-            being dismantled by Kurita forces in 2781, only to be destroyed again in 2854.
-        </description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. The academy was rebuilt after being dismantled by Kurita forces in 2781, only to be destroyed again in 2854.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3020</constructionYear>
         <destructionYear>3062</destructionYear>
@@ -6504,12 +5840,7 @@
         <name>Robinson Battle Academy (Officer) [3063]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
-            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
-            Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled
-            by Kurita forces in 2781 only to be destroyed again in 2854, the academy was rebuilt for a third time in
-            3062, following its destruction during the Jihad, this time in fortified underground bunkers.
-        </description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled by Kurita forces in 2781 only to be destroyed again in 2854, the academy was rebuilt for a third time in 3062, following its destruction during the Jihad, this time in fortified underground bunkers.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3063</constructionYear>
         <destructionYear>3071</destructionYear>
@@ -6561,12 +5892,7 @@
         <name>Robinson Battle Academy (Officer) [3079]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
-            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
-            Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled
-            by Kurita forces in 2781, it was rebuilt but destroyed again in 2854 and 3062. After a fourth destruction in
-            3071, it was rebuilt once more in 3079.
-        </description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled by Kurita forces in 2781, it was rebuilt but destroyed again in 2854 and 3062. After a fourth destruction in 3071, it was rebuilt once more in 3079.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>11813</tuition>
@@ -6617,11 +5943,7 @@
         <name>Robinson Battle Academy [2814]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the
-            NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum
-            emphasizes practical training and political indoctrination. The academy was dismantled by Kurita forces in
-            2781 and has only recently been rebuilt.
-        </description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. The academy was dismantled by Kurita forces in 2781 and has only recently been rebuilt.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>2814</constructionYear>
         <destructionYear>2854</destructionYear>
@@ -6673,11 +5995,7 @@
         <name>Robinson Battle Academy [3020]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
-            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
-            Its curriculum emphasizes practical training and political indoctrination. The academy was rebuilt after
-            being dismantled by Kurita forces in 2781, only to be destroyed again in 2854.
-        </description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. The academy was rebuilt after being dismantled by Kurita forces in 2781, only to be destroyed again in 2854.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3020</constructionYear>
         <destructionYear>3062</destructionYear>
@@ -6729,12 +6047,7 @@
         <name>Robinson Battle Academy [3063]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
-            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
-            Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled
-            by Kurita forces in 2781 only to be destroyed again in 2854, the academy was rebuilt for a third time in
-            3062, following its destruction during the Jihad, this time in fortified underground bunkers.
-        </description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled by Kurita forces in 2781 only to be destroyed again in 2854, the academy was rebuilt for a third time in 3062, following its destruction during the Jihad, this time in fortified underground bunkers.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3063</constructionYear>
         <destructionYear>3071</destructionYear>
@@ -6786,12 +6099,7 @@
         <name>Robinson Battle Academy [3079]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
-            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
-            Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled
-            by Kurita forces in 2781, it was rebuilt but destroyed again in 2854 and 3062. After a fourth destruction in
-            3071, it was rebuilt once more in 3079.
-        </description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled by Kurita forces in 2781, it was rebuilt but destroyed again in 2854 and 3062. After a fourth destruction in 3071, it was rebuilt once more in 3079.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>5688</tuition>
@@ -6842,9 +6150,7 @@
         <name>Royal New Capetown Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Royal New Capetown Military Academy, once known for its troubled past rooted in racism, has
-            evolved into a key Lyran military institution.
-        </description>
+        <description>The Royal New Capetown Military Academy, once known for its troubled past rooted in racism, has evolved into a key Lyran military institution.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Capetown</locationSystem>
@@ -6882,9 +6188,7 @@
         <name>Royal New Capetown Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Royal New Capetown Military Academy, once known for its troubled past rooted in racism, has
-            evolved into a key Lyran military institution.
-        </description>
+        <description>The Royal New Capetown Military Academy, once known for its troubled past rooted in racism, has evolved into a key Lyran military institution.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Capetown</locationSystem>
@@ -6899,8 +6203,7 @@
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Astech, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
-        <curriculum>Piloting/Ground Vehicle, Gunnery/Vehicle, Tactics, Strategy, Leadership, Astech, Artillery
-        </curriculum>
+        <curriculum>Piloting/Ground Vehicle, Gunnery/Vehicle, Tactics, Strategy, Leadership, Astech, Artillery</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Air Cavalry Command Graduate</qualification>
         <curriculum>Piloting/VTOL, Gunnery/Vehicle, Tactics, Strategy, Leadership, Astech, Artillery</curriculum>
@@ -6923,11 +6226,7 @@
         <name>Saint Cyr Military Academy</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>As the crucible of military leadership in France, Saint Cyr Military Academy boasts a lineage
-            dating back to the early 19th century. It has since transitioned to meet modern needs, offering a curriculum
-            that merges traditional warfare with strategies for interstellar combat. Graduates are known for their
-            versatility, able to lead both ground battalions and aerospace squadrons with equal proficiency.
-        </description>
+        <description>As the crucible of military leadership in France, Saint Cyr Military Academy boasts a lineage dating back to the early 19th century. It has since transitioned to meet modern needs, offering a curriculum that merges traditional warfare with strategies for interstellar combat. Graduates are known for their versatility, able to lead both ground battalions and aerospace squadrons with equal proficiency.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -6967,10 +6266,7 @@
         <name>Sakhara Academy</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Sakhara Academy is known for its rigorous training. Despite declining enrollment, it maintains high
-            standards, graduating about eighty students annually in various military disciplines. Supported by graduates
-            donations and high tuition, Sakhara remains exclusive, primarily serving the affluent.
-        </description>
+        <description>Sakhara Academy is known for its rigorous training. Despite declining enrollment, it maintains high standards, graduating about eighty students annually in various military disciplines. Supported by graduates donations and high tuition, Sakhara remains exclusive, primarily serving the affluent.</description>
         <locationSystem>Sakhara V</locationSystem>
         <constructionYear>2613</constructionYear>
         <tuition>56250</tuition>
@@ -7006,10 +6302,7 @@
         <name>Sandhurst Royal Military College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 1801 on Terra, Sandhurst has evolved into a premier training institution in the Inner
-            Sphere. The college is noted for its rigorous combined-arms training and efforts to eliminate interbranch
-            rivalries.
-        </description>
+        <description>Founded in 1801 on Terra, Sandhurst has evolved into a premier training institution in the Inner Sphere. The college is noted for its rigorous combined-arms training and efforts to eliminate interbranch rivalries.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -7032,10 +6325,7 @@
         <name>Sandhurst Royal Military College (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 1801 on Terra, Sandhurst has evolved into a premier training institution in the Inner
-            Sphere. The college is noted for its rigorous combined-arms training and efforts to eliminate interbranch
-            rivalries.
-        </description>
+        <description>Founded in 1801 on Terra, Sandhurst has evolved into a premier training institution in the Inner Sphere. The college is noted for its rigorous combined-arms training and efforts to eliminate interbranch rivalries.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -7058,10 +6348,7 @@
         <name>Sanglamore</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Sanglamore Academy has long been one of the top-ranked military academies in the Inner Sphere,
-            second only to Nagelring. Despite historically inadequate equipment, it offers comprehensive combat training
-            along with various technical and specialist courses.
-        </description>
+        <description>Sanglamore Academy has long been one of the top-ranked military academies in the Inner Sphere, second only to Nagelring. Despite historically inadequate equipment, it offers comprehensive combat training along with various technical and specialist courses.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Skye</locationSystem>
@@ -7126,10 +6413,7 @@
         <name>Sanglamore (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Sanglamore Academy has long been one of the top-ranked military academies in the Inner Sphere,
-            second only to Nagelring. Despite historically inadequate equipment, it offers comprehensive combat training
-            along with various technical and specialist courses.
-        </description>
+        <description>Sanglamore Academy has long been one of the top-ranked military academies in the Inner Sphere, second only to Nagelring. Despite historically inadequate equipment, it offers comprehensive combat training along with various technical and specialist courses.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Skye</locationSystem>
@@ -7194,9 +6478,7 @@
         <name>Sarna Martial Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sarna Martial Academy is a crucial component of the Capellan Confederation's training program,
-            offering instruction in nearly all branches of the military.
-        </description>
+        <description>The Sarna Martial Academy is a crucial component of the Capellan Confederation's training program, offering instruction in nearly all branches of the military.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sarna</locationSystem>
@@ -7238,10 +6520,7 @@
         <name>Sarna Martial Academy [3057]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sarna Martial Academy was a crucial component of the Capellan Confederation's training program,
-            offering instruction in nearly all branches of the military. After the collapse of authority in the Sarna
-            March, the academy opened its doors to all, becoming known as an independent school for mercenaries.
-        </description>
+        <description>The Sarna Martial Academy was a crucial component of the Capellan Confederation's training program, offering instruction in nearly all branches of the military. After the collapse of authority in the Sarna March, the academy opened its doors to all, becoming known as an independent school for mercenaries.</description>
         <locationSystem>Sarna</locationSystem>
         <constructionYear>3057</constructionYear>
         <closureYear>3070</closureYear>
@@ -7281,12 +6560,7 @@
         <name>Sarna Martial Academy [3070]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sarna Martial Academy was a crucial component of the Capellan Confederation's training program,
-            offering instruction in nearly all branches of the military. After the collapse of authority in the Sarna
-            March, the academy opened its doors to all, becoming known as an independent school for mercenaries. Even
-            after its reintegration into the Confederation, the academy remained independent for a time and was
-            considered the least prestigious of the major Capellan military academies.
-        </description>
+        <description>The Sarna Martial Academy was a crucial component of the Capellan Confederation's training program, offering instruction in nearly all branches of the military. After the collapse of authority in the Sarna March, the academy opened its doors to all, becoming known as an independent school for mercenaries. Even after its reintegration into the Confederation, the academy remained independent for a time and was considered the least prestigious of the major Capellan military academies.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sarna</locationSystem>
@@ -7327,9 +6601,7 @@
         <name>Sentinelry Academy</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sentinelry Academy began construction in 3081, driven by Interstellar Agriculture Concerns.
-            Training starts during Rockwellawan's brief arctic summer, hardening cadets in harsh conditions.
-        </description>
+        <description>The Sentinelry Academy began construction in 3081, driven by Interstellar Agriculture Concerns. Training starts during Rockwellawan's brief arctic summer, hardening cadets in harsh conditions.</description>
         <locationSystem>Rockwellawan</locationSystem>
         <constructionYear>3081</constructionYear>
         <destructionYear>3088</destructionYear>
@@ -7366,11 +6638,7 @@
         <name>Sentinelry Academy [3095]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sentinelry Academy began construction in 3081, driven by Interstellar Agriculture Concerns.
-            Training starts during Rockwellawan's brief arctic summer, hardening cadets in harsh conditions. In 3088,
-            the academy was devastated by a pirate attack, but plans for reconstruction were immediate, underscoring its
-            importance in local defense and officer training.
-        </description>
+        <description>The Sentinelry Academy began construction in 3081, driven by Interstellar Agriculture Concerns. Training starts during Rockwellawan's brief arctic summer, hardening cadets in harsh conditions. In 3088, the academy was devastated by a pirate attack, but plans for reconstruction were immediate, underscoring its importance in local defense and officer training.</description>
         <locationSystem>Rockwellawan</locationSystem>
         <constructionYear>3095</constructionYear>
         <tuition>10938</tuition>
@@ -7406,11 +6674,7 @@
         <name>Sian Center for Martial Disciplines</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sian Center for Martial Disciplines stands as one of the most rigorous military academies
-            within the Capellan Confederation. Prospective cadets must secure patronage from a Sang-shao or nobility and
-            undergo a Maskirovka assessment, ensuring unwavering political loyalty to House Liao. The academy's
-            curriculum blends intensive military training with comprehensive studies in civic and military philosophies.
-        </description>
+        <description>The Sian Center for Martial Disciplines stands as one of the most rigorous military academies within the Capellan Confederation. Prospective cadets must secure patronage from a Sang-shao or nobility and undergo a Maskirovka assessment, ensuring unwavering political loyalty to House Liao. The academy's curriculum blends intensive military training with comprehensive studies in civic and military philosophies.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -7430,11 +6694,7 @@
         <name>Sian Center for Martial Disciplines (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sian Center for Martial Disciplines stands as one of the most rigorous military academies
-            within the Capellan Confederation. Prospective cadets must secure patronage from a Sang-shao or nobility and
-            undergo a Maskirovka assessment, ensuring unwavering political loyalty to House Liao. The academy's
-            curriculum blends intensive military training with comprehensive studies in civic and military philosophies.
-        </description>
+        <description>The Sian Center for Martial Disciplines stands as one of the most rigorous military academies within the Capellan Confederation. Prospective cadets must secure patronage from a Sang-shao or nobility and undergo a Maskirovka assessment, ensuring unwavering political loyalty to House Liao. The academy's curriculum blends intensive military training with comprehensive studies in civic and military philosophies.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -7454,10 +6714,7 @@
         <name>Sian University (Civilian)</name>
         <type>University</type>
         <isMilitary>true</isMilitary>
-        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science,
-            economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis
-            on achieving academic excellence.
-        </description>
+        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science, economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis on achieving academic excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -7480,10 +6737,7 @@
         <name>Sian University (Military)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science,
-            economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis
-            on achieving academic excellence.
-        </description>
+        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science, economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis on achieving academic excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -7542,10 +6796,7 @@
         <name>Sian University (Military) (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science,
-            economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis
-            on achieving academic excellence.
-        </description>
+        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science, economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis on achieving academic excellence.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -7604,9 +6855,7 @@
         <name>Simon Granger Training Facility</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Located on the planet Rajkot, the Simon Granger Training Facility specializes in mountain training
-            for LAAF infantry stationed on nearby worlds.
-        </description>
+        <description>Located on the planet Rajkot, the Simon Granger Training Facility specializes in mountain training for LAAF infantry stationed on nearby worlds.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Rajkot</locationSystem>
@@ -7630,11 +6879,7 @@
         <name>Special Armed Services Training Center</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Star League Special Armed Services Training Center (SASTC) is a highly prestigious and elite
-            training center used by the SLDF to train its elite Special Forces. With rigorous qualification standards
-            and expectations, only the best of the best graduate from its programs. Those who graduate find themselves
-            part of the legendary Blackhearts.
-        </description>
+        <description>The Star League Special Armed Services Training Center (SASTC) is a highly prestigious and elite training center used by the SLDF to train its elite Special Forces. With rigorous qualification standards and expectations, only the best of the best graduate from its programs. Those who graduate find themselves part of the legendary Blackhearts.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sabik</locationSystem>
@@ -7647,8 +6892,7 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>SLDF Advanced Tactics Operative</qualification>
-        <curriculum>Gunnery/BattleArmor, Anti-Mek, Small Arms, Tech/BattleArmor, Tactics, Strategy, Leadership
-        </curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Small Arms, Tech/BattleArmor, Tactics, Strategy, Leadership</curriculum>
         <qualificationStartYear>2718</qualificationStartYear>
         <qualification>SLDF Special Forces Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -7659,10 +6903,7 @@
         <name>St. Ives Academy of Martial Sciences</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The St. Ives Academy of Martial Sciences focuses on rigorous military training and academic
-            coursework. Cadets frequently attend classes alongside civilian students from the St. Ives Science
-            Institute. Graduates of the academy are highly esteemed.
-        </description>
+        <description>The St. Ives Academy of Martial Sciences focuses on rigorous military training and academic coursework. Cadets frequently attend classes alongside civilian students from the St. Ives Science Institute. Graduates of the academy are highly esteemed.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>St. Ives</locationSystem>
@@ -7710,10 +6951,7 @@
         <name>St. Ives Academy of Martial Sciences [3036]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The St. Ives Academy of Martial Sciences focuses on rigorous military training and academic
-            coursework. Cadets frequently attend classes alongside civilian students from the St. Ives Science
-            Institute. Graduates of the academy are highly esteemed.
-        </description>
+        <description>The St. Ives Academy of Martial Sciences focuses on rigorous military training and academic coursework. Cadets frequently attend classes alongside civilian students from the St. Ives Science Institute. Graduates of the academy are highly esteemed.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>St. Ives</locationSystem>
@@ -7760,9 +6998,7 @@
         <name>Sterope Taurian Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sterope Taurian Academy is a small academy within the Taurian Concordat that trains cavalry and
-            infantry in both armored and unarmored types.
-        </description>
+        <description>The Sterope Taurian Academy is a small academy within the Taurian Concordat that trains cavalry and infantry in both armored and unarmored types.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sterope (New Taurus)</locationSystem>
@@ -7797,10 +7033,7 @@
         <name>Sun Tzu School of Combat</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sun Tzu School of Combat on Kaznejoy stands out for fostering cooperation among all military
-            branches. Its curriculum emphasizes teamwork, encouraging cadets to tackle challenges collaboratively rather
-            than competitively.
-        </description>
+        <description>The Sun Tzu School of Combat on Kaznejoy stands out for fostering cooperation among all military branches. Its curriculum emphasizes teamwork, encouraging cadets to tackle challenges collaboratively rather than competitively.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kaznejoy</locationSystem>
@@ -7841,10 +7074,7 @@
         <name>Sun Tzu School of Combat (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sun Tzu School of Combat on Kaznejoy stands out for fostering cooperation among all military
-            branches. Its curriculum emphasizes teamwork, encouraging cadets to tackle challenges collaboratively rather
-            than competitively.
-        </description>
+        <description>The Sun Tzu School of Combat on Kaznejoy stands out for fostering cooperation among all military branches. Its curriculum emphasizes teamwork, encouraging cadets to tackle challenges collaboratively rather than competitively.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kaznejoy</locationSystem>
@@ -7885,10 +7115,7 @@
         <name>Sun Zhang MekWarrior Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sun Zhang MekWarrior Academy emphasizes bushido, and its graduates receive a daishō as a symbol
-            of their honor. The Academy trains over four hundred MekWarriors annually, using abandoned cities for urban
-            combat training.
-        </description>
+        <description>The Sun Zhang MekWarrior Academy emphasizes bushido, and its graduates receive a daishō as a symbol of their honor. The Academy trains over four hundred MekWarriors annually, using abandoned cities for urban combat training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Samarkand</locationSystem>
@@ -7911,10 +7138,7 @@
         <name>Sun Zhang MekWarrior Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sun Zhang MekWarrior Academy emphasizes bushido, and its graduates receive a daishō as a symbol
-            of their honor. The Academy trains over four hundred MekWarriors annually, using abandoned cities for urban
-            combat training.
-        </description>
+        <description>The Sun Zhang MekWarrior Academy emphasizes bushido, and its graduates receive a daishō as a symbol of their honor. The Academy trains over four hundred MekWarriors annually, using abandoned cities for urban combat training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Samarkand</locationSystem>
@@ -7937,10 +7161,7 @@
         <name>Tancredi War College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Tancredi War College offers specialized courses in infantry, artillery, BattleMek, and
-            aerospace disciplines, with a strong focus on infantry and artillery training. These programs are designed
-            to enhance combat skills and physical prowess, reflecting Tancredi IV’s martial culture.
-        </description>
+        <description>The Tancredi War College offers specialized courses in infantry, artillery, BattleMek, and aerospace disciplines, with a strong focus on infantry and artillery training. These programs are designed to enhance combat skills and physical prowess, reflecting Tancredi IV’s martial culture.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tancredi IV</locationSystem>
@@ -7982,11 +7203,7 @@
         <name>Taurian Naval Institute</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Located near University City, the Taurian Naval Institute uses the University's classroom
-            facilities, while the flattened top of nearby Aerie Butte serves as the training DropPort for the
-            Institute's cadets. Cadets train under varied weather conditions to simulate a full range of potential
-            takeoff and landing scenarios.
-        </description>
+        <description>Located near University City, the Taurian Naval Institute uses the University's classroom facilities, while the flattened top of nearby Aerie Butte serves as the training DropPort for the Institute's cadets. Cadets train under varied weather conditions to simulate a full range of potential takeoff and landing scenarios.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Vandenburg</locationSystem>
@@ -8014,11 +7231,7 @@
     <academy>
         <name>Tharkad University</name>
         <type>University</type>
-        <description>Situated in Olympia on the planet Tharkad, this prestigious Lyran Commonwealth university has
-            educated numerous archons and elites of the Inner Sphere. Known for its extensive academic programs, the
-            university remains a highly sought-after choice for students across the galaxy, despite its high tuition
-            fees.
-        </description>
+        <description>Situated in Olympia on the planet Tharkad, this prestigious Lyran Commonwealth university has educated numerous archons and elites of the Inner Sphere. Known for its extensive academic programs, the university remains a highly sought-after choice for students across the galaxy, despite its high tuition fees.</description>
         <locationSystem>Tharkad</locationSystem>
         <constructionYear>2500</constructionYear>
         <tuition>15000</tuition>
@@ -8039,10 +7252,7 @@
         <name>The Nagelring</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Nagelring provides comprehensive training across multiple military occupations, alongside
-            civilian courses like chemistry and literature. Known for its stringent admission criteria, the Nagelring
-            maintains a distinct social divide between noble and non-noble students.
-        </description>
+        <description>The Nagelring provides comprehensive training across multiple military occupations, alongside civilian courses like chemistry and literature. Known for its stringent admission criteria, the Nagelring maintains a distinct social divide between noble and non-noble students.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tharkad</locationSystem>
@@ -8111,12 +7321,7 @@
         <name>The Nagelring [3085]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Nagelring offers comprehensive training across multiple military occupations, supplemented by
-            civilian courses in subjects such as chemistry and literature. Renowned for its rigorous admission
-            standards, the academy maintains a noticeable social division between noble and non-noble students. Despite
-            sustaining significant damage during the Word of Blake Jihad and Clan Wolf's attack in 3143, the Nagelring
-            continues to graduate capable officers for the Lyran Armed Forces.
-        </description>
+        <description>The Nagelring offers comprehensive training across multiple military occupations, supplemented by civilian courses in subjects such as chemistry and literature. Renowned for its rigorous admission standards, the academy maintains a noticeable social division between noble and non-noble students. Despite sustaining significant damage during the Word of Blake Jihad and Clan Wolf's attack in 3143, the Nagelring continues to graduate capable officers for the Lyran Armed Forces.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tharkad</locationSystem>
@@ -8185,11 +7390,7 @@
         <name>The War College of Goshen</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Goshen, initially established as the Goshen BattleMek Academy, is a prestigious
-            private military academy in the Federated Suns. Situated on Goshen's Tiberian continent, the college
-            expanded its curriculum within a decade to incorporate aerospace programs, prompting a name change to
-            reflect its comprehensive military training offerings.
-        </description>
+        <description>The War College of Goshen, initially established as the Goshen BattleMek Academy, is a prestigious private military academy in the Federated Suns. Situated on Goshen's Tiberian continent, the college expanded its curriculum within a decade to incorporate aerospace programs, prompting a name change to reflect its comprehensive military training offerings.</description>
         <locationSystem>Goshen</locationSystem>
         <constructionYear>2960</constructionYear>
         <tuition>8750</tuition>
@@ -8210,10 +7411,7 @@
         <name>The Warrior's Hall</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Warrior's Hall started as an officers' club and evolved into a comprehensive military academy
-            by 2765. Though it lacks the most advanced technology, the academy produces some of the finest MekWarriors
-            in the AFFS. It is known for its emphasis on military skills, often at the expense of academic subjects.
-        </description>
+        <description>The Warrior's Hall started as an officers' club and evolved into a comprehensive military academy by 2765. Though it lacks the most advanced technology, the academy produces some of the finest MekWarriors in the AFFS. It is known for its emphasis on military skills, often at the expense of academic subjects.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Syrtis</locationSystem>
@@ -8266,10 +7464,7 @@
         <name>The Warrior's Hall (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Warrior's Hall started as an officers' club and evolved into a comprehensive military academy
-            by 2765. Though it lacks the most advanced technology, the academy produces some of the finest MekWarriors
-            in the AFFS. It is known for its emphasis on military skills, often at the expense of academic subjects.
-        </description>
+        <description>The Warrior's Hall started as an officers' club and evolved into a comprehensive military academy by 2765. Though it lacks the most advanced technology, the academy produces some of the finest MekWarriors in the AFFS. It is known for its emphasis on military skills, often at the expense of academic subjects.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Syrtis</locationSystem>
@@ -8322,9 +7517,7 @@
         <name>Tikonov Martial Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Tikonov Martial Academy is one of the premier institutions of its kind. For the citizens of the
-            Sarna March, the academy has provided quality education for as long as anyone can remember.
-        </description>
+        <description>The Tikonov Martial Academy is one of the premier institutions of its kind. For the citizens of the Sarna March, the academy has provided quality education for as long as anyone can remember.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tikonov</locationSystem>
@@ -8362,9 +7555,7 @@
         <name>Tikonov Martial Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Tikonov Martial Academy is one of the premier institutions of its kind. For the citizens of the
-            Sarna March, the academy has provided quality education for as long as anyone can remember.
-        </description>
+        <description>The Tikonov Martial Academy is one of the premier institutions of its kind. For the citizens of the Sarna March, the academy has provided quality education for as long as anyone can remember.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tikonov</locationSystem>
@@ -8402,11 +7593,7 @@
         <name>Tikonov School of Military Discipline</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Built from the ruins of the old Tikonov Martial Academy, this facility graduates hundreds of
-            soldiers each year in various military specialties. However, the legacy of the past endures in the minds of
-            the local population, and the academy, along with its cadets, remains a bastion of loyalty to the Federated
-            Suns in this region.
-        </description>
+        <description>Built from the ruins of the old Tikonov Martial Academy, this facility graduates hundreds of soldiers each year in various military specialties. However, the legacy of the past endures in the minds of the local population, and the academy, along with its cadets, remains a bastion of loyalty to the Federated Suns in this region.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tikonov</locationSystem>
@@ -8444,11 +7631,7 @@
         <name>Tikonov School of Military Discipline (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Built from the ruins of the old Tikonov Martial Academy, this facility graduates hundreds of
-            soldiers each year in various military specialties. However, the legacy of the past endures in the minds of
-            the local population, and the academy, along with its cadets, remains a bastion of loyalty to the Federated
-            Suns in this region.
-        </description>
+        <description>Built from the ruins of the old Tikonov Martial Academy, this facility graduates hundreds of soldiers each year in various military specialties. However, the legacy of the past endures in the minds of the local population, and the academy, along with its cadets, remains a bastion of loyalty to the Federated Suns in this region.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tikonov</locationSystem>
@@ -8486,11 +7669,7 @@
         <name>Tri-M Mercenary Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded by the alleged former Wolf's Dragoons member Howard Hughes O'Grady, Tri-M Academy promotes
-            the financial benefits of becoming a mercenary, emphasizing that Tri-M stands for "money, money, money."
-            Unlike other academies with strict enrollment policies, Tri-M guarantees acceptance for anyone who can pay
-            their "reasonable" tuition fees.
-        </description>
+        <description>Founded by the alleged former Wolf's Dragoons member Howard Hughes O'Grady, Tri-M Academy promotes the financial benefits of becoming a mercenary, emphasizing that Tri-M stands for "money, money, money." Unlike other academies with strict enrollment policies, Tri-M guarantees acceptance for anyone who can pay their "reasonable" tuition fees.</description>
         <locationSystem>Outreach</locationSystem>
         <constructionYear>3040</constructionYear>
         <tuition>38500</tuition>
@@ -8507,10 +7686,7 @@
         <name>Tyra Miraborg Memorial Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Named after the heroic aerospace fighter pilot who killed ilKhan Leo Showers during the Clan
-            Invasion, the Tyra Miraborg Memorial Academy is the premier military academy of the Free Rasalhague
-            Republic. Despite internal rivalries, cadets develop a strong camaraderie, essential for future battles.
-        </description>
+        <description>Named after the heroic aerospace fighter pilot who killed ilKhan Leo Showers during the Clan Invasion, the Tyra Miraborg Memorial Academy is the premier military academy of the Free Rasalhague Republic. Despite internal rivalries, cadets develop a strong camaraderie, essential for future battles.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Orestes</locationSystem>
@@ -8551,10 +7727,7 @@
         <name>Tyra Miraborg Memorial Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Named after the heroic aerospace fighter pilot who killed ilKhan Leo Showers during the Clan
-            Invasion, the Tyra Miraborg Memorial Academy is the premier military academy of the Free Rasalhague
-            Republic. Despite internal rivalries, cadets develop a strong camaraderie, essential for future battles.
-        </description>
+        <description>Named after the heroic aerospace fighter pilot who killed ilKhan Leo Showers during the Clan Invasion, the Tyra Miraborg Memorial Academy is the premier military academy of the Free Rasalhague Republic. Despite internal rivalries, cadets develop a strong camaraderie, essential for future battles.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Orestes</locationSystem>
@@ -8594,9 +7767,7 @@
     <academy>
         <name>Universities of the Puget Sound States</name>
         <type>University</type>
-        <description>A group of five universities and colleges, including Pacific Lutheran University and the University
-            of Washington, the latter of which maintains an extensive computer system.
-        </description>
+        <description>A group of five universities and colleges, including Pacific Lutheran University and the University of Washington, the latter of which maintains an extensive computer system.</description>
         <locationSystem>Terra</locationSystem>
         <destructionYear>2780</destructionYear>
         <tuition>7500</tuition>
@@ -8616,9 +7787,7 @@
     <academy>
         <name>University of Blake</name>
         <type>University</type>
-        <description>After the inconclusive Terran Peace Summit of 3053, Primus Sharilar Mori opened the ComStar
-            Archives and established the University of Blake to distribute technical knowledge among the Great Houses.
-        </description>
+        <description>After the inconclusive Terran Peace Summit of 3053, Primus Sharilar Mori opened the ComStar Archives and established the University of Blake to distribute technical knowledge among the Great Houses.</description>
         <locationSystem>Terra</locationSystem>
         <constructionYear>3053</constructionYear>
         <tuition>7500</tuition>
@@ -8638,9 +7807,7 @@
     <academy>
         <name>University of Canopus</name>
         <type>University</type>
-        <description>Initially resembling more of a technical school, the University of Canopus has undergone
-            significant enhancements through Taurian expertise and Capellan financial support.
-        </description>
+        <description>Initially resembling more of a technical school, the University of Canopus has undergone significant enhancements through Taurian expertise and Capellan financial support.</description>
         <locationSystem>Canopus IV</locationSystem>
         <constructionYear>2550</constructionYear>
         <tuition>6250</tuition>
@@ -8660,9 +7827,7 @@
     <academy>
         <name>University of Harvard</name>
         <type>University</type>
-        <description>Believed to be a continuation of Harvard University from ancient Earth, this institution has been
-            educating students for hundreds of years.
-        </description>
+        <description>Believed to be a continuation of Harvard University from ancient Earth, this institution has been educating students for hundreds of years.</description>
         <locationSystem>Terra</locationSystem>
         <constructionYear>1950</constructionYear>
         <tuition>7500</tuition>
@@ -8682,9 +7847,7 @@
     <academy>
         <name>University of Lambrecht</name>
         <type>University</type>
-        <description>The University of Lambrecht specializes in sciences such as astronomy and physics, making
-            significant contributions to advancements in alloys.
-        </description>
+        <description>The University of Lambrecht specializes in sciences such as astronomy and physics, making significant contributions to advancements in alloys.</description>
         <locationSystem>Lambrecht</locationSystem>
         <constructionYear>2350</constructionYear>
         <destructionYear>2772</destructionYear>
@@ -8705,10 +7868,7 @@
     <academy>
         <name>University of Luxen</name>
         <type>University</type>
-        <description>As a beacon of higher education within the Magistracy of Canopus, the University of Luxen is
-            renowned for its exceptional Canopian Medical Sciences and Training Complex. Additionally, its School of
-            Engineering offers a diverse range of courses, including architecture and military applications.
-        </description>
+        <description>As a beacon of higher education within the Magistracy of Canopus, the University of Luxen is renowned for its exceptional Canopian Medical Sciences and Training Complex. Additionally, its School of Engineering offers a diverse range of courses, including architecture and military applications.</description>
         <locationSystem>Luxen</locationSystem>
         <constructionYear>2751</constructionYear>
         <tuition>7500</tuition>
@@ -8728,9 +7888,7 @@
     <academy>
         <name>University of Mars</name>
         <type>University</type>
-        <description>Renowned for its journalism program, the University of Mars produces the influential "Martian
-            Times" newspaper and a respected holonews program distributed throughout the Hegemony.
-        </description>
+        <description>Renowned for its journalism program, the University of Mars produces the influential "Martian Times" newspaper and a respected holonews program distributed throughout the Hegemony.</description>
         <locationSystem>Terra</locationSystem>
         <destructionYear>2770</destructionYear>
         <tuition>7500</tuition>
@@ -8747,9 +7905,7 @@
     <academy>
         <name>University of New Samarkand</name>
         <type>University</type>
-        <description>The University of New Samarkand is an educational institution located on the planet of New
-            Samarkand, renowned for its notable medical school.
-        </description>
+        <description>The University of New Samarkand is an educational institution located on the planet of New Samarkand, renowned for its notable medical school.</description>
         <locationSystem>New Samarkand</locationSystem>
         <constructionYear>2375</constructionYear>
         <tuition>12500</tuition>
@@ -8770,10 +7926,7 @@
         <name>University of Proserpina</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The University of Proserpina, affiliated with the Proserpina Hussars, offers a robust, hands-on
-            military education despite facing resource constraints. Located near volatile borders, it continues to
-            attract students seeking specialized military training.
-        </description>
+        <description>The University of Proserpina, affiliated with the Proserpina Hussars, offers a robust, hands-on military education despite facing resource constraints. Located near volatile borders, it continues to attract students seeking specialized military training.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Proserpina</locationSystem>
@@ -8812,8 +7965,7 @@
     <academy>
         <name>University of Robinson</name>
         <type>University</type>
-        <description>Since its founding, the University of Robinson has led research in advanced engineering.
-        </description>
+        <description>Since its founding, the University of Robinson has led research in advanced engineering.</description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>2500</constructionYear>
         <tuition>7500</tuition>
@@ -8833,10 +7985,7 @@
     <academy>
         <name>University of Tamar</name>
         <type>University</type>
-        <description>The University of Tamar is renowned for its business program, drawing students from prominent local
-            merchant families. This academic institution has played a pivotal role in shaping future leaders and
-            professionals in the fields of business and commerce.
-        </description>
+        <description>The University of Tamar is renowned for its business program, drawing students from prominent local merchant families. This academic institution has played a pivotal role in shaping future leaders and professionals in the fields of business and commerce.</description>
         <locationSystem>Tamar</locationSystem>
         <constructionYear>2450</constructionYear>
         <tuition>6250</tuition>
@@ -8856,10 +8005,7 @@
     <academy>
         <name>University of Terra</name>
         <type>University</type>
-        <description>The University of Terra holds historical significance as the site of the original SLCOMNET’s Prime
-            HPG. This institution has been at the forefront of advancing communication technologies, influencing the
-            development and implementation of interstellar messaging systems.
-        </description>
+        <description>The University of Terra holds historical significance as the site of the original SLCOMNET’s Prime HPG. This institution has been at the forefront of advancing communication technologies, influencing the development and implementation of interstellar messaging systems.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -8881,9 +8027,7 @@
     <academy>
         <name>University of Thorin</name>
         <type>University</type>
-        <description>Located in the dense forests of Thorin's northern continent, the University of Thorin is renowned
-            for its specialization in economics.
-        </description>
+        <description>Located in the dense forests of Thorin's northern continent, the University of Thorin is renowned for its specialization in economics.</description>
         <locationSystem>Thorin</locationSystem>
         <destructionYear>2775</destructionYear>
         <tuition>7500</tuition>
@@ -8900,10 +8044,7 @@
     <academy>
         <name>University of Washington on Donegal</name>
         <type>University</type>
-        <description>Located in the Queen Anne Hills on the continent of Seattle, this Lyran Commonwealth institution is
-            renowned for its specialization in computers and communications. It boasts some of the Inner Sphere's finest
-            computer science facilities, rivaling even those of ComStar.
-        </description>
+        <description>Located in the Queen Anne Hills on the continent of Seattle, this Lyran Commonwealth institution is renowned for its specialization in computers and communications. It boasts some of the Inner Sphere's finest computer science facilities, rivaling even those of ComStar.</description>
         <locationSystem>Donegal</locationSystem>
         <tuition>15000</tuition>
         <durationDays>900</durationDays>
@@ -8923,10 +8064,7 @@
         <name>Victoria Academy of Arms and Technology</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Victoria Academy of Arms and Technology is closely linked with the Shengli Arms factory,
-            shaping a curriculum focused primarily on technical studies. This emphasis benefits future technicians who
-            gain access to the factory's facilities.
-        </description>
+        <description>The Victoria Academy of Arms and Technology is closely linked with the Shengli Arms factory, shaping a curriculum focused primarily on technical studies. This emphasis benefits future technicians who gain access to the factory's facilities.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Victoria (CC)</locationSystem>
@@ -8970,10 +8108,7 @@
         <name>War Academy of Mars</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War Academy of Mars is part of the "War Triad" alongside Sandhurst Royal Military College and
-            the Military Academy of Aphros. Located near Olympus Mons, the academy specializes in strategic training for
-            officer cadets.
-        </description>
+        <description>The War Academy of Mars is part of the "War Triad" alongside Sandhurst Royal Military College and the Military Academy of Aphros. Located near Olympus Mons, the academy specializes in strategic training for officer cadets.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -9041,10 +8176,7 @@
         <name>War Academy of Mars [3135]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War Academy of Mars is part of the "War Triad" alongside Sandhurst Royal Military College and
-            the Military Academy of Aphros. Located near Olympus Mons, the academy specializes in strategic training for
-            officer cadets. It was destroyed during Operation SCOUR, but has since been reopened.
-        </description>
+        <description>The War Academy of Mars is part of the "War Triad" alongside Sandhurst Royal Military College and the Military Academy of Aphros. Located near Olympus Mons, the academy specializes in strategic training for officer cadets. It was destroyed during Operation SCOUR, but has since been reopened.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -9113,11 +8245,7 @@
         <name>War College of Buena</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Buena initially focused on technician courses and MekWarrior training. Over
-            time, it expanded significantly, producing highly competent technicians, MekWarriors, and aerospace pilots.
-            Training emphasizes practical experience, with cadets spending six months in the Buena Training Battalion
-            engaged in live-fire exercises and anti-pirate missions.
-        </description>
+        <description>The War College of Buena initially focused on technician courses and MekWarrior training. Over time, it expanded significantly, producing highly competent technicians, MekWarriors, and aerospace pilots. Training emphasizes practical experience, with cadets spending six months in the Buena Training Battalion engaged in live-fire exercises and anti-pirate missions.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Buena</locationSystem>
@@ -9152,10 +8280,7 @@
         <name>War College of Tamar</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Tamar is renowned for producing adept tacticians, strategists, and outstanding
-            administrators. While the academy's curriculum emphasizes leadership and administrative skills over combat,
-            it also offers training in BattleMek and aerospace operations.
-        </description>
+        <description>The War College of Tamar is renowned for producing adept tacticians, strategists, and outstanding administrators. While the academy's curriculum emphasizes leadership and administrative skills over combat, it also offers training in BattleMek and aerospace operations.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tamar</locationSystem>
@@ -9182,11 +8307,7 @@
         <name>War College of Tamar [3025]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Tamar is renowned for producing adept tacticians, strategists, and outstanding
-            administrators. While the academy's curriculum emphasizes leadership and administrative skills over combat,
-            it also provides training in BattleMek and aerospace operations. Destroyed by the DCMS in 2915, it was later
-            rebuilt under the initiative of Archon Katrina Steiner.
-        </description>
+        <description>The War College of Tamar is renowned for producing adept tacticians, strategists, and outstanding administrators. While the academy's curriculum emphasizes leadership and administrative skills over combat, it also provides training in BattleMek and aerospace operations. Destroyed by the DCMS in 2915, it was later rebuilt under the initiative of Archon Katrina Steiner.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tamar</locationSystem>
@@ -9213,10 +8334,7 @@
         <name>Warner MekWarrior Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Warner MekWarrior Academy on Solaris VII is a small and informal training school for aspiring
-            MekWarriors, founded by the second-rate arena fighter and con man Clease Vanderholf. Training is conducted
-            using four poorly maintained Chameleons.
-        </description>
+        <description>The Warner MekWarrior Academy on Solaris VII is a small and informal training school for aspiring MekWarriors, founded by the second-rate arena fighter and con man Clease Vanderholf. Training is conducted using four poorly maintained Chameleons.</description>
         <locationSystem>Solaris</locationSystem>
         <constructionYear>3000</constructionYear>
         <destructionYear>3068</destructionYear>
@@ -9236,11 +8354,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Renowned for their ferocity, Dai Da Chi warriors specialize in relentless assaults, often
-            employing unconventional tactics to overwhelm their enemies swiftly.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Renowned for their ferocity, Dai Da Chi warriors specialize in relentless assaults, often employing unconventional tactics to overwhelm their enemies swiftly.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Drozan</locationSystem>
@@ -9265,11 +8379,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Fujita warriors are masters of defensive warfare, known for their impenetrable fortifications
-            and unyielding resilience in battle.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Fujita warriors are masters of defensive warfare, known for their impenetrable fortifications and unyielding resilience in battle.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Hunan</locationSystem>
@@ -9295,11 +8405,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Stealth and precision define Hiritsu, whose warriors excel in covert operations and surgical
-            strikes against high-value targets.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Stealth and precision define Hiritsu, whose warriors excel in covert operations and surgical strikes against high-value targets.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Randar</locationSystem>
@@ -9324,11 +8430,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Ijori prides itself on traditional martial discipline, blending ancient combat techniques with
-            modern warfare to maintain battlefield honor.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Ijori prides itself on traditional martial discipline, blending ancient combat techniques with modern warfare to maintain battlefield honor.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aldebaran</locationSystem>
@@ -9354,11 +8456,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Strategically adept, Imarra warriors emphasize coordination and adaptability, making them
-            formidable opponents in dynamic combat situations.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Strategically adept, Imarra warriors emphasize coordination and adaptability, making them formidable opponents in dynamic combat situations.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -9383,11 +8481,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Kamata is synonymous with heavy armor and firepower, favoring direct confrontations and
-            overwhelming force to crush adversaries.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Kamata is synonymous with heavy armor and firepower, favoring direct confrontations and overwhelming force to crush adversaries.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Betelgeuse</locationSystem>
@@ -9412,11 +8506,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Known for their elite training, Lu Sann warriors combine physical prowess with tactical
-            genius, often leading crucial missions.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Known for their elite training, Lu Sann warriors combine physical prowess with tactical genius, often leading crucial missions.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Grand Base</locationSystem>
@@ -9443,11 +8533,7 @@
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
         <factionDiscount>0</factionDiscount>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Versatile and innovative, Ma-Tsu Kai warriors adapt to any combat scenario, using creativity
-            to outmaneuver and outthink opponents.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Versatile and innovative, Ma-Tsu Kai warriors adapt to any combat scenario, using creativity to outmaneuver and outthink opponents.</description>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Aragon</locationSystem>
         <constructionYear>2991</constructionYear>
@@ -9472,11 +8558,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Rakshasa warriors are feared for their ruthlessness and psychological warfare, demoralizing
-            enemies before striking with lethal efficiency.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Rakshasa warriors are feared for their ruthlessness and psychological warfare, demoralizing enemies before striking with lethal efficiency.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Bithinia</locationSystem>
@@ -9502,11 +8584,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Rakshasa warriors are feared for their ruthlessness and psychological warfare, demoralizing
-            enemies before striking with lethal efficiency.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Rakshasa warriors are feared for their ruthlessness and psychological warfare, demoralizing enemies before striking with lethal efficiency.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Wazan</locationSystem>
@@ -9532,11 +8610,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Tsang Xiao emphasizes spiritual discipline and inner strength, believing that mental fortitude
-            is key to martial success.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Tsang Xiao emphasizes spiritual discipline and inner strength, believing that mental fortitude is key to martial success.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Wazan</locationSystem>
@@ -9561,11 +8635,7 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
-            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
-            coordination. Elite and exclusive, White Tiger warriors are distinguished by their exceptional skill and
-            loyalty, often undertaking the most dangerous and critical missions.
-        </description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Elite and exclusive, White Tiger warriors are distinguished by their exceptional skill and loyalty, often undertaking the most dangerous and critical missions.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Highspire</locationSystem>
@@ -9590,10 +8660,7 @@
         <name>West Point Military Academy</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>A cornerstone of military leadership on Terra, West Point has been a revered academy since its
-            establishment. The institution prides itself on a legacy of producing tacticians and leaders who have played
-            pivotal roles in shaping the armed forces of the Inner Sphere.
-        </description>
+        <description>A cornerstone of military leadership on Terra, West Point has been a revered academy since its establishment. The institution prides itself on a legacy of producing tacticians and leaders who have played pivotal roles in shaping the armed forces of the Inner Sphere.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -9631,10 +8698,7 @@
         <name>Wisdom of the Dragon</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Wisdom of the Dragon is an elite officer finishing school for the DCMS. The academy maintains a
-            highly intense atmosphere, pushing cadets to their physical and mental limits while strictly adhering to
-            bushido principles.
-        </description>
+        <description>The Wisdom of the Dragon is an elite officer finishing school for the DCMS. The academy maintains a highly intense atmosphere, pushing cadets to their physical and mental limits while strictly adhering to bushido principles.</description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kagoshima</locationSystem>

--- a/MekHQ/data/universe/academies/Prestigious Academies.xml
+++ b/MekHQ/data/universe/academies/Prestigious Academies.xml
@@ -3,7 +3,9 @@
     <academy>
         <name>Academies of Keid</name>
         <type>College</type>
-        <description>The Academies of Kied consist of three distinct colleges dedicated to metallurgy, diplomatic studies, and economics, each renowned for training future leaders and staff officers.</description>
+        <description>The Academies of Kied consist of three distinct colleges dedicated to metallurgy, diplomatic
+            studies, and economics, each renowned for training future leaders and staff officers.
+        </description>
         <locationSystem>Keid</locationSystem>
         <tuition>7500</tuition>
         <durationDays>1200</durationDays>
@@ -22,7 +24,10 @@
     <academy>
         <name>Addicks University</name>
         <type>University</type>
-        <description>Located in the heart of the Inner Sphere, Addicks University is celebrated for its progressive liberal arts education, particularly in teacher training. The institution uniquely integrates its academic programs with community schools, allowing student teachers to gain invaluable hands-on experience.</description>
+        <description>Located in the heart of the Inner Sphere, Addicks University is celebrated for its progressive
+            liberal arts education, particularly in teacher training. The institution uniquely integrates its academic
+            programs with community schools, allowing student teachers to gain invaluable hands-on experience.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Addicks</locationSystem>
@@ -46,7 +51,10 @@
         <name>Aerospace and Interstellar Institute [Dover] (Year One)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Staffed by veteran officers from Operation SCOUR, the school instructs experienced crew members in fleet combat subtleties. This initiative adapts to evolving military needs, enhancing future fleet commanders' and high-ranking personnel's capabilities in complex operational environments.</description>
+        <description>Staffed by veteran officers from Operation SCOUR, the school instructs experienced crew members in
+            fleet combat subtleties. This initiative adapts to evolving military needs, enhancing future fleet
+            commanders' and high-ranking personnel's capabilities in complex operational environments.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dover</locationSystem>
@@ -66,7 +74,10 @@
         <name>Aerospace and Interstellar Institute [Dover]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Staffed by veteran officers from Operation SCOUR, the school instructs experienced crew members in fleet combat subtleties. This initiative adapts to evolving military needs, enhancing future fleet commanders' and high-ranking personnel's capabilities in complex operational environments.</description>
+        <description>Staffed by veteran officers from Operation SCOUR, the school instructs experienced crew members in
+            fleet combat subtleties. This initiative adapts to evolving military needs, enhancing future fleet
+            commanders' and high-ranking personnel's capabilities in complex operational environments.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dover</locationSystem>
@@ -92,7 +103,11 @@
         <name>Aerospace and Interstellar Institute [Midway] (Year One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Aerospace and Interstellar Institute specializes in training aerospace personnel, including DropShip and JumpShip crews. The curriculum spans covers small arms, first aid, and specialized aerospace roles. Limited crewing opportunities, especially for JumpShips, create fierce competition, pushing most cadets to train as aerospace fighter pilots.</description>
+        <description>The Aerospace and Interstellar Institute specializes in training aerospace personnel, including
+            DropShip and JumpShip crews. The curriculum spans covers small arms, first aid, and specialized aerospace
+            roles. Limited crewing opportunities, especially for JumpShips, create fierce competition, pushing most
+            cadets to train as aerospace fighter pilots.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Midway</locationSystem>
@@ -112,7 +127,11 @@
         <name>Aerospace and Interstellar Institute [Midway]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Aerospace and Interstellar Institute specializes in training aerospace personnel, including DropShip and JumpShip crews. The curriculum spans covers small arms, first aid, and specialized aerospace roles. Limited crewing opportunities, especially for JumpShips, create fierce competition, pushing most cadets to train as aerospace fighter pilots.</description>
+        <description>The Aerospace and Interstellar Institute specializes in training aerospace personnel, including
+            DropShip and JumpShip crews. The curriculum spans covers small arms, first aid, and specialized aerospace
+            roles. Limited crewing opportunities, especially for JumpShips, create fierce competition, pushing most
+            cadets to train as aerospace fighter pilots.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Midway</locationSystem>
@@ -141,7 +160,11 @@
         <name>Aitutaki Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik sentiment. The academy emphasizes physical training and survival skills in the first year, followed by advanced MekWarriorand Cavalry training. The aerospace program was discontinued after fatal accidents. Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
+        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik
+            sentiment. The academy emphasizes physical training and survival skills in the first year, followed by
+            advanced MekWarriorand Cavalry training. The aerospace program was discontinued after fatal accidents.
+            Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aitutaki</locationSystem>
@@ -170,7 +193,11 @@
         <name>Aitutaki Academy (Year One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik sentiment. The academy emphasizes physical training and survival skills in the first year, followed by advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents. Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
+        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik
+            sentiment. The academy emphasizes physical training and survival skills in the first year, followed by
+            advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents.
+            Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aitutaki</locationSystem>
@@ -190,7 +217,11 @@
         <name>Aitutaki Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik sentiment. The academy emphasizes physical training and survival skills in the first year, followed by advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents. Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
+        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik
+            sentiment. The academy emphasizes physical training and survival skills in the first year, followed by
+            advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents.
+            Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aitutaki</locationSystem>
@@ -219,7 +250,11 @@
         <name>Aitutaki Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik sentiment. The academy emphasizes physical training and survival skills in the first year, followed by advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents. Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.</description>
+        <description>Founded in 2414 by Hered Selaj, Aitutaki Military Academy has been a center of anti-Marik
+            sentiment. The academy emphasizes physical training and survival skills in the first year, followed by
+            advanced MekWarrior and Cavalry training. The aerospace program was discontinued after fatal accidents.
+            Strict traditions and combat trials among cadets, scrutinized by the LCCC, define the school's atmosphere.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aitutaki</locationSystem>
@@ -248,7 +283,11 @@
         <name>Alarion Naval Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Alarion Naval Academy, established to meet the Lyran Alliance's need for WarShip crew training, complements existing aerospace academies. It quickly became crucial for naval training in the Inner Sphere, offering rigorous programs for DropShip, JumpShip, and WarShip crews, incorporating both basic and specialized studies.</description>
+        <description>The Alarion Naval Academy, established to meet the Lyran Alliance's need for WarShip crew training,
+            complements existing aerospace academies. It quickly became crucial for naval training in the Inner Sphere,
+            offering rigorous programs for DropShip, JumpShip, and WarShip crews, incorporating both basic and
+            specialized studies.
+        </description>
         <locationSystem>Alarion</locationSystem>
         <constructionYear>3060</constructionYear>
         <destructionYear>3069</destructionYear>
@@ -282,7 +321,12 @@
         <name>Albion Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Albion Military Academy quickly became the Federated Suns' premier institution. Traditionally, it allows graduates a unique buyout option to serve directly with the Federated Suns, bypassing service requirements. Located near Avalon City, the AMA is pivotal in training various military disciplines and continues to produce highly decorated officers. Despite intense academic and physical demands resulting in a high dropout rate, its graduates often ascend to senior AFFS leadership roles.</description>
+        <description>The Albion Military Academy quickly became the Federated Suns' premier institution. Traditionally,
+            it allows graduates a unique buyout option to serve directly with the Federated Suns, bypassing service
+            requirements. Located near Avalon City, the AMA is pivotal in training various military disciplines and
+            continues to produce highly decorated officers. Despite intense academic and physical demands resulting in a
+            high dropout rate, its graduates often ascend to senior AFFS leadership roles.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Albion (LC)</locationSystem>
@@ -344,7 +388,12 @@
         <name>Albion Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Albion Military Academy quickly became the Federated Suns' premier institution. Traditionally, it allows graduates a unique buyout option to serve directly with the Federated Suns, bypassing service requirements. Located near Avalon City, the AMA is pivotal in training various military disciplines and continues to produce highly decorated officers. Despite intense academic and physical demands resulting in a high dropout rate, its graduates often ascend to senior AFFS leadership roles.</description>
+        <description>The Albion Military Academy quickly became the Federated Suns' premier institution. Traditionally,
+            it allows graduates a unique buyout option to serve directly with the Federated Suns, bypassing service
+            requirements. Located near Avalon City, the AMA is pivotal in training various military disciplines and
+            continues to produce highly decorated officers. Despite intense academic and physical demands resulting in a
+            high dropout rate, its graduates often ascend to senior AFFS leadership roles.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Albion (LC)</locationSystem>
@@ -406,7 +455,12 @@
         <name>Algedi War College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Algedi War College is particularly recognized for its mobile warfare division. This development aligns with the production of military vehicles on the Arkab worlds. The college primarily admits candidates with an Azami background, reflecting its unique cultural focus. The AWC has seen immense popularity, with its first class contributing roughly ten percent of graduates as volunteers to DCMS line units, demonstrating goodwill to the Coordinator and strengthening military ties.</description>
+        <description>The Algedi War College is particularly recognized for its mobile warfare division. This development
+            aligns with the production of military vehicles on the Arkab worlds. The college primarily admits candidates
+            with an Azami background, reflecting its unique cultural focus. The AWC has seen immense popularity, with
+            its first class contributing roughly ten percent of graduates as volunteers to DCMS line units,
+            demonstrating goodwill to the Coordinator and strengthening military ties.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Algedi</locationSystem>
@@ -441,7 +495,13 @@
         <name>Allison MechWarrior Institute</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold loyalty.</description>
+        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent
+            to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute
+            fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks
+            that occasionally escalate into conflicts. Admission is highly competitive, influenced by political
+            considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold
+            loyalty.
+        </description>
         <locationSystem>New Olympia</locationSystem>
         <constructionYear>2465</constructionYear>
         <tuition>5250</tuition>
@@ -459,7 +519,13 @@
         <name>Allison MechWarrior Institute (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks that occasionally escalate into conflicts. Admission is highly competitive, influenced by political considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold loyalty.</description>
+        <description>The Allison MechWarrior Institute stands as a premier training facility for MekWarriors, adjacent
+            to the Lloyd Marik-Stanley Aerospace School. Producing 375 MekWarrior graduates annually, the institute
+            fosters a spirited rivalry with neighboring aerospace cadets, characterized by athletic contests and pranks
+            that occasionally escalate into conflicts. Admission is highly competitive, influenced by political
+            considerations, with a portion of spots reserved for families of Dispossessed Mechwarriors to uphold
+            loyalty.
+        </description>
         <locationSystem>New Olympia</locationSystem>
         <constructionYear>2465</constructionYear>
         <tuition>13125</tuition>
@@ -477,7 +543,10 @@
         <name>An Ting University</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The An Ting University is a renowned military academy historically dedicated to training MekWarriors. ATU, enjoying support from the DCMS and local government, provides rigorous training with a commitment to military reforms and a focus on loyalty and excellence.</description>
+        <description>The An Ting University is a renowned military academy historically dedicated to training
+            MekWarriors. ATU, enjoying support from the DCMS and local government, provides rigorous training with a
+            commitment to military reforms and a focus on loyalty and excellence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>An Ting</locationSystem>
@@ -504,7 +573,10 @@
         <name>An Ting University (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The An Ting University is a renowned military academy historically dedicated to training MekWarriors. ATU, enjoying support from the DCMS and local government, provides rigorous training with a commitment to military reforms and a focus on loyalty and excellence.</description>
+        <description>The An Ting University is a renowned military academy historically dedicated to training
+            MekWarriors. ATU, enjoying support from the DCMS and local government, provides rigorous training with a
+            commitment to military reforms and a focus on loyalty and excellence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>An Ting</locationSystem>
@@ -531,7 +603,13 @@
         <name>An Ting University [3055]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The An Ting University, a renowned military academy historically dedicated to training MekWarriors, faced significant damage from both external attacks and internal strife in 3015 from Sun Zhang Cadre alumni. The academy remained shuttered until 3055 when it reopened with advancements from the Helm Memory Core. ATU, enjoying support from the DCMS and local government, provides rigorous training with a commitment to military reforms and a focus on loyalty and excellence. Despite past conflicts, it now produces capable graduates, reaffirming its status alongside prestigious institutions like the Sun Zhang MekWarrior Academy.</description>
+        <description>The An Ting University, a renowned military academy historically dedicated to training MekWarriors,
+            faced significant damage from both external attacks and internal strife in 3015 from Sun Zhang Cadre alumni.
+            The academy remained shuttered until 3055 when it reopened with advancements from the Helm Memory Core. ATU,
+            enjoying support from the DCMS and local government, provides rigorous training with a commitment to
+            military reforms and a focus on loyalty and excellence. Despite past conflicts, it now produces capable
+            graduates, reaffirming its status alongside prestigious institutions like the Sun Zhang MekWarrior Academy.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>An Ting</locationSystem>
@@ -557,7 +635,13 @@
         <name>An Ting University (Officer) [3055]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The An Ting University, a renowned military academy historically dedicated to training MekWarriors, faced significant damage from both external attacks and internal strife in 3015 from Sun Zhang Cadre alumni. The academy remained shuttered until 3055 when it reopened with advancements from the Helm Memory Core. ATU, enjoying support from the DCMS and local government, provides rigorous training with a commitment to military reforms and a focus on loyalty and excellence. Despite past conflicts, it now produces capable graduates, reaffirming its status alongside prestigious institutions like the Sun Zhang MekWarrior Academy.</description>
+        <description>The An Ting University, a renowned military academy historically dedicated to training MekWarriors,
+            faced significant damage from both external attacks and internal strife in 3015 from Sun Zhang Cadre alumni.
+            The academy remained shuttered until 3055 when it reopened with advancements from the Helm Memory Core. ATU,
+            enjoying support from the DCMS and local government, provides rigorous training with a commitment to
+            military reforms and a focus on loyalty and excellence. Despite past conflicts, it now produces capable
+            graduates, reaffirming its status alongside prestigious institutions like the Sun Zhang MekWarrior Academy.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>An Ting</locationSystem>
@@ -583,7 +667,12 @@
         <name>Annapolis Naval Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled in the Inner Sphere.</description>
+        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted
+            for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command
+            within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to
+            mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled
+            in the Inner Sphere.
+        </description>
         <locationSystem>Terra</locationSystem>
         <closureYear>2779</closureYear>
         <tuition>7350</tuition>
@@ -613,7 +702,12 @@
         <name>Annapolis Naval Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled in the Inner Sphere.</description>
+        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted
+            for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command
+            within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to
+            mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled
+            in the Inner Sphere.
+        </description>
         <locationSystem>Terra</locationSystem>
         <closureYear>2779</closureYear>
         <tuition>12600</tuition>
@@ -643,7 +737,12 @@
         <name>Annapolis Naval Academy (Officer) [ComStar]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled in the Inner Sphere.</description>
+        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted
+            for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command
+            within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to
+            mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled
+            in the Inner Sphere.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -675,7 +774,12 @@
         <name>Annapolis Naval Academy [ComStar]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled in the Inner Sphere.</description>
+        <description>Annapolis Naval Academy has been a cornerstone of naval tradition since the 19th century. Adapted
+            for the modern era, it commands the cosmos' waves, preparing officers for strategic and tactical command
+            within the fleet. Annapolis prides itself on seamlessly transitioning cadets from seafaring origins to
+            mastering the vastness of space, ensuring that tactical doctrines and leadership skills remain unparalleled
+            in the Inner Sphere.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -707,7 +811,11 @@
         <name>Apollo Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Esteemed as the premier military institution of the Rim Worlds Republic, the Apollo Military Academy is located on the capital world of the Republic. Known for its rigorous standards and distinguished graduates, AMA excels in producing MekWarriors of superior leadership and combat skills, rivaling those from the most prestigious academies in the Inner Sphere.</description>
+        <description>Esteemed as the premier military institution of the Rim Worlds Republic, the Apollo Military
+            Academy is located on the capital world of the Republic. Known for its rigorous standards and distinguished
+            graduates, AMA excels in producing MekWarriors of superior leadership and combat skills, rivaling those from
+            the most prestigious academies in the Inner Sphere.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Apollo</locationSystem>
@@ -746,7 +854,11 @@
         <name>Apollo Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Esteemed as the premier military institution of the Rim Worlds Republic, the Apollo Military Academy is located on the capital world of the Republic. Known for its rigorous standards and distinguished graduates, AMA excels in producing MekWarriors of superior leadership and combat skills, rivaling those from the most prestigious academies in the Inner Sphere.</description>
+        <description>Esteemed as the premier military institution of the Rim Worlds Republic, the Apollo Military
+            Academy is located on the capital world of the Republic. Known for its rigorous standards and distinguished
+            graduates, AMA excels in producing MekWarriors of superior leadership and combat skills, rivaling those from
+            the most prestigious academies in the Inner Sphere.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Apollo</locationSystem>
@@ -785,7 +897,11 @@
         <name>Arc Royal War College of Tamar</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Tamar was renowned for producing adept tacticians, strategists, and outstanding administrators. After Clan Wolf's initial efforts to rebuild the original college yielded poor results, hostilities with Clan Jade Falcon prompted Clan Wolf to collaborate with House Steiner, resulting in the establishment of a new War College of Tamar on the planet Arc Royal.</description>
+        <description>The War College of Tamar was renowned for producing adept tacticians, strategists, and outstanding
+            administrators. After Clan Wolf's initial efforts to rebuild the original college yielded poor results,
+            hostilities with Clan Jade Falcon prompted Clan Wolf to collaborate with House Steiner, resulting in the
+            establishment of a new War College of Tamar on the planet Arc Royal.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tamar</locationSystem>
@@ -812,7 +928,12 @@
         <name>Armstrong Flight Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The premier flight school of the Federated Suns and a leading institution in the Inner Sphere, Galax Flight Academy strategically co-located near Federated-Boeing Interstellar, the largest spacecraft manufacturer in the region. This proximity fosters close interactions with leading engineers and test pilots, enhancing practical training. The academy concentrates on high-level piloting and technician skills, benefiting from this collaborative relationship.</description>
+        <description>The premier flight school of the Federated Suns and a leading institution in the Inner Sphere,
+            Galax Flight Academy strategically co-located near Federated-Boeing Interstellar, the largest spacecraft
+            manufacturer in the region. This proximity fosters close interactions with leading engineers and test
+            pilots, enhancing practical training. The academy concentrates on high-level piloting and technician skills,
+            benefiting from this collaborative relationship.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Galax</locationSystem>
@@ -848,7 +969,12 @@
         <name>Armstrong Phoenix Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally the premier flight school of the Federated Suns and a leading institution in the Inner Sphere, the academy underwent significant changes during the Word of Blake Jihad. It was relocated and renamed Armstrong Phoenix Academy due to severe disruptions. Despite this, it maintains rigorous standards, with intense physical screenings and high skill requirements, resulting in over half of the applicants being rejected pre-examination.</description>
+        <description>Originally the premier flight school of the Federated Suns and a leading institution in the Inner
+            Sphere, the academy underwent significant changes during the Word of Blake Jihad. It was relocated and
+            renamed Armstrong Phoenix Academy due to severe disruptions. Despite this, it maintains rigorous standards,
+            with intense physical screenings and high skill requirements, resulting in over half of the applicants being
+            rejected pre-examination.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Delavan</locationSystem>
@@ -882,7 +1008,11 @@
         <name>Athene Combat School</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Athene Combat School was established during a period of high recruitment within the Free Worlds League, as part of efforts by the Dormuth Council to expand military education. Unique among its contemporaries, ACS focused exclusively on infantry training, addressing a demand for specialized infantry forces.</description>
+        <description>The Athene Combat School was established during a period of high recruitment within the Free Worlds
+            League, as part of efforts by the Dormuth Council to expand military education. Unique among its
+            contemporaries, ACS focused exclusively on infantry training, addressing a demand for specialized infantry
+            forces.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Atreus (FWL)</locationSystem>
@@ -905,7 +1035,12 @@
         <name>Atreus Officer Training College</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Officer Training College offers a unique year-long course focused on developing leadership and command skills, the only one of its kind in the League. Enrollment is open to all soldiers yet to undergo officer training, though only 5% of applicants pass on their first try. The curriculum emphasizes practical skills over theoretical knowledge, preparing officers for the complexities of daily bureaucratic responsibilities with a strong focus on delegation and time management.</description>
+        <description>The Officer Training College offers a unique year-long course focused on developing leadership and
+            command skills, the only one of its kind in the League. Enrollment is open to all soldiers yet to undergo
+            officer training, though only 5% of applicants pass on their first try. The curriculum emphasizes practical
+            skills over theoretical knowledge, preparing officers for the complexities of daily bureaucratic
+            responsibilities with a strong focus on delegation and time management.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Atreus (FWL)</locationSystem>
@@ -925,7 +1060,10 @@
         <name>Blackjack School of Conflict</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Blackjack School of Conflict is a private military academy within the Lyran Commonwealth known for its unorthodox curriculum. Founded by tutors who failed entrance exams at other academies, it offers courses that include unofficial lessons on the shadier aspects of military life.</description>
+        <description>The Blackjack School of Conflict is a private military academy within the Lyran Commonwealth known
+            for its unorthodox curriculum. Founded by tutors who failed entrance exams at other academies, it offers
+            courses that include unofficial lessons on the shadier aspects of military life.
+        </description>
         <locationSystem>Blackjack</locationSystem>
         <constructionYear>2714</constructionYear>
         <destructionYear>3050</destructionYear>
@@ -936,34 +1074,34 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>MekWarrior Graduate</qualification>
-        <curriculum>Piloting/Mek, Gunnery/Mek, Scrounge, Artillery</curriculum>
+        <curriculum>Piloting/Mek, Gunnery/Mek, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Graduate</qualification>
-        <curriculum>Piloting/Ground Vehicle, Gunnery/Vehicle, Scrounge, Artillery</curriculum>
+        <curriculum>Piloting/Ground Vehicle, Gunnery/Vehicle, Artillery</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Air Cavalry Graduate</qualification>
-        <curriculum>Piloting/VTOL, Gunnery/Vehicle, Scrounge, Artillery</curriculum>
+        <curriculum>Piloting/VTOL, Gunnery/Vehicle, Artillery</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Advanced Naval Crew Graduate</qualification>
-        <curriculum>Piloting/Naval, Gunnery/Vehicle, Scrounge, Artillery</curriculum>
+        <curriculum>Piloting/Naval, Gunnery/Vehicle, Artillery</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Aircraft Pilot Graduate</qualification>
-        <curriculum>Piloting/Aircraft, Gunnery/Aircraft, Scrounge</curriculum>
+        <curriculum>Piloting/Aircraft, Gunnery/Aircraft</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Graduate</qualification>
-        <curriculum>Gunnery/BattleArmor, Anti-Mek, Scrounge</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <qualification>Advanced Infantry Graduate</qualification>
-        <curriculum>Small Arms, Anti-Mek, Scrounge, Artillery</curriculum>
+        <curriculum>Small Arms, Anti-Mek, Artillery</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>BattleMek Technician</qualification>
-        <curriculum>Tech/Mek, Scrounge</curriculum>
+        <curriculum>Tech/Mek</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Advanced Vehicle Technician</qualification>
-        <curriculum>Tech/Mechanic, Scrounge</curriculum>
+        <curriculum>Tech/Mechanic</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Armored Infantry Technician</qualification>
-        <curriculum>Tech/BattleArmor, Scrounge</curriculum>
+        <curriculum>Tech/BattleArmor</curriculum>
         <qualificationStartYear>3058</qualificationStartYear>
         <baseAcademicSkillLevel>0</baseAcademicSkillLevel>
     </academy>
@@ -971,7 +1109,13 @@
         <name>Brotherhood Monastery</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Located in Hope City, the Brotherhood Monastery serves as the training ground for the Brotherhood of Randis, a group reminiscent of the legendary Templar Knights in their stringent adherence to moral and physical disciplines. Entry into this elite unit is highly selective, focusing on candidates who demonstrate a commitment to the Christian faith and moral integrity. The initiation process is rigorous, featuring four perilous trials testing endurance, strength, dexterity, and courage—culminating in an elaborate ceremony where successful initiates receive a distinctive uniform of red and black silk, steel mesh, and a sword.</description>
+        <description>Located in Hope City, the Brotherhood Monastery serves as the training ground for the Brotherhood
+            of Randis, a group reminiscent of the legendary Templar Knights in their stringent adherence to moral and
+            physical disciplines. Entry into this elite unit is highly selective, focusing on candidates who demonstrate
+            a commitment to the Christian faith and moral integrity. The initiation process is rigorous, featuring four
+            perilous trials testing endurance, strength, dexterity, and courage—culminating in an elaborate ceremony
+            where successful initiates receive a distinctive uniform of red and black silk, steel mesh, and a sword.
+        </description>
         <locationSystem>Randis IV (Hope IV 2988-)</locationSystem>
         <constructionYear>2988</constructionYear>
         <tuition>5250</tuition>
@@ -989,7 +1133,10 @@
         <name>Calloway Martial College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Calloway Martial College was established to address the surge in military recruitment within the Free Worlds League. As the first of three new schools created by the Dormuth Council, the academy quickly became operational, featuring its own Calloway Training Battalion.</description>
+        <description>The Calloway Martial College was established to address the surge in military recruitment within
+            the Free Worlds League. As the first of three new schools created by the Dormuth Council, the academy
+            quickly became operational, featuring its own Calloway Training Battalion.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Calloway VI</locationSystem>
@@ -1010,7 +1157,12 @@
         <name>Canopian Institute of War</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards or pursue further training at the Victoria Academy of Arms and Technology.</description>
+        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of
+            War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic
+            training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates,
+            distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal
+            Guards or pursue further training at the Victoria Academy of Arms and Technology.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1034,7 +1186,12 @@
         <name>Canopian Institute of War (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards or pursue further training at the Victoria Academy of Arms and Technology.</description>
+        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of
+            War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic
+            training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates,
+            distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal
+            Guards or pursue further training at the Victoria Academy of Arms and Technology.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1057,7 +1214,12 @@
         <name>Canopian Institute of War [3080]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards or pursue further training at the Victoria Academy of Arms and Technology.</description>
+        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of
+            War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic
+            training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates,
+            distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal
+            Guards or pursue further training at the Victoria Academy of Arms and Technology.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1080,7 +1242,12 @@
         <name>Canopian Institute of War (Officer) [3080]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates, distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal Guards or pursue further training at the Victoria Academy of Arms and Technology.</description>
+        <description>Established to enhance the Magistracy Armed Forces' training programs, the Canopian Institute of
+            War draws inspiration from the Sun Zhang MekWarrior Academy. The rigorous program spans six months of basic
+            training followed by four years of advanced training for MekWarriors or aerospace pilots. Graduates,
+            distinguished by their gold, silver, and lavender uniforms, often join elite units like the Magistracy Royal
+            Guards or pursue further training at the Victoria Academy of Arms and Technology.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1103,7 +1270,10 @@
         <name>Capella War College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established concurrently with the Capellan Hegemony, the Capella War College stands as the oldest military academy in the Capellan Confederation. Training emphasizes combined-arms tactics and includes cross-training with the local Duchy RTC.</description>
+        <description>Established concurrently with the Capellan Hegemony, the Capella War College stands as the oldest
+            military academy in the Capellan Confederation. Training emphasizes combined-arms tactics and includes
+            cross-training with the local Duchy RTC.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Capella</locationSystem>
@@ -1168,7 +1338,10 @@
         <name>Capella War College (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established concurrently with the Capellan Hegemony, the Capella War College stands as the oldest military academy in the Capellan Confederation. Training emphasizes combined-arms tactics and includes cross-training with the local Duchy RTC.</description>
+        <description>Established concurrently with the Capellan Hegemony, the Capella War College stands as the oldest
+            military academy in the Capellan Confederation. Training emphasizes combined-arms tactics and includes
+            cross-training with the local Duchy RTC.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Capella</locationSystem>
@@ -1232,7 +1405,10 @@
     <academy>
         <name>Caph Institute of Technology</name>
         <type>Military Academy</type>
-        <description>Perched on a high hill and protected by electronic barriers against native lizards, the Caph Institute of Technology specializes in natural sciences, notably paleontology and chemistry. The institute is known for inventing the Jamerson-Ulikov Water Purifier.</description>
+        <description>Perched on a high hill and protected by electronic barriers against native lizards, the Caph
+            Institute of Technology specializes in natural sciences, notably paleontology and chemistry. The institute
+            is known for inventing the Jamerson-Ulikov Water Purifier.
+        </description>
         <locationSystem>Caph</locationSystem>
         <destructionYear>2768</destructionYear>
         <tuition>7500</tuition>
@@ -1249,7 +1425,10 @@
     <academy>
         <name>College of Talitha</name>
         <type>Military Academy</type>
-        <description>The College of Talitha, one of the Golden Ten Universities of the Terran Hegemony, specializes in design studies for civilian and military products, closely collaborating with the Hegemony Research and Development Centers.</description>
+        <description>The College of Talitha, one of the Golden Ten Universities of the Terran Hegemony, specializes in
+            design studies for civilian and military products, closely collaborating with the Hegemony Research and
+            Development Centers.
+        </description>
         <locationSystem>Talitha</locationSystem>
         <destructionYear>2770</destructionYear>
         <tuition>7500</tuition>
@@ -1270,7 +1449,10 @@
         <name>Combat College of New Earth</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Built in 2331, the Combat College was the first military academy on a foreign world. It prided itself on being equal to any academy on Terra. To prove their worth, the graduating warrior and pilot class always challenged the Sandhurst graduates to a military contest.</description>
+        <description>Built in 2331, the Combat College was the first military academy on a foreign world. It prided
+            itself on being equal to any academy on Terra. To prove their worth, the graduating warrior and pilot class
+            always challenged the Sandhurst graduates to a military contest.
+        </description>
         <locationSystem>New Earth (Tau Ceti 2116-)</locationSystem>
         <constructionYear>2331</constructionYear>
         <tuition>9625</tuition>
@@ -1303,7 +1485,10 @@
         <name>Combat College of New Earth (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Built in 2331, the Combat College was the first military academy on a foreign world. It prided itself on being equal to any academy on Terra. To prove their worth, the graduating warrior and pilot class always challenged the Sandhurst graduates to a military contest.</description>
+        <description>Built in 2331, the Combat College was the first military academy on a foreign world. It prided
+            itself on being equal to any academy on Terra. To prove their worth, the graduating warrior and pilot class
+            always challenged the Sandhurst graduates to a military contest.
+        </description>
         <locationSystem>New Earth (Tau Ceti 2116-)</locationSystem>
         <constructionYear>2331</constructionYear>
         <tuition>17500</tuition>
@@ -1336,7 +1521,11 @@
         <name>Concordat Aerospace Flight School</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Operated by seasoned instructors from the Outworlds Alliance, this academy boasts a reputation for excellence. Though it produces fewer graduates than the École Militaire, its focus on quality ensures each cadet emerges as a skilled and disciplined pilot. The school plays a vital role in shaping the aerospace forces of the Taurian Concordat, fostering a legacy of proficiency and valor among its graduates.</description>
+        <description>Operated by seasoned instructors from the Outworlds Alliance, this academy boasts a reputation for
+            excellence. Though it produces fewer graduates than the École Militaire, its focus on quality ensures each
+            cadet emerges as a skilled and disciplined pilot. The school plays a vital role in shaping the aerospace
+            forces of the Taurian Concordat, fostering a legacy of proficiency and valor among its graduates.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Samantha</locationSystem>
@@ -1368,7 +1557,11 @@
         <name>Coventry Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Coventry Academy, located in Dunnigan near Port Lawrence on Coventry, is a military academy close to the Coventry Metal Works plant. Many professors at the Academy also work at the CMW plant. Due to its close ties to CMW, it has been described as a glorified cadre for the manufacturer, with graduates often requiring additional training on equipment from other manufacturers.</description>
+        <description>The Coventry Academy, located in Dunnigan near Port Lawrence on Coventry, is a military academy
+            close to the Coventry Metal Works plant. Many professors at the Academy also work at the CMW plant. Due to
+            its close ties to CMW, it has been described as a glorified cadre for the manufacturer, with graduates often
+            requiring additional training on equipment from other manufacturers.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Coventry</locationSystem>
@@ -1391,7 +1584,11 @@
         <name>Coventry Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Coventry Academy, located in Dunnigan near Port Lawrence on Coventry, is a military academy close to the Coventry Metal Works plant. Many professors at the Academy also work at the CMW plant. Due to its close ties to CMW, it has been described as a glorified cadre for the manufacturer, with graduates often requiring additional training on equipment from other manufacturers.</description>
+        <description>The Coventry Academy, located in Dunnigan near Port Lawrence on Coventry, is a military academy
+            close to the Coventry Metal Works plant. Many professors at the Academy also work at the CMW plant. Due to
+            its close ties to CMW, it has been described as a glorified cadre for the manufacturer, with graduates often
+            requiring additional training on equipment from other manufacturers.
+        </description>
         <locationSystem>Coventry</locationSystem>
         <constructionYear>2700</constructionYear>
         <destructionYear>3058</destructionYear>
@@ -1412,7 +1609,12 @@
         <name>Coventry Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally focused solely on training MekWarriors, its ties to Coventry Metal Works drew criticism, but it persisted as a crucial training ground. During the Clan Invasion, cadets and instructors valiantly defended against Clan Jade Falcon, sacrificing parts of the academy to protect Coventry. Reborn as the Coventry Military Academy in 3060 under Lyran Alliance patronage, it flourishes with modern facilities and OmniMech training.</description>
+        <description>Originally focused solely on training MekWarriors, its ties to Coventry Metal Works drew criticism,
+            but it persisted as a crucial training ground. During the Clan Invasion, cadets and instructors valiantly
+            defended against Clan Jade Falcon, sacrificing parts of the academy to protect Coventry. Reborn as the
+            Coventry Military Academy in 3060 under Lyran Alliance patronage, it flourishes with modern facilities and
+            OmniMech training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Coventry</locationSystem>
@@ -1435,7 +1637,12 @@
         <name>Coventry Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally focused solely on training MekWarriors, its ties to Coventry Metal Works drew criticism, but it persisted as a crucial training ground. During the Clan Invasion, cadets and instructors valiantly defended against Clan Jade Falcon, sacrificing parts of the academy to protect Coventry. Reborn as the Coventry Military Academy in 3060 under Lyran Alliance patronage, it flourishes with modern facilities and OmniMech training.</description>
+        <description>Originally focused solely on training MekWarriors, its ties to Coventry Metal Works drew criticism,
+            but it persisted as a crucial training ground. During the Clan Invasion, cadets and instructors valiantly
+            defended against Clan Jade Falcon, sacrificing parts of the academy to protect Coventry. Reborn as the
+            Coventry Military Academy in 3060 under Lyran Alliance patronage, it flourishes with modern facilities and
+            OmniMech training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Coventry</locationSystem>
@@ -1458,7 +1665,11 @@
         <name>Dieron District Gymnasium</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training, accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the Dieron Military District.</description>
+        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness
+            over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training,
+            accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the
+            Dieron Military District.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieron</locationSystem>
@@ -1482,7 +1693,11 @@
         <name>Dieron District Gymnasium (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training, accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the Dieron Military District.</description>
+        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness
+            over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training,
+            accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the
+            Dieron Military District.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieron</locationSystem>
@@ -1506,7 +1721,12 @@
         <name>Dieron District Gymnasium [3078]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training, accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the Dieron Military District. Briefly closed in 3068; it reopened in 3078, attracting attention with its first class of battlesuit trainees, including a notable presence of ISF agents.</description>
+        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness
+            over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training,
+            accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the
+            Dieron Military District. Briefly closed in 3068; it reopened in 3078, attracting attention with its first
+            class of battlesuit trainees, including a notable presence of ISF agents.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieron</locationSystem>
@@ -1532,7 +1752,12 @@
         <name>Dieron District Gymnasium (Officer) [3078]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training, accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the Dieron Military District. Briefly closed in 3068; it reopened in 3078, attracting attention with its first class of battlesuit trainees, including a notable presence of ISF agents.</description>
+        <description>The Dieron District Gymnasium shapes MekWarriors solely on merit. Prioritizing combat readiness
+            over prestige, it employs an innovative regimen where study time earns simulator and 'Mek training,
+            accelerating student advancement. Graduating fifteen to twenty MekWarriors annually, the DDG is vital to the
+            Dieron Military District. Briefly closed in 3068; it reopened in 3078, attracting attention with its first
+            class of battlesuit trainees, including a notable presence of ISF agents.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieron</locationSystem>
@@ -1558,7 +1783,11 @@
         <name>Dieron Warriors' Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dieron Warriors Academy on Shimonita annually produces skilled MekWarriors. Graduates are favored for recruitment into the renowned Dieron Regulars, showcasing the academy's pivotal role in regional military development. All five BattleMek regiment commanders have roots in both the Dieron draft and Sun Zhang MekWarrior Academy, highlighting the DWA's lasting influence.</description>
+        <description>The Dieron Warriors Academy on Shimonita annually produces skilled MekWarriors. Graduates are
+            favored for recruitment into the renowned Dieron Regulars, showcasing the academy's pivotal role in regional
+            military development. All five BattleMek regiment commanders have roots in both the Dieron draft and Sun
+            Zhang MekWarrior Academy, highlighting the DWA's lasting influence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Shimonita</locationSystem>
@@ -1579,7 +1808,12 @@
         <name>Dover Institute for Higher Learning</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Dover Institute for Higher Learning rose from the ashes of the People's Reconstruction Effort University of Ashio, destroyed during the Shadow War of 2865. Established in 2910 under Coordinator Shinjiro Kurita's patronage, it prioritizes scientific, technical education, and MekWarrior training. Enrollment is open to all meeting basic criteria, with a rigorous five-month basic training followed by a four-year curriculum exposing cadets to diverse combat scenarios.</description>
+        <description>The Dover Institute for Higher Learning rose from the ashes of the People's Reconstruction Effort
+            University of Ashio, destroyed during the Shadow War of 2865. Established in 2910 under Coordinator Shinjiro
+            Kurita's patronage, it prioritizes scientific, technical education, and MekWarrior training. Enrollment is
+            open to all meeting basic criteria, with a rigorous five-month basic training followed by a four-year
+            curriculum exposing cadets to diverse combat scenarios.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dover</locationSystem>
@@ -1605,7 +1839,10 @@
         <name>Ecole Militaire</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The École Militaire stands as the most renowned academy in the Taurian Concordat, offering courses covering almost every form of modern warfare. Renowned for producing elite MekWarriors, armor, and infantry units, the academy admits foreign applicants with a preference for Taurians. </description>
+        <description>The École Militaire stands as the most renowned academy in the Taurian Concordat, offering courses
+            covering almost every form of modern warfare. Renowned for producing elite MekWarriors, armor, and infantry
+            units, the academy admits foreign applicants with a preference for Taurians.
+        </description>
         <locationSystem>Taurus</locationSystem>
         <constructionYear>2500</constructionYear>
         <destructionYear>3078</destructionYear>
@@ -1642,7 +1879,12 @@
         <name>Ecole Militaire [3130]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Devastated during the Jihad, the Ecole Militaire now relies on wounded troops as temporary instructors, reminding cadets of its loss. Renowned for producing elite MekWarriors, armor, and infantry units, the academy admits foreign applicants with a preference for Taurians. Rigorous basic training precedes specialization in armor, infantry, or MekWarrior tracks, emphasizing leadership and offering Officer Candidate School slots upon graduation.</description>
+        <description>Devastated during the Jihad, the Ecole Militaire now relies on wounded troops as temporary
+            instructors, reminding cadets of its loss. Renowned for producing elite MekWarriors, armor, and infantry
+            units, the academy admits foreign applicants with a preference for Taurians. Rigorous basic training
+            precedes specialization in armor, infantry, or MekWarrior tracks, emphasizing leadership and offering
+            Officer Candidate School slots upon graduation.
+        </description>
         <locationSystem>Taurus</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>9625</tuition>
@@ -1677,7 +1919,10 @@
         <name>Emma Centrella Martial Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Emma Centrella Martial Academy succeeds the Canopian Institute of War, nestled in Astarte on Salonika's continent. Graduating its inaugural class in 3083, murmurs of discontent regarding instructional quality have surfaced, despite the MAF's efforts to secure top-tier instructors.</description>
+        <description>The Emma Centrella Martial Academy succeeds the Canopian Institute of War, nestled in Astarte on
+            Salonika's continent. Graduating its inaugural class in 3083, murmurs of discontent regarding instructional
+            quality have surfaced, despite the MAF's efforts to secure top-tier instructors.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1715,7 +1960,10 @@
         <name>Emma Centrella Martial Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Emma Centrella Martial Academy succeeds the Canopian Institute of War, nestled in Astarte on Salonika's continent. Graduating its inaugural class in 3083, murmurs of discontent regarding instructional quality have surfaced, despite the MAF's efforts to secure top-tier instructors.</description>
+        <description>The Emma Centrella Martial Academy succeeds the Canopian Institute of War, nestled in Astarte on
+            Salonika's continent. Graduating its inaugural class in 3083, murmurs of discontent regarding instructional
+            quality have surfaced, despite the MAF's efforts to secure top-tier instructors.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -1753,7 +2001,13 @@
         <name>Emporia Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Following the cataclysmic events of 3150, the Emporia Military Academy rose from the ashes of the Ritza Academy, embodying resilience and fortitude in the face of adversity. Led by a dedicated faculty and staff, it prepares cadets for the challenges of modern warfare, instilling in them the values of courage, discipline, and honor. Despite the scars of past conflicts, the academy remains steadfast in its commitment to shaping future generations of warriors, ensuring that Emporia's legacy of valor endures for generations to come.</description>
+        <description>Following the cataclysmic events of 3150, the Emporia Military Academy rose from the ashes of the
+            Ritza Academy, embodying resilience and fortitude in the face of adversity. Led by a dedicated faculty and
+            staff, it prepares cadets for the challenges of modern warfare, instilling in them the values of courage,
+            discipline, and honor. Despite the scars of past conflicts, the academy remains steadfast in its commitment
+            to shaping future generations of warriors, ensuring that Emporia's legacy of valor endures for generations
+            to come.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Emporia</locationSystem>
@@ -1791,7 +2045,13 @@
         <name>Filtvelt Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Filtvelt Military Academy, initially serving the Federated Suns' Outback region and later the Filtvelt Coalition, is built during the late Third Succession War near Undredal's capital. Similar to Kilbourne Academy, FMA offers educational opportunities to civilians in a region scarce in options. Despite lacking advanced resources like simulators, FMA excels by providing intensive practical training, producing graduates well-prepared for real combat situations, though they are often underestimated by larger military entities.</description>
+        <description>Filtvelt Military Academy, initially serving the Federated Suns' Outback region and later the
+            Filtvelt Coalition, is built during the late Third Succession War near Undredal's capital. Similar to
+            Kilbourne Academy, FMA offers educational opportunities to civilians in a region scarce in options. Despite
+            lacking advanced resources like simulators, FMA excels by providing intensive practical training, producing
+            graduates well-prepared for real combat situations, though they are often underestimated by larger military
+            entities.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Filtvelt</locationSystem>
@@ -1832,7 +2092,11 @@
         <name>Finmark Air and Space Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Finmark Air and Space Academy serves as a vital training ground for the naval officer corps of the Rim Worlds Republic. Positioned in high orbit above Finmark, the administrative hub of the Finmark Province, FASA boasts a substantial annual output of new officers. Offering a comprehensive WarShip program among its military courses, FASA plays a crucial role in shaping Republic naval personnel.</description>
+        <description>The Finmark Air and Space Academy serves as a vital training ground for the naval officer corps of
+            the Rim Worlds Republic. Positioned in high orbit above Finmark, the administrative hub of the Finmark
+            Province, FASA boasts a substantial annual output of new officers. Offering a comprehensive WarShip program
+            among its military courses, FASA plays a crucial role in shaping Republic naval personnel.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Finmark</locationSystem>
@@ -1868,7 +2132,11 @@
         <name>Finmark Air and Space Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Finmark Air and Space Academy serves as a vital training ground for the naval officer corps of the Rim Worlds Republic. Positioned in high orbit above Finmark, the administrative hub of the Finmark Province, FASA boasts a substantial annual output of new officers. Offering a comprehensive WarShip program among its military courses, FASA plays a crucial role in shaping Republic naval personnel.</description>
+        <description>The Finmark Air and Space Academy serves as a vital training ground for the naval officer corps of
+            the Rim Worlds Republic. Positioned in high orbit above Finmark, the administrative hub of the Finmark
+            Province, FASA boasts a substantial annual output of new officers. Offering a comprehensive WarShip program
+            among its military courses, FASA plays a crucial role in shaping Republic naval personnel.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Finmark</locationSystem>
@@ -1904,7 +2172,10 @@
         <name>Fleet School of Keid</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Next to the Annapolis and Kure Naval Academies, the Fleet School of Keid is the largest training facility for naval personnel in the Inner Sphere. Each school has several WarShips and JumpShips for crew training.</description>
+        <description>Next to the Annapolis and Kure Naval Academies, the Fleet School of Keid is the largest training
+            facility for naval personnel in the Inner Sphere. Each school has several WarShips and JumpShips for crew
+            training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Keid</locationSystem>
@@ -1939,7 +2210,10 @@
         <name>Fleet School of Keid (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Next to the Annapolis and Kure Naval Academies, the Fleet School of Keid is the largest training facility for naval personnel in the Inner Sphere. Each school has several WarShips and JumpShips for crew training.</description>
+        <description>Next to the Annapolis and Kure Naval Academies, the Fleet School of Keid is the largest training
+            facility for naval personnel in the Inner Sphere. Each school has several WarShips and JumpShips for crew
+            training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Keid</locationSystem>
@@ -1974,7 +2248,9 @@
         <name>Flight Academy of Graham</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Flight Academy of Graham is one of the few schools dedicated solely to training aerospace pilots and one of the few orbiting space academies. Over 2,000 pilots graduate from the academy every year.</description>
+        <description>The Flight Academy of Graham is one of the few schools dedicated solely to training aerospace
+            pilots and one of the few orbiting space academies. Over 2,000 pilots graduate from the academy every year.
+        </description>
         <locationSystem>Graham IV</locationSystem>
         <destructionYear>2767</destructionYear>
         <tuition>8750</tuition>
@@ -1998,7 +2274,9 @@
         <name>Flight Academy of Graham (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Flight Academy of Graham is one of the few schools dedicated solely to training aerospace pilots and one of the few orbiting space academies. Over 2,000 pilots graduate from the academy every year.</description>
+        <description>The Flight Academy of Graham is one of the few schools dedicated solely to training aerospace
+            pilots and one of the few orbiting space academies. Over 2,000 pilots graduate from the academy every year.
+        </description>
         <locationSystem>Graham IV</locationSystem>
         <destructionYear>2767</destructionYear>
         <tuition>14875</tuition>
@@ -2022,7 +2300,9 @@
         <name>Flight Academy of Thorin</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Flight Academy of Thorin excels in training aerospace personnel for the Lyran Commonwealth Armed Forces. Graduates, distinguished by gray-red 'school rags,' reflect Thorin's Star League legacy.</description>
+        <description>The Flight Academy of Thorin excels in training aerospace personnel for the Lyran Commonwealth
+            Armed Forces. Graduates, distinguished by gray-red 'school rags,' reflect Thorin's Star League legacy.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Thorin</locationSystem>
@@ -2058,7 +2338,10 @@
         <name>Focht War College [Kentares IV]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Following the Jihad and the destruction of the original Focht War College on Tukayyid, Kentares IV becomes the new location for the college. With significant financial backing from the Federated Suns, the college focuses on training a new generation of leaders for various military roles.</description>
+        <description>Following the Jihad and the destruction of the original Focht War College on Tukayyid, Kentares IV
+            becomes the new location for the college. With significant financial backing from the Federated Suns, the
+            college focuses on training a new generation of leaders for various military roles.
+        </description>
         <locationSystem>Kentares IV</locationSystem>
         <constructionYear>3085</constructionYear>
         <tuition>7500</tuition>
@@ -2094,7 +2377,10 @@
         <name>Focht War College (Officer) [Kentares IV]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Following the Jihad and the destruction of the original Focht War College on Tukayyid, Kentares IV becomes the new location for the college. With significant financial backing from the Federated Suns, the college focuses on training a new generation of leaders for various military roles.</description>
+        <description>Following the Jihad and the destruction of the original Focht War College on Tukayyid, Kentares IV
+            becomes the new location for the college. With significant financial backing from the Federated Suns, the
+            college focuses on training a new generation of leaders for various military roles.
+        </description>
         <locationSystem>Kentares IV</locationSystem>
         <constructionYear>3085</constructionYear>
         <tuition>14063</tuition>
@@ -2130,7 +2416,10 @@
         <name>Focht War College [Tukayyid]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Focht War College is pivotal in training the elite ComGuards and later, the forces of the Second Star League. Tukayyid's sparse civilian presence and rugged terrain made it ideal for rigorous military exercises.</description>
+        <description>The Focht War College is pivotal in training the elite ComGuards and later, the forces of the
+            Second Star League. Tukayyid's sparse civilian presence and rugged terrain made it ideal for rigorous
+            military exercises.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tukayyid</locationSystem>
@@ -2169,7 +2458,10 @@
         <name>Focht War College (Officer) [Tukayyid]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Focht War College is pivotal in training the elite ComGuards and later, the forces of the Second Star League. Tukayyid's sparse civilian presence and rugged terrain made it ideal for rigorous military exercises.</description>
+        <description>The Focht War College is pivotal in training the elite ComGuards and later, the forces of the
+            Second Star League. Tukayyid's sparse civilian presence and rugged terrain made it ideal for rigorous
+            military exercises.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tukayyid</locationSystem>
@@ -2208,7 +2500,9 @@
         <name>Frihet Training Facility (Semester One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 3055 after the loss of the Radstadt Academy during the Clan Invasion, the Frihet Training Facility became a cornerstone of the Free Rasalhague Republic's military growth efforts.</description>
+        <description>Established in 3055 after the loss of the Radstadt Academy during the Clan Invasion, the Frihet
+            Training Facility became a cornerstone of the Free Rasalhague Republic's military growth efforts.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Grumium</locationSystem>
@@ -2228,7 +2522,9 @@
         <name>Frihet Training Facility</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 3055 after the loss of the Radstadt Academy during the Clan Invasion, the Frihet Training Facility became a cornerstone of the Free Rasalhague Republic's military growth efforts.</description>
+        <description>Established in 3055 after the loss of the Radstadt Academy during the Clan Invasion, the Frihet
+            Training Facility became a cornerstone of the Free Rasalhague Republic's military growth efforts.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Grumium</locationSystem>
@@ -2266,7 +2562,10 @@
         <name>Frunze Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Frunze Military Academy is a renowned institution, central in the development of military theory and practice in the former Soviet Union. Frunze's graduates are esteemed for their deep tactical acumen and unwavering discipline, preparing them for multifaceted warfare among the stars.</description>
+        <description>The Frunze Military Academy is a renowned institution, central in the development of military
+            theory and practice in the former Soviet Union. Frunze's graduates are esteemed for their deep tactical
+            acumen and unwavering discipline, preparing them for multifaceted warfare among the stars.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -2303,7 +2602,10 @@
         <name>Frunze Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Frunze Military Academy is a renowned institution, central in the development of military theory and practice in the former Soviet Union. Frunze's graduates are esteemed for their deep tactical acumen and unwavering discipline, preparing them for multifaceted warfare among the stars.</description>
+        <description>The Frunze Military Academy is a renowned institution, central in the development of military
+            theory and practice in the former Soviet Union. Frunze's graduates are esteemed for their deep tactical
+            acumen and unwavering discipline, preparing them for multifaceted warfare among the stars.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -2340,7 +2642,11 @@
         <name>Galedon Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established on Galedon V before the formation of the Draconis Combine, the Galedon Military Academy is renowned as one of the oldest institutions of its kind. Exclusive to graduates of Galedon Military District primary schools, GMA offers comprehensive training across all DCMS branches, with a focus on rigorous physical conditioning unmatched by other academies.</description>
+        <description>Established on Galedon V before the formation of the Draconis Combine, the Galedon Military Academy
+            is renowned as one of the oldest institutions of its kind. Exclusive to graduates of Galedon Military
+            District primary schools, GMA offers comprehensive training across all DCMS branches, with a focus on
+            rigorous physical conditioning unmatched by other academies.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Galedon V</locationSystem>
@@ -2409,7 +2715,11 @@
         <name>Galedon Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established on Galedon V before the formation of the Draconis Combine, the Galedon Military Academy is renowned as one of the oldest institutions of its kind. Exclusive to graduates of Galedon Military District primary schools, GMA offers comprehensive training across all DCMS branches, with a focus on rigorous physical conditioning unmatched by other academies.</description>
+        <description>Established on Galedon V before the formation of the Draconis Combine, the Galedon Military Academy
+            is renowned as one of the oldest institutions of its kind. Exclusive to graduates of Galedon Military
+            District primary schools, GMA offers comprehensive training across all DCMS branches, with a focus on
+            rigorous physical conditioning unmatched by other academies.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Galedon V</locationSystem>
@@ -2478,7 +2788,11 @@
         <name>Gershwin Academy of Combat</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The esteemed Gershwin Academy of Combat, a private institution founded by the Gershwin Mining Collective, specializes in honing the skills of MekWarrior and armored cavalry. Graduates emerge well-equipped for diverse combat scenarios, instilled with discipline and strategic prowess. Aspiring warriors flock to GAC for its distinguished legacy and commitment to producing elite combat personnel.</description>
+        <description>The esteemed Gershwin Academy of Combat, a private institution founded by the Gershwin Mining
+            Collective, specializes in honing the skills of MekWarrior and armored cavalry. Graduates emerge
+            well-equipped for diverse combat scenarios, instilled with discipline and strategic prowess. Aspiring
+            warriors flock to GAC for its distinguished legacy and commitment to producing elite combat personnel.
+        </description>
         <locationSystem>Zollikofen</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>15750</tuition>
@@ -2507,7 +2821,11 @@
     <academy>
         <name>Gogh-Bukowski University of New Avalon</name>
         <type>University</type>
-        <description>Located on New Avalon, Gogh-Bukowski University stands as a leading arts institution in the Inner Sphere, housing schools for Written Arts, Visual Arts, and Musical Arts. With a reputation for its liberal and anti-government stance, the university has historically experienced tensions with the New Avalon Institute of Science.</description>
+        <description>Located on New Avalon, Gogh-Bukowski University stands as a leading arts institution in the Inner
+            Sphere, housing schools for Written Arts, Visual Arts, and Musical Arts. With a reputation for its liberal
+            and anti-government stance, the university has historically experienced tensions with the New Avalon
+            Institute of Science.
+        </description>
         <locationSystem>New Avalon</locationSystem>
         <constructionYear>2600</constructionYear>
         <tuition>6250</tuition>
@@ -2528,7 +2846,9 @@
         <name>Goshen BattleMek Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Goshen, founded by Generals Alexander and Truscott, is a renowned private military academy in the Federated Suns, celebrated for its production of capable combat leaders.</description>
+        <description>The War College of Goshen, founded by Generals Alexander and Truscott, is a renowned private
+            military academy in the Federated Suns, celebrated for its production of capable combat leaders.
+        </description>
         <locationSystem>Goshen</locationSystem>
         <constructionYear>2950</constructionYear>
         <closureYear>2960</closureYear>
@@ -2547,7 +2867,10 @@
         <name>Gunslinger Program</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Gunslinger Program, originally known as the Advanced Combat and Maneuvering Skills Project, was initiated by the Star League Defense Force in response to the First Hidden War. It blends ancient martial philosophies with cutting-edge technology, producing skilled duelists.</description>
+        <description>The Gunslinger Program, originally known as the Advanced Combat and Maneuvering Skills Project, was
+            initiated by the Star League Defense Force in response to the First Hidden War. It blends ancient martial
+            philosophies with cutting-edge technology, producing skilled duelists.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -2568,7 +2891,13 @@
         <name>Gunslinger Program [3062]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Gunslinger Program, originally known as the Advanced Combat and Maneuvering Skills Project, was initiated by the Star League Defense Force in response to the First Hidden War. It blends ancient martial philosophies with cutting-edge technology, producing skilled duelists. Though the original program ceased with the fall of the Star League in 2781, its revival by the Second Star League in 3062 at the Focht War College on Tukayyid. This iteration focuses on teaching the one-on-one combat style favored by the Clans, accepting troops from any member state.</description>
+        <description>The Gunslinger Program, originally known as the Advanced Combat and Maneuvering Skills Project, was
+            initiated by the Star League Defense Force in response to the First Hidden War. It blends ancient martial
+            philosophies with cutting-edge technology, producing skilled duelists. Though the original program ceased
+            with the fall of the Star League in 2781, its revival by the Second Star League in 3062 at the Focht War
+            College on Tukayyid. This iteration focuses on teaching the one-on-one combat style favored by the Clans,
+            accepting troops from any member state.
+        </description>
         <locationSystem>Tukayyid</locationSystem>
         <constructionYear>3062</constructionYear>
         <tuition>36750</tuition>
@@ -2586,7 +2915,10 @@
         <name>Hachiman Technical Institute</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Hachiman Technical Institute specializes in battlefield repair and technical training, focusing on maintaining BattleMeks, aerospace fighters, and DropShips. It admits candidates rejected by other Draconis Combine military academies, as well as select trade school graduates.</description>
+        <description>The Hachiman Technical Institute specializes in battlefield repair and technical training, focusing
+            on maintaining BattleMeks, aerospace fighters, and DropShips. It admits candidates rejected by other
+            Draconis Combine military academies, as well as select trade school graduates.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Hachiman</locationSystem>
@@ -2615,7 +2947,9 @@
         <name>Hero Training Institute [Cap Rouge]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Situated on Sillery's continent, the Hero Training Institute - Cap Rouge provides training programs for aspiring BattleMek and aerospace fighter pilots.</description>
+        <description>Situated on Sillery's continent, the Hero Training Institute - Cap Rouge provides training programs
+            for aspiring BattleMek and aerospace fighter pilots.
+        </description>
         <locationSystem>Cap Rouge</locationSystem>
         <constructionYear>3072</constructionYear>
         <tuition>35000</tuition>
@@ -2636,7 +2970,11 @@
         <name>Hero Training Institute [Maxwell]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Hero Training Institute offers an unconventional route to becoming a MekWarrior, bypassing traditional credentials. Known for its high fees and extensive advertising, HTI provides subpar training with limited hands-on experience. Nonetheless, it allows graduates to enter mercenary units or non-commissioned positions in the Free Worlds League Military.</description>
+        <description>The Hero Training Institute offers an unconventional route to becoming a MekWarrior, bypassing
+            traditional credentials. Known for its high fees and extensive advertising, HTI provides subpar training
+            with limited hands-on experience. Nonetheless, it allows graduates to enter mercenary units or
+            non-commissioned positions in the Free Worlds League Military.
+        </description>
         <locationSystem>Maxwell</locationSystem>
         <constructionYear>2989</constructionYear>
         <tuition>52500</tuition>
@@ -2663,7 +3001,10 @@
         <name>Hero Training Institute [Payvand]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The second-oldest Hero Training Institute, the Payvand campus, is located in Pejman on the Gooya continent. Despite significant investment in the Maxwell campus, Payvand remains decrepit, with aging simulators reflecting the corporation's neglect in updating its facilities.</description>
+        <description>The second-oldest Hero Training Institute, the Payvand campus, is located in Pejman on the Gooya
+            continent. Despite significant investment in the Maxwell campus, Payvand remains decrepit, with aging
+            simulators reflecting the corporation's neglect in updating its facilities.
+        </description>
         <locationSystem>Payvand</locationSystem>
         <constructionYear>3010</constructionYear>
         <tuition>35000</tuition>
@@ -2684,7 +3025,11 @@
         <name>Hero Training Institute [Sorunda]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Hero Training Institute's Sorunda campus sits on the predominantly pacifist Buddhist planet of Serenity, nestled in the Modesty Grasslands. Constructed away from population centers to minimize disruption, the academy faced initial resistance from locals. However, concerns over defense eventually led to the community's approval of its establishment.</description>
+        <description>The Hero Training Institute's Sorunda campus sits on the predominantly pacifist Buddhist planet of
+            Serenity, nestled in the Modesty Grasslands. Constructed away from population centers to minimize
+            disruption, the academy faced initial resistance from locals. However, concerns over defense eventually led
+            to the community's approval of its establishment.
+        </description>
         <locationSystem>Sorunda</locationSystem>
         <constructionYear>3073</constructionYear>
         <tuition>35000</tuition>
@@ -2705,7 +3050,10 @@
         <name>Hero Training Institute [Sterling]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Hero Training Institute's Sterling campus sits near Starlight on the Graham continent, offering training for BattleMek and aerospace fighter pilots. Sterling is among several new HTI campuses established to meet the heightened demand for military training.</description>
+        <description>The Hero Training Institute's Sterling campus sits near Starlight on the Graham continent, offering
+            training for BattleMek and aerospace fighter pilots. Sterling is among several new HTI campuses established
+            to meet the heightened demand for military training.
+        </description>
         <locationSystem>Sterling</locationSystem>
         <constructionYear>3074</constructionYear>
         <tuition>35000</tuition>
@@ -2726,7 +3074,12 @@
         <name>Hero Training Institute [Trinidad]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Trinidad, the newest Hero Training Institute campus as of 3079, sits in the Arawak Marshlands on the Arawak continent. Founded by ex-SAFE veterans, it offers the Inner Sphere's first private Special Operations training. Its "logistics studies" course, though not officially listed, commands the highest fees and the best equipment. Enrollment entails heavy screening and dean's permission, with most applicants relying on referrals.</description>
+        <description>Trinidad, the newest Hero Training Institute campus as of 3079, sits in the Arawak Marshlands on
+            the Arawak continent. Founded by ex-SAFE veterans, it offers the Inner Sphere's first private Special
+            Operations training. Its "logistics studies" course, though not officially listed, commands the highest fees
+            and the best equipment. Enrollment entails heavy screening and dean's permission, with most applicants
+            relying on referrals.
+        </description>
         <locationSystem>Trinidad</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>192500</tuition>
@@ -2746,7 +3099,10 @@
         <name>Humphreys School of Warfare</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established on Kanata in late 2762, the Humphreys School of Warfare (HSW) is one of three major military academies created by the Dormuth Council to manage high recruitment numbers in the Free Worlds League. It primarily recruits cadets from the Duchy of Andurien and nearby independent worlds.</description>
+        <description>Established on Kanata in late 2762, the Humphreys School of Warfare (HSW) is one of three major
+            military academies created by the Dormuth Council to manage high recruitment numbers in the Free Worlds
+            League. It primarily recruits cadets from the Duchy of Andurien and nearby independent worlds.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kanata</locationSystem>
@@ -2778,7 +3134,9 @@
         <name>Humphreys Training Academy (Semester One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors, providing comprehensive classes instructed by experienced lecturers.</description>
+        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors,
+            providing comprehensive classes instructed by experienced lecturers.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
@@ -2799,7 +3157,9 @@
         <name>Humphreys Training Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors, providing comprehensive classes instructed by experienced lecturers.</description>
+        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors,
+            providing comprehensive classes instructed by experienced lecturers.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
@@ -2820,7 +3180,12 @@
         <name>Humphreys Training Academy (Semester One) [3079]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>After the Andurien Secession, the Humphreys Training Academy was rebranded as the Legionary Training Academy. Upon the Free Worlds League's dissolution, the Duchy of Andurien restored its original name. Despite production challenges, the Anduriens have expanded training for battle armor and aerospace, hiring experienced Andurien Rangers as instructors. Enrollment is limited to low-risk students passing mental and physical tests.</description>
+        <description>After the Andurien Secession, the Humphreys Training Academy was rebranded as the Legionary
+            Training Academy. Upon the Free Worlds League's dissolution, the Duchy of Andurien restored its original
+            name. Despite production challenges, the Anduriens have expanded training for battle armor and aerospace,
+            hiring experienced Andurien Rangers as instructors. Enrollment is limited to low-risk students passing
+            mental and physical tests.
+        </description>
         <locationSystem>Andurien</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>4375</tuition>
@@ -2838,7 +3203,12 @@
         <name>Humphreys Training Academy [3079]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>After the Andurien Secession, the Humphreys Training Academy was rebranded as the Legionary Training Academy. Upon the Free Worlds League's dissolution, the Duchy of Andurien restored its original name. Despite production challenges, the Anduriens have expanded training for battle armor and aerospace, hiring experienced Andurien Rangers as instructors. Enrollment is limited to low-risk students passing mental and physical tests.</description>
+        <description>After the Andurien Secession, the Humphreys Training Academy was rebranded as the Legionary
+            Training Academy. Upon the Free Worlds League's dissolution, the Duchy of Andurien restored its original
+            name. Despite production challenges, the Anduriens have expanded training for battle armor and aerospace,
+            hiring experienced Andurien Rangers as instructors. Enrollment is limited to low-risk students passing
+            mental and physical tests.
+        </description>
         <locationSystem>Andurien</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>4375</tuition>
@@ -2862,7 +3232,9 @@
         <name>Illiushin Taurian Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Illiushin Taurian Academy is a small academy within the Taurian Concordat that trains conventional troops, alongside a program of IndustrialMek training.</description>
+        <description>The Illiushin Taurian Academy is a small academy within the Taurian Concordat that trains
+            conventional troops, alongside a program of IndustrialMek training.
+        </description>
         <locationSystem>Illiushin</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>8750</tuition>
@@ -2891,7 +3263,10 @@
     <academy>
         <name>Imperial Institute of Technology</name>
         <type>University</type>
-        <description>The Imperial Institute of Technology stands as the Draconis Combine's top-tier university for technology studies. It admits only the most talented students in science and mathematics, with some cadets from other academies attending for a year after passing stringent tests.</description>
+        <description>The Imperial Institute of Technology stands as the Draconis Combine's top-tier university for
+            technology studies. It admits only the most talented students in science and mathematics, with some cadets
+            from other academies attending for a year after passing stringent tests.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Xinyang</locationSystem>
@@ -2914,7 +3289,12 @@
         <name>Internal Security College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Internal Security College is where the Draconis Combine's Internal Security Force receives training. The facility is heavily fortified, surrounded by 60 kilometers of diacetylsillicate, a corrosive sand, and strictly enforces a no-fly zone within 200 km, shooting down any unauthorized aircraft. Admission to the ISC is through a classified recruitment process, and students' identities are kept secret. The ISC provides rigorous training in psychology, anatomy, and zero-g martial arts.</description>
+        <description>The Internal Security College is where the Draconis Combine's Internal Security Force receives
+            training. The facility is heavily fortified, surrounded by 60 kilometers of diacetylsillicate, a corrosive
+            sand, and strictly enforces a no-fly zone within 200 km, shooting down any unauthorized aircraft. Admission
+            to the ISC is through a classified recruitment process, and students' identities are kept secret. The ISC
+            provides rigorous training in psychology, anatomy, and zero-g martial arts.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Samarkand</locationSystem>
@@ -2937,7 +3317,9 @@
         <name>Irian Academy of Combative Science</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Irian Academy trains MekWarriors and is highly regarded among schools. Students undergo instruction in history and combat, including live fire training in the Radner Proving Grounds.</description>
+        <description>The Irian Academy trains MekWarriors and is highly regarded among schools. Students undergo
+            instruction in history and combat, including live fire training in the Radner Proving Grounds.
+        </description>
         <locationSystem>Irian</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>4375</tuition>
@@ -2954,7 +3336,10 @@
     <academy>
         <name>James McKenna University</name>
         <type>University</type>
-        <description>Situated in Glasgow on Terra, James McKenna University, named after the founder of the Terran Hegemony, specializes in foreign relations. Its distinguished program prepares graduates for prestigious roles within the Star League's diplomatic corps.</description>
+        <description>Situated in Glasgow on Terra, James McKenna University, named after the founder of the Terran
+            Hegemony, specializes in foreign relations. Its distinguished program prepares graduates for prestigious
+            roles within the Star League's diplomatic corps.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -2977,7 +3362,9 @@
         <name>Jarvis Military Proving and Training Grounds</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Jarvis Military Proving and Training Grounds serves as a key training facility for infantry and armor crews in the Free Worlds League Military.</description>
+        <description>The Jarvis Military Proving and Training Grounds serves as a key training facility for infantry and
+            armor crews in the Free Worlds League Military.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Dieudonné</locationSystem>
@@ -3009,7 +3396,10 @@
     <academy>
         <name>Jefferson University</name>
         <type>University</type>
-        <description>Jefferson University, a prominent Federated Suns institution, is renowned for its science and research programs, particularly in physics. The campus features an underground particle accelerator with extensive tunnels for cutting-edge research.</description>
+        <description>Jefferson University, a prominent Federated Suns institution, is renowned for its science and
+            research programs, particularly in physics. The campus features an underground particle accelerator with
+            extensive tunnels for cutting-edge research.
+        </description>
         <locationSystem>New Syrtis</locationSystem>
         <constructionYear>2600</constructionYear>
         <tuition>7500</tuition>
@@ -3030,7 +3420,10 @@
         <name>Kensai Kami [Aix-la-Chapelle]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against instructors and peers to reach new heights of excellence.</description>
+        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered
+            Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against
+            instructors and peers to reach new heights of excellence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aix-la-Chapelle</locationSystem>
@@ -3050,7 +3443,10 @@
         <name>Kensai Kami [Luthien]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against instructors and peers to reach new heights of excellence.</description>
+        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered
+            Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against
+            instructors and peers to reach new heights of excellence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Luthien</locationSystem>
@@ -3070,7 +3466,10 @@
         <name>Kensai Kami [McAlister]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against instructors and peers to reach new heights of excellence.</description>
+        <description>The Kensai Kami is a graduate school for elite MekWarriors of the Draconis Combine Mustered
+            Soldiery, modeled after the Star League's Gunslinger Program. It challenges top DCMS MekWarriors against
+            instructors and peers to reach new heights of excellence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>McAlister</locationSystem>
@@ -3090,7 +3489,10 @@
         <name>Kilbourne Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Kilbourne Academy, located on Kilbourne's Colorado continent near the Rio Grande, has long been a key military training institution in the Federated Suns. Renowned for producing high-quality officers for conventional forces, its graduates are as esteemed as those from more prominent academies.</description>
+        <description>Kilbourne Academy, located on Kilbourne's Colorado continent near the Rio Grande, has long been a
+            key military training institution in the Federated Suns. Renowned for producing high-quality officers for
+            conventional forces, its graduates are as esteemed as those from more prominent academies.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kilbourne</locationSystem>
@@ -3128,7 +3530,10 @@
         <name>Kilbourne Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Kilbourne Academy, located on Kilbourne's Colorado continent near the Rio Grande, has long been a key military training institution in the Federated Suns. Renowned for producing high-quality officers for conventional forces, its graduates are as esteemed as those from more prominent academies.</description>
+        <description>Kilbourne Academy, located on Kilbourne's Colorado continent near the Rio Grande, has long been a
+            key military training institution in the Federated Suns. Renowned for producing high-quality officers for
+            conventional forces, its graduates are as esteemed as those from more prominent academies.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kilbourne</locationSystem>
@@ -3166,7 +3571,11 @@
         <name>Krieg Universital</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Rooted in Prussian military traditions, the Kriegsakademie, known in the Star League as Krieg Universital, epitomizes strategic and operational excellence. Distinguished by its rigorous approach to military science and integration of technological innovation, the academy prepares officers adept in commanding both space fleets and ground operations.</description>
+        <description>Rooted in Prussian military traditions, the Kriegsakademie, known in the Star League as Krieg
+            Universital, epitomizes strategic and operational excellence. Distinguished by its rigorous approach to
+            military science and integration of technological innovation, the academy prepares officers adept in
+            commanding both space fleets and ground operations.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3215,7 +3624,10 @@
         <name>Kure Naval Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originating from Kure, Japan, the Kure Naval Academy exemplifies Earth's enduring martial spirit. Graduates are proficient in naval command and adept in JumpShip and DropShip operations, making them indispensable to the League's celestial might.</description>
+        <description>Originating from Kure, Japan, the Kure Naval Academy exemplifies Earth's enduring martial spirit.
+            Graduates are proficient in naval command and adept in JumpShip and DropShip operations, making them
+            indispensable to the League's celestial might.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3243,7 +3655,10 @@
         <name>Kure Naval Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originating from Kure, Japan, the Kure Naval Academy exemplifies Earth's enduring martial spirit. Graduates are proficient in naval command and adept in JumpShip and DropShip operations, making them indispensable to the League's celestial might.</description>
+        <description>Originating from Kure, Japan, the Kure Naval Academy exemplifies Earth's enduring martial spirit.
+            Graduates are proficient in naval command and adept in JumpShip and DropShip operations, making them
+            indispensable to the League's celestial might.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3271,7 +3686,10 @@
         <name>Legionary Training Academy (Semester One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors, providing comprehensive classes instructed by experienced lecturers. Following the Andurien Secession, the Humphreys Training Academy became the Legionary Training Academy under the Free Worlds League.</description>
+        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors,
+            providing comprehensive classes instructed by experienced lecturers. Following the Andurien Secession, the
+            Humphreys Training Academy became the Legionary Training Academy under the Free Worlds League.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
@@ -3292,7 +3710,10 @@
         <name>Legionary Training Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors, providing comprehensive classes instructed by experienced lecturers. Following the Andurien Secession, the Humphreys Training Academy became the Legionary Training Academy under the Free Worlds League.</description>
+        <description>The Humphreys Training Academy is the Duchy of Andurien's leading institution for MekWarriors,
+            providing comprehensive classes instructed by experienced lecturers. Following the Andurien Secession, the
+            Humphreys Training Academy became the Legionary Training Academy under the Free Worlds League.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Andurien</locationSystem>
@@ -3313,7 +3734,10 @@
         <name>Liao Conservatory of Military Arts</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields, with the expectation of joining veteran or elite commands upon graduation.</description>
+        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to
+            train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields,
+            with the expectation of joining veteran or elite commands upon graduation.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -3355,7 +3779,10 @@
         <name>Liao Conservatory of Military Arts (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields, with the expectation of joining veteran or elite commands upon graduation.</description>
+        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to
+            train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields,
+            with the expectation of joining veteran or elite commands upon graduation.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -3397,7 +3824,11 @@
         <name>Liao Conservatory of Military Arts [3135]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields, with the expectation of joining veteran or elite commands upon graduation. Briefly renamed the Republic Conservatory, it became a focal point during the Capellan Confederation's 3134 invasion. </description>
+        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to
+            train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields,
+            with the expectation of joining veteran or elite commands upon graduation. Briefly renamed the Republic
+            Conservatory, it became a focal point during the Capellan Confederation's 3134 invasion.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -3438,7 +3869,11 @@
         <name>Liao Conservatory of Military Arts [3135] (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields, with the expectation of joining veteran or elite commands upon graduation. Briefly renamed the Republic Conservatory, it became a focal point during the Capellan Confederation's 3134 invasion. </description>
+        <description>In 3062, the Liao Conservatory of Military Arts opened in Chang-an, the capital of Liao, aiming to
+            train elite soldiers. Students managed their own studies, balancing learning, practice, and chosen fields,
+            with the expectation of joining veteran or elite commands upon graduation. Briefly renamed the Republic
+            Conservatory, it became a focal point during the Capellan Confederation's 3134 invasion.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -3479,7 +3914,11 @@
         <name>Lloyd Marik-Stanley Aerospace School (Year One)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>For over five centuries, the Lloyd Marik-Stanley Aerospace School has been the primary training ground for essential naval personnel in the Free Worlds League. Each year, the school admits 1,000 students into a rigorous three-year basic training program. Selection is made by the Captain-General, with aptitude testing ensuring suitability for aerospace roles.</description>
+        <description>For over five centuries, the Lloyd Marik-Stanley Aerospace School has been the primary training
+            ground for essential naval personnel in the Free Worlds League. Each year, the school admits 1,000 students
+            into a rigorous three-year basic training program. Selection is made by the Captain-General, with aptitude
+            testing ensuring suitability for aerospace roles.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Marik</locationSystem>
@@ -3499,7 +3938,11 @@
         <name>Lloyd Marik-Stanley Aerospace School</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>For over five centuries, the Lloyd Marik-Stanley Aerospace School has been the primary training ground for essential naval personnel in the Free Worlds League. Each year, the school admits 1,000 students into a rigorous three-year basic training program. Selection is made by the Captain-General, with aptitude testing ensuring suitability for aerospace roles.</description>
+        <description>For over five centuries, the Lloyd Marik-Stanley Aerospace School has been the primary training
+            ground for essential naval personnel in the Free Worlds League. Each year, the school admits 1,000 students
+            into a rigorous three-year basic training program. Selection is made by the Captain-General, with aptitude
+            testing ensuring suitability for aerospace roles.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Marik</locationSystem>
@@ -3527,7 +3970,11 @@
     <academy>
         <name>Luthien University</name>
         <type>University</type>
-        <description>Situated on Luthien, this university provides a conventional educational range aimed at equipping students for civil or diplomatic roles. The curriculum encompasses history, astrography, languages, and art history, prioritizing the development of students' communicative abilities rather than technical proficiency. Graduates typically embark on careers as bureaucrats or in junior diplomatic positions.</description>
+        <description>Situated on Luthien, this university provides a conventional educational range aimed at equipping
+            students for civil or diplomatic roles. The curriculum encompasses history, astrography, languages, and art
+            history, prioritizing the development of students' communicative abilities rather than technical
+            proficiency. Graduates typically embark on careers as bureaucrats or in junior diplomatic positions.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Luthien</locationSystem>
@@ -3547,7 +3994,9 @@
         <name>Lyons School of Combat Preparedness</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Lyons School of Combat Preparedness is a publicly funded training institution renowned for its diverse student body, hailing from the Draconis Combine, Free Worlds League, and beyond.</description>
+        <description>The Lyons School of Combat Preparedness is a publicly funded training institution renowned for its
+            diverse student body, hailing from the Draconis Combine, Free Worlds League, and beyond.
+        </description>
         <locationSystem>Lyons</locationSystem>
         <constructionYear>3130</constructionYear>
         <tuition>14583</tuition>
@@ -3580,7 +4029,11 @@
         <name>Magistracy Aerospace Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Magistracy Aerospace Academy stands as one of two aerospace academies inaugurated by the Magistracy of Canopus during the Star League era. The selection of the Marantha system was deliberate, given its flourishing civilian spacecraft industry and expansive asteroid belt, which serves as an ideal locale for avoidance training and is home to a significant Belter population.</description>
+        <description>The Magistracy Aerospace Academy stands as one of two aerospace academies inaugurated by the
+            Magistracy of Canopus during the Star League era. The selection of the Marantha system was deliberate, given
+            its flourishing civilian spacecraft industry and expansive asteroid belt, which serves as an ideal locale
+            for avoidance training and is home to a significant Belter population.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Marantha</locationSystem>
@@ -3613,7 +4066,11 @@
         <name>Magistracy Institute for Strategic Studies</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Magistracy Institute for Strategic Studies stands as one of two aerospace academies founded by the Magistracy of Canopus during the Star League era, with a distinct focus on WarShip training. MISS operates from two facilities enabling thorough WarShip operations training, with an extensive and specialized program designed to prepare cadets for service in the Magistracy's naval forces.</description>
+        <description>The Magistracy Institute for Strategic Studies stands as one of two aerospace academies founded by
+            the Magistracy of Canopus during the Star League era, with a distinct focus on WarShip training. MISS
+            operates from two facilities enabling thorough WarShip operations training, with an extensive and
+            specialized program designed to prepare cadets for service in the Magistracy's naval forces.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -3643,7 +4100,12 @@
         <name>Magistracy Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Magistracy Military Academy came into being following the separation of the Magistracy Armed Forces from the Star League Defense Force. The MMA's primary emphasis lies in MekWarrior training, serving both fresh recruits and existing MAF personnel. While it doesn't function as a combined arms academy, the MMA occasionally hosts seminars covering other branches of service, thereby offering a more comprehensive military education.</description>
+        <description>The Magistracy Military Academy came into being following the separation of the Magistracy Armed
+            Forces from the Star League Defense Force. The MMA's primary emphasis lies in MekWarrior training, serving
+            both fresh recruits and existing MAF personnel. While it doesn't function as a combined arms academy, the
+            MMA occasionally hosts seminars covering other branches of service, thereby offering a more comprehensive
+            military education.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Canopus IV</locationSystem>
@@ -3663,7 +4125,11 @@
         <name>Malinovsky BattleMek and Tank Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Specializing in armored warfare, the Malinovsky Academy is a formidable institution that combines the proud heritage of Russian military engineering with the advanced technology of BattleMeks. Its cadets are rigorously trained in both theoretical knowledge and practical application, making them highly sought after for their expertise in handling the heavy metal titans on the battlefield.</description>
+        <description>Specializing in armored warfare, the Malinovsky Academy is a formidable institution that combines
+            the proud heritage of Russian military engineering with the advanced technology of BattleMeks. Its cadets
+            are rigorously trained in both theoretical knowledge and practical application, making them highly sought
+            after for their expertise in handling the heavy metal titans on the battlefield.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3694,7 +4160,11 @@
         <name>Malinovsky BattleMek and Tank Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Specializing in armored warfare, the Malinovsky Academy is a formidable institution that combines the proud heritage of Russian military engineering with the advanced technology of BattleMeks. Its cadets are rigorously trained in both theoretical knowledge and practical application, making them highly sought after for their expertise in handling the heavy metal titans on the battlefield.</description>
+        <description>Specializing in armored warfare, the Malinovsky Academy is a formidable institution that combines
+            the proud heritage of Russian military engineering with the advanced technology of BattleMeks. Its cadets
+            are rigorously trained in both theoretical knowledge and practical application, making them highly sought
+            after for their expertise in handling the heavy metal titans on the battlefield.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3725,7 +4195,11 @@
         <name>Marshalry Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Marshalry Academy trains Marshals in the Fronc Reaches. Since 3075, instruction has taken place in Freedom's Ring, with equal emphasis on law enforcement and combat training. Due to a lack of simulators, cadets learn using the BattleMeks of the instructing Marshals. This hands-on approach ensures that graduates are well-versed in both maintaining order and engaging in combat within the Reaches.</description>
+        <description>The Marshalry Academy trains Marshals in the Fronc Reaches. Since 3075, instruction has taken place
+            in Freedom's Ring, with equal emphasis on law enforcement and combat training. Due to a lack of simulators,
+            cadets learn using the BattleMeks of the instructing Marshals. This hands-on approach ensures that graduates
+            are well-versed in both maintaining order and engaging in combat within the Reaches.
+        </description>
         <locationSystem>Fronc</locationSystem>
         <constructionYear>3075</constructionYear>
         <tuition>13125</tuition>
@@ -3743,7 +4217,11 @@
         <name>Marshalry Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Marshalry Academy trains Marshals in the Fronc Reaches. Since 3075, instruction has taken place in Freedom's Ring, with equal emphasis on law enforcement and combat training. Due to a lack of simulators, cadets learn using the BattleMeks of the instructing Marshals. This hands-on approach ensures that graduates are well-versed in both maintaining order and engaging in combat within the Reaches.</description>
+        <description>The Marshalry Academy trains Marshals in the Fronc Reaches. Since 3075, instruction has taken place
+            in Freedom's Ring, with equal emphasis on law enforcement and combat training. Due to a lack of simulators,
+            cadets learn using the BattleMeks of the instructing Marshals. This hands-on approach ensures that graduates
+            are well-versed in both maintaining order and engaging in combat within the Reaches.
+        </description>
         <locationSystem>Fronc</locationSystem>
         <constructionYear>3075</constructionYear>
         <tuition>13125</tuition>
@@ -3761,7 +4239,11 @@
         <name>Martial College of Donegal</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>As the oldest military academy in the Lyran Commonwealth, the Martial College of Donegal stands out for its specialized training for WarShip and spacecraft crews, although its equipment and facilities are less modern compared to other Lyran academies. Despite its rich tradition, the MCD faces challenges due to outdated facilities.</description>
+        <description>As the oldest military academy in the Lyran Commonwealth, the Martial College of Donegal stands out
+            for its specialized training for WarShip and spacecraft crews, although its equipment and facilities are
+            less modern compared to other Lyran academies. Despite its rich tradition, the MCD faces challenges due to
+            outdated facilities.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Donegal</locationSystem>
@@ -3805,7 +4287,9 @@
         <name>Meistmorn Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Meistmorn Academy is a renowned military academy known for training MekWarriors for the Armed Forces of the Federated Suns.</description>
+        <description>Meistmorn Academy is a renowned military academy known for training MekWarriors for the Armed
+            Forces of the Federated Suns.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Doneval II</locationSystem>
@@ -3825,7 +4309,11 @@
         <name>Melissa Steiner Martial Academy of Bolan</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally established as a Lyran Commonwealth militia training facility on Bolan, the Melissa Steiner Martial Academy of Bolan underwent upgrades to become a full academy in 3054 following the loss of the Tamar War College. Regarded as a "commoner" academy, the MSMA welcomes candidates from all backgrounds within the Lyran Department of Military Education.</description>
+        <description>Originally established as a Lyran Commonwealth militia training facility on Bolan, the Melissa
+            Steiner Martial Academy of Bolan underwent upgrades to become a full academy in 3054 following the loss of
+            the Tamar War College. Regarded as a "commoner" academy, the MSMA welcomes candidates from all backgrounds
+            within the Lyran Department of Military Education.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Bolan</locationSystem>
@@ -3863,7 +4351,10 @@
         <name>Military Academy of Aphros</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>As a component of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, stands as a premier training institution, particularly renowned for hosting the SLDF's prestigious Gunslinger Program.</description>
+        <description>As a component of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
+            located on Venus, stands as a premier training institution, particularly renowned for hosting the SLDF's
+            prestigious Gunslinger Program.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3896,7 +4387,10 @@
         <name>Military Academy of Aphros (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>As a component of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, stood as a premier training institution, particularly renowned for hosting the SLDF's prestigious Gunslinger Program.</description>
+        <description>As a component of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
+            located on Venus, stood as a premier training institution, particularly renowned for hosting the SLDF's
+            prestigious Gunslinger Program.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3929,7 +4423,11 @@
         <name>Military Academy of Aphros [3061]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh environment.</description>
+        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
+            located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake
+            in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh
+            environment.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3959,7 +4457,11 @@
         <name>Military Academy of Aphros (Officer) [3061]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh environment.</description>
+        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
+            located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake
+            in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh
+            environment.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -3989,7 +4491,12 @@
         <name>Military Academy of Aphros [3085]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh environment. By 3085, the Republic of the Sphere took over, transforming it into their primary naval training facility.</description>
+        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
+            located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake
+            in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh
+            environment. By 3085, the Republic of the Sphere took over, transforming it into their primary naval
+            training facility.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -4018,7 +4525,12 @@
         <name>Military Academy of Aphros (Officer) [3085]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros, located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh environment. By 3085, the Republic of the Sphere took over, transforming it into their primary naval training facility.</description>
+        <description>Originally part of the Star League Defense Force's "War Triad," the Military Academy of Aphros,
+            located on Venus, was renowned for hosting the prestigious Gunslinger Program. Reopened by the Word of Blake
+            in Venus' last domed city, the academy exclusively trained aerospace pilots and naval crews due to the harsh
+            environment. By 3085, the Republic of the Sphere took over, transforming it into their primary naval
+            training facility.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -4047,7 +4559,9 @@
         <name>Military Academy of Somerset</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Military Academy of Somerset, a small institution focused on BattleMek and aerospace fighter training.</description>
+        <description>The Military Academy of Somerset, a small institution focused on BattleMek and aerospace fighter
+            training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Somerset</locationSystem>
@@ -4095,7 +4609,9 @@
         <name>Military Academy of Somerset (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Military Academy of Somerset, a small institution focused on BattleMek and aerospace fighter training.</description>
+        <description>The Military Academy of Somerset, a small institution focused on BattleMek and aerospace fighter
+            training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Somerset</locationSystem>
@@ -4143,7 +4659,10 @@
         <name>Minoru Kurita University</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Minoru Kurita University is an infantry training center established by Coordinator Minoru Kurita to ensure the Draconis Combine Mustered Soldiery has sufficient trained infantry. Focused on graduating large numbers of troopers quickly, MKU's training program lasts just six months.</description>
+        <description>The Minoru Kurita University is an infantry training center established by Coordinator Minoru
+            Kurita to ensure the Draconis Combine Mustered Soldiery has sufficient trained infantry. Focused on
+            graduating large numbers of troopers quickly, MKU's training program lasts just six months.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Luthien</locationSystem>
@@ -4166,7 +4685,10 @@
         <name>NAIS College of Military Science</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2614, the New Avalon Military Academy emerged to train officers for the Armed Forces of the Federated Suns after the Albion Military Academy became exclusive to the Star League Defense Force. NAMA swiftly rivaled AMA in training quality, emphasizing political loyalty to the First Prince.</description>
+        <description>Founded in 2614, the New Avalon Military Academy emerged to train officers for the Armed Forces of
+            the Federated Suns after the Albion Military Academy became exclusive to the Star League Defense Force. NAMA
+            swiftly rivaled AMA in training quality, emphasizing political loyalty to the First Prince.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Avalon</locationSystem>
@@ -4232,7 +4754,12 @@
         <name>NAIS College of Military Science [3079]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 2614, the New Avalon Military Academy emerged to train officers for the Armed Forces of the Federated Suns after the Albion Military Academy became exclusive to the Star League Defense Force. NAMA swiftly rivaled AMA in training quality, emphasizing political loyalty to the First Prince. Despite challenges, NAIS persists in producing top MekWarriors and officers, with graduates often joining mercenary units or returning to their home nations.</description>
+        <description>Founded in 2614, the New Avalon Military Academy emerged to train officers for the Armed Forces of
+            the Federated Suns after the Albion Military Academy became exclusive to the Star League Defense Force. NAMA
+            swiftly rivaled AMA in training quality, emphasizing political loyalty to the First Prince. Despite
+            challenges, NAIS persists in producing top MekWarriors and officers, with graduates often joining mercenary
+            units or returning to their home nations.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Avalon</locationSystem>
@@ -4297,7 +4824,11 @@
         <name>Nellus Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Nellus Academy is a small institution providing four years of combined academic and military instruction, readying students for enlistment in the Free Worlds League Military. Additionally, the academy imparts a unique nonverbal cant rooted in gestures, enabling graduates to communicate silently across generations.</description>
+        <description>Nellus Academy is a small institution providing four years of combined academic and military
+            instruction, readying students for enlistment in the Free Worlds League Military. Additionally, the academy
+            imparts a unique nonverbal cant rooted in gestures, enabling graduates to communicate silently across
+            generations.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Nestor</locationSystem>
@@ -4328,7 +4859,10 @@
     <academy>
         <name>New Cambridge University of Wessex</name>
         <type>University</type>
-        <description>Located near the city of Wessex, this Lyran Commonwealth institution boasts a sprawling campus. New Cambridge University specializes in electronics, robotics, and metallurgy, setting itself apart with its relatively high tuition fees. However, numerous students offset these costs through corporate scholarships.</description>
+        <description>Located near the city of Wessex, this Lyran Commonwealth institution boasts a sprawling campus. New
+            Cambridge University specializes in electronics, robotics, and metallurgy, setting itself apart with its
+            relatively high tuition fees. However, numerous students offset these costs through corporate scholarships.
+        </description>
         <locationSystem>Coventry</locationSystem>
         <constructionYear>2600</constructionYear>
         <tuition>7500</tuition>
@@ -4345,7 +4879,10 @@
     <academy>
         <name>New Earth University</name>
         <type>University</type>
-        <description>Specializing in the operation and maintenance of commercial spacecraft, New Earth University featured a dual-campus system—one on the planet’s surface and another within a massive space station that served as a training center for JumpShips and DropShips.</description>
+        <description>Specializing in the operation and maintenance of commercial spacecraft, New Earth University
+            featured a dual-campus system—one on the planet’s surface and another within a massive space station that
+            served as a training center for JumpShips and DropShips.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Earth (Tau Ceti 2116-)</locationSystem>
@@ -4383,7 +4920,11 @@
         <name>New Galedon Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3070, the closure of the Galedon Military Academy dealt a significant blow to the DCMS' training infrastructure. Acknowledging the necessity for a successor, the New Galedon Military Academy was established. This new institution, named in honor of its predecessor, serves as a tribute to the courageous cadets who sacrificed their lives defending the original academy.</description>
+        <description>In 3070, the closure of the Galedon Military Academy dealt a significant blow to the DCMS' training
+            infrastructure. Acknowledging the necessity for a successor, the New Galedon Military Academy was
+            established. This new institution, named in honor of its predecessor, serves as a tribute to the courageous
+            cadets who sacrificed their lives defending the original academy.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Matsuida</locationSystem>
@@ -4451,7 +4992,11 @@
         <name>New Galedon Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>In 3070, the closure of the Galedon Military Academy dealt a significant blow to the DCMS' training infrastructure. Acknowledging the necessity for a successor, the New Galedon Military Academy was established. This new institution, named in honor of its predecessor, serves as a tribute to the courageous cadets who sacrificed their lives defending the original academy.</description>
+        <description>In 3070, the closure of the Galedon Military Academy dealt a significant blow to the DCMS' training
+            infrastructure. Acknowledging the necessity for a successor, the New Galedon Military Academy was
+            established. This new institution, named in honor of its predecessor, serves as a tribute to the courageous
+            cadets who sacrificed their lives defending the original academy.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Matsuida</locationSystem>
@@ -4519,7 +5064,11 @@
         <name>New Hope Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The New Hope Military Academy specializes in training conventional forces while also providing MekWarrior and aerospace pilot programs. The curriculum, developed by senior commanders of the First Taurian Pride, includes practical 'Mek instruction, even in the absence of simulators, and places a strong emphasis on tactical classroom instruction.</description>
+        <description>The New Hope Military Academy specializes in training conventional forces while also providing
+            MekWarrior and aerospace pilot programs. The curriculum, developed by senior commanders of the First Taurian
+            Pride, includes practical 'Mek instruction, even in the absence of simulators, and places a strong emphasis
+            on tactical classroom instruction.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Erod's Escape</locationSystem>
@@ -4559,7 +5108,12 @@
     <academy>
         <name>New Avalon Institute of Science</name>
         <type>University</type>
-        <description>Following his successful raid on the Draconis Combine's Halstead Station and the subsequent capture of a treasure trove of Star League era knowledge, Prince Ian Davion allocated extensive resources into the founding of a new university dedicated towards studying and developing the reclaimed data. In 3016, this initiative resulted in the opening of the New Avalon Institute of Science, a premier center of learning and leader of the effort to revive LosTech innovations.</description>
+        <description>Following his successful raid on the Draconis Combine's Halstead Station and the subsequent capture
+            of a treasure trove of Star League era knowledge, Prince Ian Davion allocated extensive resources into the
+            founding of a new university dedicated towards studying and developing the reclaimed data. In 3016, this
+            initiative resulted in the opening of the New Avalon Institute of Science, a premier center of learning and
+            leader of the effort to revive LosTech innovations.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Avalon</locationSystem>
@@ -4597,7 +5151,10 @@
     <academy>
         <name>New Avalon Institute of Science [3079]</name>
         <type>University</type>
-        <description>Founded in 3016 by Prince Ian Davion, the NAIS reached prominence as a leading institute of learning and developer of LosTech. As the technological renaissance of the Inner Sphere continued, NAIS continued its mission to remain at the cutting edge of innovation and research.</description>
+        <description>Founded in 3016 by Prince Ian Davion, the NAIS reached prominence as a leading institute of
+            learning and developer of LosTech. As the technological renaissance of the Inner Sphere continued, NAIS
+            continued its mission to remain at the cutting edge of innovation and research.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Avalon</locationSystem>
@@ -4635,7 +5192,12 @@
         <name>New Vandenberg Taurian Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The New Vandenberg Taurian Academy is a crucial institution focused on training conventional troops. Renowned for its demanding curriculum, the academy specializes in defensive operations, ensuring cadets are equipped with the skills necessary to safeguard the Concordat's interests. The training encompasses advanced tactics and strategies tailored for holding defensive positions and repelling invasions.</description>
+        <description>The New Vandenberg Taurian Academy is a crucial institution focused on training conventional
+            troops. Renowned for its demanding curriculum, the academy specializes in defensive operations, ensuring
+            cadets are equipped with the skills necessary to safeguard the Concordat's interests. The training
+            encompasses advanced tactics and strategies tailored for holding defensive positions and repelling
+            invasions.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Vandenburg</locationSystem>
@@ -4666,7 +5228,11 @@
     <academy>
         <name>Noius Archipelagus Institute of Science</name>
         <type>University</type>
-        <description>The Noius Archipelagus Institute of Science prioritizes military science and technology, aiming to compete with the prestigious New Avalon Institute of Science. It primarily admits students not accepted into more esteemed institutions, often serving as a last option for those seeking to avoid standard citizenship roles.</description>
+        <description>The Noius Archipelagus Institute of Science prioritizes military science and technology, aiming to
+            compete with the prestigious New Avalon Institute of Science. It primarily admits students not accepted into
+            more esteemed institutions, often serving as a last option for those seeking to avoid standard citizenship
+            roles.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kaznejoy</locationSystem>
@@ -4689,7 +5255,11 @@
         <name>Northwind Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 2365, the Northwind Military Academy (NMA) was created to train troops specifically for the Northwind Highlanders. Endorsed by the Clan Elders of Northwind, the academy traditionally operated without the latest technology. However, it consistently produced highly skilled cadets. Admission was exclusive to individuals from Northwind or descendants of the Highlanders.</description>
+        <description>Established in 2365, the Northwind Military Academy (NMA) was created to train troops specifically
+            for the Northwind Highlanders. Endorsed by the Clan Elders of Northwind, the academy traditionally operated
+            without the latest technology. However, it consistently produced highly skilled cadets. Admission was
+            exclusive to individuals from Northwind or descendants of the Highlanders.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Northwind</locationSystem>
@@ -4742,7 +5312,11 @@
         <name>Northwind Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 2365, the Northwind Military Academy (NMA) was created to train troops specifically for the Northwind Highlanders. Endorsed by the Clan Elders of Northwind, the academy traditionally operated without the latest technology. However, it consistently produced highly skilled cadets. Admission was exclusive to individuals from Northwind or descendants of the Highlanders.</description>
+        <description>Established in 2365, the Northwind Military Academy (NMA) was created to train troops specifically
+            for the Northwind Highlanders. Endorsed by the Clan Elders of Northwind, the academy traditionally operated
+            without the latest technology. However, it consistently produced highly skilled cadets. Admission was
+            exclusive to individuals from Northwind or descendants of the Highlanders.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Northwind</locationSystem>
@@ -4795,7 +5369,10 @@
         <name>Organo Taurian Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Organo Taurian Academy specializes in training aerospace fighters, cavalry, and both armored and unarmored infantry. Despite its modest size, the academy plays a crucial role in shaping well-rounded military personnel for the Concordat's defense forces.</description>
+        <description>The Organo Taurian Academy specializes in training aerospace fighters, cavalry, and both armored
+            and unarmored infantry. Despite its modest size, the academy plays a crucial role in shaping well-rounded
+            military personnel for the Concordat's defense forces.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Organo</locationSystem>
@@ -4834,7 +5411,10 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Orloff Military Academy initiates student training at the age of twelve. Admission, except for Orloff family members, is exclusively by invitation. The academy's small scale guarantees an exceptional teacher-student ratio, enabling personalized and intensive training.</description>
+        <description>The Orloff Military Academy initiates student training at the age of twelve. Admission, except for
+            Orloff family members, is exclusively by invitation. The academy's small scale guarantees an exceptional
+            teacher-student ratio, enabling personalized and intensive training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kievanur</locationSystem>
@@ -4855,7 +5435,10 @@
         <name>Orloff Military Academy (Advanced Training)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Orloff Military Academy initiates student training at the age of twelve. Admission, except for Orloff family members, is exclusively by invitation. The academy's small scale guarantees an exceptional teacher-student ratio, enabling personalized and intensive training.</description>
+        <description>The Orloff Military Academy initiates student training at the age of twelve. Admission, except for
+            Orloff family members, is exclusively by invitation. The academy's small scale guarantees an exceptional
+            teacher-student ratio, enabling personalized and intensive training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kievanur</locationSystem>
@@ -4875,7 +5458,11 @@
         <name>Osaka Fields Proving Grounds</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Osaka Fields Proving Grounds stands as the largest of its kind in the Draconis Combine. Spread across every district and prefecture capital, these facilities offer entry into the DCMS for individuals beyond the noble classes. Osaka Fields encompasses an abandoned military base from the Succession Wars era, untamed wilderness, and three live-fire ranges tailored for BattleMek training.</description>
+        <description>The Osaka Fields Proving Grounds stands as the largest of its kind in the Draconis Combine. Spread
+            across every district and prefecture capital, these facilities offer entry into the DCMS for individuals
+            beyond the noble classes. Osaka Fields encompasses an abandoned military base from the Succession Wars era,
+            untamed wilderness, and three live-fire ranges tailored for BattleMek training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Benjamin</locationSystem>
@@ -4913,7 +5500,10 @@
         <name>Outreach Mercenary Training Command (100-Grade)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military training outside traditional state institutions. Its programs span from fundamental academic subjects to advanced military courses. The academy is open to anyone able to afford its fees.</description>
+        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military
+            training outside traditional state institutions. Its programs span from fundamental academic subjects to
+            advanced military courses. The academy is open to anyone able to afford its fees.
+        </description>
         <locationSystem>Outreach</locationSystem>
         <constructionYear>3056</constructionYear>
         <destructionYear>3067</destructionYear>
@@ -4932,7 +5522,10 @@
         <name>Outreach Mercenary Training Command (200-Grade)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military training outside traditional state institutions. Its programs span from fundamental academic subjects to advanced military courses. The academy is open to anyone able to afford its fees.</description>
+        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military
+            training outside traditional state institutions. Its programs span from fundamental academic subjects to
+            advanced military courses. The academy is open to anyone able to afford its fees.
+        </description>
         <locationSystem>Outreach</locationSystem>
         <constructionYear>3056</constructionYear>
         <destructionYear>3067</destructionYear>
@@ -4951,7 +5544,10 @@
         <name>Outreach Mercenary Training Command (300-Grade)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military training outside traditional state institutions. Its programs span from fundamental academic subjects to advanced military courses. The academy is open to anyone able to afford its fees.</description>
+        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military
+            training outside traditional state institutions. Its programs span from fundamental academic subjects to
+            advanced military courses. The academy is open to anyone able to afford its fees.
+        </description>
         <locationSystem>Outreach</locationSystem>
         <constructionYear>3056</constructionYear>
         <destructionYear>3067</destructionYear>
@@ -5021,7 +5617,10 @@
         <name>Outreach Mercenary Training Command (400-Grade)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military training outside traditional state institutions. Its programs span from fundamental academic subjects to advanced military courses. The academy is open to anyone able to afford its fees.</description>
+        <description>Operated by Wolf's Dragoons, the Outreach Mercenary Training Command provides top-tier military
+            training outside traditional state institutions. Its programs span from fundamental academic subjects to
+            advanced military courses. The academy is open to anyone able to afford its fees.
+        </description>
         <locationSystem>Outreach</locationSystem>
         <constructionYear>3056</constructionYear>
         <destructionYear>3067</destructionYear>
@@ -5091,7 +5690,11 @@
         <name>Pacifica Training School</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Pacifica Training School stands as one of the Lyran Commonwealth’s foremost MekWarrior training centers. Cadets engage in a series of solo cockpit missions, with each mission increasing in difficulty. They pilot full-size, fully operational BattleMeks within a specially designed arena, which replicates genuine battlefield conditions.</description>
+        <description>Pacifica Training School stands as one of the Lyran Commonwealth’s foremost MekWarrior training
+            centers. Cadets engage in a series of solo cockpit missions, with each mission increasing in difficulty.
+            They pilot full-size, fully operational BattleMeks within a specially designed arena, which replicates
+            genuine battlefield conditions.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Chara (Pacifica)</locationSystem>
@@ -5111,7 +5714,11 @@
         <name>Pagoda for Luthien Officers</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Pagoda for Luthien Officers, situated on Luthien, is a prestigious military academy. Often referred to as the "Pampered Luthien Officers," it exclusively admits nobility who successfully navigates a demanding application process. The academy prioritizes courtly life over combat training. Nearly all students graduate, with only those deemed truly inept facing dismissal.</description>
+        <description>The Pagoda for Luthien Officers, situated on Luthien, is a prestigious military academy. Often
+            referred to as the "Pampered Luthien Officers," it exclusively admits nobility who successfully navigates a
+            demanding application process. The academy prioritizes courtly life over combat training. Nearly all
+            students graduate, with only those deemed truly inept facing dismissal.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Luthien</locationSystem>
@@ -5131,7 +5738,11 @@
         <name>Pandora College of Military Sciences</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Renowned for its distinctive "blood band" red school rag, the Pandora College of Military Sciences prioritizes practical training and rigorous physical education to ensure cadets are combat-ready. Situated within Pandora's military and intelligence command center, PCMS provides real-world training opportunities, closely monitored by the Lyran Intelligence Corps.</description>
+        <description>Renowned for its distinctive "blood band" red school rag, the Pandora College of Military Sciences
+            prioritizes practical training and rigorous physical education to ensure cadets are combat-ready. Situated
+            within Pandora's military and intelligence command center, PCMS provides real-world training opportunities,
+            closely monitored by the Lyran Intelligence Corps.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Pandora</locationSystem>
@@ -5180,7 +5791,10 @@
     <academy>
         <name>People's Reconstruction Effort University of Ashio</name>
         <type>University</type>
-        <description>The University of Ashio aims to employ war-displaced educators and factory experts, creating a vast library and consultation group for post-war rebuilding. However, it faced opposition from the military and the ISF even before opening.</description>
+        <description>The University of Ashio aims to employ war-displaced educators and factory experts, creating a vast
+            library and consultation group for post-war rebuilding. However, it faced opposition from the military and
+            the ISF even before opening.
+        </description>
         <locationSystem>Dover</locationSystem>
         <constructionYear>2821</constructionYear>
         <destructionYear>2910</destructionYear>
@@ -5202,7 +5816,9 @@
         <name>Perdition Taurian Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Perdition Taurian Academy, located within the Taurian Concordat, is a small institution focused on training cavalry and infantry, encompassing both armored and unarmored units.</description>
+        <description>The Perdition Taurian Academy, located within the Taurian Concordat, is a small institution focused
+            on training cavalry and infantry, encompassing both armored and unarmored units.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Perdition</locationSystem>
@@ -5237,7 +5853,9 @@
         <name>Pesht University of Military Science</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Pesht University of Military Science, situated on Pesht, is a leading institution specializing in the training of elite staff officers for complex military operations.</description>
+        <description>The Pesht University of Military Science, situated on Pesht, is a leading institution specializing
+            in the training of elite staff officers for complex military operations.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Pesht</locationSystem>
@@ -5272,7 +5890,10 @@
         <name>Point Barrow Military Academy</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Point Barrow Military Academy has played a crucial role in training officers for the Armed Forces of the Federated Suns, particularly in conventional forces roles. While initially overshadowed, its graduates are highly regarded for their competence in infantry and cavalry positions.</description>
+        <description>The Point Barrow Military Academy has played a crucial role in training officers for the Armed
+            Forces of the Federated Suns, particularly in conventional forces roles. While initially overshadowed, its
+            graduates are highly regarded for their competence in infantry and cavalry positions.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Point Barrow</locationSystem>
@@ -5316,7 +5937,10 @@
         <name>Princefield Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Regarded as one of the most prestigious academies in the Free Worlds League, the Princefield Military Academy functions as a finishing school for young nobles. Admission to the academy is typically reserved for cadets with political connections or sufficient funding.</description>
+        <description>Regarded as one of the most prestigious academies in the Free Worlds League, the Princefield
+            Military Academy functions as a finishing school for young nobles. Admission to the academy is typically
+            reserved for cadets with political connections or sufficient funding.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Oriente</locationSystem>
@@ -5357,7 +5981,10 @@
         <name>Princefield Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Regarded as one of the most prestigious academies in the Free Worlds League, the Princefield Military Academy functions as a finishing school for young nobles. Admission to the academy is typically reserved for cadets with political connections or sufficient funding.</description>
+        <description>Regarded as one of the most prestigious academies in the Free Worlds League, the Princefield
+            Military Academy functions as a finishing school for young nobles. Admission to the academy is typically
+            reserved for cadets with political connections or sufficient funding.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Oriente</locationSystem>
@@ -5372,7 +5999,8 @@
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Small Arms, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
-        <curriculum>Piloting/Ground Vehicle, Gunnery/Vehicle, Tactics, Strategy, Leadership, Small Arms, Artillery</curriculum>
+        <curriculum>Piloting/Ground Vehicle, Gunnery/Vehicle, Tactics, Strategy, Leadership, Small Arms, Artillery
+        </curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Air Cavalry Command Graduate</qualification>
         <curriculum>Piloting/VTOL, Gunnery/Vehicle, Tactics, Strategy, Leadership, Small Arms, Artillery</curriculum>
@@ -5398,7 +6026,11 @@
         <name>Radstadt Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Radstadt Academy is renowned for producing elite soldiers. Cadets undergo rigorous training programs, beginning with three months of basic military discipline and advancing through specialized courses in their chosen service. The academy is famous for its demanding physical and tactical training, fostering a strong esprit de corps among cadets.</description>
+        <description>The Radstadt Academy is renowned for producing elite soldiers. Cadets undergo rigorous training
+            programs, beginning with three months of basic military discipline and advancing through specialized courses
+            in their chosen service. The academy is famous for its demanding physical and tactical training, fostering a
+            strong esprit de corps among cadets.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Radstadt</locationSystem>
@@ -5440,7 +6072,11 @@
         <name>Radstadt Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Radstadt Academy is renowned for producing elite soldiers. Cadets undergo rigorous training programs, beginning with three months of basic military discipline and advancing through specialized courses in their chosen service. The academy is famous for its demanding physical and tactical training, fostering a strong esprit de corps among cadets.</description>
+        <description>The Radstadt Academy is renowned for producing elite soldiers. Cadets undergo rigorous training
+            programs, beginning with three months of basic military discipline and advancing through specialized courses
+            in their chosen service. The academy is famous for its demanding physical and tactical training, fostering a
+            strong esprit de corps among cadets.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Radstadt</locationSystem>
@@ -5482,7 +6118,8 @@
         <name>Raina University on Skye</name>
         <type>University</type>
         <isMilitary>true</isMilitary>
-        <description>Raina University is renowned for its research and development in aeronautics and aerospace.</description>
+        <description>Raina University is renowned for its research and development in aeronautics and aerospace.
+        </description>
         <locationSystem>Skye</locationSystem>
         <constructionYear>2500</constructionYear>
         <tuition>12600</tuition>
@@ -5512,7 +6149,12 @@
         <name>Republic Conservatory</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 3062, the Liao Conservatory of Military Arts is dedicated to training elite soldiers. Students oversee their own studies, balancing learning, practice, and specialized fields, preparing to join veteran or elite commands upon graduation. Despite being briefly renamed the Republic Conservatory, the academy remains steadfast in its mission, emphasizing the cultivation of individual motivation and excellence.</description>
+        <description>Established in 3062, the Liao Conservatory of Military Arts is dedicated to training elite
+            soldiers. Students oversee their own studies, balancing learning, practice, and specialized fields,
+            preparing to join veteran or elite commands upon graduation. Despite being briefly renamed the Republic
+            Conservatory, the academy remains steadfast in its mission, emphasizing the cultivation of individual
+            motivation and excellence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -5554,7 +6196,12 @@
         <name>Republic Conservatory (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Established in 3062, the Liao Conservatory of Military Arts is dedicated to training elite soldiers. Students oversee their own studies, balancing learning, practice, and specialized fields, preparing to join veteran or elite commands upon graduation. Despite being briefly renamed the Republic Conservatory, the academy remains steadfast in its mission, emphasizing the cultivation of individual motivation and excellence.</description>
+        <description>Established in 3062, the Liao Conservatory of Military Arts is dedicated to training elite
+            soldiers. Students oversee their own studies, balancing learning, practice, and specialized fields,
+            preparing to join veteran or elite commands upon graduation. Despite being briefly renamed the Republic
+            Conservatory, the academy remains steadfast in its mission, emphasizing the cultivation of individual
+            motivation and excellence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Liao (Cynthiana 2202-)</locationSystem>
@@ -5596,7 +6243,10 @@
         <name>Ritza Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Ritza Academy stands as a bastion of martial education on Emporia, nurturing generations of warriors. Renowned for its rigorous training programs and esteemed faculty, it prepares cadets for combat across various disciplines.</description>
+        <description>The Ritza Academy stands as a bastion of martial education on Emporia, nurturing generations of
+            warriors. Renowned for its rigorous training programs and esteemed faculty, it prepares cadets for combat
+            across various disciplines.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Emporia</locationSystem>
@@ -5632,7 +6282,10 @@
         <name>Robinson Battle Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the NAIS, producing loyal troops with a strong animosity towards the Draconis Combine. The curriculum emphasizes practical training and political indoctrination.</description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the
+            NAIS, producing loyal troops with a strong animosity towards the Draconis Combine. The curriculum emphasizes
+            practical training and political indoctrination.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>2780</constructionYear>
         <closureYear>2781</closureYear>
@@ -5684,7 +6337,10 @@
         <name>Robinson Battle Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the NAIS, producing loyal troops with a strong animosity towards the Draconis Combine. The curriculum emphasizes practical training and political indoctrination.</description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the
+            NAIS, producing loyal troops with a strong animosity towards the Draconis Combine. The curriculum emphasizes
+            practical training and political indoctrination.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>2780</constructionYear>
         <closureYear>2781</closureYear>
@@ -5736,7 +6392,11 @@
         <name>Robinson Battle Academy (Officer) [2814]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. The academy was dismantled by Kurita forces in 2781 and has only recently been rebuilt.</description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the
+            NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum
+            emphasizes practical training and political indoctrination. The academy was dismantled by Kurita forces in
+            2781 and has only recently been rebuilt.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>2814</constructionYear>
         <destructionYear>2854</destructionYear>
@@ -5788,7 +6448,11 @@
         <name>Robinson Battle Academy (Officer) [3020]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. The academy was rebuilt after being dismantled by Kurita forces in 2781, only to be destroyed again in 2854.</description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
+            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
+            Its curriculum emphasizes practical training and political indoctrination. The academy was rebuilt after
+            being dismantled by Kurita forces in 2781, only to be destroyed again in 2854.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3020</constructionYear>
         <destructionYear>3062</destructionYear>
@@ -5840,7 +6504,12 @@
         <name>Robinson Battle Academy (Officer) [3063]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled by Kurita forces in 2781 only to be destroyed again in 2854, the academy was rebuilt for a third time in 3062, following its destruction during the Jihad, this time in fortified underground bunkers.</description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
+            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
+            Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled
+            by Kurita forces in 2781 only to be destroyed again in 2854, the academy was rebuilt for a third time in
+            3062, following its destruction during the Jihad, this time in fortified underground bunkers.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3063</constructionYear>
         <destructionYear>3071</destructionYear>
@@ -5892,7 +6561,12 @@
         <name>Robinson Battle Academy (Officer) [3079]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled by Kurita forces in 2781, it was rebuilt but destroyed again in 2854 and 3062. After a fourth destruction in 3071, it was rebuilt once more in 3079.</description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
+            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
+            Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled
+            by Kurita forces in 2781, it was rebuilt but destroyed again in 2854 and 3062. After a fourth destruction in
+            3071, it was rebuilt once more in 3079.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>11813</tuition>
@@ -5943,7 +6617,11 @@
         <name>Robinson Battle Academy [2814]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. The academy was dismantled by Kurita forces in 2781 and has only recently been rebuilt.</description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, rivals top institutions like the
+            NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum
+            emphasizes practical training and political indoctrination. The academy was dismantled by Kurita forces in
+            2781 and has only recently been rebuilt.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>2814</constructionYear>
         <destructionYear>2854</destructionYear>
@@ -5995,7 +6673,11 @@
         <name>Robinson Battle Academy [3020]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. The academy was rebuilt after being dismantled by Kurita forces in 2781, only to be destroyed again in 2854.</description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
+            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
+            Its curriculum emphasizes practical training and political indoctrination. The academy was rebuilt after
+            being dismantled by Kurita forces in 2781, only to be destroyed again in 2854.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3020</constructionYear>
         <destructionYear>3062</destructionYear>
@@ -6047,7 +6729,12 @@
         <name>Robinson Battle Academy [3063]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled by Kurita forces in 2781 only to be destroyed again in 2854, the academy was rebuilt for a third time in 3062, following its destruction during the Jihad, this time in fortified underground bunkers.</description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
+            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
+            Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled
+            by Kurita forces in 2781 only to be destroyed again in 2854, the academy was rebuilt for a third time in
+            3062, following its destruction during the Jihad, this time in fortified underground bunkers.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3063</constructionYear>
         <destructionYear>3071</destructionYear>
@@ -6099,7 +6786,12 @@
         <name>Robinson Battle Academy [3079]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine. Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled by Kurita forces in 2781, it was rebuilt but destroyed again in 2854 and 3062. After a fourth destruction in 3071, it was rebuilt once more in 3079.</description>
+        <description>The Robinson Battle Academy, supported by the Sandoval family, stands as a rival to top
+            institutions like the NAIS, shaping loyal troops with a deep-seated animosity towards the Draconis Combine.
+            Its curriculum emphasizes practical training and political indoctrination. Destroyed after being dismantled
+            by Kurita forces in 2781, it was rebuilt but destroyed again in 2854 and 3062. After a fourth destruction in
+            3071, it was rebuilt once more in 3079.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>3079</constructionYear>
         <tuition>5688</tuition>
@@ -6150,7 +6842,9 @@
         <name>Royal New Capetown Military Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Royal New Capetown Military Academy, once known for its troubled past rooted in racism, has evolved into a key Lyran military institution.</description>
+        <description>The Royal New Capetown Military Academy, once known for its troubled past rooted in racism, has
+            evolved into a key Lyran military institution.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Capetown</locationSystem>
@@ -6188,7 +6882,9 @@
         <name>Royal New Capetown Military Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Royal New Capetown Military Academy, once known for its troubled past rooted in racism, has evolved into a key Lyran military institution.</description>
+        <description>The Royal New Capetown Military Academy, once known for its troubled past rooted in racism, has
+            evolved into a key Lyran military institution.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Capetown</locationSystem>
@@ -6203,7 +6899,8 @@
         <curriculum>Piloting/Mek, Gunnery/Mek, Tactics, Strategy, Leadership, Astech, Artillery</curriculum>
         <qualificationStartYear>2500</qualificationStartYear>
         <qualification>Cavalry Command Graduate</qualification>
-        <curriculum>Piloting/Ground Vehicle, Gunnery/Vehicle, Tactics, Strategy, Leadership, Astech, Artillery</curriculum>
+        <curriculum>Piloting/Ground Vehicle, Gunnery/Vehicle, Tactics, Strategy, Leadership, Astech, Artillery
+        </curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Air Cavalry Command Graduate</qualification>
         <curriculum>Piloting/VTOL, Gunnery/Vehicle, Tactics, Strategy, Leadership, Astech, Artillery</curriculum>
@@ -6226,7 +6923,11 @@
         <name>Saint Cyr Military Academy</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>As the crucible of military leadership in France, Saint Cyr Military Academy boasts a lineage dating back to the early 19th century. It has since transitioned to meet modern needs, offering a curriculum that merges traditional warfare with strategies for interstellar combat. Graduates are known for their versatility, able to lead both ground battalions and aerospace squadrons with equal proficiency.</description>
+        <description>As the crucible of military leadership in France, Saint Cyr Military Academy boasts a lineage
+            dating back to the early 19th century. It has since transitioned to meet modern needs, offering a curriculum
+            that merges traditional warfare with strategies for interstellar combat. Graduates are known for their
+            versatility, able to lead both ground battalions and aerospace squadrons with equal proficiency.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -6266,7 +6967,10 @@
         <name>Sakhara Academy</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Sakhara Academy is known for its rigorous training. Despite declining enrollment, it maintains high standards, graduating about eighty students annually in various military disciplines. Supported by graduates donations and high tuition, Sakhara remains exclusive, primarily serving the affluent.</description>
+        <description>Sakhara Academy is known for its rigorous training. Despite declining enrollment, it maintains high
+            standards, graduating about eighty students annually in various military disciplines. Supported by graduates
+            donations and high tuition, Sakhara remains exclusive, primarily serving the affluent.
+        </description>
         <locationSystem>Sakhara V</locationSystem>
         <constructionYear>2613</constructionYear>
         <tuition>56250</tuition>
@@ -6302,7 +7006,10 @@
         <name>Sandhurst Royal Military College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 1801 on Terra, Sandhurst has evolved into a premier training institution in the Inner Sphere. The college is noted for its rigorous combined-arms training and efforts to eliminate interbranch rivalries.</description>
+        <description>Founded in 1801 on Terra, Sandhurst has evolved into a premier training institution in the Inner
+            Sphere. The college is noted for its rigorous combined-arms training and efforts to eliminate interbranch
+            rivalries.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -6325,7 +7032,10 @@
         <name>Sandhurst Royal Military College (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded in 1801 on Terra, Sandhurst has evolved into a premier training institution in the Inner Sphere. The college is noted for its rigorous combined-arms training and efforts to eliminate interbranch rivalries.</description>
+        <description>Founded in 1801 on Terra, Sandhurst has evolved into a premier training institution in the Inner
+            Sphere. The college is noted for its rigorous combined-arms training and efforts to eliminate interbranch
+            rivalries.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -6348,7 +7058,10 @@
         <name>Sanglamore</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Sanglamore Academy has long been one of the top-ranked military academies in the Inner Sphere, second only to Nagelring. Despite historically inadequate equipment, it offers comprehensive combat training along with various technical and specialist courses.</description>
+        <description>Sanglamore Academy has long been one of the top-ranked military academies in the Inner Sphere,
+            second only to Nagelring. Despite historically inadequate equipment, it offers comprehensive combat training
+            along with various technical and specialist courses.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Skye</locationSystem>
@@ -6413,7 +7126,10 @@
         <name>Sanglamore (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Sanglamore Academy has long been one of the top-ranked military academies in the Inner Sphere, second only to Nagelring. Despite historically inadequate equipment, it offers comprehensive combat training along with various technical and specialist courses.</description>
+        <description>Sanglamore Academy has long been one of the top-ranked military academies in the Inner Sphere,
+            second only to Nagelring. Despite historically inadequate equipment, it offers comprehensive combat training
+            along with various technical and specialist courses.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Skye</locationSystem>
@@ -6478,7 +7194,9 @@
         <name>Sarna Martial Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sarna Martial Academy is a crucial component of the Capellan Confederation's training program, offering instruction in nearly all branches of the military.</description>
+        <description>The Sarna Martial Academy is a crucial component of the Capellan Confederation's training program,
+            offering instruction in nearly all branches of the military.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sarna</locationSystem>
@@ -6520,7 +7238,10 @@
         <name>Sarna Martial Academy [3057]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sarna Martial Academy was a crucial component of the Capellan Confederation's training program, offering instruction in nearly all branches of the military. After the collapse of authority in the Sarna March, the academy opened its doors to all, becoming known as an independent school for mercenaries.</description>
+        <description>The Sarna Martial Academy was a crucial component of the Capellan Confederation's training program,
+            offering instruction in nearly all branches of the military. After the collapse of authority in the Sarna
+            March, the academy opened its doors to all, becoming known as an independent school for mercenaries.
+        </description>
         <locationSystem>Sarna</locationSystem>
         <constructionYear>3057</constructionYear>
         <closureYear>3070</closureYear>
@@ -6560,7 +7281,12 @@
         <name>Sarna Martial Academy [3070]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sarna Martial Academy was a crucial component of the Capellan Confederation's training program, offering instruction in nearly all branches of the military. After the collapse of authority in the Sarna March, the academy opened its doors to all, becoming known as an independent school for mercenaries. Even after its reintegration into the Confederation, the academy remained independent for a time and was considered the least prestigious of the major Capellan military academies.</description>
+        <description>The Sarna Martial Academy was a crucial component of the Capellan Confederation's training program,
+            offering instruction in nearly all branches of the military. After the collapse of authority in the Sarna
+            March, the academy opened its doors to all, becoming known as an independent school for mercenaries. Even
+            after its reintegration into the Confederation, the academy remained independent for a time and was
+            considered the least prestigious of the major Capellan military academies.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sarna</locationSystem>
@@ -6601,7 +7327,9 @@
         <name>Sentinelry Academy</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sentinelry Academy began construction in 3081, driven by Interstellar Agriculture Concerns. Training starts during Rockwellawan's brief arctic summer, hardening cadets in harsh conditions.</description>
+        <description>The Sentinelry Academy began construction in 3081, driven by Interstellar Agriculture Concerns.
+            Training starts during Rockwellawan's brief arctic summer, hardening cadets in harsh conditions.
+        </description>
         <locationSystem>Rockwellawan</locationSystem>
         <constructionYear>3081</constructionYear>
         <destructionYear>3088</destructionYear>
@@ -6638,7 +7366,11 @@
         <name>Sentinelry Academy [3095]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sentinelry Academy began construction in 3081, driven by Interstellar Agriculture Concerns. Training starts during Rockwellawan's brief arctic summer, hardening cadets in harsh conditions. In 3088, the academy was devastated by a pirate attack, but plans for reconstruction were immediate, underscoring its importance in local defense and officer training.</description>
+        <description>The Sentinelry Academy began construction in 3081, driven by Interstellar Agriculture Concerns.
+            Training starts during Rockwellawan's brief arctic summer, hardening cadets in harsh conditions. In 3088,
+            the academy was devastated by a pirate attack, but plans for reconstruction were immediate, underscoring its
+            importance in local defense and officer training.
+        </description>
         <locationSystem>Rockwellawan</locationSystem>
         <constructionYear>3095</constructionYear>
         <tuition>10938</tuition>
@@ -6674,7 +7406,11 @@
         <name>Sian Center for Martial Disciplines</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sian Center for Martial Disciplines stands as one of the most rigorous military academies within the Capellan Confederation. Prospective cadets must secure patronage from a Sang-shao or nobility and undergo a Maskirovka assessment, ensuring unwavering political loyalty to House Liao. The academy's curriculum blends intensive military training with comprehensive studies in civic and military philosophies.</description>
+        <description>The Sian Center for Martial Disciplines stands as one of the most rigorous military academies
+            within the Capellan Confederation. Prospective cadets must secure patronage from a Sang-shao or nobility and
+            undergo a Maskirovka assessment, ensuring unwavering political loyalty to House Liao. The academy's
+            curriculum blends intensive military training with comprehensive studies in civic and military philosophies.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -6694,7 +7430,11 @@
         <name>Sian Center for Martial Disciplines (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sian Center for Martial Disciplines stands as one of the most rigorous military academies within the Capellan Confederation. Prospective cadets must secure patronage from a Sang-shao or nobility and undergo a Maskirovka assessment, ensuring unwavering political loyalty to House Liao. The academy's curriculum blends intensive military training with comprehensive studies in civic and military philosophies.</description>
+        <description>The Sian Center for Martial Disciplines stands as one of the most rigorous military academies
+            within the Capellan Confederation. Prospective cadets must secure patronage from a Sang-shao or nobility and
+            undergo a Maskirovka assessment, ensuring unwavering political loyalty to House Liao. The academy's
+            curriculum blends intensive military training with comprehensive studies in civic and military philosophies.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -6714,7 +7454,10 @@
         <name>Sian University (Civilian)</name>
         <type>University</type>
         <isMilitary>true</isMilitary>
-        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science, economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis on achieving academic excellence.</description>
+        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science,
+            economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis
+            on achieving academic excellence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -6737,7 +7480,10 @@
         <name>Sian University (Military)</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science, economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis on achieving academic excellence.</description>
+        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science,
+            economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis
+            on achieving academic excellence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -6796,7 +7542,10 @@
         <name>Sian University (Military) (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science, economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis on achieving academic excellence.</description>
+        <description>Sian University offers a diverse array of courses, particularly in philosophy, political science,
+            economics, and interstellar relations. Enrollment is open to all Capellan citizens, with a strong emphasis
+            on achieving academic excellence.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -6855,7 +7604,9 @@
         <name>Simon Granger Training Facility</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Located on the planet Rajkot, the Simon Granger Training Facility specializes in mountain training for LAAF infantry stationed on nearby worlds.</description>
+        <description>Located on the planet Rajkot, the Simon Granger Training Facility specializes in mountain training
+            for LAAF infantry stationed on nearby worlds.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Rajkot</locationSystem>
@@ -6879,7 +7630,11 @@
         <name>Special Armed Services Training Center</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Star League Special Armed Services Training Center (SASTC) is a highly prestigious and elite training center used by the SLDF to train its elite Special Forces. With rigorous qualification standards and expectations, only the best of the best graduate from its programs. Those who graduate find themselves part of the legendary Blackhearts.</description>
+        <description>The Star League Special Armed Services Training Center (SASTC) is a highly prestigious and elite
+            training center used by the SLDF to train its elite Special Forces. With rigorous qualification standards
+            and expectations, only the best of the best graduate from its programs. Those who graduate find themselves
+            part of the legendary Blackhearts.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sabik</locationSystem>
@@ -6892,7 +7647,8 @@
         <educationLevelMax>College</educationLevelMax>
         <ageMin>16</ageMin>
         <qualification>SLDF Advanced Tactics Operative</qualification>
-        <curriculum>Gunnery/BattleArmor, Anti-Mek, Small Arms, Tech/BattleArmor, Tactics, Strategy, Leadership</curriculum>
+        <curriculum>Gunnery/BattleArmor, Anti-Mek, Small Arms, Tech/BattleArmor, Tactics, Strategy, Leadership
+        </curriculum>
         <qualificationStartYear>2718</qualificationStartYear>
         <qualification>SLDF Special Forces Graduate</qualification>
         <curriculum>Small Arms, Anti-Mek, Tactics, Strategy, Leadership</curriculum>
@@ -6903,7 +7659,10 @@
         <name>St. Ives Academy of Martial Sciences</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The St. Ives Academy of Martial Sciences focuses on rigorous military training and academic coursework. Cadets frequently attend classes alongside civilian students from the St. Ives Science Institute. Graduates of the academy are highly esteemed.</description>
+        <description>The St. Ives Academy of Martial Sciences focuses on rigorous military training and academic
+            coursework. Cadets frequently attend classes alongside civilian students from the St. Ives Science
+            Institute. Graduates of the academy are highly esteemed.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>St. Ives</locationSystem>
@@ -6951,7 +7710,10 @@
         <name>St. Ives Academy of Martial Sciences [3036]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The St. Ives Academy of Martial Sciences focuses on rigorous military training and academic coursework. Cadets frequently attend classes alongside civilian students from the St. Ives Science Institute. Graduates of the academy are highly esteemed.</description>
+        <description>The St. Ives Academy of Martial Sciences focuses on rigorous military training and academic
+            coursework. Cadets frequently attend classes alongside civilian students from the St. Ives Science
+            Institute. Graduates of the academy are highly esteemed.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>St. Ives</locationSystem>
@@ -6998,7 +7760,9 @@
         <name>Sterope Taurian Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sterope Taurian Academy is a small academy within the Taurian Concordat that trains cavalry and infantry in both armored and unarmored types.</description>
+        <description>The Sterope Taurian Academy is a small academy within the Taurian Concordat that trains cavalry and
+            infantry in both armored and unarmored types.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sterope (New Taurus)</locationSystem>
@@ -7033,7 +7797,10 @@
         <name>Sun Tzu School of Combat</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sun Tzu School of Combat on Kaznejoy stands out for fostering cooperation among all military branches. Its curriculum emphasizes teamwork, encouraging cadets to tackle challenges collaboratively rather than competitively.</description>
+        <description>The Sun Tzu School of Combat on Kaznejoy stands out for fostering cooperation among all military
+            branches. Its curriculum emphasizes teamwork, encouraging cadets to tackle challenges collaboratively rather
+            than competitively.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kaznejoy</locationSystem>
@@ -7074,7 +7841,10 @@
         <name>Sun Tzu School of Combat (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sun Tzu School of Combat on Kaznejoy stands out for fostering cooperation among all military branches. Its curriculum emphasizes teamwork, encouraging cadets to tackle challenges collaboratively rather than competitively.</description>
+        <description>The Sun Tzu School of Combat on Kaznejoy stands out for fostering cooperation among all military
+            branches. Its curriculum emphasizes teamwork, encouraging cadets to tackle challenges collaboratively rather
+            than competitively.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kaznejoy</locationSystem>
@@ -7115,7 +7885,10 @@
         <name>Sun Zhang MekWarrior Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sun Zhang MekWarrior Academy emphasizes bushido, and its graduates receive a daishō as a symbol of their honor. The Academy trains over four hundred MekWarriors annually, using abandoned cities for urban combat training.</description>
+        <description>The Sun Zhang MekWarrior Academy emphasizes bushido, and its graduates receive a daishō as a symbol
+            of their honor. The Academy trains over four hundred MekWarriors annually, using abandoned cities for urban
+            combat training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Samarkand</locationSystem>
@@ -7138,7 +7911,10 @@
         <name>Sun Zhang MekWarrior Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Sun Zhang MekWarrior Academy emphasizes bushido, and its graduates receive a daishō as a symbol of their honor. The Academy trains over four hundred MekWarriors annually, using abandoned cities for urban combat training.</description>
+        <description>The Sun Zhang MekWarrior Academy emphasizes bushido, and its graduates receive a daishō as a symbol
+            of their honor. The Academy trains over four hundred MekWarriors annually, using abandoned cities for urban
+            combat training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Samarkand</locationSystem>
@@ -7161,7 +7937,10 @@
         <name>Tancredi War College</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Tancredi War College offers specialized courses in infantry, artillery, BattleMek, and aerospace disciplines, with a strong focus on infantry and artillery training. These programs are designed to enhance combat skills and physical prowess, reflecting Tancredi IV’s martial culture.</description>
+        <description>The Tancredi War College offers specialized courses in infantry, artillery, BattleMek, and
+            aerospace disciplines, with a strong focus on infantry and artillery training. These programs are designed
+            to enhance combat skills and physical prowess, reflecting Tancredi IV’s martial culture.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tancredi IV</locationSystem>
@@ -7203,7 +7982,11 @@
         <name>Taurian Naval Institute</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Located near University City, the Taurian Naval Institute uses the University's classroom facilities, while the flattened top of nearby Aerie Butte serves as the training DropPort for the Institute's cadets. Cadets train under varied weather conditions to simulate a full range of potential takeoff and landing scenarios.</description>
+        <description>Located near University City, the Taurian Naval Institute uses the University's classroom
+            facilities, while the flattened top of nearby Aerie Butte serves as the training DropPort for the
+            Institute's cadets. Cadets train under varied weather conditions to simulate a full range of potential
+            takeoff and landing scenarios.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Vandenburg</locationSystem>
@@ -7231,7 +8014,11 @@
     <academy>
         <name>Tharkad University</name>
         <type>University</type>
-        <description>Situated in Olympia on the planet Tharkad, this prestigious Lyran Commonwealth university has educated numerous archons and elites of the Inner Sphere. Known for its extensive academic programs, the university remains a highly sought-after choice for students across the galaxy, despite its high tuition fees.</description>
+        <description>Situated in Olympia on the planet Tharkad, this prestigious Lyran Commonwealth university has
+            educated numerous archons and elites of the Inner Sphere. Known for its extensive academic programs, the
+            university remains a highly sought-after choice for students across the galaxy, despite its high tuition
+            fees.
+        </description>
         <locationSystem>Tharkad</locationSystem>
         <constructionYear>2500</constructionYear>
         <tuition>15000</tuition>
@@ -7252,7 +8039,10 @@
         <name>The Nagelring</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Nagelring provides comprehensive training across multiple military occupations, alongside civilian courses like chemistry and literature. Known for its stringent admission criteria, the Nagelring maintains a distinct social divide between noble and non-noble students.</description>
+        <description>The Nagelring provides comprehensive training across multiple military occupations, alongside
+            civilian courses like chemistry and literature. Known for its stringent admission criteria, the Nagelring
+            maintains a distinct social divide between noble and non-noble students.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tharkad</locationSystem>
@@ -7321,7 +8111,12 @@
         <name>The Nagelring [3085]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Nagelring offers comprehensive training across multiple military occupations, supplemented by civilian courses in subjects such as chemistry and literature. Renowned for its rigorous admission standards, the academy maintains a noticeable social division between noble and non-noble students. Despite sustaining significant damage during the Word of Blake Jihad and Clan Wolf's attack in 3143, the Nagelring continues to graduate capable officers for the Lyran Armed Forces.</description>
+        <description>The Nagelring offers comprehensive training across multiple military occupations, supplemented by
+            civilian courses in subjects such as chemistry and literature. Renowned for its rigorous admission
+            standards, the academy maintains a noticeable social division between noble and non-noble students. Despite
+            sustaining significant damage during the Word of Blake Jihad and Clan Wolf's attack in 3143, the Nagelring
+            continues to graduate capable officers for the Lyran Armed Forces.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tharkad</locationSystem>
@@ -7390,7 +8185,11 @@
         <name>The War College of Goshen</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Goshen, initially established as the Goshen BattleMek Academy, is a prestigious private military academy in the Federated Suns. Situated on Goshen's Tiberian continent, the college expanded its curriculum within a decade to incorporate aerospace programs, prompting a name change to reflect its comprehensive military training offerings.</description>
+        <description>The War College of Goshen, initially established as the Goshen BattleMek Academy, is a prestigious
+            private military academy in the Federated Suns. Situated on Goshen's Tiberian continent, the college
+            expanded its curriculum within a decade to incorporate aerospace programs, prompting a name change to
+            reflect its comprehensive military training offerings.
+        </description>
         <locationSystem>Goshen</locationSystem>
         <constructionYear>2960</constructionYear>
         <tuition>8750</tuition>
@@ -7411,7 +8210,10 @@
         <name>The Warrior's Hall</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Warrior's Hall started as an officers' club and evolved into a comprehensive military academy by 2765. Though it lacks the most advanced technology, the academy produces some of the finest MekWarriors in the AFFS. It is known for its emphasis on military skills, often at the expense of academic subjects.</description>
+        <description>The Warrior's Hall started as an officers' club and evolved into a comprehensive military academy
+            by 2765. Though it lacks the most advanced technology, the academy produces some of the finest MekWarriors
+            in the AFFS. It is known for its emphasis on military skills, often at the expense of academic subjects.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Syrtis</locationSystem>
@@ -7464,7 +8266,10 @@
         <name>The Warrior's Hall (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Warrior's Hall started as an officers' club and evolved into a comprehensive military academy by 2765. Though it lacks the most advanced technology, the academy produces some of the finest MekWarriors in the AFFS. It is known for its emphasis on military skills, often at the expense of academic subjects.</description>
+        <description>The Warrior's Hall started as an officers' club and evolved into a comprehensive military academy
+            by 2765. Though it lacks the most advanced technology, the academy produces some of the finest MekWarriors
+            in the AFFS. It is known for its emphasis on military skills, often at the expense of academic subjects.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Syrtis</locationSystem>
@@ -7517,7 +8322,9 @@
         <name>Tikonov Martial Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Tikonov Martial Academy is one of the premier institutions of its kind. For the citizens of the Sarna March, the academy has provided quality education for as long as anyone can remember.</description>
+        <description>The Tikonov Martial Academy is one of the premier institutions of its kind. For the citizens of the
+            Sarna March, the academy has provided quality education for as long as anyone can remember.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tikonov</locationSystem>
@@ -7555,7 +8362,9 @@
         <name>Tikonov Martial Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Tikonov Martial Academy is one of the premier institutions of its kind. For the citizens of the Sarna March, the academy has provided quality education for as long as anyone can remember.</description>
+        <description>The Tikonov Martial Academy is one of the premier institutions of its kind. For the citizens of the
+            Sarna March, the academy has provided quality education for as long as anyone can remember.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tikonov</locationSystem>
@@ -7593,7 +8402,11 @@
         <name>Tikonov School of Military Discipline</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Built from the ruins of the old Tikonov Martial Academy, this facility graduates hundreds of soldiers each year in various military specialties. However, the legacy of the past endures in the minds of the local population, and the academy, along with its cadets, remains a bastion of loyalty to the Federated Suns in this region.</description>
+        <description>Built from the ruins of the old Tikonov Martial Academy, this facility graduates hundreds of
+            soldiers each year in various military specialties. However, the legacy of the past endures in the minds of
+            the local population, and the academy, along with its cadets, remains a bastion of loyalty to the Federated
+            Suns in this region.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tikonov</locationSystem>
@@ -7631,7 +8444,11 @@
         <name>Tikonov School of Military Discipline (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Built from the ruins of the old Tikonov Martial Academy, this facility graduates hundreds of soldiers each year in various military specialties. However, the legacy of the past endures in the minds of the local population, and the academy, along with its cadets, remains a bastion of loyalty to the Federated Suns in this region.</description>
+        <description>Built from the ruins of the old Tikonov Martial Academy, this facility graduates hundreds of
+            soldiers each year in various military specialties. However, the legacy of the past endures in the minds of
+            the local population, and the academy, along with its cadets, remains a bastion of loyalty to the Federated
+            Suns in this region.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tikonov</locationSystem>
@@ -7669,7 +8486,11 @@
         <name>Tri-M Mercenary Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Founded by the alleged former Wolf's Dragoons member Howard Hughes O'Grady, Tri-M Academy promotes the financial benefits of becoming a mercenary, emphasizing that Tri-M stands for "money, money, money." Unlike other academies with strict enrollment policies, Tri-M guarantees acceptance for anyone who can pay their "reasonable" tuition fees.</description>
+        <description>Founded by the alleged former Wolf's Dragoons member Howard Hughes O'Grady, Tri-M Academy promotes
+            the financial benefits of becoming a mercenary, emphasizing that Tri-M stands for "money, money, money."
+            Unlike other academies with strict enrollment policies, Tri-M guarantees acceptance for anyone who can pay
+            their "reasonable" tuition fees.
+        </description>
         <locationSystem>Outreach</locationSystem>
         <constructionYear>3040</constructionYear>
         <tuition>38500</tuition>
@@ -7686,7 +8507,10 @@
         <name>Tyra Miraborg Memorial Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Named after the heroic aerospace fighter pilot who killed ilKhan Leo Showers during the Clan Invasion, the Tyra Miraborg Memorial Academy is the premier military academy of the Free Rasalhague Republic. Despite internal rivalries, cadets develop a strong camaraderie, essential for future battles.</description>
+        <description>Named after the heroic aerospace fighter pilot who killed ilKhan Leo Showers during the Clan
+            Invasion, the Tyra Miraborg Memorial Academy is the premier military academy of the Free Rasalhague
+            Republic. Despite internal rivalries, cadets develop a strong camaraderie, essential for future battles.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Orestes</locationSystem>
@@ -7727,7 +8551,10 @@
         <name>Tyra Miraborg Memorial Academy (Officer)</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>Named after the heroic aerospace fighter pilot who killed ilKhan Leo Showers during the Clan Invasion, the Tyra Miraborg Memorial Academy is the premier military academy of the Free Rasalhague Republic. Despite internal rivalries, cadets develop a strong camaraderie, essential for future battles.</description>
+        <description>Named after the heroic aerospace fighter pilot who killed ilKhan Leo Showers during the Clan
+            Invasion, the Tyra Miraborg Memorial Academy is the premier military academy of the Free Rasalhague
+            Republic. Despite internal rivalries, cadets develop a strong camaraderie, essential for future battles.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Orestes</locationSystem>
@@ -7767,7 +8594,9 @@
     <academy>
         <name>Universities of the Puget Sound States</name>
         <type>University</type>
-        <description>A group of five universities and colleges, including Pacific Lutheran University and the University of Washington, the latter of which maintains an extensive computer system.</description>
+        <description>A group of five universities and colleges, including Pacific Lutheran University and the University
+            of Washington, the latter of which maintains an extensive computer system.
+        </description>
         <locationSystem>Terra</locationSystem>
         <destructionYear>2780</destructionYear>
         <tuition>7500</tuition>
@@ -7787,7 +8616,9 @@
     <academy>
         <name>University of Blake</name>
         <type>University</type>
-        <description>After the inconclusive Terran Peace Summit of 3053, Primus Sharilar Mori opened the ComStar Archives and established the University of Blake to distribute technical knowledge among the Great Houses.</description>
+        <description>After the inconclusive Terran Peace Summit of 3053, Primus Sharilar Mori opened the ComStar
+            Archives and established the University of Blake to distribute technical knowledge among the Great Houses.
+        </description>
         <locationSystem>Terra</locationSystem>
         <constructionYear>3053</constructionYear>
         <tuition>7500</tuition>
@@ -7807,7 +8638,9 @@
     <academy>
         <name>University of Canopus</name>
         <type>University</type>
-        <description>Initially resembling more of a technical school, the University of Canopus has undergone significant enhancements through Taurian expertise and Capellan financial support.</description>
+        <description>Initially resembling more of a technical school, the University of Canopus has undergone
+            significant enhancements through Taurian expertise and Capellan financial support.
+        </description>
         <locationSystem>Canopus IV</locationSystem>
         <constructionYear>2550</constructionYear>
         <tuition>6250</tuition>
@@ -7827,7 +8660,9 @@
     <academy>
         <name>University of Harvard</name>
         <type>University</type>
-        <description>Believed to be a continuation of Harvard University from ancient Earth, this institution has been educating students for hundreds of years.</description>
+        <description>Believed to be a continuation of Harvard University from ancient Earth, this institution has been
+            educating students for hundreds of years.
+        </description>
         <locationSystem>Terra</locationSystem>
         <constructionYear>1950</constructionYear>
         <tuition>7500</tuition>
@@ -7847,7 +8682,9 @@
     <academy>
         <name>University of Lambrecht</name>
         <type>University</type>
-        <description>The University of Lambrecht specializes in sciences such as astronomy and physics, making significant contributions to advancements in alloys.</description>
+        <description>The University of Lambrecht specializes in sciences such as astronomy and physics, making
+            significant contributions to advancements in alloys.
+        </description>
         <locationSystem>Lambrecht</locationSystem>
         <constructionYear>2350</constructionYear>
         <destructionYear>2772</destructionYear>
@@ -7868,7 +8705,10 @@
     <academy>
         <name>University of Luxen</name>
         <type>University</type>
-        <description>As a beacon of higher education within the Magistracy of Canopus, the University of Luxen is renowned for its exceptional Canopian Medical Sciences and Training Complex. Additionally, its School of Engineering offers a diverse range of courses, including architecture and military applications.</description>
+        <description>As a beacon of higher education within the Magistracy of Canopus, the University of Luxen is
+            renowned for its exceptional Canopian Medical Sciences and Training Complex. Additionally, its School of
+            Engineering offers a diverse range of courses, including architecture and military applications.
+        </description>
         <locationSystem>Luxen</locationSystem>
         <constructionYear>2751</constructionYear>
         <tuition>7500</tuition>
@@ -7888,7 +8728,9 @@
     <academy>
         <name>University of Mars</name>
         <type>University</type>
-        <description>Renowned for its journalism program, the University of Mars produces the influential "Martian Times" newspaper and a respected holonews program distributed throughout the Hegemony.</description>
+        <description>Renowned for its journalism program, the University of Mars produces the influential "Martian
+            Times" newspaper and a respected holonews program distributed throughout the Hegemony.
+        </description>
         <locationSystem>Terra</locationSystem>
         <destructionYear>2770</destructionYear>
         <tuition>7500</tuition>
@@ -7905,7 +8747,9 @@
     <academy>
         <name>University of New Samarkand</name>
         <type>University</type>
-        <description>The University of New Samarkand is an educational institution located on the planet of New Samarkand, renowned for its notable medical school.</description>
+        <description>The University of New Samarkand is an educational institution located on the planet of New
+            Samarkand, renowned for its notable medical school.
+        </description>
         <locationSystem>New Samarkand</locationSystem>
         <constructionYear>2375</constructionYear>
         <tuition>12500</tuition>
@@ -7926,7 +8770,10 @@
         <name>University of Proserpina</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The University of Proserpina, affiliated with the Proserpina Hussars, offers a robust, hands-on military education despite facing resource constraints. Located near volatile borders, it continues to attract students seeking specialized military training.</description>
+        <description>The University of Proserpina, affiliated with the Proserpina Hussars, offers a robust, hands-on
+            military education despite facing resource constraints. Located near volatile borders, it continues to
+            attract students seeking specialized military training.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Proserpina</locationSystem>
@@ -7965,7 +8812,8 @@
     <academy>
         <name>University of Robinson</name>
         <type>University</type>
-        <description>Since its founding, the University of Robinson has led research in advanced engineering.</description>
+        <description>Since its founding, the University of Robinson has led research in advanced engineering.
+        </description>
         <locationSystem>Robinson</locationSystem>
         <constructionYear>2500</constructionYear>
         <tuition>7500</tuition>
@@ -7985,7 +8833,10 @@
     <academy>
         <name>University of Tamar</name>
         <type>University</type>
-        <description>The University of Tamar is renowned for its business program, drawing students from prominent local merchant families. This academic institution has played a pivotal role in shaping future leaders and professionals in the fields of business and commerce.</description>
+        <description>The University of Tamar is renowned for its business program, drawing students from prominent local
+            merchant families. This academic institution has played a pivotal role in shaping future leaders and
+            professionals in the fields of business and commerce.
+        </description>
         <locationSystem>Tamar</locationSystem>
         <constructionYear>2450</constructionYear>
         <tuition>6250</tuition>
@@ -8005,7 +8856,10 @@
     <academy>
         <name>University of Terra</name>
         <type>University</type>
-        <description>The University of Terra holds historical significance as the site of the original SLCOMNET’s Prime HPG. This institution has been at the forefront of advancing communication technologies, influencing the development and implementation of interstellar messaging systems.</description>
+        <description>The University of Terra holds historical significance as the site of the original SLCOMNET’s Prime
+            HPG. This institution has been at the forefront of advancing communication technologies, influencing the
+            development and implementation of interstellar messaging systems.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -8027,7 +8881,9 @@
     <academy>
         <name>University of Thorin</name>
         <type>University</type>
-        <description>Located in the dense forests of Thorin's northern continent, the University of Thorin is renowned for its specialization in economics.</description>
+        <description>Located in the dense forests of Thorin's northern continent, the University of Thorin is renowned
+            for its specialization in economics.
+        </description>
         <locationSystem>Thorin</locationSystem>
         <destructionYear>2775</destructionYear>
         <tuition>7500</tuition>
@@ -8044,7 +8900,10 @@
     <academy>
         <name>University of Washington on Donegal</name>
         <type>University</type>
-        <description>Located in the Queen Anne Hills on the continent of Seattle, this Lyran Commonwealth institution is renowned for its specialization in computers and communications. It boasts some of the Inner Sphere's finest computer science facilities, rivaling even those of ComStar.</description>
+        <description>Located in the Queen Anne Hills on the continent of Seattle, this Lyran Commonwealth institution is
+            renowned for its specialization in computers and communications. It boasts some of the Inner Sphere's finest
+            computer science facilities, rivaling even those of ComStar.
+        </description>
         <locationSystem>Donegal</locationSystem>
         <tuition>15000</tuition>
         <durationDays>900</durationDays>
@@ -8064,7 +8923,10 @@
         <name>Victoria Academy of Arms and Technology</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Victoria Academy of Arms and Technology is closely linked with the Shengli Arms factory, shaping a curriculum focused primarily on technical studies. This emphasis benefits future technicians who gain access to the factory's facilities.</description>
+        <description>The Victoria Academy of Arms and Technology is closely linked with the Shengli Arms factory,
+            shaping a curriculum focused primarily on technical studies. This emphasis benefits future technicians who
+            gain access to the factory's facilities.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Victoria (CC)</locationSystem>
@@ -8108,7 +8970,10 @@
         <name>War Academy of Mars</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War Academy of Mars is part of the "War Triad" alongside Sandhurst Royal Military College and the Military Academy of Aphros. Located near Olympus Mons, the academy specializes in strategic training for officer cadets.</description>
+        <description>The War Academy of Mars is part of the "War Triad" alongside Sandhurst Royal Military College and
+            the Military Academy of Aphros. Located near Olympus Mons, the academy specializes in strategic training for
+            officer cadets.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -8176,7 +9041,10 @@
         <name>War Academy of Mars [3135]</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War Academy of Mars is part of the "War Triad" alongside Sandhurst Royal Military College and the Military Academy of Aphros. Located near Olympus Mons, the academy specializes in strategic training for officer cadets. It was destroyed during Operation SCOUR, but has since been reopened.</description>
+        <description>The War Academy of Mars is part of the "War Triad" alongside Sandhurst Royal Military College and
+            the Military Academy of Aphros. Located near Olympus Mons, the academy specializes in strategic training for
+            officer cadets. It was destroyed during Operation SCOUR, but has since been reopened.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -8245,7 +9113,11 @@
         <name>War College of Buena</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Buena initially focused on technician courses and MekWarrior training. Over time, it expanded significantly, producing highly competent technicians, MekWarriors, and aerospace pilots. Training emphasizes practical experience, with cadets spending six months in the Buena Training Battalion engaged in live-fire exercises and anti-pirate missions.</description>
+        <description>The War College of Buena initially focused on technician courses and MekWarrior training. Over
+            time, it expanded significantly, producing highly competent technicians, MekWarriors, and aerospace pilots.
+            Training emphasizes practical experience, with cadets spending six months in the Buena Training Battalion
+            engaged in live-fire exercises and anti-pirate missions.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Buena</locationSystem>
@@ -8280,7 +9152,10 @@
         <name>War College of Tamar</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Tamar is renowned for producing adept tacticians, strategists, and outstanding administrators. While the academy's curriculum emphasizes leadership and administrative skills over combat, it also offers training in BattleMek and aerospace operations.</description>
+        <description>The War College of Tamar is renowned for producing adept tacticians, strategists, and outstanding
+            administrators. While the academy's curriculum emphasizes leadership and administrative skills over combat,
+            it also offers training in BattleMek and aerospace operations.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tamar</locationSystem>
@@ -8307,7 +9182,11 @@
         <name>War College of Tamar [3025]</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The War College of Tamar is renowned for producing adept tacticians, strategists, and outstanding administrators. While the academy's curriculum emphasizes leadership and administrative skills over combat, it also provides training in BattleMek and aerospace operations. Destroyed by the DCMS in 2915, it was later rebuilt under the initiative of Archon Katrina Steiner.</description>
+        <description>The War College of Tamar is renowned for producing adept tacticians, strategists, and outstanding
+            administrators. While the academy's curriculum emphasizes leadership and administrative skills over combat,
+            it also provides training in BattleMek and aerospace operations. Destroyed by the DCMS in 2915, it was later
+            rebuilt under the initiative of Archon Katrina Steiner.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Tamar</locationSystem>
@@ -8334,7 +9213,10 @@
         <name>Warner MekWarrior Academy</name>
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Warner MekWarrior Academy on Solaris VII is a small and informal training school for aspiring MekWarriors, founded by the second-rate arena fighter and con man Clease Vanderholf. Training is conducted using four poorly maintained Chameleons.</description>
+        <description>The Warner MekWarrior Academy on Solaris VII is a small and informal training school for aspiring
+            MekWarriors, founded by the second-rate arena fighter and con man Clease Vanderholf. Training is conducted
+            using four poorly maintained Chameleons.
+        </description>
         <locationSystem>Solaris</locationSystem>
         <constructionYear>3000</constructionYear>
         <destructionYear>3068</destructionYear>
@@ -8354,7 +9236,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Renowned for their ferocity, Dai Da Chi warriors specialize in relentless assaults, often employing unconventional tactics to overwhelm their enemies swiftly.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Renowned for their ferocity, Dai Da Chi warriors specialize in relentless assaults, often
+            employing unconventional tactics to overwhelm their enemies swiftly.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Drozan</locationSystem>
@@ -8379,7 +9265,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Fujita warriors are masters of defensive warfare, known for their impenetrable fortifications and unyielding resilience in battle.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Fujita warriors are masters of defensive warfare, known for their impenetrable fortifications
+            and unyielding resilience in battle.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Hunan</locationSystem>
@@ -8405,7 +9295,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Stealth and precision define Hiritsu, whose warriors excel in covert operations and surgical strikes against high-value targets.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Stealth and precision define Hiritsu, whose warriors excel in covert operations and surgical
+            strikes against high-value targets.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Randar</locationSystem>
@@ -8430,7 +9324,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Ijori prides itself on traditional martial discipline, blending ancient combat techniques with modern warfare to maintain battlefield honor.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Ijori prides itself on traditional martial discipline, blending ancient combat techniques with
+            modern warfare to maintain battlefield honor.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Aldebaran</locationSystem>
@@ -8456,7 +9354,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Strategically adept, Imarra warriors emphasize coordination and adaptability, making them formidable opponents in dynamic combat situations.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Strategically adept, Imarra warriors emphasize coordination and adaptability, making them
+            formidable opponents in dynamic combat situations.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Sian</locationSystem>
@@ -8481,7 +9383,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Kamata is synonymous with heavy armor and firepower, favoring direct confrontations and overwhelming force to crush adversaries.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Kamata is synonymous with heavy armor and firepower, favoring direct confrontations and
+            overwhelming force to crush adversaries.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Betelgeuse</locationSystem>
@@ -8506,7 +9412,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Known for their elite training, Lu Sann warriors combine physical prowess with tactical genius, often leading crucial missions.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Known for their elite training, Lu Sann warriors combine physical prowess with tactical
+            genius, often leading crucial missions.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Grand Base</locationSystem>
@@ -8533,7 +9443,11 @@
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
         <factionDiscount>0</factionDiscount>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Versatile and innovative, Ma-Tsu Kai warriors adapt to any combat scenario, using creativity to outmaneuver and outthink opponents.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Versatile and innovative, Ma-Tsu Kai warriors adapt to any combat scenario, using creativity
+            to outmaneuver and outthink opponents.
+        </description>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>New Aragon</locationSystem>
         <constructionYear>2991</constructionYear>
@@ -8558,7 +9472,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Rakshasa warriors are feared for their ruthlessness and psychological warfare, demoralizing enemies before striking with lethal efficiency.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Rakshasa warriors are feared for their ruthlessness and psychological warfare, demoralizing
+            enemies before striking with lethal efficiency.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Bithinia</locationSystem>
@@ -8584,7 +9502,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Rakshasa warriors are feared for their ruthlessness and psychological warfare, demoralizing enemies before striking with lethal efficiency.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Rakshasa warriors are feared for their ruthlessness and psychological warfare, demoralizing
+            enemies before striking with lethal efficiency.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Wazan</locationSystem>
@@ -8610,7 +9532,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Tsang Xiao emphasizes spiritual discipline and inner strength, believing that mental fortitude is key to martial success.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Tsang Xiao emphasizes spiritual discipline and inner strength, believing that mental fortitude
+            is key to martial success.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Wazan</locationSystem>
@@ -8635,7 +9561,11 @@
         <type>Military Academy</type>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and coordination. Elite and exclusive, White Tiger warriors are distinguished by their exceptional skill and loyalty, often undertaking the most dangerous and critical missions.</description>
+        <description>The Capellan Warrior House Orders are semi-religious, independent military groups within the
+            Capellan Confederation, reporting directly to the Chancellor. Skilled in strategic adaptability and
+            coordination. Elite and exclusive, White Tiger warriors are distinguished by their exceptional skill and
+            loyalty, often undertaking the most dangerous and critical missions.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Highspire</locationSystem>
@@ -8660,7 +9590,10 @@
         <name>West Point Military Academy</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>A cornerstone of military leadership on Terra, West Point has been a revered academy since its establishment. The institution prides itself on a legacy of producing tacticians and leaders who have played pivotal roles in shaping the armed forces of the Inner Sphere.</description>
+        <description>A cornerstone of military leadership on Terra, West Point has been a revered academy since its
+            establishment. The institution prides itself on a legacy of producing tacticians and leaders who have played
+            pivotal roles in shaping the armed forces of the Inner Sphere.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Terra</locationSystem>
@@ -8698,7 +9631,10 @@
         <name>Wisdom of the Dragon</name>
         <type>Officer Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The Wisdom of the Dragon is an elite officer finishing school for the DCMS. The academy maintains a highly intense atmosphere, pushing cadets to their physical and mental limits while strictly adhering to bushido principles.</description>
+        <description>The Wisdom of the Dragon is an elite officer finishing school for the DCMS. The academy maintains a
+            highly intense atmosphere, pushing cadets to their physical and mental limits while strictly adhering to
+            bushido principles.
+        </description>
         <factionDiscount>0</factionDiscount>
         <isFactionRestricted>true</isFactionRestricted>
         <locationSystem>Kagoshima</locationSystem>

--- a/MekHQ/data/universe/academies/Unit Education.xml
+++ b/MekHQ/data/universe/academies/Unit Education.xml
@@ -3,7 +3,10 @@
     <academy>
         <name>Unit Creche</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>A unit creche serves as a communal living and training space for the youngest children of mercenaries. While the creche fosters a strong sense of community it fails to provide the level of education afforded to more formal settings.</description>
+        <description>A unit creche serves as a communal living and training space for the youngest children of
+            mercenaries. While the creche fosters a strong sense of community it fails to provide the level of education
+            afforded to more formal settings.
+        </description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -21,7 +24,10 @@
     <academy>
         <name>Home Schooling</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>Home schooling often occurs in mercenary companies posted to remote or frontier regions where formal educational facilities are scarce. The company provides a basic education using a mix of digital resources and practical skills training.</description>
+        <description>Home schooling often occurs in mercenary companies posted to remote or frontier regions where
+            formal educational facilities are scarce. The company provides a basic education using a mix of digital
+            resources and practical skills training.
+        </description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -40,7 +46,11 @@
         <name>Apprenticeship</name>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>An apprenticeship is a hands-on training program where young recruits learn from experienced personnel. Apprentices start with basic skills, and gradually take on more responsibilities. This mentorship-based training emphasizes practical experience, but lacks any formal qualifications. Furthermore, apprenticing to an active military unit has its dangers.</description>
+        <description>An apprenticeship is a hands-on training program where young recruits learn from experienced
+            personnel. Apprentices start with basic skills, and gradually take on more responsibilities. This
+            mentorship-based training emphasizes practical experience, but lacks any formal qualifications. Furthermore,
+            apprenticing to an active military unit has its dangers.
+        </description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -80,7 +90,7 @@
         <curriculum>Astech, Tech/Vessel</curriculum>
         <qualificationStartYear>2470</qualificationStartYear>
         <qualification>Administrative Apprenticeship</qualification>
-        <curriculum>Administration, Scrounge</curriculum>
+        <curriculum>Administration, Negotiation</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Medical Apprenticeship</qualification>
         <curriculum>MedTech, Doctor</curriculum>
@@ -90,7 +100,10 @@
     <academy>
         <name>Adult Apprenticeship</name>
         <isMilitary>false</isMilitary>
-        <description>An adult apprenticeship is a hands-on training program where older recruits are integrated into a military or mercenary unit. The apprenticeship focuses heavily on learning in the field, with recruits shadowing seasoned veterans.</description>
+        <description>An adult apprenticeship is a hands-on training program where older recruits are integrated into a
+            military or mercenary unit. The apprenticeship focuses heavily on learning in the field, with recruits
+            shadowing seasoned veterans.
+        </description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -115,7 +128,7 @@
         <curriculum>Astech, Tech/Vessel</curriculum>
         <qualificationStartYear>2470</qualificationStartYear>
         <qualification>Administrative Apprenticeship</qualification>
-        <curriculum>Administration, Scrounge</curriculum>
+        <curriculum>Administration, Negotiation</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Medical Apprenticeship</qualification>
         <curriculum>MedTech, Doctor</curriculum>
@@ -126,7 +139,10 @@
         <name>In-House Boot Camp</name>
         <type>Basic Training</type>
         <isMilitary>true</isMilitary>
-        <description>In-house training is usually conducted by the unit's more experienced members. This training ensures that new members are well-prepared, cohesive, and loyal to the unit's unique culture and combat style.</description>
+        <description>In-house training is usually conducted by the unit's more experienced members. This training
+            ensures that new members are well-prepared, cohesive, and loyal to the unit's unique culture and combat
+            style.
+        </description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -153,7 +169,9 @@
         <name>In-House Basic Training</name>
         <type>Basic Training</type>
         <isMilitary>true</isMilitary>
-        <description>In-house training is usually conducted by the unit's more experienced members. Trainees undergo physical conditioning, simulator exercises, and eventually hands-on training in their chosen field.</description>
+        <description>In-house training is usually conducted by the unit's more experienced members. Trainees undergo
+            physical conditioning, simulator exercises, and eventually hands-on training in their chosen field.
+        </description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -180,7 +198,9 @@
         <name>In-House NCO Bootcamp</name>
         <type>NCO Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The In-House NCO Candidate Bootcamp is led by veteran personnel, blending physical conditioning, simulations, and practical exercises to instill leadership, cohesion, and loyalty.</description>
+        <description>The In-House NCO Candidate Bootcamp is led by veteran personnel, blending physical conditioning,
+            simulations, and practical exercises to instill leadership, cohesion, and loyalty.
+        </description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -198,7 +218,9 @@
     <academy>
         <name>In-House Warrant Officer Bootcamp</name>
         <isMilitary>true</isMilitary>
-        <description>Led by veteran experts, in-unit Warrant Officer bootcamps focus on advanced technical skills, leadership development, and unit cohesion, preparing candidates for specialized support roles.</description>
+        <description>Led by veteran experts, in-unit Warrant Officer bootcamps focus on advanced technical skills,
+            leadership development, and unit cohesion, preparing candidates for specialized support roles.
+        </description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -216,7 +238,9 @@
     <academy>
         <name>In-House Officer Bootcamp</name>
         <isMilitary>true</isMilitary>
-        <description>Officer Bootcamp emphasizes leadership, tactical acumen, and strategic planning, blending classroom instruction, simulations, and field exercises to prepare candidates for command roles.</description>
+        <description>Officer Bootcamp emphasizes leadership, tactical acumen, and strategic planning, blending classroom
+            instruction, simulations, and field exercises to prepare candidates for command roles.
+        </description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>

--- a/MekHQ/data/universe/academies/Unit Education.xml
+++ b/MekHQ/data/universe/academies/Unit Education.xml
@@ -3,10 +3,7 @@
     <academy>
         <name>Unit Creche</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>A unit creche serves as a communal living and training space for the youngest children of
-            mercenaries. While the creche fosters a strong sense of community it fails to provide the level of education
-            afforded to more formal settings.
-        </description>
+        <description>A unit creche serves as a communal living and training space for the youngest children of mercenaries. While the creche fosters a strong sense of community it fails to provide the level of education afforded to more formal settings.</description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -24,10 +21,7 @@
     <academy>
         <name>Home Schooling</name>
         <isPrepSchool>true</isPrepSchool>
-        <description>Home schooling often occurs in mercenary companies posted to remote or frontier regions where
-            formal educational facilities are scarce. The company provides a basic education using a mix of digital
-            resources and practical skills training.
-        </description>
+        <description>Home schooling often occurs in mercenary companies posted to remote or frontier regions where formal educational facilities are scarce. The company provides a basic education using a mix of digital resources and practical skills training.</description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -46,11 +40,7 @@
         <name>Apprenticeship</name>
         <isMilitary>true</isMilitary>
         <isPrepSchool>true</isPrepSchool>
-        <description>An apprenticeship is a hands-on training program where young recruits learn from experienced
-            personnel. Apprentices start with basic skills, and gradually take on more responsibilities. This
-            mentorship-based training emphasizes practical experience, but lacks any formal qualifications. Furthermore,
-            apprenticing to an active military unit has its dangers.
-        </description>
+        <description>An apprenticeship is a hands-on training program where young recruits learn from experienced personnel. Apprentices start with basic skills, and gradually take on more responsibilities. This mentorship-based training emphasizes practical experience, but lacks any formal qualifications. Furthermore, apprenticing to an active military unit has its dangers.</description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -90,7 +80,7 @@
         <curriculum>Astech, Tech/Vessel</curriculum>
         <qualificationStartYear>2470</qualificationStartYear>
         <qualification>Administrative Apprenticeship</qualification>
-        <curriculum>Administration, Negotiation</curriculum>
+        <curriculum>Administration</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Medical Apprenticeship</qualification>
         <curriculum>MedTech, Doctor</curriculum>
@@ -100,10 +90,7 @@
     <academy>
         <name>Adult Apprenticeship</name>
         <isMilitary>false</isMilitary>
-        <description>An adult apprenticeship is a hands-on training program where older recruits are integrated into a
-            military or mercenary unit. The apprenticeship focuses heavily on learning in the field, with recruits
-            shadowing seasoned veterans.
-        </description>
+        <description>An adult apprenticeship is a hands-on training program where older recruits are integrated into a military or mercenary unit. The apprenticeship focuses heavily on learning in the field, with recruits shadowing seasoned veterans.</description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -128,7 +115,7 @@
         <curriculum>Astech, Tech/Vessel</curriculum>
         <qualificationStartYear>2470</qualificationStartYear>
         <qualification>Administrative Apprenticeship</qualification>
-        <curriculum>Administration, Negotiation</curriculum>
+        <curriculum>Administration</curriculum>
         <qualificationStartYear>2300</qualificationStartYear>
         <qualification>Medical Apprenticeship</qualification>
         <curriculum>MedTech, Doctor</curriculum>
@@ -139,10 +126,7 @@
         <name>In-House Boot Camp</name>
         <type>Basic Training</type>
         <isMilitary>true</isMilitary>
-        <description>In-house training is usually conducted by the unit's more experienced members. This training
-            ensures that new members are well-prepared, cohesive, and loyal to the unit's unique culture and combat
-            style.
-        </description>
+        <description>In-house training is usually conducted by the unit's more experienced members. This training ensures that new members are well-prepared, cohesive, and loyal to the unit's unique culture and combat style.</description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -169,9 +153,7 @@
         <name>In-House Basic Training</name>
         <type>Basic Training</type>
         <isMilitary>true</isMilitary>
-        <description>In-house training is usually conducted by the unit's more experienced members. Trainees undergo
-            physical conditioning, simulator exercises, and eventually hands-on training in their chosen field.
-        </description>
+        <description>In-house training is usually conducted by the unit's more experienced members. Trainees undergo physical conditioning, simulator exercises, and eventually hands-on training in their chosen field.</description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -198,9 +180,7 @@
         <name>In-House NCO Bootcamp</name>
         <type>NCO Academy</type>
         <isMilitary>true</isMilitary>
-        <description>The In-House NCO Candidate Bootcamp is led by veteran personnel, blending physical conditioning,
-            simulations, and practical exercises to instill leadership, cohesion, and loyalty.
-        </description>
+        <description>The In-House NCO Candidate Bootcamp is led by veteran personnel, blending physical conditioning, simulations, and practical exercises to instill leadership, cohesion, and loyalty.</description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -218,9 +198,7 @@
     <academy>
         <name>In-House Warrant Officer Bootcamp</name>
         <isMilitary>true</isMilitary>
-        <description>Led by veteran experts, in-unit Warrant Officer bootcamps focus on advanced technical skills,
-            leadership development, and unit cohesion, preparing candidates for specialized support roles.
-        </description>
+        <description>Led by veteran experts, in-unit Warrant Officer bootcamps focus on advanced technical skills, leadership development, and unit cohesion, preparing candidates for specialized support roles.</description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>
@@ -238,9 +216,7 @@
     <academy>
         <name>In-House Officer Bootcamp</name>
         <isMilitary>true</isMilitary>
-        <description>Officer Bootcamp emphasizes leadership, tactical acumen, and strategic planning, blending classroom
-            instruction, simulations, and field exercises to prepare candidates for command roles.
-        </description>
+        <description>Officer Bootcamp emphasizes leadership, tactical acumen, and strategic planning, blending classroom instruction, simulations, and field exercises to prepare candidates for command roles.</description>
         <isHomeSchool>true</isHomeSchool>
         <locationSystem>Terra</locationSystem>
         <constructionYear>2300</constructionYear>


### PR DESCRIPTION
- Updated various academy curricula to replace the "Scrounge" skill with "Negotiation" or removed it where appropriate.

### Dev Notes
Scrounge was deprecated in #6430, so it doesn't make sense to have Academies issue it.