### PR TITLE
Removed Pending Scenario Check When Completing Missions/Contracts

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -30,6 +30,7 @@ package mekhq.gui;
 import static megamek.client.ratgenerator.ForceDescriptor.RATING_5;
 import static mekhq.campaign.mission.enums.MissionStatus.PARTIAL;
 import static mekhq.campaign.mission.enums.MissionStatus.SUCCESS;
+import static mekhq.campaign.mission.enums.ScenarioStatus.REFUSED_ENGAGEMENT;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -387,17 +388,9 @@ public final class BriefingTab extends CampaignGuiTab {
     }
 
     private void completeMission() {
-        ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.GUI", MekHQ.getMHQOptions().getLocale());
-
         final Mission mission = comboMission.getSelectedItem();
 
         if (mission == null) {
-            return;
-        } else if (mission.hasPendingScenarios()) {
-            JOptionPane.showMessageDialog(getFrame(),
-                  "You cannot complete a mission that has pending scenarios",
-                  "Pending Scenarios",
-                  JOptionPane.WARNING_MESSAGE);
             return;
         }
 
@@ -503,6 +496,11 @@ public final class BriefingTab extends CampaignGuiTab {
             autoAwardsController.PostMissionController(getCampaign(),
                   mission,
                   Objects.equals(String.valueOf(cmd.getStatus()), "Success"));
+        }
+
+        // Get rid of any remaining scenarios
+        for (Scenario scenario : mission.getCurrentScenarios()) {
+            scenario.setStatus(REFUSED_ENGAGEMENT);
         }
 
         final List<Mission> missions = getCampaign().getSortedMissions();


### PR DESCRIPTION
- Removed check preventing the completion of missions with pending scenarios in `completeMission()` method.
- Ensured all remaining scenarios are marked as `REFUSED_ENGAGEMENT` when completing a mission.

### Dev Notes
When concluding a mission/contract if there are any outstanding scenarios the player is blocked from concluding the mission until those scenarios are resolved or, as is more likely, GM deleted. This was creating a poor user experience and a lot of user contact on the Discord.

This PR simply removes that blocker. Upon mission end any outstanding scenarios are flagged as Refused Engagement.