### PR TITLE
Enhanced Deprecation Skill Handling

### DIFF
--- a/MekHQ/resources/mekhq/resources/SkillDeprecationTool.properties
+++ b/MekHQ/resources/mekhq/resources/SkillDeprecationTool.properties
@@ -1,5 +1,7 @@
-button.continue=Continue Without Refunding
+button.skip=Skip
+button.skipAll=Skip All
 button.refund=Refund the Skill
+button.refundAll=Refund All
 message.ic={0}, HR told me I''m scheduled for retraining.\
   <p>Apparently, my skills in ''<b>{1}</b>'' are no longer recognized by the personnel database. Something about a\
   \ ''software update.''</p>\

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -428,15 +428,20 @@ public class CampaignXmlParser {
         logger.info(String.format("[Campaign Load] Parts processed in %dms", System.currentTimeMillis() - timestamp));
         timestamp = System.currentTimeMillis();
 
+        boolean skipAllDeprecationChecks = false;
+        boolean refundAllDeprecatedSkills = false;
         for (Person person : campaign.getPersonnel()) {
             // skill types might need resetting
             person.resetSkillTypes();
 
             // Seeing as we're already looping through all personnel, we might as well have the deprecation checks
             // here, too.
-            if (!DEPRECATED_SKILLS.isEmpty()) {
+            if (!DEPRECATED_SKILLS.isEmpty() && !skipAllDeprecationChecks) {
                 // This checks to ensure the character doesn't have any Deprecated skills.
-                new SkillDeprecationTool(campaign, person);
+                SkillDeprecationTool deprecationTool = new SkillDeprecationTool(campaign,
+                      person,
+                      refundAllDeprecatedSkills);
+                skipAllDeprecationChecks = deprecationTool.isSkipAll();
             }
         }
 
@@ -1695,7 +1700,8 @@ public class CampaignXmlParser {
         retVal.setPartsInUseRequestedStockMap(partInUseStockMap);
     }
 
-    private static void processPartsInUseRequestedStockMapVal(Campaign retVal, Node wn, Map<String, Double> partsInUseRequestedStockMap) {
+    private static void processPartsInUseRequestedStockMapVal(Campaign retVal, Node wn,
+                                                              Map<String, Double> partsInUseRequestedStockMap) {
         NodeList wList = wn.getChildNodes();
 
         String key = null;

--- a/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
@@ -50,6 +50,8 @@ import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 public class SkillDeprecationTool {
     private final String RESOURCE_BUNDLE = "mekhq.resources." + getClass().getSimpleName();
 
+    private final int SKIP_ALL_DIALOG_OPTION_INDEX = 1;
+    private final int REFUND_ALL_DIALOG_OPTION_INDEX = 3;
     /**
      * A list of deprecated skills.
      *
@@ -65,6 +67,8 @@ public class SkillDeprecationTool {
 
     private final Campaign campaign;
     private final Person person;
+    private boolean skipAll = false;
+    private boolean refundAll;
 
     /**
      * Constructs a new {@code SkillDeprecationTool} for the specified campaign and person.
@@ -75,11 +79,20 @@ public class SkillDeprecationTool {
      * @param campaign the {@link Campaign} instance that provides context for the operation
      * @param person   the {@link Person} whose skills will be checked for deprecation
      */
-    public SkillDeprecationTool(Campaign campaign, Person person) {
+    public SkillDeprecationTool(Campaign campaign, Person person, boolean refundAll) {
         this.campaign = campaign;
         this.person = person;
+        this.refundAll = refundAll;
 
         checkForDeprecatedSkills(person);
+    }
+
+    public boolean isSkipAll() {
+        return skipAll;
+    }
+
+    public boolean isRefundAll() {
+        return refundAll;
     }
 
     /**
@@ -140,16 +153,22 @@ public class SkillDeprecationTool {
      * @param refundValue the XP refund value for the skill
      */
     private void triggerDialog(final Skills skills, final String skillName, final int refundValue) {
-        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
-              person,
-              null,
-              getInCharacterMessage(skillName),
-              getButtonLabels(),
-              getOutOfCharacterMessage(skillName, refundValue),
-              false);
+        ImmersiveDialogSimple dialog = null;
+        if (!refundAll) {
+            dialog = new ImmersiveDialogSimple(campaign,
+                  person,
+                  null,
+                  getInCharacterMessage(skillName),
+                  getButtonLabels(),
+                  getOutOfCharacterMessage(skillName, refundValue),
+                  true);
+        }
 
-        final int REFUND_DIALOG_OPTION_INDEX = 1;
-        if (dialog.getDialogChoice() == REFUND_DIALOG_OPTION_INDEX) {
+        if (dialog != null && dialog.getDialogChoice() == SKIP_ALL_DIALOG_OPTION_INDEX) {
+            skipAll = true;
+        }
+
+        if (isRefundAll() || (dialog != null && dialog.getDialogChoice() == REFUND_ALL_DIALOG_OPTION_INDEX)) {
             skills.removeSkill(skillName);
             int currentXp = person.getXP();
             // We use 'setXPDirect' here as the xp gain has already been factored into the tracking of xp gain, so we
@@ -180,8 +199,10 @@ public class SkillDeprecationTool {
      * @return a {@link List} of button label strings
      */
     private List<String> getButtonLabels() {
-        return List.of(getFormattedTextAt(RESOURCE_BUNDLE, "button.continue"),
-              getFormattedTextAt(RESOURCE_BUNDLE, "button.refund"));
+        return List.of(getFormattedTextAt(RESOURCE_BUNDLE, "button.skip"),
+              getFormattedTextAt(RESOURCE_BUNDLE, "button.skipAll"),
+              getFormattedTextAt(RESOURCE_BUNDLE, "button.refund"),
+              getFormattedTextAt(RESOURCE_BUNDLE, "button.refundAll"));
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
@@ -87,6 +87,14 @@ public class SkillDeprecationTool {
         checkForDeprecatedSkills(person);
     }
 
+    /**
+     * @deprecated use {@link #SkillDeprecationTool(Campaign, Person, boolean)} instead.
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
+    public SkillDeprecationTool(Campaign campaign, Person person) {
+        this(campaign, person, false);
+    }
+
     public boolean isSkipAll() {
         return skipAll;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultSkillGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultSkillGenerator.java
@@ -27,6 +27,11 @@
  */
 package mekhq.campaign.personnel.generator;
 
+import static mekhq.campaign.personnel.SkillDeprecationTool.DEPRECATED_SKILLS;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import megamek.common.Compute;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
@@ -34,9 +39,6 @@ import mekhq.campaign.RandomSkillPreferences;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class DefaultSkillGenerator extends AbstractSkillGenerator {
     //region Constructors
@@ -69,9 +71,9 @@ public class DefaultSkillGenerator extends AbstractSkillGenerator {
 
         // roll small arms skill
         if (!person.getSkills().hasSkill(SkillType.S_SMALL_ARMS)) {
-            int sarmsLvl = Utilities.generateExpLevel(
-                    (primaryRole.isSupport(true) || secondaryRole.isSupport(true))
-                            ? rskillPrefs.getSupportSmallArmsBonus() : rskillPrefs.getCombatSmallArmsBonus());
+            int sarmsLvl = Utilities.generateExpLevel((primaryRole.isSupport(true) || secondaryRole.isSupport(true)) ?
+                                                            rskillPrefs.getSupportSmallArmsBonus() :
+                                                            rskillPrefs.getCombatSmallArmsBonus());
 
             if (primaryRole.isCivilian()) {
                 sarmsLvl = 0;
@@ -101,29 +103,31 @@ public class DefaultSkillGenerator extends AbstractSkillGenerator {
         }
 
         // roll artillery skill
-        if (campaign.getCampaignOptions().isUseArtillery()
-                && (primaryRole.isMekWarrior() || primaryRole.isVehicleGunner() || primaryRole.isSoldier())
-                && Utilities.rollProbability(rskillPrefs.getArtilleryProb())) {
+        if (campaign.getCampaignOptions().isUseArtillery() &&
+                  (primaryRole.isMekWarrior() || primaryRole.isVehicleGunner() || primaryRole.isSoldier()) &&
+                  Utilities.rollProbability(rskillPrefs.getArtilleryProb())) {
             generateArtillerySkill(person, bonus);
         }
 
         // roll Negotiation skill
-        if (campaign.getCampaignOptions().isAdminsHaveNegotiation()
-                && (primaryRole.isAdministrator())) {
+        if (campaign.getCampaignOptions().isAdminsHaveNegotiation() && (primaryRole.isAdministrator())) {
             addSkill(person, SkillType.S_NEG, expLvl, rskillPrefs.randomizeSkill(), bonus, mod);
         }
 
         // roll Scrounge skill
-        if (campaign.getCampaignOptions().isAdminsHaveScrounge()
-                && (primaryRole.isAdministrator())) {
+        if (campaign.getCampaignOptions().isAdminsHaveScrounge() && (primaryRole.isAdministrator())) {
             addSkill(person, SkillType.S_SCROUNGE, expLvl, rskillPrefs.randomizeSkill(), bonus, mod);
         }
 
         // roll random secondary skill
         if (Utilities.rollProbability(rskillPrefs.getSecondSkillProb())) {
-            final List<String> possibleSkills = Arrays.stream(SkillType.skillList)
-                    .filter(stype -> !person.getSkills().hasSkill(stype))
-                    .toList();
+            List<String> possibleSkills = new ArrayList<>();
+            for (String stype : SkillType.skillList) {
+                if (!person.getSkills().hasSkill(stype) && !DEPRECATED_SKILLS.contains(SkillType.getType(stype))) {
+                    possibleSkills.add(stype);
+                }
+            }
+
             String selSkill = possibleSkills.get(Compute.randomInt(possibleSkills.size()));
             int secondLvl = Utilities.generateExpLevel(rskillPrefs.getSecondSkillBonus());
             addSkill(person, selSkill, secondLvl, rskillPrefs.randomizeSkill(), bonus);


### PR DESCRIPTION
- Added options to "Skip All" and "Refund All" deprecated skill checks for streamlined personnel management.
- Introduced boolean flags (`skipAllDeprecationChecks` and `refundAllDeprecatedSkills`) to control deprecation behaviors.
- Updated `SkillDeprecationTool` to handle new dialog choices and flag propagation.
- Prevented deprecated skills from being assigned during skill generation in `DefaultSkillGenerator`.
- Adjusted UI labels and localization to support the new deprecation handling options.

### Dev Notes
This PR adds two new buttons to the Deprecated Skills dialog: Skip All, and Refund All. This functionality is introduced to better support campaigns with a large volume of personnel.

I also added a check to character creation that prevents new characters from generating with a Deprecated skill.