### PR TITLE
Refactored Intelligence XP Costs and Skill Calculations; Blocked Illegal Skill Progression

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Skill.java
@@ -263,7 +263,7 @@ public class Skill {
      * the cost for the next valid level if it exists.</p>
      *
      * <p><b>Usage:</b> For most use cases you probably want to call {@code getCostToImprove(String)} from a
-     * {@link Person} object, as that will factor in things like {@link Intelligence}.</p></p>
+     * {@link Person} object, as that will factor in things like {@link Intelligence}.</p>
      *
      * @return the cost to improve the skill, or 0 if no valid level with a positive cost is found.
      */

--- a/MekHQ/src/mekhq/campaign/personnel/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Skill.java
@@ -122,25 +122,21 @@ public class Skill {
     }
 
     /**
-     * Determines whether the current skill or attribute level is eligible for improvement based on its type, current
-     * value, and defined rules.
+     * Evaluates whether the current skill or attribute level is eligible for improvement based on progression type,
+     * current value, and min-max limitations.
      *
-     * <p>If the type follows a "count up" progression (increasing value), the improvement is legal only if the
-     * calculated skill value has reached or exceeded the specified maximum value. Conversely, if the type follows a
-     * "count down" progression (decreasing value), the improvement is legal only if the calculated skill value has
-     * reached or dropped below the specified minimum value.</p>
+     * <p>For a "count up" progression (increasing value), the improvement is valid only if the calculated skill value
+     * is less than the defined maximum value. In contrast, for a "count down" progression (decreasing value), the
+     * improvement is valid only if the calculated skill value is greater than the defined minimum value.</p>
      *
-     * <p>The determination is based on the skill's dynamically calculated value, which incorporates the type target,
-     * level, and any applicable bonuses.</p>
-     *
-     * @return {@code true} if the current state meets the conditions for legal improvement according to the progression
-     *       type and calculated skill value, {@code false} otherwise.
+     * @return {@code true} if the current state satisfies the eligibility criteria for legal improvement based on the
+     *       progression type; {@code false} otherwise.
      */
     public boolean isImprovementLegal() {
         if (isCountUp()) {
-            return getSkillValue() >= COUNT_UP_MAX_VALUE;
+            return getSkillValue() < COUNT_UP_MAX_VALUE;
         } else {
-            return getSkillValue() <= COUNT_DOWN_MIN_VALUE;
+            return getSkillValue() > COUNT_DOWN_MIN_VALUE;
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Skill.java
@@ -28,53 +28,46 @@
  */
 package mekhq.campaign.personnel;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+import java.io.PrintWriter;
+
 import megamek.common.Compute;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
+import mekhq.campaign.randomEvents.personalities.enums.Intelligence;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import java.io.PrintWriter;
-
-import static java.lang.Math.max;
-import static java.lang.Math.min;
-
 /**
- * As ov v0.1.9, we will be tracking a group of skills on the person. These
- * skills will define personnel rather than subtypes wrapped around pilots and
- * teams. This will allow for considerably more flexibility in the kinds of
- * personnel available.
+ * As ov v0.1.9, we will be tracking a group of skills on the person. These skills will define personnel rather than
+ * subtypes wrapped around pilots and teams. This will allow for considerably more flexibility in the kinds of personnel
+ * available.
  * <p>
  * Four important characteristics will determine how each skill works
- *
- * level - this is the level of the skill. By default this will go from 0 to 10,
- * but the max will be customizable. These won't necessarily correspond to named
- * levels (e.g. Green, Elite).
- *
- * By assigning skill costs of 0 to some levels, these can basically be skipped
- * and by assigning skill costs of -1, they can be made inaccessible.
- *
- * bonus - this is a bonus that the given person has for this skill which is
- * separable from level. Primarily this allows for rpg-style attribute bonuses
- * to come into play.
- *
- * target - this is the baseline target number for the skill when level and
- * bonus are zero.
- *
- * countUp - this is a boolean that defines whether this skill's target is a
- * "roll greater than or equal to" (false) or an rpg-style bonus to a roll
- * (true)
- *
+ * <p>
+ * level - this is the level of the skill. By default this will go from 0 to 10, but the max will be customizable. These
+ * won't necessarily correspond to named levels (e.g. Green, Elite).
+ * <p>
+ * By assigning skill costs of 0 to some levels, these can basically be skipped and by assigning skill costs of -1, they
+ * can be made inaccessible.
+ * <p>
+ * bonus - this is a bonus that the given person has for this skill which is separable from level. Primarily this allows
+ * for rpg-style attribute bonuses to come into play.
+ * <p>
+ * target - this is the baseline target number for the skill when level and bonus are zero.
+ * <p>
+ * countUp - this is a boolean that defines whether this skill's target is a "roll greater than or equal to" (false) or
+ * an rpg-style bonus to a roll (true)
+ * <p>
  * The actual target number for a skill is given by
- *
- * countUp: target + lvl + bonus
- * !countUp: target - level - bonus
- *
- * by clever manipulation of these values and skill costs in campaignOptions,
- * players should be able to recreate any of the rpg versions or their own
- * homebrew system. The default setup will follow the core rule books (not
- * aToW).
+ * <p>
+ * countUp: target + lvl + bonus !countUp: target - level - bonus
+ * <p>
+ * by clever manipulation of these values and skill costs in campaignOptions, players should be able to recreate any of
+ * the rpg versions or their own homebrew system. The default setup will follow the core rule books (not aToW).
  *
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
@@ -122,15 +115,43 @@ public class Skill {
     }
 
     /**
+     * @return {@code true} if the progression type is "count up", {@code false} otherwise.
+     */
+    private boolean isCountUp() {
+        return type.countUp();
+    }
+
+    /**
+     * Determines whether the current skill or attribute level is eligible for improvement based on its type, current
+     * value, and defined rules.
+     *
+     * <p>If the type follows a "count up" progression (increasing value), the improvement is legal only if the
+     * calculated skill value has reached or exceeded the specified maximum value. Conversely, if the type follows a
+     * "count down" progression (decreasing value), the improvement is legal only if the calculated skill value has
+     * reached or dropped below the specified minimum value.</p>
+     *
+     * <p>The determination is based on the skill's dynamically calculated value, which incorporates the type target,
+     * level, and any applicable bonuses.</p>
+     *
+     * @return {@code true} if the current state meets the conditions for legal improvement according to the progression
+     *       type and calculated skill value, {@code false} otherwise.
+     */
+    public boolean isImprovementLegal() {
+        if (isCountUp()) {
+            return getSkillValue() >= COUNT_UP_MAX_VALUE;
+        } else {
+            return getSkillValue() <= COUNT_DOWN_MIN_VALUE;
+        }
+    }
+
+    /**
      * Creates a new {@link Skill} from the given experience level and bonus.
      *
      * @param type            The {@link SkillType} name.
-     * @param experienceLevel An experience level (e.g.
-     *                        {@link SkillType#EXP_GREEN}).
+     * @param experienceLevel An experience level (e.g. {@link SkillType#EXP_GREEN}).
      * @param bonus           The bonus for the resulting {@link Skill}.
-     * @return A new {@link Skill} of the appropriate type, with a level based on
-     *         {@code experienceLevel}
-     *         and the bonus.
+     *
+     * @return A new {@link Skill} of the appropriate type, with a level based on {@code experienceLevel} and the bonus.
      */
     public static Skill createFromExperience(String type, int experienceLevel, int bonus) {
         SkillType skillType = SkillType.getType(type);
@@ -142,13 +163,12 @@ public class Skill {
      * Creates a new {@link Skill} with a randomized level.
      *
      * @param type            The {@link SkillType} name.
-     * @param experienceLevel An experience level (e.g.
-     *                        {@link SkillType#EXP_GREEN}).
+     * @param experienceLevel An experience level (e.g. {@link SkillType#EXP_GREEN}).
      * @param bonus           The bonus for the resulting {@link Skill}.
      * @param rollModifier    The roll modifier on a 1D6.
-     * @return A new {@link Skill} of the appropriate type, with a randomized level
-     *         based on
-     *         the experience level and a 1D6 roll.
+     *
+     * @return A new {@link Skill} of the appropriate type, with a randomized level based on the experience level and a
+     *       1D6 roll.
      */
     public static Skill randomizeLevel(String type, int experienceLevel, int bonus, int rollModifier) {
         SkillType skillType = SkillType.getType(type);
@@ -184,11 +204,37 @@ public class Skill {
         return type;
     }
 
+    /**
+     * Calculates the final skill value based on the progression type, the current level, and any applicable bonuses,
+     * while ensuring the value stays within the legal bounds for the skill type.
+     *
+     * <p>For "count up" progression types, the final skill value is capped at the maximum allowed value. For "count
+     * down" progression types, the final skill value is capped at the minimum allowed value.</p>
+     *
+     * @return the final skill value after applying progression rules and limiting it to the legal range.
+     */
     public int getFinalSkillValue() {
-        if (type.countUp()) {
-            return min(COUNT_UP_MAX_VALUE, type.getTarget() + level + bonus);
+        if (isCountUp()) {
+            return min(COUNT_UP_MAX_VALUE, getSkillValue());
         } else {
-            return max(COUNT_DOWN_MIN_VALUE, type.getTarget() - level - bonus);
+            return max(COUNT_DOWN_MIN_VALUE, getSkillValue());
+        }
+    }
+
+    /**
+     * Calculates the raw skill value based on the type's progression rules, level, and bonus.
+     *
+     * <p>For "count up" progression types, the skill value is determined by adding the target value, level, and bonus.
+     * For "count down" progression types, it is determined by subtracting the level and bonus from the target
+     * value.</p>
+     *
+     * @return the calculated raw skill value before applying any boundaries or limits.
+     */
+    private int getSkillValue() {
+        if (isCountUp()) {
+            return type.getTarget() + level + bonus;
+        } else {
+            return type.getTarget() - level - bonus;
         }
     }
 
@@ -214,6 +260,17 @@ public class Skill {
         }
     }
 
+    /**
+     * Calculates the cost required to improve this skill to a higher level.
+     *
+     * <p>This method iterates through skill levels starting from the current level and returns
+     * the cost for the next valid level if it exists.</p>
+     *
+     * <p><b>Usage:</b> For most use cases you probably want to call {@code getCostToImprove(String)} from a
+     * {@link Person} object, as that will factor in things like {@link Intelligence}.</p></p>
+     *
+     * @return the cost to improve the skill, or 0 if no valid level with a positive cost is found.
+     */
     public int getCostToImprove() {
         int cost = 0;
         int i = 1;
@@ -236,7 +293,7 @@ public class Skill {
 
     @Override
     public String toString() {
-        if (type.countUp()) {
+        if (isCountUp()) {
             return "+" + getFinalSkillValue();
         } else {
             return getFinalSkillValue() + "+";

--- a/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
@@ -27,12 +27,13 @@
  */
 package mekhq.campaign.personnel;
 
-import static java.lang.Math.ceil;
+import static java.lang.Math.round;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.util.List;
 
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 
 /**
@@ -91,14 +92,22 @@ public class SkillDeprecationTool {
      * @param person the {@link Person} to check for deprecated skills
      */
     private void checkForDeprecatedSkills(Person person) {
-        final Skills skills = person.getSkills();
+        final CampaignOptions campaignOptions = campaign.getCampaignOptions();
 
+        final double xpCostMultiplier = campaignOptions.getXpCostMultiplier();
+
+        final boolean isUseIntelligenceMultiplier = campaignOptions.isUseIntelligenceXpMultiplier();
+        final double intelligenceMultiplier = person.getIntelligenceXpCostMultiplier(isUseIntelligenceMultiplier);
+
+        final Skills skills = person.getSkills();
         for (SkillType skillType : DEPRECATED_SKILLS) {
             final String skillName = skillType.getName();
             if (skills.hasSkill(skillName)) {
                 int refundValue = getRefundValue(skills, skillType, skillName);
-                double intelligenceMultiplier = person.getIntelligenceXpCostMultiplier(campaign.getCampaignOptions());
-                refundValue = (int) ceil(refundValue * intelligenceMultiplier);
+
+                // Intelligence cost changes should always take place before global changes
+                refundValue = (int) round(refundValue * intelligenceMultiplier);
+                refundValue = (int) round(refundValue * xpCostMultiplier);
 
                 triggerDialog(skills, skillName, refundValue);
             }

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -27,6 +27,14 @@
  */
 package mekhq.campaign.personnel.education;
 
+import static java.lang.Math.round;
+import static mekhq.campaign.personnel.SkillType.EXP_GREEN;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
+
+import java.time.LocalDate;
+import java.util.*;
+
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -38,24 +46,15 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.Skill;
 import mekhq.campaign.unit.Unit;
 
-import java.time.LocalDate;
-import java.util.*;
-
-import static java.lang.Math.round;
-import static mekhq.campaign.personnel.SkillType.EXP_GREEN;
-import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
-import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
-
 /**
  * Handles the training of combat teams within the campaign.
  *
  * <p>This class is responsible for managing the process of skill improvement and education for
- * training combat teams and their associated personnel. It identifies eligible combat teams,
- * validates their contracts and current conditions, and processes training for each team member.</p>
+ * training combat teams and their associated personnel. It identifies eligible combat teams, validates their contracts
+ * and current conditions, and processes training for each team member.</p>
  *
  * <p>Key functionality includes tracking education time for trainees, determining skills eligible
- * for training, generating skill improvement reports, and handling both individual and group
- * training scenarios.</p>
+ * for training, generating skill improvement reports, and handling both individual and group training scenarios.</p>
  *
  * <p>Main methods:
  * <ul>
@@ -89,9 +88,9 @@ public class TrainingCombatTeams {
      * Processes all training combat teams in the campaign.
      *
      * <p>This method iterates through all combat teams in the campaign and processes training for
-     * those whose role includes training. It ensures that combat teams are eligible for training
-     * by checking that their contracts are active and valid on the current date. If StratCon is
-     * used, it also verifies that the teams are deployed in their appropriate sectors.</p>
+     * those whose role includes training. It ensures that combat teams are eligible for training by checking that their
+     * contracts are active and valid on the current date. If StratCon is used, it also verifies that the teams are
+     * deployed in their appropriate sectors.</p>
      *
      * @param campaign the {@link Campaign} instance managing the combat teams and their operations
      */
@@ -109,8 +108,8 @@ public class TrainingCombatTeams {
                 continue;
             }
 
-            if (campaign.getCampaignOptions().isUseStratCon()
-                && !contract.getStratconCampaignState().isForceDeployedHere(combatTeam.getForceId())) {
+            if (campaign.getCampaignOptions().isUseStratCon() &&
+                      !contract.getStratconCampaignState().isForceDeployedHere(combatTeam.getForceId())) {
                 continue;
             }
 
@@ -122,9 +121,9 @@ public class TrainingCombatTeams {
      * Handles the training progression for an individual combat team.
      *
      * <p>This method identifies the combat team's commander and educators within the unit,
-     * collects their skills, and compares them to the skills of the trainees in the team. Eligible
-     * trainees undergo training to improve their skills, which is simulated through education
-     * time tracking and skill level progression.</p>
+     * collects their skills, and compares them to the skills of the trainees in the team. Eligible trainees undergo
+     * training to improve their skills, which is simulated through education time tracking and skill level
+     * progression.</p>
      *
      * <p>If educators or trainees lack eligible skills, appropriate reports are generated.
      * Training updates for skills and progression are logged within the campaign.</p>
@@ -138,8 +137,7 @@ public class TrainingCombatTeams {
         Person commander = combatTeam.getCommander(campaign);
 
         if (commander == null) {
-            logger.info(String.format("Failed to fetch commander for Combat Team: %s",
-                    combatTeam.getForceId()));
+            logger.info(String.format("Failed to fetch commander for Combat Team: %s", combatTeam.getForceId()));
             return;
         }
 
@@ -160,8 +158,8 @@ public class TrainingCombatTeams {
      * Handles training for all trainees within a force.
      *
      * <p>This method iterates over each unit in the specified force and processes training
-     * for all active personnel within each unit. Eligible skills are identified by comparing
-     * the educator's abilities to those of the trainees, and skill improvement is simulated.</p>
+     * for all active personnel within each unit. Eligible skills are identified by comparing the educator's abilities
+     * to those of the trainees, and skill improvement is simulated.</p>
      *
      * @param campaign       the current {@link Campaign}
      * @param force          the {@link Force} containing the units to train
@@ -208,9 +206,10 @@ public class TrainingCombatTeams {
 
                 if (educatorSkills.isEmpty() || skillsBeingTrained.isEmpty()) {
                     campaign.addReport(String.format(resources.getString("notLearningAnything.text"),
-                            trainee.getHyperlinkedFullTitle(), commander.getFullTitle(),
-                            spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
-                            CLOSING_SPAN_TAG));
+                          trainee.getHyperlinkedFullTitle(),
+                          commander.getFullTitle(),
+                          spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
+                          CLOSING_SPAN_TAG));
                     trainee.setEduAcademyName("");
                     trainee.setEduEducationTime(0);
                     continue;
@@ -227,16 +226,16 @@ public class TrainingCombatTeams {
      * Progresses a trainee's education time and improves skills if the required threshold is met.
      *
      * <p>This method calculates the education time required for the next experience level and compares
-     * it with the trainee's accumulated education time. If the required time is met or exceeded, the
-     * skill level is increased, and education time is reset or reduced as needed.</p>
+     * it with the trainee's accumulated education time. If the required time is met or exceeded, the skill level is
+     * increased, and education time is reset or reduced as needed.</p>
      *
-     * @param campaign          the current {@link Campaign}
-     * @param commander         the {@link Person} acting as the educator for the trainee
-     * @param trainee           the {@link Person} receiving training
+     * @param campaign           the current {@link Campaign}
+     * @param commander          the {@link Person} acting as the educator for the trainee
+     * @param trainee            the {@link Person} receiving training
      * @param skillsBeingTrained a list of eligible {@link Skill} objects for training
      */
-    private static void processEducationTime(Campaign campaign, Person commander,
-                                             Person trainee, List<Skill> skillsBeingTrained) {
+    private static void processEducationTime(Campaign campaign, Person commander, Person trainee,
+                                             List<Skill> skillsBeingTrained) {
         final CampaignOptions campaignOptions = campaign.getCampaignOptions();
         final String EDUCATION_STRING = "TRAINING_COMBAT_TEAM"; // Never change this
         final int WEEK_DURATION = 7; // days
@@ -261,9 +260,11 @@ public class TrainingCombatTeams {
 
             int perExperienceLevelMultiplier = EDUCATION_TIME_MULTIPLIER;
             double experienceMultiplier = campaignOptions.getXpCostMultiplier();
-            double intelligenceCostMultiplier = trainee.getIntelligenceXpCostMultiplier(campaignOptions);
+            double intelligenceCostMultiplier = trainee.getIntelligenceXpCostMultiplier(campaignOptions.isUseIntelligenceXpMultiplier());
 
-            perExperienceLevelMultiplier = (int) round(perExperienceLevelMultiplier * experienceMultiplier * intelligenceCostMultiplier);
+            // Intelligence cost changes should always take place before global changes
+            perExperienceLevelMultiplier = (int) round(perExperienceLevelMultiplier * experienceMultiplier);
+            perExperienceLevelMultiplier = (int) round(perExperienceLevelMultiplier * intelligenceCostMultiplier);
 
             int educationTimeReduction = currentExperienceLevel * perExperienceLevelMultiplier;
             if (newEducationTime >= educationTimeReduction) {
@@ -272,9 +273,12 @@ public class TrainingCombatTeams {
 
 
                 campaign.addReport(String.format(resources.getString("learnedNewSkill.text"),
-                        commander.getFullTitle(), trainee.getHyperlinkedFullTitle(),
-                        spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor()),
-                        CLOSING_SPAN_TAG, targetSkill.getType().getName(), targetSkill.getFinalSkillValue()));
+                      commander.getFullTitle(),
+                      trainee.getHyperlinkedFullTitle(),
+                      spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor()),
+                      CLOSING_SPAN_TAG,
+                      targetSkill.getType().getName(),
+                      targetSkill.getFinalSkillValue()));
             }
         }
     }
@@ -287,8 +291,8 @@ public class TrainingCombatTeams {
      *
      * @param campaign  the current {@link Campaign}
      * @param educators a {@link Set} of {@link Person} objects acting as educators
-     * @return a {@link Map} of skill names to experience levels representing the available skills
-     * for teaching
+     *
+     * @return a {@link Map} of skill names to experience levels representing the available skills for teaching
      */
     private static Map<String, Integer> createSkillsList(Campaign campaign, Set<Person> educators) {
         Map<String, Integer> educatorSkills = new HashMap<>();

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -73,6 +73,7 @@ import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.Kill;
 import mekhq.campaign.event.PersonChangedEvent;
 import mekhq.campaign.event.PersonLogEvent;
@@ -230,18 +231,25 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private final PersonnelTableModel personnelModel;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale());
+          MekHQ.getMHQOptions().getLocale());
     // endregion Variable Declarations
 
-    protected PersonnelTableMouseAdapter(CampaignGUI gui, JTable personnelTable,
-            PersonnelTableModel personnelModel) {
+    protected PersonnelTableMouseAdapter(CampaignGUI gui, JTable personnelTable, PersonnelTableModel personnelModel) {
         this.gui = gui;
         this.personnelTable = personnelTable;
         this.personnelModel = personnelModel;
     }
 
-    public static void connect(CampaignGUI gui, JTable personnelTable,
-            PersonnelTableModel personnelModel, JSplitPane splitPersonnel) {
+    private Campaign getCampaign() {
+        return gui.getCampaign();
+    }
+
+    private CampaignOptions getCampaignOptions() {
+        return getCampaign().getCampaignOptions();
+    }
+
+    public static void connect(CampaignGUI gui, JTable personnelTable, PersonnelTableModel personnelModel,
+                               JSplitPane splitPersonnel) {
         new PersonnelTableMouseAdapter(gui, personnelTable, personnelModel) {
             @Override
             public void mouseClicked(MouseEvent e) {
@@ -300,8 +308,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         promotedPersonnel.add(person);
                     }
 
-                    if ((gui.getCampaign().getCampaignOptions().isEnableAutoAwards())
-                            && (!promotedPersonnel.isEmpty())) {
+                    if ((gui.getCampaign().getCampaignOptions().isEnableAutoAwards()) &&
+                              (!promotedPersonnel.isEmpty())) {
                         AutoAwardsController autoAwardsController = new AutoAwardsController();
                         autoAwardsController.PromotionController(gui.getCampaign(), false);
                     }
@@ -356,9 +364,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     person.setPrimaryRole(gui.getCampaign(), role);
                     writePersonalityDescription(person);
                     gui.getCampaign().personUpdated(person);
-                    if (gui.getCampaign().getCampaignOptions().isUsePortraitForRole(role)
-                            && gui.getCampaign().getCampaignOptions().isAssignPortraitOnRoleChange()
-                            && person.getPortrait().hasDefaultFilename()) {
+                    if (gui.getCampaign().getCampaignOptions().isUsePortraitForRole(role) &&
+                              gui.getCampaign().getCampaignOptions().isAssignPortraitOnRoleChange() &&
+                              person.getPortrait().hasDefaultFilename()) {
                         gui.getCampaign().assignRandomPortraitFor(person);
                     }
                 }
@@ -374,13 +382,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_ADD_PREGNANCY: {
                 Stream.of(people)
-                        .filter(person -> (gui.getCampaign().getProcreation().canProcreate(
-                                gui.getCampaign().getLocalDate(), person, false) == null))
-                        .forEach(person -> {
-                            gui.getCampaign().getProcreation().addPregnancy(
-                                    gui.getCampaign(), gui.getCampaign().getLocalDate(), person, false);
-                            MekHQ.triggerEvent(new PersonChangedEvent(person));
-                        });
+                      .filter(person -> (gui.getCampaign()
+                                               .getProcreation()
+                                               .canProcreate(gui.getCampaign().getLocalDate(), person, false) == null))
+                      .forEach(person -> {
+                          gui.getCampaign()
+                                .getProcreation()
+                                .addPregnancy(gui.getCampaign(), gui.getCampaign().getLocalDate(), person, false);
+                          MekHQ.triggerEvent(new PersonChangedEvent(person));
+                      });
                 break;
             }
             case CMD_REMOVE_PREGNANCY: {
@@ -392,23 +402,30 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_REMOVE_SPOUSE: {
                 Stream.of(people)
-                        .filter(person -> gui.getCampaign().getDivorce().canDivorce(person, false) == null)
-                        .forEach(person -> gui.getCampaign().getDivorce().divorce(gui.getCampaign(),
-                                gui.getCampaign().getLocalDate(), person,
-                                SplittingSurnameStyle.valueOf(data[1])));
+                      .filter(person -> gui.getCampaign().getDivorce().canDivorce(person, false) == null)
+                      .forEach(person -> gui.getCampaign()
+                                               .getDivorce()
+                                               .divorce(gui.getCampaign(),
+                                                     gui.getCampaign().getLocalDate(),
+                                                     person,
+                                                     SplittingSurnameStyle.valueOf(data[1])));
                 break;
             }
             case CMD_ADD_SPOUSE: {
-                gui.getCampaign().getMarriage().marry(gui.getCampaign(),
-                        gui.getCampaign().getLocalDate(), selectedPerson,
-                        gui.getCampaign().getPerson(UUID.fromString(data[1])),
-                        MergingSurnameStyle.valueOf(data[2]), false);
+                gui.getCampaign()
+                      .getMarriage()
+                      .marry(gui.getCampaign(),
+                            gui.getCampaign().getLocalDate(),
+                            selectedPerson,
+                            gui.getCampaign().getPerson(UUID.fromString(data[1])),
+                            MergingSurnameStyle.valueOf(data[2]),
+                            false);
                 break;
             }
             case CMD_ADD_AWARD: {
                 for (Person person : people) {
-                    person.getAwardController().addAndLogAward(gui.getCampaign(), data[1], data[2],
-                            gui.getCampaign().getLocalDate());
+                    person.getAwardController()
+                          .addAndLogAward(gui.getCampaign(), data[1], data[2], gui.getCampaign().getLocalDate());
                 }
                 break;
             }
@@ -416,11 +433,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 for (Person person : people) {
                     try {
                         if (person.getAwardController().hasAward(data[1], data[2])) {
-                            person.getAwardController().removeAward(data[1], data[2],
-                                    (data.length > 3)
-                                            ? MekHQ.getMHQOptions().parseDisplayFormattedDate(data[3])
-                                            : null,
-                                    gui.getCampaign().getLocalDate());
+                            person.getAwardController()
+                                  .removeAward(data[1],
+                                        data[2],
+                                        (data.length > 3) ?
+                                              MekHQ.getMHQOptions().parseDisplayFormattedDate(data[3]) :
+                                              null,
+                                        gui.getCampaign().getLocalDate());
                         }
                     } catch (Exception e) {
                         logger.error("Could not remove award.", e);
@@ -479,8 +498,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                 if (!graduatingPersonnel.isEmpty()) {
                     AutoAwardsController autoAwardsController = new AutoAwardsController();
-                    autoAwardsController.PostGraduationController(gui.getCampaign(), graduatingPersonnel,
-                            academyAttributesMap);
+                    autoAwardsController.PostGraduationController(gui.getCampaign(),
+                          graduatingPersonnel,
+                          academyAttributesMap);
                 }
                 break;
             }
@@ -492,7 +512,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                     switch (educationStage) {
                         case JOURNEY_TO_CAMPUS, JOURNEY_FROM_CAMPUS -> person.changeStatus(gui.getCampaign(),
-                                gui.getCampaign().getLocalDate(), PersonnelStatus.ACTIVE);
+                              gui.getCampaign().getLocalDate(),
+                              PersonnelStatus.ACTIVE);
                         case EDUCATION -> EducationController.processForcedDropOut(gui.getCampaign(), person, academy);
                         default -> {
                         }
@@ -510,11 +531,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 selectedPerson.improveSkill(type);
                 selectedPerson.spendXP(cost);
 
-                PersonalLogger.improvedSkill(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), selectedPerson.getSkill(type).getType().getName(),
-                        selectedPerson.getSkill(type).toString());
-                gui.getCampaign().addReport(String.format(resources.getString("improved.format"),
-                        selectedPerson.getHyperlinkedName(), type));
+                PersonalLogger.improvedSkill(gui.getCampaign(),
+                      selectedPerson,
+                      gui.getCampaign().getLocalDate(),
+                      selectedPerson.getSkill(type).getType().getName(),
+                      selectedPerson.getSkill(type).toString());
+                gui.getCampaign()
+                      .addReport(String.format(resources.getString("improved.format"),
+                            selectedPerson.getHyperlinkedName(),
+                            type));
 
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
@@ -522,104 +547,141 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_ACQUIRE_ABILITY: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        selected, true);
+                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, selected, true);
                 selectedPerson.spendXP(cost);
                 final String displayName = SpecialAbility.getDisplayName(selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
+                PersonalLogger.gainedSPA(gui.getCampaign(),
+                      selectedPerson,
+                      gui.getCampaign().getLocalDate(),
+                      displayName);
+                gui.getCampaign()
+                      .addReport(String.format(resources.getString("gained.format"),
+                            selectedPerson.getHyperlinkedName(),
+                            displayName));
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_WEAPON_SPECIALIST: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.GUNNERY_WEAPON_SPECIALIST, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
+                            OptionsConstants.GUNNERY_WEAPON_SPECIALIST,
+                            selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_WEAPON_SPECIALIST), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
+                      SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_WEAPON_SPECIALIST),
+                      selected);
+                PersonalLogger.gainedSPA(gui.getCampaign(),
+                      selectedPerson,
+                      gui.getCampaign().getLocalDate(),
+                      displayName);
+                gui.getCampaign()
+                      .addReport(String.format(resources.getString("gained.format"),
+                            selectedPerson.getHyperlinkedName(),
+                            displayName));
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_SANDBLASTER: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.GUNNERY_SANDBLASTER, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, OptionsConstants.GUNNERY_SANDBLASTER, selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SANDBLASTER), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
+                      SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SANDBLASTER),
+                      selected);
+                PersonalLogger.gainedSPA(gui.getCampaign(),
+                      selectedPerson,
+                      gui.getCampaign().getLocalDate(),
+                      displayName);
+                gui.getCampaign()
+                      .addReport(String.format(resources.getString("gained.format"),
+                            selectedPerson.getHyperlinkedName(),
+                            displayName));
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_SPECIALIST: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.GUNNERY_SPECIALIST, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, OptionsConstants.GUNNERY_SPECIALIST, selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SPECIALIST), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
+                      SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SPECIALIST),
+                      selected);
+                PersonalLogger.gainedSPA(gui.getCampaign(),
+                      selectedPerson,
+                      gui.getCampaign().getLocalDate(),
+                      displayName);
+                gui.getCampaign()
+                      .addReport(String.format(resources.getString("gained.format"),
+                            selectedPerson.getHyperlinkedName(),
+                            displayName));
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_RANGEMASTER: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.GUNNERY_RANGE_MASTER, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
+                            OptionsConstants.GUNNERY_RANGE_MASTER,
+                            selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_RANGE_MASTER), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
+                      SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_RANGE_MASTER),
+                      selected);
+                PersonalLogger.gainedSPA(gui.getCampaign(),
+                      selectedPerson,
+                      gui.getCampaign().getLocalDate(),
+                      displayName);
+                gui.getCampaign()
+                      .addReport(String.format(resources.getString("gained.format"),
+                            selectedPerson.getHyperlinkedName(),
+                            displayName));
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_ENVSPEC: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.MISC_ENV_SPECIALIST, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, OptionsConstants.MISC_ENV_SPECIALIST, selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.MISC_ENV_SPECIALIST), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
+                      SpecialAbility.getDisplayName(OptionsConstants.MISC_ENV_SPECIALIST),
+                      selected);
+                PersonalLogger.gainedSPA(gui.getCampaign(),
+                      selectedPerson,
+                      gui.getCampaign().getLocalDate(),
+                      displayName);
+                gui.getCampaign()
+                      .addReport(String.format(resources.getString("gained.format"),
+                            selectedPerson.getHyperlinkedName(),
+                            displayName));
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_HUMANTRO: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.MISC_HUMAN_TRO, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, OptionsConstants.MISC_HUMAN_TRO, selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.MISC_HUMAN_TRO), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
+                      SpecialAbility.getDisplayName(OptionsConstants.MISC_HUMAN_TRO),
+                      selected);
+                PersonalLogger.gainedSPA(gui.getCampaign(),
+                      selectedPerson,
+                      gui.getCampaign().getLocalDate(),
+                      displayName);
+                gui.getCampaign()
+                      .addReport(String.format(resources.getString("gained.format"),
+                            selectedPerson.getHyperlinkedName(),
+                            displayName));
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
             }
@@ -627,24 +689,28 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
                 String ability = data[3];
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        ability, selected);
+                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, ability, selected);
                 selectedPerson.spendXP(cost);
-                final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(ability), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("spaGainedChoices.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
+                final String displayName = String.format("%s %s", SpecialAbility.getDisplayName(ability), selected);
+                PersonalLogger.gainedSPA(gui.getCampaign(),
+                      selectedPerson,
+                      gui.getCampaign().getLocalDate(),
+                      displayName);
+                gui.getCampaign()
+                      .addReport(String.format(resources.getString("spaGainedChoices.format"),
+                            selectedPerson.getHyperlinkedName(),
+                            displayName));
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_CHANGE_STATUS: {
                 PersonnelStatus status = PersonnelStatus.valueOf(data[1]);
                 for (Person person : people) {
-                    if (status.isActive() || (JOptionPane.showConfirmDialog(null,
-                            String.format(resources.getString("confirmRetireQ.format"), person.getFullTitle()),
-                            status.toString(), JOptionPane.YES_NO_OPTION) == 0)) {
+                    if (status.isActive() ||
+                              (JOptionPane.showConfirmDialog(null,
+                                    String.format(resources.getString("confirmRetireQ.format"), person.getFullTitle()),
+                                    status.toString(),
+                                    JOptionPane.YES_NO_OPTION) == 0)) {
                         person.changeStatus(gui.getCampaign(), gui.getCampaign().getLocalDate(), status);
                     }
                 }
@@ -664,26 +730,17 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_FREE: {
-                processPrisonerResolutionCommand(
-                        people,
-                        "confirmFree.format",
-                        "freeQ.text");
+                processPrisonerResolutionCommand(people, "confirmFree.format", "freeQ.text");
 
                 break;
             }
             case CMD_EXECUTE: {
-                processPrisonerResolutionCommand(
-                        people,
-                        "confirmExecute.format",
-                        "executeQ.text");
+                processPrisonerResolutionCommand(people, "confirmExecute.format", "executeQ.text");
 
                 break;
             }
             case CMD_JETTISON: {
-                processPrisonerResolutionCommand(
-                        people,
-                        "confirmJettison.format",
-                        "jettisonQ.text");
+                processPrisonerResolutionCommand(people, "confirmJettison.format", "jettisonQ.text");
 
                 break;
             }
@@ -736,17 +793,20 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // daily report entry, add the money and remove them all.
                 Money total = Money.zero();
                 total = total.plus(Arrays.stream(people)
-                        .map(person -> person.getRansomValue(gui.getCampaign()))
-                        .collect(Collectors.toList()));
+                                         .map(person -> person.getRansomValue(gui.getCampaign()))
+                                         .collect(Collectors.toList()));
 
-                if (0 == JOptionPane.showConfirmDialog(
-                        null,
-                        String.format(resources.getString("ransomQ.format"), people.length,
-                                total.toAmountAndSymbolString()),
-                        resources.getString("ransom.text"),
-                        JOptionPane.YES_NO_OPTION)) {
-                    gui.getCampaign().addReport(String.format(resources.getString("ransomReport.format"),
-                            people.length, total.toAmountAndSymbolString()));
+                if (0 ==
+                          JOptionPane.showConfirmDialog(null,
+                                String.format(resources.getString("ransomQ.format"),
+                                      people.length,
+                                      total.toAmountAndSymbolString()),
+                                resources.getString("ransom.text"),
+                                JOptionPane.YES_NO_OPTION)) {
+                    gui.getCampaign()
+                          .addReport(String.format(resources.getString("ransomReport.format"),
+                                people.length,
+                                total.toAmountAndSymbolString()));
                     gui.getCampaign().addFunds(TransactionType.RANSOM, total, resources.getString("ransom.text"));
                     for (Person person : people) {
                         gui.getCampaign().removePerson(person, false);
@@ -757,28 +817,33 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_RANSOM_FRIENDLY: {
                 Money total = Money.zero();
                 total = total.plus(Arrays.stream(people)
-                        .map(person -> person.getRansomValue(gui.getCampaign()))
-                        .collect(Collectors.toList()));
+                                         .map(person -> person.getRansomValue(gui.getCampaign()))
+                                         .collect(Collectors.toList()));
 
                 if (gui.getCampaign().getFunds().isLessThan(total)) {
-                    gui.getCampaign().addReport(String.format(resources.getString("unableToRansom.format"),
-                            people.length,
-                            total.toAmountAndSymbolString()));
+                    gui.getCampaign()
+                          .addReport(String.format(resources.getString("unableToRansom.format"),
+                                people.length,
+                                total.toAmountAndSymbolString()));
                     break;
                 }
 
-                if (0 == JOptionPane.showConfirmDialog(
-                        null,
-                        String.format(resources.getString("ransomFriendlyQ.format"), people.length,
-                                total.toAmountAndSymbolString()),
-                        resources.getString("ransom.text"),
-                        JOptionPane.YES_NO_OPTION)) {
-                    gui.getCampaign().addReport(String.format(resources.getString("ransomReport.format"),
-                            people.length, total.toAmountAndSymbolString()));
+                if (0 ==
+                          JOptionPane.showConfirmDialog(null,
+                                String.format(resources.getString("ransomFriendlyQ.format"),
+                                      people.length,
+                                      total.toAmountAndSymbolString()),
+                                resources.getString("ransom.text"),
+                                JOptionPane.YES_NO_OPTION)) {
+                    gui.getCampaign()
+                          .addReport(String.format(resources.getString("ransomReport.format"),
+                                people.length,
+                                total.toAmountAndSymbolString()));
                     gui.getCampaign().removeFunds(TransactionType.RANSOM, total, resources.getString("ransom.text"));
                     for (Person person : people) {
-                        person.changeStatus(gui.getCampaign(), gui.getCampaign().getLocalDate(),
-                                PersonnelStatus.ACTIVE);
+                        person.changeStatus(gui.getCampaign(),
+                              gui.getCampaign().getLocalDate(),
+                              PersonnelStatus.ACTIVE);
                     }
                 }
                 break;
@@ -798,12 +863,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_REMOVE: {
-                String title = (people.length == 1) ? people[0].getFullTitle()
-                        : String.format(resources.getString("numPersonnel.text"), people.length);
-                if (0 == JOptionPane.showConfirmDialog(null,
-                        String.format(resources.getString("confirmRemove.format"), title),
-                        resources.getString("removeQ.text"),
-                        JOptionPane.YES_NO_OPTION)) {
+                String title = (people.length == 1) ?
+                                     people[0].getFullTitle() :
+                                     String.format(resources.getString("numPersonnel.text"), people.length);
+                if (0 ==
+                          JOptionPane.showConfirmDialog(null,
+                                String.format(resources.getString("confirmRemove.format"), title),
+                                resources.getString("removeQ.text"),
+                                JOptionPane.YES_NO_OPTION)) {
                     for (Person person : people) {
                         gui.getCampaign().removePerson(person);
                     }
@@ -815,8 +882,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 List<Person> toRemove = new ArrayList<>();
                 for (Person person : people) {
                     if (!person.getPrimaryRole().isCivilian()) {
-                        if (gui.getCampaign().getRetirementDefectionTracker().removeFromCampaign(
-                                person, false, true, gui.getCampaign(), null)) {
+                        if (gui.getCampaign()
+                                  .getRetirementDefectionTracker()
+                                  .removeFromCampaign(person, false, true, gui.getCampaign(), null)) {
                             showDialog = true;
                         } else {
                             toRemove.add(person);
@@ -826,15 +894,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     }
                 }
                 if (showDialog) {
-                    RetirementDefectionDialog rdd = new RetirementDefectionDialog(
-                            gui, null, false);
+                    RetirementDefectionDialog rdd = new RetirementDefectionDialog(gui, null, false);
 
-                    if (rdd.wasAborted()
-                            || !gui.getCampaign().applyRetirement(rdd.totalPayout(),
-                                    rdd.getUnitAssignments())) {
+                    if (rdd.wasAborted() ||
+                              !gui.getCampaign().applyRetirement(rdd.totalPayout(), rdd.getUnitAssignments())) {
                         for (Person person : people) {
-                            gui.getCampaign().getRetirementDefectionTracker()
-                                    .removePayout(person);
+                            gui.getCampaign().getRetirementDefectionTracker().removePayout(person);
                         }
                     } else {
                         for (final Person person : toRemove) {
@@ -848,9 +913,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     } else {
                         question = String.format(resources.getString("confirmRemove.format"), people[0].getFullTitle());
                     }
-                    if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(
-                            null, question, resources.getString("removeQ.text"),
-                            JOptionPane.YES_NO_OPTION)) {
+                    if (JOptionPane.YES_OPTION ==
+                              JOptionPane.showConfirmDialog(null,
+                                    question,
+                                    resources.getString("removeQ.text"),
+                                    JOptionPane.YES_NO_OPTION)) {
                         for (Person person : people) {
                             gui.getCampaign().removePerson(person);
                         }
@@ -860,8 +927,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_EDIT: {
                 for (Person person : people) {
-                    CustomizePersonDialog npd = new CustomizePersonDialog(gui.getFrame(), true,
-                        person, gui.getCampaign());
+                    CustomizePersonDialog npd = new CustomizePersonDialog(gui.getFrame(),
+                          true,
+                          person,
+                          gui.getCampaign());
                     npd.setVisible(true);
                     gui.getCampaign().personUpdated(selectedPerson);
                 }
@@ -871,15 +940,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 EditPersonnelHitsDialog ephd = new EditPersonnelHitsDialog(gui.getFrame(), true, selectedPerson);
                 ephd.setVisible(true);
                 if (0 == selectedPerson.getHits()) {
-                    selectedPerson.setDoctorId(null, gui.getCampaign().getCampaignOptions()
-                            .getNaturalHealingWaitingPeriod());
+                    selectedPerson.setDoctorId(null,
+                          gui.getCampaign().getCampaignOptions().getNaturalHealingWaitingPeriod());
                 }
                 gui.getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_EDIT_PORTRAIT: {
-                final PortraitChooserDialog portraitDialog = new PortraitChooserDialog(
-                        gui.getFrame(), selectedPerson.getPortrait());
+                final PortraitChooserDialog portraitDialog = new PortraitChooserDialog(gui.getFrame(),
+                      selectedPerson.getPortrait());
                 if (portraitDialog.showDialog().isConfirmed()) {
                     for (Person person : people) {
                         if (!person.getPortrait().equals(portraitDialog.getSelectedItem())) {
@@ -891,8 +960,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_EDIT_BIOGRAPHY: {
-                MarkdownEditorDialog tad = new MarkdownEditorDialog(gui.getFrame(), true,
-                        resources.getString("editBiography.text"), selectedPerson.getBiography());
+                MarkdownEditorDialog tad = new MarkdownEditorDialog(gui.getFrame(),
+                      true,
+                      resources.getString("editBiography.text"),
+                      selectedPerson.getBiography());
                 tad.setVisible(true);
                 if (tad.wasChanged()) {
                     selectedPerson.setBiography(tad.getText());
@@ -908,8 +979,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_ADD_XP: {
-                PopupValueChoiceDialog pvcda = new PopupValueChoiceDialog(
-                        gui.getFrame(), true, resources.getString("xp.text"), 1, 0);
+                PopupValueChoiceDialog pvcda = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      resources.getString("xp.text"),
+                      1,
+                      0);
                 pvcda.setVisible(true);
 
                 int ia = pvcda.getValue();
@@ -926,8 +1000,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_SET_XP: {
-                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(
-                        gui.getFrame(), true, resources.getString("xp.text"), selectedPerson.getXP(), 0);
+                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      resources.getString("xp.text"),
+                      selectedPerson.getXP(),
+                      0);
                 pvcd.setVisible(true);
                 if (pvcd.getValue() < 0) {
                     return;
@@ -941,10 +1018,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_BUY_EDGE: {
                 int baseCost = gui.getCampaign().getCampaignOptions().getEdgeCost();
-                double costMultiplier = gui.getCampaign().getCampaignOptions().getXpCostMultiplier();
                 for (Person person : people) {
-                    double intelligenceCostMultiplier = person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions());
-                    int cost = (int) round(baseCost * intelligenceCostMultiplier * costMultiplier);
+                    final boolean isUseIntelligenceMultiplier = getCampaignOptions().isUseIntelligenceXpMultiplier();
+                    final double intelligenceXpCostMultiplier = person.getIntelligenceXpCostMultiplier(
+                          isUseIntelligenceMultiplier);
+                    final double xpCostMultiplier = getCampaignOptions().getXpCostMultiplier();
+
+                    // Intelligence cost changes should always take place before global changes
+                    int cost = (int) round(baseCost * intelligenceXpCostMultiplier);
+                    cost = (int) round(cost * xpCostMultiplier);
 
                     selectedPerson.spendXP(cost);
                     person.changeEdge(1);
@@ -952,16 +1034,20 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     // the week ends
                     person.changeCurrentEdge(1);
                     PersonalLogger.gainedEdge(gui.getCampaign(), person, gui.getCampaign().getLocalDate());
-                    gui.getCampaign().addReport(String.format(resources.getString("gainedEdge.format"),
-                            selectedPerson.getHyperlinkedName()));
+                    gui.getCampaign()
+                          .addReport(String.format(resources.getString("gainedEdge.format"),
+                                selectedPerson.getHyperlinkedName()));
                     gui.getCampaign().personUpdated(person);
                 }
                 break;
             }
             case CMD_SET_EDGE: {
-                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(
-                        gui.getFrame(), true, resources.getString("edge.text"), selectedPerson.getEdge(), 0,
-                        10);
+                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      resources.getString("edge.text"),
+                      selectedPerson.getEdge(),
+                      0,
+                      10);
                 pvcd.setVisible(true);
                 if (pvcd.getValue() < 0) {
                     return;
@@ -980,13 +1066,19 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 AddOrEditKillEntryDialog nkd;
                 Unit unit = selectedPerson.getUnit();
                 if (people.length > 1) {
-                    nkd = new AddOrEditKillEntryDialog(gui.getFrame(), true, null,
-                            (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
-                            gui.getCampaign().getLocalDate(), gui.getCampaign());
+                    nkd = new AddOrEditKillEntryDialog(gui.getFrame(),
+                          true,
+                          null,
+                          (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
+                          gui.getCampaign().getLocalDate(),
+                          gui.getCampaign());
                 } else {
-                    nkd = new AddOrEditKillEntryDialog(gui.getFrame(), true, selectedPerson.getId(),
-                            (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
-                            gui.getCampaign().getLocalDate(), gui.getCampaign());
+                    nkd = new AddOrEditKillEntryDialog(gui.getFrame(),
+                          true,
+                          selectedPerson.getId(),
+                          (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
+                          gui.getCampaign().getLocalDate(),
+                          gui.getCampaign());
                 }
                 nkd.setVisible(true);
                 if (nkd.getKill().isPresent()) {
@@ -1012,15 +1104,18 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_EDIT_PERSONNEL_LOG: {
-                EditPersonnelLogDialog epld = new EditPersonnelLogDialog(gui.getFrame(), true, gui.getCampaign(),
-                        selectedPerson);
+                EditPersonnelLogDialog epld = new EditPersonnelLogDialog(gui.getFrame(),
+                      true,
+                      gui.getCampaign(),
+                      selectedPerson);
                 epld.setVisible(true);
                 MekHQ.triggerEvent(new PersonLogEvent(selectedPerson));
                 break;
             }
             case CMD_ADD_LOG_ENTRY: {
-                final AddOrEditPersonnelEntryDialog addPersonnelLogDialog = new AddOrEditPersonnelEntryDialog(
-                        gui.getFrame(), null, gui.getCampaign().getLocalDate());
+                final AddOrEditPersonnelEntryDialog addPersonnelLogDialog = new AddOrEditPersonnelEntryDialog(gui.getFrame(),
+                      null,
+                      gui.getCampaign().getLocalDate());
                 if (addPersonnelLogDialog.showDialog().isConfirmed()) {
                     for (Person person : people) {
                         person.addLogEntry(addPersonnelLogDialog.getEntry().clone());
@@ -1030,15 +1125,18 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_EDIT_SCENARIO_LOG: {
-                EditScenarioLogDialog emld = new EditScenarioLogDialog(gui.getFrame(), true, gui.getCampaign(),
-                        selectedPerson);
+                EditScenarioLogDialog emld = new EditScenarioLogDialog(gui.getFrame(),
+                      true,
+                      gui.getCampaign(),
+                      selectedPerson);
                 emld.setVisible(true);
                 MekHQ.triggerEvent(new PersonLogEvent(selectedPerson));
                 break;
             }
             case CMD_ADD_SCENARIO_ENTRY: {
-                AddOrEditScenarioEntryDialog addScenarioDialog = new AddOrEditScenarioEntryDialog(
-                        gui.getFrame(), true, gui.getCampaign().getLocalDate());
+                AddOrEditScenarioEntryDialog addScenarioDialog = new AddOrEditScenarioEntryDialog(gui.getFrame(),
+                      true,
+                      gui.getCampaign().getLocalDate());
                 addScenarioDialog.setVisible(true);
                 Optional<LogEntry> scenarioEntry = addScenarioDialog.getEntry();
                 if (scenarioEntry.isPresent()) {
@@ -1051,9 +1149,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_CALLSIGN: {
                 String s = (String) JOptionPane.showInputDialog(gui.getFrame(),
-                        resources.getString("enterNewCallsign.text"), resources.getString("editCallsign.text"),
-                        JOptionPane.PLAIN_MESSAGE, null, null,
-                        selectedPerson.getCallsign());
+                      resources.getString("enterNewCallsign.text"),
+                      resources.getString("editCallsign.text"),
+                      JOptionPane.PLAIN_MESSAGE,
+                      null,
+                      null,
+                      selectedPerson.getCallsign());
                 if (null != s) {
                     selectedPerson.setCallsign(s);
                     gui.getCampaign().personUpdated(selectedPerson);
@@ -1093,8 +1194,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_EDIT_INJURIES: {
-                EditPersonnelInjuriesDialog epid = new EditPersonnelInjuriesDialog(
-                        gui.getFrame(), true, gui.getCampaign(), selectedPerson);
+                EditPersonnelInjuriesDialog epid = new EditPersonnelInjuriesDialog(gui.getFrame(),
+                      true,
+                      gui.getCampaign(),
+                      selectedPerson);
                 epid.setVisible(true);
                 MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                 break;
@@ -1102,13 +1205,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_EDIT_SALARY: {
                 int originalSalary = selectedPerson.getSalary(gui.getCampaign()).getAmount().intValue();
 
-                PopupValueChoiceDialog salaryDialog = new PopupValueChoiceDialog(
-                        gui.getFrame(),
-                        true,
-                        resources.getString("changeSalary.text"),
-                        MathUtility.clamp(originalSalary, -1, 1000000000),
-                        -1,
-                        1000000000);
+                PopupValueChoiceDialog salaryDialog = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      resources.getString("changeSalary.text"),
+                      MathUtility.clamp(originalSalary, -1, 1000000000),
+                      -1,
+                      1000000000);
 
                 salaryDialog.setVisible(true);
 
@@ -1126,11 +1228,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_GIVE_PAYMENT: {
-                PopupValueChoiceDialog pcvd = new PopupValueChoiceDialog(gui.getFrame(), true,
-                        resources.getString("givePayment.title"),
-                        1000,
-                        1,
-                        1000000);
+                PopupValueChoiceDialog pcvd = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      resources.getString("givePayment.title"),
+                      1000,
+                      1,
+                      1000000);
                 pcvd.setVisible(true);
 
                 int payment = pcvd.getValue();
@@ -1143,10 +1246,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // pay person & add expense
                 Map<Person, Money> personMoneyMap = new HashMap<>();
                 personMoneyMap.put(selectedPerson, Money.of(payment));
-                gui.getCampaign().payPersonnel(TransactionType.MISCELLANEOUS,
-                    Money.of(payment),
-                    String.format(resources.getString("givePayment.format"),selectedPerson.getFullName()),
-                    personMoneyMap);
+                gui.getCampaign()
+                      .payPersonnel(TransactionType.MISCELLANEOUS,
+                            Money.of(payment),
+                            String.format(resources.getString("givePayment.format"), selectedPerson.getFullName()),
+                            personMoneyMap);
                 MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
 
 
@@ -1178,8 +1282,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             // region Randomization Menu
             case CMD_RANDOM_NAME: {
                 for (final Person person : people) {
-                    final String[] name = RandomNameGenerator.getInstance().generateGivenNameSurnameSplit(
-                            person.getGender(), person.isClanPersonnel(), person.getOriginFaction().getShortName());
+                    final String[] name = RandomNameGenerator.getInstance()
+                                                .generateGivenNameSurnameSplit(person.getGender(),
+                                                      person.isClanPersonnel(),
+                                                      person.getOriginFaction().getShortName());
                     person.setGivenName(name[0]);
                     person.setSurname(name[1]);
                     writePersonalityDescription(person);
@@ -1217,8 +1323,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_RANDOM_ORIGIN_FACTION: {
                 for (final Person person : people) {
-                    final Faction faction = gui.getCampaign().getFactionSelector()
-                            .selectFaction(gui.getCampaign());
+                    final Faction faction = gui.getCampaign().getFactionSelector().selectFaction(gui.getCampaign());
                     if (faction != null) {
                         person.setOriginFaction(faction);
                         MekHQ.triggerEvent(new PersonChangedEvent(person));
@@ -1228,8 +1333,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_RANDOM_ORIGIN_PLANET: {
                 for (final Person person : people) {
-                    final Planet planet = gui.getCampaign().getPlanetSelector().selectPlanet(
-                            gui.getCampaign(), person.getOriginFaction());
+                    final Planet planet = gui.getCampaign()
+                                                .getPlanetSelector()
+                                                .selectPlanet(gui.getCampaign(), person.getOriginFaction());
                     if (planet != null) {
                         person.setOriginPlanet(planet);
                         MekHQ.triggerEvent(new PersonChangedEvent(person));
@@ -1264,18 +1370,17 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     /**
-     * Handles the limb replacement procedure for the selected person. This method determines the
-     * suitable doctors, calculates the cost of the procedure, and processes the surgery if the user
-     * accepts it.
+     * Handles the limb replacement procedure for the selected person. This method determines the suitable doctors,
+     * calculates the cost of the procedure, and processes the surgery if the user accepts it.
      *
      * <p>If no doctors are available with sufficient skill levels, the cost of the operation
-     * is significantly increased. Once the surgery is performed, the person's injury is updated,
-     * and associated financial and unit adjustments are made.</p>
+     * is significantly increased. Once the surgery is performed, the person's injury is updated, and associated
+     * financial and unit adjustments are made.</p>
      *
-     * @param selectedInjury  The {@link UUID} of the injury being fixed.
-     * @param selectedPerson  The {@link Person} undergoing the limb replacement procedure.
-     * @param campaign        The {@link Campaign} instance representing the current campaign,
-     *                        containing active personnel, finances, and other relevant details.
+     * @param selectedInjury The {@link UUID} of the injury being fixed.
+     * @param selectedPerson The {@link Person} undergoing the limb replacement procedure.
+     * @param campaign       The {@link Campaign} instance representing the current campaign, containing active
+     *                       personnel, finances, and other relevant details.
      */
     private void replaceLimb(String selectedInjury, Person selectedPerson, Campaign campaign) {
         List<Person> suitableDoctors = new ArrayList<>();
@@ -1284,7 +1389,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             if (person.isDoctor()) {
                 Skill skill = person.getSkill(S_DOCTOR);
 
-                if (skill != null && skill.getFinalSkillValue() >= REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5) {
+                if (skill != null &&
+                          skill.getFinalSkillValue() >= REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5) {
                     suitableDoctors.add(person);
                 }
             }
@@ -1294,7 +1400,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             if (injury.getUUID().toString().equals(selectedInjury)) {
                 BodyLocation location = injury.getLocation();
 
-                Money cost = switch(location) {
+                Money cost = switch (location) {
                     case RIGHT_ARM, LEFT_ARM -> REPLACEMENT_LIMB_COST_ARM_TYPE_5;
                     case RIGHT_HAND, LEFT_HAND -> REPLACEMENT_LIMB_COST_HAND_TYPE_5;
                     case RIGHT_LEG, LEFT_LEG -> REPLACEMENT_LIMB_COST_LEG_TYPE_5;
@@ -1312,7 +1418,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 }
 
                 ReplacementLimbDialog replacementLimbDialog = new ReplacementLimbDialog(campaign,
-                      suitableDoctors, selectedPerson, cost);
+                      suitableDoctors,
+                      selectedPerson,
+                      cost);
                 int choice = replacementLimbDialog.getDialogChoice();
 
                 // If the user chose to decline the surgery
@@ -1320,14 +1428,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     return;
                 }
 
-                campaign.getFinances().debit(MEDICAL_EXPENSES,
-                      campaign.getLocalDate(), cost,
-                      String.format(resources.getString("replaceMissingLimb.surgery"),
-                            selectedPerson.getFullTitle()));
+                campaign.getFinances()
+                      .debit(MEDICAL_EXPENSES,
+                            campaign.getLocalDate(),
+                            cost,
+                            String.format(resources.getString("replaceMissingLimb.surgery"),
+                                  selectedPerson.getFullTitle()));
 
                 int hitCount = injury.getHits();
-                Injury newInjury = REPLACEMENT_LIMB_RECOVERY.newInjury(campaign, selectedPerson,
-                      location, hitCount);
+                Injury newInjury = REPLACEMENT_LIMB_RECOVERY.newInjury(campaign, selectedPerson, location, hitCount);
                 newInjury.setWorkedOn(true);
 
                 selectedPerson.removeInjury(injury);
@@ -1346,25 +1455,22 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
      * Private method to process a list of applications to education academies.
      *
      * @param people         an array of Person objects representing the applicants
-     * @param data           an array of String objects representing the command
-     *                       data
-     * @param isReEnrollment a boolean indicating if the application is for
-     *                       re-enrollment
+     * @param data           an array of String objects representing the command data
+     * @param isReEnrollment a boolean indicating if the application is for re-enrollment
      */
     private void processApplication(Person[] people, String[] data, boolean isReEnrollment) {
         boolean applicationFailed = false;
 
         for (Person person : people) {
             if (makeEnrollmentCheck(gui.getCampaign(), person, data[1], data[2])) {
-                EducationController.performEducationPreEnrollmentActions(
-                        gui.getCampaign(),
-                        person,
-                        data[1],
-                        data[2],
-                        Integer.parseInt(data[3]),
-                        data[4],
-                        data[5],
-                        isReEnrollment);
+                EducationController.performEducationPreEnrollmentActions(gui.getCampaign(),
+                      person,
+                      data[1],
+                      data[2],
+                      Integer.parseInt(data[3]),
+                      data[4],
+                      data[5],
+                      isReEnrollment);
             } else {
                 applicationFailed = true;
             }
@@ -1372,9 +1478,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         if (applicationFailed) {
             JOptionPane.showMessageDialog(null,
-                    wordWrap(resources.getString("eduFailedApplication.text")),
-                    resources.getString("eduFailedApplication.title"),
-                    JOptionPane.WARNING_MESSAGE);
+                  wordWrap(resources.getString("eduFailedApplication.text")),
+                  resources.getString("eduFailedApplication.title"),
+                  JOptionPane.WARNING_MESSAGE);
         }
     }
 
@@ -1394,10 +1500,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             label = String.format(resources.getString("numPrisoners.text"), prisoners.length);
         }
 
-        if (0 == JOptionPane.showConfirmDialog(null,
-                String.format(resources.getString(message), label),
-                resources.getString(title),
-                JOptionPane.YES_NO_OPTION)) {
+        if (0 ==
+                  JOptionPane.showConfirmDialog(null,
+                        String.format(resources.getString(message), label),
+                        resources.getString(title),
+                        JOptionPane.YES_NO_OPTION)) {
             for (Person prisoner : prisoners) {
                 gui.getCampaign().removePerson(prisoner);
             }
@@ -1444,7 +1551,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu = new JMenu(resources.getString("changeRank.text"));
             final Profession initialProfession = Profession.getProfessionFromPersonnelRole(person.getPrimaryRole());
             for (final RankDisplay rankDisplay : RankDisplay.getRankDisplaysForSystem(person.getRankSystem(),
-                    initialProfession)) {
+                  initialProfession)) {
                 final Rank rank = person.getRankSystem().getRank(rankDisplay.getRankNumeric());
                 final Profession profession = initialProfession.getProfession(person.getRankSystem(), rank);
                 final int rankLevels = rank.getRankLevels().get(profession);
@@ -1452,12 +1559,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 if (rankLevels > 1) {
                     submenu = new JMenu(rankDisplay.toString());
                     for (int level = 0; level <= rankLevels; level++) {
-                        cbMenuItem = new JCheckBoxMenuItem(
-                                rank.getName(profession) + Utilities.getRomanNumeralsFromArabicNumber(level, true));
-                        cbMenuItem.setSelected((person.getRankNumeric() == rankDisplay.getRankNumeric())
-                                && (person.getRankLevel() == level));
-                        cbMenuItem.setActionCommand(makeCommand(CMD_RANK, String.valueOf(rankDisplay.getRankNumeric()),
-                                String.valueOf(level)));
+                        cbMenuItem = new JCheckBoxMenuItem(rank.getName(profession) +
+                                                                 Utilities.getRomanNumeralsFromArabicNumber(level,
+                                                                       true));
+                        cbMenuItem.setSelected((person.getRankNumeric() == rankDisplay.getRankNumeric()) &&
+                                                     (person.getRankLevel() == level));
+                        cbMenuItem.setActionCommand(makeCommand(CMD_RANK,
+                              String.valueOf(rankDisplay.getRankNumeric()),
+                              String.valueOf(level)));
                         cbMenuItem.addActionListener(this);
                         submenu.add(cbMenuItem);
                     }
@@ -1589,18 +1698,21 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         }
 
         if ((oneSelected) && (!person.isChild(gui.getCampaign().getLocalDate()))) {
-            List<Person> orphans = gui.getCampaign().getActivePersonnel().stream()
-                    .filter(child -> (child.isChild(gui.getCampaign().getLocalDate())) && (!child.getGenealogy().hasLivingParents()))
-                    .toList();
+            List<Person> orphans = gui.getCampaign()
+                                         .getActivePersonnel()
+                                         .stream()
+                                         .filter(child -> (child.isChild(gui.getCampaign().getLocalDate())) &&
+                                                                (!child.getGenealogy().hasLivingParents()))
+                                         .toList();
 
             if (!orphans.isEmpty()) {
                 JMenu orphanMenu = new JMenu(resources.getString("adopt.text"));
 
                 for (final Person orphan : orphans) {
                     String status = String.format(resources.getString("adopt.description"),
-                            orphan.getFullName(),
-                            orphan.getGender(),
-                            orphan.getAge(gui.getCampaign().getLocalDate()));
+                          orphan.getFullName(),
+                          orphan.getGender(),
+                          orphan.getAge(gui.getCampaign().getLocalDate()));
 
                     JMenuItem orphanItem = new JMenuItem(status);
                     orphanItem.setActionCommand(makeCommand(CMD_ADOPTION, String.valueOf(orphan.getId())));
@@ -1704,8 +1816,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         JMenuHelpers.addMenuIfNonEmpty(popup, new AssignPersonToUnitMenu(gui.getCampaign(), selected));
 
         if (oneSelected && person.getStatus().isActive()) {
-            if (gui.getCampaign().getCampaignOptions().isUseManualMarriages()
-                    && (gui.getCampaign().getMarriage().canMarry(gui.getCampaign().getLocalDate(), person, false) == null)) {
+            if (gui.getCampaign().getCampaignOptions().isUseManualMarriages() &&
+                      (gui.getCampaign().getMarriage().canMarry(gui.getCampaign().getLocalDate(), person, false) ==
+                             null)) {
                 menu = new JMenu(resources.getString("chooseSpouse.text"));
                 JMenu maleMenu = new JMenu(resources.getString("spouseMenuMale.text"));
                 JMenu femaleMenu = new JMenu(resources.getString("spouseMenuFemale.text"));
@@ -1714,42 +1827,49 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 LocalDate today = gui.getCampaign().getLocalDate();
 
                 // Get all safe potential spouses sorted by age and then by surname
-                final List<Person> personnel = gui.getCampaign().getPersonnel().stream()
-                        .filter(potentialSpouse -> gui.getCampaign().getMarriage().safeSpouse(
-                                gui.getCampaign(), gui.getCampaign().getLocalDate(), person,
-                                potentialSpouse, false))
-                        .sorted(Comparator.comparing((Person p) -> p.getAge(today))
-                                .thenComparing(Person::getSurname))
-                        .toList();
+                final List<Person> personnel = gui.getCampaign()
+                                                     .getPersonnel()
+                                                     .stream()
+                                                     .filter(potentialSpouse -> gui.getCampaign()
+                                                                                      .getMarriage()
+                                                                                      .safeSpouse(gui.getCampaign(),
+                                                                                            gui.getCampaign()
+                                                                                                  .getLocalDate(),
+                                                                                            person,
+                                                                                            potentialSpouse,
+                                                                                            false))
+                                                     .sorted(Comparator.comparing((Person p) -> p.getAge(today))
+                                                                   .thenComparing(Person::getSurname))
+                                                     .toList();
 
                 for (final Person potentialSpouse : personnel) {
                     final String status;
                     final String founder = potentialSpouse.isFounder() ? resources.getString("spouseFounder.text") : "";
                     if (potentialSpouse.getPrisonerStatus().isBondsman()) {
                         status = String.format(resources.getString("marriageBondsmanDesc.format"),
-                                potentialSpouse.getFullName(),
-                                potentialSpouse.getAge(today),
-                                potentialSpouse.getRoleDesc(),
-                                founder);
+                              potentialSpouse.getFullName(),
+                              potentialSpouse.getAge(today),
+                              potentialSpouse.getRoleDesc(),
+                              founder);
                     } else if (potentialSpouse.getPrisonerStatus().isCurrentPrisoner()) {
                         status = String.format(resources.getString("marriagePrisonerDesc.format"),
-                                potentialSpouse.getFullName(),
-                                potentialSpouse.getAge(today),
-                                potentialSpouse.getRoleDesc(),
-                                founder);
+                              potentialSpouse.getFullName(),
+                              potentialSpouse.getAge(today),
+                              potentialSpouse.getRoleDesc(),
+                              founder);
                     } else {
                         status = String.format(resources.getString("marriagePartnerDesc.format"),
-                                potentialSpouse.getFullName(),
-                                potentialSpouse.getAge(today),
-                                potentialSpouse.getRoleDesc(),
-                                founder);
+                              potentialSpouse.getFullName(),
+                              potentialSpouse.getAge(today),
+                              potentialSpouse.getRoleDesc(),
+                              founder);
                     }
 
                     spouseMenu = new JMenu(status);
 
                     for (final MergingSurnameStyle style : MergingSurnameStyle.values()) {
                         spouseMenu.add(newMenuItem(style.getDropDownText(),
-                                makeCommand(CMD_ADD_SPOUSE, potentialSpouse.getId().toString(), style.name())));
+                              makeCommand(CMD_ADD_SPOUSE, potentialSpouse.getId().toString(), style.name())));
                     }
 
                     if (potentialSpouse.getGender().isMale()) {
@@ -1771,10 +1891,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
         }
 
-        if (gui.getCampaign().getCampaignOptions().isUseManualDivorce() && (Stream.of(selected)
-                .anyMatch(p -> gui.getCampaign()
-                        .getDivorce()
-                        .canDivorce(person, false) == null))) {
+        if (gui.getCampaign().getCampaignOptions().isUseManualDivorce() &&
+                  (Stream.of(selected)
+                         .anyMatch(p -> gui.getCampaign().getDivorce().canDivorce(person, false) == null))) {
             menu = new JMenu(resources.getString("removeSpouse.text"));
 
             for (final SplittingSurnameStyle style : SplittingSurnameStyle.values()) {
@@ -1870,8 +1989,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     JMenu singleAwardMenu = new JMenu(award.getName());
                     for (String date : award.getFormattedDates()) {
                         JMenuItem specificAwardMenu = new JMenuItem(date);
-                        specificAwardMenu
-                                .setActionCommand(makeCommand(CMD_RMV_AWARD, award.getSet(), award.getName(), date));
+                        specificAwardMenu.setActionCommand(makeCommand(CMD_RMV_AWARD,
+                              award.getSet(),
+                              award.getName(),
+                              date));
                         specificAwardMenu.addActionListener(this);
                         singleAwardMenu.add(specificAwardMenu);
                     }
@@ -1954,8 +2075,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             if (oneSelected) {
                                 buildEducationMenusSingleton(campaign, person, academy, militaryMenu, civilianMenu);
                             } else {
-                                buildEducationMenusMassEnroll(campaign, Arrays.asList(selected), academy, militaryMenu,
-                                        civilianMenu);
+                                buildEducationMenusMassEnroll(campaign,
+                                      Arrays.asList(selected),
+                                      academy,
+                                      militaryMenu,
+                                      civilianMenu);
                             }
                         }
                         academyMenu.add(setAcademyMenu);
@@ -1972,36 +2096,37 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
 
             if ((oneSelected) && (StaticChecks.areAllStudents(selected))) {
-                Academy academy = getAcademy(person.getEduAcademySet(),
-                        person.getEduAcademyNameInSet());
+                Academy academy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
 
                 // this pile of if-statements just checks that the individual is eligible for
                 // re-enrollment
                 // has the person finished their education, but not yet returned to the unit?
-                if ((!person.getEduEducationStage().isJourneyToCampus())
-                        && (!person.getEduEducationStage().isEducation())) {
+                if ((!person.getEduEducationStage().isJourneyToCampus()) &&
+                          (!person.getEduEducationStage().isEducation())) {
                     // is the academy still standing?
-                    if ((campaign.getGameYear() < academy.getDestructionYear())
-                            && (campaign.getGameYear() < academy.getClosureYear())) {
+                    if ((campaign.getGameYear() < academy.getDestructionYear()) &&
+                              (campaign.getGameYear() < academy.getClosureYear())) {
                         // if the academy is local, is the system still populated?
-                        if ((!academy.isLocal())
-                                || (campaign.getCurrentSystem().getPopulation(campaign.getLocalDate()) > 0)) {
+                        if ((!academy.isLocal()) ||
+                                  (campaign.getCurrentSystem().getPopulation(campaign.getLocalDate()) > 0)) {
                             // is the person still within the correct age band?
-                            if ((person.getAge(campaign.getLocalDate()) < academy.getAgeMax())
-                                    && (person.getAge(campaign.getLocalDate()) >= academy.getAgeMin())) {
+                            if ((person.getAge(campaign.getLocalDate()) < academy.getAgeMax()) &&
+                                      (person.getAge(campaign.getLocalDate()) >= academy.getAgeMin())) {
                                 // has the person been edited at some point and is no longer qualified?
                                 if (academy.isQualified(person)) {
                                     // here we check that the person will benefit from re-enrollment
                                     int improvementPossible = 0;
 
-                                    String filteredFaction = academy.getFilteredFaction(campaign, person,
-                                            List.of(person.getEduAcademyFaction()));
+                                    String filteredFaction = academy.getFilteredFaction(campaign,
+                                          person,
+                                          List.of(person.getEduAcademyFaction()));
 
                                     if (filteredFaction != null) {
                                         int educationLevel = academy.getEducationLevel(person);
 
-                                        String[] skills = academy.getCurriculums().get(person.getEduCourseIndex())
-                                                .split(",");
+                                        String[] skills = academy.getCurriculums()
+                                                                .get(person.getEduCourseIndex())
+                                                                .split(",");
 
                                         skills = Arrays.stream(skills).map(String::trim).toArray(String[]::new);
 
@@ -2011,15 +2136,16 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                             }
 
                                             if (skill.equalsIgnoreCase("xp")) {
-                                                if (EducationLevel
-                                                        .parseToInt(person.getEduHighestEducation()) < educationLevel) {
+                                                if (EducationLevel.parseToInt(person.getEduHighestEducation()) <
+                                                          educationLevel) {
                                                     improvementPossible++;
                                                 }
                                             } else {
                                                 String skillParsed = skillParser(skill);
 
-                                                if ((person.hasSkill(skillParsed)) && (person.getSkill(skillParsed)
-                                                        .getExperienceLevel() < educationLevel)) {
+                                                if ((person.hasSkill(skillParsed)) &&
+                                                          (person.getSkill(skillParsed).getExperienceLevel() <
+                                                                 educationLevel)) {
                                                     improvementPossible++;
                                                 } else if (!person.hasSkill(skillParsed)) {
                                                     improvementPossible++;
@@ -2033,16 +2159,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                             reEnroll = new JMenuItem(resources.getString("eduReEnroll.text"));
                                             reEnroll.setToolTipText(resources.getString("eduReEnroll.toolTip"));
                                             reEnroll.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_RE_ENROLLMENT,
-                                                    academy.getSet(),
-                                                    academy.getName(),
-                                                    String.valueOf(person.getEduCourseIndex()),
-                                                    person.getEduAcademySystem(),
-                                                    person.getEduAcademyFaction()));
+                                                  academy.getSet(),
+                                                  academy.getName(),
+                                                  String.valueOf(person.getEduCourseIndex()),
+                                                  person.getEduAcademySystem(),
+                                                  person.getEduAcademyFaction()));
                                             reEnroll.addActionListener(this);
                                         } else {
                                             reEnroll = new JMenuItem(resources.getString("eduReEnrollImpossible.text"));
-                                            reEnroll.setToolTipText(
-                                                    resources.getString("eduReEnrollImpossible.toolTip"));
+                                            reEnroll.setToolTipText(resources.getString("eduReEnrollImpossible.toolTip"));
                                         }
 
                                         academyMenu.add(reEnroll);
@@ -2068,6 +2193,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         // region Spend XP Menu
         if (oneSelected && person.getStatus().isActive()) {
+            final boolean isUseIntelligenceMultiplier = getCampaignOptions().isUseIntelligenceXpMultiplier();
+            final double intelligenceXpCostMultiplier = person.getIntelligenceXpCostMultiplier(
+                  isUseIntelligenceMultiplier);
+            final double xpCostMultiplier = getCampaignOptions().getXpCostMultiplier();
+
             menu = new JMenu(resources.getString("spendXP.text"));
             if (gui.getCampaign().getCampaignOptions().isUseAbilities()) {
                 JMenu abMenu = new JMenu(resources.getString("spendOnSpecialAbilities.text"));
@@ -2083,9 +2213,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     if (!spa.isEligible(person)) {
                         continue;
                     }
-                    cost = (int) round((spa.getCost()
-                            * person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions())
-                            * gui.getCampaign().getCampaignOptions().getXpCostMultiplier()));
+                    // Intelligence cost changes should always take place before global changes
+                    cost = (int) round(spa.getCost() * intelligenceXpCostMultiplier);
+                    cost = (int) round(cost * xpCostMultiplier);
+
                     String costDesc;
                     if (cost < 0) {
                         costDesc = resources.getString("costNotPossible.text");
@@ -2096,8 +2227,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     if (spa.getName().equals(OptionsConstants.GUNNERY_WEAPON_SPECIALIST)) {
                         Unit u = person.getUnit();
                         if (null != u) {
-                            JMenu specialistMenu = new JMenu(
-                                    SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_WEAPON_SPECIALIST));
+                            JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_WEAPON_SPECIALIST));
                             TreeSet<String> uniqueWeapons = new TreeSet<>();
                             for (int j = 0; j < u.getEntity().getWeaponList().size(); j++) {
                                 Mounted<?> m = u.getEntity().getWeaponList().get(j);
@@ -2105,13 +2235,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             }
                             boolean isSpecialist = person.getOptions().booleanOption(spa.getName());
                             for (String name : uniqueWeapons) {
-                                if (!(isSpecialist
-                                        && person.getOptions().getOption(spa.getName()).stringValue().equals(name))) {
-                                    menuItem = new JMenuItem(
-                                            String.format(resources.getString("abilityDesc.format"), name, costDesc));
+                                if (!(isSpecialist &&
+                                            person.getOptions().getOption(spa.getName()).stringValue().equals(name))) {
+                                    menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
+                                          name,
+                                          costDesc));
                                     menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                                    menuItem.setActionCommand(
-                                            makeCommand(CMD_ACQUIRE_WEAPON_SPECIALIST, name, String.valueOf(cost)));
+                                    menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_WEAPON_SPECIALIST,
+                                          name,
+                                          String.valueOf(cost)));
                                     menuItem.addActionListener(this);
                                     menuItem.setEnabled(available);
                                     specialistMenu.add(menuItem);
@@ -2124,8 +2256,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     } else if (spa.getName().equals(OptionsConstants.GUNNERY_SANDBLASTER)) {
                         Unit u = person.getUnit();
                         if (null != u) {
-                            JMenu specialistMenu = new JMenu(
-                                    SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SANDBLASTER));
+                            JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SANDBLASTER));
                             TreeSet<String> uniqueWeapons = new TreeSet<>();
                             for (int j = 0; j < u.getEntity().getWeaponList().size(); j++) {
                                 Mounted<?> m = u.getEntity().getWeaponList().get(j);
@@ -2135,13 +2266,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             }
                             boolean isSpecialist = person.getOptions().booleanOption(spa.getName());
                             for (String name : uniqueWeapons) {
-                                if (!(isSpecialist
-                                        && person.getOptions().getOption(spa.getName()).stringValue().equals(name))) {
-                                    menuItem = new JMenuItem(
-                                            String.format(resources.getString("abilityDesc.format"), name, costDesc));
+                                if (!(isSpecialist &&
+                                            person.getOptions().getOption(spa.getName()).stringValue().equals(name))) {
+                                    menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
+                                          name,
+                                          costDesc));
                                     menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                                    menuItem.setActionCommand(
-                                            makeCommand(CMD_ACQUIRE_SANDBLASTER, name, String.valueOf(cost)));
+                                    menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SANDBLASTER,
+                                          name,
+                                          String.valueOf(cost)));
                                     menuItem.addActionListener(this);
                                     menuItem.setEnabled(available);
                                     specialistMenu.add(menuItem);
@@ -2152,8 +2285,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             }
                         }
                     } else if (spa.getName().equals(OptionsConstants.MISC_ENV_SPECIALIST)) {
-                        JMenu specialistMenu = new JMenu(
-                                SpecialAbility.getDisplayName(OptionsConstants.MISC_ENV_SPECIALIST));
+                        JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.MISC_ENV_SPECIALIST));
                         List<Object> tros = new ArrayList<>();
                         if (person.getOptions().getOption(OptionsConstants.MISC_ENV_SPECIALIST).booleanValue()) {
                             Object val = person.getOptions().getOption(OptionsConstants.MISC_ENV_SPECIALIST).getValue();
@@ -2164,11 +2296,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             }
                         }
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                resources.getString("envspec_fog.text"), costDesc));
+                              resources.getString("envspec_fog.text"),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
                         if (!tros.contains(Crew.ENVSPC_FOG)) {
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_ENVSPEC, Crew.ENVSPC_FOG, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ENVSPEC,
+                                  Crew.ENVSPC_FOG,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2176,10 +2310,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.ENVSPC_LIGHT)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("envspec_light.text"), costDesc));
+                                  resources.getString("envspec_light.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_ENVSPEC, Crew.ENVSPC_LIGHT, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ENVSPEC,
+                                  Crew.ENVSPC_LIGHT,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2187,10 +2323,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.ENVSPC_RAIN)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("envspec_rain.text"), costDesc));
+                                  resources.getString("envspec_rain.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_ENVSPEC, Crew.ENVSPC_RAIN, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ENVSPEC,
+                                  Crew.ENVSPC_RAIN,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2198,10 +2336,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.ENVSPC_SNOW)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("envspec_snow.text"), costDesc));
+                                  resources.getString("envspec_snow.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_ENVSPEC, Crew.ENVSPC_SNOW, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ENVSPEC,
+                                  Crew.ENVSPC_SNOW,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2209,10 +2349,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.ENVSPC_WIND)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("envspec_wind.text"), costDesc));
+                                  resources.getString("envspec_wind.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_ENVSPEC, Crew.ENVSPC_WIND, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ENVSPEC,
+                                  Crew.ENVSPC_WIND,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2220,8 +2362,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         JMenuHelpers.addMenuIfNonEmpty(abMenu, specialistMenu);
                     } else if (spa.getName().equals(OptionsConstants.MISC_HUMAN_TRO)) {
-                        JMenu specialistMenu = new JMenu(
-                                SpecialAbility.getDisplayName(OptionsConstants.MISC_HUMAN_TRO));
+                        JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.MISC_HUMAN_TRO));
                         List<Object> tros = new ArrayList<>();
                         if (person.getOptions().getOption(OptionsConstants.MISC_HUMAN_TRO).booleanValue()) {
                             Object val = person.getOptions().getOption(OptionsConstants.MISC_HUMAN_TRO).getValue();
@@ -2232,11 +2373,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             }
                         }
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                resources.getString("humantro_mek.text"), costDesc));
+                              resources.getString("humantro_mek.text"),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
                         if (!tros.contains(Crew.HUMANTRO_MEK)) {
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_MEK, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO,
+                                  Crew.HUMANTRO_MEK,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2244,10 +2387,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.HUMANTRO_AERO)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("humantro_aero.text"), costDesc));
+                                  resources.getString("humantro_aero.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_AERO, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO,
+                                  Crew.HUMANTRO_AERO,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2255,10 +2400,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.HUMANTRO_VEE)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("humantro_vee.text"), costDesc));
+                                  resources.getString("humantro_vee.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_VEE, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO,
+                                  Crew.HUMANTRO_VEE,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2266,10 +2413,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.HUMANTRO_BA)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("humantro_ba.text"), costDesc));
+                                  resources.getString("humantro_ba.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_BA, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO,
+                                  Crew.HUMANTRO_BA,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2278,42 +2427,47 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         if (specialistMenu.getMenuComponentCount() > 0) {
                             abMenu.add(specialistMenu);
                         }
-                    } else if (spa.getName().equals(OptionsConstants.GUNNERY_SPECIALIST)
-                            && !person.getOptions().booleanOption(OptionsConstants.GUNNERY_SPECIALIST)) {
-                        JMenu specialistMenu = new JMenu(
-                                SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SPECIALIST));
+                    } else if (spa.getName().equals(OptionsConstants.GUNNERY_SPECIALIST) &&
+                                     !person.getOptions().booleanOption(OptionsConstants.GUNNERY_SPECIALIST)) {
+                        JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SPECIALIST));
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                resources.getString("laserSpecialist.text"), costDesc));
+                              resources.getString("laserSpecialist.text"),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                        menuItem.setActionCommand(
-                                makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_ENERGY, String.valueOf(cost)));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST,
+                              Crew.SPECIAL_ENERGY,
+                              String.valueOf(cost)));
                         menuItem.addActionListener(this);
                         menuItem.setEnabled(available);
                         specialistMenu.add(menuItem);
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                resources.getString("missileSpecialist.text"), costDesc));
+                              resources.getString("missileSpecialist.text"),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                        menuItem.setActionCommand(
-                                makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_MISSILE, String.valueOf(cost)));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST,
+                              Crew.SPECIAL_MISSILE,
+                              String.valueOf(cost)));
                         menuItem.addActionListener(this);
                         menuItem.setEnabled(available);
                         specialistMenu.add(menuItem);
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                resources.getString("ballisticSpecialist.text"), costDesc));
+                              resources.getString("ballisticSpecialist.text"),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                        menuItem.setActionCommand(
-                                makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_BALLISTIC, String.valueOf(cost)));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST,
+                              Crew.SPECIAL_BALLISTIC,
+                              String.valueOf(cost)));
                         menuItem.addActionListener(this);
                         menuItem.setEnabled(available);
                         specialistMenu.add(menuItem);
                         abMenu.add(specialistMenu);
                     } else if (spa.getName().equals(OptionsConstants.GUNNERY_RANGE_MASTER)) {
-                        JMenu specialistMenu = new JMenu(
-                                SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_RANGE_MASTER));
+                        JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_RANGE_MASTER));
                         List<Object> ranges = new ArrayList<>();
                         if (person.getOptions().getOption(OptionsConstants.GUNNERY_RANGE_MASTER).booleanValue()) {
-                            Object val = person.getOptions().getOption(OptionsConstants.GUNNERY_RANGE_MASTER)
-                                    .getValue();
+                            Object val = person.getOptions()
+                                               .getOption(OptionsConstants.GUNNERY_RANGE_MASTER)
+                                               .getValue();
                             if (val instanceof Collection<?>) {
                                 ranges.addAll((Collection<?>) val);
                             } else {
@@ -2323,10 +2477,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!ranges.contains(Crew.RANGEMASTER_MEDIUM)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("rangemaster_med.text"), costDesc));
+                                  resources.getString("rangemaster_med.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_MEDIUM,
-                                    String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER,
+                                  Crew.RANGEMASTER_MEDIUM,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2334,11 +2490,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!ranges.contains(Crew.RANGEMASTER_LONG)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("rangemaster_lng.text"), costDesc));
+                                  resources.getString("rangemaster_lng.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_LONG, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER,
+                                  Crew.RANGEMASTER_LONG,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2346,10 +2504,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!ranges.contains(Crew.RANGEMASTER_EXTREME)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("rangemaster_xtm.text"), costDesc));
+                                  resources.getString("rangemaster_xtm.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_EXTREME,
-                                    String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER,
+                                  Crew.RANGEMASTER_EXTREME,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2358,9 +2518,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         if (specialistMenu.getMenuComponentCount() > 0) {
                             abMenu.add(specialistMenu);
                         }
-                    } else if (Optional.ofNullable((person.getOptions().getOption(spa.getName()))).isPresent()
-                            && (person.getOptions().getOption(spa.getName()).getType() == IOption.CHOICE)
-                            && !(person.getOptions().getOption(spa.getName()).booleanValue())) {
+                    } else if (Optional.ofNullable((person.getOptions().getOption(spa.getName()))).isPresent() &&
+                                     (person.getOptions().getOption(spa.getName()).getType() == IOption.CHOICE) &&
+                                     !(person.getOptions().getOption(spa.getName()).booleanValue())) {
                         JMenu specialistMenu = new JMenu(spa.getDisplayName());
                         List<String> choices = spa.getChoiceValues();
                         for (String s : choices) {
@@ -2368,10 +2528,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                 continue;
                             }
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    s, costDesc));
+                                  s,
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
                             menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_CUSTOM_CHOICE,
-                                    s, String.valueOf(cost), spa.getName()));
+                                  s,
+                                  String.valueOf(cost),
+                                  spa.getName()));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2381,10 +2544,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         }
                     } else if (!person.getOptions().booleanOption(spa.getName())) {
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                spa.getDisplayName(), costDesc));
+                              spa.getDisplayName(),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                        menuItem.setActionCommand(
-                                makeCommand(CMD_ACQUIRE_ABILITY, spa.getName(), String.valueOf(cost)));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ABILITY,
+                              spa.getName(),
+                              String.valueOf(cost)));
                         menuItem.addActionListener(this);
                         menuItem.setEnabled(available);
                         abMenu.add(menuItem);
@@ -2397,10 +2562,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             JMenu newMenu = new JMenu(resources.getString("spendOnNewSkills.text"));
             for (int i = 0; i < SkillType.getSkillList().length; i++) {
                 String type = SkillType.getSkillList()[i];
-                int cost = person.hasSkill(type) ? person.getSkill(type).getCostToImprove()
-                        : SkillType.getType(type).getCost(0);
-                cost = (int) round(cost * person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions())
-                                * gui.getCampaign().getCampaignOptions().getXpCostMultiplier());
+
+                int cost = person.getCostToImprove(type, isUseIntelligenceMultiplier);
+                cost = (int) round(cost * xpCostMultiplier);
 
                 if (cost >= 0) {
                     String desc = String.format(resources.getString("skillDesc.format"), type, cost);
@@ -2409,7 +2573,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     menuItem.addActionListener(this);
                     menuItem.setEnabled(person.getXP() >= cost);
                     if (person.hasSkill(type)) {
-                        currentMenu.add(menuItem);
+                        Skill skill = person.getSkill(type);
+                        if (skill.isImprovementLegal()) {
+                            currentMenu.add(menuItem);
+                        }
                     } else {
                         newMenu.add(menuItem);
                     }
@@ -2421,9 +2588,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             // Edge Purchasing
             if (gui.getCampaign().getCampaignOptions().isUseEdge()) {
                 JMenu edgeMenu = new JMenu(resources.getString("edge.text"));
-                int cost = (int) round(gui.getCampaign().getCampaignOptions().getEdgeCost()
-                        * person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions())
-                        * gui.getCampaign().getCampaignOptions().getXpCostMultiplier());
+
+                // Intelligence cost changes should always take place before global changes
+                int cost = (int) round(getCampaignOptions().getEdgeCost() * intelligenceXpCostMultiplier);
+                cost = (int) round(cost * xpCostMultiplier);
 
                 if ((cost >= 0) && (person.getXP() >= cost)) {
                     menuItem = new JMenuItem(String.format(resources.getString("spendOnEdge.text"), cost));
@@ -2488,9 +2656,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 menu.add(cbMenuItem);
 
                 // Aerospace pilots and gunners
-                final boolean isNotAeroOrConventional = !(person.getPrimaryRole().isAerospacePilot()
-                        || person.getPrimaryRole().isConventionalAircraftPilot()
-                        || person.getPrimaryRole().isLAMPilot());
+                final boolean isNotAeroOrConventional = !(person.getPrimaryRole().isAerospacePilot() ||
+                                                                person.getPrimaryRole().isConventionalAircraftPilot() ||
+                                                                person.getPrimaryRole().isLAMPilot());
                 final boolean isNotVessel = !person.getPrimaryRole().isVesselCrewMember();
                 final boolean isNotAeroConvOrVessel = isNotAeroOrConventional || isNotVessel;
 
@@ -2571,10 +2739,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     menu.add(cbMenuItem);
 
                     cbMenuItem = new JCheckBoxMenuItem(resources.getString("edgeTriggerFailedRefit.text"));
-                    cbMenuItem
-                            .setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
-                    cbMenuItem
-                            .setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
+                    cbMenuItem.setSelected(person.getOptions()
+                                                 .booleanOption(PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
+                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
                     if (!person.getPrimaryRole().isTech()) {
                         cbMenuItem.setForeground(new Color(150, 150, 150));
                     }
@@ -2584,8 +2752,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     // Admins
                     cbMenuItem = new JCheckBoxMenuItem(resources.getString("edgeTriggerAcquireCheck.text"));
                     cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL));
-                    cbMenuItem
-                            .setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL));
+                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL));
                     if (!person.getPrimaryRole().isAdministrator()) {
                         cbMenuItem.setForeground(new Color(150, 150, 150));
                     }
@@ -2664,20 +2832,23 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerBreakPart.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_BREAK_PART, TRUE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_REPAIR_BREAK_PART,
+                          TRUE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerFailedRefit.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT, TRUE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_REPAIR_FAILED_REFIT,
+                          TRUE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerAcquireCheck.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL, TRUE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL,
+                          TRUE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
                 }
@@ -2747,20 +2918,23 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerBreakPart.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_BREAK_PART, FALSE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_REPAIR_BREAK_PART,
+                          FALSE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerFailedRefit.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT, FALSE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_REPAIR_FAILED_REFIT,
+                          FALSE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerAcquireCheck.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL, FALSE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL,
+                          FALSE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
                 }
@@ -2879,28 +3053,28 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             miCommander.setName("miCommander");
             miCommander.setSelected(person.isCommander());
             miCommander.addActionListener(evt -> {
-                gui.getCampaign().getPersonnel().stream()
-                        .filter(Person::isCommander)
-                        .forEach(commander -> {
-                            commander.setCommander(false);
-                            gui.getCampaign().addReport(String.format(resources.getString("removedCommander.format"),
-                                    commander.getHyperlinkedFullTitle()));
-                            gui.getCampaign().personUpdated(commander);
-                        });
+                gui.getCampaign().getPersonnel().stream().filter(Person::isCommander).forEach(commander -> {
+                    commander.setCommander(false);
+                    gui.getCampaign()
+                          .addReport(String.format(resources.getString("removedCommander.format"),
+                                commander.getHyperlinkedFullTitle()));
+                    gui.getCampaign().personUpdated(commander);
+                });
                 if (miCommander.isSelected()) {
                     person.setCommander(true);
-                    gui.getCampaign().addReport(String.format(resources.getString("setAsCommander.format"),
-                            person.getHyperlinkedFullTitle()));
+                    gui.getCampaign()
+                          .addReport(String.format(resources.getString("setAsCommander.format"),
+                                person.getHyperlinkedFullTitle()));
                     gui.getCampaign().personUpdated(person);
                 }
             });
             menu.add(miCommander);
         }
 
-        if ((gui.getCampaign().getCampaignOptions().isUseManualDivorce()
-                || !gui.getCampaign().getCampaignOptions().getRandomDivorceMethod().isNone())
-                && Stream.of(selected).allMatch(p -> p.getGenealogy().hasSpouse())
-                && Stream.of(selected).allMatch(p -> p.isDivorceable() == person.isDivorceable())) {
+        if ((gui.getCampaign().getCampaignOptions().isUseManualDivorce() ||
+                   !gui.getCampaign().getCampaignOptions().getRandomDivorceMethod().isNone()) &&
+                  Stream.of(selected).allMatch(p -> p.getGenealogy().hasSpouse()) &&
+                  Stream.of(selected).allMatch(p -> p.isDivorceable() == person.isDivorceable())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miDivorceable.text"));
             cbMenuItem.setToolTipText(resources.getString("miDivorceable.toolTipText"));
             cbMenuItem.setName("miDivorceable");
@@ -2924,8 +3098,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu.add(cbMenuItem);
         }
 
-        if (Stream.of(selected).noneMatch(p -> p.getStatus().isDead())
-            && Stream.of(selected).allMatch(p -> p.isImmortal() == person.isImmortal())) {
+        if (Stream.of(selected).noneMatch(p -> p.getStatus().isDead()) &&
+                  Stream.of(selected).allMatch(p -> p.isImmortal() == person.isImmortal())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miImmortal.text"));
             cbMenuItem.setToolTipText(resources.getString("miImmortal.toolTipText"));
             cbMenuItem.setName("miImmortal");
@@ -2937,9 +3111,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu.add(cbMenuItem);
         }
 
-        if ((gui.getCampaign().getCampaignOptions().isUseManualMarriages()
-                || !gui.getCampaign().getCampaignOptions().getRandomMarriageMethod().isNone())
-                && Stream.of(selected).allMatch(p -> p.isMarriageable() == person.isMarriageable())) {
+        if ((gui.getCampaign().getCampaignOptions().isUseManualMarriages() ||
+                   !gui.getCampaign().getCampaignOptions().getRandomMarriageMethod().isNone()) &&
+                  Stream.of(selected).allMatch(p -> p.isMarriageable() == person.isMarriageable())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miMarriageable.text"));
             cbMenuItem.setToolTipText(wordWrap(resources.getString("miMarriageable.toolTipText")));
             cbMenuItem.setName("miMarriageable");
@@ -2951,13 +3125,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu.add(cbMenuItem);
         }
 
-        if ((gui.getCampaign().getCampaignOptions().isUseManualProcreation()
-                || !gui.getCampaign().getCampaignOptions().getRandomProcreationMethod().isNone())
-                && Stream.of(selected).allMatch(p -> p.getGender().isFemale())
-                && Stream.of(selected).allMatch(p -> p.isTryingToConceive() == person.isTryingToConceive())) {
+        if ((gui.getCampaign().getCampaignOptions().isUseManualProcreation() ||
+                   !gui.getCampaign().getCampaignOptions().getRandomProcreationMethod().isNone()) &&
+                  Stream.of(selected).allMatch(p -> p.getGender().isFemale()) &&
+                  Stream.of(selected).allMatch(p -> p.isTryingToConceive() == person.isTryingToConceive())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miTryingToConceive.text"));
-            cbMenuItem.setToolTipText(
-                    MultiLineTooltip.splitToolTip(resources.getString("miTryingToConceive.toolTipText"), 100));
+            cbMenuItem.setToolTipText(MultiLineTooltip.splitToolTip(resources.getString("miTryingToConceive.toolTipText"),
+                  100));
             cbMenuItem.setName("miTryingToConceive");
             cbMenuItem.setSelected(person.isTryingToConceive());
             cbMenuItem.addActionListener(evt -> {
@@ -2982,24 +3156,27 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         // 8) Random Origin Planet
         menu = new JMenu(resources.getString("randomizationMenu.text"));
 
-        menuItem = new JMenuItem(
-                resources.getString(oneSelected ? "miRandomName.single.text" : "miRandomName.bulk.text"));
+        menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                           "miRandomName.single.text" :
+                                                           "miRandomName.bulk.text"));
         menuItem.setName("miRandomName");
         menuItem.setActionCommand(CMD_RANDOM_NAME);
         menuItem.addActionListener(this);
         menu.add(menuItem);
 
         if (StaticChecks.areAllClanEligible(selected)) {
-            menuItem = new JMenuItem(resources.getString(
-                    oneSelected ? "miRandomBloodnameCheck.single.text" : "miRandomBloodnameCheck.bulk.text"));
+            menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                               "miRandomBloodnameCheck.single.text" :
+                                                               "miRandomBloodnameCheck.bulk.text"));
             menuItem.setName("miRandomBloodnameCheck");
             menuItem.setActionCommand(makeCommand(CMD_RANDOM_BLOODNAME, String.valueOf(false)));
             menuItem.addActionListener(this);
             menu.add(menuItem);
 
             if (gui.getCampaign().isGM()) {
-                menuItem = new JMenuItem(resources
-                        .getString(oneSelected ? "miRandomBloodname.single.text" : "miRandomBloodname.bulk.text"));
+                menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                                   "miRandomBloodname.single.text" :
+                                                                   "miRandomBloodname.bulk.text"));
                 menuItem.setName("miRandomBloodname");
                 menuItem.setActionCommand(makeCommand(CMD_RANDOM_BLOODNAME, String.valueOf(true)));
                 menuItem.addActionListener(this);
@@ -3007,37 +3184,42 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
         }
 
-        menuItem = new JMenuItem(
-                resources.getString(oneSelected ? "miRandomCallsign.single.text" : "miRandomCallsign.bulk.text"));
+        menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                           "miRandomCallsign.single.text" :
+                                                           "miRandomCallsign.bulk.text"));
         menuItem.setName("miRandomCallsign");
         menuItem.setActionCommand(CMD_RANDOM_CALLSIGN);
         menuItem.addActionListener(this);
         menu.add(menuItem);
 
-        menuItem = new JMenuItem(
-                resources.getString(oneSelected ? "miRandomPortrait.single.text" : "miRandomPortrait.bulk.text"));
+        menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                           "miRandomPortrait.single.text" :
+                                                           "miRandomPortrait.bulk.text"));
         menuItem.setName("miRandomPortrait");
         menuItem.setActionCommand(CMD_RANDOM_PORTRAIT);
         menuItem.addActionListener(this);
         menu.add(menuItem);
 
         if (gui.getCampaign().getCampaignOptions().getRandomOriginOptions().isRandomizeOrigin()) {
-            menuItem = new JMenuItem(
-                    resources.getString(oneSelected ? "miRandomOrigin.single.text" : "miRandomOrigin.bulk.text"));
+            menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                               "miRandomOrigin.single.text" :
+                                                               "miRandomOrigin.bulk.text"));
             menuItem.setName("miRandomOrigin");
             menuItem.setActionCommand(CMD_RANDOM_ORIGIN);
             menuItem.addActionListener(this);
             menu.add(menuItem);
 
-            menuItem = new JMenuItem(resources
-                    .getString(oneSelected ? "miRandomOriginFaction.single.text" : "miRandomOriginFaction.bulk.text"));
+            menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                               "miRandomOriginFaction.single.text" :
+                                                               "miRandomOriginFaction.bulk.text"));
             menuItem.setName("miRandomOriginFaction");
             menuItem.setActionCommand(CMD_RANDOM_ORIGIN_FACTION);
             menuItem.addActionListener(this);
             menu.add(menuItem);
 
-            menuItem = new JMenuItem(resources
-                    .getString(oneSelected ? "miRandomOriginPlanet.single.text" : "miRandomOriginPlanet.bulk.text"));
+            menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                               "miRandomOriginPlanet.single.text" :
+                                                               "miRandomOriginPlanet.bulk.text"));
             menuItem.setName("miRandomOriginPlanet");
             menuItem.setActionCommand(CMD_RANDOM_ORIGIN_PLANET);
             menuItem.addActionListener(this);
@@ -3072,22 +3254,18 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu = new JMenu(resources.getString("GMMode.text"));
 
             menuItem = new JMenu(resources.getString("changePrisonerStatus.text"));
-            menuItem.add(newCheckboxMenu(
-                    PrisonerStatus.FREE.toString(),
-                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.FREE.name()),
-                    (person.getPrisonerStatus() == PrisonerStatus.FREE)));
-            menuItem.add(newCheckboxMenu(
-                    PrisonerStatus.PRISONER.toString(),
-                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER.name()),
-                    (person.getPrisonerStatus() == PrisonerStatus.PRISONER)));
-            menuItem.add(newCheckboxMenu(
-                    PrisonerStatus.PRISONER_DEFECTOR.toString(),
-                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER_DEFECTOR.name()),
-                    (person.getPrisonerStatus() == PrisonerStatus.PRISONER_DEFECTOR)));
-            menuItem.add(newCheckboxMenu(
-                    PrisonerStatus.BONDSMAN.toString(),
-                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.BONDSMAN.name()),
-                    (person.getPrisonerStatus() == PrisonerStatus.BONDSMAN)));
+            menuItem.add(newCheckboxMenu(PrisonerStatus.FREE.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.FREE.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.FREE)));
+            menuItem.add(newCheckboxMenu(PrisonerStatus.PRISONER.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.PRISONER)));
+            menuItem.add(newCheckboxMenu(PrisonerStatus.PRISONER_DEFECTOR.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER_DEFECTOR.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.PRISONER_DEFECTOR)));
+            menuItem.add(newCheckboxMenu(PrisonerStatus.BONDSMAN.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.BONDSMAN.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.BONDSMAN)));
             menu.add(menuItem);
 
             menuItem = new JMenuItem(resources.getString("removePerson.text"));
@@ -3142,8 +3320,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                 if (oneSelected) {
                     for (Injury i : person.getInjuries()) {
-                        menuItem = new JMenuItem(
-                                String.format(resources.getString("removeInjury.format"), i.getName()));
+                        menuItem = new JMenuItem(String.format(resources.getString("removeInjury.format"),
+                              i.getName()));
                         menuItem.setActionCommand(makeCommand(CMD_REMOVE_INJURY, i.getUUID().toString()));
                         menuItem.addActionListener(this);
                         menu.add(menuItem);
@@ -3157,18 +3335,22 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
 
             if (gui.getCampaign().getCampaignOptions().isUseManualProcreation()) {
-                if (Stream.of(selected).anyMatch(p -> gui.getCampaign().getProcreation()
-                        .canProcreate(gui.getCampaign().getLocalDate(), p, false) == null)) {
-                    menuItem = new JMenuItem(
-                            resources.getString(oneSelected ? "addPregnancy.text" : "addPregnancies.text"));
+                if (Stream.of(selected)
+                          .anyMatch(p -> gui.getCampaign()
+                                               .getProcreation()
+                                               .canProcreate(gui.getCampaign().getLocalDate(), p, false) == null)) {
+                    menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                                       "addPregnancy.text" :
+                                                                       "addPregnancies.text"));
                     menuItem.setActionCommand(CMD_ADD_PREGNANCY);
                     menuItem.addActionListener(this);
                     menu.add(menuItem);
                 }
 
                 if (Stream.of(selected).anyMatch(Person::isPregnant)) {
-                    menuItem = new JMenuItem(
-                            resources.getString(oneSelected ? "removePregnancy.text" : "removePregnancies.text"));
+                    menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                                       "removePregnancy.text" :
+                                                                       "removePregnancies.text"));
                     menuItem.setActionCommand(CMD_REMOVE_PREGNANCY);
                     menuItem.addActionListener(this);
                     menu.add(menuItem);
@@ -3213,7 +3395,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
      * @param civilianMenu the civilian menu object
      */
     private void buildEducationMenusSingleton(Campaign campaign, Person person, Academy academy, JMenu militaryMenu,
-            JMenu civilianMenu) {
+                                              JMenu civilianMenu) {
         boolean showIneligibleAcademies = campaign.getCampaignOptions().isEnableShowIneligibleAcademies();
         if (campaign.getCampaignOptions().isEnableOverrideRequirements()) {
             JMenu academyOption = new JMenu(academy.getName());
@@ -3234,41 +3416,55 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             // this is only relevant if we're overriding the academy restrictions, as we
             // won't reach this point during normal play.
             if (academyFactions.isEmpty()) {
-                buildEducationSubMenus(campaign, academy, List.of(person), academyOption, campus,
-                        campaign.getFaction().getShortName());
+                buildEducationSubMenus(campaign,
+                      academy,
+                      List.of(person),
+                      academyOption,
+                      campus,
+                      campaign.getFaction().getShortName());
             } else {
-                buildEducationSubMenus(campaign, academy, List.of(person), academyOption, campus,
-                        campaign.getSystemById(campus).getFactions(campaign.getLocalDate()).get(0));
+                buildEducationSubMenus(campaign,
+                      academy,
+                      List.of(person),
+                      academyOption,
+                      campus,
+                      campaign.getSystemById(campus).getFactions(campaign.getLocalDate()).get(0));
             }
             return;
         }
 
         // has the academy been constructed, is still standing, & has not closed?
-        if ((campaign.getGameYear() >= academy.getConstructionYear())
-                && (campaign.getGameYear() < academy.getDestructionYear())
-                && (campaign.getGameYear() < academy.getClosureYear())) {
+        if ((campaign.getGameYear() >= academy.getConstructionYear()) &&
+                  (campaign.getGameYear() < academy.getDestructionYear()) &&
+                  (campaign.getGameYear() < academy.getClosureYear())) {
             // is the planet populated?
             if ((academy.isLocal()) && (campaign.getCurrentSystem().getPopulation(campaign.getLocalDate()) == 0)) {
                 if (showIneligibleAcademies) {
-                    JMenuItem academyOption = new JMenuItem("<html>" + academy.getName()
-                            + resources.getString("eduPopulationConflict.text") + "</html>");
+                    JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                  academy.getName() +
+                                                                  resources.getString("eduPopulationConflict.text") +
+                                                                  "</html>");
 
                     educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                 }
                 // is the applicant within the right age bracket?
-            } else if ((person.getAge(campaign.getLocalDate()) >= academy.getAgeMax())
-                    || (person.getAge(campaign.getLocalDate()) < academy.getAgeMin())) {
+            } else if ((person.getAge(campaign.getLocalDate()) >= academy.getAgeMax()) ||
+                             (person.getAge(campaign.getLocalDate()) < academy.getAgeMin())) {
                 if (showIneligibleAcademies) {
                     JMenuItem academyOption;
 
                     if (academy.getAgeMax() != 9999) {
-                        academyOption = new JMenuItem("<html>" + academy.getName()
-                                + String.format(resources.getString("eduAgeConflictRange.text"), academy.getAgeMin(),
-                                        academy.getAgeMax())
-                                + "</html>");
+                        academyOption = new JMenuItem("<html>" +
+                                                            academy.getName() +
+                                                            String.format(resources.getString("eduAgeConflictRange.text"),
+                                                                  academy.getAgeMin(),
+                                                                  academy.getAgeMax()) +
+                                                            "</html>");
                     } else {
-                        academyOption = new JMenuItem("<html>" + academy.getName()
-                                + String.format(resources.getString("eduAgeConflictPlus.text"), academy.getAgeMin()));
+                        academyOption = new JMenuItem("<html>" +
+                                                            academy.getName() +
+                                                            String.format(resources.getString("eduAgeConflictPlus.text"),
+                                                                  academy.getAgeMin()));
                     }
 
                     educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
@@ -3276,27 +3472,33 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // is the applicant qualified?
             } else if (!academy.isQualified(person)) {
                 if (showIneligibleAcademies) {
-                    JMenuItem academyOption = new JMenuItem("<html>" + academy.getName()
-                            + String.format(resources.getString("eduUnqualified.text"),
-                                    academy.getEducationLevelMin()));
+                    JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                  academy.getName() +
+                                                                  String.format(resources.getString(
+                                                                              "eduUnqualified.text"),
+                                                                        academy.getEducationLevelMin()));
                     educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                 }
             } else if (academy.hasRejectedApplication(person)) {
                 if (showIneligibleAcademies) {
-                    JMenuItem academyOption = new JMenuItem("<html>" + academy.getName()
-                            + String.format(resources.getString("eduRejected.text"), academy.getEducationLevelMin()));
+                    JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                  academy.getName() +
+                                                                  String.format(resources.getString("eduRejected.text"),
+                                                                        academy.getEducationLevelMin()));
                     educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                 }
             } else if (academy.isLocal()) {
                 // are any of the local academies accepting applicants from person's Faction or
                 // campaign's Faction?
-                String faction = academy.getFilteredFaction(campaign, person, campaign
-                        .getSystemById(campaign.getCurrentSystem().getId()).getFactions(campaign.getLocalDate()));
+                String faction = academy.getFilteredFaction(campaign,
+                      person,
+                      campaign.getSystemById(campaign.getCurrentSystem().getId()).getFactions(campaign.getLocalDate()));
 
                 if (faction == null) {
                     if (showIneligibleAcademies) {
-                        JMenuItem academyOption = new JMenuItem(
-                                "<html>" + academy.getName() + resources.getString("eduFactionConflict.text"));
+                        JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                      academy.getName() +
+                                                                      resources.getString("eduFactionConflict.text"));
 
                         educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                     }
@@ -3304,15 +3506,23 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     JMenu academyOption = new JMenu(academy.getName());
                     educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                    buildEducationSubMenus(campaign, academy, List.of(person), academyOption,
-                            campaign.getCurrentSystem().getId(), faction);
+                    buildEducationSubMenus(campaign,
+                          academy,
+                          List.of(person),
+                          academyOption,
+                          campaign.getCurrentSystem().getId(),
+                          faction);
                 }
             } else if (academy.isHomeSchool()) {
                 JMenu academyOption = new JMenu(academy.getName());
                 educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                buildEducationSubMenus(campaign, academy, List.of(person), academyOption,
-                        campaign.getCurrentSystem().getId(), campaign.getFaction().getShortName());
+                buildEducationSubMenus(campaign,
+                      academy,
+                      List.of(person),
+                      academyOption,
+                      campaign.getCurrentSystem().getId(),
+                      campaign.getFaction().getShortName());
             } else {
                 // what campuses are accepting applicants?
                 List<String> campuses = new ArrayList<>();
@@ -3320,40 +3530,47 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 for (String campusId : academy.getLocationSystems()) {
                     PlanetarySystem system = campaign.getSystemById(campusId);
 
-                    if (academy.getFilteredFaction(campaign, person,
-                            system.getFactions(campaign.getLocalDate())) != null) {
+                    if (academy.getFilteredFaction(campaign, person, system.getFactions(campaign.getLocalDate())) !=
+                              null) {
                         campuses.add(campusId);
                     }
                 }
 
                 if (campuses.isEmpty()) {
                     if (showIneligibleAcademies) {
-                        JMenuItem academyOption = new JMenuItem(
-                                "<html>" + academy.getName() + resources.getString("eduFactionConflict.text"));
+                        JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                      academy.getName() +
+                                                                      resources.getString("eduFactionConflict.text"));
                         educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                     }
                     // which is the nearest campus and is it in range?
                 } else {
                     String nearestCampus = Academy.getNearestCampus(campaign, campuses);
 
-                    if ((campaign.getSimplifiedTravelTime(campaign.getSystemById(nearestCampus)) / 7) > campaign
-                            .getCampaignOptions().getMaximumJumpCount()) {
+                    if ((campaign.getSimplifiedTravelTime(campaign.getSystemById(nearestCampus)) / 7) >
+                              campaign.getCampaignOptions().getMaximumJumpCount()) {
                         if (showIneligibleAcademies) {
-                            JMenuItem academyOption = new JMenuItem(
-                                    "<html>" + academy.getName() + resources.getString("eduRangeConflict.text"));
+                            JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                          academy.getName() +
+                                                                          resources.getString("eduRangeConflict.text"));
                             educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                         }
                     } else {
-                        String faction = academy.getFilteredFaction(campaign, person,
-                                campaign.getSystemById(nearestCampus).getFactions(campaign.getLocalDate()));
+                        String faction = academy.getFilteredFaction(campaign,
+                              person,
+                              campaign.getSystemById(nearestCampus).getFactions(campaign.getLocalDate()));
 
                         if (faction != null) {
                             JMenu academyOption = new JMenu(academy.getName());
 
                             educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                            buildEducationSubMenus(campaign, academy, List.of(person), academyOption, nearestCampus,
-                                    faction);
+                            buildEducationSubMenus(campaign,
+                                  academy,
+                                  List.of(person),
+                                  academyOption,
+                                  nearestCampus,
+                                  faction);
                         }
                     }
                 }
@@ -3371,7 +3588,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
      * @param civilianMenu the civilian menu object
      */
     private void buildEducationMenusMassEnroll(Campaign campaign, List<Person> personnel, Academy academy,
-            JMenu militaryMenu, JMenu civilianMenu) {
+                                               JMenu militaryMenu, JMenu civilianMenu) {
         if (campaign.getCampaignOptions().isEnableOverrideRequirements()) {
             JMenu academyOption = new JMenu(academy.getName());
 
@@ -3388,33 +3605,43 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             List<String> academyFactions = campaign.getSystemById(campus).getFactions(campaign.getLocalDate());
 
             if (academyFactions.isEmpty()) {
-                buildEducationSubMenus(campaign, academy, personnel, academyOption, campus,
-                        campaign.getFaction().getShortName());
+                buildEducationSubMenus(campaign,
+                      academy,
+                      personnel,
+                      academyOption,
+                      campus,
+                      campaign.getFaction().getShortName());
             } else {
-                buildEducationSubMenus(campaign, academy, personnel, academyOption, campus,
-                        campaign.getSystemById(campus).getFactions(campaign.getLocalDate()).get(0));
+                buildEducationSubMenus(campaign,
+                      academy,
+                      personnel,
+                      academyOption,
+                      campus,
+                      campaign.getSystemById(campus).getFactions(campaign.getLocalDate()).get(0));
             }
             return;
         }
 
         // has the academy been constructed, is still standing, & has not closed?
-        if ((campaign.getGameYear() >= academy.getConstructionYear())
-                && (campaign.getGameYear() < academy.getDestructionYear())
-                && (campaign.getGameYear() < academy.getClosureYear())) {
+        if ((campaign.getGameYear() >= academy.getConstructionYear()) &&
+                  (campaign.getGameYear() < academy.getDestructionYear()) &&
+                  (campaign.getGameYear() < academy.getClosureYear())) {
 
             // is the planet populated?
-            if ((campaign.getCurrentSystem().getPopulation(campaign.getLocalDate()) == 0)
-                    && (!academy.isHomeSchool())) {
+            if ((campaign.getCurrentSystem().getPopulation(campaign.getLocalDate()) == 0) &&
+                      (!academy.isHomeSchool())) {
                 return;
             }
 
             // are all the applicants within the right age bracket?
             // are all the applicants qualified?
             boolean arePersonnelEligible = personnel.stream()
-                    .allMatch(person -> person.getAge(campaign.getLocalDate()) < academy.getAgeMax()
-                            && person.getAge(campaign.getLocalDate()) >= academy.getAgeMin()
-                            && academy.isQualified(person)
-                            && !academy.hasRejectedApplication(person));
+                                                 .allMatch(person -> person.getAge(campaign.getLocalDate()) <
+                                                                           academy.getAgeMax() &&
+                                                                           person.getAge(campaign.getLocalDate()) >=
+                                                                                 academy.getAgeMin() &&
+                                                                           academy.isQualified(person) &&
+                                                                           !academy.hasRejectedApplication(person));
 
             // if one or more people are not eligible to attend the academy,
             // there is no point doing any further processes
@@ -3426,63 +3653,98 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // find the first faction that accepts applications from all persons in
                 // personnel
                 Optional<String> suitableFaction = personnel.stream()
-                        .map(person -> academy.getFilteredFaction(campaign, person,
-                                campaign.getCurrentSystem().getFactions(campaign.getLocalDate())))
-                        .filter(faction -> personnel.stream().allMatch(person -> Objects.equals(
-                                faction,
-                                academy.getFilteredFaction(campaign, person,
-                                        campaign.getCurrentSystem().getFactions(campaign.getLocalDate())))))
-                        .distinct()
-                        .filter(Objects::nonNull)
-                        .findFirst();
+                                                         .map(person -> academy.getFilteredFaction(campaign,
+                                                               person,
+                                                               campaign.getCurrentSystem()
+                                                                     .getFactions(campaign.getLocalDate())))
+                                                         .filter(faction -> personnel.stream()
+                                                                                  .allMatch(person -> Objects.equals(
+                                                                                        faction,
+                                                                                        academy.getFilteredFaction(
+                                                                                              campaign,
+                                                                                              person,
+                                                                                              campaign.getCurrentSystem()
+                                                                                                    .getFactions(
+                                                                                                          campaign.getLocalDate())))))
+                                                         .distinct()
+                                                         .filter(Objects::nonNull)
+                                                         .findFirst();
 
                 if (suitableFaction.isPresent()) {
                     JMenu academyOption = new JMenu(academy.getName());
                     educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                    buildEducationSubMenus(campaign, academy, personnel, academyOption,
-                            campaign.getCurrentSystem().getId(), suitableFaction.get());
+                    buildEducationSubMenus(campaign,
+                          academy,
+                          personnel,
+                          academyOption,
+                          campaign.getCurrentSystem().getId(),
+                          suitableFaction.get());
                 }
             } else if (academy.isHomeSchool()) {
                 JMenu academyOption = new JMenu(academy.getName());
                 educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                buildEducationSubMenus(campaign, academy, personnel, academyOption, campaign.getCurrentSystem().getId(),
-                        campaign.getFaction().getShortName());
+                buildEducationSubMenus(campaign,
+                      academy,
+                      personnel,
+                      academyOption,
+                      campaign.getCurrentSystem().getId(),
+                      campaign.getFaction().getShortName());
             } else {
                 // find the campuses that accept applications from all members of the group
                 List<String> suitableCampuses = personnel.stream()
-                        .flatMap(person -> academy.getLocationSystems().stream()
-                                .filter(campus -> academy.getFilteredFaction(campaign, person,
-                                        campaign.getSystemById(campus).getFactions(campaign.getLocalDate())) != null))
-                        .distinct()
-                        .filter(campus -> personnel.stream()
-                                .allMatch(person -> academy.getFilteredFaction(campaign, person,
-                                        campaign.getSystemById(campus).getFactions(campaign.getLocalDate())) != null))
-                        .collect(Collectors.toList());
+                                                      .flatMap(person -> academy.getLocationSystems()
+                                                                               .stream()
+                                                                               .filter(campus -> academy.getFilteredFaction(
+                                                                                     campaign,
+                                                                                     person,
+                                                                                     campaign.getSystemById(campus)
+                                                                                           .getFactions(campaign.getLocalDate())) !=
+                                                                                                       null))
+                                                      .distinct()
+                                                      .filter(campus -> personnel.stream()
+                                                                              .allMatch(person -> academy.getFilteredFaction(
+                                                                                    campaign,
+                                                                                    person,
+                                                                                    campaign.getSystemById(campus)
+                                                                                          .getFactions(campaign.getLocalDate())) !=
+                                                                                                        null))
+                                                      .collect(Collectors.toList());
 
                 if (!suitableCampuses.isEmpty()) {
                     String nearestCampus = Academy.getNearestCampus(campaign, suitableCampuses);
 
                     // find what factions accept an application from all members of the group
                     Optional<String> suitableFaction = personnel.stream()
-                            .map(person -> academy.getFilteredFaction(campaign, person,
-                                    campaign.getSystemById(nearestCampus).getFactions(campaign.getLocalDate())))
-                            .distinct()
-                            .filter(faction -> personnel.stream()
-                                    .allMatch(person -> faction.equals(academy.getFilteredFaction(campaign, person,
-                                            campaign.getSystemById(nearestCampus)
-                                                    .getFactions(campaign.getLocalDate())))))
-                            .findFirst();
+                                                             .map(person -> academy.getFilteredFaction(campaign,
+                                                                   person,
+                                                                   campaign.getSystemById(nearestCampus)
+                                                                         .getFactions(campaign.getLocalDate())))
+                                                             .distinct()
+                                                             .filter(faction -> personnel.stream()
+                                                                                      .allMatch(person -> faction.equals(
+                                                                                            academy.getFilteredFaction(
+                                                                                                  campaign,
+                                                                                                  person,
+                                                                                                  campaign.getSystemById(
+                                                                                                              nearestCampus)
+                                                                                                        .getFactions(
+                                                                                                              campaign.getLocalDate())))))
+                                                             .findFirst();
 
                     if (suitableFaction.isPresent()) {
-                        if ((campaign.getSimplifiedTravelTime(campaign.getSystemById(nearestCampus)) / 7) <= campaign
-                                .getCampaignOptions().getMaximumJumpCount()) {
+                        if ((campaign.getSimplifiedTravelTime(campaign.getSystemById(nearestCampus)) / 7) <=
+                                  campaign.getCampaignOptions().getMaximumJumpCount()) {
                             JMenu academyOption = new JMenu(academy.getName());
                             educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                            buildEducationSubMenus(campaign, academy, personnel, academyOption, nearestCampus,
-                                    suitableFaction.get());
+                            buildEducationSubMenus(campaign,
+                                  academy,
+                                  personnel,
+                                  academyOption,
+                                  nearestCampus,
+                                  suitableFaction.get());
                         }
                     }
                 }
@@ -3491,9 +3753,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     /**
-     * Adds an education option to the appropriate JMenu based on the type of
-     * Academy.
-     * This version accepts JMenu objects.
+     * Adds an education option to the appropriate JMenu based on the type of Academy. This version accepts JMenu
+     * objects.
      *
      * @param academy      the Academy
      * @param militaryMenu the JMenu for military education options
@@ -3509,9 +3770,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     /**
-     * Adds an education option to the appropriate JMenu based on the type of
-     * Academy.
-     * This version accepts JMenuItem objects.
+     * Adds an education option to the appropriate JMenu based on the type of Academy. This version accepts JMenuItem
+     * objects.
      *
      * @param academy      the Academy
      * @param militaryMenu the JMenu for military education options
@@ -3519,7 +3779,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
      * @param option       the option to be added to the appropriate JMenu
      */
     private static void educationJMenuItemAdder(Academy academy, JMenu militaryMenu, JMenu civilianMenu,
-            JMenuItem option) {
+                                                JMenuItem option) {
         if (academy.isMilitary()) {
             militaryMenu.add(option);
         } else {
@@ -3528,29 +3788,40 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     private void buildEducationSubMenus(Campaign campaign, Academy academy, List<Person> personnel, JMenu academyOption,
-            String campus, String faction) {
+                                        String campus, String faction) {
         JMenuItem courses;
         int courseCount = academy.getQualifications().size();
 
         if (courseCount > 0) {
             for (int courseIndex = 0; courseIndex < (courseCount); courseIndex++) {
                 // we also need to make sure the course is being offered
-                if ((campaign.getCampaignOptions().isEnableOverrideRequirements())
-                        || (campaign.getGameYear() >= academy.getQualificationStartYears().get(courseIndex))) {
+                if ((campaign.getCampaignOptions().isEnableOverrideRequirements()) ||
+                          (campaign.getGameYear() >= academy.getQualificationStartYears().get(courseIndex))) {
                     String course = academy.getQualifications().get(courseIndex);
                     courses = new JMenuItem(course);
 
                     if ((academy.isLocal()) || (academy.isHomeSchool())) {
-                        courses.setToolTipText(
-                                academy.getTooltip(campaign, personnel, courseIndex, campaign.getCurrentSystem()));
-                        courses.setActionCommand(
-                                makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT, academy.getSet(), academy.getName(),
-                                        String.valueOf(courseIndex), campaign.getCurrentSystem().getId(), faction));
+                        courses.setToolTipText(academy.getTooltip(campaign,
+                              personnel,
+                              courseIndex,
+                              campaign.getCurrentSystem()));
+                        courses.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT,
+                              academy.getSet(),
+                              academy.getName(),
+                              String.valueOf(courseIndex),
+                              campaign.getCurrentSystem().getId(),
+                              faction));
                     } else {
-                        courses.setToolTipText(
-                                academy.getTooltip(campaign, personnel, courseIndex, campaign.getSystemById(campus)));
-                        courses.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT, academy.getSet(),
-                                academy.getName(), String.valueOf(courseIndex), campus, faction));
+                        courses.setToolTipText(academy.getTooltip(campaign,
+                              personnel,
+                              courseIndex,
+                              campaign.getSystemById(campus)));
+                        courses.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT,
+                              academy.getSet(),
+                              academy.getName(),
+                              String.valueOf(courseIndex),
+                              campus,
+                              faction));
                     }
                     courses.addActionListener(this);
                     academyOption.add(courses);
@@ -3566,6 +3837,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
      * Returns a JMenuItem for a given Award.
      *
      * @param award The Award object for which the JMenuItem is to be created.
+     *
      * @return A JMenuItem representing the given Award.
      */
     private JMenuItem getAwardMenuItem(Award award) {

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -27,12 +27,28 @@
  */
 package mekhq.gui.dialog;
 
+import static java.lang.Math.round;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.ResourceBundle;
+import javax.swing.*;
+import javax.swing.RowSorter.SortKey;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+
 import megamek.client.ui.models.XTableColumnModel;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.log.PersonalLogger;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.Skill;
@@ -43,16 +59,6 @@ import mekhq.gui.enums.PersonnelTableModelColumn;
 import mekhq.gui.model.PersonnelTableModel;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
-
-import javax.swing.*;
-import javax.swing.RowSorter.SortKey;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-import java.awt.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.ResourceBundle;
 
 public final class BatchXPDialog extends JDialog {
     private static final MMLogger logger = MMLogger.create(BatchXPDialog.class);
@@ -73,19 +79,18 @@ public final class BatchXPDialog extends JDialog {
     private JCheckBox allowPrisoners;
     private JButton buttonSpendXP;
 
-    private final List<PersonnelTableModelColumn> batchXPColumns = List.of(
-            PersonnelTableModelColumn.RANK,
-            PersonnelTableModelColumn.FIRST_NAME,
-            PersonnelTableModelColumn.LAST_NAME,
-            PersonnelTableModelColumn.AGE,
-            PersonnelTableModelColumn.PERSONNEL_ROLE,
-            PersonnelTableModelColumn.XP);
+    private final List<PersonnelTableModelColumn> batchXPColumns = List.of(PersonnelTableModelColumn.RANK,
+          PersonnelTableModelColumn.FIRST_NAME,
+          PersonnelTableModelColumn.LAST_NAME,
+          PersonnelTableModelColumn.AGE,
+          PersonnelTableModelColumn.PERSONNEL_ROLE,
+          PersonnelTableModelColumn.XP);
 
     private JLabel matchedPersonnelLabel;
 
     private transient String choiceNoSkill;
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.BatchXPDialog",
-            MekHQ.getMHQOptions().getLocale());
+          MekHQ.getMHQOptions().getLocale());
 
     public BatchXPDialog(JFrame parent, Campaign campaign) {
         super(parent, "", true);
@@ -161,15 +166,16 @@ public final class BatchXPDialog extends JDialog {
         personTypeModel.addElement(new PersonTypeItem(resourceMap.getString("primaryRole.choice.text"), null));
         final PersonnelRole[] personnelRoles = PersonnelRole.values();
         for (PersonnelRole personnelRole : personnelRoles) {
-            personTypeModel.addElement(
-                    new PersonTypeItem(personnelRole.getName(campaign.getFaction().isClan()), personnelRole.ordinal()));
+            personTypeModel.addElement(new PersonTypeItem(personnelRole.getName(campaign.getFaction().isClan()),
+                  personnelRole.ordinal()));
         }
         choiceType.setModel(personTypeModel);
         choiceType.setSelectedIndex(0);
         choiceType.addActionListener(e -> {
             PersonTypeItem personTypeItem = (PersonTypeItem) Objects.requireNonNull(choiceType.getSelectedItem());
-            personnelFilter
-                    .setPrimaryRole((personTypeItem.getId() == null) ? null : personnelRoles[personTypeItem.getId()]);
+            personnelFilter.setPrimaryRole((personTypeItem.getId() == null) ?
+                                                 null :
+                                                 personnelRoles[personTypeItem.getId()]);
             updatePersonnelTable();
         });
         panel.add(choiceType);
@@ -219,8 +225,8 @@ public final class BatchXPDialog extends JDialog {
         JPanel onlyOfficersPanel = new JPanel(new GridLayout(1, 1));
         onlyOfficersPanel.setAlignmentY(JComponent.TOP_ALIGNMENT);
         onlyOfficersPanel.add(onlyOfficers);
-        onlyOfficersPanel
-                .setMaximumSize(new Dimension(Short.MAX_VALUE, (int) onlyOfficersPanel.getPreferredSize().getHeight()));
+        onlyOfficersPanel.setMaximumSize(new Dimension(Short.MAX_VALUE,
+              (int) onlyOfficersPanel.getPreferredSize().getHeight()));
         panel.add(onlyOfficersPanel);
 
         noOfficers = new JCheckBox(resourceMap.getString("noOfficers.text"));
@@ -235,8 +241,8 @@ public final class BatchXPDialog extends JDialog {
         JPanel noOfficersPanel = new JPanel(new GridLayout(1, 1));
         noOfficersPanel.setAlignmentY(JComponent.TOP_ALIGNMENT);
         noOfficersPanel.add(noOfficers);
-        noOfficersPanel
-                .setMaximumSize(new Dimension(Short.MAX_VALUE, (int) noOfficersPanel.getPreferredSize().getHeight()));
+        noOfficersPanel.setMaximumSize(new Dimension(Short.MAX_VALUE,
+              (int) noOfficersPanel.getPreferredSize().getHeight()));
         panel.add(noOfficersPanel);
 
         choiceSkill = new JComboBox<>();
@@ -250,7 +256,7 @@ public final class BatchXPDialog extends JDialog {
         choiceSkill.setSelectedIndex(0);
         choiceSkill.addActionListener(evt -> {
             if (choiceNoSkill.equals(choiceSkill.getSelectedItem())) {
-                personnelFilter.setSkill(null);
+                personnelFilter.setSkillName(null);
                 ((SpinnerNumberModel) skillLevel.getModel()).setMaximum(10);
                 skillLevel.setEnabled(false);
                 buttonSpendXP.setEnabled(false);
@@ -261,7 +267,7 @@ public final class BatchXPDialog extends JDialog {
                     logger.error("Cannot mass train unknown skill type with name " + skillName);
                     return;
                 }
-                personnelFilter.setSkill(skillName);
+                personnelFilter.setSkillName(skillName);
                 int maxSkillLevel = SkillType.getType(skillName).getMaxLevel();
                 if (maxSkillLevel == -1) {
                     skillLevel.setEnabled(false);
@@ -269,8 +275,8 @@ public final class BatchXPDialog extends JDialog {
                 } else {
                     skillLevel.setEnabled(true);
                     ((SpinnerNumberModel) skillLevel.getModel()).setMaximum(maxSkillLevel);
-                    skillLevel.getModel().setValue(
-                            MathUtility.clamp((Integer) skillLevel.getModel().getValue(), 1, maxSkillLevel));
+                    skillLevel.getModel()
+                          .setValue(MathUtility.clamp((Integer) skillLevel.getModel().getValue(), 1, maxSkillLevel));
                     buttonSpendXP.setEnabled(true);
                 }
             }
@@ -291,8 +297,8 @@ public final class BatchXPDialog extends JDialog {
 
         allowPrisoners = new JCheckBox(resourceMap.getString("allowPrisoners.text"));
         allowPrisoners.setHorizontalAlignment(SwingConstants.LEFT);
-        allowPrisoners
-                .setMaximumSize(new Dimension(Short.MAX_VALUE, (int) allowPrisoners.getPreferredSize().getHeight()));
+        allowPrisoners.setMaximumSize(new Dimension(Short.MAX_VALUE,
+              (int) allowPrisoners.getPreferredSize().getHeight()));
         allowPrisoners.addChangeListener(e -> {
             personnelFilter.setAllowPrisoners(allowPrisoners.isSelected());
             updatePersonnelTable();
@@ -300,15 +306,15 @@ public final class BatchXPDialog extends JDialog {
         JPanel allowPrisonersPanel = new JPanel(new GridLayout(1, 1));
         allowPrisonersPanel.setAlignmentY(JComponent.TOP_ALIGNMENT);
         allowPrisonersPanel.add(allowPrisoners);
-        allowPrisonersPanel.setMaximumSize(
-                new Dimension(Short.MAX_VALUE, (int) allowPrisonersPanel.getPreferredSize().getHeight()));
+        allowPrisonersPanel.setMaximumSize(new Dimension(Short.MAX_VALUE,
+              (int) allowPrisonersPanel.getPreferredSize().getHeight()));
         panel.add(allowPrisonersPanel);
 
         panel.add(Box.createVerticalGlue());
 
         matchedPersonnelLabel = new JLabel("");
-        matchedPersonnelLabel.setMaximumSize(
-                new Dimension(Short.MAX_VALUE, (int) matchedPersonnelLabel.getPreferredSize().getHeight()));
+        matchedPersonnelLabel.setMaximumSize(new Dimension(Short.MAX_VALUE,
+              (int) matchedPersonnelLabel.getPreferredSize().getHeight()));
         panel.add(matchedPersonnelLabel);
 
         JPanel buttons = new JPanel(new FlowLayout());
@@ -351,21 +357,24 @@ public final class BatchXPDialog extends JDialog {
         int improvedPersonnelCount = rows;
         while (rows > 0) {
             for (int i = 0; i < rows; ++i) {
-                Person p = personnelModel.getPerson(personnelTable.convertRowIndexToModel(i));
-                int cost;
-                if (p.hasSkill(skillName)) {
-                    cost = p.getCostToImprove(skillName);
-                } else {
-                    cost = SkillType.getType(skillName).getCost(0);
-                }
-                int startingExperienceLevel = p.getExperienceLevel(campaign, false);
+                final CampaignOptions campaignOptions = campaign.getCampaignOptions();
+
+                Person person = personnelModel.getPerson(personnelTable.convertRowIndexToModel(i));
+
+                int cost = person.getCostToImprove(skillName, campaignOptions.isUseIntelligenceXpMultiplier());
+                double costMultiplier = campaignOptions.getXpCostMultiplier();
+
+                cost = (int) round(cost * costMultiplier);
 
                 // Improve the skill and deduce the cost
-                p.improveSkill(skillName);
-                p.spendXP(cost);
-                PersonalLogger.improvedSkill(campaign, p, campaign.getLocalDate(),
-                        p.getSkill(skillName).getType().getName(), p.getSkill(skillName).toString());
-                campaign.personUpdated(p);
+                person.improveSkill(skillName);
+                person.spendXP(cost);
+                PersonalLogger.improvedSkill(campaign,
+                      person,
+                      campaign.getLocalDate(),
+                      person.getSkill(skillName).getType().getName(),
+                      person.getSkill(skillName).toString());
+                campaign.personUpdated(person);
             }
 
             // Refresh the filter and continue if we still have anyone available
@@ -374,8 +383,9 @@ public final class BatchXPDialog extends JDialog {
         }
 
         if (improvedPersonnelCount > 0) {
-            campaign.addReport(
-                    String.format(resourceMap.getString("improvedSkills.format"), skillName, improvedPersonnelCount));
+            campaign.addReport(String.format(resourceMap.getString("improvedSkills.format"),
+                  skillName,
+                  improvedPersonnelCount));
         }
     }
 
@@ -386,7 +396,7 @@ public final class BatchXPDialog extends JDialog {
         private Integer rank = null;
         private boolean onlyOfficers = false;
         private boolean noOfficers = false;
-        private String skill = null;
+        private String skillName = null;
         private int maxSkillLevel = 10;
         private boolean prisoners = false;
 
@@ -396,29 +406,32 @@ public final class BatchXPDialog extends JDialog {
 
         @Override
         public boolean include(Entry<? extends PersonnelTableModel, ? extends Integer> entry) {
-            Person p = entry.getModel().getPerson(entry.getIdentifier().intValue());
-            if (!p.getStatus().isActive()) {
+            Person person = entry.getModel().getPerson(entry.getIdentifier().intValue());
+            if (!person.getStatus().isActive()) {
                 return false;
-            } else if (!prisoners && !p.getPrisonerStatus().isFree()) {
+            } else if (!prisoners && !person.getPrisonerStatus().isFree()) {
                 return false;
-            } else if ((null != primaryRole) && (p.getPrimaryRole() != primaryRole)) {
+            } else if ((null != primaryRole) && (person.getPrimaryRole() != primaryRole)) {
                 return false;
-            } else if ((null != expLevel) && (p.getExperienceLevel(campaign, false) != expLevel)) {
+            } else if ((null != expLevel) && (person.getExperienceLevel(campaign, false) != expLevel)) {
                 return false;
-            } else if (onlyOfficers && !p.getRank().isOfficer()) {
+            } else if (onlyOfficers && !person.getRank().isOfficer()) {
                 return false;
-            } else if (noOfficers && p.getRank().isOfficer()) {
+            } else if (noOfficers && person.getRank().isOfficer()) {
                 return false;
-            } else if ((rank != null) && (p.getRankNumeric() != rank)) {
+            } else if ((rank != null) && (person.getRankNumeric() != rank)) {
                 return false;
-            } else if (null != skill) {
-                Skill s = p.getSkill(skill);
-                if (null == s) {
-                    int cost = SkillType.getType(skill).getCost(0);
-                    return (cost >= 0) && (cost <= p.getXP());
+            } else if (null != skillName) {
+                final CampaignOptions campaignOptions = campaign.getCampaignOptions();
+                final double xpCostMultiplier = campaignOptions.getXpCostMultiplier();
+                Skill skill = person.getSkill(skillName);
+                int cost = person.getCostToImprove(skillName, campaignOptions.isUseIntelligenceXpMultiplier());
+                cost = (int) round(cost * xpCostMultiplier);
+
+                if (null == skill) {
+                    return (cost >= 0) && (cost <= person.getXP());
                 } else {
-                    int cost = s.getCostToImprove();
-                    return (s.getLevel() < maxSkillLevel) && (cost >= 0) && (cost <= p.getXP());
+                    return (skill.getLevel() < maxSkillLevel) && (cost >= 0) && (cost <= person.getXP());
                 }
             }
             return true;
@@ -444,8 +457,21 @@ public final class BatchXPDialog extends JDialog {
             this.noOfficers = noOfficers;
         }
 
-        public void setSkill(String skillName) {
-            skill = skillName;
+        /**
+         * @deprecated Use {@link #setSkillName(String)} instead.
+         */
+        @Deprecated(since = "0.50.05", forRemoval = true)
+        public void setSkill(String skill) {
+            this.skillName = skill;
+        }
+
+        /**
+         * Sets the the name of the target skill.
+         *
+         * @param skillName the name of the skill to be set.
+         */
+        public void setSkillName(String skillName) {
+            this.skillName = skillName;
         }
 
         public void setMaxSkillLevel(int level) {


### PR DESCRIPTION
- Introduced a new `getCostToImprove` method in `Person`, allowing for optional intelligence-based XP scaling in skill improvements.
- Refactored intelligence experience cost multiplier logic, encapsulating it in `getIntelligenceXpCostMultiplier`.
- Updated all instances of skill cost calculations to ensure intelligence-based multipliers are applied before global campaign multipliers.
- Deprecated old methods (`getIntelligenceXpCostMultiplier(CampaignOptions)` and `getCostToImprove(String skillName)`), replaced with updated implementations.
- Enhanced methods in `SkillDeprecationTool`, `PersonnelTableMouseAdapter`, and `BatchXPDialog` to align with the revised intelligence multiplier handling.
- Improved documentation for several classes and methods, aligning comments and annotations with the updated functionality.

### Dev Notes
Fundamentally, this mostly just cleans up how we calculate xp costs for skills, with some unification of the logic for Edge and SPAs. It also fixes a bug where mass training wasn't factoring in modified xp costs from the xp cost multiplier campaign option.

Finally, in 50.04 we prevented skills from being reduced below 0 to bring us back in line with RAW. However, that created a poor play experience where players could unknowingly improve their skills for no benefit. We now block skills from being purchased if the improvement would take the skill above the cap (or below, depending on the skill type).