### PR TITLE
Corrected Briefing Room Combat Team Counter

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
@@ -27,10 +27,10 @@
  */
 package mekhq.campaign.mission.enums;
 
+import java.util.ResourceBundle;
+
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
-
-import java.util.ResourceBundle;
 
 public enum CombatRole {
     // region Enum Declarations
@@ -50,7 +50,7 @@ public enum CombatRole {
     // region Constructors
     CombatRole(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Mission",
-                MekHQ.getMHQOptions().getLocale());
+              MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }
@@ -86,36 +86,54 @@ public enum CombatRole {
     public boolean isReserve() {
         return this == RESERVE;
     }
+
+    /**
+     * Determines if this role is categorized as a combat role.
+     *
+     * <p>A role is considered a combat role if it matches one of the following predefined roles:</p>
+     * <ul>
+     *    <li>{@code FRONTLINE}</li>
+     *    <li>{@code MANEUVER}</li>
+     *    <li>{@code PATROL}</li>
+     * </ul>
+     *
+     * @return {@code true} if this role is one of the combat roles; {@code false} otherwise.
+     */
+    public boolean isCombatRole() {
+        return this == FRONTLINE || this == MANEUVER || this == PATROL;
+    }
     // endregion Boolean Comparison Methods
 
     // region File I/O
+
     /**
      * Parses a {@link String} into a {@link CombatRole} enum value.
      * <p>
-     * This method first attempts to interpret the input string as an integer and then maps it
-     * to the corresponding {@link CombatRole} based on its ordinal index. If that fails, it
-     * attempts to match the string to the name of a {@link CombatRole} using {@code Enum.valueOf(String)}.
-     * If both parsing approaches fail, it logs an error and returns the default value {@code IN_RESERVE}.
+     * This method first attempts to interpret the input string as an integer and then maps it to the corresponding
+     * {@link CombatRole} based on its ordinal index. If that fails, it attempts to match the string to the name of a
+     * {@link CombatRole} using {@code Enum.valueOf(String)}. If both parsing approaches fail, it logs an error and
+     * returns the default value {@code IN_RESERVE}.
      * </p>
      *
-     * @param text the string to be parsed into a {@link CombatRole}.
-     *             The string can represent either:
+     * @param text the string to be parsed into a {@link CombatRole}. The string can represent either:
      *             <ul>
      *               <li>An integer corresponding to the ordinal index of a {@link CombatRole}.</li>
      *               <li>The name of a {@link CombatRole}.</li>
      *             </ul>
-     * @return the corresponding {@link CombatRole} if the input is valid;
-     *         otherwise, returns {@code IN_RESERVE}.
+     *
+     * @return the corresponding {@link CombatRole} if the input is valid; otherwise, returns {@code IN_RESERVE}.
      */
     public static CombatRole parseFromString(final String text) {
         try {
             int value = Integer.parseInt(text);
             return values()[value];
-        } catch (Exception ignored) {}
+        } catch (Exception ignored) {
+        }
 
         try {
             return valueOf(text);
-        } catch (Exception ignored) {}
+        } catch (Exception ignored) {
+        }
 
         // <50.02 compatibility handler
         return switch (text) {
@@ -125,8 +143,7 @@ public enum CombatRole {
             case "IN_RESERVE", "UNASSIGNED" -> RESERVE;
             default -> {
                 MMLogger.create(CombatRole.class)
-                    .warn(String.format("Unable to parse %s into an CombatRole. Returning RESERVE.",
-                        text));
+                      .warn(String.format("Unable to parse %s into an CombatRole. Returning RESERVE.", text));
 
                 yield RESERVE;
             }
@@ -134,10 +151,10 @@ public enum CombatRole {
         };
 
         // To be uncommented once the above compatibility handler is removed.
-//        MMLogger.create(CombatRole.class)
-//            .error("Unable to parse " + text + " into an CombatRole. Returning RESERVE.");
-//
-//        return RESERVE;
+        //        MMLogger.create(CombatRole.class)
+        //            .error("Unable to parse " + text + " into an CombatRole. Returning RESERVE.");
+        //
+        //        return RESERVE;
     }
     // endregion File I/O
 

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -28,6 +28,24 @@
  */
 package mekhq.gui.view;
 
+import static megamek.client.ui.WrapLayout.wordWrap;
+import static mekhq.campaign.mission.enums.CombatRole.FRONTLINE;
+import static mekhq.campaign.mission.enums.CombatRole.MANEUVER;
+import static mekhq.campaign.mission.enums.CombatRole.PATROL;
+import static mekhq.campaign.mission.enums.CombatRole.TRAINING;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import javax.swing.*;
+import javax.swing.RowSorter.SortKey;
+import javax.swing.event.TableModelEvent;
+import javax.swing.event.TableModelListener;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+
 import megamek.client.ui.models.XTableColumnModel;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import mekhq.MekHQ;
@@ -40,27 +58,9 @@ import mekhq.campaign.personnel.SkillType;
 import mekhq.gui.model.DataTableModel;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
 
-import javax.swing.*;
-import javax.swing.RowSorter.SortKey;
-import javax.swing.event.TableModelEvent;
-import javax.swing.event.TableModelListener;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-import java.awt.*;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-
-import static megamek.client.ui.WrapLayout.wordWrap;
-import static mekhq.campaign.mission.enums.CombatRole.FRONTLINE;
-import static mekhq.campaign.mission.enums.CombatRole.MANEUVER;
-import static mekhq.campaign.mission.enums.CombatRole.PATROL;
-import static mekhq.campaign.mission.enums.CombatRole.TRAINING;
-
 /**
- * Against the Bot
- * Shows how many lances are required to be deployed on active contracts and
- * in what roles and allows the player to assign units to those roles.
+ * Against the Bot Shows how many lances are required to be deployed on active contracts and in what roles and allows
+ * the player to assign units to those roles.
  *
  * @author Neoancient
  */
@@ -83,8 +83,7 @@ public class LanceAssignmentView extends JPanel {
         cbContract = new JComboBox<>();
         cbContract.setRenderer(new DefaultListCellRenderer() {
             @Override
-            public Component getListCellRendererComponent(JList<?> list, Object value, int index,
-                                                          boolean isSelected, boolean cellHasFocus) {
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
                 return new JLabel((null == value) ? "None" : ((AtBContract) value).getName());
             }
         });
@@ -93,9 +92,7 @@ public class LanceAssignmentView extends JPanel {
         cbRole.setName("cbRole");
         cbRole.setRenderer(new DefaultListCellRenderer() {
             @Override
-            public Component getListCellRendererComponent(final JList<?> list, final Object value,
-                                                          final int index, final boolean isSelected,
-                                                          final boolean cellHasFocus) {
+            public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index, final boolean isSelected, final boolean cellHasFocus) {
                 super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof CombatRole) {
                     list.setToolTipText(wordWrap(((CombatRole) value).getToolTipText()));
@@ -117,12 +114,10 @@ public class LanceAssignmentView extends JPanel {
             column.setPreferredWidth(rlModel.getColumnWidth(i));
             column.setCellRenderer(new MekHqTableCellRenderer() {
                 @Override
-                public Component getTableCellRendererComponent(JTable table, Object value,
-                                                               boolean isSelected, boolean hasFocus,
-                                                               int row, int column) {
+                public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
                     super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-                    setHorizontalAlignment(((RequiredLancesTableModel) table.getModel()).
-                            getAlignment(table.convertColumnIndexToModel(column)));
+                    setHorizontalAlignment(((RequiredLancesTableModel) table.getModel()).getAlignment(table.convertColumnIndexToModel(
+                          column)));
                     if (table.convertColumnIndexToModel(column) > RequiredLancesTableModel.COL_CONTRACT) {
                         if (((String) value).indexOf('/') >= 0) {
                             setForeground(MekHQ.getMHQOptions().getBelowContractMinimumForeground());
@@ -132,7 +127,7 @@ public class LanceAssignmentView extends JPanel {
                 }
             });
         }
-        TableRowSorter<RequiredLancesTableModel>sorter = new TableRowSorter<>(rlModel);
+        TableRowSorter<RequiredLancesTableModel> sorter = new TableRowSorter<>(rlModel);
         tblRequiredLances.setRowSorter(sorter);
 
         tblRequiredLances.setIntercellSpacing(new Dimension(0, 0));
@@ -148,9 +143,7 @@ public class LanceAssignmentView extends JPanel {
             column.setPreferredWidth(rlModel.getColumnWidth(i));
             column.setCellRenderer(new MekHqTableCellRenderer() {
                 @Override
-                public Component getTableCellRendererComponent(JTable table, Object value,
-                                                               boolean isSelected, boolean hasFocus,
-                                                               int row, int column) {
+                public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
                     switch (column) {
                         case LanceAssignmentTableModel.COL_FORCE:
                             if (null != value) {
@@ -169,7 +162,7 @@ public class LanceAssignmentView extends JPanel {
                             break;
                         default:
                             super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-                   }
+                    }
                     return this;
                 }
             });
@@ -191,13 +184,13 @@ public class LanceAssignmentView extends JPanel {
             }
         };
         final NaturalOrderComparator noc = new NaturalOrderComparator();
-        TableRowSorter<LanceAssignmentTableModel>laSorter = new TableRowSorter<>(laModel);
+        TableRowSorter<LanceAssignmentTableModel> laSorter = new TableRowSorter<>(laModel);
         laSorter.setRowFilter(laFilter);
         laSorter.setComparator(LanceAssignmentTableModel.COL_FORCE, forceComparator);
-        laSorter.setComparator(LanceAssignmentTableModel.COL_CONTRACT, (c1, c2) ->
-                noc.compare(((AtBContract) c1).getName(), ((AtBContract) c2).getName()));
-        laSorter.setComparator(LanceAssignmentTableModel.COL_ROLE, (r1, r2) ->
-                noc.compare(r1.toString(), r2.toString()));
+        laSorter.setComparator(LanceAssignmentTableModel.COL_CONTRACT,
+              (c1, c2) -> noc.compare(((AtBContract) c1).getName(), ((AtBContract) c2).getName()));
+        laSorter.setComparator(LanceAssignmentTableModel.COL_ROLE,
+              (r1, r2) -> noc.compare(r1.toString(), r2.toString()));
         List<SortKey> sortKeys = new ArrayList<>();
         sortKeys.add(new SortKey(LanceAssignmentTableModel.COL_FORCE, SortOrder.ASCENDING));
         sorter.setSortKeys(sortKeys);
@@ -214,12 +207,12 @@ public class LanceAssignmentView extends JPanel {
         add(panRequiredLances);
 
         int cmdrStrategy = 0;
-        if ((campaign.getFlaggedCommander() != null)
-                && (campaign.getFlaggedCommander().getSkill(SkillType.S_STRATEGY) != null)) {
+        if ((campaign.getFlaggedCommander() != null) &&
+                  (campaign.getFlaggedCommander().getSkill(SkillType.S_STRATEGY) != null)) {
             cmdrStrategy = campaign.getFlaggedCommander().getSkill(SkillType.S_STRATEGY).getLevel();
         }
         int maxDeployedLances = campaign.getCampaignOptions().getBaseStrategyDeployment() +
-                campaign.getCampaignOptions().getAdditionalStrategyDeployment() * cmdrStrategy;
+                                      campaign.getCampaignOptions().getAdditionalStrategyDeployment() * cmdrStrategy;
         add(new JLabel("Maximum Deployed Forces: " + maxDeployedLances));
 
         panAssignments = new JPanel();
@@ -241,8 +234,8 @@ public class LanceAssignmentView extends JPanel {
         }
         AtBContract defaultContract = activeContracts.isEmpty() ? null : activeContracts.get(0);
         for (CombatTeam combatTeam : campaign.getCombatTeamsTable().values()) {
-            if ((combatTeam.getContract(campaign) == null)
-                    || !combatTeam.getContract(campaign).isActiveOn(campaign.getLocalDate(), true)) {
+            if ((combatTeam.getContract(campaign) == null) ||
+                      !combatTeam.getContract(campaign).isActiveOn(campaign.getLocalDate(), true)) {
                 combatTeam.setContract(defaultContract);
             }
         }
@@ -307,8 +300,8 @@ class RequiredLancesTableModel extends DataTableModel {
     public RequiredLancesTableModel(final Campaign campaign) {
         this.campaign = campaign;
         data = new ArrayList<AtBContract>();
-        columnNames = new String[]{"Contract", "Total", MANEUVER.toString(), FRONTLINE.toString(),
-            PATROL.toString(), TRAINING.toString()};
+        columnNames = new String[] { "Contract", "Total", MANEUVER.toString(), FRONTLINE.toString(), PATROL.toString(),
+                                     TRAINING.toString() };
     }
 
     @Override
@@ -363,9 +356,13 @@ class RequiredLancesTableModel extends DataTableModel {
             if (column == COL_TOTAL) {
                 int t = 0;
                 for (CombatTeam combatTeam : campaign.getAllCombatTeams()) {
-                    if (data.get(row).equals(combatTeam.getContract(campaign))
-                            && (combatTeam.getRole() != CombatRole.RESERVE)
-                            && combatTeam.isEligible(campaign)) {
+                    AtBContract assignedContract = combatTeam.getContract(campaign);
+                    boolean isCadreDuty = assignedContract.getContractType().isCadreDuty();
+                    CombatRole role = combatTeam.getRole();
+                    boolean isRoleSuitable = (isCadreDuty && role.isTraining()) || role.isCombatRole();
+                    boolean isDeploymentEligible = combatTeam.isEligible(campaign);
+
+                    if ((data.get(row).equals(assignedContract)) && isRoleSuitable && isDeploymentEligible) {
                         t++;
                     }
                 }
@@ -376,9 +373,10 @@ class RequiredLancesTableModel extends DataTableModel {
             } else if (contract.getContractType().getRequiredCombatRole().ordinal() == column - 2) {
                 int t = 0;
                 for (CombatTeam combatTeam : campaign.getAllCombatTeams()) {
-                    if (data.get(row).equals(combatTeam.getContract(campaign))
-                            && (combatTeam.getRole() == combatTeam.getContract(campaign).getContractType().getRequiredCombatRole())
-                            && combatTeam.isEligible(campaign)) {
+                    if (data.get(row).equals(combatTeam.getContract(campaign)) &&
+                              (combatTeam.getRole() ==
+                                     combatTeam.getContract(campaign).getContractType().getRequiredCombatRole()) &&
+                              combatTeam.isEligible(campaign)) {
                         t++;
                     }
                 }
@@ -405,7 +403,7 @@ class LanceAssignmentTableModel extends DataTableModel {
     public LanceAssignmentTableModel(Campaign campaign) {
         this.campaign = campaign;
         data = new ArrayList<>();
-        columnNames = new String[]{"Force", "Weight Class", "Mission", "Role"};
+        columnNames = new String[] { "Force", "Weight Class", "Mission", "Role" };
     }
 
     @Override
@@ -447,7 +445,7 @@ class LanceAssignmentTableModel extends DataTableModel {
 
     @Override
     public Object getValueAt(int row, int column) {
-        final String[] WEIGHT_CODES = {"Ultra-Light", "Light", "Medium", "Heavy", "Assault", "Super Heavy"};
+        final String[] WEIGHT_CODES = { "Ultra-Light", "Light", "Medium", "Heavy", "Assault", "Super Heavy" };
 
         if (row >= getRowCount()) {
             return "";


### PR DESCRIPTION
- Introduced `isCombatRole` method in `CombatRole` enum to classify roles as combat-related (FRONTLINE, MANEUVER, PATROL).
- Updated deployment eligibility logic in `LanceAssignmentView` to account for Cadre Duty contracts and suitable role classification (`isTraining` or `isCombatRole`).

Fix #6434