### PR TITLE
 Added Helper Methods to `PersonnelTableMouseAdapter` for Cleaner `Campaign` Access

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -51,6 +51,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFrame;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
@@ -238,6 +239,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         this.gui = gui;
         this.personnelTable = personnelTable;
         this.personnelModel = personnelModel;
+    }
+
+    private JFrame getFrame() {
+        return gui.getFrame();
     }
 
     private Campaign getCampaign() {
@@ -882,14 +887,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_EDIT: {
                 for (Person person : people) {
-                    CustomizePersonDialog npd = new CustomizePersonDialog(gui.getFrame(), true, person, getCampaign());
+                    CustomizePersonDialog npd = new CustomizePersonDialog(getFrame(), true, person, getCampaign());
                     npd.setVisible(true);
                     getCampaign().personUpdated(selectedPerson);
                 }
                 break;
             }
             case CMD_EDIT_HITS: {
-                EditPersonnelHitsDialog ephd = new EditPersonnelHitsDialog(gui.getFrame(), true, selectedPerson);
+                EditPersonnelHitsDialog ephd = new EditPersonnelHitsDialog(getFrame(), true, selectedPerson);
                 ephd.setVisible(true);
                 if (0 == selectedPerson.getHits()) {
                     selectedPerson.setDoctorId(null, getCampaignOptions().getNaturalHealingWaitingPeriod());
@@ -898,7 +903,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_EDIT_PORTRAIT: {
-                final PortraitChooserDialog portraitDialog = new PortraitChooserDialog(gui.getFrame(),
+                final PortraitChooserDialog portraitDialog = new PortraitChooserDialog(getFrame(),
                       selectedPerson.getPortrait());
                 if (portraitDialog.showDialog().isConfirmed()) {
                     for (Person person : people) {
@@ -911,7 +916,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_EDIT_BIOGRAPHY: {
-                MarkdownEditorDialog tad = new MarkdownEditorDialog(gui.getFrame(),
+                MarkdownEditorDialog tad = new MarkdownEditorDialog(getFrame(),
                       true,
                       resources.getString("editBiography.text"),
                       selectedPerson.getBiography());
@@ -930,7 +935,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_ADD_XP: {
-                PopupValueChoiceDialog pvcda = new PopupValueChoiceDialog(gui.getFrame(),
+                PopupValueChoiceDialog pvcda = new PopupValueChoiceDialog(getFrame(),
                       true,
                       resources.getString("xp.text"),
                       1,
@@ -951,7 +956,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_SET_XP: {
-                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(),
+                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(getFrame(),
                       true,
                       resources.getString("xp.text"),
                       selectedPerson.getXP(),
@@ -969,10 +974,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_BUY_EDGE: {
                 int baseCost = getCampaignOptions().getEdgeCost();
-                double costMultiplier = getCampaignOptions().getXpCostMultiplier();
+                final double xpCostMultiplier = getCampaignOptions().getXpCostMultiplier();
+                final boolean isUseIntelligenceMultiplier = getCampaignOptions().isUseIntelligenceXpMultiplier();
                 for (Person person : people) {
-                    double intelligenceCostMultiplier = person.getIntelligenceXpCostMultiplier(getCampaignOptions());
-                    int cost = (int) round(baseCost * intelligenceCostMultiplier * costMultiplier);
+                    double intelligenceXpCostMultiplier = person.getIntelligenceXpCostMultiplier(
+                          isUseIntelligenceMultiplier);
+
+                    // Intelligence cost changes should always take place before global changes
+                    int cost = (int) round(baseCost * intelligenceXpCostMultiplier);
+                    cost = (int) round(cost * xpCostMultiplier);
 
                     selectedPerson.spendXP(cost);
                     person.changeEdge(1);
@@ -987,7 +997,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_SET_EDGE: {
-                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(),
+                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(getFrame(),
                       true,
                       resources.getString("edge.text"),
                       selectedPerson.getEdge(),
@@ -1011,14 +1021,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 AddOrEditKillEntryDialog nkd;
                 Unit unit = selectedPerson.getUnit();
                 if (people.length > 1) {
-                    nkd = new AddOrEditKillEntryDialog(gui.getFrame(),
+                    nkd = new AddOrEditKillEntryDialog(getFrame(),
                           true,
                           null,
                           (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
                           getCampaign().getLocalDate(),
                           getCampaign());
                 } else {
-                    nkd = new AddOrEditKillEntryDialog(gui.getFrame(),
+                    nkd = new AddOrEditKillEntryDialog(getFrame(),
                           true,
                           selectedPerson.getId(),
                           (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
@@ -1043,13 +1053,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_EDIT_KILL_LOG: {
-                EditKillLogDialog ekld = new EditKillLogDialog(gui.getFrame(), true, getCampaign(), selectedPerson);
+                EditKillLogDialog ekld = new EditKillLogDialog(getFrame(), true, getCampaign(), selectedPerson);
                 ekld.setVisible(true);
                 MekHQ.triggerEvent(new PersonLogEvent(selectedPerson));
                 break;
             }
             case CMD_EDIT_PERSONNEL_LOG: {
-                EditPersonnelLogDialog epld = new EditPersonnelLogDialog(gui.getFrame(),
+                EditPersonnelLogDialog epld = new EditPersonnelLogDialog(getFrame(),
                       true,
                       getCampaign(),
                       selectedPerson);
@@ -1058,7 +1068,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_ADD_LOG_ENTRY: {
-                final AddOrEditPersonnelEntryDialog addPersonnelLogDialog = new AddOrEditPersonnelEntryDialog(gui.getFrame(),
+                final AddOrEditPersonnelEntryDialog addPersonnelLogDialog = new AddOrEditPersonnelEntryDialog(getFrame(),
                       null,
                       getCampaign().getLocalDate());
                 if (addPersonnelLogDialog.showDialog().isConfirmed()) {
@@ -1070,16 +1080,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_EDIT_SCENARIO_LOG: {
-                EditScenarioLogDialog emld = new EditScenarioLogDialog(gui.getFrame(),
-                      true,
-                      getCampaign(),
-                      selectedPerson);
+                EditScenarioLogDialog emld = new EditScenarioLogDialog(getFrame(), true, getCampaign(), selectedPerson);
                 emld.setVisible(true);
                 MekHQ.triggerEvent(new PersonLogEvent(selectedPerson));
                 break;
             }
             case CMD_ADD_SCENARIO_ENTRY: {
-                AddOrEditScenarioEntryDialog addScenarioDialog = new AddOrEditScenarioEntryDialog(gui.getFrame(),
+                AddOrEditScenarioEntryDialog addScenarioDialog = new AddOrEditScenarioEntryDialog(getFrame(),
                       true,
                       getCampaign().getLocalDate());
                 addScenarioDialog.setVisible(true);
@@ -1093,7 +1100,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_CALLSIGN: {
-                String s = (String) JOptionPane.showInputDialog(gui.getFrame(),
+                String s = (String) JOptionPane.showInputDialog(getFrame(),
                       resources.getString("enterNewCallsign.text"),
                       resources.getString("editCallsign.text"),
                       JOptionPane.PLAIN_MESSAGE,
@@ -1139,7 +1146,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_EDIT_INJURIES: {
-                EditPersonnelInjuriesDialog epid = new EditPersonnelInjuriesDialog(gui.getFrame(),
+                EditPersonnelInjuriesDialog epid = new EditPersonnelInjuriesDialog(getFrame(),
                       true,
                       getCampaign(),
                       selectedPerson);
@@ -1150,7 +1157,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_EDIT_SALARY: {
                 int originalSalary = selectedPerson.getSalary(getCampaign()).getAmount().intValue();
 
-                PopupValueChoiceDialog salaryDialog = new PopupValueChoiceDialog(gui.getFrame(),
+                PopupValueChoiceDialog salaryDialog = new PopupValueChoiceDialog(getFrame(),
                       true,
                       resources.getString("changeSalary.text"),
                       MathUtility.clamp(originalSalary, -1, 1000000000),
@@ -1173,7 +1180,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_GIVE_PAYMENT: {
-                PopupValueChoiceDialog pcvd = new PopupValueChoiceDialog(gui.getFrame(),
+                PopupValueChoiceDialog pcvd = new PopupValueChoiceDialog(getFrame(),
                       true,
                       resources.getString("givePayment.title"),
                       1000,
@@ -1457,7 +1464,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     private void loadGMToolsForPerson(Person person) {
-        GMToolsDialog gmToolsDialog = new GMToolsDialog(gui.getFrame(), gui, person);
+        GMToolsDialog gmToolsDialog = new GMToolsDialog(getFrame(), gui, person);
         gmToolsDialog.setVisible(true);
         getCampaign().personUpdated(person);
     }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -73,6 +73,7 @@ import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.Kill;
 import mekhq.campaign.event.PersonChangedEvent;
 import mekhq.campaign.event.PersonLogEvent;
@@ -230,18 +231,25 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private final PersonnelTableModel personnelModel;
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI",
-            MekHQ.getMHQOptions().getLocale());
+          MekHQ.getMHQOptions().getLocale());
     // endregion Variable Declarations
 
-    protected PersonnelTableMouseAdapter(CampaignGUI gui, JTable personnelTable,
-            PersonnelTableModel personnelModel) {
+    protected PersonnelTableMouseAdapter(CampaignGUI gui, JTable personnelTable, PersonnelTableModel personnelModel) {
         this.gui = gui;
         this.personnelTable = personnelTable;
         this.personnelModel = personnelModel;
     }
 
-    public static void connect(CampaignGUI gui, JTable personnelTable,
-            PersonnelTableModel personnelModel, JSplitPane splitPersonnel) {
+    private Campaign getCampaign() {
+        return gui.getCampaign();
+    }
+
+    private CampaignOptions getCampaignOptions() {
+        return getCampaign().getCampaignOptions();
+    }
+
+    public static void connect(CampaignGUI gui, JTable personnelTable, PersonnelTableModel personnelModel,
+                               JSplitPane splitPersonnel) {
         new PersonnelTableMouseAdapter(gui, personnelTable, personnelModel) {
             @Override
             public void mouseClicked(MouseEvent e) {
@@ -295,15 +303,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     final int rank = Integer.parseInt(data[1]);
                     final int level = (data.length > 2) ? Integer.parseInt(data[2]) : 0;
                     for (final Person person : people) {
-                        person.changeRank(gui.getCampaign(), rank, level, true);
+                        person.changeRank(getCampaign(), rank, level, true);
 
                         promotedPersonnel.add(person);
                     }
 
-                    if ((gui.getCampaign().getCampaignOptions().isEnableAutoAwards())
-                            && (!promotedPersonnel.isEmpty())) {
+                    if ((getCampaignOptions().isEnableAutoAwards()) && (!promotedPersonnel.isEmpty())) {
                         AutoAwardsController autoAwardsController = new AutoAwardsController();
-                        autoAwardsController.PromotionController(gui.getCampaign(), false);
+                        autoAwardsController.PromotionController(getCampaign(), false);
                     }
                 } catch (Exception e) {
                     logger.error("", e);
@@ -353,13 +360,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_PRIMARY_ROLE: {
                 PersonnelRole role = PersonnelRole.valueOf(data[1]);
                 for (final Person person : people) {
-                    person.setPrimaryRole(gui.getCampaign(), role);
+                    person.setPrimaryRole(getCampaign(), role);
                     writePersonalityDescription(person);
-                    gui.getCampaign().personUpdated(person);
-                    if (gui.getCampaign().getCampaignOptions().isUsePortraitForRole(role)
-                            && gui.getCampaign().getCampaignOptions().isAssignPortraitOnRoleChange()
-                            && person.getPortrait().hasDefaultFilename()) {
-                        gui.getCampaign().assignRandomPortraitFor(person);
+                    getCampaign().personUpdated(person);
+                    if (getCampaignOptions().isUsePortraitForRole(role) &&
+                              getCampaignOptions().isAssignPortraitOnRoleChange() &&
+                              person.getPortrait().hasDefaultFilename()) {
+                        getCampaign().assignRandomPortraitFor(person);
                     }
                 }
                 break;
@@ -368,47 +375,52 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 PersonnelRole role = PersonnelRole.valueOf(data[1]);
                 for (final Person person : people) {
                     person.setSecondaryRole(role);
-                    gui.getCampaign().personUpdated(person);
+                    getCampaign().personUpdated(person);
                 }
                 break;
             }
             case CMD_ADD_PREGNANCY: {
                 Stream.of(people)
-                        .filter(person -> (gui.getCampaign().getProcreation().canProcreate(
-                                gui.getCampaign().getLocalDate(), person, false) == null))
-                        .forEach(person -> {
-                            gui.getCampaign().getProcreation().addPregnancy(
-                                    gui.getCampaign(), gui.getCampaign().getLocalDate(), person, false);
-                            MekHQ.triggerEvent(new PersonChangedEvent(person));
-                        });
+                      .filter(person -> (getCampaign().getProcreation()
+                                               .canProcreate(getCampaign().getLocalDate(), person, false) == null))
+                      .forEach(person -> {
+                          getCampaign().getProcreation()
+                                .addPregnancy(getCampaign(), getCampaign().getLocalDate(), person, false);
+                          MekHQ.triggerEvent(new PersonChangedEvent(person));
+                      });
                 break;
             }
             case CMD_REMOVE_PREGNANCY: {
                 Stream.of(people).filter(Person::isPregnant).forEach(person -> {
-                    gui.getCampaign().getProcreation().removePregnancy(person);
+                    getCampaign().getProcreation().removePregnancy(person);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 });
                 break;
             }
             case CMD_REMOVE_SPOUSE: {
                 Stream.of(people)
-                        .filter(person -> gui.getCampaign().getDivorce().canDivorce(person, false) == null)
-                        .forEach(person -> gui.getCampaign().getDivorce().divorce(gui.getCampaign(),
-                                gui.getCampaign().getLocalDate(), person,
-                                SplittingSurnameStyle.valueOf(data[1])));
+                      .filter(person -> getCampaign().getDivorce().canDivorce(person, false) == null)
+                      .forEach(person -> getCampaign().getDivorce()
+                                               .divorce(getCampaign(),
+                                                     getCampaign().getLocalDate(),
+                                                     person,
+                                                     SplittingSurnameStyle.valueOf(data[1])));
                 break;
             }
             case CMD_ADD_SPOUSE: {
-                gui.getCampaign().getMarriage().marry(gui.getCampaign(),
-                        gui.getCampaign().getLocalDate(), selectedPerson,
-                        gui.getCampaign().getPerson(UUID.fromString(data[1])),
-                        MergingSurnameStyle.valueOf(data[2]), false);
+                getCampaign().getMarriage()
+                      .marry(getCampaign(),
+                            getCampaign().getLocalDate(),
+                            selectedPerson,
+                            getCampaign().getPerson(UUID.fromString(data[1])),
+                            MergingSurnameStyle.valueOf(data[2]),
+                            false);
                 break;
             }
             case CMD_ADD_AWARD: {
                 for (Person person : people) {
-                    person.getAwardController().addAndLogAward(gui.getCampaign(), data[1], data[2],
-                            gui.getCampaign().getLocalDate());
+                    person.getAwardController()
+                          .addAndLogAward(getCampaign(), data[1], data[2], getCampaign().getLocalDate());
                 }
                 break;
             }
@@ -416,11 +428,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 for (Person person : people) {
                     try {
                         if (person.getAwardController().hasAward(data[1], data[2])) {
-                            person.getAwardController().removeAward(data[1], data[2],
-                                    (data.length > 3)
-                                            ? MekHQ.getMHQOptions().parseDisplayFormattedDate(data[3])
-                                            : null,
-                                    gui.getCampaign().getLocalDate());
+                            person.getAwardController()
+                                  .removeAward(data[1],
+                                        data[2],
+                                        (data.length > 3) ?
+                                              MekHQ.getMHQOptions().parseDisplayFormattedDate(data[3]) :
+                                              null,
+                                        getCampaign().getLocalDate());
                         }
                     } catch (Exception e) {
                         logger.error("Could not remove award.", e);
@@ -464,7 +478,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     List<Object> individualAcademyAttributes = new ArrayList<>();
 
                     // if graduating, process autoAwards component for this person
-                    if (EducationController.processNewDay(gui.getCampaign(), person, true)) {
+                    if (EducationController.processNewDay(getCampaign(), person, true)) {
                         graduatingPersonnel.add(person.getId());
 
                         individualAcademyAttributes.add(academy.getEducationLevel(person));
@@ -479,8 +493,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                 if (!graduatingPersonnel.isEmpty()) {
                     AutoAwardsController autoAwardsController = new AutoAwardsController();
-                    autoAwardsController.PostGraduationController(gui.getCampaign(), graduatingPersonnel,
-                            academyAttributesMap);
+                    autoAwardsController.PostGraduationController(getCampaign(),
+                          graduatingPersonnel,
+                          academyAttributesMap);
                 }
                 break;
             }
@@ -491,9 +506,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     EducationStage educationStage = person.getEduEducationStage();
 
                     switch (educationStage) {
-                        case JOURNEY_TO_CAMPUS, JOURNEY_FROM_CAMPUS -> person.changeStatus(gui.getCampaign(),
-                                gui.getCampaign().getLocalDate(), PersonnelStatus.ACTIVE);
-                        case EDUCATION -> EducationController.processForcedDropOut(gui.getCampaign(), person, academy);
+                        case JOURNEY_TO_CAMPUS, JOURNEY_FROM_CAMPUS ->
+                              person.changeStatus(getCampaign(), getCampaign().getLocalDate(), PersonnelStatus.ACTIVE);
+                        case EDUCATION -> EducationController.processForcedDropOut(getCampaign(), person, academy);
                         default -> {
                         }
                     }
@@ -506,146 +521,158 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_IMPROVE: {
                 String type = data[1];
                 int cost = Integer.parseInt(data[2]);
-                int oldExpLevel = selectedPerson.getExperienceLevel(gui.getCampaign(), false);
+                int oldExpLevel = selectedPerson.getExperienceLevel(getCampaign(), false);
                 selectedPerson.improveSkill(type);
                 selectedPerson.spendXP(cost);
 
-                PersonalLogger.improvedSkill(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), selectedPerson.getSkill(type).getType().getName(),
-                        selectedPerson.getSkill(type).toString());
-                gui.getCampaign().addReport(String.format(resources.getString("improved.format"),
-                        selectedPerson.getHyperlinkedName(), type));
+                PersonalLogger.improvedSkill(getCampaign(),
+                      selectedPerson,
+                      getCampaign().getLocalDate(),
+                      selectedPerson.getSkill(type).getType().getName(),
+                      selectedPerson.getSkill(type).toString());
+                getCampaign().addReport(String.format(resources.getString("improved.format"),
+                      selectedPerson.getHyperlinkedName(),
+                      type));
 
-                gui.getCampaign().personUpdated(selectedPerson);
+                getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_ABILITY: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        selected, true);
+                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, selected, true);
                 selectedPerson.spendXP(cost);
                 final String displayName = SpecialAbility.getDisplayName(selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
-                gui.getCampaign().personUpdated(selectedPerson);
+                PersonalLogger.gainedSPA(getCampaign(), selectedPerson, getCampaign().getLocalDate(), displayName);
+                getCampaign().addReport(String.format(resources.getString("gained.format"),
+                      selectedPerson.getHyperlinkedName(),
+                      displayName));
+                getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_WEAPON_SPECIALIST: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.GUNNERY_WEAPON_SPECIALIST, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
+                            OptionsConstants.GUNNERY_WEAPON_SPECIALIST,
+                            selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_WEAPON_SPECIALIST), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
-                gui.getCampaign().personUpdated(selectedPerson);
+                      SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_WEAPON_SPECIALIST),
+                      selected);
+                PersonalLogger.gainedSPA(getCampaign(), selectedPerson, getCampaign().getLocalDate(), displayName);
+                getCampaign().addReport(String.format(resources.getString("gained.format"),
+                      selectedPerson.getHyperlinkedName(),
+                      displayName));
+                getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_SANDBLASTER: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.GUNNERY_SANDBLASTER, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, OptionsConstants.GUNNERY_SANDBLASTER, selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SANDBLASTER), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
-                gui.getCampaign().personUpdated(selectedPerson);
+                      SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SANDBLASTER),
+                      selected);
+                PersonalLogger.gainedSPA(getCampaign(), selectedPerson, getCampaign().getLocalDate(), displayName);
+                getCampaign().addReport(String.format(resources.getString("gained.format"),
+                      selectedPerson.getHyperlinkedName(),
+                      displayName));
+                getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_SPECIALIST: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.GUNNERY_SPECIALIST, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, OptionsConstants.GUNNERY_SPECIALIST, selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SPECIALIST), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
-                gui.getCampaign().personUpdated(selectedPerson);
+                      SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SPECIALIST),
+                      selected);
+                PersonalLogger.gainedSPA(getCampaign(), selectedPerson, getCampaign().getLocalDate(), displayName);
+                getCampaign().addReport(String.format(resources.getString("gained.format"),
+                      selectedPerson.getHyperlinkedName(),
+                      displayName));
+                getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_RANGEMASTER: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.GUNNERY_RANGE_MASTER, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
+                            OptionsConstants.GUNNERY_RANGE_MASTER,
+                            selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_RANGE_MASTER), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
-                gui.getCampaign().personUpdated(selectedPerson);
+                      SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_RANGE_MASTER),
+                      selected);
+                PersonalLogger.gainedSPA(getCampaign(), selectedPerson, getCampaign().getLocalDate(), displayName);
+                getCampaign().addReport(String.format(resources.getString("gained.format"),
+                      selectedPerson.getHyperlinkedName(),
+                      displayName));
+                getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_ENVSPEC: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.MISC_ENV_SPECIALIST, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, OptionsConstants.MISC_ENV_SPECIALIST, selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.MISC_ENV_SPECIALIST), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
-                gui.getCampaign().personUpdated(selectedPerson);
+                      SpecialAbility.getDisplayName(OptionsConstants.MISC_ENV_SPECIALIST),
+                      selected);
+                PersonalLogger.gainedSPA(getCampaign(), selectedPerson, getCampaign().getLocalDate(), displayName);
+                getCampaign().addReport(String.format(resources.getString("gained.format"),
+                      selectedPerson.getHyperlinkedName(),
+                      displayName));
+                getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_HUMANTRO: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        OptionsConstants.MISC_HUMAN_TRO, selected);
+                selectedPerson.getOptions()
+                      .acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, OptionsConstants.MISC_HUMAN_TRO, selected);
                 selectedPerson.spendXP(cost);
                 final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(OptionsConstants.MISC_HUMAN_TRO), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("gained.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
-                gui.getCampaign().personUpdated(selectedPerson);
+                      SpecialAbility.getDisplayName(OptionsConstants.MISC_HUMAN_TRO),
+                      selected);
+                PersonalLogger.gainedSPA(getCampaign(), selectedPerson, getCampaign().getLocalDate(), displayName);
+                getCampaign().addReport(String.format(resources.getString("gained.format"),
+                      selectedPerson.getHyperlinkedName(),
+                      displayName));
+                getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_ACQUIRE_CUSTOM_CHOICE: {
                 String selected = data[1];
                 int cost = Integer.parseInt(data[2]);
                 String ability = data[3];
-                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES,
-                        ability, selected);
+                selectedPerson.getOptions().acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, ability, selected);
                 selectedPerson.spendXP(cost);
-                final String displayName = String.format("%s %s",
-                        SpecialAbility.getDisplayName(ability), selected);
-                PersonalLogger.gainedSPA(gui.getCampaign(), selectedPerson,
-                        gui.getCampaign().getLocalDate(), displayName);
-                gui.getCampaign().addReport(String.format(resources.getString("spaGainedChoices.format"),
-                        selectedPerson.getHyperlinkedName(), displayName));
-                gui.getCampaign().personUpdated(selectedPerson);
+                final String displayName = String.format("%s %s", SpecialAbility.getDisplayName(ability), selected);
+                PersonalLogger.gainedSPA(getCampaign(), selectedPerson, getCampaign().getLocalDate(), displayName);
+                getCampaign().addReport(String.format(resources.getString("spaGainedChoices.format"),
+                      selectedPerson.getHyperlinkedName(),
+                      displayName));
+                getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_CHANGE_STATUS: {
                 PersonnelStatus status = PersonnelStatus.valueOf(data[1]);
                 for (Person person : people) {
-                    if (status.isActive() || (JOptionPane.showConfirmDialog(null,
-                            String.format(resources.getString("confirmRetireQ.format"), person.getFullTitle()),
-                            status.toString(), JOptionPane.YES_NO_OPTION) == 0)) {
-                        person.changeStatus(gui.getCampaign(), gui.getCampaign().getLocalDate(), status);
+                    if (status.isActive() ||
+                              (JOptionPane.showConfirmDialog(null,
+                                    String.format(resources.getString("confirmRetireQ.format"), person.getFullTitle()),
+                                    status.toString(),
+                                    JOptionPane.YES_NO_OPTION) == 0)) {
+                        person.changeStatus(getCampaign(), getCampaign().getLocalDate(), status);
                     }
                 }
                 break;
@@ -655,7 +682,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     PrisonerStatus status = PrisonerStatus.valueOf(data[1]);
                     for (Person person : people) {
                         if (person.getPrisonerStatus() != status) {
-                            person.setPrisonerStatus(gui.getCampaign(), status, true);
+                            person.setPrisonerStatus(getCampaign(), status, true);
                         }
                     }
                 } catch (Exception e) {
@@ -664,33 +691,24 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_FREE: {
-                processPrisonerResolutionCommand(
-                        people,
-                        "confirmFree.format",
-                        "freeQ.text");
+                processPrisonerResolutionCommand(people, "confirmFree.format", "freeQ.text");
 
                 break;
             }
             case CMD_EXECUTE: {
-                processPrisonerResolutionCommand(
-                        people,
-                        "confirmExecute.format",
-                        "executeQ.text");
+                processPrisonerResolutionCommand(people, "confirmExecute.format", "executeQ.text");
 
                 break;
             }
             case CMD_JETTISON: {
-                processPrisonerResolutionCommand(
-                        people,
-                        "confirmJettison.format",
-                        "jettisonQ.text");
+                processPrisonerResolutionCommand(people, "confirmJettison.format", "jettisonQ.text");
 
                 break;
             }
             case CMD_RECRUIT: {
                 for (Person person : people) {
                     if (person.getPrisonerStatus().isPrisonerDefector()) {
-                        person.setPrisonerStatus(gui.getCampaign(), PrisonerStatus.FREE, true);
+                        person.setPrisonerStatus(getCampaign(), PrisonerStatus.FREE, true);
                     }
                 }
                 break;
@@ -698,13 +716,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_ABTAKHA: {
                 for (Person person : people) {
                     if (person.getPrisonerStatus().isBondsman()) {
-                        person.setPrisonerStatus(gui.getCampaign(), PrisonerStatus.FREE, true);
+                        person.setPrisonerStatus(getCampaign(), PrisonerStatus.FREE, true);
                     }
                 }
                 break;
             }
             case CMD_ADOPTION: {
-                Person orphan = gui.getCampaign().getPerson(UUID.fromString(data[1]));
+                Person orphan = getCampaign().getPerson(UUID.fromString(data[1]));
 
                 // clear the old parents
                 for (Person parent : orphan.getGenealogy().getParents()) {
@@ -736,20 +754,22 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // daily report entry, add the money and remove them all.
                 Money total = Money.zero();
                 total = total.plus(Arrays.stream(people)
-                        .map(person -> person.getRansomValue(gui.getCampaign()))
-                        .collect(Collectors.toList()));
+                                         .map(person -> person.getRansomValue(getCampaign()))
+                                         .collect(Collectors.toList()));
 
-                if (0 == JOptionPane.showConfirmDialog(
-                        null,
-                        String.format(resources.getString("ransomQ.format"), people.length,
-                                total.toAmountAndSymbolString()),
-                        resources.getString("ransom.text"),
-                        JOptionPane.YES_NO_OPTION)) {
-                    gui.getCampaign().addReport(String.format(resources.getString("ransomReport.format"),
-                            people.length, total.toAmountAndSymbolString()));
-                    gui.getCampaign().addFunds(TransactionType.RANSOM, total, resources.getString("ransom.text"));
+                if (0 ==
+                          JOptionPane.showConfirmDialog(null,
+                                String.format(resources.getString("ransomQ.format"),
+                                      people.length,
+                                      total.toAmountAndSymbolString()),
+                                resources.getString("ransom.text"),
+                                JOptionPane.YES_NO_OPTION)) {
+                    getCampaign().addReport(String.format(resources.getString("ransomReport.format"),
+                          people.length,
+                          total.toAmountAndSymbolString()));
+                    getCampaign().addFunds(TransactionType.RANSOM, total, resources.getString("ransom.text"));
                     for (Person person : people) {
-                        gui.getCampaign().removePerson(person, false);
+                        getCampaign().removePerson(person, false);
                     }
                 }
                 break;
@@ -757,28 +777,29 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_RANSOM_FRIENDLY: {
                 Money total = Money.zero();
                 total = total.plus(Arrays.stream(people)
-                        .map(person -> person.getRansomValue(gui.getCampaign()))
-                        .collect(Collectors.toList()));
+                                         .map(person -> person.getRansomValue(getCampaign()))
+                                         .collect(Collectors.toList()));
 
-                if (gui.getCampaign().getFunds().isLessThan(total)) {
-                    gui.getCampaign().addReport(String.format(resources.getString("unableToRansom.format"),
-                            people.length,
-                            total.toAmountAndSymbolString()));
+                if (getCampaign().getFunds().isLessThan(total)) {
+                    getCampaign().addReport(String.format(resources.getString("unableToRansom.format"),
+                          people.length,
+                          total.toAmountAndSymbolString()));
                     break;
                 }
 
-                if (0 == JOptionPane.showConfirmDialog(
-                        null,
-                        String.format(resources.getString("ransomFriendlyQ.format"), people.length,
-                                total.toAmountAndSymbolString()),
-                        resources.getString("ransom.text"),
-                        JOptionPane.YES_NO_OPTION)) {
-                    gui.getCampaign().addReport(String.format(resources.getString("ransomReport.format"),
-                            people.length, total.toAmountAndSymbolString()));
-                    gui.getCampaign().removeFunds(TransactionType.RANSOM, total, resources.getString("ransom.text"));
+                if (0 ==
+                          JOptionPane.showConfirmDialog(null,
+                                String.format(resources.getString("ransomFriendlyQ.format"),
+                                      people.length,
+                                      total.toAmountAndSymbolString()),
+                                resources.getString("ransom.text"),
+                                JOptionPane.YES_NO_OPTION)) {
+                    getCampaign().addReport(String.format(resources.getString("ransomReport.format"),
+                          people.length,
+                          total.toAmountAndSymbolString()));
+                    getCampaign().removeFunds(TransactionType.RANSOM, total, resources.getString("ransom.text"));
                     for (Person person : people) {
-                        person.changeStatus(gui.getCampaign(), gui.getCampaign().getLocalDate(),
-                                PersonnelStatus.ACTIVE);
+                        person.changeStatus(getCampaign(), getCampaign().getLocalDate(), PersonnelStatus.ACTIVE);
                     }
                 }
                 break;
@@ -789,23 +810,25 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     boolean status = Boolean.parseBoolean(data[2]);
                     for (Person person : people) {
                         person.setEdgeTrigger(trigger, status);
-                        gui.getCampaign().personUpdated(person);
+                        getCampaign().personUpdated(person);
                     }
                 } else {
                     selectedPerson.changeEdgeTrigger(trigger);
-                    gui.getCampaign().personUpdated(selectedPerson);
+                    getCampaign().personUpdated(selectedPerson);
                 }
                 break;
             }
             case CMD_REMOVE: {
-                String title = (people.length == 1) ? people[0].getFullTitle()
-                        : String.format(resources.getString("numPersonnel.text"), people.length);
-                if (0 == JOptionPane.showConfirmDialog(null,
-                        String.format(resources.getString("confirmRemove.format"), title),
-                        resources.getString("removeQ.text"),
-                        JOptionPane.YES_NO_OPTION)) {
+                String title = (people.length == 1) ?
+                                     people[0].getFullTitle() :
+                                     String.format(resources.getString("numPersonnel.text"), people.length);
+                if (0 ==
+                          JOptionPane.showConfirmDialog(null,
+                                String.format(resources.getString("confirmRemove.format"), title),
+                                resources.getString("removeQ.text"),
+                                JOptionPane.YES_NO_OPTION)) {
                     for (Person person : people) {
-                        gui.getCampaign().removePerson(person);
+                        getCampaign().removePerson(person);
                     }
                 }
                 break;
@@ -815,8 +838,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 List<Person> toRemove = new ArrayList<>();
                 for (Person person : people) {
                     if (!person.getPrimaryRole().isCivilian()) {
-                        if (gui.getCampaign().getRetirementDefectionTracker().removeFromCampaign(
-                                person, false, true, gui.getCampaign(), null)) {
+                        if (getCampaign().getRetirementDefectionTracker()
+                                  .removeFromCampaign(person, false, true, getCampaign(), null)) {
                             showDialog = true;
                         } else {
                             toRemove.add(person);
@@ -826,19 +849,16 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     }
                 }
                 if (showDialog) {
-                    RetirementDefectionDialog rdd = new RetirementDefectionDialog(
-                            gui, null, false);
+                    RetirementDefectionDialog rdd = new RetirementDefectionDialog(gui, null, false);
 
-                    if (rdd.wasAborted()
-                            || !gui.getCampaign().applyRetirement(rdd.totalPayout(),
-                                    rdd.getUnitAssignments())) {
+                    if (rdd.wasAborted() ||
+                              !getCampaign().applyRetirement(rdd.totalPayout(), rdd.getUnitAssignments())) {
                         for (Person person : people) {
-                            gui.getCampaign().getRetirementDefectionTracker()
-                                    .removePayout(person);
+                            getCampaign().getRetirementDefectionTracker().removePayout(person);
                         }
                     } else {
                         for (final Person person : toRemove) {
-                            gui.getCampaign().removePerson(person);
+                            getCampaign().removePerson(person);
                         }
                     }
                 } else {
@@ -848,11 +868,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     } else {
                         question = String.format(resources.getString("confirmRemove.format"), people[0].getFullTitle());
                     }
-                    if (JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(
-                            null, question, resources.getString("removeQ.text"),
-                            JOptionPane.YES_NO_OPTION)) {
+                    if (JOptionPane.YES_OPTION ==
+                              JOptionPane.showConfirmDialog(null,
+                                    question,
+                                    resources.getString("removeQ.text"),
+                                    JOptionPane.YES_NO_OPTION)) {
                         for (Person person : people) {
-                            gui.getCampaign().removePerson(person);
+                            getCampaign().removePerson(person);
                         }
                     }
                 }
@@ -860,10 +882,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_EDIT: {
                 for (Person person : people) {
-                    CustomizePersonDialog npd = new CustomizePersonDialog(gui.getFrame(), true,
-                        person, gui.getCampaign());
+                    CustomizePersonDialog npd = new CustomizePersonDialog(gui.getFrame(), true, person, getCampaign());
                     npd.setVisible(true);
-                    gui.getCampaign().personUpdated(selectedPerson);
+                    getCampaign().personUpdated(selectedPerson);
                 }
                 break;
             }
@@ -871,28 +892,29 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 EditPersonnelHitsDialog ephd = new EditPersonnelHitsDialog(gui.getFrame(), true, selectedPerson);
                 ephd.setVisible(true);
                 if (0 == selectedPerson.getHits()) {
-                    selectedPerson.setDoctorId(null, gui.getCampaign().getCampaignOptions()
-                            .getNaturalHealingWaitingPeriod());
+                    selectedPerson.setDoctorId(null, getCampaignOptions().getNaturalHealingWaitingPeriod());
                 }
-                gui.getCampaign().personUpdated(selectedPerson);
+                getCampaign().personUpdated(selectedPerson);
                 break;
             }
             case CMD_EDIT_PORTRAIT: {
-                final PortraitChooserDialog portraitDialog = new PortraitChooserDialog(
-                        gui.getFrame(), selectedPerson.getPortrait());
+                final PortraitChooserDialog portraitDialog = new PortraitChooserDialog(gui.getFrame(),
+                      selectedPerson.getPortrait());
                 if (portraitDialog.showDialog().isConfirmed()) {
                     for (Person person : people) {
                         if (!person.getPortrait().equals(portraitDialog.getSelectedItem())) {
                             person.setPortrait(portraitDialog.getSelectedItem());
-                            gui.getCampaign().personUpdated(person);
+                            getCampaign().personUpdated(person);
                         }
                     }
                 }
                 break;
             }
             case CMD_EDIT_BIOGRAPHY: {
-                MarkdownEditorDialog tad = new MarkdownEditorDialog(gui.getFrame(), true,
-                        resources.getString("editBiography.text"), selectedPerson.getBiography());
+                MarkdownEditorDialog tad = new MarkdownEditorDialog(gui.getFrame(),
+                      true,
+                      resources.getString("editBiography.text"),
+                      selectedPerson.getBiography());
                 tad.setVisible(true);
                 if (tad.wasChanged()) {
                     selectedPerson.setBiography(tad.getText());
@@ -902,14 +924,17 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_ADD_1_XP: {
                 for (Person person : people) {
-                    person.awardXP(gui.getCampaign(), 1);
+                    person.awardXP(getCampaign(), 1);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;
             }
             case CMD_ADD_XP: {
-                PopupValueChoiceDialog pvcda = new PopupValueChoiceDialog(
-                        gui.getFrame(), true, resources.getString("xp.text"), 1, 0);
+                PopupValueChoiceDialog pvcda = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      resources.getString("xp.text"),
+                      1,
+                      0);
                 pvcda.setVisible(true);
 
                 int ia = pvcda.getValue();
@@ -920,30 +945,33 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 }
 
                 for (Person person : people) {
-                    person.awardXP(gui.getCampaign(), ia);
+                    person.awardXP(getCampaign(), ia);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;
             }
             case CMD_SET_XP: {
-                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(
-                        gui.getFrame(), true, resources.getString("xp.text"), selectedPerson.getXP(), 0);
+                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      resources.getString("xp.text"),
+                      selectedPerson.getXP(),
+                      0);
                 pvcd.setVisible(true);
                 if (pvcd.getValue() < 0) {
                     return;
                 }
                 int i = pvcd.getValue();
                 for (Person person : people) {
-                    person.setXP(gui.getCampaign(), i);
+                    person.setXP(getCampaign(), i);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;
             }
             case CMD_BUY_EDGE: {
-                int baseCost = gui.getCampaign().getCampaignOptions().getEdgeCost();
-                double costMultiplier = gui.getCampaign().getCampaignOptions().getXpCostMultiplier();
+                int baseCost = getCampaignOptions().getEdgeCost();
+                double costMultiplier = getCampaignOptions().getXpCostMultiplier();
                 for (Person person : people) {
-                    double intelligenceCostMultiplier = person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions());
+                    double intelligenceCostMultiplier = person.getIntelligenceXpCostMultiplier(getCampaignOptions());
                     int cost = (int) round(baseCost * intelligenceCostMultiplier * costMultiplier);
 
                     selectedPerson.spendXP(cost);
@@ -951,17 +979,20 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     // Make the new edge point available to support personnel, but don't reset until
                     // the week ends
                     person.changeCurrentEdge(1);
-                    PersonalLogger.gainedEdge(gui.getCampaign(), person, gui.getCampaign().getLocalDate());
-                    gui.getCampaign().addReport(String.format(resources.getString("gainedEdge.format"),
-                            selectedPerson.getHyperlinkedName()));
-                    gui.getCampaign().personUpdated(person);
+                    PersonalLogger.gainedEdge(getCampaign(), person, getCampaign().getLocalDate());
+                    getCampaign().addReport(String.format(resources.getString("gainedEdge.format"),
+                          selectedPerson.getHyperlinkedName()));
+                    getCampaign().personUpdated(person);
                 }
                 break;
             }
             case CMD_SET_EDGE: {
-                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(
-                        gui.getFrame(), true, resources.getString("edge.text"), selectedPerson.getEdge(), 0,
-                        10);
+                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      resources.getString("edge.text"),
+                      selectedPerson.getEdge(),
+                      0,
+                      10);
                 pvcd.setVisible(true);
                 if (pvcd.getValue() < 0) {
                     return;
@@ -971,8 +1002,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     person.setEdge(i);
                     // Reset currentEdge for support people
                     person.resetCurrentEdge();
-                    PersonalLogger.changedEdge(gui.getCampaign(), person, gui.getCampaign().getLocalDate());
-                    gui.getCampaign().personUpdated(person);
+                    PersonalLogger.changedEdge(getCampaign(), person, getCampaign().getLocalDate());
+                    getCampaign().personUpdated(person);
                 }
                 break;
             }
@@ -980,13 +1011,19 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 AddOrEditKillEntryDialog nkd;
                 Unit unit = selectedPerson.getUnit();
                 if (people.length > 1) {
-                    nkd = new AddOrEditKillEntryDialog(gui.getFrame(), true, null,
-                            (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
-                            gui.getCampaign().getLocalDate(), gui.getCampaign());
+                    nkd = new AddOrEditKillEntryDialog(gui.getFrame(),
+                          true,
+                          null,
+                          (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
+                          getCampaign().getLocalDate(),
+                          getCampaign());
                 } else {
-                    nkd = new AddOrEditKillEntryDialog(gui.getFrame(), true, selectedPerson.getId(),
-                            (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
-                            gui.getCampaign().getLocalDate(), gui.getCampaign());
+                    nkd = new AddOrEditKillEntryDialog(gui.getFrame(),
+                          true,
+                          selectedPerson.getId(),
+                          (unit != null) ? unit.getName() : resources.getString("bareHands.text"),
+                          getCampaign().getLocalDate(),
+                          getCampaign());
                 }
                 nkd.setVisible(true);
                 if (nkd.getKill().isPresent()) {
@@ -995,32 +1032,35 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         for (Person person : people) {
                             Kill k = kill.clone();
                             k.setPilotId(person.getId());
-                            gui.getCampaign().addKill(k);
+                            getCampaign().addKill(k);
                             MekHQ.triggerEvent(new PersonLogEvent(person));
                         }
                     } else {
-                        gui.getCampaign().addKill(kill);
+                        getCampaign().addKill(kill);
                         MekHQ.triggerEvent(new PersonLogEvent(selectedPerson));
                     }
                 }
                 break;
             }
             case CMD_EDIT_KILL_LOG: {
-                EditKillLogDialog ekld = new EditKillLogDialog(gui.getFrame(), true, gui.getCampaign(), selectedPerson);
+                EditKillLogDialog ekld = new EditKillLogDialog(gui.getFrame(), true, getCampaign(), selectedPerson);
                 ekld.setVisible(true);
                 MekHQ.triggerEvent(new PersonLogEvent(selectedPerson));
                 break;
             }
             case CMD_EDIT_PERSONNEL_LOG: {
-                EditPersonnelLogDialog epld = new EditPersonnelLogDialog(gui.getFrame(), true, gui.getCampaign(),
-                        selectedPerson);
+                EditPersonnelLogDialog epld = new EditPersonnelLogDialog(gui.getFrame(),
+                      true,
+                      getCampaign(),
+                      selectedPerson);
                 epld.setVisible(true);
                 MekHQ.triggerEvent(new PersonLogEvent(selectedPerson));
                 break;
             }
             case CMD_ADD_LOG_ENTRY: {
-                final AddOrEditPersonnelEntryDialog addPersonnelLogDialog = new AddOrEditPersonnelEntryDialog(
-                        gui.getFrame(), null, gui.getCampaign().getLocalDate());
+                final AddOrEditPersonnelEntryDialog addPersonnelLogDialog = new AddOrEditPersonnelEntryDialog(gui.getFrame(),
+                      null,
+                      getCampaign().getLocalDate());
                 if (addPersonnelLogDialog.showDialog().isConfirmed()) {
                     for (Person person : people) {
                         person.addLogEntry(addPersonnelLogDialog.getEntry().clone());
@@ -1030,15 +1070,18 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_EDIT_SCENARIO_LOG: {
-                EditScenarioLogDialog emld = new EditScenarioLogDialog(gui.getFrame(), true, gui.getCampaign(),
-                        selectedPerson);
+                EditScenarioLogDialog emld = new EditScenarioLogDialog(gui.getFrame(),
+                      true,
+                      getCampaign(),
+                      selectedPerson);
                 emld.setVisible(true);
                 MekHQ.triggerEvent(new PersonLogEvent(selectedPerson));
                 break;
             }
             case CMD_ADD_SCENARIO_ENTRY: {
-                AddOrEditScenarioEntryDialog addScenarioDialog = new AddOrEditScenarioEntryDialog(
-                        gui.getFrame(), true, gui.getCampaign().getLocalDate());
+                AddOrEditScenarioEntryDialog addScenarioDialog = new AddOrEditScenarioEntryDialog(gui.getFrame(),
+                      true,
+                      getCampaign().getLocalDate());
                 addScenarioDialog.setVisible(true);
                 Optional<LogEntry> scenarioEntry = addScenarioDialog.getEntry();
                 if (scenarioEntry.isPresent()) {
@@ -1051,12 +1094,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_CALLSIGN: {
                 String s = (String) JOptionPane.showInputDialog(gui.getFrame(),
-                        resources.getString("enterNewCallsign.text"), resources.getString("editCallsign.text"),
-                        JOptionPane.PLAIN_MESSAGE, null, null,
-                        selectedPerson.getCallsign());
+                      resources.getString("enterNewCallsign.text"),
+                      resources.getString("editCallsign.text"),
+                      JOptionPane.PLAIN_MESSAGE,
+                      null,
+                      null,
+                      selectedPerson.getCallsign());
                 if (null != s) {
                     selectedPerson.setCallsign(s);
-                    gui.getCampaign().personUpdated(selectedPerson);
+                    getCampaign().personUpdated(selectedPerson);
                 }
                 break;
             }
@@ -1089,26 +1135,27 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_REPLACE_MISSING_LIMB: {
-                replaceLimb(data[1], selectedPerson, gui.getCampaign());
+                replaceLimb(data[1], selectedPerson, getCampaign());
                 break;
             }
             case CMD_EDIT_INJURIES: {
-                EditPersonnelInjuriesDialog epid = new EditPersonnelInjuriesDialog(
-                        gui.getFrame(), true, gui.getCampaign(), selectedPerson);
+                EditPersonnelInjuriesDialog epid = new EditPersonnelInjuriesDialog(gui.getFrame(),
+                      true,
+                      getCampaign(),
+                      selectedPerson);
                 epid.setVisible(true);
                 MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
                 break;
             }
             case CMD_EDIT_SALARY: {
-                int originalSalary = selectedPerson.getSalary(gui.getCampaign()).getAmount().intValue();
+                int originalSalary = selectedPerson.getSalary(getCampaign()).getAmount().intValue();
 
-                PopupValueChoiceDialog salaryDialog = new PopupValueChoiceDialog(
-                        gui.getFrame(),
-                        true,
-                        resources.getString("changeSalary.text"),
-                        MathUtility.clamp(originalSalary, -1, 1000000000),
-                        -1,
-                        1000000000);
+                PopupValueChoiceDialog salaryDialog = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      resources.getString("changeSalary.text"),
+                      MathUtility.clamp(originalSalary, -1, 1000000000),
+                      -1,
+                      1000000000);
 
                 salaryDialog.setVisible(true);
 
@@ -1126,11 +1173,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_GIVE_PAYMENT: {
-                PopupValueChoiceDialog pcvd = new PopupValueChoiceDialog(gui.getFrame(), true,
-                        resources.getString("givePayment.title"),
-                        1000,
-                        1,
-                        1000000);
+                PopupValueChoiceDialog pcvd = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      resources.getString("givePayment.title"),
+                      1000,
+                      1,
+                      1000000);
                 pcvd.setVisible(true);
 
                 int payment = pcvd.getValue();
@@ -1143,10 +1191,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // pay person & add expense
                 Map<Person, Money> personMoneyMap = new HashMap<>();
                 personMoneyMap.put(selectedPerson, Money.of(payment));
-                gui.getCampaign().payPersonnel(TransactionType.MISCELLANEOUS,
-                    Money.of(payment),
-                    String.format(resources.getString("givePayment.format"),selectedPerson.getFullName()),
-                    personMoneyMap);
+                getCampaign().payPersonnel(TransactionType.MISCELLANEOUS,
+                      Money.of(payment),
+                      String.format(resources.getString("givePayment.format"), selectedPerson.getFullName()),
+                      personMoneyMap);
                 MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
 
 
@@ -1169,7 +1217,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_ADD_RANDOM_ABILITY: {
                 SingleSpecialAbilityGenerator singleSpecialAbilityGenerator = new SingleSpecialAbilityGenerator();
                 for (Person person : people) {
-                    singleSpecialAbilityGenerator.rollSPA(gui.getCampaign(), person);
+                    singleSpecialAbilityGenerator.rollSPA(getCampaign(), person);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;
@@ -1178,8 +1226,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             // region Randomization Menu
             case CMD_RANDOM_NAME: {
                 for (final Person person : people) {
-                    final String[] name = RandomNameGenerator.getInstance().generateGivenNameSurnameSplit(
-                            person.getGender(), person.isClanPersonnel(), person.getOriginFaction().getShortName());
+                    final String[] name = RandomNameGenerator.getInstance()
+                                                .generateGivenNameSurnameSplit(person.getGender(),
+                                                      person.isClanPersonnel(),
+                                                      person.getOriginFaction().getShortName());
                     person.setGivenName(name[0]);
                     person.setSurname(name[1]);
                     writePersonalityDescription(person);
@@ -1190,7 +1240,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_RANDOM_BLOODNAME: {
                 final boolean ignoreDice = (data.length > 1) && Boolean.parseBoolean(data[1]);
                 for (final Person person : people) {
-                    gui.getCampaign().checkBloodnameAdd(person, ignoreDice);
+                    getCampaign().checkBloodnameAdd(person, ignoreDice);
                 }
                 break;
             }
@@ -1203,22 +1253,21 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_RANDOM_PORTRAIT: {
                 for (final Person person : people) {
-                    gui.getCampaign().assignRandomPortraitFor(person);
+                    getCampaign().assignRandomPortraitFor(person);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;
             }
             case CMD_RANDOM_ORIGIN: {
                 for (final Person person : people) {
-                    gui.getCampaign().assignRandomOriginFor(person);
+                    getCampaign().assignRandomOriginFor(person);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
                 }
                 break;
             }
             case CMD_RANDOM_ORIGIN_FACTION: {
                 for (final Person person : people) {
-                    final Faction faction = gui.getCampaign().getFactionSelector()
-                            .selectFaction(gui.getCampaign());
+                    final Faction faction = getCampaign().getFactionSelector().selectFaction(getCampaign());
                     if (faction != null) {
                         person.setOriginFaction(faction);
                         MekHQ.triggerEvent(new PersonChangedEvent(person));
@@ -1228,8 +1277,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_RANDOM_ORIGIN_PLANET: {
                 for (final Person person : people) {
-                    final Planet planet = gui.getCampaign().getPlanetSelector().selectPlanet(
-                            gui.getCampaign(), person.getOriginFaction());
+                    final Planet planet = getCampaign().getPlanetSelector()
+                                                .selectPlanet(getCampaign(), person.getOriginFaction());
                     if (planet != null) {
                         person.setOriginPlanet(planet);
                         MekHQ.triggerEvent(new PersonChangedEvent(person));
@@ -1264,18 +1313,17 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     /**
-     * Handles the limb replacement procedure for the selected person. This method determines the
-     * suitable doctors, calculates the cost of the procedure, and processes the surgery if the user
-     * accepts it.
+     * Handles the limb replacement procedure for the selected person. This method determines the suitable doctors,
+     * calculates the cost of the procedure, and processes the surgery if the user accepts it.
      *
      * <p>If no doctors are available with sufficient skill levels, the cost of the operation
-     * is significantly increased. Once the surgery is performed, the person's injury is updated,
-     * and associated financial and unit adjustments are made.</p>
+     * is significantly increased. Once the surgery is performed, the person's injury is updated, and associated
+     * financial and unit adjustments are made.</p>
      *
-     * @param selectedInjury  The {@link UUID} of the injury being fixed.
-     * @param selectedPerson  The {@link Person} undergoing the limb replacement procedure.
-     * @param campaign        The {@link Campaign} instance representing the current campaign,
-     *                        containing active personnel, finances, and other relevant details.
+     * @param selectedInjury The {@link UUID} of the injury being fixed.
+     * @param selectedPerson The {@link Person} undergoing the limb replacement procedure.
+     * @param campaign       The {@link Campaign} instance representing the current campaign, containing active
+     *                       personnel, finances, and other relevant details.
      */
     private void replaceLimb(String selectedInjury, Person selectedPerson, Campaign campaign) {
         List<Person> suitableDoctors = new ArrayList<>();
@@ -1284,7 +1332,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             if (person.isDoctor()) {
                 Skill skill = person.getSkill(S_DOCTOR);
 
-                if (skill != null && skill.getFinalSkillValue() >= REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5) {
+                if (skill != null &&
+                          skill.getFinalSkillValue() >= REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5) {
                     suitableDoctors.add(person);
                 }
             }
@@ -1294,7 +1343,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             if (injury.getUUID().toString().equals(selectedInjury)) {
                 BodyLocation location = injury.getLocation();
 
-                Money cost = switch(location) {
+                Money cost = switch (location) {
                     case RIGHT_ARM, LEFT_ARM -> REPLACEMENT_LIMB_COST_ARM_TYPE_5;
                     case RIGHT_HAND, LEFT_HAND -> REPLACEMENT_LIMB_COST_HAND_TYPE_5;
                     case RIGHT_LEG, LEFT_LEG -> REPLACEMENT_LIMB_COST_LEG_TYPE_5;
@@ -1312,7 +1361,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 }
 
                 ReplacementLimbDialog replacementLimbDialog = new ReplacementLimbDialog(campaign,
-                      suitableDoctors, selectedPerson, cost);
+                      suitableDoctors,
+                      selectedPerson,
+                      cost);
                 int choice = replacementLimbDialog.getDialogChoice();
 
                 // If the user chose to decline the surgery
@@ -1320,14 +1371,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     return;
                 }
 
-                campaign.getFinances().debit(MEDICAL_EXPENSES,
-                      campaign.getLocalDate(), cost,
-                      String.format(resources.getString("replaceMissingLimb.surgery"),
-                            selectedPerson.getFullTitle()));
+                campaign.getFinances()
+                      .debit(MEDICAL_EXPENSES,
+                            campaign.getLocalDate(),
+                            cost,
+                            String.format(resources.getString("replaceMissingLimb.surgery"),
+                                  selectedPerson.getFullTitle()));
 
                 int hitCount = injury.getHits();
-                Injury newInjury = REPLACEMENT_LIMB_RECOVERY.newInjury(campaign, selectedPerson,
-                      location, hitCount);
+                Injury newInjury = REPLACEMENT_LIMB_RECOVERY.newInjury(campaign, selectedPerson, location, hitCount);
                 newInjury.setWorkedOn(true);
 
                 selectedPerson.removeInjury(injury);
@@ -1346,25 +1398,22 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
      * Private method to process a list of applications to education academies.
      *
      * @param people         an array of Person objects representing the applicants
-     * @param data           an array of String objects representing the command
-     *                       data
-     * @param isReEnrollment a boolean indicating if the application is for
-     *                       re-enrollment
+     * @param data           an array of String objects representing the command data
+     * @param isReEnrollment a boolean indicating if the application is for re-enrollment
      */
     private void processApplication(Person[] people, String[] data, boolean isReEnrollment) {
         boolean applicationFailed = false;
 
         for (Person person : people) {
-            if (makeEnrollmentCheck(gui.getCampaign(), person, data[1], data[2])) {
-                EducationController.performEducationPreEnrollmentActions(
-                        gui.getCampaign(),
-                        person,
-                        data[1],
-                        data[2],
-                        Integer.parseInt(data[3]),
-                        data[4],
-                        data[5],
-                        isReEnrollment);
+            if (makeEnrollmentCheck(getCampaign(), person, data[1], data[2])) {
+                EducationController.performEducationPreEnrollmentActions(getCampaign(),
+                      person,
+                      data[1],
+                      data[2],
+                      Integer.parseInt(data[3]),
+                      data[4],
+                      data[5],
+                      isReEnrollment);
             } else {
                 applicationFailed = true;
             }
@@ -1372,9 +1421,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         if (applicationFailed) {
             JOptionPane.showMessageDialog(null,
-                    wordWrap(resources.getString("eduFailedApplication.text")),
-                    resources.getString("eduFailedApplication.title"),
-                    JOptionPane.WARNING_MESSAGE);
+                  wordWrap(resources.getString("eduFailedApplication.text")),
+                  resources.getString("eduFailedApplication.title"),
+                  JOptionPane.WARNING_MESSAGE);
         }
     }
 
@@ -1394,22 +1443,23 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             label = String.format(resources.getString("numPrisoners.text"), prisoners.length);
         }
 
-        if (0 == JOptionPane.showConfirmDialog(null,
-                String.format(resources.getString(message), label),
-                resources.getString(title),
-                JOptionPane.YES_NO_OPTION)) {
+        if (0 ==
+                  JOptionPane.showConfirmDialog(null,
+                        String.format(resources.getString(message), label),
+                        resources.getString(title),
+                        JOptionPane.YES_NO_OPTION)) {
             for (Person prisoner : prisoners) {
-                gui.getCampaign().removePerson(prisoner);
+                getCampaign().removePerson(prisoner);
             }
         }
 
-        processAdHocExecution(gui.getCampaign(), prisoners.length);
+        processAdHocExecution(getCampaign(), prisoners.length);
     }
 
     private void loadGMToolsForPerson(Person person) {
         GMToolsDialog gmToolsDialog = new GMToolsDialog(gui.getFrame(), gui, person);
         gmToolsDialog.setVisible(true);
-        gui.getCampaign().personUpdated(person);
+        getCampaign().personUpdated(person);
     }
 
     private Person[] getSelectedPeople() {
@@ -1444,7 +1494,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu = new JMenu(resources.getString("changeRank.text"));
             final Profession initialProfession = Profession.getProfessionFromPersonnelRole(person.getPrimaryRole());
             for (final RankDisplay rankDisplay : RankDisplay.getRankDisplaysForSystem(person.getRankSystem(),
-                    initialProfession)) {
+                  initialProfession)) {
                 final Rank rank = person.getRankSystem().getRank(rankDisplay.getRankNumeric());
                 final Profession profession = initialProfession.getProfession(person.getRankSystem(), rank);
                 final int rankLevels = rank.getRankLevels().get(profession);
@@ -1452,12 +1502,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 if (rankLevels > 1) {
                     submenu = new JMenu(rankDisplay.toString());
                     for (int level = 0; level <= rankLevels; level++) {
-                        cbMenuItem = new JCheckBoxMenuItem(
-                                rank.getName(profession) + Utilities.getRomanNumeralsFromArabicNumber(level, true));
-                        cbMenuItem.setSelected((person.getRankNumeric() == rankDisplay.getRankNumeric())
-                                && (person.getRankLevel() == level));
-                        cbMenuItem.setActionCommand(makeCommand(CMD_RANK, String.valueOf(rankDisplay.getRankNumeric()),
-                                String.valueOf(level)));
+                        cbMenuItem = new JCheckBoxMenuItem(rank.getName(profession) +
+                                                                 Utilities.getRomanNumeralsFromArabicNumber(level,
+                                                                       true));
+                        cbMenuItem.setSelected((person.getRankNumeric() == rankDisplay.getRankNumeric()) &&
+                                                     (person.getRankLevel() == level));
+                        cbMenuItem.setActionCommand(makeCommand(CMD_RANK,
+                              String.valueOf(rankDisplay.getRankNumeric()),
+                              String.valueOf(level)));
                         cbMenuItem.addActionListener(this);
                         submenu.add(cbMenuItem);
                     }
@@ -1474,7 +1526,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         }
 
         menu = new JMenu(resources.getString("changeRankSystem.text"));
-        final RankSystem campaignRankSystem = gui.getCampaign().getRankSystem();
+        final RankSystem campaignRankSystem = getCampaign().getRankSystem();
         // First allow them to revert to the campaign system
         cbMenuItem = new JCheckBoxMenuItem(resources.getString("useCampaignRankSystem.text"));
         cbMenuItem.setSelected(campaignRankSystem.equals(person.getRankSystem()));
@@ -1564,14 +1616,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
 
         if (StaticChecks.areAllPrisoners(selected)) {
-            if (gui.getCampaign().getLocation().isOnPlanet()) {
+            if (getCampaign().getLocation().isOnPlanet()) {
                 popup.add(newMenuItem(resources.getString("free.text"), CMD_FREE));
                 popup.add(newMenuItem(resources.getString("execute.text"), CMD_EXECUTE));
             } else {
                 popup.add(newMenuItem(resources.getString("jettison.text"), CMD_JETTISON));
             }
 
-            if (StaticChecks.areAllPrisoners(selected) && gui.getCampaign().isGM()) {
+            if (StaticChecks.areAllPrisoners(selected) && getCampaign().isGM()) {
                 popup.add(newMenuItem(resources.getString("ransom.text"), CMD_RANSOM));
             }
 
@@ -1579,28 +1631,30 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 popup.add(newMenuItem(resources.getString("recruit.text"), CMD_RECRUIT));
             }
 
-            if ((gui.getCampaign().getFaction().isClan()) && (StaticChecks.areAnyBondsmen(selected))) {
+            if ((getCampaign().getFaction().isClan()) && (StaticChecks.areAnyBondsmen(selected))) {
                 popup.add(newMenuItem(resources.getString("abtakha.text"), CMD_ABTAKHA));
             }
         }
 
-        if (Stream.of(selected).allMatch(p -> p.getStatus().isPoW()) && gui.getCampaign().isGM()) {
+        if (Stream.of(selected).allMatch(p -> p.getStatus().isPoW()) && getCampaign().isGM()) {
             popup.add(newMenuItem(resources.getString("ransom.text"), CMD_RANSOM_FRIENDLY));
         }
 
-        if ((oneSelected) && (!person.isChild(gui.getCampaign().getLocalDate()))) {
-            List<Person> orphans = gui.getCampaign().getActivePersonnel().stream()
-                    .filter(child -> (child.isChild(gui.getCampaign().getLocalDate())) && (!child.getGenealogy().hasLivingParents()))
-                    .toList();
+        if ((oneSelected) && (!person.isChild(getCampaign().getLocalDate()))) {
+            List<Person> orphans = getCampaign().getActivePersonnel()
+                                         .stream()
+                                         .filter(child -> (child.isChild(getCampaign().getLocalDate())) &&
+                                                                (!child.getGenealogy().hasLivingParents()))
+                                         .toList();
 
             if (!orphans.isEmpty()) {
                 JMenu orphanMenu = new JMenu(resources.getString("adopt.text"));
 
                 for (final Person orphan : orphans) {
                     String status = String.format(resources.getString("adopt.description"),
-                            orphan.getFullName(),
-                            orphan.getGender(),
-                            orphan.getAge(gui.getCampaign().getLocalDate()));
+                          orphan.getFullName(),
+                          orphan.getGender(),
+                          orphan.getAge(getCampaign().getLocalDate()));
 
                     JMenuItem orphanItem = new JMenuItem(status);
                     orphanItem.setActionCommand(makeCommand(CMD_ADOPTION, String.valueOf(orphan.getId())));
@@ -1619,7 +1673,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             boolean allCanPerform = true;
 
             for (Person selectedPerson : getSelectedPeople()) {
-                if (!selectedPerson.canPerformRole(gui.getCampaign().getLocalDate(), role, true)) {
+                if (!selectedPerson.canPerformRole(getCampaign().getLocalDate(), role, true)) {
                     allCanPerform = false;
                     break;
                 }
@@ -1642,7 +1696,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             boolean allCanPerform = true;
 
             for (Person selectedPerson : getSelectedPeople()) {
-                if (!selectedPerson.canPerformRole(gui.getCampaign().getLocalDate(), role, false)) {
+                if (!selectedPerson.canPerformRole(getCampaign().getLocalDate(), role, false)) {
                     allCanPerform = false;
                     break;
                 }
@@ -1661,7 +1715,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         JMenuHelpers.addMenuIfNonEmpty(popup, menu);
 
         // change salary
-        if (gui.getCampaign().getCampaignOptions().isPayForSalaries() && StaticChecks.areAllActive(selected)) {
+        if (getCampaignOptions().isPayForSalaries() && StaticChecks.areAllActive(selected)) {
             menuItem = new JMenuItem(resources.getString("setSalary.text"));
             menuItem.setActionCommand(CMD_EDIT_SALARY);
             menuItem.addActionListener(this);
@@ -1676,7 +1730,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             popup.add(menuItem);
         }
 
-        if (oneSelected && gui.getCampaign().getCampaignOptions().isUseAdvancedMedical()) {
+        if (oneSelected && getCampaignOptions().isUseAdvancedMedical()) {
             List<Injury> missingLimbInjuries = new ArrayList<>();
 
             for (Injury injury : person.getInjuries()) {
@@ -1701,55 +1755,59 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
         }
 
-        JMenuHelpers.addMenuIfNonEmpty(popup, new AssignPersonToUnitMenu(gui.getCampaign(), selected));
+        JMenuHelpers.addMenuIfNonEmpty(popup, new AssignPersonToUnitMenu(getCampaign(), selected));
 
         if (oneSelected && person.getStatus().isActive()) {
-            if (gui.getCampaign().getCampaignOptions().isUseManualMarriages()
-                    && (gui.getCampaign().getMarriage().canMarry(gui.getCampaign().getLocalDate(), person, false) == null)) {
+            if (getCampaignOptions().isUseManualMarriages() &&
+                      (getCampaign().getMarriage().canMarry(getCampaign().getLocalDate(), person, false) == null)) {
                 menu = new JMenu(resources.getString("chooseSpouse.text"));
                 JMenu maleMenu = new JMenu(resources.getString("spouseMenuMale.text"));
                 JMenu femaleMenu = new JMenu(resources.getString("spouseMenuFemale.text"));
                 JMenu spouseMenu;
 
-                LocalDate today = gui.getCampaign().getLocalDate();
+                LocalDate today = getCampaign().getLocalDate();
 
                 // Get all safe potential spouses sorted by age and then by surname
-                final List<Person> personnel = gui.getCampaign().getPersonnel().stream()
-                        .filter(potentialSpouse -> gui.getCampaign().getMarriage().safeSpouse(
-                                gui.getCampaign(), gui.getCampaign().getLocalDate(), person,
-                                potentialSpouse, false))
-                        .sorted(Comparator.comparing((Person p) -> p.getAge(today))
-                                .thenComparing(Person::getSurname))
-                        .toList();
+                final List<Person> personnel = getCampaign().getPersonnel()
+                                                     .stream()
+                                                     .filter(potentialSpouse -> getCampaign().getMarriage()
+                                                                                      .safeSpouse(getCampaign(),
+                                                                                            getCampaign().getLocalDate(),
+                                                                                            person,
+                                                                                            potentialSpouse,
+                                                                                            false))
+                                                     .sorted(Comparator.comparing((Person p) -> p.getAge(today))
+                                                                   .thenComparing(Person::getSurname))
+                                                     .toList();
 
                 for (final Person potentialSpouse : personnel) {
                     final String status;
                     final String founder = potentialSpouse.isFounder() ? resources.getString("spouseFounder.text") : "";
                     if (potentialSpouse.getPrisonerStatus().isBondsman()) {
                         status = String.format(resources.getString("marriageBondsmanDesc.format"),
-                                potentialSpouse.getFullName(),
-                                potentialSpouse.getAge(today),
-                                potentialSpouse.getRoleDesc(),
-                                founder);
+                              potentialSpouse.getFullName(),
+                              potentialSpouse.getAge(today),
+                              potentialSpouse.getRoleDesc(),
+                              founder);
                     } else if (potentialSpouse.getPrisonerStatus().isCurrentPrisoner()) {
                         status = String.format(resources.getString("marriagePrisonerDesc.format"),
-                                potentialSpouse.getFullName(),
-                                potentialSpouse.getAge(today),
-                                potentialSpouse.getRoleDesc(),
-                                founder);
+                              potentialSpouse.getFullName(),
+                              potentialSpouse.getAge(today),
+                              potentialSpouse.getRoleDesc(),
+                              founder);
                     } else {
                         status = String.format(resources.getString("marriagePartnerDesc.format"),
-                                potentialSpouse.getFullName(),
-                                potentialSpouse.getAge(today),
-                                potentialSpouse.getRoleDesc(),
-                                founder);
+                              potentialSpouse.getFullName(),
+                              potentialSpouse.getAge(today),
+                              potentialSpouse.getRoleDesc(),
+                              founder);
                     }
 
                     spouseMenu = new JMenu(status);
 
                     for (final MergingSurnameStyle style : MergingSurnameStyle.values()) {
                         spouseMenu.add(newMenuItem(style.getDropDownText(),
-                                makeCommand(CMD_ADD_SPOUSE, potentialSpouse.getId().toString(), style.name())));
+                              makeCommand(CMD_ADD_SPOUSE, potentialSpouse.getId().toString(), style.name())));
                     }
 
                     if (potentialSpouse.getGender().isMale()) {
@@ -1771,10 +1829,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
         }
 
-        if (gui.getCampaign().getCampaignOptions().isUseManualDivorce() && (Stream.of(selected)
-                .anyMatch(p -> gui.getCampaign()
-                        .getDivorce()
-                        .canDivorce(person, false) == null))) {
+        if (getCampaignOptions().isUseManualDivorce() &&
+                  (Stream.of(selected).anyMatch(p -> getCampaign().getDivorce().canDivorce(person, false) == null))) {
             menu = new JMenu(resources.getString("removeSpouse.text"));
 
             for (final SplittingSurnameStyle style : SplittingSurnameStyle.values()) {
@@ -1793,7 +1849,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         Collections.sort(setNames);
 
         for (String setName : setNames) {
-            if ((setName.equals("standard")) && (gui.getCampaign().getCampaignOptions().isIgnoreStandardSet())) {
+            if ((setName.equals("standard")) && (getCampaignOptions().isIgnoreStandardSet())) {
                 continue;
             }
 
@@ -1870,8 +1926,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     JMenu singleAwardMenu = new JMenu(award.getName());
                     for (String date : award.getFormattedDates()) {
                         JMenuItem specificAwardMenu = new JMenuItem(date);
-                        specificAwardMenu
-                                .setActionCommand(makeCommand(CMD_RMV_AWARD, award.getSet(), award.getName(), date));
+                        specificAwardMenu.setActionCommand(makeCommand(CMD_RMV_AWARD,
+                              award.getSet(),
+                              award.getName(),
+                              date));
                         specificAwardMenu.addActionListener(this);
                         singleAwardMenu.add(specificAwardMenu);
                     }
@@ -1902,12 +1960,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         // endregion Awards Menu
 
         // region Education Menu
-        if (gui.getCampaign().getCampaignOptions().isUseEducationModule()) {
+        if (getCampaignOptions().isUseEducationModule()) {
             JMenu academyMenu = new JMenu(resources.getString("eduEducation.text"));
 
             // we use 'campaign' a lot here, so let's store it, so we don't have to re-call
             // it every time
-            Campaign campaign = gui.getCampaign();
+            Campaign campaign = getCampaign();
 
             if (StaticChecks.areAllActive(selected)) {
                 if (Arrays.stream(selected).noneMatch(prospectiveStudent -> person.needsFixing())) {
@@ -1954,8 +2012,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             if (oneSelected) {
                                 buildEducationMenusSingleton(campaign, person, academy, militaryMenu, civilianMenu);
                             } else {
-                                buildEducationMenusMassEnroll(campaign, Arrays.asList(selected), academy, militaryMenu,
-                                        civilianMenu);
+                                buildEducationMenusMassEnroll(campaign,
+                                      Arrays.asList(selected),
+                                      academy,
+                                      militaryMenu,
+                                      civilianMenu);
                             }
                         }
                         academyMenu.add(setAcademyMenu);
@@ -1972,36 +2033,37 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
 
             if ((oneSelected) && (StaticChecks.areAllStudents(selected))) {
-                Academy academy = getAcademy(person.getEduAcademySet(),
-                        person.getEduAcademyNameInSet());
+                Academy academy = getAcademy(person.getEduAcademySet(), person.getEduAcademyNameInSet());
 
                 // this pile of if-statements just checks that the individual is eligible for
                 // re-enrollment
                 // has the person finished their education, but not yet returned to the unit?
-                if ((!person.getEduEducationStage().isJourneyToCampus())
-                        && (!person.getEduEducationStage().isEducation())) {
+                if ((!person.getEduEducationStage().isJourneyToCampus()) &&
+                          (!person.getEduEducationStage().isEducation())) {
                     // is the academy still standing?
-                    if ((campaign.getGameYear() < academy.getDestructionYear())
-                            && (campaign.getGameYear() < academy.getClosureYear())) {
+                    if ((campaign.getGameYear() < academy.getDestructionYear()) &&
+                              (campaign.getGameYear() < academy.getClosureYear())) {
                         // if the academy is local, is the system still populated?
-                        if ((!academy.isLocal())
-                                || (campaign.getCurrentSystem().getPopulation(campaign.getLocalDate()) > 0)) {
+                        if ((!academy.isLocal()) ||
+                                  (campaign.getCurrentSystem().getPopulation(campaign.getLocalDate()) > 0)) {
                             // is the person still within the correct age band?
-                            if ((person.getAge(campaign.getLocalDate()) < academy.getAgeMax())
-                                    && (person.getAge(campaign.getLocalDate()) >= academy.getAgeMin())) {
+                            if ((person.getAge(campaign.getLocalDate()) < academy.getAgeMax()) &&
+                                      (person.getAge(campaign.getLocalDate()) >= academy.getAgeMin())) {
                                 // has the person been edited at some point and is no longer qualified?
                                 if (academy.isQualified(person)) {
                                     // here we check that the person will benefit from re-enrollment
                                     int improvementPossible = 0;
 
-                                    String filteredFaction = academy.getFilteredFaction(campaign, person,
-                                            List.of(person.getEduAcademyFaction()));
+                                    String filteredFaction = academy.getFilteredFaction(campaign,
+                                          person,
+                                          List.of(person.getEduAcademyFaction()));
 
                                     if (filteredFaction != null) {
                                         int educationLevel = academy.getEducationLevel(person);
 
-                                        String[] skills = academy.getCurriculums().get(person.getEduCourseIndex())
-                                                .split(",");
+                                        String[] skills = academy.getCurriculums()
+                                                                .get(person.getEduCourseIndex())
+                                                                .split(",");
 
                                         skills = Arrays.stream(skills).map(String::trim).toArray(String[]::new);
 
@@ -2011,15 +2073,16 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                             }
 
                                             if (skill.equalsIgnoreCase("xp")) {
-                                                if (EducationLevel
-                                                        .parseToInt(person.getEduHighestEducation()) < educationLevel) {
+                                                if (EducationLevel.parseToInt(person.getEduHighestEducation()) <
+                                                          educationLevel) {
                                                     improvementPossible++;
                                                 }
                                             } else {
                                                 String skillParsed = skillParser(skill);
 
-                                                if ((person.hasSkill(skillParsed)) && (person.getSkill(skillParsed)
-                                                        .getExperienceLevel() < educationLevel)) {
+                                                if ((person.hasSkill(skillParsed)) &&
+                                                          (person.getSkill(skillParsed).getExperienceLevel() <
+                                                                 educationLevel)) {
                                                     improvementPossible++;
                                                 } else if (!person.hasSkill(skillParsed)) {
                                                     improvementPossible++;
@@ -2033,16 +2096,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                             reEnroll = new JMenuItem(resources.getString("eduReEnroll.text"));
                                             reEnroll.setToolTipText(resources.getString("eduReEnroll.toolTip"));
                                             reEnroll.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_RE_ENROLLMENT,
-                                                    academy.getSet(),
-                                                    academy.getName(),
-                                                    String.valueOf(person.getEduCourseIndex()),
-                                                    person.getEduAcademySystem(),
-                                                    person.getEduAcademyFaction()));
+                                                  academy.getSet(),
+                                                  academy.getName(),
+                                                  String.valueOf(person.getEduCourseIndex()),
+                                                  person.getEduAcademySystem(),
+                                                  person.getEduAcademyFaction()));
                                             reEnroll.addActionListener(this);
                                         } else {
                                             reEnroll = new JMenuItem(resources.getString("eduReEnrollImpossible.text"));
-                                            reEnroll.setToolTipText(
-                                                    resources.getString("eduReEnrollImpossible.toolTip"));
+                                            reEnroll.setToolTipText(resources.getString("eduReEnrollImpossible.toolTip"));
                                         }
 
                                         academyMenu.add(reEnroll);
@@ -2069,7 +2131,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         // region Spend XP Menu
         if (oneSelected && person.getStatus().isActive()) {
             menu = new JMenu(resources.getString("spendXP.text"));
-            if (gui.getCampaign().getCampaignOptions().isUseAbilities()) {
+            if (getCampaignOptions().isUseAbilities()) {
                 JMenu abMenu = new JMenu(resources.getString("spendOnSpecialAbilities.text"));
                 int cost;
 
@@ -2083,9 +2145,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     if (!spa.isEligible(person)) {
                         continue;
                     }
-                    cost = (int) round((spa.getCost()
-                            * person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions())
-                            * gui.getCampaign().getCampaignOptions().getXpCostMultiplier()));
+                    cost = (int) round((spa.getCost() *
+                                              person.getIntelligenceXpCostMultiplier(getCampaignOptions()) *
+                                              getCampaignOptions().getXpCostMultiplier()));
                     String costDesc;
                     if (cost < 0) {
                         costDesc = resources.getString("costNotPossible.text");
@@ -2096,8 +2158,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     if (spa.getName().equals(OptionsConstants.GUNNERY_WEAPON_SPECIALIST)) {
                         Unit u = person.getUnit();
                         if (null != u) {
-                            JMenu specialistMenu = new JMenu(
-                                    SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_WEAPON_SPECIALIST));
+                            JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_WEAPON_SPECIALIST));
                             TreeSet<String> uniqueWeapons = new TreeSet<>();
                             for (int j = 0; j < u.getEntity().getWeaponList().size(); j++) {
                                 Mounted<?> m = u.getEntity().getWeaponList().get(j);
@@ -2105,13 +2166,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             }
                             boolean isSpecialist = person.getOptions().booleanOption(spa.getName());
                             for (String name : uniqueWeapons) {
-                                if (!(isSpecialist
-                                        && person.getOptions().getOption(spa.getName()).stringValue().equals(name))) {
-                                    menuItem = new JMenuItem(
-                                            String.format(resources.getString("abilityDesc.format"), name, costDesc));
+                                if (!(isSpecialist &&
+                                            person.getOptions().getOption(spa.getName()).stringValue().equals(name))) {
+                                    menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
+                                          name,
+                                          costDesc));
                                     menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                                    menuItem.setActionCommand(
-                                            makeCommand(CMD_ACQUIRE_WEAPON_SPECIALIST, name, String.valueOf(cost)));
+                                    menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_WEAPON_SPECIALIST,
+                                          name,
+                                          String.valueOf(cost)));
                                     menuItem.addActionListener(this);
                                     menuItem.setEnabled(available);
                                     specialistMenu.add(menuItem);
@@ -2124,8 +2187,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     } else if (spa.getName().equals(OptionsConstants.GUNNERY_SANDBLASTER)) {
                         Unit u = person.getUnit();
                         if (null != u) {
-                            JMenu specialistMenu = new JMenu(
-                                    SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SANDBLASTER));
+                            JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SANDBLASTER));
                             TreeSet<String> uniqueWeapons = new TreeSet<>();
                             for (int j = 0; j < u.getEntity().getWeaponList().size(); j++) {
                                 Mounted<?> m = u.getEntity().getWeaponList().get(j);
@@ -2135,13 +2197,15 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             }
                             boolean isSpecialist = person.getOptions().booleanOption(spa.getName());
                             for (String name : uniqueWeapons) {
-                                if (!(isSpecialist
-                                        && person.getOptions().getOption(spa.getName()).stringValue().equals(name))) {
-                                    menuItem = new JMenuItem(
-                                            String.format(resources.getString("abilityDesc.format"), name, costDesc));
+                                if (!(isSpecialist &&
+                                            person.getOptions().getOption(spa.getName()).stringValue().equals(name))) {
+                                    menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
+                                          name,
+                                          costDesc));
                                     menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                                    menuItem.setActionCommand(
-                                            makeCommand(CMD_ACQUIRE_SANDBLASTER, name, String.valueOf(cost)));
+                                    menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SANDBLASTER,
+                                          name,
+                                          String.valueOf(cost)));
                                     menuItem.addActionListener(this);
                                     menuItem.setEnabled(available);
                                     specialistMenu.add(menuItem);
@@ -2152,8 +2216,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             }
                         }
                     } else if (spa.getName().equals(OptionsConstants.MISC_ENV_SPECIALIST)) {
-                        JMenu specialistMenu = new JMenu(
-                                SpecialAbility.getDisplayName(OptionsConstants.MISC_ENV_SPECIALIST));
+                        JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.MISC_ENV_SPECIALIST));
                         List<Object> tros = new ArrayList<>();
                         if (person.getOptions().getOption(OptionsConstants.MISC_ENV_SPECIALIST).booleanValue()) {
                             Object val = person.getOptions().getOption(OptionsConstants.MISC_ENV_SPECIALIST).getValue();
@@ -2164,11 +2227,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             }
                         }
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                resources.getString("envspec_fog.text"), costDesc));
+                              resources.getString("envspec_fog.text"),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
                         if (!tros.contains(Crew.ENVSPC_FOG)) {
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_ENVSPEC, Crew.ENVSPC_FOG, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ENVSPEC,
+                                  Crew.ENVSPC_FOG,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2176,10 +2241,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.ENVSPC_LIGHT)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("envspec_light.text"), costDesc));
+                                  resources.getString("envspec_light.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_ENVSPEC, Crew.ENVSPC_LIGHT, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ENVSPEC,
+                                  Crew.ENVSPC_LIGHT,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2187,10 +2254,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.ENVSPC_RAIN)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("envspec_rain.text"), costDesc));
+                                  resources.getString("envspec_rain.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_ENVSPEC, Crew.ENVSPC_RAIN, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ENVSPEC,
+                                  Crew.ENVSPC_RAIN,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2198,10 +2267,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.ENVSPC_SNOW)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("envspec_snow.text"), costDesc));
+                                  resources.getString("envspec_snow.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_ENVSPEC, Crew.ENVSPC_SNOW, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ENVSPEC,
+                                  Crew.ENVSPC_SNOW,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2209,10 +2280,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.ENVSPC_WIND)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("envspec_wind.text"), costDesc));
+                                  resources.getString("envspec_wind.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_ENVSPEC, Crew.ENVSPC_WIND, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ENVSPEC,
+                                  Crew.ENVSPC_WIND,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2220,8 +2293,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         JMenuHelpers.addMenuIfNonEmpty(abMenu, specialistMenu);
                     } else if (spa.getName().equals(OptionsConstants.MISC_HUMAN_TRO)) {
-                        JMenu specialistMenu = new JMenu(
-                                SpecialAbility.getDisplayName(OptionsConstants.MISC_HUMAN_TRO));
+                        JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.MISC_HUMAN_TRO));
                         List<Object> tros = new ArrayList<>();
                         if (person.getOptions().getOption(OptionsConstants.MISC_HUMAN_TRO).booleanValue()) {
                             Object val = person.getOptions().getOption(OptionsConstants.MISC_HUMAN_TRO).getValue();
@@ -2232,11 +2304,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                             }
                         }
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                resources.getString("humantro_mek.text"), costDesc));
+                              resources.getString("humantro_mek.text"),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
                         if (!tros.contains(Crew.HUMANTRO_MEK)) {
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_MEK, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO,
+                                  Crew.HUMANTRO_MEK,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2244,10 +2318,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.HUMANTRO_AERO)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("humantro_aero.text"), costDesc));
+                                  resources.getString("humantro_aero.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_AERO, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO,
+                                  Crew.HUMANTRO_AERO,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2255,10 +2331,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.HUMANTRO_VEE)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("humantro_vee.text"), costDesc));
+                                  resources.getString("humantro_vee.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_VEE, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO,
+                                  Crew.HUMANTRO_VEE,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2266,10 +2344,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!tros.contains(Crew.HUMANTRO_BA)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("humantro_ba.text"), costDesc));
+                                  resources.getString("humantro_ba.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_HUMANTRO, Crew.HUMANTRO_BA, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_HUMANTRO,
+                                  Crew.HUMANTRO_BA,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2278,42 +2358,47 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         if (specialistMenu.getMenuComponentCount() > 0) {
                             abMenu.add(specialistMenu);
                         }
-                    } else if (spa.getName().equals(OptionsConstants.GUNNERY_SPECIALIST)
-                            && !person.getOptions().booleanOption(OptionsConstants.GUNNERY_SPECIALIST)) {
-                        JMenu specialistMenu = new JMenu(
-                                SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SPECIALIST));
+                    } else if (spa.getName().equals(OptionsConstants.GUNNERY_SPECIALIST) &&
+                                     !person.getOptions().booleanOption(OptionsConstants.GUNNERY_SPECIALIST)) {
+                        JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_SPECIALIST));
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                resources.getString("laserSpecialist.text"), costDesc));
+                              resources.getString("laserSpecialist.text"),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                        menuItem.setActionCommand(
-                                makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_ENERGY, String.valueOf(cost)));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST,
+                              Crew.SPECIAL_ENERGY,
+                              String.valueOf(cost)));
                         menuItem.addActionListener(this);
                         menuItem.setEnabled(available);
                         specialistMenu.add(menuItem);
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                resources.getString("missileSpecialist.text"), costDesc));
+                              resources.getString("missileSpecialist.text"),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                        menuItem.setActionCommand(
-                                makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_MISSILE, String.valueOf(cost)));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST,
+                              Crew.SPECIAL_MISSILE,
+                              String.valueOf(cost)));
                         menuItem.addActionListener(this);
                         menuItem.setEnabled(available);
                         specialistMenu.add(menuItem);
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                resources.getString("ballisticSpecialist.text"), costDesc));
+                              resources.getString("ballisticSpecialist.text"),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                        menuItem.setActionCommand(
-                                makeCommand(CMD_ACQUIRE_SPECIALIST, Crew.SPECIAL_BALLISTIC, String.valueOf(cost)));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_SPECIALIST,
+                              Crew.SPECIAL_BALLISTIC,
+                              String.valueOf(cost)));
                         menuItem.addActionListener(this);
                         menuItem.setEnabled(available);
                         specialistMenu.add(menuItem);
                         abMenu.add(specialistMenu);
                     } else if (spa.getName().equals(OptionsConstants.GUNNERY_RANGE_MASTER)) {
-                        JMenu specialistMenu = new JMenu(
-                                SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_RANGE_MASTER));
+                        JMenu specialistMenu = new JMenu(SpecialAbility.getDisplayName(OptionsConstants.GUNNERY_RANGE_MASTER));
                         List<Object> ranges = new ArrayList<>();
                         if (person.getOptions().getOption(OptionsConstants.GUNNERY_RANGE_MASTER).booleanValue()) {
-                            Object val = person.getOptions().getOption(OptionsConstants.GUNNERY_RANGE_MASTER)
-                                    .getValue();
+                            Object val = person.getOptions()
+                                               .getOption(OptionsConstants.GUNNERY_RANGE_MASTER)
+                                               .getValue();
                             if (val instanceof Collection<?>) {
                                 ranges.addAll((Collection<?>) val);
                             } else {
@@ -2323,10 +2408,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!ranges.contains(Crew.RANGEMASTER_MEDIUM)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("rangemaster_med.text"), costDesc));
+                                  resources.getString("rangemaster_med.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_MEDIUM,
-                                    String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER,
+                                  Crew.RANGEMASTER_MEDIUM,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2334,11 +2421,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!ranges.contains(Crew.RANGEMASTER_LONG)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("rangemaster_lng.text"), costDesc));
+                                  resources.getString("rangemaster_lng.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(
-                                    makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_LONG, String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER,
+                                  Crew.RANGEMASTER_LONG,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2346,10 +2435,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                         if (!ranges.contains(Crew.RANGEMASTER_EXTREME)) {
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    resources.getString("rangemaster_xtm.text"), costDesc));
+                                  resources.getString("rangemaster_xtm.text"),
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER, Crew.RANGEMASTER_EXTREME,
-                                    String.valueOf(cost)));
+                            menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_RANGEMASTER,
+                                  Crew.RANGEMASTER_EXTREME,
+                                  String.valueOf(cost)));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2358,9 +2449,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         if (specialistMenu.getMenuComponentCount() > 0) {
                             abMenu.add(specialistMenu);
                         }
-                    } else if (Optional.ofNullable((person.getOptions().getOption(spa.getName()))).isPresent()
-                            && (person.getOptions().getOption(spa.getName()).getType() == IOption.CHOICE)
-                            && !(person.getOptions().getOption(spa.getName()).booleanValue())) {
+                    } else if (Optional.ofNullable((person.getOptions().getOption(spa.getName()))).isPresent() &&
+                                     (person.getOptions().getOption(spa.getName()).getType() == IOption.CHOICE) &&
+                                     !(person.getOptions().getOption(spa.getName()).booleanValue())) {
                         JMenu specialistMenu = new JMenu(spa.getDisplayName());
                         List<String> choices = spa.getChoiceValues();
                         for (String s : choices) {
@@ -2368,10 +2459,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                 continue;
                             }
                             menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                    s, costDesc));
+                                  s,
+                                  costDesc));
                             menuItem.setToolTipText(wordWrap(spa.getDescription()));
                             menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_CUSTOM_CHOICE,
-                                    s, String.valueOf(cost), spa.getName()));
+                                  s,
+                                  String.valueOf(cost),
+                                  spa.getName()));
                             menuItem.addActionListener(this);
                             menuItem.setEnabled(available);
                             specialistMenu.add(menuItem);
@@ -2381,10 +2475,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                         }
                     } else if (!person.getOptions().booleanOption(spa.getName())) {
                         menuItem = new JMenuItem(String.format(resources.getString("abilityDesc.format"),
-                                spa.getDisplayName(), costDesc));
+                              spa.getDisplayName(),
+                              costDesc));
                         menuItem.setToolTipText(wordWrap(spa.getDescription()));
-                        menuItem.setActionCommand(
-                                makeCommand(CMD_ACQUIRE_ABILITY, spa.getName(), String.valueOf(cost)));
+                        menuItem.setActionCommand(makeCommand(CMD_ACQUIRE_ABILITY,
+                              spa.getName(),
+                              String.valueOf(cost)));
                         menuItem.addActionListener(this);
                         menuItem.setEnabled(available);
                         abMenu.add(menuItem);
@@ -2397,10 +2493,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             JMenu newMenu = new JMenu(resources.getString("spendOnNewSkills.text"));
             for (int i = 0; i < SkillType.getSkillList().length; i++) {
                 String type = SkillType.getSkillList()[i];
-                int cost = person.hasSkill(type) ? person.getSkill(type).getCostToImprove()
-                        : SkillType.getType(type).getCost(0);
-                cost = (int) round(cost * person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions())
-                                * gui.getCampaign().getCampaignOptions().getXpCostMultiplier());
+                int cost = person.hasSkill(type) ?
+                                 person.getSkill(type).getCostToImprove() :
+                                 SkillType.getType(type).getCost(0);
+                cost = (int) round(cost *
+                                         person.getIntelligenceXpCostMultiplier(getCampaignOptions()) *
+                                         getCampaignOptions().getXpCostMultiplier());
 
                 if (cost >= 0) {
                     String desc = String.format(resources.getString("skillDesc.format"), type, cost);
@@ -2419,11 +2517,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             JMenuHelpers.addMenuIfNonEmpty(menu, newMenu);
 
             // Edge Purchasing
-            if (gui.getCampaign().getCampaignOptions().isUseEdge()) {
+            if (getCampaignOptions().isUseEdge()) {
                 JMenu edgeMenu = new JMenu(resources.getString("edge.text"));
-                int cost = (int) round(gui.getCampaign().getCampaignOptions().getEdgeCost()
-                        * person.getIntelligenceXpCostMultiplier(gui.getCampaign().getCampaignOptions())
-                        * gui.getCampaign().getCampaignOptions().getXpCostMultiplier());
+                int cost = (int) round(getCampaignOptions().getEdgeCost() *
+                                             person.getIntelligenceXpCostMultiplier(getCampaignOptions()) *
+                                             getCampaignOptions().getXpCostMultiplier());
 
                 if ((cost >= 0) && (person.getXP() >= cost)) {
                     menuItem = new JMenuItem(String.format(resources.getString("spendOnEdge.text"), cost));
@@ -2437,7 +2535,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             // endregion Spend XP Menu
 
             // region Edge Triggers
-            if (gui.getCampaign().getCampaignOptions().isUseEdge()) {
+            if (getCampaignOptions().isUseEdge()) {
                 menu = new JMenu(resources.getString("setEdgeTriggers.text"));
 
                 // Start of Edge reroll options
@@ -2488,9 +2586,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 menu.add(cbMenuItem);
 
                 // Aerospace pilots and gunners
-                final boolean isNotAeroOrConventional = !(person.getPrimaryRole().isAerospacePilot()
-                        || person.getPrimaryRole().isConventionalAircraftPilot()
-                        || person.getPrimaryRole().isLAMPilot());
+                final boolean isNotAeroOrConventional = !(person.getPrimaryRole().isAerospacePilot() ||
+                                                                person.getPrimaryRole().isConventionalAircraftPilot() ||
+                                                                person.getPrimaryRole().isLAMPilot());
                 final boolean isNotVessel = !person.getPrimaryRole().isVesselCrewMember();
                 final boolean isNotAeroConvOrVessel = isNotAeroOrConventional || isNotVessel;
 
@@ -2549,7 +2647,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 menu.add(cbMenuItem);
 
                 // Support Edge
-                if (gui.getCampaign().getCampaignOptions().isUseSupportEdge()) {
+                if (getCampaignOptions().isUseSupportEdge()) {
                     // Doctors
                     cbMenuItem = new JCheckBoxMenuItem(resources.getString("edgeTriggerHealCheck.text"));
                     cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_MEDICAL));
@@ -2571,10 +2669,10 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     menu.add(cbMenuItem);
 
                     cbMenuItem = new JCheckBoxMenuItem(resources.getString("edgeTriggerFailedRefit.text"));
-                    cbMenuItem
-                            .setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
-                    cbMenuItem
-                            .setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
+                    cbMenuItem.setSelected(person.getOptions()
+                                                 .booleanOption(PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
+                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_REPAIR_FAILED_REFIT));
                     if (!person.getPrimaryRole().isTech()) {
                         cbMenuItem.setForeground(new Color(150, 150, 150));
                     }
@@ -2584,8 +2682,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     // Admins
                     cbMenuItem = new JCheckBoxMenuItem(resources.getString("edgeTriggerAcquireCheck.text"));
                     cbMenuItem.setSelected(person.getOptions().booleanOption(PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL));
-                    cbMenuItem
-                            .setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL));
+                    cbMenuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL));
                     if (!person.getPrimaryRole().isAdministrator()) {
                         cbMenuItem.setForeground(new Color(150, 150, 150));
                     }
@@ -2598,7 +2696,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
             popup.add(menu);
         } else if (StaticChecks.areAllActive(selected)) {
-            if (gui.getCampaign().getCampaignOptions().isUseEdge()) {
+            if (getCampaignOptions().isUseEdge()) {
                 menu = new JMenu(resources.getString("setEdgeTriggers.text"));
                 submenu = new JMenu(resources.getString("On.text"));
 
@@ -2657,27 +2755,30 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 menuItem.addActionListener(this);
                 submenu.add(menuItem);
 
-                if (gui.getCampaign().getCampaignOptions().isUseSupportEdge()) {
+                if (getCampaignOptions().isUseSupportEdge()) {
                     menuItem = new JMenuItem(resources.getString("edgeTriggerHealCheck.text"));
                     menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_MEDICAL, TRUE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerBreakPart.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_BREAK_PART, TRUE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_REPAIR_BREAK_PART,
+                          TRUE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerFailedRefit.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT, TRUE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_REPAIR_FAILED_REFIT,
+                          TRUE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerAcquireCheck.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL, TRUE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL,
+                          TRUE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
                 }
@@ -2740,27 +2841,30 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 menuItem.addActionListener(this);
                 submenu.add(menuItem);
 
-                if (gui.getCampaign().getCampaignOptions().isUseSupportEdge()) {
+                if (getCampaignOptions().isUseSupportEdge()) {
                     menuItem = new JMenuItem(resources.getString("edgeTriggerHealCheck.text"));
                     menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_MEDICAL, FALSE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerBreakPart.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_BREAK_PART, FALSE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_REPAIR_BREAK_PART,
+                          FALSE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerFailedRefit.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_REPAIR_FAILED_REFIT, FALSE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_REPAIR_FAILED_REFIT,
+                          FALSE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
 
                     menuItem = new JMenuItem(resources.getString("edgeTriggerAcquireCheck.text"));
-                    menuItem.setActionCommand(
-                            makeCommand(CMD_EDGE_TRIGGER, PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL, FALSE));
+                    menuItem.setActionCommand(makeCommand(CMD_EDGE_TRIGGER,
+                          PersonnelOptions.EDGE_ADMIN_ACQUIRE_FAIL,
+                          FALSE));
                     menuItem.addActionListener(this);
                     submenu.add(menuItem);
                 }
@@ -2843,7 +2947,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         menuItem.setEnabled(true);
         popup.add(menuItem);
 
-        if (gui.getCampaign().getCampaignOptions().isUseAtB() && StaticChecks.areAllActive(selected)) {
+        if (getCampaignOptions().isUseAtB() && StaticChecks.areAllActive(selected)) {
             menuItem = new JMenuItem(resources.getString("sack.text"));
             menuItem.setActionCommand(CMD_SACK);
             menuItem.addActionListener(this);
@@ -2879,28 +2983,25 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             miCommander.setName("miCommander");
             miCommander.setSelected(person.isCommander());
             miCommander.addActionListener(evt -> {
-                gui.getCampaign().getPersonnel().stream()
-                        .filter(Person::isCommander)
-                        .forEach(commander -> {
-                            commander.setCommander(false);
-                            gui.getCampaign().addReport(String.format(resources.getString("removedCommander.format"),
-                                    commander.getHyperlinkedFullTitle()));
-                            gui.getCampaign().personUpdated(commander);
-                        });
+                getCampaign().getPersonnel().stream().filter(Person::isCommander).forEach(commander -> {
+                    commander.setCommander(false);
+                    getCampaign().addReport(String.format(resources.getString("removedCommander.format"),
+                          commander.getHyperlinkedFullTitle()));
+                    getCampaign().personUpdated(commander);
+                });
                 if (miCommander.isSelected()) {
                     person.setCommander(true);
-                    gui.getCampaign().addReport(String.format(resources.getString("setAsCommander.format"),
-                            person.getHyperlinkedFullTitle()));
-                    gui.getCampaign().personUpdated(person);
+                    getCampaign().addReport(String.format(resources.getString("setAsCommander.format"),
+                          person.getHyperlinkedFullTitle()));
+                    getCampaign().personUpdated(person);
                 }
             });
             menu.add(miCommander);
         }
 
-        if ((gui.getCampaign().getCampaignOptions().isUseManualDivorce()
-                || !gui.getCampaign().getCampaignOptions().getRandomDivorceMethod().isNone())
-                && Stream.of(selected).allMatch(p -> p.getGenealogy().hasSpouse())
-                && Stream.of(selected).allMatch(p -> p.isDivorceable() == person.isDivorceable())) {
+        if ((getCampaignOptions().isUseManualDivorce() || !getCampaignOptions().getRandomDivorceMethod().isNone()) &&
+                  Stream.of(selected).allMatch(p -> p.getGenealogy().hasSpouse()) &&
+                  Stream.of(selected).allMatch(p -> p.isDivorceable() == person.isDivorceable())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miDivorceable.text"));
             cbMenuItem.setToolTipText(resources.getString("miDivorceable.toolTipText"));
             cbMenuItem.setName("miDivorceable");
@@ -2924,8 +3025,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu.add(cbMenuItem);
         }
 
-        if (Stream.of(selected).noneMatch(p -> p.getStatus().isDead())
-            && Stream.of(selected).allMatch(p -> p.isImmortal() == person.isImmortal())) {
+        if (Stream.of(selected).noneMatch(p -> p.getStatus().isDead()) &&
+                  Stream.of(selected).allMatch(p -> p.isImmortal() == person.isImmortal())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miImmortal.text"));
             cbMenuItem.setToolTipText(resources.getString("miImmortal.toolTipText"));
             cbMenuItem.setName("miImmortal");
@@ -2937,9 +3038,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu.add(cbMenuItem);
         }
 
-        if ((gui.getCampaign().getCampaignOptions().isUseManualMarriages()
-                || !gui.getCampaign().getCampaignOptions().getRandomMarriageMethod().isNone())
-                && Stream.of(selected).allMatch(p -> p.isMarriageable() == person.isMarriageable())) {
+        if ((getCampaignOptions().isUseManualMarriages() || !getCampaignOptions().getRandomMarriageMethod().isNone()) &&
+                  Stream.of(selected).allMatch(p -> p.isMarriageable() == person.isMarriageable())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miMarriageable.text"));
             cbMenuItem.setToolTipText(wordWrap(resources.getString("miMarriageable.toolTipText")));
             cbMenuItem.setName("miMarriageable");
@@ -2951,13 +3051,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu.add(cbMenuItem);
         }
 
-        if ((gui.getCampaign().getCampaignOptions().isUseManualProcreation()
-                || !gui.getCampaign().getCampaignOptions().getRandomProcreationMethod().isNone())
-                && Stream.of(selected).allMatch(p -> p.getGender().isFemale())
-                && Stream.of(selected).allMatch(p -> p.isTryingToConceive() == person.isTryingToConceive())) {
+        if ((getCampaignOptions().isUseManualProcreation() ||
+                   !getCampaignOptions().getRandomProcreationMethod().isNone()) &&
+                  Stream.of(selected).allMatch(p -> p.getGender().isFemale()) &&
+                  Stream.of(selected).allMatch(p -> p.isTryingToConceive() == person.isTryingToConceive())) {
             cbMenuItem = new JCheckBoxMenuItem(resources.getString("miTryingToConceive.text"));
-            cbMenuItem.setToolTipText(
-                    MultiLineTooltip.splitToolTip(resources.getString("miTryingToConceive.toolTipText"), 100));
+            cbMenuItem.setToolTipText(MultiLineTooltip.splitToolTip(resources.getString("miTryingToConceive.toolTipText"),
+                  100));
             cbMenuItem.setName("miTryingToConceive");
             cbMenuItem.setSelected(person.isTryingToConceive());
             cbMenuItem.addActionListener(evt -> {
@@ -2982,24 +3082,27 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         // 8) Random Origin Planet
         menu = new JMenu(resources.getString("randomizationMenu.text"));
 
-        menuItem = new JMenuItem(
-                resources.getString(oneSelected ? "miRandomName.single.text" : "miRandomName.bulk.text"));
+        menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                           "miRandomName.single.text" :
+                                                           "miRandomName.bulk.text"));
         menuItem.setName("miRandomName");
         menuItem.setActionCommand(CMD_RANDOM_NAME);
         menuItem.addActionListener(this);
         menu.add(menuItem);
 
         if (StaticChecks.areAllClanEligible(selected)) {
-            menuItem = new JMenuItem(resources.getString(
-                    oneSelected ? "miRandomBloodnameCheck.single.text" : "miRandomBloodnameCheck.bulk.text"));
+            menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                               "miRandomBloodnameCheck.single.text" :
+                                                               "miRandomBloodnameCheck.bulk.text"));
             menuItem.setName("miRandomBloodnameCheck");
             menuItem.setActionCommand(makeCommand(CMD_RANDOM_BLOODNAME, String.valueOf(false)));
             menuItem.addActionListener(this);
             menu.add(menuItem);
 
-            if (gui.getCampaign().isGM()) {
-                menuItem = new JMenuItem(resources
-                        .getString(oneSelected ? "miRandomBloodname.single.text" : "miRandomBloodname.bulk.text"));
+            if (getCampaign().isGM()) {
+                menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                                   "miRandomBloodname.single.text" :
+                                                                   "miRandomBloodname.bulk.text"));
                 menuItem.setName("miRandomBloodname");
                 menuItem.setActionCommand(makeCommand(CMD_RANDOM_BLOODNAME, String.valueOf(true)));
                 menuItem.addActionListener(this);
@@ -3007,37 +3110,42 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
         }
 
-        menuItem = new JMenuItem(
-                resources.getString(oneSelected ? "miRandomCallsign.single.text" : "miRandomCallsign.bulk.text"));
+        menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                           "miRandomCallsign.single.text" :
+                                                           "miRandomCallsign.bulk.text"));
         menuItem.setName("miRandomCallsign");
         menuItem.setActionCommand(CMD_RANDOM_CALLSIGN);
         menuItem.addActionListener(this);
         menu.add(menuItem);
 
-        menuItem = new JMenuItem(
-                resources.getString(oneSelected ? "miRandomPortrait.single.text" : "miRandomPortrait.bulk.text"));
+        menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                           "miRandomPortrait.single.text" :
+                                                           "miRandomPortrait.bulk.text"));
         menuItem.setName("miRandomPortrait");
         menuItem.setActionCommand(CMD_RANDOM_PORTRAIT);
         menuItem.addActionListener(this);
         menu.add(menuItem);
 
-        if (gui.getCampaign().getCampaignOptions().getRandomOriginOptions().isRandomizeOrigin()) {
-            menuItem = new JMenuItem(
-                    resources.getString(oneSelected ? "miRandomOrigin.single.text" : "miRandomOrigin.bulk.text"));
+        if (getCampaignOptions().getRandomOriginOptions().isRandomizeOrigin()) {
+            menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                               "miRandomOrigin.single.text" :
+                                                               "miRandomOrigin.bulk.text"));
             menuItem.setName("miRandomOrigin");
             menuItem.setActionCommand(CMD_RANDOM_ORIGIN);
             menuItem.addActionListener(this);
             menu.add(menuItem);
 
-            menuItem = new JMenuItem(resources
-                    .getString(oneSelected ? "miRandomOriginFaction.single.text" : "miRandomOriginFaction.bulk.text"));
+            menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                               "miRandomOriginFaction.single.text" :
+                                                               "miRandomOriginFaction.bulk.text"));
             menuItem.setName("miRandomOriginFaction");
             menuItem.setActionCommand(CMD_RANDOM_ORIGIN_FACTION);
             menuItem.addActionListener(this);
             menu.add(menuItem);
 
-            menuItem = new JMenuItem(resources
-                    .getString(oneSelected ? "miRandomOriginPlanet.single.text" : "miRandomOriginPlanet.bulk.text"));
+            menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                               "miRandomOriginPlanet.single.text" :
+                                                               "miRandomOriginPlanet.bulk.text"));
             menuItem.setName("miRandomOriginPlanet");
             menuItem.setActionCommand(CMD_RANDOM_ORIGIN_PLANET);
             menuItem.addActionListener(this);
@@ -3066,28 +3174,24 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         // endregion Original Unit
 
         // region GM Menu
-        if (gui.getCampaign().isGM()) {
+        if (getCampaign().isGM()) {
             popup.addSeparator();
 
             menu = new JMenu(resources.getString("GMMode.text"));
 
             menuItem = new JMenu(resources.getString("changePrisonerStatus.text"));
-            menuItem.add(newCheckboxMenu(
-                    PrisonerStatus.FREE.toString(),
-                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.FREE.name()),
-                    (person.getPrisonerStatus() == PrisonerStatus.FREE)));
-            menuItem.add(newCheckboxMenu(
-                    PrisonerStatus.PRISONER.toString(),
-                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER.name()),
-                    (person.getPrisonerStatus() == PrisonerStatus.PRISONER)));
-            menuItem.add(newCheckboxMenu(
-                    PrisonerStatus.PRISONER_DEFECTOR.toString(),
-                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER_DEFECTOR.name()),
-                    (person.getPrisonerStatus() == PrisonerStatus.PRISONER_DEFECTOR)));
-            menuItem.add(newCheckboxMenu(
-                    PrisonerStatus.BONDSMAN.toString(),
-                    makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.BONDSMAN.name()),
-                    (person.getPrisonerStatus() == PrisonerStatus.BONDSMAN)));
+            menuItem.add(newCheckboxMenu(PrisonerStatus.FREE.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.FREE.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.FREE)));
+            menuItem.add(newCheckboxMenu(PrisonerStatus.PRISONER.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.PRISONER)));
+            menuItem.add(newCheckboxMenu(PrisonerStatus.PRISONER_DEFECTOR.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.PRISONER_DEFECTOR.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.PRISONER_DEFECTOR)));
+            menuItem.add(newCheckboxMenu(PrisonerStatus.BONDSMAN.toString(),
+                  makeCommand(CMD_CHANGE_PRISONER_STATUS, PrisonerStatus.BONDSMAN.name()),
+                  (person.getPrisonerStatus() == PrisonerStatus.BONDSMAN)));
             menu.add(menuItem);
 
             menuItem = new JMenuItem(resources.getString("removePerson.text"));
@@ -3095,7 +3199,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menuItem.addActionListener(this);
             menu.add(menuItem);
 
-            if (!gui.getCampaign().getCampaignOptions().isUseAdvancedMedical()) {
+            if (!getCampaignOptions().isUseAdvancedMedical()) {
                 menuItem = new JMenuItem(resources.getString("editHits.text"));
                 menuItem.setActionCommand(CMD_EDIT_HITS);
                 menuItem.addActionListener(this);
@@ -3117,7 +3221,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menuItem.addActionListener(this);
             menu.add(menuItem);
 
-            if (gui.getCampaign().getCampaignOptions().isUseEdge()) {
+            if (getCampaignOptions().isUseEdge()) {
                 menuItem = new JMenuItem(resources.getString("setEdge.text"));
                 menuItem.setActionCommand(CMD_SET_EDGE);
                 menuItem.addActionListener(this);
@@ -3134,7 +3238,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 menu.add(menuItem);
             }
 
-            if (gui.getCampaign().getCampaignOptions().isUseAdvancedMedical()) {
+            if (getCampaignOptions().isUseAdvancedMedical()) {
                 menuItem = new JMenuItem(resources.getString("removeAllInjuries.text"));
                 menuItem.setActionCommand(CMD_CLEAR_INJURIES);
                 menuItem.addActionListener(this);
@@ -3142,8 +3246,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                 if (oneSelected) {
                     for (Injury i : person.getInjuries()) {
-                        menuItem = new JMenuItem(
-                                String.format(resources.getString("removeInjury.format"), i.getName()));
+                        menuItem = new JMenuItem(String.format(resources.getString("removeInjury.format"),
+                              i.getName()));
                         menuItem.setActionCommand(makeCommand(CMD_REMOVE_INJURY, i.getUUID().toString()));
                         menuItem.addActionListener(this);
                         menu.add(menuItem);
@@ -3156,40 +3260,43 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 }
             }
 
-            if (gui.getCampaign().getCampaignOptions().isUseManualProcreation()) {
-                if (Stream.of(selected).anyMatch(p -> gui.getCampaign().getProcreation()
-                        .canProcreate(gui.getCampaign().getLocalDate(), p, false) == null)) {
-                    menuItem = new JMenuItem(
-                            resources.getString(oneSelected ? "addPregnancy.text" : "addPregnancies.text"));
+            if (getCampaignOptions().isUseManualProcreation()) {
+                if (Stream.of(selected)
+                          .anyMatch(p -> getCampaign().getProcreation()
+                                               .canProcreate(getCampaign().getLocalDate(), p, false) == null)) {
+                    menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                                       "addPregnancy.text" :
+                                                                       "addPregnancies.text"));
                     menuItem.setActionCommand(CMD_ADD_PREGNANCY);
                     menuItem.addActionListener(this);
                     menu.add(menuItem);
                 }
 
                 if (Stream.of(selected).anyMatch(Person::isPregnant)) {
-                    menuItem = new JMenuItem(
-                            resources.getString(oneSelected ? "removePregnancy.text" : "removePregnancies.text"));
+                    menuItem = new JMenuItem(resources.getString(oneSelected ?
+                                                                       "removePregnancy.text" :
+                                                                       "removePregnancies.text"));
                     menuItem.setActionCommand(CMD_REMOVE_PREGNANCY);
                     menuItem.addActionListener(this);
                     menu.add(menuItem);
                 }
             }
 
-            if (gui.getCampaign().getCampaignOptions().isUseLoyaltyModifiers()) {
+            if (getCampaignOptions().isUseLoyaltyModifiers()) {
                 menuItem = new JMenuItem(resources.getString("regenerateLoyalty.text"));
                 menuItem.setActionCommand(CMD_LOYALTY);
                 menuItem.addActionListener(this);
                 menu.add(menuItem);
             }
 
-            if (gui.getCampaign().getCampaignOptions().isUseRandomPersonalities()) {
+            if (getCampaignOptions().isUseRandomPersonalities()) {
                 menuItem = new JMenuItem(resources.getString("regeneratePersonality.text"));
                 menuItem.setActionCommand(CMD_PERSONALITY);
                 menuItem.addActionListener(this);
                 menu.add(menuItem);
             }
 
-            if (gui.getCampaign().getCampaignOptions().isUseAbilities()) {
+            if (getCampaignOptions().isUseAbilities()) {
                 menuItem = new JMenuItem(resources.getString("addRandomSPA.text"));
                 menuItem.setActionCommand(CMD_ADD_RANDOM_ABILITY);
                 menuItem.addActionListener(this);
@@ -3213,7 +3320,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
      * @param civilianMenu the civilian menu object
      */
     private void buildEducationMenusSingleton(Campaign campaign, Person person, Academy academy, JMenu militaryMenu,
-            JMenu civilianMenu) {
+                                              JMenu civilianMenu) {
         boolean showIneligibleAcademies = campaign.getCampaignOptions().isEnableShowIneligibleAcademies();
         if (campaign.getCampaignOptions().isEnableOverrideRequirements()) {
             JMenu academyOption = new JMenu(academy.getName());
@@ -3234,41 +3341,55 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             // this is only relevant if we're overriding the academy restrictions, as we
             // won't reach this point during normal play.
             if (academyFactions.isEmpty()) {
-                buildEducationSubMenus(campaign, academy, List.of(person), academyOption, campus,
-                        campaign.getFaction().getShortName());
+                buildEducationSubMenus(campaign,
+                      academy,
+                      List.of(person),
+                      academyOption,
+                      campus,
+                      campaign.getFaction().getShortName());
             } else {
-                buildEducationSubMenus(campaign, academy, List.of(person), academyOption, campus,
-                        campaign.getSystemById(campus).getFactions(campaign.getLocalDate()).get(0));
+                buildEducationSubMenus(campaign,
+                      academy,
+                      List.of(person),
+                      academyOption,
+                      campus,
+                      campaign.getSystemById(campus).getFactions(campaign.getLocalDate()).get(0));
             }
             return;
         }
 
         // has the academy been constructed, is still standing, & has not closed?
-        if ((campaign.getGameYear() >= academy.getConstructionYear())
-                && (campaign.getGameYear() < academy.getDestructionYear())
-                && (campaign.getGameYear() < academy.getClosureYear())) {
+        if ((campaign.getGameYear() >= academy.getConstructionYear()) &&
+                  (campaign.getGameYear() < academy.getDestructionYear()) &&
+                  (campaign.getGameYear() < academy.getClosureYear())) {
             // is the planet populated?
             if ((academy.isLocal()) && (campaign.getCurrentSystem().getPopulation(campaign.getLocalDate()) == 0)) {
                 if (showIneligibleAcademies) {
-                    JMenuItem academyOption = new JMenuItem("<html>" + academy.getName()
-                            + resources.getString("eduPopulationConflict.text") + "</html>");
+                    JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                  academy.getName() +
+                                                                  resources.getString("eduPopulationConflict.text") +
+                                                                  "</html>");
 
                     educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                 }
                 // is the applicant within the right age bracket?
-            } else if ((person.getAge(campaign.getLocalDate()) >= academy.getAgeMax())
-                    || (person.getAge(campaign.getLocalDate()) < academy.getAgeMin())) {
+            } else if ((person.getAge(campaign.getLocalDate()) >= academy.getAgeMax()) ||
+                             (person.getAge(campaign.getLocalDate()) < academy.getAgeMin())) {
                 if (showIneligibleAcademies) {
                     JMenuItem academyOption;
 
                     if (academy.getAgeMax() != 9999) {
-                        academyOption = new JMenuItem("<html>" + academy.getName()
-                                + String.format(resources.getString("eduAgeConflictRange.text"), academy.getAgeMin(),
-                                        academy.getAgeMax())
-                                + "</html>");
+                        academyOption = new JMenuItem("<html>" +
+                                                            academy.getName() +
+                                                            String.format(resources.getString("eduAgeConflictRange.text"),
+                                                                  academy.getAgeMin(),
+                                                                  academy.getAgeMax()) +
+                                                            "</html>");
                     } else {
-                        academyOption = new JMenuItem("<html>" + academy.getName()
-                                + String.format(resources.getString("eduAgeConflictPlus.text"), academy.getAgeMin()));
+                        academyOption = new JMenuItem("<html>" +
+                                                            academy.getName() +
+                                                            String.format(resources.getString("eduAgeConflictPlus.text"),
+                                                                  academy.getAgeMin()));
                     }
 
                     educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
@@ -3276,27 +3397,33 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // is the applicant qualified?
             } else if (!academy.isQualified(person)) {
                 if (showIneligibleAcademies) {
-                    JMenuItem academyOption = new JMenuItem("<html>" + academy.getName()
-                            + String.format(resources.getString("eduUnqualified.text"),
-                                    academy.getEducationLevelMin()));
+                    JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                  academy.getName() +
+                                                                  String.format(resources.getString(
+                                                                              "eduUnqualified.text"),
+                                                                        academy.getEducationLevelMin()));
                     educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                 }
             } else if (academy.hasRejectedApplication(person)) {
                 if (showIneligibleAcademies) {
-                    JMenuItem academyOption = new JMenuItem("<html>" + academy.getName()
-                            + String.format(resources.getString("eduRejected.text"), academy.getEducationLevelMin()));
+                    JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                  academy.getName() +
+                                                                  String.format(resources.getString("eduRejected.text"),
+                                                                        academy.getEducationLevelMin()));
                     educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                 }
             } else if (academy.isLocal()) {
                 // are any of the local academies accepting applicants from person's Faction or
                 // campaign's Faction?
-                String faction = academy.getFilteredFaction(campaign, person, campaign
-                        .getSystemById(campaign.getCurrentSystem().getId()).getFactions(campaign.getLocalDate()));
+                String faction = academy.getFilteredFaction(campaign,
+                      person,
+                      campaign.getSystemById(campaign.getCurrentSystem().getId()).getFactions(campaign.getLocalDate()));
 
                 if (faction == null) {
                     if (showIneligibleAcademies) {
-                        JMenuItem academyOption = new JMenuItem(
-                                "<html>" + academy.getName() + resources.getString("eduFactionConflict.text"));
+                        JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                      academy.getName() +
+                                                                      resources.getString("eduFactionConflict.text"));
 
                         educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                     }
@@ -3304,15 +3431,23 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     JMenu academyOption = new JMenu(academy.getName());
                     educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                    buildEducationSubMenus(campaign, academy, List.of(person), academyOption,
-                            campaign.getCurrentSystem().getId(), faction);
+                    buildEducationSubMenus(campaign,
+                          academy,
+                          List.of(person),
+                          academyOption,
+                          campaign.getCurrentSystem().getId(),
+                          faction);
                 }
             } else if (academy.isHomeSchool()) {
                 JMenu academyOption = new JMenu(academy.getName());
                 educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                buildEducationSubMenus(campaign, academy, List.of(person), academyOption,
-                        campaign.getCurrentSystem().getId(), campaign.getFaction().getShortName());
+                buildEducationSubMenus(campaign,
+                      academy,
+                      List.of(person),
+                      academyOption,
+                      campaign.getCurrentSystem().getId(),
+                      campaign.getFaction().getShortName());
             } else {
                 // what campuses are accepting applicants?
                 List<String> campuses = new ArrayList<>();
@@ -3320,40 +3455,47 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 for (String campusId : academy.getLocationSystems()) {
                     PlanetarySystem system = campaign.getSystemById(campusId);
 
-                    if (academy.getFilteredFaction(campaign, person,
-                            system.getFactions(campaign.getLocalDate())) != null) {
+                    if (academy.getFilteredFaction(campaign, person, system.getFactions(campaign.getLocalDate())) !=
+                              null) {
                         campuses.add(campusId);
                     }
                 }
 
                 if (campuses.isEmpty()) {
                     if (showIneligibleAcademies) {
-                        JMenuItem academyOption = new JMenuItem(
-                                "<html>" + academy.getName() + resources.getString("eduFactionConflict.text"));
+                        JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                      academy.getName() +
+                                                                      resources.getString("eduFactionConflict.text"));
                         educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                     }
                     // which is the nearest campus and is it in range?
                 } else {
                     String nearestCampus = Academy.getNearestCampus(campaign, campuses);
 
-                    if ((campaign.getSimplifiedTravelTime(campaign.getSystemById(nearestCampus)) / 7) > campaign
-                            .getCampaignOptions().getMaximumJumpCount()) {
+                    if ((campaign.getSimplifiedTravelTime(campaign.getSystemById(nearestCampus)) / 7) >
+                              campaign.getCampaignOptions().getMaximumJumpCount()) {
                         if (showIneligibleAcademies) {
-                            JMenuItem academyOption = new JMenuItem(
-                                    "<html>" + academy.getName() + resources.getString("eduRangeConflict.text"));
+                            JMenuItem academyOption = new JMenuItem("<html>" +
+                                                                          academy.getName() +
+                                                                          resources.getString("eduRangeConflict.text"));
                             educationJMenuItemAdder(academy, militaryMenu, civilianMenu, academyOption);
                         }
                     } else {
-                        String faction = academy.getFilteredFaction(campaign, person,
-                                campaign.getSystemById(nearestCampus).getFactions(campaign.getLocalDate()));
+                        String faction = academy.getFilteredFaction(campaign,
+                              person,
+                              campaign.getSystemById(nearestCampus).getFactions(campaign.getLocalDate()));
 
                         if (faction != null) {
                             JMenu academyOption = new JMenu(academy.getName());
 
                             educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                            buildEducationSubMenus(campaign, academy, List.of(person), academyOption, nearestCampus,
-                                    faction);
+                            buildEducationSubMenus(campaign,
+                                  academy,
+                                  List.of(person),
+                                  academyOption,
+                                  nearestCampus,
+                                  faction);
                         }
                     }
                 }
@@ -3371,7 +3513,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
      * @param civilianMenu the civilian menu object
      */
     private void buildEducationMenusMassEnroll(Campaign campaign, List<Person> personnel, Academy academy,
-            JMenu militaryMenu, JMenu civilianMenu) {
+                                               JMenu militaryMenu, JMenu civilianMenu) {
         if (campaign.getCampaignOptions().isEnableOverrideRequirements()) {
             JMenu academyOption = new JMenu(academy.getName());
 
@@ -3388,33 +3530,43 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             List<String> academyFactions = campaign.getSystemById(campus).getFactions(campaign.getLocalDate());
 
             if (academyFactions.isEmpty()) {
-                buildEducationSubMenus(campaign, academy, personnel, academyOption, campus,
-                        campaign.getFaction().getShortName());
+                buildEducationSubMenus(campaign,
+                      academy,
+                      personnel,
+                      academyOption,
+                      campus,
+                      campaign.getFaction().getShortName());
             } else {
-                buildEducationSubMenus(campaign, academy, personnel, academyOption, campus,
-                        campaign.getSystemById(campus).getFactions(campaign.getLocalDate()).get(0));
+                buildEducationSubMenus(campaign,
+                      academy,
+                      personnel,
+                      academyOption,
+                      campus,
+                      campaign.getSystemById(campus).getFactions(campaign.getLocalDate()).get(0));
             }
             return;
         }
 
         // has the academy been constructed, is still standing, & has not closed?
-        if ((campaign.getGameYear() >= academy.getConstructionYear())
-                && (campaign.getGameYear() < academy.getDestructionYear())
-                && (campaign.getGameYear() < academy.getClosureYear())) {
+        if ((campaign.getGameYear() >= academy.getConstructionYear()) &&
+                  (campaign.getGameYear() < academy.getDestructionYear()) &&
+                  (campaign.getGameYear() < academy.getClosureYear())) {
 
             // is the planet populated?
-            if ((campaign.getCurrentSystem().getPopulation(campaign.getLocalDate()) == 0)
-                    && (!academy.isHomeSchool())) {
+            if ((campaign.getCurrentSystem().getPopulation(campaign.getLocalDate()) == 0) &&
+                      (!academy.isHomeSchool())) {
                 return;
             }
 
             // are all the applicants within the right age bracket?
             // are all the applicants qualified?
             boolean arePersonnelEligible = personnel.stream()
-                    .allMatch(person -> person.getAge(campaign.getLocalDate()) < academy.getAgeMax()
-                            && person.getAge(campaign.getLocalDate()) >= academy.getAgeMin()
-                            && academy.isQualified(person)
-                            && !academy.hasRejectedApplication(person));
+                                                 .allMatch(person -> person.getAge(campaign.getLocalDate()) <
+                                                                           academy.getAgeMax() &&
+                                                                           person.getAge(campaign.getLocalDate()) >=
+                                                                                 academy.getAgeMin() &&
+                                                                           academy.isQualified(person) &&
+                                                                           !academy.hasRejectedApplication(person));
 
             // if one or more people are not eligible to attend the academy,
             // there is no point doing any further processes
@@ -3426,63 +3578,98 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 // find the first faction that accepts applications from all persons in
                 // personnel
                 Optional<String> suitableFaction = personnel.stream()
-                        .map(person -> academy.getFilteredFaction(campaign, person,
-                                campaign.getCurrentSystem().getFactions(campaign.getLocalDate())))
-                        .filter(faction -> personnel.stream().allMatch(person -> Objects.equals(
-                                faction,
-                                academy.getFilteredFaction(campaign, person,
-                                        campaign.getCurrentSystem().getFactions(campaign.getLocalDate())))))
-                        .distinct()
-                        .filter(Objects::nonNull)
-                        .findFirst();
+                                                         .map(person -> academy.getFilteredFaction(campaign,
+                                                               person,
+                                                               campaign.getCurrentSystem()
+                                                                     .getFactions(campaign.getLocalDate())))
+                                                         .filter(faction -> personnel.stream()
+                                                                                  .allMatch(person -> Objects.equals(
+                                                                                        faction,
+                                                                                        academy.getFilteredFaction(
+                                                                                              campaign,
+                                                                                              person,
+                                                                                              campaign.getCurrentSystem()
+                                                                                                    .getFactions(
+                                                                                                          campaign.getLocalDate())))))
+                                                         .distinct()
+                                                         .filter(Objects::nonNull)
+                                                         .findFirst();
 
                 if (suitableFaction.isPresent()) {
                     JMenu academyOption = new JMenu(academy.getName());
                     educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                    buildEducationSubMenus(campaign, academy, personnel, academyOption,
-                            campaign.getCurrentSystem().getId(), suitableFaction.get());
+                    buildEducationSubMenus(campaign,
+                          academy,
+                          personnel,
+                          academyOption,
+                          campaign.getCurrentSystem().getId(),
+                          suitableFaction.get());
                 }
             } else if (academy.isHomeSchool()) {
                 JMenu academyOption = new JMenu(academy.getName());
                 educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                buildEducationSubMenus(campaign, academy, personnel, academyOption, campaign.getCurrentSystem().getId(),
-                        campaign.getFaction().getShortName());
+                buildEducationSubMenus(campaign,
+                      academy,
+                      personnel,
+                      academyOption,
+                      campaign.getCurrentSystem().getId(),
+                      campaign.getFaction().getShortName());
             } else {
                 // find the campuses that accept applications from all members of the group
                 List<String> suitableCampuses = personnel.stream()
-                        .flatMap(person -> academy.getLocationSystems().stream()
-                                .filter(campus -> academy.getFilteredFaction(campaign, person,
-                                        campaign.getSystemById(campus).getFactions(campaign.getLocalDate())) != null))
-                        .distinct()
-                        .filter(campus -> personnel.stream()
-                                .allMatch(person -> academy.getFilteredFaction(campaign, person,
-                                        campaign.getSystemById(campus).getFactions(campaign.getLocalDate())) != null))
-                        .collect(Collectors.toList());
+                                                      .flatMap(person -> academy.getLocationSystems()
+                                                                               .stream()
+                                                                               .filter(campus -> academy.getFilteredFaction(
+                                                                                     campaign,
+                                                                                     person,
+                                                                                     campaign.getSystemById(campus)
+                                                                                           .getFactions(campaign.getLocalDate())) !=
+                                                                                                       null))
+                                                      .distinct()
+                                                      .filter(campus -> personnel.stream()
+                                                                              .allMatch(person -> academy.getFilteredFaction(
+                                                                                    campaign,
+                                                                                    person,
+                                                                                    campaign.getSystemById(campus)
+                                                                                          .getFactions(campaign.getLocalDate())) !=
+                                                                                                        null))
+                                                      .collect(Collectors.toList());
 
                 if (!suitableCampuses.isEmpty()) {
                     String nearestCampus = Academy.getNearestCampus(campaign, suitableCampuses);
 
                     // find what factions accept an application from all members of the group
                     Optional<String> suitableFaction = personnel.stream()
-                            .map(person -> academy.getFilteredFaction(campaign, person,
-                                    campaign.getSystemById(nearestCampus).getFactions(campaign.getLocalDate())))
-                            .distinct()
-                            .filter(faction -> personnel.stream()
-                                    .allMatch(person -> faction.equals(academy.getFilteredFaction(campaign, person,
-                                            campaign.getSystemById(nearestCampus)
-                                                    .getFactions(campaign.getLocalDate())))))
-                            .findFirst();
+                                                             .map(person -> academy.getFilteredFaction(campaign,
+                                                                   person,
+                                                                   campaign.getSystemById(nearestCampus)
+                                                                         .getFactions(campaign.getLocalDate())))
+                                                             .distinct()
+                                                             .filter(faction -> personnel.stream()
+                                                                                      .allMatch(person -> faction.equals(
+                                                                                            academy.getFilteredFaction(
+                                                                                                  campaign,
+                                                                                                  person,
+                                                                                                  campaign.getSystemById(
+                                                                                                              nearestCampus)
+                                                                                                        .getFactions(
+                                                                                                              campaign.getLocalDate())))))
+                                                             .findFirst();
 
                     if (suitableFaction.isPresent()) {
-                        if ((campaign.getSimplifiedTravelTime(campaign.getSystemById(nearestCampus)) / 7) <= campaign
-                                .getCampaignOptions().getMaximumJumpCount()) {
+                        if ((campaign.getSimplifiedTravelTime(campaign.getSystemById(nearestCampus)) / 7) <=
+                                  campaign.getCampaignOptions().getMaximumJumpCount()) {
                             JMenu academyOption = new JMenu(academy.getName());
                             educationJMenuAdder(academy, militaryMenu, civilianMenu, academyOption);
 
-                            buildEducationSubMenus(campaign, academy, personnel, academyOption, nearestCampus,
-                                    suitableFaction.get());
+                            buildEducationSubMenus(campaign,
+                                  academy,
+                                  personnel,
+                                  academyOption,
+                                  nearestCampus,
+                                  suitableFaction.get());
                         }
                     }
                 }
@@ -3491,9 +3678,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     /**
-     * Adds an education option to the appropriate JMenu based on the type of
-     * Academy.
-     * This version accepts JMenu objects.
+     * Adds an education option to the appropriate JMenu based on the type of Academy. This version accepts JMenu
+     * objects.
      *
      * @param academy      the Academy
      * @param militaryMenu the JMenu for military education options
@@ -3509,9 +3695,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     /**
-     * Adds an education option to the appropriate JMenu based on the type of
-     * Academy.
-     * This version accepts JMenuItem objects.
+     * Adds an education option to the appropriate JMenu based on the type of Academy. This version accepts JMenuItem
+     * objects.
      *
      * @param academy      the Academy
      * @param militaryMenu the JMenu for military education options
@@ -3519,7 +3704,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
      * @param option       the option to be added to the appropriate JMenu
      */
     private static void educationJMenuItemAdder(Academy academy, JMenu militaryMenu, JMenu civilianMenu,
-            JMenuItem option) {
+                                                JMenuItem option) {
         if (academy.isMilitary()) {
             militaryMenu.add(option);
         } else {
@@ -3528,29 +3713,40 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     private void buildEducationSubMenus(Campaign campaign, Academy academy, List<Person> personnel, JMenu academyOption,
-            String campus, String faction) {
+                                        String campus, String faction) {
         JMenuItem courses;
         int courseCount = academy.getQualifications().size();
 
         if (courseCount > 0) {
             for (int courseIndex = 0; courseIndex < (courseCount); courseIndex++) {
                 // we also need to make sure the course is being offered
-                if ((campaign.getCampaignOptions().isEnableOverrideRequirements())
-                        || (campaign.getGameYear() >= academy.getQualificationStartYears().get(courseIndex))) {
+                if ((campaign.getCampaignOptions().isEnableOverrideRequirements()) ||
+                          (campaign.getGameYear() >= academy.getQualificationStartYears().get(courseIndex))) {
                     String course = academy.getQualifications().get(courseIndex);
                     courses = new JMenuItem(course);
 
                     if ((academy.isLocal()) || (academy.isHomeSchool())) {
-                        courses.setToolTipText(
-                                academy.getTooltip(campaign, personnel, courseIndex, campaign.getCurrentSystem()));
-                        courses.setActionCommand(
-                                makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT, academy.getSet(), academy.getName(),
-                                        String.valueOf(courseIndex), campaign.getCurrentSystem().getId(), faction));
+                        courses.setToolTipText(academy.getTooltip(campaign,
+                              personnel,
+                              courseIndex,
+                              campaign.getCurrentSystem()));
+                        courses.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT,
+                              academy.getSet(),
+                              academy.getName(),
+                              String.valueOf(courseIndex),
+                              campaign.getCurrentSystem().getId(),
+                              faction));
                     } else {
-                        courses.setToolTipText(
-                                academy.getTooltip(campaign, personnel, courseIndex, campaign.getSystemById(campus)));
-                        courses.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT, academy.getSet(),
-                                academy.getName(), String.valueOf(courseIndex), campus, faction));
+                        courses.setToolTipText(academy.getTooltip(campaign,
+                              personnel,
+                              courseIndex,
+                              campaign.getSystemById(campus)));
+                        courses.setActionCommand(makeCommand(CMD_BEGIN_EDUCATION_ENROLLMENT,
+                              academy.getSet(),
+                              academy.getName(),
+                              String.valueOf(courseIndex),
+                              campus,
+                              faction));
                     }
                     courses.addActionListener(this);
                     academyOption.add(courses);
@@ -3566,13 +3762,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
      * Returns a JMenuItem for a given Award.
      *
      * @param award The Award object for which the JMenuItem is to be created.
+     *
      * @return A JMenuItem representing the given Award.
      */
     private JMenuItem getAwardMenuItem(Award award) {
         StringBuilder awardMenuItem = new StringBuilder();
         awardMenuItem.append(String.format("%s", award.getName()));
 
-        if (gui.getCampaign().getCampaignOptions().getAwardBonusStyle().isBoth()) {
+        if (getCampaignOptions().getAwardBonusStyle().isBoth()) {
             if ((award.getXPReward() != 0) || (award.getEdgeReward() != 0)) {
                 awardMenuItem.append(" (");
 
@@ -3589,13 +3786,13 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                 awardMenuItem.append(')');
             }
-        } else if (gui.getCampaign().getCampaignOptions().getAwardBonusStyle().isXP()) {
+        } else if (getCampaignOptions().getAwardBonusStyle().isXP()) {
             if (award.getXPReward() != 0) {
                 awardMenuItem.append(" (");
 
                 awardMenuItem.append(award.getXPReward()).append(" XP)");
             }
-        } else if (gui.getCampaign().getCampaignOptions().getAwardBonusStyle().isEdge()) {
+        } else if (getCampaignOptions().getAwardBonusStyle().isEdge()) {
 
             if (award.getEdgeReward() != 0) {
                 awardMenuItem.append(" (");


### PR DESCRIPTION
- Introduced helper methods `getCampaign()` and `getCampaignOptions()` to streamline campaign data access.
- Replaced multiple instances of `gui.getCampaign()` and `gui.getCampaign().getCampaignOptions()` with new helper methods for improved readability and maintainability.
- Updated references throughout the various command cases to use the new helper methods consistently.

### Dev Notes
This PR replaces 164 instances of `gui.getCampaign()` with the `getCampaign()` helper.
And 45 instances of `gui.getCampaign().getCampaignOptions()` with the `getCampaignOptions()` helper.
