### PR TITLE
Improved StratCon Fog of War Clarity

### DIFF
--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -27,6 +27,7 @@
  */
 package mekhq.gui;
 
+import static java.awt.Color.BLUE;
 import static mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment.Allied;
 import static mekhq.campaign.stratcon.StratconScenario.ScenarioState.PRIMARY_FORCES_COMMITTED;
 import static mekhq.campaign.stratcon.StratconScenario.ScenarioState.UNRESOLVED;
@@ -345,7 +346,7 @@ public class StratconPanel extends JPanel implements ActionListener {
 
         g2D.setTransform(initialTransform);
         if (clickedPoint != null) {
-            g2D.setColor(Color.BLUE);
+            g2D.setColor(BLUE);
             g2D.drawRect((int) clickedPoint.getX(), (int) clickedPoint.getY(), 2, 2);
         }
     }
@@ -456,7 +457,7 @@ public class StratconPanel extends JPanel implements ActionListener {
                         BufferedImage fogOfWarLayerImage = getImage(StratconBiomeManifest.FOG_OF_WAR,
                                 ImageType.TerrainTile);
                         if (fogOfWarLayerImage != null) {
-                            fogOfWarLayerImage = addTintToBufferedImage(fogOfWarLayerImage, Color.RED);
+                            fogOfWarLayerImage = addTintToBufferedImage(fogOfWarLayerImage, BLUE);
                             g2D.drawImage(fogOfWarLayerImage, null, graphHex.xpoints[1], graphHex.ypoints[0]);
                         }
 

--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -27,20 +27,11 @@
  */
 package mekhq.gui;
 
-import megamek.common.util.ImageUtil;
-import megamek.logging.MMLogger;
-import mekhq.MekHQ;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.force.Force;
-import mekhq.campaign.mission.AtBDynamicScenario;
-import mekhq.campaign.stratcon.*;
-import mekhq.campaign.stratcon.StratconBiomeManifest.ImageType;
-import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
-import mekhq.gui.stratcon.StratconScenarioWizard;
-import mekhq.gui.stratcon.TrackForceAssignmentUI;
+import static mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment.Allied;
+import static mekhq.campaign.stratcon.StratconScenario.ScenarioState.PRIMARY_FORCES_COMMITTED;
+import static mekhq.campaign.stratcon.StratconScenario.ScenarioState.UNRESOLVED;
+import static mekhq.utilities.ImageUtilities.addTintToBufferedImage;
 
-import javax.imageio.ImageIO;
-import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -51,15 +42,36 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import javax.imageio.ImageIO;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JLabel;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
 
-import static mekhq.campaign.mission.ScenarioForceTemplate.ForceAlignment.Allied;
-import static mekhq.campaign.stratcon.StratconScenario.ScenarioState.PRIMARY_FORCES_COMMITTED;
-import static mekhq.campaign.stratcon.StratconScenario.ScenarioState.UNRESOLVED;
+import megamek.common.util.ImageUtil;
+import megamek.logging.MMLogger;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.force.Force;
+import mekhq.campaign.mission.AtBDynamicScenario;
+import mekhq.campaign.stratcon.StratconBiomeManifest;
+import mekhq.campaign.stratcon.StratconBiomeManifest.ImageType;
+import mekhq.campaign.stratcon.StratconCampaignState;
+import mekhq.campaign.stratcon.StratconCoords;
+import mekhq.campaign.stratcon.StratconFacility;
+import mekhq.campaign.stratcon.StratconFacilityFactory;
+import mekhq.campaign.stratcon.StratconRulesManager;
+import mekhq.campaign.stratcon.StratconScenario;
+import mekhq.campaign.stratcon.StratconScenario.ScenarioState;
+import mekhq.campaign.stratcon.StratconTrackState;
+import mekhq.gui.stratcon.StratconScenarioWizard;
+import mekhq.gui.stratcon.TrackForceAssignmentUI;
 
 /**
  * This panel handles AtB-Stratcon GUI interactions with a specific scenario
@@ -444,6 +456,7 @@ public class StratconPanel extends JPanel implements ActionListener {
                         BufferedImage fogOfWarLayerImage = getImage(StratconBiomeManifest.FOG_OF_WAR,
                                 ImageType.TerrainTile);
                         if (fogOfWarLayerImage != null) {
+                            fogOfWarLayerImage = addTintToBufferedImage(fogOfWarLayerImage, Color.RED);
                             g2D.drawImage(fogOfWarLayerImage, null, graphHex.xpoints[1], graphHex.ypoints[0]);
                         }
 

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -27,6 +27,39 @@
  */
 package mekhq.gui.view;
 
+import static java.awt.Color.BLACK;
+import static java.awt.Color.RED;
+import static megamek.client.ui.WrapLayout.wordWrap;
+import static megamek.common.EntityWeightClass.WEIGHT_ULTRA_LIGHT;
+import static mekhq.campaign.personnel.Person.getLoyaltyName;
+import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffectiveFatigue;
+import static mekhq.utilities.ImageUtilities.addTintToImageIcon;
+import static org.jfree.chart.ChartColor.DARK_BLUE;
+import static org.jfree.chart.ChartColor.DARK_RED;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.Dialog.ModalityType;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Image;
+import java.awt.Insets;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
+import javax.accessibility.AccessibleRelation;
+import javax.swing.*;
+import javax.swing.table.TableColumn;
+
 import megamek.codeUtilities.MathUtility;
 import megamek.common.icons.Portrait;
 import megamek.common.options.IOption;
@@ -39,7 +72,11 @@ import mekhq.campaign.Kill;
 import mekhq.campaign.event.PersonChangedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.log.LogEntry;
-import mekhq.campaign.personnel.*;
+import mekhq.campaign.personnel.Award;
+import mekhq.campaign.personnel.Injury;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
+import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.education.Academy;
 import mekhq.campaign.personnel.education.EducationController;
 import mekhq.campaign.personnel.enums.GenderDescriptors;
@@ -55,28 +92,6 @@ import mekhq.gui.model.PersonnelEventLogModel;
 import mekhq.gui.model.PersonnelKillLogModel;
 import mekhq.gui.utilities.MarkdownRenderer;
 import mekhq.gui.utilities.WrapLayout;
-
-import javax.accessibility.AccessibleRelation;
-import javax.swing.*;
-import javax.swing.table.TableColumn;
-import java.awt.*;
-import java.awt.Dialog.ModalityType;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.util.*;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static java.awt.Color.BLACK;
-import static java.awt.Color.RED;
-import static megamek.client.ui.WrapLayout.wordWrap;
-import static megamek.common.EntityWeightClass.WEIGHT_ULTRA_LIGHT;
-import static mekhq.campaign.personnel.Person.getLoyaltyName;
-import static mekhq.utilities.ImageUtilities.addTintToImage;
-import static org.jfree.chart.ChartColor.DARK_BLUE;
-import static org.jfree.chart.ChartColor.DARK_RED;
-import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffectiveFatigue;
 
 /**
  * A custom panel that gets filled in with goodies from a Person record
@@ -599,11 +614,11 @@ public class PersonViewPanel extends JScrollablePanel {
 
         PersonnelStatus status = person.getStatus();
         if (status.isDead()) {
-            portraitImageIcon = addTintToImage(portraitImageIcon.getImage(), DARK_RED);
+            portraitImageIcon = addTintToImageIcon(portraitImageIcon.getImage(), DARK_RED);
         } else if (status.isRetired()) {
-            portraitImageIcon = addTintToImage(portrait.getImage(100), DARK_BLUE);
+            portraitImageIcon = addTintToImageIcon(portrait.getImage(100), DARK_BLUE);
         } else if (status.isDepartedUnit()) {
-            portraitImageIcon = addTintToImage(portrait.getImage(100), BLACK);
+            portraitImageIcon = addTintToImageIcon(portrait.getImage(100), BLACK);
         }
 
         return portraitImageIcon;

--- a/MekHQ/src/mekhq/utilities/ImageUtilities.java
+++ b/MekHQ/src/mekhq/utilities/ImageUtilities.java
@@ -27,14 +27,17 @@
  */
 package mekhq.utilities;
 
+import static java.lang.Math.round;
+
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import javax.swing.ImageIcon;
+
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
-
-import javax.swing.*;
-import java.awt.*;
-import java.awt.image.BufferedImage;
-
-import static java.lang.Math.round;
 
 public class ImageUtilities {
     /**
@@ -88,10 +91,10 @@ public class ImageUtilities {
      *
      * @return an {@link ImageIcon} containing the tinted image.
      *
-     * @see #addTintToImage(Image, Color, boolean, Double) for more advanced configurations.
+     * @see #addTintToImageIcon(Image, Color, boolean, Double) for more advanced configurations.
      */
-    public static ImageIcon addTintToImage(Image image, Color tintColor) {
-        return addTintToImage(image, tintColor, true, null);
+    public static ImageIcon addTintToImageIcon(Image image, Color tintColor) {
+        return addTintToImageIcon(image, tintColor, true, null);
     }
 
     /**
@@ -113,9 +116,9 @@ public class ImageUtilities {
      *
      * @return an {@link ImageIcon} containing the image with the applied tint.
      *
-     * @see #addTintToImage(Image, Color) for default behavior.
+     * @see #addTintToImageIcon(Image, Color) for default behavior.
      */
-    public static ImageIcon addTintToImage(Image image, Color tint, boolean nonTransparentOnly,
+    public static ImageIcon addTintToImageIcon(Image image, Color tint, boolean nonTransparentOnly,
                                            @Nullable Double transparencyPercent) {
         BufferedImage tintedImage = new BufferedImage(
               image.getWidth(null),
@@ -142,6 +145,85 @@ public class ImageUtilities {
         return new ImageIcon(tintedImage);
     }
 
+    /**
+     * Applies a default tint to a {@link BufferedImage} and returns the modified image.
+     *
+     * <p>This method adds a tint overlay of the specified color to the provided {@link BufferedImage}.
+     * By default, the tint is applied only to non-transparent areas, and a transparency level of 50% is used if none is
+     * specified.
+     *
+     * @param image     The {@link BufferedImage} on which the tint will be applied.
+     * @param tintColor The {@link Color} to use as the tint.
+     *
+     * @return A new {@link BufferedImage} containing the original image with the tint applied.
+     *
+     * @see #addTintToBufferedImage(BufferedImage, Color, boolean, Double)
+     */
+    public static BufferedImage addTintToBufferedImage(BufferedImage image, Color tintColor) {
+        return addTintToBufferedImage(image, tintColor, true, null);
+    }
+
+    /**
+     * Applies a tint to a BufferedImage and returns the modified image.
+     *
+     * <p>The method overlays a specified color tint on the original image. You can optionally apply
+     * the tint only to non-transparent areas or specify the transparency level of the tint.
+     *
+     * @param image               The original {@link BufferedImage} to which the tint will be added.
+     * @param tint                The {@link Color} to use as the tint.
+     * @param nonTransparentOnly  If {@code true}, applies the tint only to non-transparent areas.
+     * @param transparencyPercent The transparency level of the tinted overlay (0.0 to 1.0), where {@code 1.0} is fully
+     *                            opaque and {@code 0.0} is fully transparent. If {@code null}, a default of 50%
+     *                            transparency is applied.
+     *
+     * @return A new {@link BufferedImage} with the specified tint applied.
+     */
+    public static BufferedImage addTintToBufferedImage(BufferedImage image, Color tint, boolean nonTransparentOnly, @Nullable Double transparencyPercent) {
+        // Create a new BufferedImage with the same dimensions and type as the original
+        BufferedImage tintedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
+
+        // Draw the original image onto the new BufferedImage
+        Graphics2D graphics = tintedImage.createGraphics();
+        graphics.drawImage(image, 0, 0, null);
+
+        // If applying the tint only to non-transparent areas, set the appropriate composite
+        if (nonTransparentOnly) {
+            graphics.setComposite(AlphaComposite.SrcAtop);
+        }
+
+        // Generate a new color with the specified transparency
+        int alpha = getAlpha(transparencyPercent == null ? 0.5 : transparencyPercent);
+        graphics.setColor(new Color(tint.getRed(), tint.getGreen(), tint.getBlue(), alpha));
+
+        // Apply the tint color to the entire image
+        graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
+
+        // Dispose of the Graphics2D object to free resources
+        graphics.dispose();
+
+        // Return the tinted BufferedImage
+        return tintedImage;
+    }
+
+    /**
+     * Converts a transparency percentage into an alpha value for ARGB colors.
+     *
+     * <p>This method maps a transparency percentage (from {@code 0.0} to {@code 1.0})
+     * to an integer alpha value (from 0 to 255) usable with ARGB colors.</p>
+     * <ul>
+     *     <li>A value of {@code 1.0} (fully opaque) will return {@code 0} for maximum alpha.</li>
+     *     <li>A value of {@code 0.0} (fully transparent) will return {@code 255} for full transparency.</li>
+     * </ul>
+     *
+     * @param transparencyPercent A percentage representing transparency. Must be between {@code 0.0} and {@code 1.0},
+     *                            inclusive.
+     *
+     * @return An integer alpha value ranging from 0 (fully opaque) to 255 (fully transparent), calculated from the
+     *       provided percentage.
+     *
+     * @throws IllegalArgumentException If {@code transparencyPercent} is outside the range of {@code 0.0} to
+     *                                  {@code 1.0}.
+     */
     private static int getAlpha(double transparencyPercent) {
         if (transparencyPercent < 0.0 || transparencyPercent > 1.0) {
             throw new IllegalArgumentException("Transparency percent must be between 0.0 and 1.0.");


### PR DESCRIPTION
- Renamed `addTintToImage` to `addTintToImageIcon` for clarity and added a new `addTintToBufferedImage` method to handle `BufferedImage` tinting.
- Updated `StratconPanel` to use the new tinting methods for better image handling and improved readability.

Fix #4353

### Dev Notes
Earlier in the 50.05 dev cycle I added a couple of utility methods to allow us to very easily tint images. This PR expands it to StratCon so that Sectors are more readable. The original Fog of War was really hard to read sometimes. This should make things much clearer. For our colorblind users the original fog of war texture is still used, so we're not just relying on color.

<img width="370" alt="image" src="https://github.com/user-attachments/assets/22940549-5a85-4a41-901f-970451bce027" />
