### PR TITLE
Added Optional Autosave at Mission/Contract End

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -632,7 +632,8 @@ optionSaveDaily.text=Save daily (before a new day starts)
 optionSaveWeekly.text=Save weekly (before a new week starts)
 optionSaveMonthly.text=Save monthly (before a new month starts)
 optionSaveYearly.text=Save yearly (before new year starts)
-checkSaveBeforeMissions.text=Save before attempting a scenario?
+checkSaveBeforeScenarios.text=Save before attempting a scenario?
+checkSaveBeforeMissionEnd.text=Save before concluding a mission or contract?
 labelSavedGamesCount.text=Maximum number of autosaved games
 ## New Day Tab
 newDayTab.title=New Day Options

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -27,11 +27,11 @@
  */
 package mekhq;
 
-import megamek.SuiteConstants;
-
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.Month;
+
+import megamek.SuiteConstants;
 
 /**
  * These are constants that hold across MekHQ.
@@ -50,7 +50,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final int FACTION_GENERATOR_BORDER_RANGE_CLAN = 90;
     public static final int FACTION_GENERATOR_BORDER_RANGE_NEAR_PERIPHERY = 90;
     public static final int FACTION_GENERATOR_BORDER_RANGE_DEEP_PERIPHERY = 210; // a bit more than this distance
-                                                                                 // between HL and NC
+    // between HL and NC
     public static final LocalDate FORTRESS_REPUBLIC = LocalDate.of(3135, Month.NOVEMBER, 1);
     // endregion Faction Generation Constants
 
@@ -66,7 +66,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String LONG_DISPLAY_DATE_FORMAT = "longDisplayDateFormat";
     public static final String HISTORICAL_DAILY_LOG = "historicalDailyLog";
     public static final int MAX_HISTORICAL_LOG_DAYS = 120; // max number of days that will be stored in the history,
-                                                           // also used as a limit in the UI
+    // also used as a limit in the UI
     public static final String COMPANY_GENERATOR_STARTUP = "companyGeneratorStartup";
     public static final String SHOW_COMPANY_GENERATOR = "showCompanyGenerator";
     public static final String SHOW_UNIT_PICTURES_ON_TOE = "showUnitPicturesOnTOE";
@@ -153,7 +153,13 @@ public final class MHQConstants extends SuiteConstants {
     public static final String SAVE_WEEKLY_KEY = "saveWeekly";
     public static final String SAVE_MONTHLY_KEY = "saveMonthly";
     public static final String SAVE_YEARLY_KEY = "saveYearly";
+    /**
+     * @deprecated use {@link #SAVE_BEFORE_SCENARIOS_KEY} instead.
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     public static final String SAVE_BEFORE_MISSIONS_KEY = "saveBeforeMissions";
+    public static final String SAVE_BEFORE_SCENARIOS_KEY = "saveBeforeScenarios";
+    public static final String SAVE_BEFORE_MISSION_END = "saveBeforeMissionEnd";
     public static final String MAXIMUM_NUMBER_SAVES_KEY = "maximumNumberAutoSaves";
     public static final int DEFAULT_NUMBER_SAVES = 5;
     // endregion Autosave
@@ -310,16 +316,26 @@ public final class MHQConstants extends SuiteConstants {
     // endregion StoryArcs
 
     // region Backgrounds
-    public static final String NAME_MIDDLE_WORD_CORPORATE = Paths.get("data/universe/backgrounds/randomCompanyNameGenerator/middleWordCorporate.csv").toString();
-    public static final String NAME_MIDDLE_WORD_CORPORATE_USER = Paths.get("userdata/data/universe/backgrounds/randomCompanyNameGenerator/middleWordCorporate.csv").toString();
-    public static final String NAME_END_WORD_CORPORATE = Paths.get("data/universe/backgrounds/randomCompanyNameGenerator/endWordCorporate.csv").toString();
-    public static final String NAME_END_WORD_CORPORATE_USER = Paths.get("userdata/data/universe/backgrounds/randomCompanyNameGenerator/endWordCorporate.csv").toString();
-    public static final String NAME_MIDDLE_WORD_MERCENARY = Paths.get("data/universe/backgrounds/randomCompanyNameGenerator/middleWordMercenary.csv").toString();
-    public static final String NAME_MIDDLE_WORD_MERCENARY_USER = Paths.get("userdata/data/universe/backgrounds/randomCompanyNameGenerator/middleWordMercenary.csv").toString();
-    public static final String NAME_END_WORD_MERCENARY = Paths.get("data/universe/backgrounds/randomCompanyNameGenerator/endWordMercenary.csv").toString();
-    public static final String NAME_END_WORD_MERCENARY_USER = Paths.get("userdata/data/universe/backgrounds/randomCompanyNameGenerator/endWordMercenary.csv").toString();
-    public static final String NAME_PRE_FAB = Paths.get("data/universe/backgrounds/randomCompanyNameGenerator/preFab.csv").toString();
-    public static final String NAME_PRE_FAB_USER = Paths.get("userdata/data/universe/backgrounds/randomCompanyNameGenerator/preFab.csv").toString();
+    public static final String NAME_MIDDLE_WORD_CORPORATE = Paths.get(
+          "data/universe/backgrounds/randomCompanyNameGenerator/middleWordCorporate.csv").toString();
+    public static final String NAME_MIDDLE_WORD_CORPORATE_USER = Paths.get(
+          "userdata/data/universe/backgrounds/randomCompanyNameGenerator/middleWordCorporate.csv").toString();
+    public static final String NAME_END_WORD_CORPORATE = Paths.get(
+          "data/universe/backgrounds/randomCompanyNameGenerator/endWordCorporate.csv").toString();
+    public static final String NAME_END_WORD_CORPORATE_USER = Paths.get(
+          "userdata/data/universe/backgrounds/randomCompanyNameGenerator/endWordCorporate.csv").toString();
+    public static final String NAME_MIDDLE_WORD_MERCENARY = Paths.get(
+          "data/universe/backgrounds/randomCompanyNameGenerator/middleWordMercenary.csv").toString();
+    public static final String NAME_MIDDLE_WORD_MERCENARY_USER = Paths.get(
+          "userdata/data/universe/backgrounds/randomCompanyNameGenerator/middleWordMercenary.csv").toString();
+    public static final String NAME_END_WORD_MERCENARY = Paths.get(
+          "data/universe/backgrounds/randomCompanyNameGenerator/endWordMercenary.csv").toString();
+    public static final String NAME_END_WORD_MERCENARY_USER = Paths.get(
+          "userdata/data/universe/backgrounds/randomCompanyNameGenerator/endWordMercenary.csv").toString();
+    public static final String NAME_PRE_FAB = Paths.get(
+          "data/universe/backgrounds/randomCompanyNameGenerator/preFab.csv").toString();
+    public static final String NAME_PRE_FAB_USER = Paths.get(
+          "userdata/data/universe/backgrounds/randomCompanyNameGenerator/preFab.csv").toString();
     // endregion Backgrounds
 
     // endregion File Paths

--- a/MekHQ/src/mekhq/MHQOptions.java
+++ b/MekHQ/src/mekhq/MHQOptions.java
@@ -27,16 +27,16 @@
  */
 package mekhq;
 
+import java.awt.Color;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import javax.swing.UIManager;
+
 import megamek.SuiteOptions;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.universe.enums.CompanyGenerationMethod;
 import mekhq.gui.enums.ForceIconOperationalStatusStyle;
 import mekhq.gui.enums.PersonnelFilterStyle;
-
-import javax.swing.*;
-import java.awt.*;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 
 public final class MHQOptions extends SuiteOptions {
     // region Display Tab
@@ -45,9 +45,9 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public String getDisplayFormattedDate(final @Nullable LocalDate date) {
-        return (date != null)
-                ? date.format(DateTimeFormatter.ofPattern(getDisplayDateFormat()).withLocale(getDateLocale()))
-                : "";
+        return (date != null) ?
+                     date.format(DateTimeFormatter.ofPattern(getDisplayDateFormat()).withLocale(getDateLocale())) :
+                     "";
     }
 
     public void setDisplayDateFormat(String value) {
@@ -59,14 +59,14 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public String getLongDisplayDateFormat() {
-        return userPreferences.node(MHQConstants.DISPLAY_NODE).get(MHQConstants.LONG_DISPLAY_DATE_FORMAT,
-                "EEEE, MMMM d, yyyy");
+        return userPreferences.node(MHQConstants.DISPLAY_NODE)
+                     .get(MHQConstants.LONG_DISPLAY_DATE_FORMAT, "EEEE, MMMM d, yyyy");
     }
 
     public String getLongDisplayFormattedDate(LocalDate date) {
-        return (date != null)
-                ? date.format(DateTimeFormatter.ofPattern(getLongDisplayDateFormat()).withLocale(getDateLocale()))
-                : "";
+        return (date != null) ?
+                     date.format(DateTimeFormatter.ofPattern(getLongDisplayDateFormat()).withLocale(getDateLocale())) :
+                     "";
     }
 
     public void setLongDisplayDateFormat(String value) {
@@ -82,8 +82,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public boolean getCompanyGeneratorStartup() {
-        return userPreferences.node(MHQConstants.DISPLAY_NODE).getBoolean(MHQConstants.COMPANY_GENERATOR_STARTUP,
-                false);
+        return userPreferences.node(MHQConstants.DISPLAY_NODE)
+                     .getBoolean(MHQConstants.COMPANY_GENERATOR_STARTUP, false);
     }
 
     public void setCompanyGeneratorStartup(final boolean value) {
@@ -108,8 +108,8 @@ public final class MHQOptions extends SuiteOptions {
 
     // region Command Center Tab
     public boolean getCommandCenterUseUnitMarket() {
-        return userPreferences.node(MHQConstants.DISPLAY_NODE).getBoolean(MHQConstants.COMMAND_CENTER_USE_UNIT_MARKET,
-                true);
+        return userPreferences.node(MHQConstants.DISPLAY_NODE)
+                     .getBoolean(MHQConstants.COMMAND_CENTER_USE_UNIT_MARKET, true);
     }
 
     public void setCommandCenterUseUnitMarket(boolean value) {
@@ -128,89 +128,90 @@ public final class MHQOptions extends SuiteOptions {
     // region Interstellar Map Tab
     public boolean getInterstellarMapShowJumpRadius() {
         return userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_JUMP_RADIUS, true);
+                     .getBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_JUMP_RADIUS, true);
     }
 
     public void setInterstellarMapShowJumpRadius(final boolean value) {
-        userPreferences.node(MHQConstants.DISPLAY_NODE).putBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_JUMP_RADIUS,
-                value);
+        userPreferences.node(MHQConstants.DISPLAY_NODE)
+              .putBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_JUMP_RADIUS, value);
     }
 
     public double getInterstellarMapShowJumpRadiusMinimumZoom() {
         return userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getDouble(MHQConstants.INTERSTELLAR_MAP_SHOW_JUMP_RADIUS_MINIMUM_ZOOM, 3d);
+                     .getDouble(MHQConstants.INTERSTELLAR_MAP_SHOW_JUMP_RADIUS_MINIMUM_ZOOM, 3d);
     }
 
     public void setInterstellarMapShowJumpRadiusMinimumZoom(final double value) {
         userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .putDouble(MHQConstants.INTERSTELLAR_MAP_SHOW_JUMP_RADIUS_MINIMUM_ZOOM, value);
+              .putDouble(MHQConstants.INTERSTELLAR_MAP_SHOW_JUMP_RADIUS_MINIMUM_ZOOM, value);
     }
 
     public Color getInterstellarMapJumpRadiusColour() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getInt(MHQConstants.INTERSTELLAR_MAP_JUMP_RADIUS_COLOUR, Color.DARK_GRAY.getRGB()));
+                               .getInt(MHQConstants.INTERSTELLAR_MAP_JUMP_RADIUS_COLOUR, Color.DARK_GRAY.getRGB()));
     }
 
     public void setInterstellarMapJumpRadiusColour(final Color value) {
-        userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.INTERSTELLAR_MAP_JUMP_RADIUS_COLOUR,
-                value.getRGB());
+        userPreferences.node(MHQConstants.DISPLAY_NODE)
+              .putInt(MHQConstants.INTERSTELLAR_MAP_JUMP_RADIUS_COLOUR, value.getRGB());
     }
 
     public boolean getInterstellarMapShowPlanetaryAcquisitionRadius() {
         return userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_PLANETARY_ACQUISITION_RADIUS, false);
+                     .getBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_PLANETARY_ACQUISITION_RADIUS, false);
     }
 
     public void setInterstellarMapShowPlanetaryAcquisitionRadius(final boolean value) {
         userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .putBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_PLANETARY_ACQUISITION_RADIUS, value);
+              .putBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_PLANETARY_ACQUISITION_RADIUS, value);
     }
 
     public double getInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom() {
         return userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getDouble(MHQConstants.INTERSTELLAR_MAP_SHOW_PLANETARY_ACQUISITION_RADIUS_MINIMUM_ZOOM, 2d);
+                     .getDouble(MHQConstants.INTERSTELLAR_MAP_SHOW_PLANETARY_ACQUISITION_RADIUS_MINIMUM_ZOOM, 2d);
     }
 
     public void setInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom(final double value) {
         userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .putDouble(MHQConstants.INTERSTELLAR_MAP_SHOW_PLANETARY_ACQUISITION_RADIUS_MINIMUM_ZOOM, value);
+              .putDouble(MHQConstants.INTERSTELLAR_MAP_SHOW_PLANETARY_ACQUISITION_RADIUS_MINIMUM_ZOOM, value);
     }
 
     public Color getInterstellarMapPlanetaryAcquisitionRadiusColour() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getInt(MHQConstants.INTERSTELLAR_MAP_PLANETARY_ACQUISITION_RADIUS_COLOUR, 0xFF505050));
+                               .getInt(MHQConstants.INTERSTELLAR_MAP_PLANETARY_ACQUISITION_RADIUS_COLOUR, 0xFF505050));
     }
 
     public void setInterstellarMapPlanetaryAcquisitionRadiusColour(final Color value) {
         userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .putInt(MHQConstants.INTERSTELLAR_MAP_PLANETARY_ACQUISITION_RADIUS_COLOUR, value.getRGB());
+              .putInt(MHQConstants.INTERSTELLAR_MAP_PLANETARY_ACQUISITION_RADIUS_COLOUR, value.getRGB());
     }
 
     public boolean getInterstellarMapShowContractSearchRadius() {
         return userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_CONTRACT_SEARCH_RADIUS, false);
+                     .getBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_CONTRACT_SEARCH_RADIUS, false);
     }
 
     public void setInterstellarMapShowContractSearchRadius(final boolean value) {
         userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .putBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_CONTRACT_SEARCH_RADIUS, value);
+              .putBoolean(MHQConstants.INTERSTELLAR_MAP_SHOW_CONTRACT_SEARCH_RADIUS, value);
     }
 
     public Color getInterstellarMapContractSearchRadiusColour() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getInt(MHQConstants.INTERSTELLAR_MAP_CONTRACT_SEARCH_RADIUS_COLOUR, 0xFF606060));
+                               .getInt(MHQConstants.INTERSTELLAR_MAP_CONTRACT_SEARCH_RADIUS_COLOUR, 0xFF606060));
     }
 
     public void setInterstellarMapContractSearchRadiusColour(final Color value) {
         userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .putInt(MHQConstants.INTERSTELLAR_MAP_CONTRACT_SEARCH_RADIUS_COLOUR, value.getRGB());
+              .putInt(MHQConstants.INTERSTELLAR_MAP_CONTRACT_SEARCH_RADIUS_COLOUR, value.getRGB());
     }
     // endregion Interstellar Map Tab
 
     // region Personnel Tab
     public PersonnelFilterStyle getPersonnelFilterStyle() {
         return PersonnelFilterStyle.valueOf(userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .get(MHQConstants.PERSONNEL_FILTER_STYLE, PersonnelFilterStyle.STANDARD.name()));
+                                                  .get(MHQConstants.PERSONNEL_FILTER_STYLE,
+                                                        PersonnelFilterStyle.STANDARD.name()));
     }
 
     public void setPersonnelFilterStyle(PersonnelFilterStyle value) {
@@ -218,21 +219,21 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public boolean getPersonnelFilterOnPrimaryRole() {
-        return userPreferences.node(MHQConstants.DISPLAY_NODE).getBoolean(MHQConstants.PERSONNEL_FILTER_ON_PRIMARY_ROLE,
-                false);
+        return userPreferences.node(MHQConstants.DISPLAY_NODE)
+                     .getBoolean(MHQConstants.PERSONNEL_FILTER_ON_PRIMARY_ROLE, false);
     }
 
     public void setPersonnelFilterOnPrimaryRole(boolean value) {
-        userPreferences.node(MHQConstants.DISPLAY_NODE).putBoolean(MHQConstants.PERSONNEL_FILTER_ON_PRIMARY_ROLE,
-                value);
+        userPreferences.node(MHQConstants.DISPLAY_NODE)
+              .putBoolean(MHQConstants.PERSONNEL_FILTER_ON_PRIMARY_ROLE, value);
     }
     // endregion Personnel Tab
     // endregion Display Tab
 
     // region Colours
     public Color getDeployedForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.DEPLOYED_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.DEPLOYED_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setDeployedForeground(Color value) {
@@ -240,8 +241,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getDeployedBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.DEPLOYED_BACKGROUND,
-                Color.LIGHT_GRAY.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.DEPLOYED_BACKGROUND, Color.LIGHT_GRAY.getRGB()));
     }
 
     public void setDeployedBackground(Color value) {
@@ -250,27 +251,28 @@ public final class MHQOptions extends SuiteOptions {
 
     public Color getBelowContractMinimumForeground() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getInt(MHQConstants.BELOW_CONTRACT_MINIMUM_FOREGROUND, Color.RED.getRGB()));
+                               .getInt(MHQConstants.BELOW_CONTRACT_MINIMUM_FOREGROUND, Color.RED.getRGB()));
     }
 
     public void setBelowContractMinimumForeground(Color value) {
-        userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.BELOW_CONTRACT_MINIMUM_FOREGROUND,
-                value.getRGB());
+        userPreferences.node(MHQConstants.DISPLAY_NODE)
+              .putInt(MHQConstants.BELOW_CONTRACT_MINIMUM_FOREGROUND, value.getRGB());
     }
 
     public Color getBelowContractMinimumBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(
-                MHQConstants.BELOW_CONTRACT_MINIMUM_BACKGROUND, UIManager.getColor("Table.background").getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.BELOW_CONTRACT_MINIMUM_BACKGROUND,
+                                     UIManager.getColor("Table.background").getRGB()));
     }
 
     public void setBelowContractMinimumBackground(Color value) {
-        userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.BELOW_CONTRACT_MINIMUM_BACKGROUND,
-                value.getRGB());
+        userPreferences.node(MHQConstants.DISPLAY_NODE)
+              .putInt(MHQConstants.BELOW_CONTRACT_MINIMUM_BACKGROUND, value.getRGB());
     }
 
     public Color getInTransitForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.IN_TRANSIT_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.IN_TRANSIT_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setInTransitForeground(Color value) {
@@ -278,8 +280,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getInTransitBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.IN_TRANSIT_BACKGROUND,
-                Color.MAGENTA.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.IN_TRANSIT_BACKGROUND, Color.MAGENTA.getRGB()));
     }
 
     public void setInTransitBackground(Color value) {
@@ -287,8 +289,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getRefittingForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.REFITTING_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.REFITTING_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setRefittingForeground(Color value) {
@@ -296,8 +298,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getRefittingBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.REFITTING_BACKGROUND,
-                Color.CYAN.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.REFITTING_BACKGROUND, Color.CYAN.getRGB()));
     }
 
     public void setRefittingBackground(Color value) {
@@ -305,8 +307,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getMothballingForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.MOTHBALLING_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.MOTHBALLING_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setMothballingForeground(Color value) {
@@ -314,8 +316,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getMothballingBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.MOTHBALLING_BACKGROUND,
-                0xFF9999FF));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.MOTHBALLING_BACKGROUND, 0xFF9999FF));
     }
 
     public void setMothballingBackground(Color value) {
@@ -323,8 +325,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getMothballedForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.MOTHBALLED_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.MOTHBALLED_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setMothballedForeground(Color value) {
@@ -332,8 +334,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getMothballedBackground() {
-        return new Color(
-                userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.MOTHBALLED_BACKGROUND, 0xFFCCCCFF));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.MOTHBALLED_BACKGROUND, 0xFFCCCCFF));
     }
 
     public void setMothballedBackground(Color value) {
@@ -341,8 +343,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getNotRepairableForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.NOT_REPAIRABLE_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.NOT_REPAIRABLE_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setNotRepairableForeground(Color value) {
@@ -350,8 +352,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getNotRepairableBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.NOT_REPAIRABLE_BACKGROUND,
-                0xFFBE9637));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.NOT_REPAIRABLE_BACKGROUND, 0xFFBE9637));
     }
 
     public void setNotRepairableBackground(Color value) {
@@ -359,8 +361,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getNonFunctionalForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.NON_FUNCTIONAL_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.NON_FUNCTIONAL_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setNonFunctionalForeground(Color value) {
@@ -368,8 +370,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getNonFunctionalBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.NON_FUNCTIONAL_BACKGROUND,
-                0xFFCD5C5C));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.NON_FUNCTIONAL_BACKGROUND, 0xFFCD5C5C));
     }
 
     public void setNonFunctionalBackground(Color value) {
@@ -378,27 +380,27 @@ public final class MHQOptions extends SuiteOptions {
 
     public Color getNeedsPartsFixedForeground() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getInt(MHQConstants.NEEDS_PARTS_FIXED_FOREGROUND, Color.BLACK.getRGB()));
+                               .getInt(MHQConstants.NEEDS_PARTS_FIXED_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setNeedsPartsFixedForeground(Color value) {
-        userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.NEEDS_PARTS_FIXED_FOREGROUND,
-                value.getRGB());
+        userPreferences.node(MHQConstants.DISPLAY_NODE)
+              .putInt(MHQConstants.NEEDS_PARTS_FIXED_FOREGROUND, value.getRGB());
     }
 
     public Color getNeedsPartsFixedBackground() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getInt(MHQConstants.NEEDS_PARTS_FIXED_BACKGROUND, 0xFFEEEE00));
+                               .getInt(MHQConstants.NEEDS_PARTS_FIXED_BACKGROUND, 0xFFEEEE00));
     }
 
     public void setNeedsPartsFixedBackground(Color value) {
-        userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.NEEDS_PARTS_FIXED_BACKGROUND,
-                value.getRGB());
+        userPreferences.node(MHQConstants.DISPLAY_NODE)
+              .putInt(MHQConstants.NEEDS_PARTS_FIXED_BACKGROUND, value.getRGB());
     }
 
     public Color getUnmaintainedForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.UNMAINTAINED_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.UNMAINTAINED_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setUnmaintainedForeground(Color value) {
@@ -406,8 +408,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getUnmaintainedBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.UNMAINTAINED_BACKGROUND,
-                Color.ORANGE.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.UNMAINTAINED_BACKGROUND, Color.ORANGE.getRGB()));
     }
 
     public void setUnmaintainedBackground(Color value) {
@@ -415,8 +417,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getUncrewedForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.UNCREWED_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.UNCREWED_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setUncrewedForeground(Color value) {
@@ -424,8 +426,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getUncrewedBackground() {
-        return new Color(
-                userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.UNCREWED_BACKGROUND, 0xFFDA82FF));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.UNCREWED_BACKGROUND, 0xFFDA82FF));
     }
 
     public void setUncrewedBackground(Color value) {
@@ -433,8 +435,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getLoanOverdueForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.LOAN_OVERDUE_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.LOAN_OVERDUE_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setLoanOverdueForeground(Color value) {
@@ -442,8 +444,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getLoanOverdueBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.LOAN_OVERDUE_BACKGROUND,
-                Color.RED.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.LOAN_OVERDUE_BACKGROUND, Color.RED.getRGB()));
     }
 
     public void setLoanOverdueBackground(Color value) {
@@ -451,8 +453,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getInjuredForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.INJURED_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.INJURED_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setInjuredForeground(Color value) {
@@ -460,8 +462,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getInjuredBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.INJURED_BACKGROUND,
-                Color.RED.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.INJURED_BACKGROUND, Color.RED.getRGB()));
     }
 
     public void setInjuredBackground(Color value) {
@@ -469,8 +471,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getHealedInjuriesForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.HEALED_INJURIES_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.HEALED_INJURIES_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setHealedInjuriesForeground(Color value) {
@@ -478,8 +480,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getHealedInjuriesBackground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.HEALED_INJURIES_BACKGROUND,
-                0xEE9A00));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.HEALED_INJURIES_BACKGROUND, 0xEE9A00));
     }
 
     public void setHealedInjuriesBackground(Color value) {
@@ -487,8 +489,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getPregnantForeground() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.PREGNANT_FOREGROUND,
-                Color.BLACK.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.PREGNANT_FOREGROUND, Color.BLACK.getRGB()));
     }
 
     public void setPregnantForeground(Color value) {
@@ -496,8 +498,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getPregnantBackground() {
-        return new Color(
-                userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.PREGNANT_BACKGROUND, 0X2BAD43));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.PREGNANT_BACKGROUND, 0X2BAD43));
     }
 
     public void setPregnantBackground(Color value) {
@@ -505,8 +507,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getGoneForeground() {
-        return new Color(
-                userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.GONE_FOREGROUND, 0xffffff));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.GONE_FOREGROUND, 0xffffff));
     }
 
     public void setGoneForeground(Color value) {
@@ -514,8 +516,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getGoneBackground() {
-        return new Color(
-                userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.GONE_BACKGROUND, 0x222222));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.GONE_BACKGROUND, 0x222222));
     }
 
     public void setGoneBackground(Color value) {
@@ -523,8 +525,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getAbsentForeground() {
-        return new Color(
-                userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.ABSENT_FOREGROUND, 0x000000));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.ABSENT_FOREGROUND, 0x000000));
     }
 
     public void setAbsentForeground(Color value) {
@@ -532,8 +534,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getAbsentBackground() {
-        return new Color(
-                userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.ABSENT_BACKGROUND, 0xffffff));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.ABSENT_BACKGROUND, 0xffffff));
     }
 
     public void setAbsentBackground(Color value) {
@@ -541,8 +543,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getFatiguedForeground() {
-        return new Color(
-                userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.FATIGUED_FOREGROUND, 0x000000));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.FATIGUED_FOREGROUND, 0x000000));
     }
 
     public void setFatiguedForeground(Color value) {
@@ -550,8 +552,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getFatiguedBackground() {
-        return new Color(
-                userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.FATIGUED_BACKGROUND, 0xeeee00));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.FATIGUED_BACKGROUND, 0xeeee00));
     }
 
     public void setFatiguedBackground(Color value) {
@@ -560,17 +562,17 @@ public final class MHQOptions extends SuiteOptions {
 
     public Color getStratConHexCoordForeground() {
         return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
-                .getInt(MHQConstants.STRATCON_HEX_COORD_FOREGROUND, Color.GREEN.getRGB()));
+                               .getInt(MHQConstants.STRATCON_HEX_COORD_FOREGROUND, Color.GREEN.getRGB()));
     }
 
     public void setStratConHexCoordForeground(Color value) {
-        userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.STRATCON_HEX_COORD_FOREGROUND,
-                value.getRGB());
+        userPreferences.node(MHQConstants.DISPLAY_NODE)
+              .putInt(MHQConstants.STRATCON_HEX_COORD_FOREGROUND, value.getRGB());
     }
 
     public Color getFontColorNegative() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.FONT_COLOR_NEGATIVE,
-                Color.RED.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.FONT_COLOR_NEGATIVE, Color.RED.getRGB()));
     }
 
     /**
@@ -585,8 +587,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getFontColorPositive() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.FONT_COLOR_POSITIVE,
-                Color.GREEN.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.FONT_COLOR_POSITIVE, Color.GREEN.getRGB()));
     }
 
     /**
@@ -601,8 +603,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getFontColorWarning() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.FONT_COLOR_WARNING,
-                Color.ORANGE.getRGB()));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.FONT_COLOR_WARNING, Color.ORANGE.getRGB()));
     }
 
     /**
@@ -618,8 +620,8 @@ public final class MHQOptions extends SuiteOptions {
 
 
     public Color getFontColorSkillUltraGreen() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.FONT_COLOR_SKILL_ULTRAGREEN,
-                0xDF5341));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.FONT_COLOR_SKILL_ULTRAGREEN, 0xDF5341));
     }
 
     /**
@@ -630,12 +632,13 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public void setFontColorSkillUltraGreen(Color value) {
-        userPreferences.node(MHQConstants.DISPLAY_NODE).putInt(MHQConstants.FONT_COLOR_SKILL_ULTRAGREEN, value.getRGB());
+        userPreferences.node(MHQConstants.DISPLAY_NODE)
+              .putInt(MHQConstants.FONT_COLOR_SKILL_ULTRAGREEN, value.getRGB());
     }
 
     public Color getFontColorSkillGreen() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.FONT_COLOR_SKILL_GREEN,
-                0xCFAB43));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.FONT_COLOR_SKILL_GREEN, 0xCFAB43));
     }
 
     /**
@@ -650,8 +653,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getFontColorSkillRegular() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.FONT_COLOR_SKILL_REGULAR,
-                0x7FCF43));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.FONT_COLOR_SKILL_REGULAR, 0x7FCF43));
     }
 
     /**
@@ -666,8 +669,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getFontColorSkillVeteran() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.FONT_COLOR_SKILL_VETERAN,
-                0x5CE8E0));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.FONT_COLOR_SKILL_VETERAN, 0x5CE8E0));
     }
 
     /**
@@ -682,8 +685,8 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public Color getFontColorSkillElite() {
-        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE).getInt(MHQConstants.FONT_COLOR_SKILL_ELITE,
-                0xC344C3));
+        return new Color(userPreferences.node(MHQConstants.DISPLAY_NODE)
+                               .getInt(MHQConstants.FONT_COLOR_SKILL_ELITE, 0xC344C3));
     }
 
     /**
@@ -702,6 +705,7 @@ public final class MHQOptions extends SuiteOptions {
      * Converts the font color to a hexadecimal color representation.
      *
      * @param color the font color to convert
+     *
      * @return the hexadecimal color representation of the font color
      */
     public String convertFontColorToHexColor(Color color) {
@@ -715,8 +719,8 @@ public final class MHQOptions extends SuiteOptions {
 
     // region Fonts
     public String getMedicalViewDialogHandwritingFont() {
-        return userPreferences.node(MHQConstants.FONTS_NODE).get(MHQConstants.MEDICAL_VIEW_DIALOG_HANDWRITING_FONT,
-                "Angelina");
+        return userPreferences.node(MHQConstants.FONTS_NODE)
+                     .get(MHQConstants.MEDICAL_VIEW_DIALOG_HANDWRITING_FONT, "Angelina");
     }
 
     public void setMedicalViewDialogHandwritingFont(final String value) {
@@ -765,18 +769,43 @@ public final class MHQOptions extends SuiteOptions {
         userPreferences.node(MHQConstants.AUTOSAVE_NODE).putBoolean(MHQConstants.SAVE_YEARLY_KEY, value);
     }
 
+
+    /**
+     * @deprecated use {@link #getAutosaveBeforeScenariosValue()} instead.
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     public boolean getAutosaveBeforeMissionsValue() {
-        return userPreferences.node(MHQConstants.AUTOSAVE_NODE).getBoolean(MHQConstants.SAVE_BEFORE_MISSIONS_KEY,
-                true);
+        return getAutosaveBeforeScenariosValue();
     }
 
+    /**
+     * @deprecated use {@link #setAutosaveBeforeScenariosValue(boolean)} instead.
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     public void setAutosaveBeforeMissionsValue(boolean value) {
-        userPreferences.node(MHQConstants.AUTOSAVE_NODE).putBoolean(MHQConstants.SAVE_BEFORE_MISSIONS_KEY, value);
+        setAutosaveBeforeScenariosValue(value);
+    }
+
+    public boolean getAutosaveBeforeScenariosValue() {
+        return userPreferences.node(MHQConstants.AUTOSAVE_NODE)
+                     .getBoolean(MHQConstants.SAVE_BEFORE_SCENARIOS_KEY, true);
+    }
+
+    public void setAutosaveBeforeScenariosValue(boolean value) {
+        userPreferences.node(MHQConstants.AUTOSAVE_NODE).putBoolean(MHQConstants.SAVE_BEFORE_SCENARIOS_KEY, value);
+    }
+
+    public boolean getAutosaveBeforeMissionEndValue() {
+        return userPreferences.node(MHQConstants.AUTOSAVE_NODE).getBoolean(MHQConstants.SAVE_BEFORE_MISSION_END, false);
+    }
+
+    public void setAutosaveBeforeMissionEndValue(boolean value) {
+        userPreferences.node(MHQConstants.AUTOSAVE_NODE).putBoolean(MHQConstants.SAVE_BEFORE_MISSION_END, value);
     }
 
     public int getMaximumNumberOfAutosavesValue() {
-        return userPreferences.node(MHQConstants.AUTOSAVE_NODE).getInt(MHQConstants.MAXIMUM_NUMBER_SAVES_KEY,
-                MHQConstants.DEFAULT_NUMBER_SAVES);
+        return userPreferences.node(MHQConstants.AUTOSAVE_NODE)
+                     .getInt(MHQConstants.MAXIMUM_NUMBER_SAVES_KEY, MHQConstants.DEFAULT_NUMBER_SAVES);
     }
 
     public void setMaximumNumberOfAutosavesValue(int value) {
@@ -810,52 +839,52 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public boolean getNewDayOptimizeMedicalAssignments() {
-        return userPreferences.node(MHQConstants.NEW_DAY_NODE).getBoolean(MHQConstants.NEW_DAY_OPTIMIZE_MEDICAL_ASSIGNMENTS, false);
+        return userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                     .getBoolean(MHQConstants.NEW_DAY_OPTIMIZE_MEDICAL_ASSIGNMENTS, false);
     }
 
     public void setNewDayOptimizeMedicalAssignments(final boolean value) {
-        userPreferences.node(MHQConstants.NEW_DAY_NODE).putBoolean(MHQConstants.NEW_DAY_OPTIMIZE_MEDICAL_ASSIGNMENTS, value);
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_OPTIMIZE_MEDICAL_ASSIGNMENTS, value);
     }
 
     public boolean getNewDayForceIconOperationalStatus() {
         return userPreferences.node(MHQConstants.NEW_DAY_NODE)
-                .getBoolean(MHQConstants.NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS, true);
+                     .getBoolean(MHQConstants.NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS, true);
     }
 
     public void setNewDayForceIconOperationalStatus(final boolean value) {
-        userPreferences.node(MHQConstants.NEW_DAY_NODE).putBoolean(MHQConstants.NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS,
-                value);
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .putBoolean(MHQConstants.NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS, value);
     }
 
     public ForceIconOperationalStatusStyle getNewDayForceIconOperationalStatusStyle() {
-        return ForceIconOperationalStatusStyle.valueOf(userPreferences.node(MHQConstants.NEW_DAY_NODE).get(
-                MHQConstants.NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS_STYLE,
-                ForceIconOperationalStatusStyle.BORDER.name()));
+        return ForceIconOperationalStatusStyle.valueOf(userPreferences.node(MHQConstants.NEW_DAY_NODE)
+                                                             .get(MHQConstants.NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS_STYLE,
+                                                                   ForceIconOperationalStatusStyle.BORDER.name()));
     }
 
     public void setNewDayForceIconOperationalStatusStyle(final ForceIconOperationalStatusStyle value) {
-        userPreferences.node(MHQConstants.NEW_DAY_NODE).put(MHQConstants.NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS_STYLE,
-                value.name());
+        userPreferences.node(MHQConstants.NEW_DAY_NODE)
+              .put(MHQConstants.NEW_DAY_FORCE_ICON_OPERATIONAL_STATUS_STYLE, value.name());
     }
     // endregion New Day
 
     // region Campaign XML Save Options
+
     /**
-     * @return A value indicating if the campaign should be written to a gzipped
-     *         file, if possible.
+     * @return A value indicating if the campaign should be written to a gzipped file, if possible.
      */
     public boolean getPreferGzippedOutput() {
-        return userPreferences.node(MHQConstants.XML_SAVES_NODE).getBoolean(MHQConstants.PREFER_GZIPPED_CAMPAIGN_FILE,
-                true);
+        return userPreferences.node(MHQConstants.XML_SAVES_NODE)
+                     .getBoolean(MHQConstants.PREFER_GZIPPED_CAMPAIGN_FILE, true);
     }
 
     /**
-     * Sets a hint indicating that the campaign should be gzipped, if possible.
-     * This allows the Save dialog to present the user with the correct file
-     * type on subsequent saves.
+     * Sets a hint indicating that the campaign should be gzipped, if possible. This allows the Save dialog to present
+     * the user with the correct file type on subsequent saves.
      *
-     * @param value A value indicating whether or not the campaign should be gzipped
-     *              if possible.
+     * @param value A value indicating whether or not the campaign should be gzipped if possible.
      */
     public void setPreferGzippedOutput(boolean value) {
         userPreferences.node(MHQConstants.XML_SAVES_NODE).putBoolean(MHQConstants.PREFER_GZIPPED_CAMPAIGN_FILE, value);
@@ -879,61 +908,55 @@ public final class MHQOptions extends SuiteOptions {
     // endregion Campaign XML Save Options
 
     // region File Paths
+
     /**
-     * @return the path of the folder to load when loading or saving bulk rank
-     *         systems
+     * @return the path of the folder to load when loading or saving bulk rank systems
      */
     public String getRankSystemsPath() {
-        return userPreferences.node(MHQConstants.FILE_PATH_NODE).get(MHQConstants.RANK_SYSTEMS_DIRECTORY_PATH,
-                "userdata/data/universe/");
+        return userPreferences.node(MHQConstants.FILE_PATH_NODE)
+                     .get(MHQConstants.RANK_SYSTEMS_DIRECTORY_PATH, "userdata/data/universe/");
     }
 
     /**
-     * This sets the path where one saves or loads their rank systems from, as this
-     * is not required
-     * for any data but improves UX.
+     * This sets the path where one saves or loads their rank systems from, as this is not required for any data but
+     * improves UX.
      *
-     * @param value the path where the person saved their last bulk rank system
-     *              export
+     * @param value the path where the person saved their last bulk rank system export
      */
     public void setRankSystemsPath(final String value) {
         userPreferences.node(MHQConstants.FILE_PATH_NODE).put(MHQConstants.RANK_SYSTEMS_DIRECTORY_PATH, value);
     }
 
     /**
-     * @return the path of the folder to load when loading or saving an individual
-     *         rank system
+     * @return the path of the folder to load when loading or saving an individual rank system
      */
     public String getIndividualRankSystemPath() {
-        return userPreferences.node(MHQConstants.FILE_PATH_NODE).get(MHQConstants.INDIVIDUAL_RANK_SYSTEM_DIRECTORY_PATH,
-                "userdata/data/universe/");
+        return userPreferences.node(MHQConstants.FILE_PATH_NODE)
+                     .get(MHQConstants.INDIVIDUAL_RANK_SYSTEM_DIRECTORY_PATH, "userdata/data/universe/");
     }
 
     /**
-     * This sets the path where one saves or loads their individual rank system, as
-     * this is not
-     * required for any data but improves UX.
+     * This sets the path where one saves or loads their individual rank system, as this is not required for any data
+     * but improves UX.
      *
-     * @param value the path where the person saved their last individual rank
-     *              system.
+     * @param value the path where the person saved their last individual rank system.
      */
     public void setIndividualRankSystemPath(final String value) {
-        userPreferences.node(MHQConstants.FILE_PATH_NODE).put(MHQConstants.INDIVIDUAL_RANK_SYSTEM_DIRECTORY_PATH,
-                value);
+        userPreferences.node(MHQConstants.FILE_PATH_NODE)
+              .put(MHQConstants.INDIVIDUAL_RANK_SYSTEM_DIRECTORY_PATH, value);
     }
 
     /**
      * @return the path of the folder to load when exporting a unit sprite
      */
     public String getUnitSpriteExportPath() {
-        return userPreferences.node(MHQConstants.FILE_PATH_NODE).get(MHQConstants.UNIT_SPRITE_EXPORT_DIRECTORY_PATH,
-                "");
+        return userPreferences.node(MHQConstants.FILE_PATH_NODE)
+                     .get(MHQConstants.UNIT_SPRITE_EXPORT_DIRECTORY_PATH, "");
     }
 
     /**
-     * This sets the path where one saves their unit sprite during export, as this
-     * is not
-     * required for any data but improves UX.
+     * This sets the path where one saves their unit sprite during export, as this is not required for any data but
+     * improves UX.
      *
      * @param value the path where the person saved their last unit sprite export
      */
@@ -945,25 +968,23 @@ public final class MHQOptions extends SuiteOptions {
      * @return the path of the folder to load when exporting a layered force icon
      */
     public String getLayeredForceIconPath() {
-        return userPreferences.node(MHQConstants.FILE_PATH_NODE).get(MHQConstants.LAYERED_FORCE_ICON_DIRECTORY_PATH,
-                "userdata/data/images/force/");
+        return userPreferences.node(MHQConstants.FILE_PATH_NODE)
+                     .get(MHQConstants.LAYERED_FORCE_ICON_DIRECTORY_PATH, "userdata/data/images/force/");
     }
 
     /**
-     * This sets the path where one saves their layered force icon during export, as
-     * this is not
-     * required for any data but improves UX.
+     * This sets the path where one saves their layered force icon during export, as this is not required for any data
+     * but improves UX.
      *
-     * @param value the path where the person saved their last layered force icon
-     *              export
+     * @param value the path where the person saved their last layered force icon export
      */
     public void setLayeredForceIconPath(final String value) {
         userPreferences.node(MHQConstants.FILE_PATH_NODE).put(MHQConstants.LAYERED_FORCE_ICON_DIRECTORY_PATH, value);
     }
 
     public String getCompanyGenerationDirectoryPath() {
-        return userPreferences.node(MHQConstants.FILE_PATH_NODE).get(MHQConstants.COMPANY_GENERATION_DIRECTORY_PATH,
-                "mmconf/mhqCompanyGenerationPresets/");
+        return userPreferences.node(MHQConstants.FILE_PATH_NODE)
+                     .get(MHQConstants.COMPANY_GENERATION_DIRECTORY_PATH, "mmconf/mhqCompanyGenerationPresets/");
     }
 
     public void setCompanyGenerationDirectoryPath(final String value) {
@@ -995,48 +1016,49 @@ public final class MHQOptions extends SuiteOptions {
     }
 
     public void setStartGameClientDelay(final int startGameClientDelay) {
-        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE).putInt(MHQConstants.START_GAME_CLIENT_DELAY,
-                startGameClientDelay);
+        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
+              .putInt(MHQConstants.START_GAME_CLIENT_DELAY, startGameClientDelay);
     }
 
     public int getStartGameClientRetryCount() {
-        return userPreferences.node(MHQConstants.MISCELLANEOUS_NODE).getInt(MHQConstants.START_GAME_CLIENT_RETRY_COUNT,
-                1000);
+        return userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
+                     .getInt(MHQConstants.START_GAME_CLIENT_RETRY_COUNT, 1000);
     }
 
     public void setStartGameClientRetryCount(final int startGameClientRetryCount) {
-        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE).putInt(MHQConstants.START_GAME_CLIENT_RETRY_COUNT,
-                startGameClientRetryCount);
+        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
+              .putInt(MHQConstants.START_GAME_CLIENT_RETRY_COUNT, startGameClientRetryCount);
     }
 
     public int getStartGameBotClientDelay() {
-        return userPreferences.node(MHQConstants.MISCELLANEOUS_NODE).getInt(MHQConstants.START_GAME_BOT_CLIENT_DELAY,
-                50);
+        return userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
+                     .getInt(MHQConstants.START_GAME_BOT_CLIENT_DELAY, 50);
     }
 
     public void setStartGameBotClientDelay(final int startGameBotClientDelay) {
-        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE).putInt(MHQConstants.START_GAME_BOT_CLIENT_DELAY,
-                startGameBotClientDelay);
+        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
+              .putInt(MHQConstants.START_GAME_BOT_CLIENT_DELAY, startGameBotClientDelay);
     }
 
     public int getStartGameBotClientRetryCount() {
         return userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
-                .getInt(MHQConstants.START_GAME_BOT_CLIENT_RETRY_COUNT, 250);
+                     .getInt(MHQConstants.START_GAME_BOT_CLIENT_RETRY_COUNT, 250);
     }
 
     public void setStartGameBotClientRetryCount(final int startGameBotClientRetryCount) {
-        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE).putInt(MHQConstants.START_GAME_BOT_CLIENT_RETRY_COUNT,
-                startGameBotClientRetryCount);
+        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
+              .putInt(MHQConstants.START_GAME_BOT_CLIENT_RETRY_COUNT, startGameBotClientRetryCount);
     }
 
     public CompanyGenerationMethod getDefaultCompanyGenerationMethod() {
         return CompanyGenerationMethod.valueOf(userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
-                .get(MHQConstants.DEFAULT_COMPANY_GENERATION_METHOD, CompanyGenerationMethod.WINDCHILD.name()));
+                                                     .get(MHQConstants.DEFAULT_COMPANY_GENERATION_METHOD,
+                                                           CompanyGenerationMethod.WINDCHILD.name()));
     }
 
     public void setDefaultCompanyGenerationMethod(final CompanyGenerationMethod value) {
-        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE).put(MHQConstants.DEFAULT_COMPANY_GENERATION_METHOD,
-                value.name());
+        userPreferences.node(MHQConstants.MISCELLANEOUS_NODE)
+              .put(MHQConstants.DEFAULT_COMPANY_GENERATION_METHOD, value.name());
     }
     // endregion Miscellaneous Options
 }

--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -224,6 +224,18 @@ public class MekHQ implements GameListener {
     }
 
     /**
+     * Retrieves the autosave service instance associated with this instance of {@link MekHQ}.
+     *
+     * <p>This service is responsible for handling autosave operations, such as saving the current state
+     * of the campaign or mission. It provides an interface to manage autosave requests.</p>
+     *
+     * @return the {@link IAutosaveService} instance responsible for managing autosave operations.
+     */
+    public IAutosaveService getAutosaveService() {
+        return autosaveService;
+    }
+
+    /**
      * These need to be migrated to the Suite Constants / Suite Options Setup
      *
      * @since 50.04
@@ -433,7 +445,8 @@ public class MekHQ implements GameListener {
      * @param autoResolveBehaviorSettings The auto resolve behavior settings to use if running an AtB scenario and auto
      *                                    resolve is wanted
      */
-    public void startHost(Scenario scenario, boolean loadSavegame, List<Unit> meks, @Nullable BehaviorSettings autoResolveBehaviorSettings) {
+    public void startHost(Scenario scenario, boolean loadSavegame, List<Unit> meks,
+                          @Nullable BehaviorSettings autoResolveBehaviorSettings) {
         HostDialog hostDialog = new HostDialog(campaignGUI.getFrame(), getCampaign().getName());
         hostDialog.setVisible(true);
 
@@ -442,7 +455,7 @@ public class MekHQ implements GameListener {
             return;
         }
 
-        this.autosaveService.requestBeforeMissionAutosave(getCampaign());
+        this.autosaveService.requestBeforeScenarioAutosave(getCampaign());
 
         final String playerName = hostDialog.getPlayerName();
         final String password = hostDialog.getServerPass();
@@ -719,7 +732,7 @@ public class MekHQ implements GameListener {
      */
     public void startAutoResolve(AtBScenario scenario, List<Unit> units) {
 
-        this.autosaveService.requestBeforeMissionAutosave(getCampaign());
+        this.autosaveService.requestBeforeScenarioAutosave(getCampaign());
 
         if (getCampaign().getCampaignOptions().isAutoResolveVictoryChanceEnabled()) {
             var proceed = AutoResolveChanceDialog.showDialog(campaignGUI.getFrame(),

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -387,8 +387,6 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     private void completeMission() {
-        ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI", MekHQ.getMHQOptions().getLocale());
-
         final Mission mission = comboMission.getSelectedItem();
 
         if (mission == null) {
@@ -400,6 +398,8 @@ public final class BriefingTab extends CampaignGuiTab {
                   JOptionPane.WARNING_MESSAGE);
             return;
         }
+
+        getCampaign().getApp().getAutosaveService().requestBeforeMissionEndAutosave(getCampaign());
 
         final CompleteMissionDialog cmd = new CompleteMissionDialog(getFrame());
         if (!cmd.showDialog().isConfirmed()) {

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -27,6 +27,20 @@
  */
 package mekhq.gui.dialog;
 
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.FlowLayout;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Hashtable;
+import java.util.Objects;
+import javax.swing.*;
+import javax.swing.GroupLayout.Alignment;
+
 import megamek.MMConstants;
 import megamek.client.ui.Messages;
 import megamek.client.ui.baseComponents.MMComboBox;
@@ -47,1686 +61,1592 @@ import mekhq.gui.enums.ForceIconOperationalStatusStyle;
 import mekhq.gui.enums.PersonnelFilterStyle;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
 
-import javax.swing.*;
-import javax.swing.GroupLayout.Alignment;
-import java.awt.*;
-import java.awt.event.KeyEvent;
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.Hashtable;
-import java.util.Objects;
-
 /**
- * MHQOptionsDialog is a dialog that allows the user to configure various options in MegaMekHQ.
- * It extends the {@link AbstractMHQButtonDialog} class and inherits its common dialog features.
- * The dialog allows configuration of options related to display, colors, fonts, autosave,
- * startup behavior, notifications, and various other miscellaneous options.
+ * MHQOptionsDialog is a dialog that allows the user to configure various options in MegaMekHQ. It extends the
+ * {@link AbstractMHQButtonDialog} class and inherits its common dialog features. The dialog allows configuration of
+ * options related to display, colors, fonts, autosave, startup behavior, notifications, and various other miscellaneous
+ * options.
  * <p>
  * To create an instance of MHQOptionsDialog, invoke one of its constructors with a frame as a parameter.
  * <p>
- * Example Usage:
- * JFrame frame = new JFrame("Main Frame");
- * MHQOptionsDialog dialog = new MHQOptionsDialog(frame);
+ * Example Usage: JFrame frame = new JFrame("Main Frame"); MHQOptionsDialog dialog = new MHQOptionsDialog(frame);
  * dialog.setVisible(true);
  * <p>
  * This dialog uses the following Mnemonics: C, D, M, M, S, U, W, Y
  */
 public class MHQOptionsDialog extends AbstractMHQButtonDialog {
-        private static final MMLogger logger = MMLogger.create(MHQOptionsDialog.class);
+    private static final MMLogger logger = MMLogger.create(MHQOptionsDialog.class);
 
-        // region Variable Declaration
-        // region Display
-        private JTextField optionDisplayDateFormat;
-        private JTextField optionLongDisplayDateFormat;
-        private final JSlider guiScale = new JSlider();
-        private JCheckBox optionHistoricalDailyLog;
-        private JCheckBox chkCompanyGeneratorStartup;
-        private JCheckBox chkShowCompanyGenerator;
-        private JCheckBox chkShowUnitPicturesOnTOE;
+    // region Variable Declaration
+    // region Display
+    private JTextField optionDisplayDateFormat;
+    private JTextField optionLongDisplayDateFormat;
+    private final JSlider guiScale = new JSlider();
+    private JCheckBox optionHistoricalDailyLog;
+    private JCheckBox chkCompanyGeneratorStartup;
+    private JCheckBox chkShowCompanyGenerator;
+    private JCheckBox chkShowUnitPicturesOnTOE;
+
+    // region Command Center Tab
+    private JCheckBox optionCommandCenterUseUnitMarket;
+    private JCheckBox optionCommandCenterMRMS;
+    // endregion Command Center Tab
+
+    // region Interstellar Map Tab
+    private JCheckBox chkInterstellarMapShowJumpRadius;
+    private JSpinner spnInterstellarMapShowJumpRadiusMinimumZoom;
+    private ColourSelectorButton btnInterstellarMapJumpRadiusColour;
+    private JCheckBox chkInterstellarMapShowPlanetaryAcquisitionRadius;
+    private JSpinner spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom;
+    private ColourSelectorButton btnInterstellarMapPlanetaryAcquisitionRadiusColour;
+    private JCheckBox chkInterstellarMapShowContractSearchRadius;
+    private ColourSelectorButton btnInterstellarMapContractSearchRadiusColour;
+    // endregion Interstellar Map Tab
+
+    // region Personnel Tab
+    private JComboBox<PersonnelFilterStyle> optionPersonnelFilterStyle;
+    private JCheckBox optionPersonnelFilterOnPrimaryRole;
+    // endregion Personnel Tab
+    // endregion Display
+
+    // region Colours
+    private ColourSelectorButton optionDeployedForeground;
+    private ColourSelectorButton optionDeployedBackground;
+    private ColourSelectorButton optionBelowContractMinimumForeground;
+    private ColourSelectorButton optionBelowContractMinimumBackground;
+    private ColourSelectorButton optionInTransitForeground;
+    private ColourSelectorButton optionInTransitBackground;
+    private ColourSelectorButton optionRefittingForeground;
+    private ColourSelectorButton optionRefittingBackground;
+    private ColourSelectorButton optionMothballingForeground;
+    private ColourSelectorButton optionMothballingBackground;
+    private ColourSelectorButton optionMothballedForeground;
+    private ColourSelectorButton optionMothballedBackground;
+    private ColourSelectorButton optionNotRepairableForeground;
+    private ColourSelectorButton optionNotRepairableBackground;
+    private ColourSelectorButton optionNonFunctionalForeground;
+    private ColourSelectorButton optionNonFunctionalBackground;
+    private ColourSelectorButton optionNeedsPartsFixedForeground;
+    private ColourSelectorButton optionNeedsPartsFixedBackground;
+    private ColourSelectorButton optionUnmaintainedForeground;
+    private ColourSelectorButton optionUnmaintainedBackground;
+    private ColourSelectorButton optionUncrewedForeground;
+    private ColourSelectorButton optionUncrewedBackground;
+    private ColourSelectorButton optionLoanOverdueForeground;
+    private ColourSelectorButton optionLoanOverdueBackground;
+    private ColourSelectorButton optionInjuredForeground;
+    private ColourSelectorButton optionInjuredBackground;
+    private ColourSelectorButton optionHealedInjuriesForeground;
+    private ColourSelectorButton optionHealedInjuriesBackground;
+    private ColourSelectorButton optionPregnantForeground;
+    private ColourSelectorButton optionPregnantBackground;
+    private ColourSelectorButton optionGoneForeground;
+    private ColourSelectorButton optionGoneBackground;
+    private ColourSelectorButton optionAbsentForeground;
+    private ColourSelectorButton optionAbsentBackground;
+    private ColourSelectorButton optionFatiguedForeground;
+    private ColourSelectorButton optionFatiguedBackground;
+    private ColourSelectorButton optionStratConHexCoordForeground;
+    private ColourSelectorButton optionFontColorNegative;
+    private ColourSelectorButton optionFontColorWarning;
+    private ColourSelectorButton optionFontColorPositive;
+    private ColourSelectorButton optionFontColorSkillUltraGreen;
+    private ColourSelectorButton optionFontColorSkillGreen;
+    private ColourSelectorButton optionFontColorSkillRegular;
+    private ColourSelectorButton optionFontColorSkillVeteran;
+    private ColourSelectorButton optionFontColorSkillElite;
+    // endregion Colors
+
+    // region Fonts
+    private FontComboBox comboMedicalViewDialogHandwritingFont;
+    // endregion Fonts
+
+    // region Autosave
+    private JRadioButton optionNoSave;
+    private JRadioButton optionSaveDaily;
+    private JRadioButton optionSaveWeekly;
+    private JRadioButton optionSaveMonthly;
+    private JRadioButton optionSaveYearly;
+    private JCheckBox checkSaveBeforeScenarios;
+    private JCheckBox checkSaveBeforeContractEnd;
+    private JSpinner spinnerSavedGamesCount;
+    // endregion Autosave
+
+    // region New Day
+    private JCheckBox chkNewDayAstechPoolFill;
+    private JCheckBox chkNewDayMedicPoolFill;
+    private JCheckBox chkNewDayMRMS;
+    private JCheckBox chkNewDayOptimizeMedicalAssignments;
+    private JCheckBox chkNewDayForceIconOperationalStatus;
+    private MMComboBox<ForceIconOperationalStatusStyle> comboNewDayForceIconOperationalStatusStyle;
+    // endregion New Day
+
+    // region Campaign XML Save
+    private JCheckBox optionPreferGzippedOutput;
+    private JCheckBox optionWriteCustomsToXML;
+    private JCheckBox optionSaveMothballState;
+    // endregion Campaign XML Save
+
+    // region Nag Tab
+    private JCheckBox optionUnmaintainedUnitsNag;
+    private JCheckBox optionPregnantCombatantNag;
+    private JCheckBox optionPrisonersNag;
+    private JCheckBox optionAdminStrainNag;
+    private JCheckBox optionUntreatedPersonnelNag;
+    private JCheckBox optionNoCommanderNag;
+    private JCheckBox optionContractEndedNag;
+    private JCheckBox optionInsufficientAstechsNag;
+    private JCheckBox optionInsufficientAstechTimeNag;
+    private JCheckBox optionInsufficientMedicsNag;
+    private JCheckBox optionShortDeploymentNag;
+    private JCheckBox optionUnresolvedStratConContactsNag;
+    private JCheckBox optionOutstandingScenariosNag;
+    private JCheckBox optionInvalidFactionNag;
+    private JCheckBox optionUnableToAffordExpensesNag;
+    private JCheckBox optionUnableToAffordLoanPaymentNag;
+    private JCheckBox optionUnableToAffordJumpNag;
+    // endregion Nag Tab
+
+    // region Miscellaneous
+    private JTextField txtUserDir;
+    private JSpinner spnStartGameDelay;
+    private JSpinner spnStartGameClientDelay;
+    private JSpinner spnStartGameClientRetryCount;
+    private JSpinner spnStartGameBotClientDelay;
+    private JSpinner spnStartGameBotClientRetryCount;
+    private MMComboBox<CompanyGenerationMethod> comboDefaultCompanyGenerationMethod;
+    // endregion Miscellaneous
+    // endregion Variable Declarations
+
+    // region Constructors
+    public MHQOptionsDialog(final JFrame frame) {
+        super(frame, true, "MHQOptionsDialog", "MHQOptionsDialog.title");
+        initialize();
+        setInitialState();
+    }
+    // endregion Constructors
+
+    // region Initialization
+
+    /**
+     * This dialog uses the following Mnemonics: C, D, M, M, S, U, W, Y
+     */
+    @Override
+    protected Container createCenterPane() {
+        JTabbedPane optionsTabbedPane = new JTabbedPane();
+        optionsTabbedPane.setName("optionsTabbedPane");
+        optionsTabbedPane.add(resources.getString("displayTab.title"), new JScrollPaneWithSpeed(createDisplayTab()));
+        optionsTabbedPane.add(resources.getString("coloursTab.title"), new JScrollPaneWithSpeed(createColoursTab()));
+        optionsTabbedPane.add(resources.getString("fontsTab.title"), new JScrollPaneWithSpeed(createFontsTab()));
+        optionsTabbedPane.add(resources.getString("autosaveTab.title"), new JScrollPaneWithSpeed(createAutosaveTab()));
+        optionsTabbedPane.add(resources.getString("newDayTab.title"), new JScrollPaneWithSpeed(createNewDayTab()));
+        optionsTabbedPane.add(resources.getString("campaignXMLSaveTab.title"),
+              new JScrollPaneWithSpeed(createCampaignXMLSaveTab()));
+        optionsTabbedPane.add(resources.getString("nagTab.title"), new JScrollPaneWithSpeed(createNagTab()));
+        optionsTabbedPane.add(resources.getString("miscellaneousTab.title"),
+              new JScrollPaneWithSpeed(createMiscellaneousTab()));
+        return optionsTabbedPane;
+    }
+
+    private JPanel createDisplayTab() {
+        guiScale.setMajorTickSpacing(3);
+        guiScale.setMinimum(7);
+        guiScale.setMaximum(24);
+        Hashtable<Integer, JComponent> table = new Hashtable<>();
+        table.put(7, new JLabel("70%"));
+        table.put(10, new JLabel("100%"));
+        table.put(16, new JLabel("160%"));
+        table.put(22, new JLabel("220%"));
+        guiScale.setLabelTable(table);
+        guiScale.setPaintTicks(true);
+        guiScale.setPaintLabels(true);
+        guiScale.setValue((int) (GUIPreferences.getInstance().getGUIScale() * 10));
+        guiScale.setToolTipText(Messages.getString("CommonSettingsDialog.guiScaleTT"));
+        JLabel guiScaleLabel = new JLabel(Messages.getString("CommonSettingsDialog.guiScale"));
+        JPanel scaleLine = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        scaleLine.add(guiScaleLabel);
+        scaleLine.add(Box.createHorizontalStrut(5));
+        scaleLine.add(guiScale);
+
+        // Initialize Components Used in ActionListeners
+        final JLabel lblInterstellarMapShowJumpRadiusMinimumZoom = new JLabel();
+        final JLabel lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom = new JLabel();
+
+        // Create Panel Components
+        JLabel labelDisplayDateFormat = new JLabel(resources.getString("labelDisplayDateFormat.text"));
+        JLabel labelDisplayDateFormatExample = new JLabel();
+        optionDisplayDateFormat = new JTextField();
+        optionDisplayDateFormat.addActionListener(evt -> labelDisplayDateFormatExample.setText(validateDateFormat(
+              optionDisplayDateFormat.getText()) ?
+                                                                                                     LocalDate.now()
+                                                                                                           .format(
+                                                                                                                 DateTimeFormatter.ofPattern(
+                                                                                                                             optionDisplayDateFormat.getText())
+                                                                                                                       .withLocale(
+                                                                                                                             MekHQ.getMHQOptions()
+                                                                                                                                   .getDateLocale())) :
+                                                                                                     resources.getString(
+                                                                                                           "invalidDateFormat.error")));
+
+        JLabel labelLongDisplayDateFormat = new JLabel(resources.getString("labelLongDisplayDateFormat.text"));
+        JLabel labelLongDisplayDateFormatExample = new JLabel();
+        optionLongDisplayDateFormat = new JTextField();
+        optionLongDisplayDateFormat.addActionListener(evt -> labelLongDisplayDateFormatExample.setText(
+              validateDateFormat(optionLongDisplayDateFormat.getText()) ?
+                    LocalDate.now()
+                          .format(DateTimeFormatter.ofPattern(optionLongDisplayDateFormat.getText())
+                                        .withLocale(MekHQ.getMHQOptions().getDateLocale())) :
+                    resources.getString("invalidDateFormat.error")));
+
+        optionHistoricalDailyLog = new JCheckBox(resources.getString("optionHistoricalDailyLog.text"));
+        optionHistoricalDailyLog.setToolTipText(resources.getString("optionHistoricalDailyLog.toolTipText"));
+
+        chkCompanyGeneratorStartup = new JCheckBox(resources.getString("chkCompanyGeneratorStartup.text"));
+        chkCompanyGeneratorStartup.setToolTipText(resources.getString("chkCompanyGeneratorStartup.toolTipText"));
+        chkCompanyGeneratorStartup.setName("chkCompanyGeneratorStartup");
+
+        chkShowCompanyGenerator = new JCheckBox(resources.getString("chkShowCompanyGenerator.text"));
+        chkShowCompanyGenerator.setToolTipText(resources.getString("chkShowCompanyGenerator.toolTipText"));
+        chkShowCompanyGenerator.setName("chkShowCompanyGenerator");
+
+        chkShowUnitPicturesOnTOE = new JCheckBox(resources.getString("chkShowUnitPicturesOnTOE.text"));
+        chkShowUnitPicturesOnTOE.setToolTipText(resources.getString("chkShowUnitPicturesOnTOE.toolTipText"));
+        chkShowUnitPicturesOnTOE.setName("chkShowUnitPicturesOnTOE");
 
         // region Command Center Tab
-        private JCheckBox optionCommandCenterUseUnitMarket;
-        private JCheckBox optionCommandCenterMRMS;
+        JLabel labelCommandCenterDisplay = new JLabel(resources.getString("labelCommandCenterDisplay.text"));
+
+        optionCommandCenterUseUnitMarket = new JCheckBox(resources.getString("optionCommandCenterUseUnitMarket.text"));
+        optionCommandCenterUseUnitMarket.setToolTipText(resources.getString(
+              "optionCommandCenterUseUnitMarket.toolTipText"));
+
+        optionCommandCenterMRMS = new JCheckBox(resources.getString("optionCommandCenterMRMS.text"));
+        optionCommandCenterMRMS.setToolTipText(resources.getString("optionCommandCenterMRMS.toolTipText"));
         // endregion Command Center Tab
 
         // region Interstellar Map Tab
-        private JCheckBox chkInterstellarMapShowJumpRadius;
-        private JSpinner spnInterstellarMapShowJumpRadiusMinimumZoom;
-        private ColourSelectorButton btnInterstellarMapJumpRadiusColour;
-        private JCheckBox chkInterstellarMapShowPlanetaryAcquisitionRadius;
-        private JSpinner spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom;
-        private ColourSelectorButton btnInterstellarMapPlanetaryAcquisitionRadiusColour;
-        private JCheckBox chkInterstellarMapShowContractSearchRadius;
-        private ColourSelectorButton btnInterstellarMapContractSearchRadiusColour;
+        final JLabel lblInterstellarMapTab = new JLabel(resources.getString("lblInterstellarMapTab.text"));
+        lblInterstellarMapTab.setName("lblInterstellarMapTab");
+
+        chkInterstellarMapShowJumpRadius = new JCheckBox(resources.getString("chkInterstellarMapShowJumpRadius.text"));
+        chkInterstellarMapShowJumpRadius.setToolTipText(resources.getString(
+              "chkInterstellarMapShowJumpRadius.toolTipText"));
+        chkInterstellarMapShowJumpRadius.setName("chkInterstellarMapShowJumpRadius");
+        chkInterstellarMapShowJumpRadius.addActionListener(evt -> {
+            final boolean selected = chkInterstellarMapShowJumpRadius.isSelected();
+            lblInterstellarMapShowJumpRadiusMinimumZoom.setEnabled(selected);
+            spnInterstellarMapShowJumpRadiusMinimumZoom.setEnabled(selected);
+            btnInterstellarMapJumpRadiusColour.setEnabled(selected);
+        });
+
+        lblInterstellarMapShowJumpRadiusMinimumZoom.setText(resources.getString(
+              "lblInterstellarMapShowJumpRadiusMinimumZoom.text"));
+        lblInterstellarMapShowJumpRadiusMinimumZoom.setToolTipText(resources.getString(
+              "lblInterstellarMapShowJumpRadiusMinimumZoom.toolTipText"));
+        lblInterstellarMapShowJumpRadiusMinimumZoom.setName("lblInterstellarMapShowJumpRadiusMinimumZoom");
+
+        spnInterstellarMapShowJumpRadiusMinimumZoom = new JSpinner(new SpinnerNumberModel(3d, 0d, 10d, 0.5));
+        spnInterstellarMapShowJumpRadiusMinimumZoom.setToolTipText(resources.getString(
+              "lblInterstellarMapShowJumpRadiusMinimumZoom.toolTipText"));
+        spnInterstellarMapShowJumpRadiusMinimumZoom.setName("spnInterstellarMapShowJumpRadiusMinimumZoom");
+
+        btnInterstellarMapJumpRadiusColour = new ColourSelectorButton(resources.getString(
+              "btnInterstellarMapJumpRadiusColour.text"));
+        btnInterstellarMapJumpRadiusColour.setToolTipText(resources.getString(
+              "btnInterstellarMapJumpRadiusColour.toolTipText"));
+        btnInterstellarMapJumpRadiusColour.setName("btnInterstellarMapJumpRadiusColour");
+
+        chkInterstellarMapShowPlanetaryAcquisitionRadius = new JCheckBox(resources.getString(
+              "chkInterstellarMapShowPlanetaryAcquisitionRadius.text"));
+        chkInterstellarMapShowPlanetaryAcquisitionRadius.setToolTipText(resources.getString(
+              "chkInterstellarMapShowPlanetaryAcquisitionRadius.toolTipText"));
+        chkInterstellarMapShowPlanetaryAcquisitionRadius.setName("chkInterstellarMapShowPlanetaryAcquisitionRadius");
+        chkInterstellarMapShowPlanetaryAcquisitionRadius.addActionListener(evt -> {
+            final boolean selected = chkInterstellarMapShowPlanetaryAcquisitionRadius.isSelected();
+            lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setEnabled(selected);
+            spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setEnabled(selected);
+            btnInterstellarMapPlanetaryAcquisitionRadiusColour.setEnabled(selected);
+        });
+
+        lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setText(resources.getString(
+              "lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.text"));
+        lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setToolTipText(resources.getString(
+              "lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.toolTipText"));
+        lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setName(
+              "lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom");
+
+        spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom = new JSpinner(new SpinnerNumberModel(2d,
+              0d,
+              10d,
+              0.5));
+        spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setToolTipText(resources.getString(
+              "lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.toolTipText"));
+        spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setName(
+              "spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom");
+
+        btnInterstellarMapPlanetaryAcquisitionRadiusColour = new ColourSelectorButton(resources.getString(
+              "btnInterstellarMapPlanetaryAcquisitionRadiusColour.text"));
+        btnInterstellarMapPlanetaryAcquisitionRadiusColour.setToolTipText(resources.getString(
+              "btnInterstellarMapPlanetaryAcquisitionRadiusColour.toolTipText"));
+        btnInterstellarMapPlanetaryAcquisitionRadiusColour.setName("btnInterstellarMapPlanetaryAcquisitionRadiusColour");
+
+        chkInterstellarMapShowContractSearchRadius = new JCheckBox(resources.getString(
+              "chkInterstellarMapShowContractSearchRadius.text"));
+        chkInterstellarMapShowContractSearchRadius.setToolTipText(resources.getString(
+              "chkInterstellarMapShowContractSearchRadius.toolTipText"));
+        chkInterstellarMapShowContractSearchRadius.setName("chkInterstellarMapShowContractSearchRadius");
+        chkInterstellarMapShowContractSearchRadius.addActionListener(evt -> btnInterstellarMapContractSearchRadiusColour.setEnabled(
+              chkInterstellarMapShowContractSearchRadius.isSelected()));
+
+        btnInterstellarMapContractSearchRadiusColour = new ColourSelectorButton(resources.getString(
+              "btnInterstellarMapContractSearchRadiusColour.text"));
+        btnInterstellarMapContractSearchRadiusColour.setToolTipText(resources.getString(
+              "btnInterstellarMapContractSearchRadiusColour.toolTipText"));
+        btnInterstellarMapContractSearchRadiusColour.setName("btnInterstellarMapContractSearchRadiusColour");
         // endregion Interstellar Map Tab
 
         // region Personnel Tab
-        private JComboBox<PersonnelFilterStyle> optionPersonnelFilterStyle;
-        private JCheckBox optionPersonnelFilterOnPrimaryRole;
-        // endregion Personnel Tab
-        // endregion Display
-
-        // region Colours
-        private ColourSelectorButton optionDeployedForeground;
-        private ColourSelectorButton optionDeployedBackground;
-        private ColourSelectorButton optionBelowContractMinimumForeground;
-        private ColourSelectorButton optionBelowContractMinimumBackground;
-        private ColourSelectorButton optionInTransitForeground;
-        private ColourSelectorButton optionInTransitBackground;
-        private ColourSelectorButton optionRefittingForeground;
-        private ColourSelectorButton optionRefittingBackground;
-        private ColourSelectorButton optionMothballingForeground;
-        private ColourSelectorButton optionMothballingBackground;
-        private ColourSelectorButton optionMothballedForeground;
-        private ColourSelectorButton optionMothballedBackground;
-        private ColourSelectorButton optionNotRepairableForeground;
-        private ColourSelectorButton optionNotRepairableBackground;
-        private ColourSelectorButton optionNonFunctionalForeground;
-        private ColourSelectorButton optionNonFunctionalBackground;
-        private ColourSelectorButton optionNeedsPartsFixedForeground;
-        private ColourSelectorButton optionNeedsPartsFixedBackground;
-        private ColourSelectorButton optionUnmaintainedForeground;
-        private ColourSelectorButton optionUnmaintainedBackground;
-        private ColourSelectorButton optionUncrewedForeground;
-        private ColourSelectorButton optionUncrewedBackground;
-        private ColourSelectorButton optionLoanOverdueForeground;
-        private ColourSelectorButton optionLoanOverdueBackground;
-        private ColourSelectorButton optionInjuredForeground;
-        private ColourSelectorButton optionInjuredBackground;
-        private ColourSelectorButton optionHealedInjuriesForeground;
-        private ColourSelectorButton optionHealedInjuriesBackground;
-        private ColourSelectorButton optionPregnantForeground;
-        private ColourSelectorButton optionPregnantBackground;
-        private ColourSelectorButton optionGoneForeground;
-        private ColourSelectorButton optionGoneBackground;
-        private ColourSelectorButton optionAbsentForeground;
-        private ColourSelectorButton optionAbsentBackground;
-        private ColourSelectorButton optionFatiguedForeground;
-        private ColourSelectorButton optionFatiguedBackground;
-        private ColourSelectorButton optionStratConHexCoordForeground;
-        private ColourSelectorButton optionFontColorNegative;
-        private ColourSelectorButton optionFontColorWarning;
-        private ColourSelectorButton optionFontColorPositive;
-        private ColourSelectorButton optionFontColorSkillUltraGreen;
-        private ColourSelectorButton optionFontColorSkillGreen;
-        private ColourSelectorButton optionFontColorSkillRegular;
-        private ColourSelectorButton optionFontColorSkillVeteran;
-        private ColourSelectorButton optionFontColorSkillElite;
-        // endregion Colors
-
-        // region Fonts
-        private FontComboBox comboMedicalViewDialogHandwritingFont;
-        // endregion Fonts
-
-        // region Autosave
-        private JRadioButton optionNoSave;
-        private JRadioButton optionSaveDaily;
-        private JRadioButton optionSaveWeekly;
-        private JRadioButton optionSaveMonthly;
-        private JRadioButton optionSaveYearly;
-        private JCheckBox checkSaveBeforeMissions;
-        private JSpinner spinnerSavedGamesCount;
-        // endregion Autosave
-
-        // region New Day
-        private JCheckBox chkNewDayAstechPoolFill;
-        private JCheckBox chkNewDayMedicPoolFill;
-        private JCheckBox chkNewDayMRMS;
-        private JCheckBox chkNewDayOptimizeMedicalAssignments;
-        private JCheckBox chkNewDayForceIconOperationalStatus;
-        private MMComboBox<ForceIconOperationalStatusStyle> comboNewDayForceIconOperationalStatusStyle;
-        // endregion New Day
-
-        // region Campaign XML Save
-        private JCheckBox optionPreferGzippedOutput;
-        private JCheckBox optionWriteCustomsToXML;
-        private JCheckBox optionSaveMothballState;
-        // endregion Campaign XML Save
-
-        // region Nag Tab
-        private JCheckBox optionUnmaintainedUnitsNag;
-        private JCheckBox optionPregnantCombatantNag;
-        private JCheckBox optionPrisonersNag;
-        private JCheckBox optionAdminStrainNag;
-        private JCheckBox optionUntreatedPersonnelNag;
-        private JCheckBox optionNoCommanderNag;
-        private JCheckBox optionContractEndedNag;
-        private JCheckBox optionInsufficientAstechsNag;
-        private JCheckBox optionInsufficientAstechTimeNag;
-        private JCheckBox optionInsufficientMedicsNag;
-        private JCheckBox optionShortDeploymentNag;
-        private JCheckBox optionUnresolvedStratConContactsNag;
-        private JCheckBox optionOutstandingScenariosNag;
-        private JCheckBox optionInvalidFactionNag;
-        private JCheckBox optionUnableToAffordExpensesNag;
-        private JCheckBox optionUnableToAffordLoanPaymentNag;
-        private JCheckBox optionUnableToAffordJumpNag;
-        // endregion Nag Tab
-
-        // region Miscellaneous
-        private JTextField txtUserDir;
-        private JSpinner spnStartGameDelay;
-        private JSpinner spnStartGameClientDelay;
-        private JSpinner spnStartGameClientRetryCount;
-        private JSpinner spnStartGameBotClientDelay;
-        private JSpinner spnStartGameBotClientRetryCount;
-        private MMComboBox<CompanyGenerationMethod> comboDefaultCompanyGenerationMethod;
-        // endregion Miscellaneous
-        // endregion Variable Declarations
-
-        // region Constructors
-        public MHQOptionsDialog(final JFrame frame) {
-                super(frame, true, "MHQOptionsDialog", "MHQOptionsDialog.title");
-                initialize();
-                setInitialState();
-        }
-        // endregion Constructors
-
-        // region Initialization
-        /**
-         * This dialog uses the following Mnemonics:
-         * C, D, M, M, S, U, W, Y
-         */
-        @Override
-        protected Container createCenterPane() {
-                JTabbedPane optionsTabbedPane = new JTabbedPane();
-                optionsTabbedPane.setName("optionsTabbedPane");
-                optionsTabbedPane.add(resources.getString("displayTab.title"),
-                                new JScrollPaneWithSpeed(createDisplayTab()));
-                optionsTabbedPane.add(resources.getString("coloursTab.title"),
-                                new JScrollPaneWithSpeed(createColoursTab()));
-                optionsTabbedPane.add(resources.getString("fontsTab.title"),
-                                new JScrollPaneWithSpeed(createFontsTab()));
-                optionsTabbedPane.add(resources.getString("autosaveTab.title"),
-                                new JScrollPaneWithSpeed(createAutosaveTab()));
-                optionsTabbedPane.add(resources.getString("newDayTab.title"),
-                                new JScrollPaneWithSpeed(createNewDayTab()));
-                optionsTabbedPane.add(resources.getString("campaignXMLSaveTab.title"),
-                                new JScrollPaneWithSpeed(createCampaignXMLSaveTab()));
-                optionsTabbedPane.add(resources.getString("nagTab.title"),
-                                new JScrollPaneWithSpeed(createNagTab()));
-                optionsTabbedPane.add(resources.getString("miscellaneousTab.title"),
-                                new JScrollPaneWithSpeed(createMiscellaneousTab()));
-                return optionsTabbedPane;
-        }
-
-        private JPanel createDisplayTab() {
-            guiScale.setMajorTickSpacing(3);
-            guiScale.setMinimum(7);
-            guiScale.setMaximum(24);
-            Hashtable<Integer, JComponent> table = new Hashtable<>();
-            table.put(7, new JLabel("70%"));
-            table.put(10, new JLabel("100%"));
-            table.put(16, new JLabel("160%"));
-            table.put(22, new JLabel("220%"));
-            guiScale.setLabelTable(table);
-            guiScale.setPaintTicks(true);
-            guiScale.setPaintLabels(true);
-            guiScale.setValue((int) (GUIPreferences.getInstance().getGUIScale() * 10));
-            guiScale.setToolTipText(Messages.getString("CommonSettingsDialog.guiScaleTT"));
-            JLabel guiScaleLabel = new JLabel(Messages.getString("CommonSettingsDialog.guiScale"));
-            JPanel scaleLine = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-            scaleLine.add(guiScaleLabel);
-            scaleLine.add(Box.createHorizontalStrut(5));
-            scaleLine.add(guiScale);
-
-                // Initialize Components Used in ActionListeners
-                final JLabel lblInterstellarMapShowJumpRadiusMinimumZoom = new JLabel();
-                final JLabel lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom = new JLabel();
-
-                // Create Panel Components
-                JLabel labelDisplayDateFormat = new JLabel(resources.getString("labelDisplayDateFormat.text"));
-                JLabel labelDisplayDateFormatExample = new JLabel();
-                optionDisplayDateFormat = new JTextField();
-                optionDisplayDateFormat.addActionListener(evt -> labelDisplayDateFormatExample.setText(
-                                validateDateFormat(optionDisplayDateFormat.getText())
-                                                ? LocalDate.now().format(DateTimeFormatter
-                                                                .ofPattern(optionDisplayDateFormat.getText())
-                                                                .withLocale(MekHQ.getMHQOptions().getDateLocale()))
-                                                : resources.getString("invalidDateFormat.error")));
-
-                JLabel labelLongDisplayDateFormat = new JLabel(resources.getString("labelLongDisplayDateFormat.text"));
-                JLabel labelLongDisplayDateFormatExample = new JLabel();
-                optionLongDisplayDateFormat = new JTextField();
-                optionLongDisplayDateFormat.addActionListener(evt -> labelLongDisplayDateFormatExample.setText(
-                                validateDateFormat(optionLongDisplayDateFormat.getText())
-                                                ? LocalDate.now().format(DateTimeFormatter
-                                                                .ofPattern(optionLongDisplayDateFormat.getText())
-                                                                .withLocale(MekHQ.getMHQOptions().getDateLocale()))
-                                                : resources.getString("invalidDateFormat.error")));
-
-                optionHistoricalDailyLog = new JCheckBox(resources.getString("optionHistoricalDailyLog.text"));
-                optionHistoricalDailyLog.setToolTipText(resources.getString("optionHistoricalDailyLog.toolTipText"));
-
-                chkCompanyGeneratorStartup = new JCheckBox(resources.getString("chkCompanyGeneratorStartup.text"));
-                chkCompanyGeneratorStartup
-                                .setToolTipText(resources.getString("chkCompanyGeneratorStartup.toolTipText"));
-                chkCompanyGeneratorStartup.setName("chkCompanyGeneratorStartup");
-
-                chkShowCompanyGenerator = new JCheckBox(resources.getString("chkShowCompanyGenerator.text"));
-                chkShowCompanyGenerator.setToolTipText(resources.getString("chkShowCompanyGenerator.toolTipText"));
-                chkShowCompanyGenerator.setName("chkShowCompanyGenerator");
-
-                chkShowUnitPicturesOnTOE = new JCheckBox(resources.getString("chkShowUnitPicturesOnTOE.text"));
-                chkShowUnitPicturesOnTOE.setToolTipText(resources.getString("chkShowUnitPicturesOnTOE.toolTipText"));
-                chkShowUnitPicturesOnTOE.setName("chkShowUnitPicturesOnTOE");
-
-                // region Command Center Tab
-                JLabel labelCommandCenterDisplay = new JLabel(resources.getString("labelCommandCenterDisplay.text"));
-
-                optionCommandCenterUseUnitMarket = new JCheckBox(
-                                resources.getString("optionCommandCenterUseUnitMarket.text"));
-                optionCommandCenterUseUnitMarket
-                                .setToolTipText(resources.getString("optionCommandCenterUseUnitMarket.toolTipText"));
-
-                optionCommandCenterMRMS = new JCheckBox(resources.getString("optionCommandCenterMRMS.text"));
-                optionCommandCenterMRMS.setToolTipText(resources.getString("optionCommandCenterMRMS.toolTipText"));
-                // endregion Command Center Tab
-
-                // region Interstellar Map Tab
-                final JLabel lblInterstellarMapTab = new JLabel(resources.getString("lblInterstellarMapTab.text"));
-                lblInterstellarMapTab.setName("lblInterstellarMapTab");
-
-                chkInterstellarMapShowJumpRadius = new JCheckBox(
-                                resources.getString("chkInterstellarMapShowJumpRadius.text"));
-                chkInterstellarMapShowJumpRadius
-                                .setToolTipText(resources.getString("chkInterstellarMapShowJumpRadius.toolTipText"));
-                chkInterstellarMapShowJumpRadius.setName("chkInterstellarMapShowJumpRadius");
-                chkInterstellarMapShowJumpRadius.addActionListener(evt -> {
-                        final boolean selected = chkInterstellarMapShowJumpRadius.isSelected();
-                        lblInterstellarMapShowJumpRadiusMinimumZoom.setEnabled(selected);
-                        spnInterstellarMapShowJumpRadiusMinimumZoom.setEnabled(selected);
-                        btnInterstellarMapJumpRadiusColour.setEnabled(selected);
-                });
-
-                lblInterstellarMapShowJumpRadiusMinimumZoom
-                                .setText(resources.getString("lblInterstellarMapShowJumpRadiusMinimumZoom.text"));
-                lblInterstellarMapShowJumpRadiusMinimumZoom.setToolTipText(
-                                resources.getString("lblInterstellarMapShowJumpRadiusMinimumZoom.toolTipText"));
-                lblInterstellarMapShowJumpRadiusMinimumZoom.setName("lblInterstellarMapShowJumpRadiusMinimumZoom");
-
-                spnInterstellarMapShowJumpRadiusMinimumZoom = new JSpinner(new SpinnerNumberModel(3d, 0d, 10d, 0.5));
-                spnInterstellarMapShowJumpRadiusMinimumZoom.setToolTipText(
-                                resources.getString("lblInterstellarMapShowJumpRadiusMinimumZoom.toolTipText"));
-                spnInterstellarMapShowJumpRadiusMinimumZoom.setName("spnInterstellarMapShowJumpRadiusMinimumZoom");
-
-                btnInterstellarMapJumpRadiusColour = new ColourSelectorButton(
-                                resources.getString("btnInterstellarMapJumpRadiusColour.text"));
-                btnInterstellarMapJumpRadiusColour
-                                .setToolTipText(resources.getString("btnInterstellarMapJumpRadiusColour.toolTipText"));
-                btnInterstellarMapJumpRadiusColour.setName("btnInterstellarMapJumpRadiusColour");
-
-                chkInterstellarMapShowPlanetaryAcquisitionRadius = new JCheckBox(
-                                resources.getString("chkInterstellarMapShowPlanetaryAcquisitionRadius.text"));
-                chkInterstellarMapShowPlanetaryAcquisitionRadius.setToolTipText(
-                                resources.getString("chkInterstellarMapShowPlanetaryAcquisitionRadius.toolTipText"));
-                chkInterstellarMapShowPlanetaryAcquisitionRadius
-                                .setName("chkInterstellarMapShowPlanetaryAcquisitionRadius");
-                chkInterstellarMapShowPlanetaryAcquisitionRadius.addActionListener(evt -> {
-                        final boolean selected = chkInterstellarMapShowPlanetaryAcquisitionRadius.isSelected();
-                        lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setEnabled(selected);
-                        spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setEnabled(selected);
-                        btnInterstellarMapPlanetaryAcquisitionRadiusColour.setEnabled(selected);
-                });
-
-                lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setText(resources
-                                .getString("lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.text"));
-                lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setToolTipText(resources
-                                .getString("lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.toolTipText"));
-                lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom
-                                .setName("lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom");
-
-                spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom = new JSpinner(
-                                new SpinnerNumberModel(2d, 0d, 10d, 0.5));
-                spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setToolTipText(resources
-                                .getString("lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.toolTipText"));
-                spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom
-                                .setName("spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom");
-
-                btnInterstellarMapPlanetaryAcquisitionRadiusColour = new ColourSelectorButton(
-                                resources.getString("btnInterstellarMapPlanetaryAcquisitionRadiusColour.text"));
-                btnInterstellarMapPlanetaryAcquisitionRadiusColour.setToolTipText(
-                                resources.getString("btnInterstellarMapPlanetaryAcquisitionRadiusColour.toolTipText"));
-                btnInterstellarMapPlanetaryAcquisitionRadiusColour
-                                .setName("btnInterstellarMapPlanetaryAcquisitionRadiusColour");
-
-                chkInterstellarMapShowContractSearchRadius = new JCheckBox(
-                                resources.getString("chkInterstellarMapShowContractSearchRadius.text"));
-                chkInterstellarMapShowContractSearchRadius.setToolTipText(
-                                resources.getString("chkInterstellarMapShowContractSearchRadius.toolTipText"));
-                chkInterstellarMapShowContractSearchRadius.setName("chkInterstellarMapShowContractSearchRadius");
-                chkInterstellarMapShowContractSearchRadius
-                                .addActionListener(evt -> btnInterstellarMapContractSearchRadiusColour
-                                                .setEnabled(chkInterstellarMapShowContractSearchRadius.isSelected()));
-
-                btnInterstellarMapContractSearchRadiusColour = new ColourSelectorButton(
-                                resources.getString("btnInterstellarMapContractSearchRadiusColour.text"));
-                btnInterstellarMapContractSearchRadiusColour.setToolTipText(
-                                resources.getString("btnInterstellarMapContractSearchRadiusColour.toolTipText"));
-                btnInterstellarMapContractSearchRadiusColour.setName("btnInterstellarMapContractSearchRadiusColour");
-                // endregion Interstellar Map Tab
-
-                // region Personnel Tab
-                JLabel labelPersonnelDisplay = new JLabel(resources.getString("labelPersonnelDisplay.text"));
-
-                JLabel labelPersonnelFilterStyle = new JLabel(resources.getString("optionPersonnelFilterStyle.text"));
-                labelPersonnelFilterStyle.setToolTipText(resources.getString("optionPersonnelFilterStyle.toolTipText"));
-
-                optionPersonnelFilterStyle = new JComboBox<>(PersonnelFilterStyle.values());
-                optionPersonnelFilterStyle.setRenderer(new DefaultListCellRenderer() {
-                        @Override
-                        public Component getListCellRendererComponent(final JList<?> list, final Object value,
-                                        final int index, final boolean isSelected,
-                                        final boolean cellHasFocus) {
-                                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-                                if (value instanceof PersonnelFilterStyle) {
-                                        list.setToolTipText(((PersonnelFilterStyle) value).getToolTipText());
-                                }
-                                return this;
-                        }
-                });
-
-                optionPersonnelFilterOnPrimaryRole = new JCheckBox(
-                                resources.getString("optionPersonnelFilterOnPrimaryRole.text"));
-                // endregion Personnel Tab
-
-                // Programmatically Assign Accessibility Labels
-                lblInterstellarMapShowJumpRadiusMinimumZoom.setLabelFor(spnInterstellarMapShowJumpRadiusMinimumZoom);
-                lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom
-                                .setLabelFor(spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom);
-
-                // Disable Panel Portions by Default
-                chkInterstellarMapShowJumpRadius.setSelected(true);
-                chkInterstellarMapShowJumpRadius.doClick();
-                chkInterstellarMapShowPlanetaryAcquisitionRadius.setSelected(true);
-                chkInterstellarMapShowPlanetaryAcquisitionRadius.doClick();
-                chkInterstellarMapShowContractSearchRadius.setSelected(true);
-                chkInterstellarMapShowContractSearchRadius.doClick();
-
-                // Layout the UI
-                JPanel body = new JPanel();
-                GroupLayout layout = new GroupLayout(body);
-                body.setLayout(layout);
-
-                layout.setAutoCreateGaps(true);
-                layout.setAutoCreateContainerGaps(true);
-
-                layout.setVerticalGroup(
-                                layout.createSequentialGroup()
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(labelDisplayDateFormat)
-                                                                .addComponent(optionDisplayDateFormat)
-                                                                .addComponent(labelDisplayDateFormatExample,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(labelLongDisplayDateFormat)
-                                                                .addComponent(optionLongDisplayDateFormat)
-                                                                .addComponent(labelLongDisplayDateFormatExample,
-                                                                                Alignment.TRAILING))
-                                    .addComponent(scaleLine)
-                                                .addComponent(optionHistoricalDailyLog)
-                                                .addComponent(chkCompanyGeneratorStartup)
-                                                .addComponent(chkShowCompanyGenerator)
-                                                .addComponent(chkShowUnitPicturesOnTOE)
-                                                .addComponent(labelCommandCenterDisplay)
-                                                .addComponent(optionCommandCenterUseUnitMarket)
-                                                .addComponent(optionCommandCenterMRMS)
-                                                .addComponent(lblInterstellarMapTab)
-                                                .addComponent(chkInterstellarMapShowJumpRadius)
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(lblInterstellarMapShowJumpRadiusMinimumZoom)
-                                                                .addComponent(spnInterstellarMapShowJumpRadiusMinimumZoom,
-                                                                                Alignment.TRAILING))
-                                                .addComponent(btnInterstellarMapJumpRadiusColour)
-                                                .addComponent(chkInterstellarMapShowPlanetaryAcquisitionRadius)
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom)
-                                                                .addComponent(spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom,
-                                                                                Alignment.TRAILING))
-                                                .addComponent(btnInterstellarMapPlanetaryAcquisitionRadiusColour)
-                                                .addComponent(chkInterstellarMapShowContractSearchRadius)
-                                                .addComponent(btnInterstellarMapContractSearchRadiusColour)
-                                                .addComponent(labelPersonnelDisplay)
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(labelPersonnelFilterStyle)
-                                                                .addComponent(optionPersonnelFilterStyle,
-                                                                                GroupLayout.DEFAULT_SIZE,
-                                                                                GroupLayout.DEFAULT_SIZE, 40))
-                                                .addComponent(optionPersonnelFilterOnPrimaryRole));
-
-                layout.setHorizontalGroup(
-                                layout.createParallelGroup(Alignment.LEADING)
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(labelDisplayDateFormat)
-                                                                .addComponent(optionDisplayDateFormat)
-                                                                .addComponent(labelDisplayDateFormatExample))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(labelLongDisplayDateFormat)
-                                                                .addComponent(optionLongDisplayDateFormat)
-                                                                .addComponent(labelLongDisplayDateFormatExample))
-                                    .addComponent(scaleLine)
-                                                .addComponent(optionHistoricalDailyLog)
-                                                .addComponent(chkCompanyGeneratorStartup)
-                                                .addComponent(chkShowCompanyGenerator)
-                                                .addComponent(chkShowUnitPicturesOnTOE)
-                                                .addComponent(labelCommandCenterDisplay)
-                                                .addComponent(optionCommandCenterUseUnitMarket)
-                                                .addComponent(optionCommandCenterMRMS)
-                                                .addComponent(lblInterstellarMapTab)
-                                                .addComponent(chkInterstellarMapShowJumpRadius)
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblInterstellarMapShowJumpRadiusMinimumZoom)
-                                                                .addComponent(spnInterstellarMapShowJumpRadiusMinimumZoom))
-                                                .addComponent(btnInterstellarMapJumpRadiusColour)
-                                                .addComponent(chkInterstellarMapShowPlanetaryAcquisitionRadius)
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom)
-                                                                .addComponent(spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom))
-                                                .addComponent(btnInterstellarMapPlanetaryAcquisitionRadiusColour)
-                                                .addComponent(chkInterstellarMapShowContractSearchRadius)
-                                                .addComponent(btnInterstellarMapContractSearchRadiusColour)
-                                                .addComponent(labelPersonnelDisplay)
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(labelPersonnelFilterStyle)
-                                                                .addComponent(optionPersonnelFilterStyle))
-                                                .addComponent(optionPersonnelFilterOnPrimaryRole));
-
-                return body;
-        }
-
-        private JPanel createColoursTab() {
-                // region Create Graphical Components
-                optionDeployedForeground = new ColourSelectorButton(
-                                resources.getString("optionDeployedForeground.text"));
-
-                optionDeployedBackground = new ColourSelectorButton(
-                                resources.getString("optionDeployedBackground.text"));
-
-                optionBelowContractMinimumForeground = new ColourSelectorButton(
-                                resources.getString("optionBelowContractMinimumForeground.text"));
-
-                optionBelowContractMinimumBackground = new ColourSelectorButton(
-                                resources.getString("optionBelowContractMinimumBackground.text"));
-
-                optionInTransitForeground = new ColourSelectorButton(
-                                resources.getString("optionInTransitForeground.text"));
-
-                optionInTransitBackground = new ColourSelectorButton(
-                                resources.getString("optionInTransitBackground.text"));
-
-                optionRefittingForeground = new ColourSelectorButton(
-                                resources.getString("optionRefittingForeground.text"));
-
-                optionRefittingBackground = new ColourSelectorButton(
-                                resources.getString("optionRefittingBackground.text"));
-
-                optionMothballingForeground = new ColourSelectorButton(
-                                resources.getString("optionMothballingForeground.text"));
-
-                optionMothballingBackground = new ColourSelectorButton(
-                                resources.getString("optionMothballingBackground.text"));
-
-                optionMothballedForeground = new ColourSelectorButton(
-                                resources.getString("optionMothballedForeground.text"));
-
-                optionMothballedBackground = new ColourSelectorButton(
-                                resources.getString("optionMothballedBackground.text"));
-
-                optionNotRepairableForeground = new ColourSelectorButton(
-                                resources.getString("optionNotRepairableForeground.text"));
-
-                optionNotRepairableBackground = new ColourSelectorButton(
-                                resources.getString("optionNotRepairableBackground.text"));
-
-                optionNonFunctionalForeground = new ColourSelectorButton(
-                                resources.getString("optionNonFunctionalForeground.text"));
-
-                optionNonFunctionalBackground = new ColourSelectorButton(
-                                resources.getString("optionNonFunctionalBackground.text"));
-
-                optionNeedsPartsFixedForeground = new ColourSelectorButton(
-                                resources.getString("optionNeedsPartsFixedForeground.text"));
-
-                optionNeedsPartsFixedBackground = new ColourSelectorButton(
-                                resources.getString("optionNeedsPartsFixedBackground.text"));
-
-                optionUnmaintainedForeground = new ColourSelectorButton(
-                                resources.getString("optionUnmaintainedForeground.text"));
-
-                optionUnmaintainedBackground = new ColourSelectorButton(
-                                resources.getString("optionUnmaintainedBackground.text"));
-
-                optionUncrewedForeground = new ColourSelectorButton(
-                                resources.getString("optionUncrewedForeground.text"));
-
-                optionUncrewedBackground = new ColourSelectorButton(
-                                resources.getString("optionUncrewedBackground.text"));
-
-                optionLoanOverdueForeground = new ColourSelectorButton(
-                                resources.getString("optionLoanOverdueForeground.text"));
-
-                optionLoanOverdueBackground = new ColourSelectorButton(
-                                resources.getString("optionLoanOverdueBackground.text"));
-
-                optionInjuredForeground = new ColourSelectorButton(resources.getString("optionInjuredForeground.text"));
-
-                optionInjuredBackground = new ColourSelectorButton(resources.getString("optionInjuredBackground.text"));
-
-                optionHealedInjuriesForeground = new ColourSelectorButton(
-                                resources.getString("optionHealedInjuriesForeground.text"));
-
-                optionHealedInjuriesBackground = new ColourSelectorButton(
-                                resources.getString("optionHealedInjuriesBackground.text"));
-
-                optionPregnantForeground = new ColourSelectorButton(
-                                resources.getString("optionPregnantForeground.text"));
-
-                optionPregnantBackground = new ColourSelectorButton(
-                                resources.getString("optionPregnantBackground.text"));
-
-                optionGoneForeground = new ColourSelectorButton(
-                                resources.getString("optionGoneForeground.text"));
-
-                optionGoneBackground = new ColourSelectorButton(
-                                resources.getString("optionGoneBackground.text"));
-
-                optionAbsentForeground = new ColourSelectorButton(
-                                resources.getString("optionAbsentForeground.text"));
-
-                optionAbsentBackground = new ColourSelectorButton(
-                                resources.getString("optionAbsentBackground.text"));
-
-                optionFatiguedForeground = new ColourSelectorButton(
-                                resources.getString("optionFatiguedForeground.text"));
-
-                optionFatiguedBackground = new ColourSelectorButton(
-                                resources.getString("optionFatiguedBackground.text"));
-
-                optionStratConHexCoordForeground = new ColourSelectorButton(
-                                resources.getString("optionStratConHexCoordForeground.text"));
-
-                optionFontColorNegative = new ColourSelectorButton(resources.getString("optionFontColorNegative.text"));
-
-                optionFontColorWarning = new ColourSelectorButton(resources.getString("optionFontColorWarning.text"));
-
-                optionFontColorPositive = new ColourSelectorButton(resources.getString("optionFontColorPositive.text"));
-
-                optionFontColorSkillUltraGreen = new ColourSelectorButton(resources.getString("optionFontColorSkillUltraGreen.text"));
-
-                optionFontColorSkillGreen = new ColourSelectorButton(resources.getString("optionFontColorSkillGreen.text"));
-
-                optionFontColorSkillRegular = new ColourSelectorButton(resources.getString("optionFontColorSkillRegular.text"));
-
-                optionFontColorSkillVeteran = new ColourSelectorButton(resources.getString("optionFontColorSkillVeteran.text"));
-
-                optionFontColorSkillElite = new ColourSelectorButton(resources.getString("optionFontColorSkillElite.text"));
-
-                // endregion Create Graphical Components
-
-                // region Layout
-                // Layout the UI
-                JPanel body = new JPanel();
-                GroupLayout layout = new GroupLayout(body);
-                body.setLayout(layout);
-
-                layout.setAutoCreateGaps(true);
-                layout.setAutoCreateContainerGaps(true);
-
-                layout.setVerticalGroup(
-                                layout.createSequentialGroup()
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionDeployedForeground)
-                                                                .addComponent(optionDeployedBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionBelowContractMinimumForeground)
-                                                                .addComponent(optionBelowContractMinimumBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionInTransitForeground)
-                                                                .addComponent(optionInTransitBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionRefittingForeground)
-                                                                .addComponent(optionRefittingBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionMothballingForeground)
-                                                                .addComponent(optionMothballingBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionMothballedForeground)
-                                                                .addComponent(optionMothballedBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionNotRepairableForeground)
-                                                                .addComponent(optionNotRepairableBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionNonFunctionalForeground)
-                                                                .addComponent(optionNonFunctionalBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionNeedsPartsFixedForeground)
-                                                                .addComponent(optionNeedsPartsFixedBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionUnmaintainedForeground)
-                                                                .addComponent(optionUnmaintainedBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionUncrewedForeground)
-                                                                .addComponent(optionUncrewedBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionLoanOverdueForeground)
-                                                                .addComponent(optionLoanOverdueBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionInjuredForeground)
-                                                                .addComponent(optionInjuredBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionHealedInjuriesForeground)
-                                                                .addComponent(optionHealedInjuriesBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionPregnantForeground)
-                                                                .addComponent(optionPregnantBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionGoneForeground)
-                                                                .addComponent(optionGoneBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionAbsentForeground)
-                                                                .addComponent(optionAbsentBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionFatiguedForeground)
-                                                                .addComponent(optionFatiguedBackground,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionStratConHexCoordForeground))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionFontColorNegative)
-                                                                .addComponent(optionFontColorPositive,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionFontColorWarning)
-                                                                .addComponent(optionFontColorSkillUltraGreen,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionFontColorSkillGreen)
-                                                                .addComponent(optionFontColorSkillRegular,
-                                                                                Alignment.TRAILING))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(optionFontColorSkillVeteran)
-                                                                .addComponent(optionFontColorSkillElite,
-                                                                                Alignment.TRAILING)));
-
-                layout.setHorizontalGroup(
-                                layout.createParallelGroup(Alignment.LEADING)
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionDeployedForeground)
-                                                                .addComponent(optionDeployedBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionBelowContractMinimumForeground)
-                                                                .addComponent(optionBelowContractMinimumBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionInTransitForeground)
-                                                                .addComponent(optionInTransitBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionRefittingForeground)
-                                                                .addComponent(optionRefittingBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionMothballingForeground)
-                                                                .addComponent(optionMothballingBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionMothballedForeground)
-                                                                .addComponent(optionMothballedBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionNotRepairableForeground)
-                                                                .addComponent(optionNotRepairableBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionNonFunctionalForeground)
-                                                                .addComponent(optionNonFunctionalBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionNeedsPartsFixedForeground)
-                                                                .addComponent(optionNeedsPartsFixedBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionUnmaintainedForeground)
-                                                                .addComponent(optionUnmaintainedBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionUncrewedForeground)
-                                                                .addComponent(optionUncrewedBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionLoanOverdueForeground)
-                                                                .addComponent(optionLoanOverdueBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionInjuredForeground)
-                                                                .addComponent(optionInjuredBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionHealedInjuriesForeground)
-                                                                .addComponent(optionHealedInjuriesBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionPregnantForeground)
-                                                                .addComponent(optionPregnantBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionGoneForeground)
-                                                                .addComponent(optionGoneBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionAbsentForeground)
-                                                                .addComponent(optionAbsentBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionFatiguedForeground)
-                                                                .addComponent(optionFatiguedBackground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionStratConHexCoordForeground))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionFontColorNegative)
-                                                                .addComponent(optionFontColorPositive))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionFontColorWarning)
-                                                                .addComponent(optionFontColorSkillUltraGreen))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionFontColorSkillGreen)
-                                                                .addComponent(optionFontColorSkillRegular))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(optionFontColorSkillVeteran)
-                                                                .addComponent(optionFontColorSkillElite)));
-                // endregion Layout
-
-                return body;
-        }
-
-        private JPanel createFontsTab() {
-                // Create Panel Components
-                final JLabel lblMedicalViewDialogHandwritingFont = new JLabel(
-                                resources.getString("lblMedicalViewDialogHandwritingFont.text"));
-                lblMedicalViewDialogHandwritingFont
-                                .setToolTipText(resources.getString("lblMedicalViewDialogHandwritingFont.toolTipText"));
-                lblMedicalViewDialogHandwritingFont.setName("lblMedicalViewDialogHandwritingFont");
-
-                comboMedicalViewDialogHandwritingFont = new FontComboBox("comboMedicalViewDialogHandwritingFont");
-                comboMedicalViewDialogHandwritingFont
-                                .setToolTipText(resources.getString("lblMedicalViewDialogHandwritingFont.toolTipText"));
-
-                // Programmatically Assign Accessibility Labels
-                lblMedicalViewDialogHandwritingFont.setLabelFor(comboMedicalViewDialogHandwritingFont);
-
-                // Layout the UI
-                final JPanel panel = new JPanel();
-                panel.setName("fontPanel");
-                final GroupLayout layout = new GroupLayout(panel);
-                panel.setLayout(layout);
-
-                layout.setAutoCreateGaps(true);
-                layout.setAutoCreateContainerGaps(true);
-
-                layout.setVerticalGroup(
-                                layout.createSequentialGroup()
-                                                .addGroup(layout.createParallelGroup(Alignment.LEADING)
-                                                                .addComponent(lblMedicalViewDialogHandwritingFont)
-                                                                .addComponent(comboMedicalViewDialogHandwritingFont,
-                                                                                GroupLayout.DEFAULT_SIZE,
-                                                                                GroupLayout.DEFAULT_SIZE, 40)));
-
-                layout.setHorizontalGroup(
-                                layout.createParallelGroup(Alignment.LEADING)
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblMedicalViewDialogHandwritingFont)
-                                                                .addComponent(comboMedicalViewDialogHandwritingFont)));
-
-                return panel;
-        }
-
-        private JPanel createAutosaveTab() {
-                // Create Panel Components
-                optionNoSave = new JRadioButton(resources.getString("optionNoSave.text"));
-                optionNoSave.setMnemonic(KeyEvent.VK_N);
-
-                optionSaveDaily = new JRadioButton(resources.getString("optionSaveDaily.text"));
-                optionSaveDaily.setMnemonic(KeyEvent.VK_D);
-
-                optionSaveWeekly = new JRadioButton(resources.getString("optionSaveWeekly.text"));
-                optionSaveWeekly.setMnemonic(KeyEvent.VK_W);
-
-                optionSaveMonthly = new JRadioButton(resources.getString("optionSaveMonthly.text"));
-                optionSaveMonthly.setMnemonic(KeyEvent.VK_M);
-
-                optionSaveYearly = new JRadioButton(resources.getString("optionSaveYearly.text"));
-                optionSaveYearly.setMnemonic(KeyEvent.VK_Y);
-
-                ButtonGroup saveFrequencyGroup = new ButtonGroup();
-                saveFrequencyGroup.add(optionNoSave);
-                saveFrequencyGroup.add(optionSaveDaily);
-                saveFrequencyGroup.add(optionSaveWeekly);
-                saveFrequencyGroup.add(optionSaveMonthly);
-                saveFrequencyGroup.add(optionSaveYearly);
-
-                checkSaveBeforeMissions = new JCheckBox(resources.getString("checkSaveBeforeMissions.text"));
-                checkSaveBeforeMissions.setMnemonic(KeyEvent.VK_S);
-
-                JLabel labelSavedGamesCount = new JLabel(resources.getString("labelSavedGamesCount.text"));
-                spinnerSavedGamesCount = new JSpinner(new SpinnerNumberModel(1, 1, 10, 1));
-                labelSavedGamesCount.setLabelFor(spinnerSavedGamesCount);
-
-                // Layout the UI
-                JPanel body = new JPanel();
-                GroupLayout layout = new GroupLayout(body);
-                body.setLayout(layout);
-
-                layout.setAutoCreateGaps(true);
-                layout.setAutoCreateContainerGaps(true);
-
-                layout.setVerticalGroup(
-                                layout.createSequentialGroup()
-                                                .addComponent(optionNoSave)
-                                                .addComponent(optionSaveDaily)
-                                                .addComponent(optionSaveWeekly)
-                                                .addComponent(optionSaveMonthly)
-                                                .addComponent(optionSaveYearly)
-                                                .addComponent(checkSaveBeforeMissions)
-                                                .addGroup(layout.createParallelGroup(Alignment.LEADING)
-                                                                .addComponent(labelSavedGamesCount)
-                                                                .addComponent(spinnerSavedGamesCount,
-                                                                                GroupLayout.DEFAULT_SIZE,
-                                                                                GroupLayout.DEFAULT_SIZE, 40)));
-
-                layout.setHorizontalGroup(
-                                layout.createParallelGroup(Alignment.LEADING)
-                                                .addComponent(optionNoSave)
-                                                .addComponent(optionSaveDaily)
-                                                .addComponent(optionSaveWeekly)
-                                                .addComponent(optionSaveMonthly)
-                                                .addComponent(optionSaveYearly)
-                                                .addComponent(checkSaveBeforeMissions)
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(labelSavedGamesCount)
-                                                                .addComponent(spinnerSavedGamesCount)));
-
-                return body;
-        }
-
-        private JPanel createNewDayTab() {
-                // Initialize Components Used in ActionListeners
-                final JLabel lblNewDayForceIconOperationalStatusStyle = new JLabel(
-                                resources.getString("lblNewDayForceIconOperationalStatusStyle.text"));
-
-                // Create Panel Components
-                chkNewDayAstechPoolFill = new JCheckBox(resources.getString("chkNewDayAstechPoolFill.text"));
-                chkNewDayAstechPoolFill.setToolTipText(resources.getString("chkNewDayAstechPoolFill.toolTipText"));
-                chkNewDayAstechPoolFill.setName("chkNewDayAstechPoolFill");
-
-                chkNewDayMedicPoolFill = new JCheckBox(resources.getString("chkNewDayMedicPoolFill.text"));
-                chkNewDayMedicPoolFill.setToolTipText(resources.getString("chkNewDayMedicPoolFill.toolTipText"));
-                chkNewDayMedicPoolFill.setName("chkNewDayMedicPoolFill");
-
-                chkNewDayMRMS = new JCheckBox(resources.getString("chkNewDayMRMS.text"));
-                chkNewDayMRMS.setToolTipText(resources.getString("chkNewDayMRMS.toolTipText"));
-                chkNewDayMRMS.setName("chkNewDayMRMS");
-
-                chkNewDayOptimizeMedicalAssignments = new JCheckBox(resources.getString("chkNewDayOptimizeMedicalAssignments.text"));
-                chkNewDayOptimizeMedicalAssignments.setToolTipText(resources.getString("chkNewDayOptimizeMedicalAssignments.toolTipText"));
-                chkNewDayOptimizeMedicalAssignments.setName("chkNewDayOptimizeMedicalAssignments.text");
-
-                chkNewDayForceIconOperationalStatus = new JCheckBox(
-                                resources.getString("chkNewDayForceIconOperationalStatus.text"));
-                chkNewDayForceIconOperationalStatus
-                                .setToolTipText(resources.getString("chkNewDayForceIconOperationalStatus.toolTipText"));
-                chkNewDayForceIconOperationalStatus.setName("chkNewDayForceIconOperationalStatus");
-                chkNewDayForceIconOperationalStatus.addActionListener(evt -> {
-                        final boolean selected = chkNewDayForceIconOperationalStatus.isSelected();
-                        lblNewDayForceIconOperationalStatusStyle.setEnabled(selected);
-                        comboNewDayForceIconOperationalStatusStyle.setEnabled(selected);
-                });
-
-                lblNewDayForceIconOperationalStatusStyle.setToolTipText(
-                                resources.getString("lblNewDayForceIconOperationalStatusStyle.toolTipText"));
-                lblNewDayForceIconOperationalStatusStyle.setName("lblNewDayForceIconOperationalStatusStyle");
-
-                comboNewDayForceIconOperationalStatusStyle = new MMComboBox<>(
-                                "comboNewDayForceIconOperationalStatusStyle", ForceIconOperationalStatusStyle.values());
-                comboNewDayForceIconOperationalStatusStyle.setToolTipText(
-                                resources.getString("lblNewDayForceIconOperationalStatusStyle.toolTipText"));
-                comboNewDayForceIconOperationalStatusStyle.setRenderer(new DefaultListCellRenderer() {
-                        @Override
-                        public Component getListCellRendererComponent(final JList<?> list, final Object value,
-                                        final int index, final boolean isSelected,
-                                        final boolean cellHasFocus) {
-                                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-                                if (value instanceof ForceIconOperationalStatusStyle) {
-                                        list.setToolTipText(((ForceIconOperationalStatusStyle) value).getToolTipText());
-                                }
-                                return this;
-                        }
-                });
-
-                // Programmatically Assign Accessibility Labels
-                lblNewDayForceIconOperationalStatusStyle.setLabelFor(comboNewDayForceIconOperationalStatusStyle);
-
-                // Disable Panel Portions by Default
-                chkNewDayForceIconOperationalStatus.setSelected(true);
-                chkNewDayForceIconOperationalStatus.doClick();
-
-                // Layout the UI
-                final JPanel panel = new JPanel();
-                panel.setName("newDayPanel");
-                final GroupLayout layout = new GroupLayout(panel);
-                panel.setLayout(layout);
-
-                layout.setAutoCreateGaps(true);
-                layout.setAutoCreateContainerGaps(true);
-
-                layout.setVerticalGroup(
-                                layout.createSequentialGroup()
-                                                .addComponent(chkNewDayAstechPoolFill)
-                                                .addComponent(chkNewDayMedicPoolFill)
-                                                .addComponent(chkNewDayMRMS)
-                                                .addComponent(chkNewDayOptimizeMedicalAssignments)
-                                                .addComponent(chkNewDayForceIconOperationalStatus)
-                                                .addGroup(layout.createParallelGroup(Alignment.LEADING)
-                                                                .addComponent(lblNewDayForceIconOperationalStatusStyle)
-                                                                .addComponent(comboNewDayForceIconOperationalStatusStyle,
-                                                                                GroupLayout.DEFAULT_SIZE,
-                                                                                GroupLayout.DEFAULT_SIZE, 40)));
-
-                layout.setHorizontalGroup(
-                                layout.createParallelGroup(Alignment.LEADING)
-                                                .addComponent(chkNewDayAstechPoolFill)
-                                                .addComponent(chkNewDayMedicPoolFill)
-                                                .addComponent(chkNewDayMRMS)
-                                                .addComponent(chkNewDayOptimizeMedicalAssignments)
-                                                .addComponent(chkNewDayForceIconOperationalStatus)
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblNewDayForceIconOperationalStatusStyle)
-                                                                .addComponent(comboNewDayForceIconOperationalStatusStyle)));
-
-                return panel;
-        }
-
-        private JPanel createCampaignXMLSaveTab() {
-                // Create Panel Components
-                optionPreferGzippedOutput = new JCheckBox(resources.getString("optionPreferGzippedOutput.text"));
-                optionPreferGzippedOutput.setToolTipText(resources.getString("optionPreferGzippedOutput.toolTipText"));
-
-                optionWriteCustomsToXML = new JCheckBox(resources.getString("optionWriteCustomsToXML.text"));
-                optionWriteCustomsToXML.setMnemonic(KeyEvent.VK_C);
-
-                optionSaveMothballState = new JCheckBox(resources.getString("optionSaveMothballState.text"));
-                optionSaveMothballState.setToolTipText(resources.getString("optionSaveMothballState.toolTipText"));
-                optionSaveMothballState.setMnemonic(KeyEvent.VK_U);
-
-                // Layout the UI
-                JPanel body = new JPanel();
-                GroupLayout layout = new GroupLayout(body);
-                body.setLayout(layout);
-
-                layout.setAutoCreateGaps(true);
-                layout.setAutoCreateContainerGaps(true);
-
-                layout.setVerticalGroup(
-                                layout.createSequentialGroup()
-                                                .addComponent(optionPreferGzippedOutput)
-                                                .addComponent(optionWriteCustomsToXML)
-                                                .addComponent(optionSaveMothballState));
-
-                layout.setHorizontalGroup(
-                                layout.createParallelGroup(Alignment.LEADING)
-                                                .addComponent(optionPreferGzippedOutput)
-                                                .addComponent(optionWriteCustomsToXML)
-                                                .addComponent(optionSaveMothballState));
-
-                return body;
-        }
-
-        private JPanel createNagTab() {
-                // Create Panel Components
-                optionUnmaintainedUnitsNag = new JCheckBox(resources.getString("optionUnmaintainedUnitsNag.text"));
-                optionUnmaintainedUnitsNag
-                                .setToolTipText(resources.getString("optionUnmaintainedUnitsNag.toolTipText"));
-                optionUnmaintainedUnitsNag.setName("optionUnmaintainedUnitsNag");
-
-                optionPregnantCombatantNag = new JCheckBox(resources.getString("optionPregnantCombatantNag.text"));
-                optionPregnantCombatantNag
-                                .setToolTipText(resources.getString("optionPregnantCombatantNag.toolTipText"));
-                optionPregnantCombatantNag.setName("optionPregnantCombatantNag");
-
-                optionPrisonersNag = new JCheckBox(resources.getString("optionPrisonersNag.text"));
-                optionPrisonersNag.setToolTipText(resources.getString("optionPrisonersNag.toolTipText"));
-                optionPrisonersNag.setName("optionPrisonersNag");
-
-                optionAdminStrainNag = new JCheckBox(resources.getString("optionAdminStrainNag.text"));
-                optionAdminStrainNag.setToolTipText(resources.getString("optionAdminStrainNag.toolTipText"));
-                optionAdminStrainNag.setName("optionAdminStrainNag");
-
-                optionUntreatedPersonnelNag = new JCheckBox(resources.getString("optionUntreatedPersonnelNag.text"));
-                optionUntreatedPersonnelNag
-                                .setToolTipText(resources.getString("optionUntreatedPersonnelNag.toolTipText"));
-                optionUntreatedPersonnelNag.setName("optionUntreatedPersonnelNag");
-
-                optionNoCommanderNag = new JCheckBox(resources.getString("optionNoCommanderNag.text"));
-                optionNoCommanderNag.setToolTipText(resources.getString("optionNoCommanderNag.toolTipText"));
-                optionNoCommanderNag.setName("optionNoCommanderNag");
-
-                optionContractEndedNag = new JCheckBox(resources.getString("optionContractEndedNag.text"));
-                optionContractEndedNag.setToolTipText(resources.getString("optionContractEndedNag.toolTipText"));
-                optionContractEndedNag.setName("optionContractEndedNag");
-
-                optionInsufficientAstechsNag = new JCheckBox(resources.getString("optionInsufficientAstechsNag.text"));
-                optionInsufficientAstechsNag
-                                .setToolTipText(resources.getString("optionInsufficientAstechsNag.toolTipText"));
-                optionInsufficientAstechsNag.setName("optionInsufficientAstechsNag");
-
-                optionInsufficientAstechTimeNag = new JCheckBox(
-                                resources.getString("optionInsufficientAstechTimeNag.text"));
-                optionInsufficientAstechTimeNag
-                                .setToolTipText(resources.getString("optionInsufficientAstechTimeNag.toolTipText"));
-                optionInsufficientAstechTimeNag.setName("optionInsufficientAstechTimeNag");
-
-                optionInsufficientMedicsNag = new JCheckBox(resources.getString("optionInsufficientMedicsNag.text"));
-                optionInsufficientMedicsNag
-                                .setToolTipText(resources.getString("optionInsufficientMedicsNag.toolTipText"));
-                optionInsufficientMedicsNag.setName("optionInsufficientMedicsNag");
-
-                optionShortDeploymentNag = new JCheckBox(resources.getString("optionShortDeploymentNag.text"));
-                optionShortDeploymentNag.setToolTipText(resources.getString("optionShortDeploymentNag.toolTipText"));
-                optionShortDeploymentNag.setName("optionShortDeploymentNag");
-
-                optionUnresolvedStratConContactsNag = new JCheckBox(
-                                resources.getString("optionUnresolvedStratConContactsNag.text"));
-                optionUnresolvedStratConContactsNag
-                                .setToolTipText(resources.getString("optionUnresolvedStratConContactsNag.toolTipText"));
-                optionUnresolvedStratConContactsNag.setName("optionUnresolvedStratConContactsNag");
-
-                optionOutstandingScenariosNag = new JCheckBox(
-                                resources.getString("optionOutstandingScenariosNag.text"));
-                optionOutstandingScenariosNag
-                                .setToolTipText(resources.getString("optionOutstandingScenariosNag.toolTipText"));
-                optionOutstandingScenariosNag.setName("optionOutstandingScenariosNag");
-
-                optionInvalidFactionNag = new JCheckBox(resources.getString("optionInvalidFactionNag.text"));
-                optionInvalidFactionNag.setToolTipText(resources.getString("optionInvalidFactionNag.toolTipText"));
-                optionInvalidFactionNag.setName("optionInvalidFactionNag");
-
-                optionUnableToAffordExpensesNag = new JCheckBox(
-                                resources.getString("optionUnableToAffordExpensesNag.text"));
-                optionUnableToAffordExpensesNag
-                                .setToolTipText(resources.getString("optionUnableToAffordExpensesNag.toolTipText"));
-                optionUnableToAffordExpensesNag.setName("optionUnableToAffordExpensesNag");
-
-                optionUnableToAffordLoanPaymentNag = new JCheckBox(
-                                resources.getString("optionUnableToAffordLoanPaymentNag.text"));
-                optionUnableToAffordLoanPaymentNag
-                                .setToolTipText(resources.getString("optionUnableToAffordLoanPaymentNag.toolTipText"));
-                optionUnableToAffordLoanPaymentNag.setName("optionUnableToAffordLoanPaymentNag");
-
-                optionUnableToAffordJumpNag = new JCheckBox(resources.getString("optionUnableToAffordJumpNag.text"));
-                optionUnableToAffordJumpNag
-                                .setToolTipText(resources.getString("optionUnableToAffordJumpNag.toolTipText"));
-                optionUnableToAffordJumpNag.setName("optionUnableToAffordJumpNag");
-
-                // Layout the UI
-                final JPanel panel = new JPanel();
-                panel.setName("nagPanel");
-                final GroupLayout layout = new GroupLayout(panel);
-                layout.setAutoCreateGaps(true);
-                layout.setAutoCreateContainerGaps(true);
-                panel.setLayout(layout);
-
-                layout.setVerticalGroup(
-                                layout.createSequentialGroup()
-                                                .addComponent(optionUnmaintainedUnitsNag)
-                                                .addComponent(optionPregnantCombatantNag)
-                                                .addComponent(optionPrisonersNag)
-                                                .addComponent(optionAdminStrainNag)
-                                                .addComponent(optionUntreatedPersonnelNag)
-                                                .addComponent(optionNoCommanderNag)
-                                                .addComponent(optionContractEndedNag)
-                                                .addComponent(optionInsufficientAstechsNag)
-                                                .addComponent(optionInsufficientAstechTimeNag)
-                                                .addComponent(optionInsufficientMedicsNag)
-                                                .addComponent(optionShortDeploymentNag)
-                                                .addComponent(optionUnresolvedStratConContactsNag)
-                                                .addComponent(optionOutstandingScenariosNag)
-                                                .addComponent(optionInvalidFactionNag)
-                                                .addComponent(optionUnableToAffordExpensesNag)
-                                                .addComponent(optionUnableToAffordLoanPaymentNag)
-                                                .addComponent(optionUnableToAffordJumpNag));
-
-                layout.setHorizontalGroup(
-                                layout.createParallelGroup(Alignment.LEADING)
-                                                .addComponent(optionUnmaintainedUnitsNag)
-                                                .addComponent(optionPregnantCombatantNag)
-                                                .addComponent(optionPrisonersNag)
-                                                .addComponent(optionAdminStrainNag)
-                                                .addComponent(optionUntreatedPersonnelNag)
-                                                .addComponent(optionNoCommanderNag)
-                                                .addComponent(optionContractEndedNag)
-                                                .addComponent(optionInsufficientAstechsNag)
-                                                .addComponent(optionInsufficientAstechTimeNag)
-                                                .addComponent(optionInsufficientMedicsNag)
-                                                .addComponent(optionShortDeploymentNag)
-                                                .addComponent(optionUnresolvedStratConContactsNag)
-                                                .addComponent(optionOutstandingScenariosNag)
-                                                .addComponent(optionInvalidFactionNag)
-                                                .addComponent(optionUnableToAffordExpensesNag)
-                                                .addComponent(optionUnableToAffordLoanPaymentNag)
-                                                .addComponent(optionUnableToAffordJumpNag));
-
-                return panel;
-        }
-
-        private JPanel createMiscellaneousTab() {
-                // Create Panel Components
-                final JLabel lblUserDir = new JLabel(resources.getString("lblUserDir.text"));
-                lblUserDir.setToolTipText(resources.getString("lblUserDir.toolTipText"));
-                lblUserDir.setName("lblUserDir");
-
-                txtUserDir = new JTextField(20);
-                txtUserDir.setToolTipText(resources.getString("lblUserDir.toolTipText"));
-                txtUserDir.setName("txtUserDir");
-
-                JButton userDirChooser = new JButton("...");
-                userDirChooser.addActionListener(e -> CommonSettingsDialog.fileChooseUserDir(txtUserDir, getFrame()));
-                userDirChooser.setToolTipText(resources.getString("userDirChooser.title"));
-
-                JButton userDirHelp = new JButton("Help");
-                try {
-                        String helpTitle = Messages.getString("UserDirHelpDialog.title");
-                        URL helpFile = new File(MMConstants.USER_DIR_README_FILE).toURI().toURL();
-                        userDirHelp.addActionListener(
-                                        e -> new HelpDialog(helpTitle, helpFile, getFrame()).setVisible(true));
-                } catch (MalformedURLException e) {
-                        logger.error("Could not find the user data directory readme file at "
-                                        + MMConstants.USER_DIR_README_FILE);
+        JLabel labelPersonnelDisplay = new JLabel(resources.getString("labelPersonnelDisplay.text"));
+
+        JLabel labelPersonnelFilterStyle = new JLabel(resources.getString("optionPersonnelFilterStyle.text"));
+        labelPersonnelFilterStyle.setToolTipText(resources.getString("optionPersonnelFilterStyle.toolTipText"));
+
+        optionPersonnelFilterStyle = new JComboBox<>(PersonnelFilterStyle.values());
+        optionPersonnelFilterStyle.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
+                                                          final boolean isSelected, final boolean cellHasFocus) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                if (value instanceof PersonnelFilterStyle) {
+                    list.setToolTipText(((PersonnelFilterStyle) value).getToolTipText());
                 }
-
-                final JLabel lblStartGameDelay = new JLabel(resources.getString("lblStartGameDelay.text"));
-                lblStartGameDelay.setToolTipText(resources.getString("lblStartGameDelay.toolTipText"));
-                lblStartGameDelay.setName("lblStartGameDelay");
-
-                spnStartGameDelay = new JSpinner(new SpinnerNumberModel(1000, 250, 2500, 25));
-                spnStartGameDelay.setToolTipText(resources.getString("lblStartGameDelay.toolTipText"));
-                spnStartGameDelay.setName("spnStartGameDelay");
-
-                final JLabel lblStartGameClientDelay = new JLabel(resources.getString("lblStartGameClientDelay.text"));
-                lblStartGameClientDelay.setToolTipText(resources.getString("lblStartGameClientDelay.toolTipText"));
-                lblStartGameClientDelay.setName("lblStartGameClientDelay");
-
-                spnStartGameClientDelay = new JSpinner(new SpinnerNumberModel(50, 50, 2500, 25));
-                spnStartGameClientDelay.setToolTipText(resources.getString("lblStartGameClientDelay.toolTipText"));
-                spnStartGameClientDelay.setName("spnStartGameClientDelay");
-
-                final JLabel lblStartGameClientRetryCount = new JLabel(
-                                resources.getString("lblStartGameClientRetryCount.text"));
-                lblStartGameClientRetryCount
-                                .setToolTipText(resources.getString("lblStartGameClientRetryCount.toolTipText"));
-                lblStartGameClientRetryCount.setName("lblStartGameClientRetryCount");
-
-                spnStartGameClientRetryCount = new JSpinner(new SpinnerNumberModel(1000, 100, 2500, 50));
-                spnStartGameClientRetryCount
-                                .setToolTipText(resources.getString("lblStartGameClientRetryCount.toolTipText"));
-                spnStartGameClientRetryCount.setName("spnStartGameClientRetryCount");
-
-                final JLabel lblStartGameBotClientDelay = new JLabel(
-                                resources.getString("lblStartGameBotClientDelay.text"));
-                lblStartGameBotClientDelay
-                                .setToolTipText(resources.getString("lblStartGameBotClientDelay.toolTipText"));
-                lblStartGameBotClientDelay.setName("lblStartGameBotClientDelay");
-
-                spnStartGameBotClientDelay = new JSpinner(new SpinnerNumberModel(50, 50, 2500, 25));
-                spnStartGameBotClientDelay
-                                .setToolTipText(resources.getString("lblStartGameBotClientDelay.toolTipText"));
-                spnStartGameBotClientDelay.setName("spnBotClientStartGameDelay");
-
-                final JLabel lblStartGameBotClientRetryCount = new JLabel(
-                                resources.getString("lblStartGameBotClientRetryCount.text"));
-                lblStartGameBotClientRetryCount
-                                .setToolTipText(resources.getString("lblStartGameBotClientRetryCount.toolTipText"));
-                lblStartGameBotClientRetryCount.setName("lblStartGameBotClientRetryCount");
-
-                spnStartGameBotClientRetryCount = new JSpinner(new SpinnerNumberModel(250, 100, 2500, 50));
-                spnStartGameBotClientRetryCount
-                                .setToolTipText(resources.getString("lblStartGameBotClientRetryCount.toolTipText"));
-                spnStartGameBotClientRetryCount.setName("spnStartGameBotClientRetryCount");
-
-                final JLabel lblDefaultCompanyGenerationMethod = new JLabel(
-                                resources.getString("lblDefaultCompanyGenerationMethod.text"));
-                lblDefaultCompanyGenerationMethod
-                                .setToolTipText(resources.getString("lblDefaultCompanyGenerationMethod.toolTipText"));
-                lblDefaultCompanyGenerationMethod.setName("lblDefaultCompanyGenerationMethod");
-
-                comboDefaultCompanyGenerationMethod = new MMComboBox<>("comboDefaultCompanyGenerationMethod",
-                                CompanyGenerationMethod.values());
-                comboDefaultCompanyGenerationMethod
-                                .setToolTipText(resources.getString("lblDefaultCompanyGenerationMethod.toolTipText"));
-                comboDefaultCompanyGenerationMethod.setRenderer(new DefaultListCellRenderer() {
-                        @Override
-                        public Component getListCellRendererComponent(final JList<?> list, final Object value,
-                                        final int index, final boolean isSelected,
-                                        final boolean cellHasFocus) {
-                                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-                                if (value instanceof CompanyGenerationMethod) {
-                                        list.setToolTipText(((CompanyGenerationMethod) value).getToolTipText());
-                                }
-                                return this;
-                        }
-                });
-
-                // Layout the UI
-                JPanel body = new JPanel();
-                GroupLayout layout = new GroupLayout(body);
-                body.setLayout(layout);
-
-                layout.setAutoCreateGaps(true);
-                layout.setAutoCreateContainerGaps(true);
-
-                layout.setVerticalGroup(
-                                layout.createSequentialGroup()
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(lblUserDir)
-                                                                .addComponent(txtUserDir)
-                                                                .addComponent(userDirChooser)
-                                                                .addComponent(userDirHelp, GroupLayout.DEFAULT_SIZE,
-                                                                                GroupLayout.DEFAULT_SIZE, 40))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(lblStartGameDelay)
-                                                                .addComponent(spnStartGameDelay,
-                                                                                GroupLayout.DEFAULT_SIZE,
-                                                                                GroupLayout.DEFAULT_SIZE, 40))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(lblStartGameClientDelay)
-                                                                .addComponent(spnStartGameClientDelay,
-                                                                                GroupLayout.DEFAULT_SIZE,
-                                                                                GroupLayout.DEFAULT_SIZE, 40))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(lblStartGameClientRetryCount)
-                                                                .addComponent(spnStartGameClientRetryCount,
-                                                                                GroupLayout.DEFAULT_SIZE,
-                                                                                GroupLayout.DEFAULT_SIZE, 40))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(lblStartGameBotClientDelay)
-                                                                .addComponent(spnStartGameBotClientDelay,
-                                                                                GroupLayout.DEFAULT_SIZE,
-                                                                                GroupLayout.DEFAULT_SIZE, 40))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(lblStartGameBotClientRetryCount)
-                                                                .addComponent(spnStartGameBotClientRetryCount,
-                                                                                GroupLayout.DEFAULT_SIZE,
-                                                                                GroupLayout.DEFAULT_SIZE, 40))
-                                                .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                                .addComponent(lblDefaultCompanyGenerationMethod)
-                                                                .addComponent(comboDefaultCompanyGenerationMethod)));
-
-                layout.setHorizontalGroup(
-                                layout.createParallelGroup(Alignment.LEADING)
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblUserDir)
-                                                                .addComponent(txtUserDir)
-                                                                .addComponent(userDirChooser)
-                                                                .addComponent(userDirHelp))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblStartGameDelay)
-                                                                .addComponent(spnStartGameDelay))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblStartGameClientDelay)
-                                                                .addComponent(spnStartGameClientDelay))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblStartGameClientRetryCount)
-                                                                .addComponent(spnStartGameClientRetryCount))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblStartGameBotClientDelay)
-                                                                .addComponent(spnStartGameBotClientDelay))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblStartGameBotClientRetryCount)
-                                                                .addComponent(spnStartGameBotClientRetryCount))
-                                                .addGroup(layout.createSequentialGroup()
-                                                                .addComponent(lblDefaultCompanyGenerationMethod)
-                                                                .addComponent(comboDefaultCompanyGenerationMethod)));
-
-                return body;
-        }
-        // endregion Initialization
-
-        @Override
-        protected void okAction() {
-            if (GUIPreferences.getInstance().getGUIScale() * 10 != guiScale.getValue()) {
-                GUIPreferences.getInstance().setValue(GUIPreferences.GUI_SCALE, 0.1 * guiScale.getValue());
-                MekHQ.updateGuiScaling();
+                return this;
             }
-                if (validateDateFormat(optionDisplayDateFormat.getText())) {
-                        MekHQ.getMHQOptions().setDisplayDateFormat(optionDisplayDateFormat.getText());
+        });
+
+        optionPersonnelFilterOnPrimaryRole = new JCheckBox(resources.getString("optionPersonnelFilterOnPrimaryRole.text"));
+        // endregion Personnel Tab
+
+        // Programmatically Assign Accessibility Labels
+        lblInterstellarMapShowJumpRadiusMinimumZoom.setLabelFor(spnInterstellarMapShowJumpRadiusMinimumZoom);
+        lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setLabelFor(
+              spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom);
+
+        // Disable Panel Portions by Default
+        chkInterstellarMapShowJumpRadius.setSelected(true);
+        chkInterstellarMapShowJumpRadius.doClick();
+        chkInterstellarMapShowPlanetaryAcquisitionRadius.setSelected(true);
+        chkInterstellarMapShowPlanetaryAcquisitionRadius.doClick();
+        chkInterstellarMapShowContractSearchRadius.setSelected(true);
+        chkInterstellarMapShowContractSearchRadius.doClick();
+
+        // Layout the UI
+        JPanel body = new JPanel();
+        GroupLayout layout = new GroupLayout(body);
+        body.setLayout(layout);
+
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        layout.setVerticalGroup(layout.createSequentialGroup()
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(labelDisplayDateFormat)
+                                                      .addComponent(optionDisplayDateFormat)
+                                                      .addComponent(labelDisplayDateFormatExample, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(labelLongDisplayDateFormat)
+                                                      .addComponent(optionLongDisplayDateFormat)
+                                                      .addComponent(labelLongDisplayDateFormatExample,
+                                                            Alignment.TRAILING))
+                                      .addComponent(scaleLine)
+                                      .addComponent(optionHistoricalDailyLog)
+                                      .addComponent(chkCompanyGeneratorStartup)
+                                      .addComponent(chkShowCompanyGenerator)
+                                      .addComponent(chkShowUnitPicturesOnTOE)
+                                      .addComponent(labelCommandCenterDisplay)
+                                      .addComponent(optionCommandCenterUseUnitMarket)
+                                      .addComponent(optionCommandCenterMRMS)
+                                      .addComponent(lblInterstellarMapTab)
+                                      .addComponent(chkInterstellarMapShowJumpRadius)
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(lblInterstellarMapShowJumpRadiusMinimumZoom)
+                                                      .addComponent(spnInterstellarMapShowJumpRadiusMinimumZoom,
+                                                            Alignment.TRAILING))
+                                      .addComponent(btnInterstellarMapJumpRadiusColour)
+                                      .addComponent(chkInterstellarMapShowPlanetaryAcquisitionRadius)
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(
+                                                            lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom)
+                                                      .addComponent(
+                                                            spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom,
+                                                            Alignment.TRAILING))
+                                      .addComponent(btnInterstellarMapPlanetaryAcquisitionRadiusColour)
+                                      .addComponent(chkInterstellarMapShowContractSearchRadius)
+                                      .addComponent(btnInterstellarMapContractSearchRadiusColour)
+                                      .addComponent(labelPersonnelDisplay)
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(labelPersonnelFilterStyle)
+                                                      .addComponent(optionPersonnelFilterStyle,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            40))
+                                      .addComponent(optionPersonnelFilterOnPrimaryRole));
+
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(labelDisplayDateFormat)
+                                                        .addComponent(optionDisplayDateFormat)
+                                                        .addComponent(labelDisplayDateFormatExample))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(labelLongDisplayDateFormat)
+                                                        .addComponent(optionLongDisplayDateFormat)
+                                                        .addComponent(labelLongDisplayDateFormatExample))
+                                        .addComponent(scaleLine)
+                                        .addComponent(optionHistoricalDailyLog)
+                                        .addComponent(chkCompanyGeneratorStartup)
+                                        .addComponent(chkShowCompanyGenerator)
+                                        .addComponent(chkShowUnitPicturesOnTOE)
+                                        .addComponent(labelCommandCenterDisplay)
+                                        .addComponent(optionCommandCenterUseUnitMarket)
+                                        .addComponent(optionCommandCenterMRMS)
+                                        .addComponent(lblInterstellarMapTab)
+                                        .addComponent(chkInterstellarMapShowJumpRadius)
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblInterstellarMapShowJumpRadiusMinimumZoom)
+                                                        .addComponent(spnInterstellarMapShowJumpRadiusMinimumZoom))
+                                        .addComponent(btnInterstellarMapJumpRadiusColour)
+                                        .addComponent(chkInterstellarMapShowPlanetaryAcquisitionRadius)
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(
+                                                              lblInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom)
+                                                        .addComponent(
+                                                              spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom))
+                                        .addComponent(btnInterstellarMapPlanetaryAcquisitionRadiusColour)
+                                        .addComponent(chkInterstellarMapShowContractSearchRadius)
+                                        .addComponent(btnInterstellarMapContractSearchRadiusColour)
+                                        .addComponent(labelPersonnelDisplay)
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(labelPersonnelFilterStyle)
+                                                        .addComponent(optionPersonnelFilterStyle))
+                                        .addComponent(optionPersonnelFilterOnPrimaryRole));
+
+        return body;
+    }
+
+    private JPanel createColoursTab() {
+        // region Create Graphical Components
+        optionDeployedForeground = new ColourSelectorButton(resources.getString("optionDeployedForeground.text"));
+
+        optionDeployedBackground = new ColourSelectorButton(resources.getString("optionDeployedBackground.text"));
+
+        optionBelowContractMinimumForeground = new ColourSelectorButton(resources.getString(
+              "optionBelowContractMinimumForeground.text"));
+
+        optionBelowContractMinimumBackground = new ColourSelectorButton(resources.getString(
+              "optionBelowContractMinimumBackground.text"));
+
+        optionInTransitForeground = new ColourSelectorButton(resources.getString("optionInTransitForeground.text"));
+
+        optionInTransitBackground = new ColourSelectorButton(resources.getString("optionInTransitBackground.text"));
+
+        optionRefittingForeground = new ColourSelectorButton(resources.getString("optionRefittingForeground.text"));
+
+        optionRefittingBackground = new ColourSelectorButton(resources.getString("optionRefittingBackground.text"));
+
+        optionMothballingForeground = new ColourSelectorButton(resources.getString("optionMothballingForeground.text"));
+
+        optionMothballingBackground = new ColourSelectorButton(resources.getString("optionMothballingBackground.text"));
+
+        optionMothballedForeground = new ColourSelectorButton(resources.getString("optionMothballedForeground.text"));
+
+        optionMothballedBackground = new ColourSelectorButton(resources.getString("optionMothballedBackground.text"));
+
+        optionNotRepairableForeground = new ColourSelectorButton(resources.getString(
+              "optionNotRepairableForeground.text"));
+
+        optionNotRepairableBackground = new ColourSelectorButton(resources.getString(
+              "optionNotRepairableBackground.text"));
+
+        optionNonFunctionalForeground = new ColourSelectorButton(resources.getString(
+              "optionNonFunctionalForeground.text"));
+
+        optionNonFunctionalBackground = new ColourSelectorButton(resources.getString(
+              "optionNonFunctionalBackground.text"));
+
+        optionNeedsPartsFixedForeground = new ColourSelectorButton(resources.getString(
+              "optionNeedsPartsFixedForeground.text"));
+
+        optionNeedsPartsFixedBackground = new ColourSelectorButton(resources.getString(
+              "optionNeedsPartsFixedBackground.text"));
+
+        optionUnmaintainedForeground = new ColourSelectorButton(resources.getString("optionUnmaintainedForeground.text"));
+
+        optionUnmaintainedBackground = new ColourSelectorButton(resources.getString("optionUnmaintainedBackground.text"));
+
+        optionUncrewedForeground = new ColourSelectorButton(resources.getString("optionUncrewedForeground.text"));
+
+        optionUncrewedBackground = new ColourSelectorButton(resources.getString("optionUncrewedBackground.text"));
+
+        optionLoanOverdueForeground = new ColourSelectorButton(resources.getString("optionLoanOverdueForeground.text"));
+
+        optionLoanOverdueBackground = new ColourSelectorButton(resources.getString("optionLoanOverdueBackground.text"));
+
+        optionInjuredForeground = new ColourSelectorButton(resources.getString("optionInjuredForeground.text"));
+
+        optionInjuredBackground = new ColourSelectorButton(resources.getString("optionInjuredBackground.text"));
+
+        optionHealedInjuriesForeground = new ColourSelectorButton(resources.getString(
+              "optionHealedInjuriesForeground.text"));
+
+        optionHealedInjuriesBackground = new ColourSelectorButton(resources.getString(
+              "optionHealedInjuriesBackground.text"));
+
+        optionPregnantForeground = new ColourSelectorButton(resources.getString("optionPregnantForeground.text"));
+
+        optionPregnantBackground = new ColourSelectorButton(resources.getString("optionPregnantBackground.text"));
+
+        optionGoneForeground = new ColourSelectorButton(resources.getString("optionGoneForeground.text"));
+
+        optionGoneBackground = new ColourSelectorButton(resources.getString("optionGoneBackground.text"));
+
+        optionAbsentForeground = new ColourSelectorButton(resources.getString("optionAbsentForeground.text"));
+
+        optionAbsentBackground = new ColourSelectorButton(resources.getString("optionAbsentBackground.text"));
+
+        optionFatiguedForeground = new ColourSelectorButton(resources.getString("optionFatiguedForeground.text"));
+
+        optionFatiguedBackground = new ColourSelectorButton(resources.getString("optionFatiguedBackground.text"));
+
+        optionStratConHexCoordForeground = new ColourSelectorButton(resources.getString(
+              "optionStratConHexCoordForeground.text"));
+
+        optionFontColorNegative = new ColourSelectorButton(resources.getString("optionFontColorNegative.text"));
+
+        optionFontColorWarning = new ColourSelectorButton(resources.getString("optionFontColorWarning.text"));
+
+        optionFontColorPositive = new ColourSelectorButton(resources.getString("optionFontColorPositive.text"));
+
+        optionFontColorSkillUltraGreen = new ColourSelectorButton(resources.getString(
+              "optionFontColorSkillUltraGreen.text"));
+
+        optionFontColorSkillGreen = new ColourSelectorButton(resources.getString("optionFontColorSkillGreen.text"));
+
+        optionFontColorSkillRegular = new ColourSelectorButton(resources.getString("optionFontColorSkillRegular.text"));
+
+        optionFontColorSkillVeteran = new ColourSelectorButton(resources.getString("optionFontColorSkillVeteran.text"));
+
+        optionFontColorSkillElite = new ColourSelectorButton(resources.getString("optionFontColorSkillElite.text"));
+
+        // endregion Create Graphical Components
+
+        // region Layout
+        // Layout the UI
+        JPanel body = new JPanel();
+        GroupLayout layout = new GroupLayout(body);
+        body.setLayout(layout);
+
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        layout.setVerticalGroup(layout.createSequentialGroup()
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionDeployedForeground)
+                                                      .addComponent(optionDeployedBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionBelowContractMinimumForeground)
+                                                      .addComponent(optionBelowContractMinimumBackground,
+                                                            Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionInTransitForeground)
+                                                      .addComponent(optionInTransitBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionRefittingForeground)
+                                                      .addComponent(optionRefittingBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionMothballingForeground)
+                                                      .addComponent(optionMothballingBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionMothballedForeground)
+                                                      .addComponent(optionMothballedBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionNotRepairableForeground)
+                                                      .addComponent(optionNotRepairableBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionNonFunctionalForeground)
+                                                      .addComponent(optionNonFunctionalBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionNeedsPartsFixedForeground)
+                                                      .addComponent(optionNeedsPartsFixedBackground,
+                                                            Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionUnmaintainedForeground)
+                                                      .addComponent(optionUnmaintainedBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionUncrewedForeground)
+                                                      .addComponent(optionUncrewedBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionLoanOverdueForeground)
+                                                      .addComponent(optionLoanOverdueBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionInjuredForeground)
+                                                      .addComponent(optionInjuredBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionHealedInjuriesForeground)
+                                                      .addComponent(optionHealedInjuriesBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionPregnantForeground)
+                                                      .addComponent(optionPregnantBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionGoneForeground)
+                                                      .addComponent(optionGoneBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionAbsentForeground)
+                                                      .addComponent(optionAbsentBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionFatiguedForeground)
+                                                      .addComponent(optionFatiguedBackground, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionStratConHexCoordForeground))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionFontColorNegative)
+                                                      .addComponent(optionFontColorPositive, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionFontColorWarning)
+                                                      .addComponent(optionFontColorSkillUltraGreen, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionFontColorSkillGreen)
+                                                      .addComponent(optionFontColorSkillRegular, Alignment.TRAILING))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(optionFontColorSkillVeteran)
+                                                      .addComponent(optionFontColorSkillElite, Alignment.TRAILING)));
+
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionDeployedForeground)
+                                                        .addComponent(optionDeployedBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionBelowContractMinimumForeground)
+                                                        .addComponent(optionBelowContractMinimumBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionInTransitForeground)
+                                                        .addComponent(optionInTransitBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionRefittingForeground)
+                                                        .addComponent(optionRefittingBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionMothballingForeground)
+                                                        .addComponent(optionMothballingBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionMothballedForeground)
+                                                        .addComponent(optionMothballedBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionNotRepairableForeground)
+                                                        .addComponent(optionNotRepairableBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionNonFunctionalForeground)
+                                                        .addComponent(optionNonFunctionalBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionNeedsPartsFixedForeground)
+                                                        .addComponent(optionNeedsPartsFixedBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionUnmaintainedForeground)
+                                                        .addComponent(optionUnmaintainedBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionUncrewedForeground)
+                                                        .addComponent(optionUncrewedBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionLoanOverdueForeground)
+                                                        .addComponent(optionLoanOverdueBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionInjuredForeground)
+                                                        .addComponent(optionInjuredBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionHealedInjuriesForeground)
+                                                        .addComponent(optionHealedInjuriesBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionPregnantForeground)
+                                                        .addComponent(optionPregnantBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionGoneForeground)
+                                                        .addComponent(optionGoneBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionAbsentForeground)
+                                                        .addComponent(optionAbsentBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionFatiguedForeground)
+                                                        .addComponent(optionFatiguedBackground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionStratConHexCoordForeground))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionFontColorNegative)
+                                                        .addComponent(optionFontColorPositive))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionFontColorWarning)
+                                                        .addComponent(optionFontColorSkillUltraGreen))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionFontColorSkillGreen)
+                                                        .addComponent(optionFontColorSkillRegular))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(optionFontColorSkillVeteran)
+                                                        .addComponent(optionFontColorSkillElite)));
+        // endregion Layout
+
+        return body;
+    }
+
+    private JPanel createFontsTab() {
+        // Create Panel Components
+        final JLabel lblMedicalViewDialogHandwritingFont = new JLabel(resources.getString(
+              "lblMedicalViewDialogHandwritingFont.text"));
+        lblMedicalViewDialogHandwritingFont.setToolTipText(resources.getString(
+              "lblMedicalViewDialogHandwritingFont.toolTipText"));
+        lblMedicalViewDialogHandwritingFont.setName("lblMedicalViewDialogHandwritingFont");
+
+        comboMedicalViewDialogHandwritingFont = new FontComboBox("comboMedicalViewDialogHandwritingFont");
+        comboMedicalViewDialogHandwritingFont.setToolTipText(resources.getString(
+              "lblMedicalViewDialogHandwritingFont.toolTipText"));
+
+        // Programmatically Assign Accessibility Labels
+        lblMedicalViewDialogHandwritingFont.setLabelFor(comboMedicalViewDialogHandwritingFont);
+
+        // Layout the UI
+        final JPanel panel = new JPanel();
+        panel.setName("fontPanel");
+        final GroupLayout layout = new GroupLayout(panel);
+        panel.setLayout(layout);
+
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        layout.setVerticalGroup(layout.createSequentialGroup()
+                                      .addGroup(layout.createParallelGroup(Alignment.LEADING)
+                                                      .addComponent(lblMedicalViewDialogHandwritingFont)
+                                                      .addComponent(comboMedicalViewDialogHandwritingFont,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            40)));
+
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblMedicalViewDialogHandwritingFont)
+                                                        .addComponent(comboMedicalViewDialogHandwritingFont)));
+
+        return panel;
+    }
+
+    private JPanel createAutosaveTab() {
+        // Create Panel Components
+        optionNoSave = new JRadioButton(resources.getString("optionNoSave.text"));
+        optionNoSave.setMnemonic(KeyEvent.VK_N);
+
+        optionSaveDaily = new JRadioButton(resources.getString("optionSaveDaily.text"));
+        optionSaveDaily.setMnemonic(KeyEvent.VK_D);
+
+        optionSaveWeekly = new JRadioButton(resources.getString("optionSaveWeekly.text"));
+        optionSaveWeekly.setMnemonic(KeyEvent.VK_W);
+
+        optionSaveMonthly = new JRadioButton(resources.getString("optionSaveMonthly.text"));
+        optionSaveMonthly.setMnemonic(KeyEvent.VK_M);
+
+        optionSaveYearly = new JRadioButton(resources.getString("optionSaveYearly.text"));
+        optionSaveYearly.setMnemonic(KeyEvent.VK_Y);
+
+        ButtonGroup saveFrequencyGroup = new ButtonGroup();
+        saveFrequencyGroup.add(optionNoSave);
+        saveFrequencyGroup.add(optionSaveDaily);
+        saveFrequencyGroup.add(optionSaveWeekly);
+        saveFrequencyGroup.add(optionSaveMonthly);
+        saveFrequencyGroup.add(optionSaveYearly);
+
+        checkSaveBeforeScenarios = new JCheckBox(resources.getString("checkSaveBeforeScenarios.text"));
+        checkSaveBeforeScenarios.setMnemonic(KeyEvent.VK_S);
+
+        checkSaveBeforeContractEnd = new JCheckBox(resources.getString("checkSaveBeforeMissionEnd.text"));
+
+        JLabel labelSavedGamesCount = new JLabel(resources.getString("labelSavedGamesCount.text"));
+        spinnerSavedGamesCount = new JSpinner(new SpinnerNumberModel(1, 1, 10, 1));
+        labelSavedGamesCount.setLabelFor(spinnerSavedGamesCount);
+
+        // Layout the UI
+        JPanel body = new JPanel();
+        GroupLayout layout = new GroupLayout(body);
+        body.setLayout(layout);
+
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        layout.setVerticalGroup(layout.createSequentialGroup()
+                                      .addComponent(optionNoSave)
+                                      .addComponent(optionSaveDaily)
+                                      .addComponent(optionSaveWeekly)
+                                      .addComponent(optionSaveMonthly)
+                                      .addComponent(optionSaveYearly)
+                                      .addComponent(checkSaveBeforeScenarios)
+                                      .addComponent(checkSaveBeforeContractEnd)
+                                      .addGroup(layout.createParallelGroup(Alignment.LEADING)
+                                                      .addComponent(labelSavedGamesCount)
+                                                      .addComponent(spinnerSavedGamesCount,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            40)));
+
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
+                                        .addComponent(optionNoSave)
+                                        .addComponent(optionSaveDaily)
+                                        .addComponent(optionSaveWeekly)
+                                        .addComponent(optionSaveMonthly)
+                                        .addComponent(optionSaveYearly)
+                                        .addComponent(checkSaveBeforeScenarios)
+                                        .addComponent(checkSaveBeforeContractEnd)
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(labelSavedGamesCount)
+                                                        .addComponent(spinnerSavedGamesCount)));
+
+        return body;
+    }
+
+    private JPanel createNewDayTab() {
+        // Initialize Components Used in ActionListeners
+        final JLabel lblNewDayForceIconOperationalStatusStyle = new JLabel(resources.getString(
+              "lblNewDayForceIconOperationalStatusStyle.text"));
+
+        // Create Panel Components
+        chkNewDayAstechPoolFill = new JCheckBox(resources.getString("chkNewDayAstechPoolFill.text"));
+        chkNewDayAstechPoolFill.setToolTipText(resources.getString("chkNewDayAstechPoolFill.toolTipText"));
+        chkNewDayAstechPoolFill.setName("chkNewDayAstechPoolFill");
+
+        chkNewDayMedicPoolFill = new JCheckBox(resources.getString("chkNewDayMedicPoolFill.text"));
+        chkNewDayMedicPoolFill.setToolTipText(resources.getString("chkNewDayMedicPoolFill.toolTipText"));
+        chkNewDayMedicPoolFill.setName("chkNewDayMedicPoolFill");
+
+        chkNewDayMRMS = new JCheckBox(resources.getString("chkNewDayMRMS.text"));
+        chkNewDayMRMS.setToolTipText(resources.getString("chkNewDayMRMS.toolTipText"));
+        chkNewDayMRMS.setName("chkNewDayMRMS");
+
+        chkNewDayOptimizeMedicalAssignments = new JCheckBox(resources.getString(
+              "chkNewDayOptimizeMedicalAssignments.text"));
+        chkNewDayOptimizeMedicalAssignments.setToolTipText(resources.getString(
+              "chkNewDayOptimizeMedicalAssignments.toolTipText"));
+        chkNewDayOptimizeMedicalAssignments.setName("chkNewDayOptimizeMedicalAssignments.text");
+
+        chkNewDayForceIconOperationalStatus = new JCheckBox(resources.getString(
+              "chkNewDayForceIconOperationalStatus.text"));
+        chkNewDayForceIconOperationalStatus.setToolTipText(resources.getString(
+              "chkNewDayForceIconOperationalStatus.toolTipText"));
+        chkNewDayForceIconOperationalStatus.setName("chkNewDayForceIconOperationalStatus");
+        chkNewDayForceIconOperationalStatus.addActionListener(evt -> {
+            final boolean selected = chkNewDayForceIconOperationalStatus.isSelected();
+            lblNewDayForceIconOperationalStatusStyle.setEnabled(selected);
+            comboNewDayForceIconOperationalStatusStyle.setEnabled(selected);
+        });
+
+        lblNewDayForceIconOperationalStatusStyle.setToolTipText(resources.getString(
+              "lblNewDayForceIconOperationalStatusStyle.toolTipText"));
+        lblNewDayForceIconOperationalStatusStyle.setName("lblNewDayForceIconOperationalStatusStyle");
+
+        comboNewDayForceIconOperationalStatusStyle = new MMComboBox<>("comboNewDayForceIconOperationalStatusStyle",
+              ForceIconOperationalStatusStyle.values());
+        comboNewDayForceIconOperationalStatusStyle.setToolTipText(resources.getString(
+              "lblNewDayForceIconOperationalStatusStyle.toolTipText"));
+        comboNewDayForceIconOperationalStatusStyle.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
+                                                          final boolean isSelected, final boolean cellHasFocus) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                if (value instanceof ForceIconOperationalStatusStyle) {
+                    list.setToolTipText(((ForceIconOperationalStatusStyle) value).getToolTipText());
                 }
+                return this;
+            }
+        });
 
-                if (validateDateFormat(optionLongDisplayDateFormat.getText())) {
-                        MekHQ.getMHQOptions().setLongDisplayDateFormat(optionLongDisplayDateFormat.getText());
-                }
-                MekHQ.getMHQOptions().setHistoricalDailyLog(optionHistoricalDailyLog.isSelected());
-                MekHQ.getMHQOptions().setCompanyGeneratorStartup(chkCompanyGeneratorStartup.isSelected());
-                MekHQ.getMHQOptions().setShowCompanyGenerator(chkShowCompanyGenerator.isSelected());
-                MekHQ.getMHQOptions().setShowUnitPicturesOnTOE(chkShowUnitPicturesOnTOE.isSelected());
+        // Programmatically Assign Accessibility Labels
+        lblNewDayForceIconOperationalStatusStyle.setLabelFor(comboNewDayForceIconOperationalStatusStyle);
 
-                // Command Center Tab
-                MekHQ.getMHQOptions().setCommandCenterUseUnitMarket(optionCommandCenterUseUnitMarket.isSelected());
-                MekHQ.getMHQOptions().setCommandCenterMRMS(optionCommandCenterMRMS.isSelected());
+        // Disable Panel Portions by Default
+        chkNewDayForceIconOperationalStatus.setSelected(true);
+        chkNewDayForceIconOperationalStatus.doClick();
 
-                // Interstellar Map Tab
-                MekHQ.getMHQOptions().setInterstellarMapShowJumpRadius(chkInterstellarMapShowJumpRadius.isSelected());
-                MekHQ.getMHQOptions().setInterstellarMapShowJumpRadiusMinimumZoom(
-                                (Double) spnInterstellarMapShowJumpRadiusMinimumZoom.getValue());
-                MekHQ.getMHQOptions()
-                                .setInterstellarMapJumpRadiusColour(btnInterstellarMapJumpRadiusColour.getColour());
-                MekHQ.getMHQOptions().setInterstellarMapShowPlanetaryAcquisitionRadius(
-                                chkInterstellarMapShowPlanetaryAcquisitionRadius.isSelected());
-                MekHQ.getMHQOptions().setInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom(
-                                (Double) spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.getValue());
-                MekHQ.getMHQOptions().setInterstellarMapPlanetaryAcquisitionRadiusColour(
-                                btnInterstellarMapPlanetaryAcquisitionRadiusColour.getColour());
-                MekHQ.getMHQOptions().setInterstellarMapShowContractSearchRadius(
-                                chkInterstellarMapShowContractSearchRadius.isSelected());
-                MekHQ.getMHQOptions().setInterstellarMapContractSearchRadiusColour(
-                                btnInterstellarMapContractSearchRadiusColour.getColour());
+        // Layout the UI
+        final JPanel panel = new JPanel();
+        panel.setName("newDayPanel");
+        final GroupLayout layout = new GroupLayout(panel);
+        panel.setLayout(layout);
 
-                // Personnel Tab
-                MekHQ.getMHQOptions().setPersonnelFilterStyle((PersonnelFilterStyle) Objects
-                                .requireNonNull(optionPersonnelFilterStyle.getSelectedItem()));
-                MekHQ.getMHQOptions().setPersonnelFilterOnPrimaryRole(optionPersonnelFilterOnPrimaryRole.isSelected());
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
 
-                // Colours
-                MekHQ.getMHQOptions().setDeployedForeground(optionDeployedForeground.getColour());
-                MekHQ.getMHQOptions().setDeployedBackground(optionDeployedBackground.getColour());
-                MekHQ.getMHQOptions()
-                                .setBelowContractMinimumForeground(optionBelowContractMinimumForeground.getColour());
-                MekHQ.getMHQOptions()
-                                .setBelowContractMinimumBackground(optionBelowContractMinimumBackground.getColour());
-                MekHQ.getMHQOptions().setInTransitForeground(optionInTransitForeground.getColour());
-                MekHQ.getMHQOptions().setInTransitBackground(optionInTransitBackground.getColour());
-                MekHQ.getMHQOptions().setRefittingForeground(optionRefittingForeground.getColour());
-                MekHQ.getMHQOptions().setRefittingBackground(optionRefittingBackground.getColour());
-                MekHQ.getMHQOptions().setMothballingForeground(optionMothballingForeground.getColour());
-                MekHQ.getMHQOptions().setMothballingBackground(optionMothballingBackground.getColour());
-                MekHQ.getMHQOptions().setMothballedForeground(optionMothballedForeground.getColour());
-                MekHQ.getMHQOptions().setMothballedBackground(optionMothballedBackground.getColour());
-                MekHQ.getMHQOptions().setNotRepairableForeground(optionNotRepairableForeground.getColour());
-                MekHQ.getMHQOptions().setNotRepairableBackground(optionNotRepairableBackground.getColour());
-                MekHQ.getMHQOptions().setNonFunctionalForeground(optionNonFunctionalForeground.getColour());
-                MekHQ.getMHQOptions().setNonFunctionalBackground(optionNonFunctionalBackground.getColour());
-                MekHQ.getMHQOptions().setNeedsPartsFixedForeground(optionNeedsPartsFixedForeground.getColour());
-                MekHQ.getMHQOptions().setNeedsPartsFixedBackground(optionNeedsPartsFixedBackground.getColour());
-                MekHQ.getMHQOptions().setUnmaintainedForeground(optionUnmaintainedForeground.getColour());
-                MekHQ.getMHQOptions().setUnmaintainedBackground(optionUnmaintainedBackground.getColour());
-                MekHQ.getMHQOptions().setUncrewedForeground(optionUncrewedForeground.getColour());
-                MekHQ.getMHQOptions().setUncrewedBackground(optionUncrewedBackground.getColour());
-                MekHQ.getMHQOptions().setLoanOverdueForeground(optionLoanOverdueForeground.getColour());
-                MekHQ.getMHQOptions().setLoanOverdueBackground(optionLoanOverdueBackground.getColour());
-                MekHQ.getMHQOptions().setInjuredForeground(optionInjuredForeground.getColour());
-                MekHQ.getMHQOptions().setInjuredBackground(optionInjuredBackground.getColour());
-                MekHQ.getMHQOptions().setHealedInjuriesForeground(optionHealedInjuriesForeground.getColour());
-                MekHQ.getMHQOptions().setHealedInjuriesBackground(optionHealedInjuriesBackground.getColour());
-                MekHQ.getMHQOptions().setPregnantForeground(optionPregnantForeground.getColour());
-                MekHQ.getMHQOptions().setPregnantBackground(optionPregnantBackground.getColour());
-                MekHQ.getMHQOptions().setGoneForeground(optionGoneForeground.getColour());
-                MekHQ.getMHQOptions().setGoneBackground(optionGoneBackground.getColour());
-                MekHQ.getMHQOptions().setAbsentForeground(optionAbsentForeground.getColour());
-                MekHQ.getMHQOptions().setAbsentBackground(optionAbsentBackground.getColour());
-                MekHQ.getMHQOptions().setFatiguedForeground(optionFatiguedForeground.getColour());
-                MekHQ.getMHQOptions().setFatiguedBackground(optionFatiguedBackground.getColour());
-                MekHQ.getMHQOptions().setStratConHexCoordForeground(optionStratConHexCoordForeground.getColour());
-                MekHQ.getMHQOptions().setFontColorNegative(optionFontColorNegative.getColour());
-                MekHQ.getMHQOptions().setFontColorWarning(optionFontColorWarning.getColour());
-                MekHQ.getMHQOptions().setFontColorPositive(optionFontColorPositive.getColour());
-                MekHQ.getMHQOptions().setFontColorSkillUltraGreen(optionFontColorSkillUltraGreen.getColour());
-                MekHQ.getMHQOptions().setFontColorSkillGreen(optionFontColorSkillGreen.getColour());
-                MekHQ.getMHQOptions().setFontColorSkillRegular(optionFontColorSkillRegular.getColour());
-                MekHQ.getMHQOptions().setFontColorSkillVeteran(optionFontColorSkillVeteran.getColour());
-                MekHQ.getMHQOptions().setFontColorSkillElite(optionFontColorSkillElite.getColour());
+        layout.setVerticalGroup(layout.createSequentialGroup()
+                                      .addComponent(chkNewDayAstechPoolFill)
+                                      .addComponent(chkNewDayMedicPoolFill)
+                                      .addComponent(chkNewDayMRMS)
+                                      .addComponent(chkNewDayOptimizeMedicalAssignments)
+                                      .addComponent(chkNewDayForceIconOperationalStatus)
+                                      .addGroup(layout.createParallelGroup(Alignment.LEADING)
+                                                      .addComponent(lblNewDayForceIconOperationalStatusStyle)
+                                                      .addComponent(comboNewDayForceIconOperationalStatusStyle,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            40)));
 
-                MekHQ.getMHQOptions().setMedicalViewDialogHandwritingFont(
-                                comboMedicalViewDialogHandwritingFont.getFont().getFamily());
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
+                                        .addComponent(chkNewDayAstechPoolFill)
+                                        .addComponent(chkNewDayMedicPoolFill)
+                                        .addComponent(chkNewDayMRMS)
+                                        .addComponent(chkNewDayOptimizeMedicalAssignments)
+                                        .addComponent(chkNewDayForceIconOperationalStatus)
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblNewDayForceIconOperationalStatusStyle)
+                                                        .addComponent(comboNewDayForceIconOperationalStatusStyle)));
 
-                MekHQ.getMHQOptions().setNoAutosaveValue(optionNoSave.isSelected());
-                MekHQ.getMHQOptions().setAutosaveDailyValue(optionSaveDaily.isSelected());
-                MekHQ.getMHQOptions().setAutosaveWeeklyValue(optionSaveWeekly.isSelected());
-                MekHQ.getMHQOptions().setAutosaveMonthlyValue(optionSaveMonthly.isSelected());
-                MekHQ.getMHQOptions().setAutosaveYearlyValue(optionSaveYearly.isSelected());
-                MekHQ.getMHQOptions().setAutosaveBeforeMissionsValue(checkSaveBeforeMissions.isSelected());
-                MekHQ.getMHQOptions().setMaximumNumberOfAutosavesValue((Integer) spinnerSavedGamesCount.getValue());
+        return panel;
+    }
 
-                MekHQ.getMHQOptions().setNewDayAstechPoolFill(chkNewDayAstechPoolFill.isSelected());
-                MekHQ.getMHQOptions().setNewDayMedicPoolFill(chkNewDayMedicPoolFill.isSelected());
-                MekHQ.getMHQOptions().setNewDayMRMS(chkNewDayMRMS.isSelected());
-                MekHQ.getMHQOptions().setNewDayOptimizeMedicalAssignments(chkNewDayOptimizeMedicalAssignments.isSelected());
-                MekHQ.getMHQOptions()
-                                .setNewDayForceIconOperationalStatus(chkNewDayForceIconOperationalStatus.isSelected());
-                MekHQ.getMHQOptions().setNewDayForceIconOperationalStatusStyle(
-                                Objects.requireNonNull(comboNewDayForceIconOperationalStatusStyle.getSelectedItem()));
+    private JPanel createCampaignXMLSaveTab() {
+        // Create Panel Components
+        optionPreferGzippedOutput = new JCheckBox(resources.getString("optionPreferGzippedOutput.text"));
+        optionPreferGzippedOutput.setToolTipText(resources.getString("optionPreferGzippedOutput.toolTipText"));
 
-                MekHQ.getMHQOptions().setPreferGzippedOutput(optionPreferGzippedOutput.isSelected());
-                MekHQ.getMHQOptions().setWriteCustomsToXML(optionWriteCustomsToXML.isSelected());
-                MekHQ.getMHQOptions().setSaveMothballState(optionSaveMothballState.isSelected());
+        optionWriteCustomsToXML = new JCheckBox(resources.getString("optionWriteCustomsToXML.text"));
+        optionWriteCustomsToXML.setMnemonic(KeyEvent.VK_C);
 
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNMAINTAINED_UNITS,
-                                optionUnmaintainedUnitsNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_PREGNANT_COMBATANT,
-                                optionPregnantCombatantNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_PRISONERS,
-                      optionPrisonersNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_ADMIN_STRAIN,
-                      optionAdminStrainNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNTREATED_PERSONNEL,
-                                optionUntreatedPersonnelNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_NO_COMMANDER,
-                                optionNoCommanderNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_CONTRACT_ENDED,
-                                optionContractEndedNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECHS,
-                                optionInsufficientAstechsNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME,
-                                optionInsufficientAstechTimeNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_MEDICS,
-                                optionInsufficientMedicsNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_SHORT_DEPLOYMENT,
-                                optionShortDeploymentNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS,
-                                optionUnresolvedStratConContactsNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_OUTSTANDING_SCENARIOS,
-                                optionOutstandingScenariosNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_INVALID_FACTION,
-                                optionInvalidFactionNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_EXPENSES,
-                                optionUnableToAffordExpensesNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_LOAN_PAYMENT,
-                                optionUnableToAffordLoanPaymentNag.isSelected());
-                MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP,
-                                optionUnableToAffordJumpNag.isSelected());
+        optionSaveMothballState = new JCheckBox(resources.getString("optionSaveMothballState.text"));
+        optionSaveMothballState.setToolTipText(resources.getString("optionSaveMothballState.toolTipText"));
+        optionSaveMothballState.setMnemonic(KeyEvent.VK_U);
 
-                PreferenceManager.getClientPreferences().setUserDir(txtUserDir.getText());
-                PreferenceManager.getInstance().save();
-                MekHQ.getMHQOptions().setStartGameDelay((Integer) spnStartGameDelay.getValue());
-                MekHQ.getMHQOptions().setStartGameClientDelay((Integer) spnStartGameClientDelay.getValue());
-                MekHQ.getMHQOptions().setStartGameClientRetryCount((Integer) spnStartGameClientRetryCount.getValue());
-                MekHQ.getMHQOptions().setStartGameBotClientDelay((Integer) spnStartGameBotClientDelay.getValue());
-                MekHQ.getMHQOptions()
-                                .setStartGameBotClientRetryCount((Integer) spnStartGameBotClientRetryCount.getValue());
-                MekHQ.getMHQOptions().setDefaultCompanyGenerationMethod(
-                                Objects.requireNonNull(comboDefaultCompanyGenerationMethod.getSelectedItem()));
+        // Layout the UI
+        JPanel body = new JPanel();
+        GroupLayout layout = new GroupLayout(body);
+        body.setLayout(layout);
 
-                MekHQ.triggerEvent(new MHQOptionsChangedEvent());
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        layout.setVerticalGroup(layout.createSequentialGroup()
+                                      .addComponent(optionPreferGzippedOutput)
+                                      .addComponent(optionWriteCustomsToXML)
+                                      .addComponent(optionSaveMothballState));
+
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
+                                        .addComponent(optionPreferGzippedOutput)
+                                        .addComponent(optionWriteCustomsToXML)
+                                        .addComponent(optionSaveMothballState));
+
+        return body;
+    }
+
+    private JPanel createNagTab() {
+        // Create Panel Components
+        optionUnmaintainedUnitsNag = new JCheckBox(resources.getString("optionUnmaintainedUnitsNag.text"));
+        optionUnmaintainedUnitsNag.setToolTipText(resources.getString("optionUnmaintainedUnitsNag.toolTipText"));
+        optionUnmaintainedUnitsNag.setName("optionUnmaintainedUnitsNag");
+
+        optionPregnantCombatantNag = new JCheckBox(resources.getString("optionPregnantCombatantNag.text"));
+        optionPregnantCombatantNag.setToolTipText(resources.getString("optionPregnantCombatantNag.toolTipText"));
+        optionPregnantCombatantNag.setName("optionPregnantCombatantNag");
+
+        optionPrisonersNag = new JCheckBox(resources.getString("optionPrisonersNag.text"));
+        optionPrisonersNag.setToolTipText(resources.getString("optionPrisonersNag.toolTipText"));
+        optionPrisonersNag.setName("optionPrisonersNag");
+
+        optionAdminStrainNag = new JCheckBox(resources.getString("optionAdminStrainNag.text"));
+        optionAdminStrainNag.setToolTipText(resources.getString("optionAdminStrainNag.toolTipText"));
+        optionAdminStrainNag.setName("optionAdminStrainNag");
+
+        optionUntreatedPersonnelNag = new JCheckBox(resources.getString("optionUntreatedPersonnelNag.text"));
+        optionUntreatedPersonnelNag.setToolTipText(resources.getString("optionUntreatedPersonnelNag.toolTipText"));
+        optionUntreatedPersonnelNag.setName("optionUntreatedPersonnelNag");
+
+        optionNoCommanderNag = new JCheckBox(resources.getString("optionNoCommanderNag.text"));
+        optionNoCommanderNag.setToolTipText(resources.getString("optionNoCommanderNag.toolTipText"));
+        optionNoCommanderNag.setName("optionNoCommanderNag");
+
+        optionContractEndedNag = new JCheckBox(resources.getString("optionContractEndedNag.text"));
+        optionContractEndedNag.setToolTipText(resources.getString("optionContractEndedNag.toolTipText"));
+        optionContractEndedNag.setName("optionContractEndedNag");
+
+        optionInsufficientAstechsNag = new JCheckBox(resources.getString("optionInsufficientAstechsNag.text"));
+        optionInsufficientAstechsNag.setToolTipText(resources.getString("optionInsufficientAstechsNag.toolTipText"));
+        optionInsufficientAstechsNag.setName("optionInsufficientAstechsNag");
+
+        optionInsufficientAstechTimeNag = new JCheckBox(resources.getString("optionInsufficientAstechTimeNag.text"));
+        optionInsufficientAstechTimeNag.setToolTipText(resources.getString("optionInsufficientAstechTimeNag.toolTipText"));
+        optionInsufficientAstechTimeNag.setName("optionInsufficientAstechTimeNag");
+
+        optionInsufficientMedicsNag = new JCheckBox(resources.getString("optionInsufficientMedicsNag.text"));
+        optionInsufficientMedicsNag.setToolTipText(resources.getString("optionInsufficientMedicsNag.toolTipText"));
+        optionInsufficientMedicsNag.setName("optionInsufficientMedicsNag");
+
+        optionShortDeploymentNag = new JCheckBox(resources.getString("optionShortDeploymentNag.text"));
+        optionShortDeploymentNag.setToolTipText(resources.getString("optionShortDeploymentNag.toolTipText"));
+        optionShortDeploymentNag.setName("optionShortDeploymentNag");
+
+        optionUnresolvedStratConContactsNag = new JCheckBox(resources.getString(
+              "optionUnresolvedStratConContactsNag.text"));
+        optionUnresolvedStratConContactsNag.setToolTipText(resources.getString(
+              "optionUnresolvedStratConContactsNag.toolTipText"));
+        optionUnresolvedStratConContactsNag.setName("optionUnresolvedStratConContactsNag");
+
+        optionOutstandingScenariosNag = new JCheckBox(resources.getString("optionOutstandingScenariosNag.text"));
+        optionOutstandingScenariosNag.setToolTipText(resources.getString("optionOutstandingScenariosNag.toolTipText"));
+        optionOutstandingScenariosNag.setName("optionOutstandingScenariosNag");
+
+        optionInvalidFactionNag = new JCheckBox(resources.getString("optionInvalidFactionNag.text"));
+        optionInvalidFactionNag.setToolTipText(resources.getString("optionInvalidFactionNag.toolTipText"));
+        optionInvalidFactionNag.setName("optionInvalidFactionNag");
+
+        optionUnableToAffordExpensesNag = new JCheckBox(resources.getString("optionUnableToAffordExpensesNag.text"));
+        optionUnableToAffordExpensesNag.setToolTipText(resources.getString("optionUnableToAffordExpensesNag.toolTipText"));
+        optionUnableToAffordExpensesNag.setName("optionUnableToAffordExpensesNag");
+
+        optionUnableToAffordLoanPaymentNag = new JCheckBox(resources.getString("optionUnableToAffordLoanPaymentNag.text"));
+        optionUnableToAffordLoanPaymentNag.setToolTipText(resources.getString(
+              "optionUnableToAffordLoanPaymentNag.toolTipText"));
+        optionUnableToAffordLoanPaymentNag.setName("optionUnableToAffordLoanPaymentNag");
+
+        optionUnableToAffordJumpNag = new JCheckBox(resources.getString("optionUnableToAffordJumpNag.text"));
+        optionUnableToAffordJumpNag.setToolTipText(resources.getString("optionUnableToAffordJumpNag.toolTipText"));
+        optionUnableToAffordJumpNag.setName("optionUnableToAffordJumpNag");
+
+        // Layout the UI
+        final JPanel panel = new JPanel();
+        panel.setName("nagPanel");
+        final GroupLayout layout = new GroupLayout(panel);
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+        panel.setLayout(layout);
+
+        layout.setVerticalGroup(layout.createSequentialGroup()
+                                      .addComponent(optionUnmaintainedUnitsNag)
+                                      .addComponent(optionPregnantCombatantNag)
+                                      .addComponent(optionPrisonersNag)
+                                      .addComponent(optionAdminStrainNag)
+                                      .addComponent(optionUntreatedPersonnelNag)
+                                      .addComponent(optionNoCommanderNag)
+                                      .addComponent(optionContractEndedNag)
+                                      .addComponent(optionInsufficientAstechsNag)
+                                      .addComponent(optionInsufficientAstechTimeNag)
+                                      .addComponent(optionInsufficientMedicsNag)
+                                      .addComponent(optionShortDeploymentNag)
+                                      .addComponent(optionUnresolvedStratConContactsNag)
+                                      .addComponent(optionOutstandingScenariosNag)
+                                      .addComponent(optionInvalidFactionNag)
+                                      .addComponent(optionUnableToAffordExpensesNag)
+                                      .addComponent(optionUnableToAffordLoanPaymentNag)
+                                      .addComponent(optionUnableToAffordJumpNag));
+
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
+                                        .addComponent(optionUnmaintainedUnitsNag)
+                                        .addComponent(optionPregnantCombatantNag)
+                                        .addComponent(optionPrisonersNag)
+                                        .addComponent(optionAdminStrainNag)
+                                        .addComponent(optionUntreatedPersonnelNag)
+                                        .addComponent(optionNoCommanderNag)
+                                        .addComponent(optionContractEndedNag)
+                                        .addComponent(optionInsufficientAstechsNag)
+                                        .addComponent(optionInsufficientAstechTimeNag)
+                                        .addComponent(optionInsufficientMedicsNag)
+                                        .addComponent(optionShortDeploymentNag)
+                                        .addComponent(optionUnresolvedStratConContactsNag)
+                                        .addComponent(optionOutstandingScenariosNag)
+                                        .addComponent(optionInvalidFactionNag)
+                                        .addComponent(optionUnableToAffordExpensesNag)
+                                        .addComponent(optionUnableToAffordLoanPaymentNag)
+                                        .addComponent(optionUnableToAffordJumpNag));
+
+        return panel;
+    }
+
+    private JPanel createMiscellaneousTab() {
+        // Create Panel Components
+        final JLabel lblUserDir = new JLabel(resources.getString("lblUserDir.text"));
+        lblUserDir.setToolTipText(resources.getString("lblUserDir.toolTipText"));
+        lblUserDir.setName("lblUserDir");
+
+        txtUserDir = new JTextField(20);
+        txtUserDir.setToolTipText(resources.getString("lblUserDir.toolTipText"));
+        txtUserDir.setName("txtUserDir");
+
+        JButton userDirChooser = new JButton("...");
+        userDirChooser.addActionListener(e -> CommonSettingsDialog.fileChooseUserDir(txtUserDir, getFrame()));
+        userDirChooser.setToolTipText(resources.getString("userDirChooser.title"));
+
+        JButton userDirHelp = new JButton("Help");
+        try {
+            String helpTitle = Messages.getString("UserDirHelpDialog.title");
+            URL helpFile = new File(MMConstants.USER_DIR_README_FILE).toURI().toURL();
+            userDirHelp.addActionListener(e -> new HelpDialog(helpTitle, helpFile, getFrame()).setVisible(true));
+        } catch (MalformedURLException e) {
+            logger.error("Could not find the user data directory readme file at " + MMConstants.USER_DIR_README_FILE);
         }
 
-        private void setInitialState() {
-            guiScale.setValue((int) (GUIPreferences.getInstance().getGUIScale() * 10));
-                optionDisplayDateFormat.setText(MekHQ.getMHQOptions().getDisplayDateFormat());
-                optionLongDisplayDateFormat.setText(MekHQ.getMHQOptions().getLongDisplayDateFormat());
-                optionHistoricalDailyLog.setSelected(MekHQ.getMHQOptions().getHistoricalDailyLog());
-                chkCompanyGeneratorStartup.setSelected(MekHQ.getMHQOptions().getCompanyGeneratorStartup());
-                chkShowCompanyGenerator.setSelected(MekHQ.getMHQOptions().getShowCompanyGenerator());
-                chkShowUnitPicturesOnTOE.setSelected(MekHQ.getMHQOptions().getShowUnitPicturesOnTOE());
+        final JLabel lblStartGameDelay = new JLabel(resources.getString("lblStartGameDelay.text"));
+        lblStartGameDelay.setToolTipText(resources.getString("lblStartGameDelay.toolTipText"));
+        lblStartGameDelay.setName("lblStartGameDelay");
 
-                // Command Center Tab
-                optionCommandCenterUseUnitMarket.setSelected(MekHQ.getMHQOptions().getCommandCenterUseUnitMarket());
-                optionCommandCenterMRMS.setSelected(MekHQ.getMHQOptions().getCommandCenterMRMS());
+        spnStartGameDelay = new JSpinner(new SpinnerNumberModel(1000, 250, 2500, 25));
+        spnStartGameDelay.setToolTipText(resources.getString("lblStartGameDelay.toolTipText"));
+        spnStartGameDelay.setName("spnStartGameDelay");
 
-                // Interstellar Map Tab
-                if (chkInterstellarMapShowJumpRadius.isSelected() != MekHQ.getMHQOptions()
-                                .getInterstellarMapShowJumpRadius()) {
-                        chkInterstellarMapShowJumpRadius.doClick();
+        final JLabel lblStartGameClientDelay = new JLabel(resources.getString("lblStartGameClientDelay.text"));
+        lblStartGameClientDelay.setToolTipText(resources.getString("lblStartGameClientDelay.toolTipText"));
+        lblStartGameClientDelay.setName("lblStartGameClientDelay");
+
+        spnStartGameClientDelay = new JSpinner(new SpinnerNumberModel(50, 50, 2500, 25));
+        spnStartGameClientDelay.setToolTipText(resources.getString("lblStartGameClientDelay.toolTipText"));
+        spnStartGameClientDelay.setName("spnStartGameClientDelay");
+
+        final JLabel lblStartGameClientRetryCount = new JLabel(resources.getString("lblStartGameClientRetryCount.text"));
+        lblStartGameClientRetryCount.setToolTipText(resources.getString("lblStartGameClientRetryCount.toolTipText"));
+        lblStartGameClientRetryCount.setName("lblStartGameClientRetryCount");
+
+        spnStartGameClientRetryCount = new JSpinner(new SpinnerNumberModel(1000, 100, 2500, 50));
+        spnStartGameClientRetryCount.setToolTipText(resources.getString("lblStartGameClientRetryCount.toolTipText"));
+        spnStartGameClientRetryCount.setName("spnStartGameClientRetryCount");
+
+        final JLabel lblStartGameBotClientDelay = new JLabel(resources.getString("lblStartGameBotClientDelay.text"));
+        lblStartGameBotClientDelay.setToolTipText(resources.getString("lblStartGameBotClientDelay.toolTipText"));
+        lblStartGameBotClientDelay.setName("lblStartGameBotClientDelay");
+
+        spnStartGameBotClientDelay = new JSpinner(new SpinnerNumberModel(50, 50, 2500, 25));
+        spnStartGameBotClientDelay.setToolTipText(resources.getString("lblStartGameBotClientDelay.toolTipText"));
+        spnStartGameBotClientDelay.setName("spnBotClientStartGameDelay");
+
+        final JLabel lblStartGameBotClientRetryCount = new JLabel(resources.getString(
+              "lblStartGameBotClientRetryCount.text"));
+        lblStartGameBotClientRetryCount.setToolTipText(resources.getString("lblStartGameBotClientRetryCount.toolTipText"));
+        lblStartGameBotClientRetryCount.setName("lblStartGameBotClientRetryCount");
+
+        spnStartGameBotClientRetryCount = new JSpinner(new SpinnerNumberModel(250, 100, 2500, 50));
+        spnStartGameBotClientRetryCount.setToolTipText(resources.getString("lblStartGameBotClientRetryCount.toolTipText"));
+        spnStartGameBotClientRetryCount.setName("spnStartGameBotClientRetryCount");
+
+        final JLabel lblDefaultCompanyGenerationMethod = new JLabel(resources.getString(
+              "lblDefaultCompanyGenerationMethod.text"));
+        lblDefaultCompanyGenerationMethod.setToolTipText(resources.getString(
+              "lblDefaultCompanyGenerationMethod.toolTipText"));
+        lblDefaultCompanyGenerationMethod.setName("lblDefaultCompanyGenerationMethod");
+
+        comboDefaultCompanyGenerationMethod = new MMComboBox<>("comboDefaultCompanyGenerationMethod",
+              CompanyGenerationMethod.values());
+        comboDefaultCompanyGenerationMethod.setToolTipText(resources.getString(
+              "lblDefaultCompanyGenerationMethod.toolTipText"));
+        comboDefaultCompanyGenerationMethod.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
+                                                          final boolean isSelected, final boolean cellHasFocus) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                if (value instanceof CompanyGenerationMethod) {
+                    list.setToolTipText(((CompanyGenerationMethod) value).getToolTipText());
                 }
-                spnInterstellarMapShowJumpRadiusMinimumZoom
-                                .setValue(MekHQ.getMHQOptions().getInterstellarMapShowJumpRadiusMinimumZoom());
-                btnInterstellarMapJumpRadiusColour
-                                .setColour(MekHQ.getMHQOptions().getInterstellarMapJumpRadiusColour());
-                if (chkInterstellarMapShowPlanetaryAcquisitionRadius.isSelected() != MekHQ.getMHQOptions()
-                                .getInterstellarMapShowPlanetaryAcquisitionRadius()) {
-                        chkInterstellarMapShowPlanetaryAcquisitionRadius.doClick();
-                }
-                spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setValue(
-                                MekHQ.getMHQOptions().getInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom());
-                btnInterstellarMapPlanetaryAcquisitionRadiusColour
-                                .setColour(MekHQ.getMHQOptions().getInterstellarMapPlanetaryAcquisitionRadiusColour());
-                if (chkInterstellarMapShowContractSearchRadius.isSelected() != MekHQ.getMHQOptions()
-                                .getInterstellarMapShowContractSearchRadius()) {
-                        chkInterstellarMapShowContractSearchRadius.doClick();
-                }
-                btnInterstellarMapContractSearchRadiusColour
-                                .setColour(MekHQ.getMHQOptions().getInterstellarMapContractSearchRadiusColour());
+                return this;
+            }
+        });
 
-                // Personnel Tab
-                optionPersonnelFilterStyle.setSelectedItem(MekHQ.getMHQOptions().getPersonnelFilterStyle());
-                optionPersonnelFilterOnPrimaryRole.setSelected(MekHQ.getMHQOptions().getPersonnelFilterOnPrimaryRole());
+        // Layout the UI
+        JPanel body = new JPanel();
+        GroupLayout layout = new GroupLayout(body);
+        body.setLayout(layout);
 
-                // Colours
-                optionDeployedForeground.setColour(MekHQ.getMHQOptions().getDeployedForeground());
-                optionDeployedBackground.setColour(MekHQ.getMHQOptions().getDeployedBackground());
-                optionBelowContractMinimumForeground
-                                .setColour(MekHQ.getMHQOptions().getBelowContractMinimumForeground());
-                optionBelowContractMinimumBackground
-                                .setColour(MekHQ.getMHQOptions().getBelowContractMinimumBackground());
-                optionInTransitForeground.setColour(MekHQ.getMHQOptions().getInTransitForeground());
-                optionInTransitBackground.setColour(MekHQ.getMHQOptions().getInTransitBackground());
-                optionRefittingForeground.setColour(MekHQ.getMHQOptions().getRefittingForeground());
-                optionRefittingBackground.setColour(MekHQ.getMHQOptions().getRefittingBackground());
-                optionMothballingForeground.setColour(MekHQ.getMHQOptions().getMothballingForeground());
-                optionMothballingBackground.setColour(MekHQ.getMHQOptions().getMothballingBackground());
-                optionMothballedForeground.setColour(MekHQ.getMHQOptions().getMothballedForeground());
-                optionMothballedBackground.setColour(MekHQ.getMHQOptions().getMothballedBackground());
-                optionNotRepairableForeground.setColour(MekHQ.getMHQOptions().getNotRepairableForeground());
-                optionNotRepairableBackground.setColour(MekHQ.getMHQOptions().getNotRepairableBackground());
-                optionNonFunctionalForeground.setColour(MekHQ.getMHQOptions().getNonFunctionalForeground());
-                optionNonFunctionalBackground.setColour(MekHQ.getMHQOptions().getNonFunctionalBackground());
-                optionNeedsPartsFixedForeground.setColour(MekHQ.getMHQOptions().getNeedsPartsFixedForeground());
-                optionNeedsPartsFixedBackground.setColour(MekHQ.getMHQOptions().getNeedsPartsFixedBackground());
-                optionUnmaintainedForeground.setColour(MekHQ.getMHQOptions().getUnmaintainedForeground());
-                optionUnmaintainedBackground.setColour(MekHQ.getMHQOptions().getUnmaintainedBackground());
-                optionUncrewedForeground.setColour(MekHQ.getMHQOptions().getUncrewedForeground());
-                optionUncrewedBackground.setColour(MekHQ.getMHQOptions().getUncrewedBackground());
-                optionLoanOverdueForeground.setColour(MekHQ.getMHQOptions().getLoanOverdueForeground());
-                optionLoanOverdueBackground.setColour(MekHQ.getMHQOptions().getLoanOverdueBackground());
-                optionInjuredForeground.setColour(MekHQ.getMHQOptions().getInjuredForeground());
-                optionInjuredBackground.setColour(MekHQ.getMHQOptions().getInjuredBackground());
-                optionHealedInjuriesForeground.setColour(MekHQ.getMHQOptions().getHealedInjuriesForeground());
-                optionHealedInjuriesBackground.setColour(MekHQ.getMHQOptions().getHealedInjuriesBackground());
-                optionPregnantForeground.setColour(MekHQ.getMHQOptions().getPregnantForeground());
-                optionPregnantBackground.setColour(MekHQ.getMHQOptions().getPregnantBackground());
-                optionGoneForeground.setColour(MekHQ.getMHQOptions().getGoneForeground());
-                optionGoneBackground.setColour(MekHQ.getMHQOptions().getGoneBackground());
-                optionAbsentForeground.setColour(MekHQ.getMHQOptions().getAbsentForeground());
-                optionAbsentBackground.setColour(MekHQ.getMHQOptions().getAbsentBackground());
-                optionFatiguedForeground.setColour(MekHQ.getMHQOptions().getFatiguedForeground());
-                optionFatiguedBackground.setColour(MekHQ.getMHQOptions().getFatiguedBackground());
-                optionStratConHexCoordForeground.setColour(MekHQ.getMHQOptions().getStratConHexCoordForeground());
-                optionFontColorNegative.setColour(MekHQ.getMHQOptions().getFontColorNegative());
-                optionFontColorWarning.setColour(MekHQ.getMHQOptions().getFontColorWarning());
-                optionFontColorPositive.setColour(MekHQ.getMHQOptions().getFontColorPositive());
-                optionFontColorSkillUltraGreen.setColour(MekHQ.getMHQOptions().getFontColorSkillUltraGreen());
-                optionFontColorSkillGreen.setColour(MekHQ.getMHQOptions().getFontColorSkillGreen());
-                optionFontColorSkillRegular.setColour(MekHQ.getMHQOptions().getFontColorSkillRegular());
-                optionFontColorSkillVeteran.setColour(MekHQ.getMHQOptions().getFontColorSkillVeteran());
-                optionFontColorSkillElite.setColour(MekHQ.getMHQOptions().getFontColorSkillElite());
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
 
-                comboMedicalViewDialogHandwritingFont.setSelectedItem(
-                                new FontDisplay(MekHQ.getMHQOptions().getMedicalViewDialogHandwritingFont()));
+        layout.setVerticalGroup(layout.createSequentialGroup()
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(lblUserDir)
+                                                      .addComponent(txtUserDir)
+                                                      .addComponent(userDirChooser)
+                                                      .addComponent(userDirHelp,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            40))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(lblStartGameDelay)
+                                                      .addComponent(spnStartGameDelay,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            40))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(lblStartGameClientDelay)
+                                                      .addComponent(spnStartGameClientDelay,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            40))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(lblStartGameClientRetryCount)
+                                                      .addComponent(spnStartGameClientRetryCount,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            40))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(lblStartGameBotClientDelay)
+                                                      .addComponent(spnStartGameBotClientDelay,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            40))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(lblStartGameBotClientRetryCount)
+                                                      .addComponent(spnStartGameBotClientRetryCount,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            GroupLayout.DEFAULT_SIZE,
+                                                            40))
+                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                                                      .addComponent(lblDefaultCompanyGenerationMethod)
+                                                      .addComponent(comboDefaultCompanyGenerationMethod)));
 
-                optionNoSave.setSelected(MekHQ.getMHQOptions().getNoAutosaveValue());
-                optionSaveDaily.setSelected(MekHQ.getMHQOptions().getAutosaveDailyValue());
-                optionSaveWeekly.setSelected(MekHQ.getMHQOptions().getAutosaveWeeklyValue());
-                optionSaveMonthly.setSelected(MekHQ.getMHQOptions().getAutosaveMonthlyValue());
-                optionSaveYearly.setSelected(MekHQ.getMHQOptions().getAutosaveYearlyValue());
-                checkSaveBeforeMissions.setSelected(MekHQ.getMHQOptions().getAutosaveBeforeMissionsValue());
-                spinnerSavedGamesCount.setValue(MekHQ.getMHQOptions().getMaximumNumberOfAutosavesValue());
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblUserDir)
+                                                        .addComponent(txtUserDir)
+                                                        .addComponent(userDirChooser)
+                                                        .addComponent(userDirHelp))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblStartGameDelay)
+                                                        .addComponent(spnStartGameDelay))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblStartGameClientDelay)
+                                                        .addComponent(spnStartGameClientDelay))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblStartGameClientRetryCount)
+                                                        .addComponent(spnStartGameClientRetryCount))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblStartGameBotClientDelay)
+                                                        .addComponent(spnStartGameBotClientDelay))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblStartGameBotClientRetryCount)
+                                                        .addComponent(spnStartGameBotClientRetryCount))
+                                        .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(lblDefaultCompanyGenerationMethod)
+                                                        .addComponent(comboDefaultCompanyGenerationMethod)));
 
-                chkNewDayAstechPoolFill.setSelected(MekHQ.getMHQOptions().getNewDayAstechPoolFill());
-                chkNewDayMedicPoolFill.setSelected(MekHQ.getMHQOptions().getNewDayMedicPoolFill());
-                chkNewDayMRMS.setSelected(MekHQ.getMHQOptions().getNewDayOptimizeMedicalAssignments());
-            chkNewDayOptimizeMedicalAssignments.setSelected(MekHQ.getMHQOptions().getNewDayMRMS());
-                if (chkNewDayForceIconOperationalStatus.isSelected() != MekHQ.getMHQOptions()
-                                .getNewDayForceIconOperationalStatus()) {
-                        chkNewDayForceIconOperationalStatus.doClick();
-                }
-                comboNewDayForceIconOperationalStatusStyle
-                                .setSelectedItem(MekHQ.getMHQOptions().getNewDayForceIconOperationalStatusStyle());
+        return body;
+    }
+    // endregion Initialization
 
-                optionPreferGzippedOutput.setSelected(MekHQ.getMHQOptions().getPreferGzippedOutput());
-                optionWriteCustomsToXML.setSelected(MekHQ.getMHQOptions().getWriteCustomsToXML());
-                optionSaveMothballState.setSelected(MekHQ.getMHQOptions().getSaveMothballState());
-
-                optionUnmaintainedUnitsNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNMAINTAINED_UNITS));
-                optionPregnantCombatantNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_PREGNANT_COMBATANT));
-                optionPrisonersNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_PRISONERS));
-                optionAdminStrainNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_ADMIN_STRAIN));
-                optionUntreatedPersonnelNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNTREATED_PERSONNEL));
-                optionNoCommanderNag
-                                .setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_NO_COMMANDER));
-                optionContractEndedNag
-                                .setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_CONTRACT_ENDED));
-                optionInsufficientAstechsNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECHS));
-                optionInsufficientAstechTimeNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME));
-                optionInsufficientMedicsNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_MEDICS));
-                optionShortDeploymentNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_SHORT_DEPLOYMENT));
-                optionUnresolvedStratConContactsNag.setSelected(MekHQ.getMHQOptions()
-                                .getNagDialogIgnore(MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS));
-                optionOutstandingScenariosNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_OUTSTANDING_SCENARIOS));
-                optionInvalidFactionNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INVALID_FACTION));
-                optionUnableToAffordExpensesNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_EXPENSES));
-                optionUnableToAffordLoanPaymentNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_LOAN_PAYMENT));
-                optionUnableToAffordJumpNag.setSelected(
-                                MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP));
-
-                txtUserDir.setText(PreferenceManager.getClientPreferences().getUserDir());
-                spnStartGameDelay.setValue(MekHQ.getMHQOptions().getStartGameDelay());
-                spnStartGameClientDelay.setValue(MekHQ.getMHQOptions().getStartGameClientDelay());
-                spnStartGameClientRetryCount.setValue(MekHQ.getMHQOptions().getStartGameClientRetryCount());
-                spnStartGameBotClientDelay.setValue(MekHQ.getMHQOptions().getStartGameBotClientDelay());
-                spnStartGameBotClientRetryCount.setValue(MekHQ.getMHQOptions().getStartGameBotClientRetryCount());
-                comboDefaultCompanyGenerationMethod
-                                .setSelectedItem(MekHQ.getMHQOptions().getDefaultCompanyGenerationMethod());
+    @Override
+    protected void okAction() {
+        if (GUIPreferences.getInstance().getGUIScale() * 10 != guiScale.getValue()) {
+            GUIPreferences.getInstance().setValue(GUIPreferences.GUI_SCALE, 0.1 * guiScale.getValue());
+            MekHQ.updateGuiScaling();
+        }
+        if (validateDateFormat(optionDisplayDateFormat.getText())) {
+            MekHQ.getMHQOptions().setDisplayDateFormat(optionDisplayDateFormat.getText());
         }
 
-        // region Data Validation
-        private boolean validateDateFormat(final String format) {
-                try {
-                        LocalDate.now().format(DateTimeFormatter.ofPattern(format)
-                                        .withLocale(MekHQ.getMHQOptions().getDateLocale()));
-                } catch (Exception ignored) {
-                        return false;
-                }
-                return true;
+        if (validateDateFormat(optionLongDisplayDateFormat.getText())) {
+            MekHQ.getMHQOptions().setLongDisplayDateFormat(optionLongDisplayDateFormat.getText());
         }
-        // endregion Data Validation
+        MekHQ.getMHQOptions().setHistoricalDailyLog(optionHistoricalDailyLog.isSelected());
+        MekHQ.getMHQOptions().setCompanyGeneratorStartup(chkCompanyGeneratorStartup.isSelected());
+        MekHQ.getMHQOptions().setShowCompanyGenerator(chkShowCompanyGenerator.isSelected());
+        MekHQ.getMHQOptions().setShowUnitPicturesOnTOE(chkShowUnitPicturesOnTOE.isSelected());
+
+        // Command Center Tab
+        MekHQ.getMHQOptions().setCommandCenterUseUnitMarket(optionCommandCenterUseUnitMarket.isSelected());
+        MekHQ.getMHQOptions().setCommandCenterMRMS(optionCommandCenterMRMS.isSelected());
+
+        // Interstellar Map Tab
+        MekHQ.getMHQOptions().setInterstellarMapShowJumpRadius(chkInterstellarMapShowJumpRadius.isSelected());
+        MekHQ.getMHQOptions()
+              .setInterstellarMapShowJumpRadiusMinimumZoom((Double) spnInterstellarMapShowJumpRadiusMinimumZoom.getValue());
+        MekHQ.getMHQOptions().setInterstellarMapJumpRadiusColour(btnInterstellarMapJumpRadiusColour.getColour());
+        MekHQ.getMHQOptions()
+              .setInterstellarMapShowPlanetaryAcquisitionRadius(chkInterstellarMapShowPlanetaryAcquisitionRadius.isSelected());
+        MekHQ.getMHQOptions()
+              .setInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom((Double) spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.getValue());
+        MekHQ.getMHQOptions()
+              .setInterstellarMapPlanetaryAcquisitionRadiusColour(btnInterstellarMapPlanetaryAcquisitionRadiusColour.getColour());
+        MekHQ.getMHQOptions()
+              .setInterstellarMapShowContractSearchRadius(chkInterstellarMapShowContractSearchRadius.isSelected());
+        MekHQ.getMHQOptions()
+              .setInterstellarMapContractSearchRadiusColour(btnInterstellarMapContractSearchRadiusColour.getColour());
+
+        // Personnel Tab
+        MekHQ.getMHQOptions()
+              .setPersonnelFilterStyle((PersonnelFilterStyle) Objects.requireNonNull(optionPersonnelFilterStyle.getSelectedItem()));
+        MekHQ.getMHQOptions().setPersonnelFilterOnPrimaryRole(optionPersonnelFilterOnPrimaryRole.isSelected());
+
+        // Colours
+        MekHQ.getMHQOptions().setDeployedForeground(optionDeployedForeground.getColour());
+        MekHQ.getMHQOptions().setDeployedBackground(optionDeployedBackground.getColour());
+        MekHQ.getMHQOptions().setBelowContractMinimumForeground(optionBelowContractMinimumForeground.getColour());
+        MekHQ.getMHQOptions().setBelowContractMinimumBackground(optionBelowContractMinimumBackground.getColour());
+        MekHQ.getMHQOptions().setInTransitForeground(optionInTransitForeground.getColour());
+        MekHQ.getMHQOptions().setInTransitBackground(optionInTransitBackground.getColour());
+        MekHQ.getMHQOptions().setRefittingForeground(optionRefittingForeground.getColour());
+        MekHQ.getMHQOptions().setRefittingBackground(optionRefittingBackground.getColour());
+        MekHQ.getMHQOptions().setMothballingForeground(optionMothballingForeground.getColour());
+        MekHQ.getMHQOptions().setMothballingBackground(optionMothballingBackground.getColour());
+        MekHQ.getMHQOptions().setMothballedForeground(optionMothballedForeground.getColour());
+        MekHQ.getMHQOptions().setMothballedBackground(optionMothballedBackground.getColour());
+        MekHQ.getMHQOptions().setNotRepairableForeground(optionNotRepairableForeground.getColour());
+        MekHQ.getMHQOptions().setNotRepairableBackground(optionNotRepairableBackground.getColour());
+        MekHQ.getMHQOptions().setNonFunctionalForeground(optionNonFunctionalForeground.getColour());
+        MekHQ.getMHQOptions().setNonFunctionalBackground(optionNonFunctionalBackground.getColour());
+        MekHQ.getMHQOptions().setNeedsPartsFixedForeground(optionNeedsPartsFixedForeground.getColour());
+        MekHQ.getMHQOptions().setNeedsPartsFixedBackground(optionNeedsPartsFixedBackground.getColour());
+        MekHQ.getMHQOptions().setUnmaintainedForeground(optionUnmaintainedForeground.getColour());
+        MekHQ.getMHQOptions().setUnmaintainedBackground(optionUnmaintainedBackground.getColour());
+        MekHQ.getMHQOptions().setUncrewedForeground(optionUncrewedForeground.getColour());
+        MekHQ.getMHQOptions().setUncrewedBackground(optionUncrewedBackground.getColour());
+        MekHQ.getMHQOptions().setLoanOverdueForeground(optionLoanOverdueForeground.getColour());
+        MekHQ.getMHQOptions().setLoanOverdueBackground(optionLoanOverdueBackground.getColour());
+        MekHQ.getMHQOptions().setInjuredForeground(optionInjuredForeground.getColour());
+        MekHQ.getMHQOptions().setInjuredBackground(optionInjuredBackground.getColour());
+        MekHQ.getMHQOptions().setHealedInjuriesForeground(optionHealedInjuriesForeground.getColour());
+        MekHQ.getMHQOptions().setHealedInjuriesBackground(optionHealedInjuriesBackground.getColour());
+        MekHQ.getMHQOptions().setPregnantForeground(optionPregnantForeground.getColour());
+        MekHQ.getMHQOptions().setPregnantBackground(optionPregnantBackground.getColour());
+        MekHQ.getMHQOptions().setGoneForeground(optionGoneForeground.getColour());
+        MekHQ.getMHQOptions().setGoneBackground(optionGoneBackground.getColour());
+        MekHQ.getMHQOptions().setAbsentForeground(optionAbsentForeground.getColour());
+        MekHQ.getMHQOptions().setAbsentBackground(optionAbsentBackground.getColour());
+        MekHQ.getMHQOptions().setFatiguedForeground(optionFatiguedForeground.getColour());
+        MekHQ.getMHQOptions().setFatiguedBackground(optionFatiguedBackground.getColour());
+        MekHQ.getMHQOptions().setStratConHexCoordForeground(optionStratConHexCoordForeground.getColour());
+        MekHQ.getMHQOptions().setFontColorNegative(optionFontColorNegative.getColour());
+        MekHQ.getMHQOptions().setFontColorWarning(optionFontColorWarning.getColour());
+        MekHQ.getMHQOptions().setFontColorPositive(optionFontColorPositive.getColour());
+        MekHQ.getMHQOptions().setFontColorSkillUltraGreen(optionFontColorSkillUltraGreen.getColour());
+        MekHQ.getMHQOptions().setFontColorSkillGreen(optionFontColorSkillGreen.getColour());
+        MekHQ.getMHQOptions().setFontColorSkillRegular(optionFontColorSkillRegular.getColour());
+        MekHQ.getMHQOptions().setFontColorSkillVeteran(optionFontColorSkillVeteran.getColour());
+        MekHQ.getMHQOptions().setFontColorSkillElite(optionFontColorSkillElite.getColour());
+
+        MekHQ.getMHQOptions()
+              .setMedicalViewDialogHandwritingFont(comboMedicalViewDialogHandwritingFont.getFont().getFamily());
+
+        MekHQ.getMHQOptions().setNoAutosaveValue(optionNoSave.isSelected());
+        MekHQ.getMHQOptions().setAutosaveDailyValue(optionSaveDaily.isSelected());
+        MekHQ.getMHQOptions().setAutosaveWeeklyValue(optionSaveWeekly.isSelected());
+        MekHQ.getMHQOptions().setAutosaveMonthlyValue(optionSaveMonthly.isSelected());
+        MekHQ.getMHQOptions().setAutosaveYearlyValue(optionSaveYearly.isSelected());
+        MekHQ.getMHQOptions().setAutosaveBeforeScenariosValue(checkSaveBeforeScenarios.isSelected());
+        MekHQ.getMHQOptions().setAutosaveBeforeMissionEndValue(checkSaveBeforeContractEnd.isSelected());
+        MekHQ.getMHQOptions().setMaximumNumberOfAutosavesValue((Integer) spinnerSavedGamesCount.getValue());
+
+        MekHQ.getMHQOptions().setNewDayAstechPoolFill(chkNewDayAstechPoolFill.isSelected());
+        MekHQ.getMHQOptions().setNewDayMedicPoolFill(chkNewDayMedicPoolFill.isSelected());
+        MekHQ.getMHQOptions().setNewDayMRMS(chkNewDayMRMS.isSelected());
+        MekHQ.getMHQOptions().setNewDayOptimizeMedicalAssignments(chkNewDayOptimizeMedicalAssignments.isSelected());
+        MekHQ.getMHQOptions().setNewDayForceIconOperationalStatus(chkNewDayForceIconOperationalStatus.isSelected());
+        MekHQ.getMHQOptions()
+              .setNewDayForceIconOperationalStatusStyle(Objects.requireNonNull(
+                    comboNewDayForceIconOperationalStatusStyle.getSelectedItem()));
+
+        MekHQ.getMHQOptions().setPreferGzippedOutput(optionPreferGzippedOutput.isSelected());
+        MekHQ.getMHQOptions().setWriteCustomsToXML(optionWriteCustomsToXML.isSelected());
+        MekHQ.getMHQOptions().setSaveMothballState(optionSaveMothballState.isSelected());
+
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_UNMAINTAINED_UNITS, optionUnmaintainedUnitsNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_PREGNANT_COMBATANT, optionPregnantCombatantNag.isSelected());
+        MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_PRISONERS, optionPrisonersNag.isSelected());
+        MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_ADMIN_STRAIN, optionAdminStrainNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_UNTREATED_PERSONNEL, optionUntreatedPersonnelNag.isSelected());
+        MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_NO_COMMANDER, optionNoCommanderNag.isSelected());
+        MekHQ.getMHQOptions().setNagDialogIgnore(MHQConstants.NAG_CONTRACT_ENDED, optionContractEndedNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECHS, optionInsufficientAstechsNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME,
+                    optionInsufficientAstechTimeNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_MEDICS, optionInsufficientMedicsNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_SHORT_DEPLOYMENT, optionShortDeploymentNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS,
+                    optionUnresolvedStratConContactsNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_OUTSTANDING_SCENARIOS, optionOutstandingScenariosNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_INVALID_FACTION, optionInvalidFactionNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_EXPENSES,
+                    optionUnableToAffordExpensesNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_LOAN_PAYMENT,
+                    optionUnableToAffordLoanPaymentNag.isSelected());
+        MekHQ.getMHQOptions()
+              .setNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP, optionUnableToAffordJumpNag.isSelected());
+
+        PreferenceManager.getClientPreferences().setUserDir(txtUserDir.getText());
+        PreferenceManager.getInstance().save();
+        MekHQ.getMHQOptions().setStartGameDelay((Integer) spnStartGameDelay.getValue());
+        MekHQ.getMHQOptions().setStartGameClientDelay((Integer) spnStartGameClientDelay.getValue());
+        MekHQ.getMHQOptions().setStartGameClientRetryCount((Integer) spnStartGameClientRetryCount.getValue());
+        MekHQ.getMHQOptions().setStartGameBotClientDelay((Integer) spnStartGameBotClientDelay.getValue());
+        MekHQ.getMHQOptions().setStartGameBotClientRetryCount((Integer) spnStartGameBotClientRetryCount.getValue());
+        MekHQ.getMHQOptions()
+              .setDefaultCompanyGenerationMethod(Objects.requireNonNull(comboDefaultCompanyGenerationMethod.getSelectedItem()));
+
+        MekHQ.triggerEvent(new MHQOptionsChangedEvent());
+    }
+
+    private void setInitialState() {
+        guiScale.setValue((int) (GUIPreferences.getInstance().getGUIScale() * 10));
+        optionDisplayDateFormat.setText(MekHQ.getMHQOptions().getDisplayDateFormat());
+        optionLongDisplayDateFormat.setText(MekHQ.getMHQOptions().getLongDisplayDateFormat());
+        optionHistoricalDailyLog.setSelected(MekHQ.getMHQOptions().getHistoricalDailyLog());
+        chkCompanyGeneratorStartup.setSelected(MekHQ.getMHQOptions().getCompanyGeneratorStartup());
+        chkShowCompanyGenerator.setSelected(MekHQ.getMHQOptions().getShowCompanyGenerator());
+        chkShowUnitPicturesOnTOE.setSelected(MekHQ.getMHQOptions().getShowUnitPicturesOnTOE());
+
+        // Command Center Tab
+        optionCommandCenterUseUnitMarket.setSelected(MekHQ.getMHQOptions().getCommandCenterUseUnitMarket());
+        optionCommandCenterMRMS.setSelected(MekHQ.getMHQOptions().getCommandCenterMRMS());
+
+        // Interstellar Map Tab
+        if (chkInterstellarMapShowJumpRadius.isSelected() != MekHQ.getMHQOptions().getInterstellarMapShowJumpRadius()) {
+            chkInterstellarMapShowJumpRadius.doClick();
+        }
+        spnInterstellarMapShowJumpRadiusMinimumZoom.setValue(MekHQ.getMHQOptions()
+                                                                   .getInterstellarMapShowJumpRadiusMinimumZoom());
+        btnInterstellarMapJumpRadiusColour.setColour(MekHQ.getMHQOptions().getInterstellarMapJumpRadiusColour());
+        if (chkInterstellarMapShowPlanetaryAcquisitionRadius.isSelected() !=
+                  MekHQ.getMHQOptions().getInterstellarMapShowPlanetaryAcquisitionRadius()) {
+            chkInterstellarMapShowPlanetaryAcquisitionRadius.doClick();
+        }
+        spnInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom.setValue(MekHQ.getMHQOptions()
+                                                                                   .getInterstellarMapShowPlanetaryAcquisitionRadiusMinimumZoom());
+        btnInterstellarMapPlanetaryAcquisitionRadiusColour.setColour(MekHQ.getMHQOptions()
+                                                                           .getInterstellarMapPlanetaryAcquisitionRadiusColour());
+        if (chkInterstellarMapShowContractSearchRadius.isSelected() !=
+                  MekHQ.getMHQOptions().getInterstellarMapShowContractSearchRadius()) {
+            chkInterstellarMapShowContractSearchRadius.doClick();
+        }
+        btnInterstellarMapContractSearchRadiusColour.setColour(MekHQ.getMHQOptions()
+                                                                     .getInterstellarMapContractSearchRadiusColour());
+
+        // Personnel Tab
+        optionPersonnelFilterStyle.setSelectedItem(MekHQ.getMHQOptions().getPersonnelFilterStyle());
+        optionPersonnelFilterOnPrimaryRole.setSelected(MekHQ.getMHQOptions().getPersonnelFilterOnPrimaryRole());
+
+        // Colours
+        optionDeployedForeground.setColour(MekHQ.getMHQOptions().getDeployedForeground());
+        optionDeployedBackground.setColour(MekHQ.getMHQOptions().getDeployedBackground());
+        optionBelowContractMinimumForeground.setColour(MekHQ.getMHQOptions().getBelowContractMinimumForeground());
+        optionBelowContractMinimumBackground.setColour(MekHQ.getMHQOptions().getBelowContractMinimumBackground());
+        optionInTransitForeground.setColour(MekHQ.getMHQOptions().getInTransitForeground());
+        optionInTransitBackground.setColour(MekHQ.getMHQOptions().getInTransitBackground());
+        optionRefittingForeground.setColour(MekHQ.getMHQOptions().getRefittingForeground());
+        optionRefittingBackground.setColour(MekHQ.getMHQOptions().getRefittingBackground());
+        optionMothballingForeground.setColour(MekHQ.getMHQOptions().getMothballingForeground());
+        optionMothballingBackground.setColour(MekHQ.getMHQOptions().getMothballingBackground());
+        optionMothballedForeground.setColour(MekHQ.getMHQOptions().getMothballedForeground());
+        optionMothballedBackground.setColour(MekHQ.getMHQOptions().getMothballedBackground());
+        optionNotRepairableForeground.setColour(MekHQ.getMHQOptions().getNotRepairableForeground());
+        optionNotRepairableBackground.setColour(MekHQ.getMHQOptions().getNotRepairableBackground());
+        optionNonFunctionalForeground.setColour(MekHQ.getMHQOptions().getNonFunctionalForeground());
+        optionNonFunctionalBackground.setColour(MekHQ.getMHQOptions().getNonFunctionalBackground());
+        optionNeedsPartsFixedForeground.setColour(MekHQ.getMHQOptions().getNeedsPartsFixedForeground());
+        optionNeedsPartsFixedBackground.setColour(MekHQ.getMHQOptions().getNeedsPartsFixedBackground());
+        optionUnmaintainedForeground.setColour(MekHQ.getMHQOptions().getUnmaintainedForeground());
+        optionUnmaintainedBackground.setColour(MekHQ.getMHQOptions().getUnmaintainedBackground());
+        optionUncrewedForeground.setColour(MekHQ.getMHQOptions().getUncrewedForeground());
+        optionUncrewedBackground.setColour(MekHQ.getMHQOptions().getUncrewedBackground());
+        optionLoanOverdueForeground.setColour(MekHQ.getMHQOptions().getLoanOverdueForeground());
+        optionLoanOverdueBackground.setColour(MekHQ.getMHQOptions().getLoanOverdueBackground());
+        optionInjuredForeground.setColour(MekHQ.getMHQOptions().getInjuredForeground());
+        optionInjuredBackground.setColour(MekHQ.getMHQOptions().getInjuredBackground());
+        optionHealedInjuriesForeground.setColour(MekHQ.getMHQOptions().getHealedInjuriesForeground());
+        optionHealedInjuriesBackground.setColour(MekHQ.getMHQOptions().getHealedInjuriesBackground());
+        optionPregnantForeground.setColour(MekHQ.getMHQOptions().getPregnantForeground());
+        optionPregnantBackground.setColour(MekHQ.getMHQOptions().getPregnantBackground());
+        optionGoneForeground.setColour(MekHQ.getMHQOptions().getGoneForeground());
+        optionGoneBackground.setColour(MekHQ.getMHQOptions().getGoneBackground());
+        optionAbsentForeground.setColour(MekHQ.getMHQOptions().getAbsentForeground());
+        optionAbsentBackground.setColour(MekHQ.getMHQOptions().getAbsentBackground());
+        optionFatiguedForeground.setColour(MekHQ.getMHQOptions().getFatiguedForeground());
+        optionFatiguedBackground.setColour(MekHQ.getMHQOptions().getFatiguedBackground());
+        optionStratConHexCoordForeground.setColour(MekHQ.getMHQOptions().getStratConHexCoordForeground());
+        optionFontColorNegative.setColour(MekHQ.getMHQOptions().getFontColorNegative());
+        optionFontColorWarning.setColour(MekHQ.getMHQOptions().getFontColorWarning());
+        optionFontColorPositive.setColour(MekHQ.getMHQOptions().getFontColorPositive());
+        optionFontColorSkillUltraGreen.setColour(MekHQ.getMHQOptions().getFontColorSkillUltraGreen());
+        optionFontColorSkillGreen.setColour(MekHQ.getMHQOptions().getFontColorSkillGreen());
+        optionFontColorSkillRegular.setColour(MekHQ.getMHQOptions().getFontColorSkillRegular());
+        optionFontColorSkillVeteran.setColour(MekHQ.getMHQOptions().getFontColorSkillVeteran());
+        optionFontColorSkillElite.setColour(MekHQ.getMHQOptions().getFontColorSkillElite());
+
+        comboMedicalViewDialogHandwritingFont.setSelectedItem(new FontDisplay(MekHQ.getMHQOptions()
+                                                                                    .getMedicalViewDialogHandwritingFont()));
+
+        optionNoSave.setSelected(MekHQ.getMHQOptions().getNoAutosaveValue());
+        optionSaveDaily.setSelected(MekHQ.getMHQOptions().getAutosaveDailyValue());
+        optionSaveWeekly.setSelected(MekHQ.getMHQOptions().getAutosaveWeeklyValue());
+        optionSaveMonthly.setSelected(MekHQ.getMHQOptions().getAutosaveMonthlyValue());
+        optionSaveYearly.setSelected(MekHQ.getMHQOptions().getAutosaveYearlyValue());
+        checkSaveBeforeScenarios.setSelected(MekHQ.getMHQOptions().getAutosaveBeforeScenariosValue());
+        checkSaveBeforeContractEnd.setSelected(MekHQ.getMHQOptions().getAutosaveBeforeMissionEndValue());
+        spinnerSavedGamesCount.setValue(MekHQ.getMHQOptions().getMaximumNumberOfAutosavesValue());
+
+        chkNewDayAstechPoolFill.setSelected(MekHQ.getMHQOptions().getNewDayAstechPoolFill());
+        chkNewDayMedicPoolFill.setSelected(MekHQ.getMHQOptions().getNewDayMedicPoolFill());
+        chkNewDayMRMS.setSelected(MekHQ.getMHQOptions().getNewDayOptimizeMedicalAssignments());
+        chkNewDayOptimizeMedicalAssignments.setSelected(MekHQ.getMHQOptions().getNewDayMRMS());
+        if (chkNewDayForceIconOperationalStatus.isSelected() !=
+                  MekHQ.getMHQOptions().getNewDayForceIconOperationalStatus()) {
+            chkNewDayForceIconOperationalStatus.doClick();
+        }
+        comboNewDayForceIconOperationalStatusStyle.setSelectedItem(MekHQ.getMHQOptions()
+                                                                         .getNewDayForceIconOperationalStatusStyle());
+
+        optionPreferGzippedOutput.setSelected(MekHQ.getMHQOptions().getPreferGzippedOutput());
+        optionWriteCustomsToXML.setSelected(MekHQ.getMHQOptions().getWriteCustomsToXML());
+        optionSaveMothballState.setSelected(MekHQ.getMHQOptions().getSaveMothballState());
+
+        optionUnmaintainedUnitsNag.setSelected(MekHQ.getMHQOptions()
+                                                     .getNagDialogIgnore(MHQConstants.NAG_UNMAINTAINED_UNITS));
+        optionPregnantCombatantNag.setSelected(MekHQ.getMHQOptions()
+                                                     .getNagDialogIgnore(MHQConstants.NAG_PREGNANT_COMBATANT));
+        optionPrisonersNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_PRISONERS));
+        optionAdminStrainNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_ADMIN_STRAIN));
+        optionUntreatedPersonnelNag.setSelected(MekHQ.getMHQOptions()
+                                                      .getNagDialogIgnore(MHQConstants.NAG_UNTREATED_PERSONNEL));
+        optionNoCommanderNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_NO_COMMANDER));
+        optionContractEndedNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_CONTRACT_ENDED));
+        optionInsufficientAstechsNag.setSelected(MekHQ.getMHQOptions()
+                                                       .getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECHS));
+        optionInsufficientAstechTimeNag.setSelected(MekHQ.getMHQOptions()
+                                                          .getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_ASTECH_TIME));
+        optionInsufficientMedicsNag.setSelected(MekHQ.getMHQOptions()
+                                                      .getNagDialogIgnore(MHQConstants.NAG_INSUFFICIENT_MEDICS));
+        optionShortDeploymentNag.setSelected(MekHQ.getMHQOptions()
+                                                   .getNagDialogIgnore(MHQConstants.NAG_SHORT_DEPLOYMENT));
+        optionUnresolvedStratConContactsNag.setSelected(MekHQ.getMHQOptions()
+                                                              .getNagDialogIgnore(MHQConstants.NAG_UNRESOLVED_STRATCON_CONTACTS));
+        optionOutstandingScenariosNag.setSelected(MekHQ.getMHQOptions()
+                                                        .getNagDialogIgnore(MHQConstants.NAG_OUTSTANDING_SCENARIOS));
+        optionInvalidFactionNag.setSelected(MekHQ.getMHQOptions().getNagDialogIgnore(MHQConstants.NAG_INVALID_FACTION));
+        optionUnableToAffordExpensesNag.setSelected(MekHQ.getMHQOptions()
+                                                          .getNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_EXPENSES));
+        optionUnableToAffordLoanPaymentNag.setSelected(MekHQ.getMHQOptions()
+                                                             .getNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_LOAN_PAYMENT));
+        optionUnableToAffordJumpNag.setSelected(MekHQ.getMHQOptions()
+                                                      .getNagDialogIgnore(MHQConstants.NAG_UNABLE_TO_AFFORD_JUMP));
+
+        txtUserDir.setText(PreferenceManager.getClientPreferences().getUserDir());
+        spnStartGameDelay.setValue(MekHQ.getMHQOptions().getStartGameDelay());
+        spnStartGameClientDelay.setValue(MekHQ.getMHQOptions().getStartGameClientDelay());
+        spnStartGameClientRetryCount.setValue(MekHQ.getMHQOptions().getStartGameClientRetryCount());
+        spnStartGameBotClientDelay.setValue(MekHQ.getMHQOptions().getStartGameBotClientDelay());
+        spnStartGameBotClientRetryCount.setValue(MekHQ.getMHQOptions().getStartGameBotClientRetryCount());
+        comboDefaultCompanyGenerationMethod.setSelectedItem(MekHQ.getMHQOptions().getDefaultCompanyGenerationMethod());
+    }
+
+    // region Data Validation
+    private boolean validateDateFormat(final String format) {
+        try {
+            LocalDate.now()
+                  .format(DateTimeFormatter.ofPattern(format).withLocale(MekHQ.getMHQOptions().getDateLocale()));
+        } catch (Exception ignored) {
+            return false;
+        }
+        return true;
+    }
+    // endregion Data Validation
 }

--- a/MekHQ/src/mekhq/service/IAutosaveService.java
+++ b/MekHQ/src/mekhq/service/IAutosaveService.java
@@ -30,8 +30,7 @@ package mekhq.service;
 import mekhq.campaign.Campaign;
 
 /**
- * Handles the possible auto-save situations
- * in MekHQ.
+ * Handles the possible auto-save situations in MekHQ.
  */
 public interface IAutosaveService {
     /**
@@ -42,9 +41,22 @@ public interface IAutosaveService {
     void requestDayAdvanceAutosave(Campaign campaign);
 
     /**
-     * Handles auto-saving before a mission starts.
+     * @deprecated use {@link #requestBeforeScenarioAutosave} instead.
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
+    void requestBeforeMissionAutosave(Campaign campaign);
+
+    /**
+     * Handles auto-saving before a scenario starts.
      *
      * @param campaign Campaign to save
      */
-    void requestBeforeMissionAutosave(Campaign campaign);
+    void requestBeforeScenarioAutosave(Campaign campaign);
+
+    /**
+     * Handles auto-saving before a mission or contract ends.
+     *
+     * @param campaign Campaign to save
+     */
+    void requestBeforeMissionEndAutosave(Campaign campaign);
 }


### PR DESCRIPTION
- Updated autosave implementation to replace `requestBeforeMissionAutosave` with `requestBeforeScenarioAutosave` for more accurate naming.
- Added support for autosaving before mission/contract conclusion via the new method `requestBeforeMissionEndAutosave` in `IAutosaveService`.
- Deprecated `SAVE_BEFORE_MISSIONS_KEY` and replaced it with `SAVE_BEFORE_SCENARIOS_KEY` in `MHQConstants`.
- Introduced relevant GUI adjustments for new autosave features, including updated labels in `GUI.properties`.

Fix #4506