### PR TITLE
Make planetary acquisitions even slower to be in line with RAW

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -8252,15 +8252,15 @@ public class Campaign implements ITechManager {
         int currentTransitTime = (distance > 0) ? (int) Math.ceil(getCurrentSystem().getTimeToJumpPoint(1.0)) : 0;
         int originTransitTime = (distance > 0) ? (int) Math.ceil(system.getTimeToJumpPoint(1.0)) : 0;
 
-        // CO 51 (latest) has much longer average part times. Let's adjust
-        // amazonFreeShipping
-        // based on what getUnitTransitTime is set in the options in an attempt to get
-        // some
-        // delivery times more in line with RAW's one-month minimum. Default is
-        // TRANSIT_UNIT_MONTH
+        // CO 51 (errata) has much longer average part times.
+        // Let's adjust amazonFreeShipping
+        // based on what getUnitTransitTime is set in
+        // the options in an attempt to get some
+        // delivery times more in line with RAW's two-month minimum.
+        // Default campaign option is TRANSIT_UNIT_MONTH
         int amazonFreeShipping = switch (campaignOptions.getUnitTransitTime()) {
-            case TRANSIT_UNIT_MONTH -> 7 + (d6(7 * (1 + jumps)));
-            case TRANSIT_UNIT_WEEK -> 2 + (d6(2 * (1 + jumps)));
+            case TRANSIT_UNIT_MONTH -> 30 + (d6(14 * (1 + jumps)));
+            case TRANSIT_UNIT_WEEK -> 7 + (d6(4 * (1 + jumps)));
             default -> d6(1 + jumps);
         };
         return (recharges * 7) + currentTransitTime + originTransitTime + amazonFreeShipping;


### PR DESCRIPTION
#6161 was not drastic enough. It should be two-month minimum for PA deliveries. This drags delivery times out even further for Planetary Acquisitions. 