### PR TITLE
Refactored Command Rights Calculation For Contracts

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
@@ -27,6 +27,20 @@
  */
 package mekhq.campaign.market.contractMarket;
 
+import static java.lang.Math.min;
+import static megamek.common.Compute.d6;
+import static megamek.common.enums.SkillLevel.REGULAR;
+import static megamek.common.enums.SkillLevel.VETERAN;
+import static mekhq.campaign.force.CombatTeam.getStandardForceSize;
+import static mekhq.campaign.mission.AtBContract.getEffectiveNumUnits;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
 import megamek.Version;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.enums.SkillLevel;
@@ -47,19 +61,9 @@ import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import java.io.PrintWriter;
-import java.util.*;
-
-import static java.lang.Math.min;
-import static megamek.common.Compute.d6;
-import static megamek.common.enums.SkillLevel.REGULAR;
-import static megamek.common.enums.SkillLevel.VETERAN;
-import static mekhq.campaign.force.CombatTeam.getStandardForceSize;
-import static mekhq.campaign.mission.AtBContract.getEffectiveNumUnits;
-
 /**
- * Abstract base class for various Contract Market types in AtB/Stratcon. Responsible for generation
- * and initialization of AtBContracts.
+ * Abstract base class for various Contract Market types in AtB/Stratcon. Responsible for generation and initialization
+ * of AtBContracts.
  */
 public abstract class AbstractContractMarket {
     public static final int CLAUSE_COMMAND = 0;
@@ -68,9 +72,15 @@ public abstract class AbstractContractMarket {
     public static final int CLAUSE_TRANSPORT = 3;
     public static final int CLAUSE_NUM = 4;
 
+    // Command Rights thresholds
+    private static final int MERCENARY_THRESHOLD_INTEGRATED = 3;
+    private static final int MERCENARY_THRESHOLD_HOUSE = 8;
+    private static final int MERCENARY_THRESHOLD_LIAISON = 12;
+    private static final int NON_MERCENARY_THRESHOLD = 12;
+
     /**
-     * The portion of combat teams we expect to be performing combat actions.
-     * This is one in 'x' where 'x' is the value set here.
+     * The portion of combat teams we expect to be performing combat actions. This is one in 'x' where 'x' is the value
+     * set here.
      */
     static final double COMBAT_FORCE_DIVIDER = 2;
 
@@ -95,8 +105,7 @@ public abstract class AbstractContractMarket {
     protected HashMap<Integer, Integer> followupContracts = new HashMap<>();
 
     /**
-     * An arbitrary maximum number of attempts to find a random employer faction that
-     * is not a Mercenary.
+     * An arbitrary maximum number of attempts to find a random employer faction that is not a Mercenary.
      */
     protected static final int MAXIMUM_ATTEMPTS_TO_FIND_NON_MERC_EMPLOYER = 20;
 
@@ -106,21 +115,23 @@ public abstract class AbstractContractMarket {
 
     /**
      * Generate a new contract and add it to the market.
+     *
      * @param campaign
+     *
      * @return The newly generated contract
      */
     public abstract AtBContract addAtBContract(Campaign campaign);
 
     /**
      * Generate available contract offers for the player's force.
+     *
      * @param campaign
      * @param newCampaign Boolean indicating whether this is a fresh campaign.
      */
     public abstract void generateContractOffers(Campaign campaign, boolean newCampaign);
 
     /**
-     * Generate followup contracts and add them to the market if the currently selected market type
-     * supports them.
+     * Generate followup contracts and add them to the market if the currently selected market type supports them.
      *
      * @param campaign The current campaign.
      * @param contract The AtBContract being completed and used as a basis for followup missions
@@ -128,10 +139,12 @@ public abstract class AbstractContractMarket {
     public abstract void checkForFollowup(Campaign campaign, AtBContract contract);
 
     /**
-     * Calculate the total payment modifier for the contract based on the configured market method
-     * (e.g., CAM_OPS, ATB_MONTHLY).
+     * Calculate the total payment modifier for the contract based on the configured market method (e.g., CAM_OPS,
+     * ATB_MONTHLY).
+     *
      * @param campaign
      * @param contract
+     *
      * @return a double representing the total payment multiplier.
      */
     public abstract double calculatePaymentMultiplier(Campaign campaign, AtBContract contract);
@@ -141,7 +154,6 @@ public abstract class AbstractContractMarket {
     }
 
     /**
-     *
      * @return the Method (e.g., CAM_OPS, ATB_MONTHLY) associated with the Contract Market instance
      */
     public ContractMarketMethod getMethod() {
@@ -150,6 +162,7 @@ public abstract class AbstractContractMarket {
 
     /**
      * Empty an available contract from the market.
+     *
      * @param c contract to remove
      */
     public void removeContract(Contract c) {
@@ -160,25 +173,28 @@ public abstract class AbstractContractMarket {
     }
 
     /**
-     * Rerolls a specific clause in a contract, typically as part of a negotiation process.
-     * This method adjusts the clause based on the provided clause type and associated modifiers,
-     * ensuring the contract reflects updated terms.
+     * Rerolls a specific clause in a contract, typically as part of a negotiation process. This method adjusts the
+     * clause based on the provided clause type and associated modifiers, ensuring the contract reflects updated terms.
      *
      * <p>The recalculated clause values can affect aspects such as command, salvage, transport,
-     * or support terms. Special rules, such as overrides for Clan technology salvage, may also be
-     * applied when rerolling specific clauses.
+     * or support terms. Special rules, such as overrides for Clan technology salvage, may also be applied when
+     * rerolling specific clauses.
      *
      * @param contract the contract being negotiated, which will have its terms modified
-     * @param clause the type of clause to be rerolled (e.g., command, salvage, transport, or support)
+     * @param clause   the type of clause to be rerolled (e.g., command, salvage, transport, or support)
      * @param campaign the active campaign context, used to access campaign-specific options and rules
      */
     public void rerollClause(AtBContract contract, int clause, Campaign campaign) {
+        final Faction faction = campaign.getFaction();
+        final boolean isMercenary = faction.isMercenary();
         if (null != clauseMods.get(contract.getId())) {
             switch (clause) {
-                case CLAUSE_COMMAND -> rollCommandClause(contract, clauseMods.get(contract.getId()).mods[clause]);
+                case CLAUSE_COMMAND ->
+                      rollCommandClause(contract, clauseMods.get(contract.getId()).mods[clause], isMercenary);
                 case CLAUSE_SALVAGE -> {
-                    rollSalvageClause(contract, clauseMods.get(contract.getId()).mods[clause],
-                        campaign.getCampaignOptions().getContractMaxSalvagePercentage());
+                    rollSalvageClause(contract,
+                          clauseMods.get(contract.getId()).mods[clause],
+                          campaign.getCampaignOptions().getContractMaxSalvagePercentage());
 
                     contract.clanTechSalvageOverride();
                 }
@@ -192,8 +208,10 @@ public abstract class AbstractContractMarket {
 
     /**
      * Returns the number of rerolls used so far for a specific clause.
+     *
      * @param c
      * @param clause ID representing the type of clause.
+     *
      * @return
      */
     public int getRerollsUsed(Contract c, int clause) {
@@ -212,6 +230,7 @@ public abstract class AbstractContractMarket {
 
     /**
      * Empties the market and generates a new batch of contract offers for an existing campaign.
+     *
      * @param campaign
      */
     public void generateContractOffers(Campaign campaign) {
@@ -225,8 +244,8 @@ public abstract class AbstractContractMarket {
     }
 
     /**
-     * Calculates the required number of combat teams for a contract based on campaign options,
-     * contract details, and variance factors.
+     * Calculates the required number of combat teams for a contract based on campaign options, contract details, and
+     * variance factors.
      *
      * <p>
      * This method determines the number of combat teams needed to deploy, taking into account factors such as:
@@ -240,9 +259,10 @@ public abstract class AbstractContractMarket {
      * The method ensures values are clamped to maintain a minimum deployment of at least 1 combat
      * team while not exceeding the maximum deployable combat teams.
      *
-     * @param campaign        the campaign containing relevant options and faction information
-     * @param contract        the contract that specifies details such as subcontract status
-     * @param bypassVariance  a flag indicating whether variance adjustments should be bypassed
+     * @param campaign       the campaign containing relevant options and faction information
+     * @param contract       the contract that specifies details such as subcontract status
+     * @param bypassVariance a flag indicating whether variance adjustments should be bypassed
+     *
      * @return the calculated number of required combat teams, ensuring it meets game rules and constraints
      */
     public int calculateRequiredCombatTeams(Campaign campaign, AtBContract contract, boolean bypassVariance) {
@@ -290,8 +310,8 @@ public abstract class AbstractContractMarket {
      * Calculates the variance factor based on the given roll value and a fixed formation size divisor.
      *
      * <p>
-     * The variance factor is determined by applying a multiplier to the fixed formation size divisor.
-     * The multiplier varies based on the roll value:
+     * The variance factor is determined by applying a multiplier to the fixed formation size divisor. The multiplier
+     * varies based on the roll value:
      * <ul>
      *   <li><b>Roll 2:</b> Multiplier is 0.75.</li>
      *   <li><b>Roll 3:</b> Multiplier is 0.5.</li>
@@ -301,6 +321,7 @@ public abstract class AbstractContractMarket {
      * </ul>
      *
      * @param roll the roll value used to determine the multiplier
+     *
      * @return the calculated variance factor as a double
      */
     private double calculateVarianceFactor(int roll) {
@@ -319,12 +340,12 @@ public abstract class AbstractContractMarket {
      * Calculates the bypass variance reduction based on the available forces.
      *
      * <p>
-     * The reduction is calculated by dividing the available forces by a fixed factor of 3
-     * and rounding down to the nearest whole number. This value is used in scenarios where
-     * variance adjustments are bypassed.
+     * The reduction is calculated by dividing the available forces by a fixed factor of 3 and rounding down to the
+     * nearest whole number. This value is used in scenarios where variance adjustments are bypassed.
      * </p>
      *
      * @param availableForces the total number of forces available
+     *
      * @return the bypass variance reduction as an integer
      */
     private int calculateBypassVarianceReduction(int availableForces) {
@@ -335,11 +356,12 @@ public abstract class AbstractContractMarket {
      * Calculates the maximum number of deployable combat teams based on the given campaign's options.
      *
      * <p>
-     * This method retrieves campaign options and calculates the total deployable combat teams using
-     * the base strategy deployment, additional strategy deployment, and the campaign's commander strategy.
+     * This method retrieves campaign options and calculates the total deployable combat teams using the base strategy
+     * deployment, additional strategy deployment, and the campaign's commander strategy.
      * </p>
      *
      * @param campaign the campaign object containing the necessary data to perform the calculation
+     *
      * @return the total number of deployable combat teams
      */
     public int calculateMaxDeployableCombatTeams(Campaign campaign) {
@@ -377,16 +399,90 @@ public abstract class AbstractContractMarket {
         }
     }
 
+    /**
+     * @deprecated use {@link #rollCommandClause(Contract, int, boolean)} instead.
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     protected void rollCommandClause(final Contract contract, final int modifier) {
+        rollCommandClause(contract, modifier, true);
+    }
+
+    /**
+     * Calculates and sets the command rights clause for a contract based on a roll and modifier.
+     *
+     * <p>This method determines the appropriate {@link ContractCommandRights} for the given {@link Contract},
+     * using the result of a dice roll (with modifiers). The logic differentiates between mercenary and non-mercenary
+     * contracts, as these have different thresholds for command rights determination.</p>
+     *
+     * <ul>
+     *   <li>For mercenaries, the command rights are determined using multiple thresholds, defined by constants,
+     *       and can be one of the following:
+     *       <ul>
+     *         <li>{@link ContractCommandRights#INTEGRATED}</li>
+     *         <li>{@link ContractCommandRights#HOUSE}</li>
+     *         <li>{@link ContractCommandRights#LIAISON}</li>
+     *         <li>{@link ContractCommandRights#INDEPENDENT}</li>
+     *       </ul>
+     *   </li>
+     *   <li>For non-mercenaries, only two outcomes are possible:
+     *       <ul>
+     *         <li>{@link ContractCommandRights#INTEGRATED}</li>
+     *         <li>{@link ContractCommandRights#HOUSE}</li>
+     *       </ul>
+     *   </li>
+     * </ul>
+     *
+     * @param contract    The {@link Contract} whose command rights will be set based on the roll outcome.
+     * @param modifier    The numeric modifier applied to the dice roll value.
+     * @param isMercenary Indicates whether the contract applies to a mercenary, which affects the thresholds used for
+     *                    determining command rights.
+     */
+    protected void rollCommandClause(final Contract contract, final int modifier, boolean isMercenary) {
         final int roll = d6(2) + modifier;
-        if (roll < 3) {
-            contract.setCommandRights(ContractCommandRights.INTEGRATED);
-        } else if (roll < 8) {
-            contract.setCommandRights(ContractCommandRights.HOUSE);
-        } else if (roll < 12) {
-            contract.setCommandRights(ContractCommandRights.LIAISON);
+
+        if (isMercenary) {
+            // Handle mercenary thresholds
+            contract.setCommandRights(determineMercenaryCommandRights(roll));
         } else {
-            contract.setCommandRights(ContractCommandRights.INDEPENDENT);
+            // Handle non-mercenary thresholds
+            contract.setCommandRights(roll < NON_MERCENARY_THRESHOLD ?
+                                            ContractCommandRights.INTEGRATED :
+                                            ContractCommandRights.HOUSE);
+        }
+    }
+
+    /**
+     * Determines the command rights for a mercenary contract based on a roll.
+     *
+     * <p>This method evaluates the roll against predefined thresholds to determine and return the appropriate
+     * {@link ContractCommandRights} for mercenaries</p>
+     *
+     * <ul>
+     *   <li>Results:
+     *       <ul>
+     *         <li>Less than {@code MERCENARY_THRESHOLD_INTEGRATED}: {@link ContractCommandRights#INTEGRATED}</li>
+     *         <li>Between {@code MERCENARY_THRESHOLD_INTEGRATED} (inclusive) and {@code MERCENARY_THRESHOLD_HOUSE}:
+     *             {@link ContractCommandRights#HOUSE}</li>
+     *         <li>Between {@code MERCENARY_THRESHOLD_HOUSE} (inclusive) and {@code MERCENARY_THRESHOLD_LIAISON}:
+     *             {@link ContractCommandRights#LIAISON}</li>
+     *         <li>Greater than or equal to {@code MERCENARY_THRESHOLD_LIAISON}: {@link ContractCommandRights#INDEPENDENT}</li>
+     *       </ul>
+     *   </li>
+     * </ul>
+     *
+     * @param roll The total value of a dice roll (with modifiers) used to determine command rights.
+     *
+     * @return The {@link ContractCommandRights} determined based on the roll value.
+     */
+    ContractCommandRights determineMercenaryCommandRights(int roll) {
+        if (roll < MERCENARY_THRESHOLD_INTEGRATED) {
+            return ContractCommandRights.INTEGRATED;
+        } else if (roll < MERCENARY_THRESHOLD_HOUSE) {
+            return ContractCommandRights.HOUSE;
+        } else if (roll < MERCENARY_THRESHOLD_LIAISON) {
+            return ContractCommandRights.LIAISON;
+        } else {
+            return ContractCommandRights.INDEPENDENT;
         }
     }
 
@@ -437,18 +533,16 @@ public abstract class AbstractContractMarket {
 
     protected AtBContractType findMissionType(int unitRatingMod, boolean majorPower) {
         final AtBContractType[][] table = {
-            // col 0: IS Houses
-            { AtBContractType.GUERRILLA_WARFARE, AtBContractType.RECON_RAID, AtBContractType.PIRATE_HUNTING,
-                AtBContractType.PLANETARY_ASSAULT, AtBContractType.OBJECTIVE_RAID,
-                AtBContractType.OBJECTIVE_RAID,
+              // col 0: IS Houses
+              { AtBContractType.GUERRILLA_WARFARE, AtBContractType.RECON_RAID, AtBContractType.PIRATE_HUNTING,
+                AtBContractType.PLANETARY_ASSAULT, AtBContractType.OBJECTIVE_RAID, AtBContractType.OBJECTIVE_RAID,
                 AtBContractType.EXTRACTION_RAID, AtBContractType.RECON_RAID, AtBContractType.GARRISON_DUTY,
                 AtBContractType.CADRE_DUTY, AtBContractType.RELIEF_DUTY },
-            // col 1: Others
-            { AtBContractType.GUERRILLA_WARFARE, AtBContractType.RECON_RAID, AtBContractType.PLANETARY_ASSAULT,
+              // col 1: Others
+              { AtBContractType.GUERRILLA_WARFARE, AtBContractType.RECON_RAID, AtBContractType.PLANETARY_ASSAULT,
                 AtBContractType.OBJECTIVE_RAID, AtBContractType.EXTRACTION_RAID, AtBContractType.PIRATE_HUNTING,
                 AtBContractType.SECURITY_DUTY, AtBContractType.OBJECTIVE_RAID, AtBContractType.GARRISON_DUTY,
-                AtBContractType.CADRE_DUTY, AtBContractType.DIVERSIONARY_RAID }
-        };
+                AtBContractType.CADRE_DUTY, AtBContractType.DIVERSIONARY_RAID } };
         int roll = MathUtility.clamp(d6(2) + unitRatingMod - IUnitRating.DRAGOON_C, 2, 12);
         return table[majorPower ? 0 : 1][roll - 2];
     }
@@ -459,30 +553,33 @@ public abstract class AbstractContractMarket {
         } else if (contract.getContractType().isRiotDuty()) {
             contract.setEnemyCode("REB");
         } else {
-            contract.setEnemyCode(RandomFactionGenerator.getInstance().getEnemy(contract.getEmployerCode(),
-                contract.getContractType().isGarrisonType()));
+            contract.setEnemyCode(RandomFactionGenerator.getInstance()
+                                        .getEnemy(contract.getEmployerCode(),
+                                              contract.getContractType().isGarrisonType()));
         }
     }
 
     protected void setAttacker(AtBContract contract) {
-        boolean isAttacker = !contract.getContractType().isGarrisonType()
-            || (contract.getContractType().isReliefDuty() && (d6() < 4))
-            || contract.getEnemy().isRebel();
+        boolean isAttacker = !contract.getContractType().isGarrisonType() ||
+                                   (contract.getContractType().isReliefDuty() && (d6() < 4)) ||
+                                   contract.getEnemy().isRebel();
         contract.setAttacker(isAttacker);
     }
 
     protected void setSystemId(AtBContract contract) throws NoContractLocationFoundException {
         // FIXME : Windchild : I don't work properly
         if (contract.isAttacker()) {
-            contract.setSystemId(RandomFactionGenerator.getInstance().getMissionTarget(contract.getEmployerCode(),
-                contract.getEnemyCode()));
+            contract.setSystemId(RandomFactionGenerator.getInstance()
+                                       .getMissionTarget(contract.getEmployerCode(), contract.getEnemyCode()));
         } else {
-            contract.setSystemId(RandomFactionGenerator.getInstance().getMissionTarget(contract.getEnemyCode(),
-                contract.getEmployerCode()));
+            contract.setSystemId(RandomFactionGenerator.getInstance()
+                                       .getMissionTarget(contract.getEnemyCode(), contract.getEmployerCode()));
         }
         if (contract.getSystem() == null) {
-            String errorMsg = "Could not find contract location for "
-                + contract.getEmployerCode() + " vs. " + contract.getEnemyCode();
+            String errorMsg = "Could not find contract location for " +
+                                    contract.getEmployerCode() +
+                                    " vs. " +
+                                    contract.getEnemyCode();
             logger.warn(errorMsg);
             throw new NoContractLocationFoundException(errorMsg);
         }
@@ -495,9 +592,8 @@ public abstract class AbstractContractMarket {
     }
 
     /**
-     * Sets the ally rating (skill and quality) for the contract.
-     * The ally rating is determined by modifiers influenced by the employer faction,
-     * contract type, historical context, and a random roll.
+     * Sets the ally rating (skill and quality) for the contract. The ally rating is determined by modifiers influenced
+     * by the employer faction, contract type, historical context, and a random roll.
      *
      * <p>The calculated ally skill and quality ratings are assigned to the contract.</p>
      *
@@ -532,9 +628,8 @@ public abstract class AbstractContractMarket {
     }
 
     /**
-     * Sets the enemy rating (skill and quality) for the contract.
-     * The enemy rating is determined by modifiers based on the enemy faction,
-     * whether the faction is attacking or defending, historical context, and a random roll.
+     * Sets the enemy rating (skill and quality) for the contract. The enemy rating is determined by modifiers based on
+     * the enemy faction, whether the faction is attacking or defending, historical context, and a random roll.
      *
      * <p>The calculated enemy skill and quality ratings are assigned to the contract.</p>
      *
@@ -574,8 +669,8 @@ public abstract class AbstractContractMarket {
     }
 
     /**
-     * Calculates the modifiers for a faction based on its attributes, such as whether it is:
-     * a rebel, pirate, independent, a minor power, or a Clan faction.
+     * Calculates the modifiers for a faction based on its attributes, such as whether it is: a rebel, pirate,
+     * independent, a minor power, or a Clan faction.
      *
      * <p>Faction modifiers are determined as follows:</p>
      * <ul>
@@ -586,6 +681,7 @@ public abstract class AbstractContractMarket {
      * </ul>
      *
      * @param faction the faction for which the modifiers are being calculated.
+     *
      * @return the calculated modifier for the faction.
      */
     private int calculateFactionModifiers(Faction faction) {
@@ -611,8 +707,8 @@ public abstract class AbstractContractMarket {
     }
 
     /**
-     * Calculates the modifiers for a contract based on its type and whether the faction
-     * is in an attacker role or defender role.
+     * Calculates the modifiers for a contract based on its type and whether the faction is in an attacker role or
+     * defender role.
      *
      * <p>Contract type modifiers are determined as follows:</p>
      * <ul>
@@ -623,6 +719,7 @@ public abstract class AbstractContractMarket {
      *
      * @param contractType the type of the contract (e.g., Guerrilla Warfare, Cadre Duty, etc.).
      * @param isAttacker   a boolean indicating whether the faction is in an attacker role.
+     *
      * @return the calculated modifier for the contract type.
      */
     private int calculateContractTypeModifiers(AtBContractType contractType, boolean isAttacker) {
@@ -642,9 +739,9 @@ public abstract class AbstractContractMarket {
     }
 
     /**
-     * Calculates modifiers based on the historical period in which the given year falls.
-     * Modifiers are applied to non-Clan factions based on the progressive degradation or
-     * recovery of combat capabilities during the Succession Wars and Renaissance periods.
+     * Calculates modifiers based on the historical period in which the given year falls. Modifiers are applied to
+     * non-Clan factions based on the progressive degradation or recovery of combat capabilities during the Succession
+     * Wars and Renaissance periods.
      *
      * <p>The modifiers are determined as follows:</p>
      * <ul>
@@ -654,6 +751,7 @@ public abstract class AbstractContractMarket {
      * </ul>
      *
      * @param year the year of the contract, which determines the historical period.
+     *
      * @return the calculated historical modifier to be applied.
      */
     private int calculateHistoricalModifiers(int year) {
@@ -730,12 +828,12 @@ public abstract class AbstractContractMarket {
                     for (int i = 0; i < nl2.getLength(); i++) {
                         Node wn3 = nl2.item(i);
                         if (wn3.getNodeName().equalsIgnoreCase("mods")) {
-                            String [] s = wn3.getTextContent().split(",");
+                            String[] s = wn3.getTextContent().split(",");
                             for (int j = 0; j < s.length; j++) {
                                 cm.mods[j] = Integer.parseInt(s[j]);
                             }
                         } else if (wn3.getNodeName().equalsIgnoreCase("rerollsUsed")) {
-                            String [] s = wn3.getTextContent().split(",");
+                            String[] s = wn3.getTextContent().split(",");
                             for (int j = 0; j < s.length; j++) {
                                 cm.rerollsUsed[j] = Integer.parseInt(s[j]);
                             }
@@ -795,13 +893,12 @@ public abstract class AbstractContractMarket {
      * the random clause bonuses should be persistent.
      */
     protected static class ClauseMods {
-        public int[] rerollsUsed = {0, 0, 0, 0};
-        public int[] mods = {0, 0, 0, 0};
+        public int[] rerollsUsed = { 0, 0, 0, 0 };
+        public int[] mods = { 0, 0, 0, 0 };
     }
 
     /**
-     * Exception indicating that no valid location was generated for a contract and that the contract
-     * is invalid.
+     * Exception indicating that no valid location was generated for a contract and that the contract is invalid.
      */
     public static class NoContractLocationFoundException extends RuntimeException {
         public NoContractLocationFoundException(String message) {

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -28,6 +28,20 @@
  */
 package mekhq.campaign.market.contractMarket;
 
+import static java.lang.Math.floor;
+import static megamek.codeUtilities.MathUtility.clamp;
+import static megamek.common.Compute.d6;
+import static megamek.common.enums.SkillLevel.ELITE;
+import static megamek.common.enums.SkillLevel.GREEN;
+import static megamek.common.enums.SkillLevel.REGULAR;
+import static megamek.common.enums.SkillLevel.VETERAN;
+import static mekhq.campaign.mission.AtBContract.getEffectiveNumUnits;
+import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Set;
+
 import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
@@ -43,25 +57,15 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.rating.IUnitRating;
-import mekhq.campaign.universe.*;
-
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Set;
-
-import static java.lang.Math.floor;
-import static megamek.codeUtilities.MathUtility.clamp;
-import static megamek.common.Compute.d6;
-import static megamek.common.enums.SkillLevel.ELITE;
-import static megamek.common.enums.SkillLevel.GREEN;
-import static megamek.common.enums.SkillLevel.REGULAR;
-import static megamek.common.enums.SkillLevel.VETERAN;
-import static mekhq.campaign.mission.AtBContract.getEffectiveNumUnits;
-import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
+import mekhq.campaign.universe.Faction;
+import mekhq.campaign.universe.Factions;
+import mekhq.campaign.universe.PlanetarySystem;
+import mekhq.campaign.universe.RandomFactionGenerator;
+import mekhq.campaign.universe.Systems;
 
 /**
  * Contract offers that are generated monthly under AtB rules.
- *
+ * <p>
  * Based on PersonnelMarket
  *
  * @author Neoancient
@@ -84,7 +88,8 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
     @Override
     public void generateContractOffers(Campaign campaign, boolean newCampaign) {
-        boolean isGrayMonday = isGrayMonday(campaign.getLocalDate(), campaign.getCampaignOptions().isSimulateGrayMonday());
+        boolean isGrayMonday = isGrayMonday(campaign.getLocalDate(),
+              campaign.getCampaignOptions().isSimulateGrayMonday());
         boolean hasActiveContract = campaign.hasActiveContract() || campaign.hasActiveAtBContract(true);
 
         if (((campaign.getLocalDate().getDayOfMonth() == 1)) || newCampaign) {
@@ -123,7 +128,8 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
             Set<Faction> currentFactions = campaign.getCurrentSystem().getFactionSet(campaign.getLocalDate());
             final boolean inMinorFaction = currentFactions.stream()
-                    .noneMatch(faction -> faction.isISMajorOrSuperPower() || faction.isClan());
+                                                 .noneMatch(faction -> faction.isISMajorOrSuperPower() ||
+                                                                             faction.isClan());
             if (inMinorFaction) {
                 numContracts--;
             }
@@ -140,7 +146,8 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                 // Just one faction. Are there any others nearby?
                 Faction onlyFaction = currentFactions.iterator().next();
                 if (!onlyFaction.isPeriphery()) {
-                    for (PlanetarySystem key : Systems.getInstance().getNearbySystems(campaign.getCurrentSystem(), 30)) {
+                    for (PlanetarySystem key : Systems.getInstance()
+                                                     .getNearbySystems(campaign.getCurrentSystem(), 30)) {
                         for (Faction f : key.getFactionSet(campaign.getLocalDate())) {
                             if (!onlyFaction.equals(f)) {
                                 inBackwater = false;
@@ -153,11 +160,10 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                     }
                 }
             } else {
-                logger.warn(
-                        "Unable to find any factions around "
-                                + campaign.getCurrentSystem().getName(campaign.getLocalDate())
-                                + " on "
-                                + campaign.getLocalDate());
+                logger.warn("Unable to find any factions around " +
+                                  campaign.getCurrentSystem().getName(campaign.getLocalDate()) +
+                                  " on " +
+                                  campaign.getLocalDate());
             }
 
             if (inBackwater) {
@@ -187,8 +193,8 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
              */
             for (Faction f : campaign.getCurrentSystem().getFactionSet(campaign.getLocalDate())) {
                 try {
-                    if (f.getStartingPlanet(campaign.getLocalDate()).equals(campaign.getCurrentSystem().getId())
-                            && RandomFactionGenerator.getInstance().getEmployerSet().contains(f.getShortName())) {
+                    if (f.getStartingPlanet(campaign.getLocalDate()).equals(campaign.getCurrentSystem().getId()) &&
+                              RandomFactionGenerator.getInstance().getEmployerSet().contains(f.getShortName())) {
                         AtBContract c = generateAtBContract(campaign, f.getShortName(), unitRatingMod);
                         if (c != null) {
                             contracts.add(c);
@@ -245,8 +251,10 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                 AtBContract retVal = null;
                 while ((retries > 0) && (retVal == null)) {
                     // Send only 1 retry down because we're handling retries in our loop
-                    retVal = generateAtBContract(campaign, RandomFactionGenerator.getInstance().getEmployer(),
-                            unitRatingMod, 1);
+                    retVal = generateAtBContract(campaign,
+                          RandomFactionGenerator.getInstance().getEmployer(),
+                          unitRatingMod,
+                          1);
                     retries--;
                 }
                 return retVal;
@@ -262,7 +270,8 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         return generateAtBContract(campaign, employer, unitRatingMod, MAXIMUM_GENERATION_RETRIES);
     }
 
-    private @Nullable AtBContract generateAtBContract(Campaign campaign, @Nullable String employer, int unitRatingMod, int retries) {
+    private @Nullable AtBContract generateAtBContract(Campaign campaign, @Nullable String employer, int unitRatingMod,
+                                                      int retries) {
         if (employer == null) {
             logger.warn("Could not generate an AtB Contract because there was no employer!");
             return null;
@@ -292,7 +301,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         }
         contract.setEmployerCode(employer, campaign.getGameYear());
         contract.setContractType(findMissionType(unitRatingMod,
-                Factions.getInstance().getFaction(contract.getEmployerCode()).isISMajorOrSuperPower()));
+              Factions.getInstance().getFaction(contract.getEmployerCode()).isISMajorOrSuperPower()));
 
         setEnemyCode(contract);
         setIsRiotDuty(contract);
@@ -302,9 +311,14 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
          * (ComStar, Mercs not under contract) are more likely to have garrison-type
          * contracts and less likely to have battle-type contracts unless at war.
          */
-        if (RandomFactionGenerator.getInstance().getFactionHints().isNeutral(Factions.getInstance().getFaction(employer)) &&
-                !RandomFactionGenerator.getInstance().getFactionHints().isAtWarWith(Factions.getInstance().getFaction(employer),
-                        Factions.getInstance().getFaction(contract.getEnemyCode()), campaign.getLocalDate())) {
+        if (RandomFactionGenerator.getInstance()
+                  .getFactionHints()
+                  .isNeutral(Factions.getInstance().getFaction(employer)) &&
+                  !RandomFactionGenerator.getInstance()
+                         .getFactionHints()
+                         .isAtWarWith(Factions.getInstance().getFaction(employer),
+                               Factions.getInstance().getFaction(contract.getEnemyCode()),
+                               campaign.getLocalDate())) {
             if (contract.getContractType().isPlanetaryAssault()) {
                 contract.setContractType(AtBContractType.GARRISON_DUTY);
             } else if (contract.getContractType().isReliefDuty()) {
@@ -322,8 +336,8 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
             jp = contract.getJumpPath(campaign);
         } catch (NullPointerException ex) {
             // could not calculate jump path; leave jp null
-            logger.warn("Could not calculate jump path to contract location: "
-                    + contract.getSystem().getName(campaign.getLocalDate()), ex);
+            logger.warn("Could not calculate jump path to contract location: " +
+                              contract.getSystem().getName(campaign.getLocalDate()), ex);
         }
 
         if (jp == null) {
@@ -350,29 +364,31 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         contract.calculateContract(campaign);
 
         contract.setName(String.format("%s - %s - %s %s",
-                contract.getStartDate().format(DateTimeFormatter.ofPattern("yyyy")
-                        .withLocale(MekHQ.getMHQOptions().getDateLocale())), employer,
-                        contract.getSystem().getName(contract.getStartDate()), contract.getContractType()));
+              contract.getStartDate()
+                    .format(DateTimeFormatter.ofPattern("yyyy").withLocale(MekHQ.getMHQOptions().getDateLocale())),
+              employer,
+              contract.getSystem().getName(contract.getStartDate()),
+              contract.getContractType()));
 
         contract.clanTechSalvageOverride();
 
         return contract;
     }
 
-    protected AtBContract generateAtBSubcontract(Campaign campaign,
-            AtBContract parent, int unitRatingMod) {
+    protected AtBContract generateAtBSubcontract(Campaign campaign, AtBContract parent, int unitRatingMod) {
         AtBContract contract = new AtBContract("New Subcontract");
         contract.setEmployerCode(parent.getEmployerCode(), campaign.getGameYear());
         contract.setContractType(findMissionType(unitRatingMod,
-                Factions.getInstance().getFaction(contract.getEmployerCode()).isISMajorOrSuperPower()));
+              Factions.getInstance().getFaction(contract.getEmployerCode()).isISMajorOrSuperPower()));
 
         if (contract.getContractType().isPirateHunting()) {
             contract.setEnemyCode("PIR");
         } else if (contract.getContractType().isRiotDuty()) {
             contract.setEnemyCode("REB");
         } else {
-            contract.setEnemyCode(RandomFactionGenerator.getInstance().getEnemy(contract.getEmployerCode(),
-                    contract.getContractType().isGarrisonType()));
+            contract.setEnemyCode(RandomFactionGenerator.getInstance()
+                                        .getEnemy(contract.getEmployerCode(),
+                                              contract.getContractType().isGarrisonType()));
         }
         if (contract.getContractType().isGarrisonDuty() && contract.getEnemy().isRebel()) {
             contract.setContractType(AtBContractType.RIOT_DUTY);
@@ -426,8 +442,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         contract.setCommandRights(ContractCommandRights.values()[Math.max(parent.getCommandRights().ordinal() - 1, 0)]);
         contract.setSalvageExchange(parent.isSalvageExchange());
         contract.setSalvagePct(Math.max(parent.getSalvagePct() - 10, 0));
-        contract.setStraightSupport(Math.max(parent.getStraightSupport() - 20,
-                0));
+        contract.setStraightSupport(Math.max(parent.getStraightSupport() - 20, 0));
         if (parent.getBattleLossComp() <= 10) {
             contract.setBattleLossComp(0);
         } else if (parent.getBattleLossComp() <= 20) {
@@ -443,9 +458,11 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         contract.calculateContract(campaign);
 
         contract.setName(String.format("%s - %s - %s Subcontract %s",
-                contract.getStartDate().format(DateTimeFormatter.ofPattern("yyyy")
-                        .withLocale(MekHQ.getMHQOptions().getDateLocale())), contract.getEmployer(),
-                contract.getSystem().getName(parent.getStartDate()), contract.getContractType()));
+              contract.getStartDate()
+                    .format(DateTimeFormatter.ofPattern("yyyy").withLocale(MekHQ.getMHQOptions().getDateLocale())),
+              contract.getEmployer(),
+              contract.getSystem().getName(parent.getStartDate()),
+              contract.getContractType()));
 
         contract.clanTechSalvageOverride();
 
@@ -455,11 +472,10 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
     /**
      * Creates and adds a follow-up contract based on the just concluded contract.
      * <p>
-     * This method generates a new contract (`AtBContract`) as a follow-up to the provided `contract`.
-     * Certain properties of the original contract, such as employer, enemy, skill, system location,
-     * and other details, are carried over or modified as necessary based on the contract type.
-     * The method ensures that the follow-up contract contains all necessary details and is
-     * correctly initialized.
+     * This method generates a new contract (`AtBContract`) as a follow-up to the provided `contract`. Certain
+     * properties of the original contract, such as employer, enemy, skill, system location, and other details, are
+     * carried over or modified as necessary based on the contract type. The method ensures that the follow-up contract
+     * contains all necessary details and is correctly initialized.
      * </p>
      *
      * <p>
@@ -467,13 +483,12 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
      * `generateAtBContract` to maintain compatibility and consistency.
      * </p>
      *
-     * @param campaign the {@link Campaign} to which the follow-up contract belongs.
-     *                 This is used for retrieving campaign-wide settings and applying modifiers.
-     * @param contract the {@link AtBContract} that serves as the base for generating the follow-up contract.
-     *                 Key details from this contract are reused or adapted for the follow-up.
+     * @param campaign the {@link Campaign} to which the follow-up contract belongs. This is used for retrieving
+     *                 campaign-wide settings and applying modifiers.
+     * @param contract the {@link AtBContract} that serves as the base for generating the follow-up contract. Key
+     *                 details from this contract are reused or adapted for the follow-up.
      */
-    private void addFollowup(Campaign campaign,
-            AtBContract contract) {
+    private void addFollowup(Campaign campaign, AtBContract contract) {
         if (followupContracts.containsValue(contract.getId())) {
             return;
         }
@@ -611,13 +626,12 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
     @Override
     public void checkForFollowup(Campaign campaign, AtBContract contract) {
         AtBContractType type = contract.getContractType();
-        if (type.isDiversionaryRaid() || type.isReconRaid()
-            || type.isRiotDuty()) {
+        if (type.isDiversionaryRaid() || type.isReconRaid() || type.isRiotDuty()) {
             int roll = d6();
             if (roll == 6) {
                 addFollowup(campaign, contract);
                 campaign.addReport(
-                    "Your employer has offered a follow-up contract (available on the <a href=\"CONTRACT_MARKET\">contract market</a>).");
+                      "Your employer has offered a follow-up contract (available on the <a href=\"CONTRACT_MARKET\">contract market</a>).");
             }
         }
     }
@@ -634,23 +648,34 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
          * the highest admin skill, or higher negotiation if the admin
          * skills are equal.
          */
-        Person adminCommand = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_COMMAND, SkillType.S_ADMIN, SkillType.S_NEG);
-        Person adminTransport = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_TRANSPORT, SkillType.S_ADMIN, SkillType.S_NEG);
-        Person adminLogistics = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_LOGISTICS, SkillType.S_ADMIN, SkillType.S_NEG);
-        int adminCommandExp = (adminCommand == null) ? SkillType.EXP_ULTRA_GREEN : adminCommand.getSkill(SkillType.S_ADMIN).getExperienceLevel();
-        int adminTransportExp = (adminTransport == null) ? SkillType.EXP_ULTRA_GREEN : adminTransport.getSkill(SkillType.S_ADMIN).getExperienceLevel();
-        int adminLogisticsExp = (adminLogistics == null) ? SkillType.EXP_ULTRA_GREEN : adminLogistics.getSkill(SkillType.S_ADMIN).getExperienceLevel();
+        Person adminCommand = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_COMMAND,
+              SkillType.S_ADMIN,
+              SkillType.S_NEG);
+        Person adminTransport = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_TRANSPORT,
+              SkillType.S_ADMIN,
+              SkillType.S_NEG);
+        Person adminLogistics = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_LOGISTICS,
+              SkillType.S_ADMIN,
+              SkillType.S_NEG);
+        int adminCommandExp = (adminCommand == null) ?
+                                    SkillType.EXP_ULTRA_GREEN :
+                                    adminCommand.getSkill(SkillType.S_ADMIN).getExperienceLevel();
+        int adminTransportExp = (adminTransport == null) ?
+                                      SkillType.EXP_ULTRA_GREEN :
+                                      adminTransport.getSkill(SkillType.S_ADMIN).getExperienceLevel();
+        int adminLogisticsExp = (adminLogistics == null) ?
+                                      SkillType.EXP_ULTRA_GREEN :
+                                      adminLogistics.getSkill(SkillType.S_ADMIN).getExperienceLevel();
 
         /* Treat government units like merc units that have a retainer contract */
-        if ((!campaign.getFaction().isMercenary() && !campaign.getFaction().isPirate())
-                || (null != campaign.getRetainerEmployerCode())) {
+        if ((!campaign.getFaction().isMercenary() && !campaign.getFaction().isPirate()) ||
+                  (null != campaign.getRetainerEmployerCode())) {
             for (int i = 0; i < CLAUSE_NUM; i++) {
                 mods.mods[i]++;
             }
         }
 
-        if (campaign.getCampaignOptions().isMercSizeLimited() &&
-                campaign.getFaction().isMercenary()) {
+        if (campaign.getCampaignOptions().isMercSizeLimited() && campaign.getFaction().isMercenary()) {
             int max = (unitRatingMod + 1) * 12;
             int numMods = (getEffectiveNumUnits(campaign) - max) / 2;
             while (numMods > 0) {
@@ -676,7 +701,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         }
 
         if (Factions.getInstance().getFaction(contract.getEnemyCode()).isClan() &&
-                !Factions.getInstance().getFaction(contract.getEmployerCode()).isClan()) {
+                  !Factions.getInstance().getFaction(contract.getEmployerCode()).isClan()) {
             for (int i = 0; i < 4; i++) {
                 if (i == CLAUSE_SALVAGE) {
                     mods.mods[i] -= 2;
@@ -694,11 +719,9 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
             }
         }
 
-        int[][] missionMods = {
-                { 1, 0, 1, 0 }, { 0, 1, -1, -3 }, { -3, 0, 2, 1 }, { -2, 1, -1, -1 },
-                { -2, 0, 2, 3 }, { -1, 1, 1, 1 }, { -2, 3, -2, -1 }, { 2, 2, -1, -1 },
-                { 0, 2, 2, 1 }, { -1, 0, 1, 2 }, { -1, -2, 1, -1 }, { -1, -1, 2, 1 }
-        };
+        int[][] missionMods = { { 1, 0, 1, 0 }, { 0, 1, -1, -3 }, { -3, 0, 2, 1 }, { -2, 1, -1, -1 }, { -2, 0, 2, 3 },
+                                { -1, 1, 1, 1 }, { -2, 3, -2, -1 }, { 2, 2, -1, -1 }, { 0, 2, 2, 1 }, { -1, 0, 1, 2 },
+                                { -1, -2, 1, -1 }, { -1, -1, 2, 1 } };
         for (int i = 0; i < 4; i++) {
             mods.mods[i] += missionMods[contract.getContractType().ordinal()][i];
         }
@@ -726,21 +749,19 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         mods.mods[CLAUSE_SUPPORT] -= modifier;
         mods.mods[CLAUSE_TRANSPORT] -= modifier;
 
-        if (campaign.getFaction().isMercenary()) {
-            rollCommandClause(contract, mods.mods[CLAUSE_COMMAND]);
-        } else {
-            contract.setCommandRights(ContractCommandRights.INTEGRATED);
-        }
-        rollSalvageClause(contract, mods.mods[CLAUSE_SALVAGE],
-                campaign.getCampaignOptions().getContractMaxSalvagePercentage());
+        rollCommandClause(contract, mods.mods[CLAUSE_COMMAND], campaign.getFaction().isMercenary());
+
+        rollSalvageClause(contract,
+              mods.mods[CLAUSE_SALVAGE],
+              campaign.getCampaignOptions().getContractMaxSalvagePercentage());
         rollSupportClause(contract, mods.mods[CLAUSE_SUPPORT]);
         rollTransportClause(contract, mods.mods[CLAUSE_TRANSPORT]);
     }
 
     /**
-     * Calculates the negotiation modifier for a contract based on the employer's faction type.
-     * The modifier reflects the negotiation capabilities of the employer, making it harder to
-     * achieve favorable results with more influential or powerful employers.
+     * Calculates the negotiation modifier for a contract based on the employer's faction type. The modifier reflects
+     * the negotiation capabilities of the employer, making it harder to achieve favorable results with more influential
+     * or powerful employers.
      *
      * <p>The negotiation modifier is determined as follows:
      * <ul>
@@ -751,6 +772,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
      * </ul>
      *
      * @param employerFaction The {@link Faction} that is performing the negotiation.
+     *
      * @return An integer representing the negotiation modifier corresponding to the employer's capabilities.
      */
     private static int getEmployerNegotiatorModifier(Faction employerFaction) {

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
@@ -27,6 +27,16 @@
  */
 package mekhq.campaign.market.contractMarket;
 
+import static megamek.common.Compute.d6;
+import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
 import megamek.common.Compute;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
@@ -34,7 +44,9 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.market.enums.ContractMarketMethod;
 import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.mission.Contract;
 import mekhq.campaign.mission.enums.AtBContractType;
+import mekhq.campaign.mission.enums.ContractCommandRights;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.rating.CamOpsReputation.ReputationController;
@@ -43,12 +55,6 @@ import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Faction.Tag;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.enums.HiringHallLevel;
-
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-
-import static megamek.common.Compute.d6;
-import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
 
 /**
  * Contract Market as described in Campaign Operations, 4th printing.
@@ -77,9 +83,9 @@ public class CamOpsContractMarket extends AbstractContractMarket {
 
     @Override
     public void generateContractOffers(Campaign campaign, boolean newCampaign) {
-        boolean isGrayMonday = isGrayMonday(campaign.getLocalDate(), campaign.getCampaignOptions().isSimulateGrayMonday());
-        boolean hasActiveContract = campaign.hasActiveContract()
-            || campaign.hasActiveAtBContract(true);
+        boolean isGrayMonday = isGrayMonday(campaign.getLocalDate(),
+              campaign.getCampaignOptions().isSimulateGrayMonday());
+        boolean hasActiveContract = campaign.hasActiveContract() || campaign.hasActiveAtBContract(true);
 
         if (!(campaign.getLocalDate().getDayOfMonth() == 1) && !newCampaign) {
             return;
@@ -94,15 +100,15 @@ public class CamOpsContractMarket extends AbstractContractMarket {
         new ArrayList<>(contracts).forEach(this::removeContract);
         // TODO: Allow subcontracts?
         //for (AtBContract contract : campaign.getActiveAtBContracts()) {
-            //checkForSubcontracts(campaign, contract, unitRatingMod);
+        //checkForSubcontracts(campaign, contract, unitRatingMod);
         //}
         // TODO: CamopsMarket: allow players to choose negotiators and send them out, removing them
         // from other tasks they're doing. For now just use the highest negotiation skill on the force.
         int ratingMod = campaign.getReputation().getReputationModifier();
         HiringHallModifiers hiringHallModifiers = getHiringHallModifiers(campaign);
         int negotiationSkill = findNegotiationSkill(campaign);
-        int numOffers = getNumberOfOffers(
-            rollNegotiation(negotiationSkill, ratingMod + hiringHallModifiers.offersMod) - BASE_NEGOTIATION_TARGET);
+        int numOffers = getNumberOfOffers(rollNegotiation(negotiationSkill, ratingMod + hiringHallModifiers.offersMod) -
+                                                BASE_NEGOTIATION_TARGET);
 
         if (isGrayMonday) {
             for (int i = 0; i < numOffers; i++) {
@@ -249,13 +255,28 @@ public class CamOpsContractMarket extends AbstractContractMarket {
         contract.initContractDetails(campaign);
         contract.calculateContract(campaign);
         contract.setName(String.format("%s - %s - %s %s",
-            contract.getStartDate().format(DateTimeFormatter.ofPattern("yyyy")
-                .withLocale(MekHQ.getMHQOptions().getDateLocale())), contract.getEmployer(),
-            contract.getSystem().getName(contract.getStartDate()), contract.getContractType()));
+              contract.getStartDate()
+                    .format(DateTimeFormatter.ofPattern("yyyy").withLocale(MekHQ.getMHQOptions().getDateLocale())),
+              contract.getEmployer(),
+              contract.getSystem().getName(contract.getStartDate()),
+              contract.getContractType()));
 
         contract.clanTechSalvageOverride();
 
         return Optional.of(contract);
+    }
+
+    @Override
+    protected void rollCommandClause(final Contract contract, final int modifier, boolean isMercenary) {
+        final int roll = d6(2) + modifier;
+
+        if (isMercenary) {
+            // Handle mercenaries
+            contract.setCommandRights(determineMercenaryCommandRights(roll));
+        } else {
+            // Handle non-mercenaries
+            contract.setCommandRights(ContractCommandRights.INTEGRATED);
+        }
     }
 
     private Faction determineEmployer(Campaign campaign, int ratingMod, HiringHallModifiers hiringHallModifiers) {
@@ -291,7 +312,7 @@ public class CamOpsContractMarket extends AbstractContractMarket {
                 filtered.add(faction);
             }
         }
-        Random rand  = new Random();
+        Random rand = new Random();
         return filtered.get(rand.nextInt(filtered.size()));
     }
 
@@ -323,10 +344,10 @@ public class CamOpsContractMarket extends AbstractContractMarket {
                 tags.add(Tag.MAJOR);
             } else {
                 if (Factions.getInstance()
-                    .getActiveFactions(campaign.getLocalDate())
-                    .stream()
-                    .anyMatch(Faction::isSuperPower)) {
-                        tags.add(Tag.SUPER);
+                          .getActiveFactions(campaign.getLocalDate())
+                          .stream()
+                          .anyMatch(Faction::isSuperPower)) {
+                    tags.add(Tag.SUPER);
                 } else {
                     tags.add(Tag.MAJOR);
                 }
@@ -340,7 +361,7 @@ public class CamOpsContractMarket extends AbstractContractMarket {
             return MissionSelector.getPirateMission(Compute.d6(2), 0);
         }
         int margin = rollNegotiation(findNegotiationSkill(campaign),
-            ratingMod + getHiringHallModifiers(campaign).missionsMod) - BASE_NEGOTIATION_TARGET;
+              ratingMod + getHiringHallModifiers(campaign).missionsMod) - BASE_NEGOTIATION_TARGET;
         boolean isClan = campaign.getFaction().isClan();
         if (employer.isInnerSphere() || employer.isClan()) {
             return MissionSelector.getInnerSphereClanMission(Compute.d6(2), margin, isClan);
@@ -356,9 +377,9 @@ public class CamOpsContractMarket extends AbstractContractMarket {
 
     private ContractTerms getContractTerms(Campaign campaign, AtBContract contract) {
         return new ContractTerms(contract.getContractType(),
-            contract.getEmployerFaction(),
-            campaign.getReputation().getReputationFactor(),
-            campaign.getLocalDate());
+              contract.getEmployerFaction(),
+              campaign.getReputation().getReputationFactor(),
+              campaign.getLocalDate());
     }
 
     private void setContractClauses(AtBContract contract, ContractTerms terms) {


### PR DESCRIPTION
- Added `rollCommandClause` logic to differentiate between mercenary and non-mercenary contracts.
- Introduced new thresholds for determining mercenary command rights.
- Created `determineMercenaryCommandRights` method for cleaner threshold-based logic.
- Deprecated the old `rollCommandClause` method.
- Updated usage of `rollCommandClause` across related classes to support the new functionality.

Fix #6424

### Dev Notes
This just allows non-mercenary forces to get `Integrated` _or_ `House` command rights. Having play for non-mercenary factions completely locked out of StratCon's map felt really bleh. I opted to cap it at 'House' as it doesn't matter how big the command is, or how competent the player-commander, they're still under the control of their faction.

For the in-dev CamOps Contract Market, I leveraged an Override to ensure we remain RAW. Not that anyone can use that contract market yet, but hey, future proofing! :D