### PR TITLE
Enforced Blind Drop Settings in Briefing Room

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/BotForce.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForce.java
@@ -27,13 +27,27 @@
  */
 package mekhq.campaign.mission;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import megamek.Version;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.bot.princess.CardinalEdge;
 import megamek.client.bot.princess.PrincessException;
 import megamek.client.ui.swing.util.PlayerColour;
-import megamek.common.*;
+import megamek.common.Board;
+import megamek.common.Compute;
+import megamek.common.Entity;
+import megamek.common.EntityListFile;
+import megamek.common.IStartingPositions;
+import megamek.common.UnitNameTracker;
 import megamek.common.icons.Camouflage;
 import megamek.logging.MMLogger;
 import mekhq.Utilities;
@@ -44,11 +58,6 @@ import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class BotForce implements IPlayerSettings {
     private static final MMLogger logger = MMLogger.create(BotForce.class);
@@ -87,19 +96,27 @@ public class BotForce implements IPlayerSettings {
     }
 
     public BotForce(String name, int team, int start, List<Entity> entityList) {
-        this(name, team, start, start, entityList,
-                new Camouflage(Camouflage.COLOUR_CAMOUFLAGE, PlayerColour.BLUE.name()),
-                PlayerColour.BLUE);
+        this(name,
+              team,
+              start,
+              start,
+              entityList,
+              new Camouflage(Camouflage.COLOUR_CAMOUFLAGE, PlayerColour.BLUE.name()),
+              PlayerColour.BLUE);
     }
 
     public BotForce(String name, int team, int start, int home, List<Entity> entityList) {
-        this(name, team, start, home, entityList,
-                new Camouflage(Camouflage.COLOUR_CAMOUFLAGE, PlayerColour.BLUE.name()),
-                PlayerColour.BLUE);
+        this(name,
+              team,
+              start,
+              home,
+              entityList,
+              new Camouflage(Camouflage.COLOUR_CAMOUFLAGE, PlayerColour.BLUE.name()),
+              PlayerColour.BLUE);
     }
 
-    public BotForce(String name, int team, int start, int home, List<Entity> entityList,
-            Camouflage camouflage, PlayerColour colour) {
+    public BotForce(String name, int team, int start, int home, List<Entity> entityList, Camouflage camouflage,
+                    PlayerColour colour) {
         this.name = name;
         this.team = team;
         this.startingPos = start;
@@ -351,7 +368,7 @@ public class BotForce implements IPlayerSettings {
         for (Entity entity : getFullEntityList(c)) {
             if (entity == null) {
                 logger.error(
-                        "Null entity when calculating the BV a bot force, we should never find a null here. Please investigate");
+                      "Null entity when calculating the BV a bot force, we should never find a null here. Please investigate");
             } else {
                 bv += entity.calculateBattleValue(true, false);
             }
@@ -365,7 +382,7 @@ public class BotForce implements IPlayerSettings {
         for (Entity entity : getFixedEntityList()) {
             if (entity == null) {
                 logger.error(
-                        "Null entity when calculating the BV a bot force, we should never find a null here. Please investigate");
+                      "Null entity when calculating the BV a bot force, we should never find a null here. Please investigate");
             } else {
                 bv += entity.calculateBattleValue(true, false);
             }
@@ -447,11 +464,11 @@ public class BotForce implements IPlayerSettings {
     }
 
     /**
-     * Checks to see if a given unit has a crew member among the traitor personnel
-     * IDs. This is used
-     * primarily to determine if a unit can be deployed to a scenario.
+     * Checks to see if a given unit has a crew member among the traitor personnel IDs. This is used primarily to
+     * determine if a unit can be deployed to a scenario.
      *
      * @param unit
+     *
      * @return a boolean indicating whether this unit is a traitor
      */
     public boolean isTraitor(Unit unit) {
@@ -466,12 +483,18 @@ public class BotForce implements IPlayerSettings {
     public BotForceStub generateStub(Campaign c) {
         List<String> stubs = Utilities.generateEntityStub(getFullEntityList(c));
         return new BotForceStub("<html>" +
-                getName() + " <i>" +
-                ((getTeam() == 1) ? "Allied" : "Enemy") + "</i>" +
-                " Start: " + IStartingPositions.START_LOCATION_NAMES[getStartingPos()] +
-                " BV: " + getTotalBV(c) +
-                ((null == getBotForceRandomizer()) ? "" : "<br>Random: " + getBotForceRandomizer().getDescription(c)) +
-                "</html>", stubs);
+                                      getName() +
+                                      " <i>" +
+                                      ((getTeam() == 1) ? "Allied" : "Enemy") +
+                                      "</i>" +
+                                      " Start: " +
+                                      IStartingPositions.START_LOCATION_NAMES[getStartingPos()] +
+                                      " BV: " +
+                                      getTotalBV(c) +
+                                      ((null == getBotForceRandomizer()) ?
+                                             "" :
+                                             "<br>Random: " + getBotForceRandomizer().getDescription(c)) +
+                                      "</html>", stubs, getTeam());
     }
 
     public void writeToXML(final PrintWriter pw, int indent) {
@@ -507,8 +530,10 @@ public class BotForce implements IPlayerSettings {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "behaviorSettings");
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "forcedWithdrawal", behaviorSettings.isForcedWithdrawal());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "autoFlee", behaviorSettings.shouldAutoFlee());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "selfPreservationIndex",
-                behaviorSettings.getSelfPreservationIndex());
+        MHQXMLUtility.writeSimpleXMLTag(pw,
+              indent,
+              "selfPreservationIndex",
+              behaviorSettings.getSelfPreservationIndex());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "fallShameIndex", behaviorSettings.getFallShameIndex());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "hyperAggressionIndex", behaviorSettings.getHyperAggressionIndex());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "destinationEdge", behaviorSettings.getDestinationEdge().ordinal());
@@ -551,8 +576,9 @@ public class BotForce implements IPlayerSettings {
                 } else if (wn2.getNodeName().equalsIgnoreCase("traitor")) {
                     traitors.add(UUID.fromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("botForceRandomizer")) {
-                    BotForceRandomizer bfRandomizer = BotForceRandomizer.generateInstanceFromXML(wn2, campaign,
-                            version);
+                    BotForceRandomizer bfRandomizer = BotForceRandomizer.generateInstanceFromXML(wn2,
+                          campaign,
+                          version);
                     setBotForceRandomizer(bfRandomizer);
                 } else if (wn2.getNodeName().equalsIgnoreCase("entities")) {
                     NodeList nl2 = wn2.getChildNodes();

--- a/MekHQ/src/mekhq/campaign/mission/BotForceStub.java
+++ b/MekHQ/src/mekhq/campaign/mission/BotForceStub.java
@@ -32,14 +32,20 @@ import java.util.List;
 public class BotForceStub {
     private String name;
     private List<String> entityList;
+    private int team;
 
-    public BotForceStub(String name, List<String> entityList) {
+    public BotForceStub(String name, List<String> entityList, int team) {
         this.name = name;
         this.entityList = entityList;
+        this.team = team;
     }
 
     public String getName() {
         return name;
+    }
+
+    public int getTeam() {
+        return team;
     }
 
     public List<String> getEntityList() {

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -28,13 +28,30 @@
  */
 package mekhq.campaign.mission;
 
+import java.io.PrintWriter;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.Vector;
+
 import megamek.Version;
 import megamek.client.ui.swing.lobby.LobbyUtility;
 import megamek.common.Board;
 import megamek.common.Entity;
 import megamek.common.MapSettings;
 import megamek.common.annotations.Nullable;
-import megamek.common.planetaryconditions.*;
+import megamek.common.planetaryconditions.Atmosphere;
+import megamek.common.planetaryconditions.BlowingSand;
+import megamek.common.planetaryconditions.EMI;
+import megamek.common.planetaryconditions.Fog;
+import megamek.common.planetaryconditions.Light;
+import megamek.common.planetaryconditions.PlanetaryConditions;
+import megamek.common.planetaryconditions.Weather;
+import megamek.common.planetaryconditions.Wind;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -50,11 +67,6 @@ import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import java.io.PrintWriter;
-import java.text.ParseException;
-import java.time.LocalDate;
-import java.util.*;
 
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
@@ -513,9 +525,8 @@ public class Scenario implements IPlayerSettings {
     }
 
     /**
-     * Read the values from a PlanetaryConditions object into the Scenario variables
-     * for planetary conditions.
-     * This is necessary because MekHQ has XML and MegaMek doesn't.
+     * Read the values from a PlanetaryConditions object into the Scenario variables for planetary conditions. This is
+     * necessary because MekHQ has XML and MegaMek doesn't.
      *
      * @param planetaryConditions A PlanetaryConditions object
      */
@@ -720,11 +731,11 @@ public class Scenario implements IPlayerSettings {
     }
 
     /**
-     * Get a List of all traitor Units in this scenario. This function just combines
-     * the results from
+     * Get a List of all traitor Units in this scenario. This function just combines the results from
      * BotForce#getTraitorUnits across all BotForces.
      *
      * @param c - A Campaign pointer
+     *
      * @return a List of traitor Units
      */
     public List<Unit> getTraitorUnits(Campaign c) {
@@ -736,15 +747,13 @@ public class Scenario implements IPlayerSettings {
     }
 
     /**
-     * Tests whether a given entity is a traitor in this Scenario by checking
-     * external id values. This should
-     * also be usable against entities that are ejected pilots from the original
-     * traitor entity.
+     * Tests whether a given entity is a traitor in this Scenario by checking external id values. This should also be
+     * usable against entities that are ejected pilots from the original traitor entity.
      *
      * @param en a MegaMek Entity
      * @param c  a Campaign pointer
-     * @return a boolean indicating whether this entity is a traitor in this
-     *         Scenario.
+     *
+     * @return a boolean indicating whether this entity is a traitor in this Scenario.
      */
     public boolean isTraitor(Entity en, Campaign c) {
         if ("-1".equals(en.getExternalIdAsString())) {
@@ -758,15 +767,16 @@ public class Scenario implements IPlayerSettings {
         }
         // also make sure that the crew's external id does not match a traitor in
         // case of ejected pilots
-        return (null != en.getCrew())
-            && !"-1".equals(en.getCrew().getExternalIdAsString())
-            && isTraitor(UUID.fromString(en.getCrew().getExternalIdAsString()));
+        return (null != en.getCrew()) &&
+                     !"-1".equals(en.getCrew().getExternalIdAsString()) &&
+                     isTraitor(UUID.fromString(en.getCrew().getExternalIdAsString()));
     }
 
     /**
      * Given a Person's id, is that person a traitor in this Scenario
      *
      * @param personId - a UUID giving a person's id in the campaign
+     *
      * @return a boolean indicating if this person is a traitor in the Scenario
      */
     public boolean isTraitor(UUID personId) {
@@ -787,14 +797,13 @@ public class Scenario implements IPlayerSettings {
     }
 
     /**
-     * Determines whether a unit is eligible to deploy to the scenario. If a
-     * ScenarioDeploymentLimit is present
-     * the unit type will be checked to make sure it is valid. The function also
-     * checks to see if the unit is
-     * a traitor unit which will disallow deployment.
+     * Determines whether a unit is eligible to deploy to the scenario. If a ScenarioDeploymentLimit is present the unit
+     * type will be checked to make sure it is valid. The function also checks to see if the unit is a traitor unit
+     * which will disallow deployment.
      *
      * @param unit     - The Unit to be deployed
      * @param campaign - a pointer to the Campaign
+     *
      * @return true if the unit is eligible, otherwise false
      */
     public boolean canDeploy(Unit unit, Campaign campaign) {
@@ -816,6 +825,7 @@ public class Scenario implements IPlayerSettings {
      *
      * @param units    - a Vector made up of Units to be deployed
      * @param campaign - a pointer to the Campaign
+     *
      * @return true if all units in the list are eligible, otherwise false
      */
     public boolean canDeployUnits(Vector<Unit> units, Campaign campaign) {
@@ -829,7 +839,8 @@ public class Scenario implements IPlayerSettings {
             }
         }
         if (null != deploymentLimit) {
-            return (deploymentLimit.getCurrentQuantity(this, campaign) + additionalQuantity) <= deploymentLimit.getQuantityCap(campaign);
+            return (deploymentLimit.getCurrentQuantity(this, campaign) + additionalQuantity) <=
+                         deploymentLimit.getQuantityCap(campaign);
         }
         return true;
     }
@@ -839,8 +850,8 @@ public class Scenario implements IPlayerSettings {
      *
      * @param forces list of forces
      * @param c      the campaign that the forces are part of
-     * @return true if all units in all forces in the list are eligible, otherwise
-     *         false
+     *
+     * @return true if all units in all forces in the list are eligible, otherwise false
      */
     public boolean canDeployForces(Vector<Force> forces, Campaign c) {
         int additionalQuantity = 0;
@@ -856,7 +867,8 @@ public class Scenario implements IPlayerSettings {
             }
         }
         if (null != deploymentLimit) {
-            return (deploymentLimit.getCurrentQuantity(this, c) + additionalQuantity) <= deploymentLimit.getQuantityCap(c);
+            return (deploymentLimit.getCurrentQuantity(this, c) + additionalQuantity) <=
+                         deploymentLimit.getQuantityCap(c);
         }
         return true;
     }
@@ -981,7 +993,7 @@ public class Scenario implements IPlayerSettings {
     }
 
     protected void loadFieldsFromXmlNode(final Node wn, final Version version, final Campaign campaign)
-            throws ParseException {
+          throws ParseException {
         // Do nothing
     }
 
@@ -1078,7 +1090,10 @@ public class Scenario implements IPlayerSettings {
                 } else if (wn2.getNodeName().equalsIgnoreCase("botForceStub")) {
                     String name = MHQXMLUtility.unEscape(wn2.getAttributes().getNamedItem("name").getTextContent());
                     List<String> stub = getEntityStub(wn2);
-                    retVal.botForcesStubs.add(new BotForceStub(name, stub));
+                    int team = Integer.parseInt(MHQXMLUtility.unEscape(wn2.getAttributes()
+                                                                             .getNamedItem("team")
+                                                                             .getTextContent()));
+                    retVal.botForcesStubs.add(new BotForceStub(name, stub, team));
                 } else if (wn2.getNodeName().equalsIgnoreCase("botForce")) {
                     BotForce bf = new BotForce();
                     try {
@@ -1105,8 +1120,8 @@ public class Scenario implements IPlayerSettings {
                     retVal.mapSizeY = Integer.parseInt(xy[1]);
                 } else if (wn2.getNodeName().equalsIgnoreCase("map")) {
                     retVal.map = wn2.getTextContent().trim();
-                } else if (wn2.getNodeName().equalsIgnoreCase("start")
-                        || wn2.getNodeName().equalsIgnoreCase("startingPos")) {
+                } else if (wn2.getNodeName().equalsIgnoreCase("start") ||
+                                 wn2.getNodeName().equalsIgnoreCase("startingPos")) {
                     retVal.startingPos = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("startOffset")) {
                     retVal.startOffset = Integer.parseInt(wn2.getTextContent());
@@ -1138,8 +1153,9 @@ public class Scenario implements IPlayerSettings {
                     EMI emi = Boolean.parseBoolean(wn2.getTextContent()) ? EMI.EMI : EMI.EMI_NONE;
                     retVal.emi = emi;
                 } else if (wn2.getNodeName().equalsIgnoreCase("blowingSand")) {
-                    BlowingSand blowingSand = Boolean.parseBoolean(wn2.getTextContent()) ? BlowingSand.BLOWING_SAND
-                            : BlowingSand.BLOWING_SAND_NONE;
+                    BlowingSand blowingSand = Boolean.parseBoolean(wn2.getTextContent()) ?
+                                                    BlowingSand.BLOWING_SAND :
+                                                    BlowingSand.BLOWING_SAND_NONE;
                     retVal.blowingSand = blowingSand;
                 } else if (wn2.getNodeName().equalsIgnoreCase("shiftWindDirection")) {
                     retVal.shiftWindDirection = Boolean.parseBoolean(wn2.getTextContent());
@@ -1184,8 +1200,9 @@ public class Scenario implements IPlayerSettings {
     }
 
     public boolean isFriendlyUnit(Entity entity, Campaign campaign) {
-        return getForces(campaign).getUnits().stream()
-                .anyMatch(unitID -> unitID.equals(UUID.fromString(entity.getExternalIdAsString())));
+        return getForces(campaign).getUnits()
+                     .stream()
+                     .anyMatch(unitID -> unitID.equals(UUID.fromString(entity.getExternalIdAsString())));
     }
 
     public boolean getHasTrack() {

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -1039,6 +1039,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
         }
 
         private void maybeShowPopup(MouseEvent e) {
+            final boolean isBlindDrop = campaign.getGameOptions().getOption("blind_drop").booleanValue();
             final JPopupMenu popup = new JPopupMenu();
             if (e.isPopupTrigger()) {
                 final TreePath path = tree.getPathForLocation(e.getX(), e.getY());
@@ -1049,7 +1050,8 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
                 JMenuItem menuItem;
                 if ((path.getPathCount() > 1) &&
                           (tree.getSelectionRows() != null) &&
-                          (tree.getSelectionRows()[0] != 0)) {
+                          (tree.getSelectionRows()[0] != 0) &&
+                          !isBlindDrop) {
                     menuItem = new JMenuItem("Edit Unit...");
                     menuItem.setActionCommand("EDIT_UNIT");
                     menuItem.addActionListener(this);

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -28,8 +28,34 @@
  */
 package mekhq.gui.view;
 
+import static megamek.common.Entity.getEntityMajorTypeName;
+
+import java.awt.Component;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemListener;
+import java.awt.event.MouseEvent;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.UUID;
+import java.util.Vector;
+import javax.swing.*;
+import javax.swing.event.MouseInputAdapter;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreePath;
+import javax.swing.tree.TreeSelectionModel;
+
 import megamek.client.ui.dialogs.BotConfigDialog;
 import megamek.client.ui.swing.UnitEditorDialog;
+import megamek.common.Entity;
 import megamek.common.IStartingPositions;
 import megamek.common.annotations.Nullable;
 import megamek.common.planetaryconditions.Atmosphere;
@@ -40,21 +66,14 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.force.ForceStub;
 import mekhq.campaign.force.UnitStub;
-import mekhq.campaign.mission.*;
+import mekhq.campaign.mission.AtBDynamicScenario;
+import mekhq.campaign.mission.AtBScenario;
+import mekhq.campaign.mission.BotForceStub;
+import mekhq.campaign.mission.Loot;
+import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.mission.ScenarioForceTemplate;
+import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.gui.baseComponents.JScrollablePanel;
-
-import javax.swing.*;
-import javax.swing.event.MouseInputAdapter;
-import javax.swing.event.TreeModelListener;
-import javax.swing.tree.*;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.ItemListener;
-import java.awt.event.MouseEvent;
-import java.text.DecimalFormat;
-import java.util.List;
-import java.util.*;
 
 /**
  * @author Neoancient
@@ -177,9 +196,8 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
         txtReport.setEditable(false);
         txtReport.setLineWrap(true);
         txtReport.setWrapStyleWord(true);
-        txtReport.setBorder(BorderFactory.createCompoundBorder(
-                BorderFactory.createTitledBorder("After-Action Report"),
-                BorderFactory.createEmptyBorder(5,5,5,5)));
+        txtReport.setBorder(BorderFactory.createCompoundBorder(BorderFactory.createTitledBorder("After-Action Report"),
+              BorderFactory.createEmptyBorder(5, 5, 5, 5)));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = y++;
@@ -193,7 +211,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
     private void fillStats() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ScenarioViewPanel",
-                MekHQ.getMHQOptions().getLocale());
+              MekHQ.getMHQOptions().getLocale());
         lblStatus = new JLabel();
 
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
@@ -253,14 +271,44 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
             panStats.add(tree, gridBagConstraints);
         }
 
+        boolean isBlindDrop = campaign.getGameOptions().getOption("blind_drop").booleanValue();
+        boolean isTrueBlindDrop = campaign.getGameOptions().getOption("real_blind_drop").booleanValue();
+
         for (int i = 0; i < botStubs.size(); i++) {
-            if (null == botStubs.get(i)) {
+            BotForceStub botStub = botStubs.get(i);
+            if (botStub == null) {
                 continue;
             }
 
-            DefaultMutableTreeNode top = new DefaultMutableTreeNode(botStubs.get(i).getName());
-            for (String en : botStubs.get(i).getEntityList()) {
-                top.add(new DefaultMutableTreeNode(en));
+            int team = botStub.getTeam();
+            DefaultMutableTreeNode top = new DefaultMutableTreeNode(botStub.getName());
+            List<String> allEntries = botStub.getEntityList();
+            for (String entry : allEntries) {
+                if ((team != 1) && isTrueBlindDrop) {
+                    continue;
+                }
+
+                if ((team != 1) && isBlindDrop) {
+                    int unitIndex = allEntries.indexOf(entry);
+                    Entity entity = scenario.getBotForce(i).getFullEntityList(campaign).get(unitIndex);
+
+                    if (entity == null) {
+                        String label = "???";
+                        top.add(new DefaultMutableTreeNode(label));
+                        continue;
+                    }
+
+                    String weightClass = entity.getWeightClassName();
+                    long entityType = entity.getEntityType();
+                    String unitType = getEntityMajorTypeName(entityType);
+
+                    String label = weightClass + ' ' + unitType;
+                    top.add(new DefaultMutableTreeNode(label));
+                    continue;
+                }
+
+                top.add(new DefaultMutableTreeNode(entry));
+
             }
             JTree tree = new JTree(top);
             tree.collapsePath(new TreePath(top));
@@ -315,7 +363,8 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
                 for (int forceID : scenario.getForceIDs()) {
                     forceBuilder.append(campaign.getForce(forceID).getFullName());
                     forceBuilder.append("<br/>");
-                    ScenarioForceTemplate template = ((AtBDynamicScenario) scenario).getPlayerForceTemplates().get(forceID);
+                    ScenarioForceTemplate template = ((AtBDynamicScenario) scenario).getPlayerForceTemplates()
+                                                           .get(forceID);
                     if (template != null && template.getActualDeploymentZone() >= 0) {
                         forceBuilder.append("Deploy: ");
                         forceBuilder.append(IStartingPositions.START_LOCATION_NAMES[template.getActualDeploymentZone()]);
@@ -360,8 +409,9 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
         if (scenario.getStatus().isCurrent()) {
             btnReroll = new JButton(scenario.getRerollsRemaining() +
-                    " Reroll" + ((scenario.getRerollsRemaining() == 1)?"":"s") +
-                    " Remaining");
+                                          " Reroll" +
+                                          ((scenario.getRerollsRemaining() == 1) ? "" : "s") +
+                                          " Remaining");
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = y++;
             gridBagConstraints.gridwidth = 1;
@@ -475,9 +525,11 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
     /**
      * Worker function that generates UI elements appropriate for planet-side scenarios
+     *
      * @param gridBagConstraints Current grid bag constraints in use
-     * @param resourceMap Text resource
-     * @param y current row in the parent UI element
+     * @param resourceMap        Text resource
+     * @param y                  current row in the parent UI element
+     *
      * @return the row at which we wind up after doing all this
      */
     private int fillPlanetSideStats(GridBagConstraints gridBagConstraints, ResourceBundle resourceMap, int y) {
@@ -702,9 +754,11 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
     /**
      * Worker function that generates UI elements appropriate for space scenarios
+     *
      * @param gridBagConstraints Current grid bag constraints in use
-     * @param resourceMap Text resource
-     * @param y current row in the parent UI element
+     * @param resourceMap        Text resource
+     * @param y                  current row in the parent UI element
+     *
      * @return the row at which we wind up after doing all this
      */
     private int fillSpaceStats(GridBagConstraints gridBagConstraints, ResourceBundle resourceMap, int y) {
@@ -745,9 +799,11 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
     /**
      * Worker function that generates UI elements appropriate for low atmosphere scenarios
+     *
      * @param gridBagConstraints Current grid bag constraints in use
-     * @param resourceMap Text resource
-     * @param y current row in the parent UI element
+     * @param resourceMap        Text resource
+     * @param y                  current row in the parent UI element
+     *
      * @return the row at which we wind up after doing all this
      */
     private int fillLowAtmoStats(GridBagConstraints gridBagConstraints, ResourceBundle resourceMap, int y) {
@@ -802,8 +858,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
          */
         for (int i = 0; i < REROLL_NUM; i++) {
             if (chkReroll[i] != null) {
-                chkReroll[i].setEnabled(checkedBoxes < scenario.getRerollsRemaining() ||
-                        chkReroll[i].isSelected());
+                chkReroll[i].setEnabled(checkedBoxes < scenario.getRerollsRemaining() || chkReroll[i].isSelected());
             }
         }
     }
@@ -853,8 +908,9 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
             lblEMIDesc.setText(emiDesc);
         }
         btnReroll.setText(scenario.getRerollsRemaining() +
-                " Reroll" + ((scenario.getRerollsRemaining() == 1)?"":"s") +
-                " Remaining");
+                                " Reroll" +
+                                ((scenario.getRerollsRemaining() == 1) ? "" : "s") +
+                                " Remaining");
         btnReroll.setEnabled(scenario.getRerollsRemaining() > 0);
         countRerollBoxes();
     }
@@ -889,8 +945,8 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
         @Override
         public boolean isLeaf(final @Nullable Object node) {
-            return (node instanceof UnitStub)
-                    || ((node instanceof ForceStub) && ((ForceStub) node).getAllChildren().isEmpty());
+            return (node instanceof UnitStub) ||
+                         ((node instanceof ForceStub) && ((ForceStub) node).getAllChildren().isEmpty());
         }
 
         @Override
@@ -919,9 +975,8 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
         }
 
         @Override
-        public Component getTreeCellRendererComponent(final JTree tree, final Object value,
-                                                      final boolean selected, final boolean expanded,
-                                                      final boolean leaf, final int row,
+        public Component getTreeCellRendererComponent(final JTree tree, final Object value, final boolean selected,
+                                                      final boolean expanded, final boolean leaf, final int row,
                                                       final boolean hasFocus) {
             super.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, hasFocus);
             setIcon(getIcon(value));
@@ -954,9 +1009,9 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
 
             if (command.equalsIgnoreCase("CONFIG_BOT")) {
                 BotConfigDialog pbd = new BotConfigDialog(frame,
-                        null,
-                        scenario.getBotForce(forceIndex).getBehaviorSettings(),
-                        null);
+                      null,
+                      scenario.getBotForce(forceIndex).getBehaviorSettings(),
+                      null);
                 pbd.setBotName(scenario.getBotForce(forceIndex).getName());
                 pbd.setVisible(true);
                 if (!pbd.getResult().isCancelled()) {
@@ -967,7 +1022,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
                 if ((tree.getSelectionCount() > 0) && (tree.getSelectionRows() != null)) {
                     int unitIndex = tree.getSelectionRows()[0] - 1;
                     UnitEditorDialog editorDialog = new UnitEditorDialog(frame,
-                            scenario.getBotForce(this.forceIndex).getFullEntityList(campaign).get(unitIndex));
+                          scenario.getBotForce(this.forceIndex).getFullEntityList(campaign).get(unitIndex));
                     editorDialog.setVisible(true);
                 }
             }
@@ -992,8 +1047,9 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
                 }
 
                 JMenuItem menuItem;
-                if ((path.getPathCount() > 1) && (tree.getSelectionRows() != null)
-                    && (tree.getSelectionRows()[0] != 0)) {
+                if ((path.getPathCount() > 1) &&
+                          (tree.getSelectionRows() != null) &&
+                          (tree.getSelectionRows()[0] != 0)) {
                     menuItem = new JMenuItem("Edit Unit...");
                     menuItem.setActionCommand("EDIT_UNIT");
                     menuItem.addActionListener(this);


### PR DESCRIPTION
- Added `team` property to `BotForceStub` to support differentiated teams for scenarios.
- Refactored blind drop handling in `AtBScenarioViewPanel` to improve unit representation under specific conditions.

### Dev Notes
Now players using Blind Drop will not be able to peep at the enemy forces prior to dropping.

#### Blind Drop
If vanilla Blind Drop is enabled the OpFor forces will have their weight and type classes visible.

Players are also prevented from editing those units - so they can't gain extra information that way, instead.

Unfortunately, this removes the ability for the player to edit the damage of allied units. This was an all or nothing deal, I'm afraid. Players can still edit those units in the MegaMek lobby, however.

<img width="480" alt="image" src="https://github.com/user-attachments/assets/4fd3fb51-5ccc-423f-98e9-434e05d2a721" />

#### Real Blind Drop
If Real Blind Drop is enabled only the title bar of the OpFor will be visible, not the individual units.

In the below screenshot the hostile force title bars cannot be expanded.
<img width="511" alt="image" src="https://github.com/user-attachments/assets/b0125319-817a-4664-a593-aef02ad81183" />
