### PR TITLE
Issue 6399: Load Entity in Specific Transporter when Recalculating Free Space

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/ShipTransportedUnitsSummary.java
+++ b/MekHQ/src/mekhq/campaign/unit/ShipTransportedUnitsSummary.java
@@ -28,7 +28,12 @@
 
 package mekhq.campaign.unit;
 
-import megamek.common.*;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Vector;
+
+import megamek.common.Transporter;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.Utilities;
@@ -36,8 +41,6 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.campaign.utilities.CampaignTransportUtilities;
-
-import java.util.*;
 
 /**
  * Tracks what units this transport is transporting, and its current capacity for its different transporter types.
@@ -52,7 +55,7 @@ public class ShipTransportedUnitsSummary extends AbstractTransportedUnitsSummary
      * @param transport unit this summary is about
      */
     public ShipTransportedUnitsSummary(Unit transport) {
-        super(transport);
+        super(transport, CampaignTransportType.SHIP_TRANSPORT);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/unit/TacticalTransportedUnitsSummary.java
+++ b/MekHQ/src/mekhq/campaign/unit/TacticalTransportedUnitsSummary.java
@@ -28,18 +28,18 @@
 
 package mekhq.campaign.unit;
 
-import megamek.common.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import megamek.common.Transporter;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.campaign.utilities.CampaignTransportUtilities;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
 
 /**
  * Tracks what units this transport is transporting, and its current capacity for its different transporter types.
@@ -51,7 +51,7 @@ public class TacticalTransportedUnitsSummary extends AbstractTransportedUnitsSum
     private static final MMLogger logger = MMLogger.create(TacticalTransportedUnitsSummary.class);
 
     public TacticalTransportedUnitsSummary(Unit transport) {
-        super(transport);
+        super(transport, CampaignTransportType.TACTICAL_TRANSPORT);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/unit/TowTransportedUnitsSummary.java
+++ b/MekHQ/src/mekhq/campaign/unit/TowTransportedUnitsSummary.java
@@ -28,6 +28,14 @@
 
 package mekhq.campaign.unit;
 
+import static mekhq.campaign.enums.CampaignTransportType.TOW_TRANSPORT;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Vector;
+import java.util.stream.Collectors;
+
 import megamek.common.Entity;
 import megamek.common.Tank;
 import megamek.common.TankTrailerHitch;
@@ -37,11 +45,6 @@ import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.unit.enums.TransporterType;
-
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static mekhq.campaign.enums.CampaignTransportType.TOW_TRANSPORT;
 
 /**
  * Tracks what units this tractor is towing, and its current capacity for towing more units if it
@@ -59,7 +62,7 @@ public class TowTransportedUnitsSummary extends AbstractTransportedUnitsSummary{
     private static final MMLogger logger = MMLogger.create(TowTransportedUnitsSummary.class);
 
     public TowTransportedUnitsSummary(Unit transport) {
-        super(transport);
+        super(transport, TOW_TRANSPORT);
     }
 
     /**


### PR DESCRIPTION
Fixes #6399

It was saving the correct `TransporterType` it just wasn't utilized when recalculating the transport's space. Now it will attempt to load entities into the correct `TransporterType`/class of `Transporter`.