### PR TITLE
 Added Birth Announcements

### DIFF
--- a/MekHQ/resources/mekhq/resources/AbstractProcreation.properties
+++ b/MekHQ/resources/mekhq/resources/AbstractProcreation.properties
@@ -1,0 +1,26 @@
+# suppress inspection "UnusedProperty" for whole file
+## Procreation
+# AbstractProcreation Class
+cannotProcreate.Gender.text=MekHQ procreation is female-based, and thus males cannot procreate.
+cannotProcreate.NotTryingForABaby.text=She is not trying for a baby.
+cannotProcreate.AlreadyPregnant.text=She is already pregnant.
+cannotProcreate.Inactive.text=She is currently inactive.
+cannotProcreate.Deployed.text=She is actively deployed.
+cannotProcreate.Child.text=She is a child. Those 18 and under cannot procreate in MekHQ.
+cannotProcreate.TooOld.text=She is too old to have child. Those fifty-one and over cannot procreate in MekHQ.
+cannotProcreate.ClanPersonnel.text=She is from a clan, and clan personnel procreation is disabled.
+cannotProcreate.Prisoner.text=She is a prisoner, and prisoner procreation is disabled.
+cannotProcreate.NoSpouse.text=She does not have a spouse and relationshipless random procreation is disabled.
+cannotProcreate.RandomClanPersonnel.text=She is from a clan, and random clan personnel procreation is disabled.
+cannotProcreate.RandomPrisoner.text=She is a prisoner, and random prisoner procreation is disabled.
+cannotProcreate.FemaleSpouse.text=Her spouse is female, and thus they cannot have a biological child.
+cannotProcreate.SpouseNotTryingForABaby.text=Her spouse is not trying for a baby.
+cannotProcreate.InactiveSpouse.text=Her spouse is inactive.
+cannotProcreate.DeployedSpouse.text=Her spouse is currently deployed.
+cannotProcreate.ChildSpouse.text=Her spouse is a child, and thus they cannot have children.
+cannotProcreate.ClanPersonnelSpouse.text=Her spouse is from a clan, and clan personnel procreation is disabled.
+cannotProcreate.PrisonerSpouse.text=Her spouse is a prisoner, and prisoner procreation is disabled.
+babyAmount.text=a baby,twins,triplets,quadruplets,quintuplets,sextuplets,septuplets,octuplets,nonuplets,decuplets
+babyConceived.report={0} has conceived {1}
+multipleBabiesBorn.report={0} has given birth to {1}!
+babyBorn.report={0} has given birth to {1}, a baby {2}!

--- a/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
@@ -1,0 +1,289 @@
+# suppress inspection "UnusedMessageFormatParameter" for whole file
+# suppress inspection "UnusedProperty" for whole file
+# Buttons
+button.response.positive=Fantastic news! I''ll be down shortly.
+button.response.neutral=I''m glad {0} and the baby are ok.
+button.response.negative=Another baby!? People know contraception isn''t LosTech, right?
+button.response.suppress=I''m not interested in this kind of update.
+# Data
+babyBorn.parentTitle.female=mother
+babyBorn.parentTitle.male=father
+babyBorn.parentTitle.neutral=parent
+babyBorn.childTitle.female=girl
+babyBorn.childTitle.male=boy
+babyBorn.childTitle.neutral=tyke
+lance.innerSphere=Lance
+lance.clan=Star
+lance.comStar=Level II
+squad.innerSphere=Squad
+squad.clan=Point
+squad.comStar=Level I
+# OOC
+babyBorn.message.ooc=If you have <b>Advanced Medical</b> enabled, it will take around 10 days for {0} to recover from\
+  \ giving birth. It is strongly encouraged that you do <b>not</b> deploy this character until <b>after</b> they have\
+  \ completed their postpartum recovery. Failure to heed this warning may complicate their recovery.\
+  <p>If <b>Advanced Medical</b> is disabled, {0} will have received a single <i>Hit</i>.</p>\
+  <p>If you select the final option, all future announcements of this type will be disabled. They can be re-enabled in\
+  \ Campaign Options.</p>
+# IC
+## Single Child
+babyBorn.message.0.ic=At {1}-local, {2} gave birth to a baby {10}, weighing {15}kg.\
+  <p>The delivery proceeded in accordance with our usual protocols. Minor complications were managed effectively, and\
+  \ both {5} and child are stable.</p>\
+  <p>Further medical monitoring will continue for the next 24 hours.</p>
+babyBorn.message.1.ic=Amidst the challenges we face, a bit of hope just arrived.\
+  <p>{2} has given birth to a beautiful baby {10}, {15}kg, and both {5} and baby are doing well.</p>\
+  <p>{3}''s beside {9}self with pride. Moments like this remind us why we keep pushing forward.</p>
+babyBorn.message.2.ic=Good news: {2} gave birth to a baby {10}, {15}kg, and from the way the kid screamed on arrival, I''d\
+  \ say {12}''{16, choice, 0#ve|1#s} got a future as a {17} leader.\
+  <p>{3}''s already complaining about sleep deprivation.</p>\
+  <p>{4} and baby are both healthy. Send earplugs if you''ve got any to spare.</p>
+babyBorn.message.3.ic=We''ve got some good news to break the routine - {2} just welcomed a baby {10} into the world,\
+  \ {15}kg, healthy and strong.\
+  <p>Everyone is overjoyed, and the whole medbay''s buzzing with excitement.</p>\
+  <p>Sometimes, we get moments worth celebrating.</p>
+babyBorn.message.4.ic=It''s been a rough road, but today we got a reminder of what we''re fighting for. {2}''s little {10}\
+  \ arrived safely, weighing {15}kg.\
+  <p>Labor was tough, but {3} pulled through.</p>\
+  <p>Right now {7}''{0, choice, 0#re|1#s} holding {13} close, whispering words I can''t quite catch. It''s a rare moment\
+  \ of quiet.</p>
+babyBorn.message.5.ic=At {1}-local, {2} gave birth to a baby {10}, {15}kg.\
+  <p>No major complications during delivery and both {5} and child are stable and resting.</p>\
+  <p>Routine postpartum monitoring will continue for 48 hours. No further interventions anticipated.</p>
+babyBorn.message.6.ic=Amid the constant chaos, a new life joined us today.\
+  <p>{2} delivered a baby {10} at {1}-local, weighing {15}kg.</p>\
+  <p>As I watch {3} hold {13}, it strikes me how resilient the human spirit is. Even as we fight and endure, life finds\
+  \ a way to keep going.</p>
+babyBorn.message.7.ic={2} delivered a baby {10}, {15}kg. Birth occurred at {1}-local.\
+  <p>Labor required minor medical intervention.</p>\
+  <p>Recovery protocol initiated. Anticipated downtime for {3} is one week, minimum.</p>
+babyBorn.message.8.ic=You''ll want to swing by the medbay when you get a minute - {2} just had {9} baby!\
+  <p>Little {10} came in at {15}kg, and {12}''{16, choice, 0#ve|1#s} got a grip like a vice already.</p>\
+  <p>Everyone''s pretty happy down here for a change. Figured you''d want to know.</p>
+babyBorn.message.9.ic={2} gave birth at {1}-local to a baby {10} weighing {15}kg.\
+  <p>Delivery was uneventful and proceeded as expected.</p>\
+  <p>Postpartum checks indicate both {5} and child are stable. No complications noted. Standard recovery time applies.</p>
+babyBorn.message.10.ic=Amidst the constant emergencies, life found a way to surprise us today.\
+  <p>{2} welcomed a baby {10} into the world - {15}kg and healthy!</p>\
+  <p>Watching {3} hold {9} child, I couldn''t help but think that maybe, just maybe, there''s still a future worth\
+  \ fighting for.</p>
+babyBorn.message.11.ic=In case you''re wondering about that new siren, it''s {2}''s brand-new baby!\
+  <p>Came into the world at {1}-local, weighing {15}kg, and already yelling orders.</p>\
+  <p>{4} and baby are fine. My ears aren''t.</p>
+babyBorn.message.12.ic=In a place where loss seems constant, we''ve finally got a win.\
+  <p>{2} delivered a healthy baby {10} at {1}-local, weighing {15}kg.</p>\
+  <p>Labor was tough - {3} pushed through with remarkable strength. Both are safe and recovering.</p>\
+  <p>In the darkest of times, life still fights back.</p>
+babyBorn.message.13.ic={2} delivered a baby {10}, {15}kg. Labor was prolonged, and we had a brief scare\
+  \ with fetal distress, but everything turned out fine.\
+  <p>{3}''s already talking about how the kid''s gonna be an Officer. Poor thing doesn''t know what\
+  \ {12}''{16, choice, 0#re|1#s} in for.</p>
+babyBorn.message.14.ic=There''s something humbling about seeing new life begin while we''re constantly reminded of how\
+  \ easily it can end.\
+  <p>{2}''s baby {10} arrived at dawn, weighing {15}kg.</p>\
+  <p>{3} fought through a difficult labor, but they both made it.</p>\
+  <p>In this place, with so much destruction around us, it feels like a miracle.</p>
+babyBorn.message.15.ic=Some good news for once - {2} welcomed a baby {10} today, {15}kg and full of spirit.\
+  <p>Delivery went well, both are healthy, and this unit just got a little bit stronger because of it.</p>\
+  <p>I know it''s hard to keep morale up, but this is a reminder that we''re still building a future worth protecting.</p>
+babyBorn.message.16.ic={2} gave birth to a baby {10}, {15}kg.\
+  <p>We encountered a brief complication with umbilical cord entanglement, but intervention was successful.</p>\
+  <p>{3}''s a bit shaken, but the baby is fine.</p>\
+  <p>It''s strange how moments of fear can end with relief. Baby hasn''t let go of {9} hand since.</p>
+babyBorn.message.17.ic={2} gave birth today at {1}-local. It was a tough delivery, but {7} pulled through.\
+  <p>The baby {10}, weighing {15}kg, is strong and healthy.</p>\
+  <p>{3}''s beaming, and already making plans for {14} first training session. I''d say we just gained a new recruit.</p>
+babyBorn.message.18.ic=You''ll be pleased to know that {3} just expanded {9} {17}.\
+  <p>Baby {10}, {15}kg, arrived earlier today. No complications, just a lot of noise.</p>\
+  <p>{3}''s already bragging about how {11} new recruit is built for the scrum.</p>\
+  <p>Morale''s up in the medbay - nice to see some smiles around here.</p>
+babyBorn.message.19.ic=Birth completed at {1}-local.\
+  <p>{2} delivered a baby {10}, {15}kg.</p>\
+  <p>Labor was managed with standard protocols.</p>\
+  <p>Immediate health checks indicate stable condition for both {5} and child. Return to duty for {3} is authorized after\
+  \ the mandatory recovery period.</p>
+babyBorn.message.20.ic=We had a scare.\
+  <p>{2} delivered a baby {10}, {15}kg, but suffered postpartum hemorrhage. Medical team acted fast, and we stabilized\
+  \ {8}, but it was touch and go.</p>\
+  <p>Both {5} and baby are resting now, and the MedTechs haven''t left {9} side.</p>\
+  <p>It''s a rough world out there, but they made it.</p>
+babyBorn.message.21.ic={2}''s new baby {10} arrived today - {15}kg, lungs like a banshee.\
+  <p>Labor went smoothly, but we might need soundproofing for the nursery.</p>\
+  <p>{3}''s already convinced {12}''ll be the next great hero of our time. Baby just wants more sleep.</p>
+babyBorn.message.22.ic=At sunrise, {2} brought a new life into our midst - a baby {10}, {15}kg, strong and healthy.\
+  <p>In a profession like ours, it''s humbling to witness the quiet strength of new beginnings. It''s a moment worth\
+  \ holding onto.</p>
+babyBorn.message.23.ic={2} successfully delivered a baby {10} at {1}-local, weighing {15}kg.\
+  <p>Delivery was typical, and {3} handled it with {9} usual grit.</p>\
+  <p>Both {5} and child are stable and {3}''s already showing off {9} little warrior.</p>
+babyBorn.message.24.ic=In a job defined by conflict and survival, today I witnessed something refreshingly pure.\
+  <p>{2} gave birth to a baby {10}, {15}kg.</p>\
+  <p>It''s strange how, in the harshest of times, life insists on continuing. Maybe it''s a sign that there''s something\
+  \ worth fighting for after all.</p>
+babyBorn.message.25.ic=We''ve got some fresh news from the medbay - {2} just welcomed {9} baby {10}!\
+  <p>Weighs {15}kg and already got a grip that could crush a can.</p>\
+  <p>Both are doing great, and {3}''s been beaming like a lighthouse. Drop by when you get a minute!</p>
+babyBorn.message.26.ic={2} delivered a baby {10} at {1}-local, weighing {15}kg.\
+  <p>There were mild complications due to prolonged labor, but nothing beyond standard medical management.</p>\
+  <p>Both {5} and child are in stable condition.</p>\
+  <p>We will continue routine monitoring. I''ve got a MedTech staying with them, providing support.</p>
+babyBorn.message.27.ic={2}''s delivery was rough - a baby {10}, {15}kg.\
+  <p>{6} experienced significant bleeding during the birthing process and required immediate intervention. We managed to\
+  \ stabilize {8}, but it was a tense few minutes.</p>\
+  <p>{3}''s recovering now, and the baby is healthy.</p>\
+  <p>It''s a relief. I was really worried we''d lose them both.</p>
+babyBorn.message.28.ic=In a world that seems constantly on fire, today we witnessed a moment of peace.\
+  <p>{2} gave birth to a baby {10}, weighing {15}kg.</p>\
+  <p>When {3} held {13} for the first time, they had tears in {11} eyes. It''s not often we get to see something so\
+  \ pure.</p>\
+  <p>Both {5} and baby are doing well.</p>
+babyBorn.message.29.ic={2} delivered a baby {10} at {1}-local, weighing {15}kg.\
+  <p>Labor was tough - but {7} fought through it like a true warrior.</p>\
+  <p>Both are stable, and {3}''s already planning to teach {13} the ways of the world.</p>\
+  <p>They''re a strong family, no doubt about it.</p>
+babyBorn.message.30.ic={2} just rolled out our latest recruit: a baby {10}, weighing in at {15}kg.\
+  <p>{11}''{16, choice, 0#re|1#s} loud, sturdy, and definitely got {14} {5}''s stubborn streak.</p>\
+  <p>No major issues. Baby and {5} are both doing well, just a bit tired.</p>
+babyBorn.message.31.ic=Sometimes, life catches you off guard.\
+  <p>{2} gave birth to a baby {10}, {15}kg, after a long and complicated labor.</p>\
+  <p>For a moment, it looked like we might lose them both. But {3} fought hard and pulled through.</p>\
+  <p>They''re both stable now.</p>
+babyBorn.message.32.ic={2} delivered a baby {10} at {1}-local, weighing {15}kg.\
+  <p>Delivery was straightforward with no complications.</p>\
+  <p>Both {5} and child are resting comfortably.</p>\
+  <p>{3}''s been grinning like a fool. Good to see some happiness around here.</p>
+babyBorn.message.33.ic={2} just deployed a new addition - a baby {10}, {15}kg.\
+  <p>Kid''s got a cry that could wake the whole base. {3}''s doing fine, though, just a bit worn out.</p>\
+  <p>{11}''{16, choice, 0#re|1#s} already bragging about how the kid''s hands are perfect for ''Mek controls.</p>\
+  <p>Gonna be a while before that''s true.</p>
+babyBorn.message.34.ic=We almost lost them.\
+  <p>{2} delivered a baby {10}, {15}kg, after severe postpartum complications. We had to intervene with emergency\
+  \ measures, but both are stable now.</p>\
+  <p>The MedTechs haven''t left {9} side, and {3} is just holding the baby like {7}''{0, choice, 0#re|1#s} afraid\
+  \ {12}''ll disappear.</p>\
+  <p>It was a close call. {11} nearly did.</p>
+babyBorn.message.35.ic={2} gave birth at {1}-local to a baby {10}, weighing {15}kg.\
+  <p>Labor was long and rough, but {3} pulled through. Both {5} and baby are stable.</p>\
+  <p>{3}''s been trying to act tough, but I caught {8} wiping {9} eyes.
+babyBorn.message.36.ic={2} just welcomed {9} baby {10} into the world, {15}kg, and I swear {12}''{16, choice, 0#ve|1#s}\
+  \ already got {14} {5}''s attitude.\
+  <p>{3}''s fine, just exhausted, and the little one''s already kicking like a trooper.</p>\
+  <p>{3}''s promising {12}''ll be leading the next {17}. At this rate, I almost believe {8}.</p>
+babyBorn.message.37.ic=In a job where people are just statistics, today felt different.\
+  <p>{2} gave birth to a baby 10}, {15}kg, without any major complications.</p>\
+  <p>Seeing {3} holding {9} child, it hit me how fragile and resilient life can be at once. Moments like this remind us\
+  \ of the simple things worth fighting for.</p>
+babyBorn.message.38.ic=I am pleased to report that {2} successfully delivered a baby {10} at {1}-local, weighing {15}kg\
+  \kg.\
+  <p>The procedure was efficient with no unexpected complications.</p>\
+  <p>Both {5} and child are resting and in good health.</p>
+babyBorn.message.39.ic=It was a tense few hours, but I''m happy to report that {2} delivered a baby {10} at {1}-local,\
+  \ weighing {15}kg.\
+  <p>We faced a brief complication with low fetal heart rate, but {3} pushed through.</p>\
+  <p>Both are stable now. Sometimes, luck is on our side.</p>
+babyBorn.message.40.ic=It''s official - {2}''s a {5}!\
+  <p>Baby {10} arrived at {1}-local, {15}kg, with a voice that could wake the dead.</p>\
+  <p>{3}''s already claiming the kid has "Officer''s lungs."</p>\
+  <p>Morale''s definitely on the rise down here.</p>
+babyBorn.message.41.ic=After everything we''ve faced, it''s good to have a reason to smile.\
+  <p>{2} welcomed {9} baby {10} today at {1}-local, {15}kg, healthy and beautiful.</p>\
+  <p>Seeing them together reminded me that life does find a way to persist, even in the most trying circumstances.</p>
+babyBorn.message.42.ic=It got dicey for a while.\
+  <p>{2} gave birth to a baby {10}, {15}kg, but suffered severe bleeding during delivery.</p>\
+  <p>We managed to control the hemorrhage, and both {5} and child are stable now.</p>\
+  <p>The MedTechs have been keeping watch, and the little guy''s strong.</p>\
+  <p>Sometimes it feels like a win just to make it through.</p>
+babyBorn.message.43.ic={2} just introduced us to the loudest thing on base: a baby {10}, {15}kg. Healthy\
+  \ lungs on this one.\
+  <p>Labor went fine, and {3}''s convinced {12}''ll be piloting a ''Mek before {12}''s walking.</p>\
+  <p>No complications, just a lot of noise.
+babyBorn.message.44.ic=We needed a reason to believe things could get better, and today we got one.\
+  <p>{2} gave birth to a baby {10}, {15}kg, healthy and strong.</p>\
+  <p>{3}''s already talking about making {13} a little pilot''s harness. Meanwhile, the baby looks like an angry\
+  \ potato.</p>\
+  <p>In times like these, it''s good to be reminded that life keeps moving forward. Potatoes and all.</p>
+babyBorn.message.45.ic=Wanted to give you the update - {2} gave birth at {1}-local.\
+  <p>Little guy came in at {15}kg. No complications, just a bit of a long labor.</p>\
+  <p>{3}''s still trying to process that {7}''s actually a {5}.</p>\
+  <p>Medbay''s in a surprisingly good mood for once.</p>
+babyBorn.message.46.ic=After weeks of losses and hard battles, today gave us a reminder of why we keep pushing forward.\
+  <p>{2} gave birth to a baby {10}, {15}kg, and both are in good health.</p>\
+  <p>Seeing {3}''s face light up was a rare moment of peace.</p>\
+  <p>It''s not much, but it''s enough to keep us going.</p>
+babyBorn.message.47.ic={2}''s latest "project" just concluded - a baby {10}, {15}kg, and according to {3}, already\
+  \ looking like a natural-born MekWarrior.</p>\
+  <p>Why do they always say that?</p>\
+  <p>No issues during delivery. Though we might need to give {3} instructions on how to hold a child.</p>
+babyBorn.message.48.ic={2} gave birth to a baby {10} at {1}-local, weighing {15}kg.\
+  <p>Labor was longer than expected, and there were a few tense moments when we had to manage some fetal distress.</p>\
+  <p>{3} showed incredible resilience, and the medical team worked efficiently.</p>\
+  <p>I''m relieved to say both {5} and child are now stable and resting.</p>
+babyBorn.message.49.ic={2} just welcomed our newest warrior - a baby {10}, {15}kg.\
+  <p>No complications, just a bit of yelling from both parties.</p>\
+  <p>{3}''s convinced the kid''s got a natural battle cry. I''m just glad it''s over.</p>\
+  <p>Can I go back to patching up the wounded? They scream less.</p>
+## Twins
+babyBorn.message.0.twins.ic={2} gave birth to <b>twins</b> earlier today. The delivery was successful with no major complications.\
+  <p>Both newborns are stable, and {3} is recovering as expected.</p>\
+  <p>Medical monitoring will continue for the next 24-48 hours.</p>
+babyBorn.message.1.twins.ic={2} delivered <b>twins</b> earlier today - both healthy and stable.\
+  <p>Labor was challenging, but {3} showed incredible strength. Everyone is doing well and resting comfortably.</p>\
+  <p>The medical team will keep an eye on them for the standard recovery period.</p>
+babyBorn.message.2.twins.ic=Just when we thought things couldn't get more interesting - {2} gave birth to <b>twins</b>!\
+  <p>Both arrived safely and are already showing some attitude. {3}'s doing well, just a bit tired.</p>\
+  <p>The medbay, on the other hand, is buzzing - who knew we'd get two new recruits at once?</p>
+babyBorn.message.3.twins.ic=Today brought a welcome surprise - {2} delivered <b>twins</b>!\
+  <p>Both are healthy and stable, and {3} is recovering well after a long labor.</p>\
+  <p>It's a rare bit of joy around here, and it's lifted everyone's spirits.</p>
+babyBorn.message.4.twins.ic=We've got a bit of unexpected news - {2} just gave birth to <b>twins</b>.\
+  <p>Both arrived in good shape, though {3}'s probably going to need some extra rest after pulling double duty.</p>\
+  <p>The medbay's a bit noisier now, but it's a good kind of noise for a change.</p>>
+babyBorn.message.5.twins.ic=After a long and demanding labor, {2} successfully delivered <b>twins</b>.\
+  <p>There were a few tense moments, but {3}'s strength carried her through and both newborns are healthy and stable.</p>\
+  <p>We're monitoring them closely, but the outlook is positive.</p>
+babyBorn.message.6.twins.ic={2} delivered <b>twins</b> earlier today. Both newborns are healthy and showing good vitals.\
+  <p>The delivery took longer than usual, but no significant complications arose.</p>\
+  <p>{3}'s resting and in good spirits, and we're optimistic about their recovery.</p>
+babyBorn.message.7.twins.ic=It's not often we get a moment of genuine hope, but today brought just that.\
+  <p>{2} gave birth to <b>twins</b> - a double blessing when we least expected it. Both are healthy, and {3} is stable.</p>\
+  <p>Seeing those tiny faces reminded us why we keep fighting.</p>\
+  <p>We'll keep them under observation, but for now, they're safe and sound.</p>
+babyBorn.message.8.twins.ic={2} successfully delivered <b>twins</b> today.\
+  <p>The delivery went well, and both newborns are stable.</p>\
+  <p>{3} is tired but doing well.</p>\
+  <p>It's not often we see double the joy around here - definitely a bright spot in the day.</p>
+babyBorn.message.9.twins.ic=Well, the medbay just got a little more crowded - {2} delivered <b>twins</b> earlier today!\
+  <b>Both newborns are healthy and arrived safely, though I think we're all still wrapping our heads around the surprise.</p>\
+  <p>{3} did incredibly well, handling the unexpected challenge with her usual grit.</p>\
+  <p>Looks like we'll need to find some extra blankets.</p>
+## Triplets
+babyBorn.message.0.triplets.ic={2} gave birth to <b>triplets</b> earlier today.\
+  <p>All three newborns arrived safely and are in stable condition.</p>\
+  <p>The delivery was complex and required additional medical support, but {3} remained strong throughout the process.</p>\
+  <p>We are monitoring both the mother and the newborns closely, but all initial health checks indicate that they are\
+  \ doing well.</p>
+babyBorn.message.1.triplets.ic=We've officially hit the jackpot - {2} gave birth to <b>triplets</b>!\
+  <p>All three arrived healthy and loud, making the medbay feel like a nursery on overdrive.</p>\
+  <p>Labor was intense, but {3} pulled through like a champ.</p>\
+  <p>It's not often we get news this good, and morale is definitely up.</p>
+babyBorn.message.2.triplets.ic=Well, that was unexpected - {2} gave birth to <b>triplets</b>!\
+  <p>All three newborns are doing well, and {3} is stable, though understandably exhausted.</p>\
+  <p>The medbay's already buzzing about how we're going to keep up with this tiny {17}.
+babyBorn.message.3.triplets.ic=In a world where challenges never seem to let up, today brought a remarkable surprise -\
+  \ {2} delivered <b>triplets</b>.\
+  <p>Despite the difficulties of a multiple birth, all three newborns are healthy, and {3} is recovering well.</p>\
+  <p>It's rare to see such a clear victory in the medbay, and it's done wonders for morale.</p>
+babyBorn.message.4.triplets.ic=I'm not going to lie - when {2} went into labor, we didn't expect <b>triplets</b>.\
+  <p>The delivery was tough, but {3}'s resilience got her through it.</p>\
+  <p>All three newborns are stable, though they arrived a bit earlier than anticipated. We're keeping a close eye on\
+  \ them to ensure they maintain good health.</p>
+## More than triplets
+babyBorn.message.quadrupletsPlus.ic=You're not going to believe this one.\
+  <p>The medbay just experienced something unprecedented - {2} has given birth, and it's safe to say we got more than we\
+  \ bargained for. I'm still trying to wrap my head around it myself.</p>\
+  <p>The delivery was intense and required the entire medical team on deck. We had to work fast and efficiently, but\
+  \ {3} showed an unbelievable amount of grit. We weren't just delivering one or two - it felt like an entire {17} showed\
+  \ up at once.</p>\
+  <p>All <b>{18}</b> newborns are stable, and {3} is resting.</p>\
+  <p>We'll continue to monitor them closely, but it looks like we just gained quite a few new faces around here. You\
+  \ might want to swing by when you have a moment - this one's worth seeing.</p>

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -690,6 +690,10 @@ lblAnnounceChildBirthdays.text=Always Announce 18th Birthdays \u26A0
 lblAnnounceChildBirthdays.tooltip=If enabled, 18th birthdays will always be announced.\
   <br>\
   <br><b>Warning:</b> Enabling this option will override any other settings.
+# createLifeEventsPanel
+lblLifeEventsPanel.text=Life Events \uD83C\uDF1F
+lblShowLifeEventDialogBirths.text=Personnel Giving Birth
+lblShowLifeEventDialogBirths.tooltip=Whenever a child is born, an in character dialog will appear announcing the event.
 # createBackgroundsTab
 lblBackgroundsTab.text=Background Options \u270E
 # createRandomBackgroundsPanel

--- a/MekHQ/resources/mekhq/resources/Personnel.properties
+++ b/MekHQ/resources/mekhq/resources/Personnel.properties
@@ -2,9 +2,6 @@
 ## Generic Personnel Resources
 Trueborn.text=Trueborn
 Freeborn.text=Freeborn
-
-
-
 ## Divorce
 # AbstractDivorce Class
 cannotDivorce.NotMarried.text=They cannot divorce as they are not married.
@@ -23,9 +20,6 @@ cannotDivorce.OppositeSexDivorceDisabled.text=They cannot randomly divorce as th
 cannotDivorce.SameSexDivorceDisabled.text=They cannot randomly divorce as they are in a same-sex marriage and same-sex random divorce is disabled.
 divorce.report=%s has divorced %s.
 widowed.report=%s has widowed %s.
-
-
-
 ## Enums
 # AgeGroup Enum
 AgeGroup.ELDER.text=Elder
@@ -42,7 +36,6 @@ AgeGroup.TODDLER.text=Toddler
 AgeGroup.TODDLER.toolTipText=Personnel are Toddlers from their 1st birthday until their 3rd birthday.
 AgeGroup.BABY.text=Baby
 AgeGroup.BABY.toolTipText=Personnel are babies until their 1st birthday.
-
 # Award Enum
 AwardBonuses.BOTH.text=XP/Edge
 AwardBonuses.BOTH.toolTipText=All Award bonuses are enabled
@@ -52,7 +45,6 @@ AwardBonuses.EDGE.text=Edge
 AwardBonuses.EDGE.toolTipText=Only Edge Award bonuses are enabled
 AwardBonuses.NONE.text=None
 AwardBonuses.NONE.toolTipText=All Award bonuses are disabled
-
 #AcademyType Enum
 AcademyType.NONE.text=None
 AcademyType.NONE.toolTipText=Academy type is undefined.
@@ -72,7 +64,6 @@ AcademyType.WARRANT_OFFICER_ACADEMY.text=Warrant Officer Academy
 AcademyType.WARRANT_OFFICER_ACADEMY.toolTipText=This academy is classified as a Warrant Officer academy.
 AcademyType.OFFICER_ACADEMY.text=Officer Academy
 AcademyType.OFFICER_ACADEMY.toolTipText=This academy is classified as an Officer academy.
-
 #EducationLevel Enum
 EducationLevel.EARLY_CHILDHOOD.text=Early Childhood
 EducationLevel.EARLY_CHILDHOOD.toolTipText=This individual has not graduated from high school.
@@ -84,7 +75,6 @@ EducationLevel.POST_GRADUATE.text=Post-Graduate
 EducationLevel.POST_GRADUATE.toolTipText=This individual has earned their Master's degree.
 EducationLevel.DOCTORATE.text=Doctorate
 EducationLevel.DOCTORATE.toolTipText=This individual has earned their Doctorate.
-
 #EducationStage Enum
 EducationStage.NONE.text=None
 EducationStage.NONE.toolTipText=This individual is not currently undergoing education or training.
@@ -98,7 +88,6 @@ EducationStage.DROPPING_OUT.text=Dropping Out
 EducationStage.DROPPING_OUT.toolTipText=This individual is dropping out of their education.
 EducationStage.JOURNEY_FROM_CAMPUS.text=Journeying from Campus
 EducationStage.JOURNEY_FROM_CAMPUS.toolTipText=This individual is journeying from campus.
-
 # BabySurnameStyle Enum
 BabySurnameStyle.FATHERS.text=Fathers
 BabySurnameStyle.FATHERS.toolTipText=The baby will use the father's surname, or the mother's surname if there is no father
@@ -124,7 +113,6 @@ BabySurnameStyle.ICELANDIC_COMBINATION_NYMICS.text=Icelandic Combined Nymics
 BabySurnameStyle.ICELANDIC_COMBINATION_NYMICS.toolTipText=The baby will use an Icelandic matronymic surname followed by an Icelandic patronymic surname, or an Icelandic matronymic surname if there is no father.
 BabySurnameStyle.RUSSIAN_PATRONYMICS.text=Russian Patronymics
 BabySurnameStyle.RUSSIAN_PATRONYMICS.toolTipText=The baby will use a basic Anglicized Russian patronymic surname (e.g. Romanovich, Romanovna, Nikolaevich, Nikolaevna), or the mother's surname if there is no father.
-
 # BodyLocation Enum
 BodyLocation.HEAD.text=Head
 BodyLocation.CHEST.text=Chest
@@ -139,7 +127,6 @@ BodyLocation.RIGHT_FOOT.text=Right Foot
 BodyLocation.LEFT_FOOT.text=Left Foot
 BodyLocation.INTERNAL.text=Innards
 BodyLocation.GENERIC.text=
-
 # FamilialConnectionType Enum
 FamilialConnectionType.MARRIED.text=Married
 FamilialConnectionType.DIVORCED.text=Divorced
@@ -148,13 +135,11 @@ FamilialConnectionType.PARTNER.text=Partner
 FamilialConnectionType.SINGLE_PARENT.text=Single Parent
 FamilialConnectionType.ADOPTED.text=Adopted
 FamilialConnectionType.UNDEFINED.text=ERROR
-
 # FamilialRelationshipDisplayLevel Enum
 FamilialRelationshipDisplayLevel.SPOUSE.text=Spouse
 FamilialRelationshipDisplayLevel.PARENTS_CHILDREN_SIBLINGS.text=Parents, Siblings, and Children
 FamilialRelationshipDisplayLevel.GRANDPARENTS_GRANDCHILDREN.text=Grandparents and Grandchildren
 FamilialRelationshipDisplayLevel.AUNTS_UNCLES_COUSINS.text=Aunts, Uncles, and Cousins
-
 # FamilialRelationshipType Enum
 FamilialRelationshipType.adopted=Adoptive
 FamilialRelationshipType.great=Great-
@@ -210,11 +195,9 @@ FamilialRelationshipType.STEPSIBLING.OTHER.text=Stepsibling
 FamilialRelationshipType.STEPCHILD.MALE.text=Stepson
 FamilialRelationshipType.STEPCHILD.FEMALE.text=Stepdaughter
 FamilialRelationshipType.STEPCHILD.OTHER.text=Stepchild
-
 # FormerSpouseReason Enum
 FormerSpouseReason.WIDOWED.text=Widowed
 FormerSpouseReason.DIVORCE.text=Divorced
-
 # GenderDescriptors Enum
 GenderDescriptors.MALE.text=male
 GenderDescriptors.FEMALE.text=female
@@ -231,7 +214,6 @@ GenderDescriptors.THEIR.text=their
 GenderDescriptors.THEIRS.text=theirs
 GenderDescriptors.BOY.text=boy
 GenderDescriptors.GIRL.text=girl
-
 # ManeiDominiClass Enum
 ManeiDominiClass.NONE.text=None
 ManeiDominiClass.GHOST.text=Ghost
@@ -241,7 +223,6 @@ ManeiDominiClass.ZOMBIE.text=Zombie
 ManeiDominiClass.PHANTOM.text=Phantom
 ManeiDominiClass.SPECTER.text=Specter
 ManeiDominiClass.POLTERGEIST.text=Poltergeist
-
 # ManeiDominiRank Enum
 ManeiDominiRank.NONE.text=None
 ManeiDominiRank.ALPHA.text=Alpha
@@ -251,7 +232,6 @@ ManeiDominiRank.TAU.text=Tau
 ManeiDominiRank.DELTA.text=Delta
 ManeiDominiRank.SIGMA.text=Sigma
 ManeiDominiRank.OMICRON.text=Omicron
-
 # MergingSurnameStyle Enum
 MergingSurnameStyle.NO_CHANGE.text=No Change
 MergingSurnameStyle.NO_CHANGE.toolTipText=Neither you nor your spouse change their surname
@@ -295,7 +275,6 @@ MergingSurnameStyle.FEMALE.dropDownText=Both share the female spouse's surname (
 MergingSurnameStyle.WEIGHTED.text=Weighted
 MergingSurnameStyle.WEIGHTED.toolTipText=The surname style used will be randomly determined through set weights
 MergingSurnameStyle.WEIGHTED.dropDownText=Surname style randomly determined through set weights
-
 # PersonnelRole Enum
 PersonnelRole.MEKWARRIOR.text=MekWarrior
 PersonnelRole.LAM_PILOT.text=LAM Pilot
@@ -327,7 +306,6 @@ PersonnelRole.ADMINISTRATOR_TRANSPORT.text=Admin/Transport
 PersonnelRole.ADMINISTRATOR_HR.text=Admin/HR
 PersonnelRole.DEPENDENT.text=Dependent
 PersonnelRole.NONE.text=None
-
 # Phenotype Enum
 Phenotype.MEKWARRIOR.text=MekWarrior
 Phenotype.MEKWARRIOR.toolTipText=Probability of a trueborn person with appropriate bonuses for MekWarriors. Does not apply to non-clan factions.
@@ -349,7 +327,6 @@ Phenotype.NONE.text=None
 Phenotype.NONE.toolTipText=This person is freeborn
 Phenotype.GENERAL.text=General
 Phenotype.GENERAL.toolTipText=Error: this should never be displayed and is used for generation
-
 # Profession Enum
 Profession.MEKWARRIOR.text=MekWarrior
 Profession.MEKWARRIOR.toolTipText=The MekWarrior Profession contains MekWarriors, LAM Pilots, and ProtoMek Pilots.
@@ -369,37 +346,31 @@ Profession.ADMINISTRATOR.text=Administrator
 Profession.ADMINISTRATOR.toolTipText=The Administrator Profession contains the four types of administrators.
 Profession.CIVILIAN.text=Civilian
 Profession.CIVILIAN.toolTipText=The Civilian Profession contains Dependents and None.
-
 # RandomDeathMethod Enum
 RandomDeathMethod.NONE.text=Disabled
 RandomDeathMethod.NONE.toolTipText=Random death is disabled
 RandomDeathMethod.RANDOM.text=Enabled
 RandomDeathMethod.RANDOM.toolTipText=Random death is enabled
-
 # RandomDependentMethod Enum
 RandomDependentMethod.NONE.text=Disabled
 RandomDependentMethod.NONE.toolTipText=Random dependent addition and removal is disabled.
 RandomDependentMethod.AGAINST_THE_BOT.text=Against the Bot
 RandomDependentMethod.AGAINST_THE_BOT.toolTipText=This follows the dependent addition and removal rules as per the AtB rules in docs/AtB Stuff.
-
 # RandomDivorceMethod
 RandomDivorceMethod.NONE.text=Disabled
 RandomDivorceMethod.NONE.toolTipText=Random divorce is disabled.
 RandomDivorceMethod.DICE_ROLL.text=Dice Roll
 RandomDivorceMethod.DICE_ROLL.toolTipText=A die is rolled each week to determine whether a marriage ends in divorce. The options below determine how many sides this dice has. Divorce occurs on a roll of 1.
-
 # RandomMarriageMethod Enum
 RandomMarriageMethod.NONE.text=Disabled
 RandomMarriageMethod.NONE.toolTipText=Random marriage is disabled.
 RandomMarriageMethod.DICE_ROLL.text=Dice Roll
 RandomMarriageMethod.DICE_ROLL.toolTipText=A die is rolled each week to determine whether an eligible character gets married to another eligible character. The options below determine how many sides this dice has. Marriage occurs on a roll of 1.
-
 # RandomProcreationMethod Enum
 RandomProcreationMethod.NONE.text=Disabled
 RandomProcreationMethod.NONE.toolTipText=Random procreation is disabled.
 RandomProcreationMethod.DICE_ROLL.text=Dice Roll
 RandomProcreationMethod.DICE_ROLL.toolTipText=Once per week roll a die with sides equal to those set below. On a roll of 1 the character falls pregnant.
-
 # TurnoverTargetNumberMethod Enum
 TurnoverTargetNumberMethod.FIXED.text=Fixed
 TurnoverTargetNumberMethod.FIXED.toolTipText=Turnover checks use a fixed target number, assigned below.
@@ -407,7 +378,6 @@ TurnoverTargetNumberMethod.ADMINISTRATION.text=Administration
 TurnoverTargetNumberMethod.ADMINISTRATION.toolTipText=The Target number is based on the mean Administration skill across all Admin/HR personnel.
 TurnoverTargetNumberMethod.NEGOTIATION.text=Negotiation
 TurnoverTargetNumberMethod.NEGOTIATION.toolTipText=The Target number is based on the mean Negotiation skill across all Admin/HR personnel.
-
 # TurnoverFrequency Enum
 TurnoverFrequency.NEVER.text=Never
 TurnoverFrequency.NEVER.toolTipText=Never prompt for turnover checks.
@@ -419,7 +389,6 @@ TurnoverFrequency.QUARTERLY.text=Quarterly
 TurnoverFrequency.QUARTERLY.toolTipText=Turnover check prompts occur every three months.
 TurnoverFrequency.ANNUALLY.text=Annually
 TurnoverFrequency.ANNUALLY.toolTipText=Turnover check prompts occur annually.
-
 # ForceReliabilityMethod Enum
 ForceReliabilityMethod.UNIT_RATING.text=Dynamic: Unit Rating
 ForceReliabilityMethod.UNIT_RATING.toolTipText=Unit Rating modifies desertion and Mutiny checks
@@ -435,13 +404,11 @@ ForceReliabilityMethod.OVERRIDE_D.text=Fixed: D (Reliable-Questionable / Clan Ga
 ForceReliabilityMethod.OVERRIDE_D.toolTipText=Desertion checks have no modifier. Mutiny checks have a -1 modifier
 ForceReliabilityMethod.OVERRIDE_F.text=Fixed: F (Questionable)
 ForceReliabilityMethod.OVERRIDE_F.toolTipText=Desertion and Mutiny checks have a -1 modifier.
-
 # MutinyMethod Enum
 MutinyMethod.CAMPAIGN_OPERATIONS.text=Campaign Operations
 MutinyMethod.CAMPAIGN_OPERATIONS.toolTipText=Where possible, this option follows the rules outlined in Campaign Operations.
 MutinyMethod.ADVANCED_MUTINIES.text=Advanced Mutinies
 MutinyMethod.ADVANCED_MUTINIES.toolTipText=This option expands on Campaign Operations, attempting to provide a more nuanced and interactive experience.
-
 # LeadershipMethod Enum
 LeadershipMethod.REGULAR.text=Regular
 LeadershipMethod.REGULAR.toolTipText=The average mercenary company. Applies no additional modifiers.
@@ -453,7 +420,6 @@ LeadershipMethod.FAMILY.text=Family
 LeadershipMethod.FAMILY.toolTipText=Family treats everyone equally, but the unit lacks discipline. Applies a -1 modifier to Desertion rolls, but a +1 modifier to Mutiny rolls.
 LeadershipMethod.IRON_FIST.text=Iron Fist
 LeadershipMethod.IRON_FIST.toolTipText=Where there's a whip, there's a way. Applies a +1 modifier to Desertion and Mutiny rolls, but both desertions and mutinies are more impactful.
-
 # RankSystemType Enum
 RankSystemType.DEFAULT.text=Default Rank System
 RankSystemType.DEFAULT.toolTipText=This rank system is a default MekHQ rank system and is stored within the standard data path.
@@ -461,7 +427,6 @@ RankSystemType.USER_DATA.text=User Data Rank System
 RankSystemType.USER_DATA.toolTipText=This rank system is stored within the user data folder.
 RankSystemType.CAMPAIGN.text=Campaign Custom Rank System
 RankSystemType.CAMPAIGN.toolTipText=This rank system is unique to a specific campaign, and is the chosen rank system for that campaign. A campaign may only have a single campaign custom rank system.
-
 # ROMDesignation Enum
 ROMDesignation.NONE.text=None (Automatically Set)
 ROMDesignation.EPSILON.text=Epsilon
@@ -478,7 +443,6 @@ ROMDesignation.OMICRON.text=Omicron
 ROMDesignation.CHI.text=Chi
 ROMDesignation.GAMMA.text=Gamma
 ROMDesignation.KAPPA.text=Kappa
-
 # SplittingSurnameStyle Enum
 SplittingSurnameStyle.ORIGIN_CHANGES_SURNAME.text=Yours Reverts
 SplittingSurnameStyle.ORIGIN_CHANGES_SURNAME.toolTipText=You revert to your maiden surname.
@@ -497,7 +461,6 @@ SplittingSurnameStyle.WEIGHTED.toolTipText=The surname style used will be random
 SplittingSurnameStyle.WEIGHTED.dropDownText=Surname style randomly determined through set weights
 SplittingSurnameStyle.WEIGHTED.ApplicationError.title=Surname Separation Error
 SplittingSurnameStyle.WEIGHTED.ApplicationError.text=Cannot set surnames for the marriage of %s to %s. Please open up an issue on the MekHQ tracker including all log files, your previous campaign save file, your latest campaign save file, and all customs.
-
 # TenYearAgeRange Enum
 TenYearAgeRange.UNDER_ONE.text=Under 1
 TenYearAgeRange.ONE_FOUR.text=1-4
@@ -510,7 +473,6 @@ TenYearAgeRange.FIFTY_FIVE_SIXTY_FOUR.text=55-64
 TenYearAgeRange.SIXTY_FIVE_SEVENTY_FOUR.text=65-74
 TenYearAgeRange.SEVENTY_FIVE_EIGHTY_FOUR.text=75-84
 TenYearAgeRange.EIGHTY_FIVE_OR_OLDER.text=85 and Older
-
 # TimeInDisplayFormat Enum
 TimeInDisplayFormat.DAYS.text=Day(s)
 TimeInDisplayFormat.DAYS.displayFormat=%d day(s)
@@ -522,19 +484,6 @@ TimeInDisplayFormat.MONTHS_YEARS.text=Month(s) and Year(s)
 TimeInDisplayFormat.MONTHS_YEARS.displayFormat=%d month(s) and %d year(s)
 TimeInDisplayFormat.YEARS.text=Year(s)
 TimeInDisplayFormat.YEARS.displayFormat=%d year(s)
-
-# SecondChanceCaste Enum
-SecondChanceCaste.NONE.text=None
-SecondChanceCaste.NONE.toolTipText=Warrior Caste washouts are not given a second chance.
-SecondChanceCaste.BA.text=Battle Armor
-SecondChanceCaste.BA.toolTipText=Warrior Caste washouts are given a second chance in a Battle Armor Sibko.
-SecondChanceCaste.INFANTRY.text=Conventional Infantry
-SecondChanceCaste.INFANTRY.toolTipText=Warrior Caste washouts are given a second chance in a Conventional Infantry Sibko.
-SecondChanceCaste.VEHICLE.text=Vehicle
-SecondChanceCaste.VEHICLE.toolTipText=Warrior Caste washouts are given a second chance in a Vehicle Sibko.
-
-
-
 ## Marriage
 # AbstractMarriage Class
 cannotMarry.NotMarriageable.text=They are not marriageable.
@@ -547,35 +496,6 @@ cannotMarry.Prisoner.text=They are a prisoner, and prisoner marriage is disabled
 cannotMarry.RandomClanPersonnel.text=They are from a clan, and random clan personnel marriage is disabled.
 cannotMarry.RandomPrisoner.text=They are a prisoner, and random prisoner marriage is disabled.
 marriage.report=%s has married %s!
-
-
-
-## Procreation
-# AbstractProcreation Class
-cannotProcreate.Gender.text=MekHQ procreation is female-based, and thus males cannot procreate.
-cannotProcreate.NotTryingForABaby.text=She is not trying for a baby.
-cannotProcreate.AlreadyPregnant.text=She is already pregnant.
-cannotProcreate.Inactive.text=She is currently inactive.
-cannotProcreate.Deployed.text=She is actively deployed.
-cannotProcreate.Child.text=She is a child. Those 18 and under cannot procreate in MekHQ.
-cannotProcreate.TooOld.text=She is too old to have child. Those fifty-one and over cannot procreate in MekHQ.
-cannotProcreate.ClanPersonnel.text=She is from a clan, and clan personnel procreation is disabled.
-cannotProcreate.Prisoner.text=She is a prisoner, and prisoner procreation is disabled.
-cannotProcreate.NoSpouse.text=She does not have a spouse and relationshipless random procreation is disabled.
-cannotProcreate.RandomClanPersonnel.text=She is from a clan, and random clan personnel procreation is disabled.
-cannotProcreate.RandomPrisoner.text=She is a prisoner, and random prisoner procreation is disabled.
-cannotProcreate.FemaleSpouse.text=Her spouse is female, and thus they cannot have a biological child.
-cannotProcreate.SpouseNotTryingForABaby.text=Her spouse is not trying for a baby.
-cannotProcreate.InactiveSpouse.text=Her spouse is inactive.
-cannotProcreate.DeployedSpouse.text=Her spouse is currently deployed.
-cannotProcreate.ChildSpouse.text=Her spouse is a child, and thus they cannot have children.
-cannotProcreate.ClanPersonnelSpouse.text=Her spouse is from a clan, and clan personnel procreation is disabled.
-cannotProcreate.PrisonerSpouse.text=Her spouse is a prisoner, and prisoner procreation is disabled.
-babyAmount.text=a baby,twins,triplets,quadruplets,quintuplets,sextuplets,septuplets,octuplets,nonuplets,decuplets
-babyConceived.report=%s has conceived %s
-multipleBabiesBorn.report=%s has given birth to %s!
-babyBorn.report=%s has given birth to %s, a baby %s!
-
 ## General
 # Person Class
 resurrected.report=%s has been resurrected

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -312,6 +312,9 @@ public class CampaignOptions {
     private boolean announceOfficersOnly;
     private boolean announceChildBirthdays;
 
+    // Life Events
+    private boolean showLifeEventDialogBirths;
+
     // Marriage
     private boolean useManualMarriages;
     private boolean useClanPersonnelMarriages;
@@ -882,6 +885,9 @@ public class CampaignOptions {
         setAnnounceRecruitmentAnniversaries(true);
         setAnnounceOfficersOnly(true);
         setAnnounceChildBirthdays(true);
+
+        // Life Events
+        setShowLifeEventDialogBirths(true);
 
         // Marriage
         setUseManualMarriages(true);
@@ -2252,6 +2258,16 @@ public class CampaignOptions {
         this.announceChildBirthdays = announceChildBirthdays;
     }
     // endregion anniversaries
+
+    //startregiona Life Events
+    public boolean isShowLifeEventDialogBirths() {
+        return showLifeEventDialogBirths;
+    }
+
+    public void setShowLifeEventDialogBirths(final boolean showLifeEventDialogBirths) {
+        this.showLifeEventDialogBirths = showLifeEventDialogBirths;
+    }
+    //endregion Life Events
 
     // region Dependents
     public boolean isUseRandomDependentAddition() {
@@ -4974,6 +4990,10 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "announceChildBirthdays", isAnnounceChildBirthdays());
         // endregion Announcements
 
+        // region Life Events
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "showLifeEventDialogBirths", isShowLifeEventDialogBirths());
+        // endregion Life Events
+
         // region Marriage
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useManualMarriages", isUseManualMarriages());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useClanPersonnelMarriages", isUseClanPersonnelMarriages());
@@ -5351,8 +5371,7 @@ public class CampaignOptions {
                     retVal.mistakeXP = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("vocationalXP")
                                  // <50.03 compatibility handler
-                                 ||
-                                 wn2.getNodeName().equalsIgnoreCase("idleXP")) {
+                                 || wn2.getNodeName().equalsIgnoreCase("idleXP")) {
                     retVal.vocationalXP = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("vocationalXPTargetNumber")
                                  // <50.03 compatibility handler
@@ -5720,6 +5739,8 @@ public class CampaignOptions {
                     retVal.setAnnounceOfficersOnly(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("announceChildBirthdays")) {
                     retVal.setAnnounceChildBirthdays(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("showLifeEventDialogBirths")) {
+                    retVal.setShowLifeEventDialogBirths(Boolean.parseBoolean(wn2.getTextContent().trim()));
                     // endregion anniversaries
 
                     // region Marriage
@@ -5788,8 +5809,9 @@ public class CampaignOptions {
                         if (wn3.getNodeType() != Node.ELEMENT_NODE) {
                             continue;
                         }
-                        retVal.getDivorceSurnameWeights().put(SplittingSurnameStyle.valueOf(wn3.getNodeName().trim()),
-                              Integer.parseInt(wn3.getTextContent().trim()));
+                        retVal.getDivorceSurnameWeights()
+                              .put(SplittingSurnameStyle.valueOf(wn3.getNodeName().trim()),
+                                    Integer.parseInt(wn3.getTextContent().trim()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("randomDivorceMethod")) {
                     retVal.setRandomDivorceMethod(RandomDivorceMethod.valueOf(wn2.getTextContent().trim()));

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/BirthAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/BirthAnnouncement.java
@@ -25,7 +25,7 @@
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
  */
-package mekhq.campaign.personnel.procreation;
+package mekhq.campaign.personnel.lifeEvents;
 
 import static megamek.common.Compute.randomInt;
 import static megamek.common.enums.Gender.FEMALE;

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -27,13 +27,23 @@
  */
 package mekhq.campaign.personnel.procreation;
 
+import static mekhq.campaign.personnel.education.EducationController.setInitialEducationLevel;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.UUID;
+
 import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.options.IOption;
 import mekhq.MHQConstants;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.ExtraData.IntKey;
@@ -51,16 +61,10 @@ import mekhq.campaign.randomEvents.prisoners.enums.PrisonerStatus;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Planet;
 
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-
-import static mekhq.campaign.personnel.education.EducationController.setInitialEducationLevel;
-
 /**
- * AbstractProcreation is the baseline class for procreation and birth in MekHQ. It holds all the
- * common logic for procreation, and is implemented by classes defining how to determine if a female
- * person will randomly procreate on a given day.
+ * AbstractProcreation is the baseline class for procreation and birth in MekHQ. It holds all the common logic for
+ * procreation, and is implemented by classes defining how to determine if a female person will randomly procreate on a
+ * given day.
  */
 public abstract class AbstractProcreation {
     //region Variable Declarations
@@ -74,8 +78,7 @@ public abstract class AbstractProcreation {
     public static final IntKey PREGNANCY_CHILDREN_DATA = new IntKey("procreation:children");
     public static final StringKey PREGNANCY_FATHER_DATA = new StringKey("procreation:father");
 
-    private static final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale());
+    private static final String RESOURCE_BUNDLE = "mekhq.resources." + AbstractProcreation.class.getSimpleName();
     //endregion Variable Declarations
 
     //region Constructors
@@ -136,10 +139,13 @@ public abstract class AbstractProcreation {
     //endregion Getters/Setters
 
     //region Determination Methods
+
     /**
      * This method determines the number of babies a person will give birth to.
-     * @param multiplePregnancyOccurrences the X occurrences for there to be a single multiple
-     *                                    child occurrence (i.e., 1 in X)
+     *
+     * @param multiplePregnancyOccurrences the X occurrences for there to be a single multiple child occurrence (i.e., 1
+     *                                     in X)
+     *
      * @return the number of babies the person will give birth to, limited to decuplets
      */
     protected int determineNumberOfBabies(final int multiplePregnancyOccurrences) {
@@ -151,8 +157,8 @@ public abstract class AbstractProcreation {
     }
 
     /**
-     * This method determines the duration for a pregnancy, with a variance determined through a
-     * Gaussian distribution with a maximum spread of approximately six weeks.
+     * This method determines the duration for a pregnancy, with a variance determined through a Gaussian distribution
+     * with a maximum spread of approximately six weeks.
      * <p>
      * TODO : Swap me to instead use a distribution function that generates an overall length,
      * TODO : Including pre-term and post-term births
@@ -162,8 +168,7 @@ public abstract class AbstractProcreation {
     private int determinePregnancyDuration() {
         // This creates a random range of approximately six weeks with which to modify the standard
         // pregnancy duration to create a randomized pregnancy duration
-        final double gaussian = Math.sqrt(-2.0 * Math.log(Math.random()))
-                * Math.cos(2.0 * Math.PI * Math.random());
+        final double gaussian = Math.sqrt(-2.0 * Math.log(Math.random())) * Math.cos(2.0 * Math.PI * Math.random());
         // To not get unusual results, we limit the variance to +/- 4.0 (almost 6 weeks).
         // A base length of 268 creates a solid enough duration for now.
         return 268 + (int) Math.round(MathUtility.clamp(gaussian, -4d, 4d) * 10.0);
@@ -171,105 +176,108 @@ public abstract class AbstractProcreation {
 
     /**
      * This determines the current week of the pregnancy
-     * @param today the current date
+     *
+     * @param today  the current date
      * @param person the pregnant person
+     *
      * @return the current week of their pregnancy
      */
     public int determinePregnancyWeek(final LocalDate today, final Person person) {
-        return (int) Math.max(Math.ceil(ChronoUnit.DAYS.between(
-                person.getExpectedDueDate().minusDays(MHQConstants.PREGNANCY_STANDARD_DURATION),
-                today) / 7f), 1);
+        return (int) Math.max(Math.ceil(ChronoUnit.DAYS.between(person.getExpectedDueDate()
+                                                                      .minusDays(MHQConstants.PREGNANCY_STANDARD_DURATION),
+              today) / 7f), 1);
     }
 
     /**
      * This determines the father of the baby.
      *
      * @param campaign the campaign the baby is part of
-     * @param mother the mother of the baby
+     * @param mother   the mother of the baby
      */
     protected @Nullable Person determineFather(final Campaign campaign, final Person mother) {
-        return (campaign.getCampaignOptions().isDetermineFatherAtBirth() && mother.getGenealogy().hasSpouse())
-                ? mother.getGenealogy().getSpouse()
-                : ((mother.getExtraData().get(PREGNANCY_FATHER_DATA) != null)
-                        ? campaign.getPerson(UUID.fromString(mother.getExtraData().get(PREGNANCY_FATHER_DATA)))
-                        : null);
+        return (campaign.getCampaignOptions().isDetermineFatherAtBirth() && mother.getGenealogy().hasSpouse()) ?
+                     mother.getGenealogy().getSpouse() :
+                     ((mother.getExtraData().get(PREGNANCY_FATHER_DATA) != null) ?
+                            campaign.getPerson(UUID.fromString(mother.getExtraData().get(PREGNANCY_FATHER_DATA))) :
+                            null);
     }
     //endregion Determination Methods
 
     /**
      * This is used to determine if a person can procreate
-     * @param today the current date
-     * @param person the person to determine for
+     *
+     * @param today             the current date
+     * @param person            the person to determine for
      * @param randomProcreation if this is for random procreation or manual procreation
+     *
      * @return null if they can, otherwise the reason why they cannot
      */
-    public @Nullable String canProcreate(final LocalDate today, final Person person,
-                                         final boolean randomProcreation) {
+    public @Nullable String canProcreate(final LocalDate today, final Person person, final boolean randomProcreation) {
         if (person.getGender().isMale()) {
-            return resources.getString("cannotProcreate.Gender.text");
+            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.Gender.text");
         }
 
         if (!person.isTryingToConceive()) {
-            return resources.getString("cannotProcreate.NotTryingForABaby.text");
+            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.NotTryingForABaby.text");
         }
 
         if (person.isPregnant()) {
-            return resources.getString("cannotProcreate.AlreadyPregnant.text");
+            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.AlreadyPregnant.text");
         }
 
         if (!person.getStatus().isActive()) {
-            return resources.getString("cannotProcreate.Inactive.text");
+            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.Inactive.text");
         }
 
         if (person.isDeployed()) {
-            return resources.getString("cannotProcreate.Deployed.text");
+            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.Deployed.text");
         }
 
         // Not allowing under-18s to procreate is project policy
         if (person.isChild(today, true)) {
-            return resources.getString("cannotProcreate.Child.text");
+            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.Child.text");
         }
 
         if (person.getAge(today) >= 51) {
-            return resources.getString("cannotProcreate.TooOld.text");
+            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.TooOld.text");
         }
 
         if (!isUseClanPersonnelProcreation() && person.isClanPersonnel()) {
-            return resources.getString("cannotProcreate.ClanPersonnel.text");
+            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.ClanPersonnel.text");
         }
 
         if (!isUsePrisonerProcreation() && person.getPrisonerStatus().isCurrentPrisoner()) {
-            return resources.getString("cannotProcreate.Prisoner.text");
+            return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.Prisoner.text");
         }
 
         if (randomProcreation) {
             if (!isUseRelationshiplessProcreation() && !person.getGenealogy().hasSpouse()) {
-                return resources.getString("cannotProcreate.NoSpouse.text");
+                return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.NoSpouse.text");
             }
 
             if (!isUseRandomClanPersonnelProcreation() && person.isClanPersonnel()) {
-                return resources.getString("cannotProcreate.RandomClanPersonnel.text");
+                return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.RandomClanPersonnel.text");
             }
 
             if (!isUseRandomPrisonerProcreation() && person.getPrisonerStatus().isCurrentPrisoner()) {
-                return resources.getString("cannotProcreate.RandomPrisoner.text");
+                return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.RandomPrisoner.text");
             }
 
             if (person.getGenealogy().hasSpouse()) {
                 if (person.getGenealogy().getSpouse().getGender().isFemale()) {
-                    return resources.getString("cannotProcreate.FemaleSpouse.text");
+                    return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.FemaleSpouse.text");
                 }
 
                 if (!person.getGenealogy().getSpouse().isTryingToConceive()) {
-                    return resources.getString("cannotProcreate.SpouseNotTryingForABaby.text");
+                    return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.SpouseNotTryingForABaby.text");
                 }
 
                 if (!person.getGenealogy().getSpouse().getStatus().isActive()) {
-                    return resources.getString("cannotProcreate.InactiveSpouse.text");
+                    return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.InactiveSpouse.text");
                 }
 
                 if (person.getGenealogy().getSpouse().isDeployed()) {
-                    return resources.getString("cannotProcreate.DeployedSpouse.text");
+                    return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.DeployedSpouse.text");
                 }
 
                 // Not allowing under-18s to procreate is project policy
@@ -277,16 +285,16 @@ public abstract class AbstractProcreation {
                 // However, we're keeping it as we don't want campaigns from pre-policy
                 // implementation being able to circumnavigate project policy.
                 if (person.getGenealogy().getSpouse().isChild(today, true)) {
-                    return resources.getString("cannotProcreate.ChildSpouse.text");
+                    return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.ChildSpouse.text");
                 }
 
                 if (!isUseRandomClanPersonnelProcreation() && person.getGenealogy().getSpouse().isClanPersonnel()) {
-                    return resources.getString("cannotProcreate.ClanPersonnelSpouse.text");
+                    return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.ClanPersonnelSpouse.text");
                 }
 
-                if (!isUseRandomPrisonerProcreation()
-                        && person.getGenealogy().getSpouse().getPrisonerStatus().isCurrentPrisoner()) {
-                    return resources.getString("cannotProcreate.PrisonerSpouse.text");
+                if (!isUseRandomPrisonerProcreation() &&
+                          person.getGenealogy().getSpouse().getPrisonerStatus().isCurrentPrisoner()) {
+                    return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.PrisonerSpouse.text");
                 }
             }
         }
@@ -296,33 +304,32 @@ public abstract class AbstractProcreation {
 
     /**
      * This method is how a person becomes pregnant.
-     * @param campaign the campaign the person is a part of
-     * @param today the current date
-     * @param mother the newly pregnant mother
+     *
+     * @param campaign   the campaign the person is a part of
+     * @param today      the current date
+     * @param mother     the newly pregnant mother
      * @param isNoReport true if no message should be posted to the daily report
      */
     public void addPregnancy(final Campaign campaign, final LocalDate today, final Person mother, boolean isNoReport) {
-        addPregnancy(
-                campaign,
-                today,
-                mother,
-                determineNumberOfBabies(campaign.getCampaignOptions().getMultiplePregnancyOccurrences()),
-                isNoReport
-        );
+        addPregnancy(campaign,
+              today,
+              mother,
+              determineNumberOfBabies(campaign.getCampaignOptions().getMultiplePregnancyOccurrences()),
+              isNoReport);
     }
 
     /**
-     * This method is how a person becomes pregnant with the specified number of children. They have
-     * their due date set, and the parentage of the pregnancy is determined.
+     * This method is how a person becomes pregnant with the specified number of children. They have their due date set,
+     * and the parentage of the pregnancy is determined.
      *
-     * @param campaign the campaign the person is a part of
-     * @param today the current date
-     * @param mother the newly pregnant mother
-     * @param size the number of children the mother is having
+     * @param campaign   the campaign the person is a part of
+     * @param today      the current date
+     * @param mother     the newly pregnant mother
+     * @param size       the number of children the mother is having
      * @param isNoReport true if no message should be posted to the daily report
      */
-    public void addPregnancy(final Campaign campaign, final LocalDate today, final Person mother,
-                             final int size, boolean isNoReport) {
+    public void addPregnancy(final Campaign campaign, final LocalDate today, final Person mother, final int size,
+                             boolean isNoReport) {
         if (size < 1) {
             return;
         }
@@ -333,15 +340,17 @@ public abstract class AbstractProcreation {
 
         mother.getExtraData().set(PREGNANCY_CHILDREN_DATA, size);
 
-        mother.getExtraData().set(PREGNANCY_FATHER_DATA, mother.getGenealogy().hasSpouse()
-                ? mother.getGenealogy().getSpouse().getId().toString() : null);
+        mother.getExtraData()
+              .set(PREGNANCY_FATHER_DATA,
+                    mother.getGenealogy().hasSpouse() ? mother.getGenealogy().getSpouse().getId().toString() : null);
 
-        final String babyAmount = resources.getString("babyAmount.text").split(",")[size - 1];
+        final String babyAmount = getFormattedTextAt(RESOURCE_BUNDLE, "babyAmount.text").split(",")[size - 1];
 
         if (!isNoReport) {
-            campaign.addReport(String.format(resources.getString("babyConceived.report"),
-                    mother.getHyperlinkedName(),
-                    babyAmount).trim());
+            campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE,
+                  "babyConceived.report",
+                  mother.getHyperlinkedName(),
+                  babyAmount).trim());
         }
 
         if (campaign.getCampaignOptions().isLogProcreation()) {
@@ -349,13 +358,16 @@ public abstract class AbstractProcreation {
 
             if (mother.getGenealogy().hasSpouse()) {
                 PersonalLogger.spouseConceived(mother.getGenealogy().getSpouse(),
-                        mother.getFullName(), today, babyAmount);
+                      mother.getFullName(),
+                      today,
+                      babyAmount);
             }
         }
     }
 
     /**
      * Removes a pregnancy and clears all related data from the provided person
+     *
      * @param person the person to clear the pregnancy data for
      */
     public void removePregnancy(final Person person) {
@@ -366,14 +378,14 @@ public abstract class AbstractProcreation {
     }
 
     /**
-     * This method is how a mother gives birth to a number of babies and has them added to the
-     * campaign.
+     * This method is how a mother gives birth to a number of babies and has them added to the campaign.
      *
      * @param campaign the campaign to add the baby in question to
-     * @param today today's date
-     * @param mother the mother giving birth
+     * @param today    today's date
+     * @param mother   the mother giving birth
      */
     public void birth(final Campaign campaign, final LocalDate today, final Person mother) {
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
         // Determine the number of children
         final int size = mother.getExtraData().get(PREGNANCY_CHILDREN_DATA, 1);
 
@@ -385,31 +397,34 @@ public abstract class AbstractProcreation {
 
         // Output a specific report to the campaign if they are giving birth to multiple children
         if (size > 1) {
-            campaign.addReport(String.format(resources.getString("multipleBabiesBorn.report"),
-                    mother.getHyperlinkedName(),
-                    resources.getString("babyAmount.text").split(",")[size - 1]));
+            campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE,
+                  "multipleBabiesBorn.report",
+                  mother.getHyperlinkedName(),
+                  getFormattedTextAt(RESOURCE_BUNDLE, "babyAmount.text").split(",")[size - 1]));
         }
 
         // Create Babies
         for (int i = 0; i < size; i++) {
             // Create a baby
-            final Person baby = campaign.newDependent(
-                Gender.RANDOMIZE, mother.getOriginFaction(), campaign.getLocation().getPlanet());
-            baby.setSurname(campaign.getCampaignOptions().getBabySurnameStyle()
-                    .generateBabySurname(mother, father, baby.getGender()));
+            final Person baby = campaign.newDependent(Gender.RANDOMIZE,
+                  mother.getOriginFaction(),
+                  campaign.getLocation().getPlanet());
+            baby.setSurname(campaignOptions.getBabySurnameStyle()
+                                  .generateBabySurname(mother, father, baby.getGender()));
             baby.setDateOfBirth(today);
 
             // Create reports and log the birth
-            campaign.addReport(String.format(resources.getString("babyBorn.report"),
-                    mother.getHyperlinkedName(), baby.getHyperlinkedName(),
-                    GenderDescriptors.BOY_GIRL.getDescriptor(baby.getGender())));
+            campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE,
+                  "babyBorn.report",
+                  mother.getHyperlinkedName(),
+                  baby.getHyperlinkedName(),
+                  GenderDescriptors.BOY_GIRL.getDescriptor(baby.getGender())));
             logAndUpdateFamily(campaign, today, mother, baby, father);
 
             // Founder Tag Assignment
-            if (campaign.getCampaignOptions().isAssignNonPrisonerBabiesFounderTag()
-                    && !prisonerStatus.isCurrentPrisoner()) {
+            if (campaignOptions.isAssignNonPrisonerBabiesFounderTag() && !prisonerStatus.isCurrentPrisoner()) {
                 baby.setFounder(true);
-            } else if (campaign.getCampaignOptions().isAssignChildrenOfFoundersFounderTag()) {
+            } else if (campaignOptions.isAssignChildrenOfFoundersFounderTag()) {
                 baby.setFounder(baby.getGenealogy().getParents().stream().anyMatch(Person::isFounder));
             }
 
@@ -426,6 +441,11 @@ public abstract class AbstractProcreation {
             if (mother.getStatus().isStudent()) {
                 mother.addEduTagAlong(baby.getId());
                 baby.changeStatus(campaign, today, PersonnelStatus.ON_LEAVE);
+            }
+
+            // Alert the player
+            if (campaignOptions.isShowLifeEventDialogBirths()) {
+                new BirthAnnouncement(campaign, mother, baby.getGender(), size);
             }
         }
 
@@ -454,12 +474,13 @@ public abstract class AbstractProcreation {
      * Logs the birth of a baby and updates the genealogy information of the family.
      *
      * @param campaign the ongoing campaign
-     * @param today the current date
-     * @param mother the mother of the baby
-     * @param baby the newborn baby
-     * @param father the father of the baby, null if unknown
+     * @param today    the current date
+     * @param mother   the mother of the baby
+     * @param baby     the newborn baby
+     * @param father   the father of the baby, null if unknown
      */
-    private static void logAndUpdateFamily(Campaign campaign, LocalDate today, Person mother, Person baby, Person father) {
+    private static void logAndUpdateFamily(Campaign campaign, LocalDate today, Person mother, Person baby,
+                                           Person father) {
         if (campaign.getCampaignOptions().isLogProcreation()) {
             MedicalLogger.deliveredBaby(mother, baby, today);
             if (father != null) {
@@ -478,17 +499,19 @@ public abstract class AbstractProcreation {
     }
 
     /**
-     * Creates baby/babies and performs any necessary operations such as setting birthdate, creating reports,
-     * updating genealogy, setting education, loyalty, personality, and recruiting the baby.
-     * This version is for historic births that occur as part of a character's background.
+     * Creates baby/babies and performs any necessary operations such as setting birthdate, creating reports, updating
+     * genealogy, setting education, loyalty, personality, and recruiting the baby. This version is for historic births
+     * that occur as part of a character's background.
      *
      * @param campaign the campaign object
-     * @param today the current date
-     * @param mother the mother person object
-     * @param father the father person object, can be null if the father is unknown
+     * @param today    the current date
+     * @param mother   the mother person object
+     * @param father   the father person object, can be null if the father is unknown
+     *
      * @return the babies
      */
-    public List<Person> birthHistoric(final Campaign campaign, final LocalDate today, final Person mother, @Nullable final Person father) {
+    public List<Person> birthHistoric(final Campaign campaign, final LocalDate today, final Person mother,
+                                      @Nullable final Person father) {
         List<Person> babies = new ArrayList<>();
 
         // Determine the number of children
@@ -506,8 +529,9 @@ public abstract class AbstractProcreation {
 
             final Person baby = campaign.newDependent(Gender.RANDOMIZE, originFaction, originPlanet);
 
-            baby.setSurname(campaign.getCampaignOptions().getBabySurnameStyle()
-                    .generateBabySurname(mother, father, baby.getGender()));
+            baby.setSurname(campaign.getCampaignOptions()
+                                  .getBabySurnameStyle()
+                                  .generateBabySurname(mother, father, baby.getGender()));
 
             baby.setDateOfBirth(mother.getDueDate());
 
@@ -544,12 +568,12 @@ public abstract class AbstractProcreation {
 
     /**
      * This is used to process procreation when a person dies with the Pregnancy Complications status
+     *
      * @param campaign the campaign to add the baby to
-     * @param today the current date
-     * @param person the person to process
+     * @param today    the current date
+     * @param person   the person to process
      */
-    public void processPregnancyComplications(final Campaign campaign, final LocalDate today,
-                                              final Person person) {
+    public void processPregnancyComplications(final Campaign campaign, final LocalDate today, final Person person) {
         // The child might be able to be born, albeit into a world without their mother.
         // The status, however, can be manually set for males and for those who are not pregnant.
         // This is purposeful to allow for player customization, and thus we first check if they
@@ -570,6 +594,7 @@ public abstract class AbstractProcreation {
      * Calculates the chance of a baby being born based on the pregnancy week.
      *
      * @param pregnancyWeek the week of the pregnancy
+     *
      * @return the chance of a baby being born, ranging from 0.0 to 1.0
      */
     private static double getBabyBornChance(int pregnancyWeek) {
@@ -577,9 +602,9 @@ public abstract class AbstractProcreation {
             case 23 -> 1;
             case 24 -> 2;
             case 25 -> 3;
-            default -> (pregnancyWeek > 25 && pregnancyWeek <= 29) ? 4 :
-                    (pregnancyWeek > 29 && pregnancyWeek <=35) ? 5 :
-                            (pregnancyWeek > 35) ? 6 : 0;
+            default -> (pregnancyWeek > 25 && pregnancyWeek <= 29) ?
+                             4 :
+                             (pregnancyWeek > 29 && pregnancyWeek <= 35) ? 5 : (pregnancyWeek > 35) ? 6 : 0;
         };
 
         return switch (range) {
@@ -594,11 +619,13 @@ public abstract class AbstractProcreation {
     }
 
     //region New Day
+
     /**
      * Process new day procreation for an individual
+     *
      * @param campaign the campaign to process
-     * @param today the current day
-     * @param person the person to process
+     * @param today    the current day
+     * @param person   the person to process
      */
     public void processNewWeek(final Campaign campaign, final LocalDate today, final Person person) {
         // Instantly return for male personnel
@@ -616,8 +643,7 @@ public abstract class AbstractProcreation {
             }
 
             if (campaign.getCampaignOptions().isUseMaternityLeave()) {
-                if (person.getStatus().isActive()
-                    && (person.getDueDate().minusWeeks(20).isBefore(today))) {
+                if (person.getStatus().isActive() && (person.getDueDate().minusWeeks(20).isBefore(today))) {
                     person.changeStatus(campaign, today, PersonnelStatus.ON_MATERNITY_LEAVE);
                 }
             }
@@ -630,26 +656,29 @@ public abstract class AbstractProcreation {
     }
 
     /**
-     * Checks if a person randomly procreates on the given day in the campaign.
-     * If the person does procreate, add a pregnancy to the campaign for the person.
+     * Checks if a person randomly procreates on the given day in the campaign. If the person does procreate, add a
+     * pregnancy to the campaign for the person.
      *
-     * @param campaign The campaign to check procreation for.
-     * @param today The current date.
-     * @param person The person to check for procreation.
+     * @param campaign   The campaign to check procreation for.
+     * @param today      The current date.
+     * @param person     The person to check for procreation.
      * @param isNoReport true, if the player shouldn't be informed, otherwise false
      */
-    public void processRandomProcreationCheck(final Campaign campaign, final LocalDate today,
-                                              final Person person, boolean isNoReport) {
+    public void processRandomProcreationCheck(final Campaign campaign, final LocalDate today, final Person person,
+                                              boolean isNoReport) {
         if (randomlyProcreates(today, person)) {
             addPregnancy(campaign, today, person, isNoReport);
         }
     }
 
     //region Random Procreation
+
     /**
      * Determines if a non-pregnant woman procreates on a given day
-     * @param today the current day
+     *
+     * @param today  the current day
      * @param person the person in question
+     *
      * @return true if they do, otherwise false
      */
     protected boolean randomlyProcreates(final LocalDate today, final Person person) {
@@ -662,7 +691,9 @@ public abstract class AbstractProcreation {
 
     /**
      * Determines if a person with an eligible partner procreates
+     *
      * @param person the person to determine for
+     *
      * @return true if they do, otherwise false
      */
     protected abstract boolean procreation(Person person);

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -57,6 +57,7 @@ import mekhq.campaign.personnel.enums.GenderDescriptors;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.enums.RandomProcreationMethod;
 import mekhq.campaign.personnel.enums.education.EducationLevel;
+import mekhq.campaign.personnel.lifeEvents.BirthAnnouncement;
 import mekhq.campaign.randomEvents.prisoners.enums.PrisonerStatus;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Planet;

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/BirthAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/BirthAnnouncement.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.campaign.personnel.procreation;
+
+import static megamek.common.Compute.randomInt;
+import static megamek.common.enums.Gender.FEMALE;
+import static megamek.common.enums.Gender.MALE;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
+import static mekhq.campaign.personnel.enums.PersonnelRole.BATTLE_ARMOUR;
+import static mekhq.campaign.personnel.enums.PersonnelRole.SOLDIER;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static org.apache.commons.text.WordUtils.capitalize;
+
+import java.util.List;
+
+import megamek.common.annotations.Nullable;
+import megamek.common.enums.Gender;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.randomEvents.personalities.PersonalityController.PronounData;
+import mekhq.campaign.universe.Faction;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+
+/**
+ * Handles the creation of birth announcements.
+ *
+ * <p>This class generates and displays the in-character and out-of-character messages for a character's childbirth
+ * event, incorporating campaign context and personalized pronoun and title handling for both parent and child.</p>
+ */
+public class BirthAnnouncement {
+    private static String RESOURCE_BUNDLE = "mekhq.resources." + BirthAnnouncement.class.getSimpleName();
+
+    private final Campaign campaign;
+    private final Person parent;
+
+    private final static double AVERAGE_BABY_WEIGHT_IN_KG = 3.5;
+    private final static int SUPPRESS_DIALOG_RESPONSE_INDEX = 3;
+
+
+    /**
+     * Constructs a birth announcement for a given campaign, parent, and baby gender.
+     *
+     * @param campaign   The campaign context providing data like faction and active personnel.
+     * @param parent     The parent {@link Person} giving birth, whose details are used in the announcement.
+     * @param babyGender The gender of the newborn.
+     */
+    public BirthAnnouncement(Campaign campaign, Person parent, Gender babyGender, int babyCount) {
+        this.campaign = campaign;
+        this.parent = parent;
+
+        String parentFirstName = parent.getFirstName();
+        String inCharacterMessage = getInCharacterMessage(babyGender, babyCount, parentFirstName);
+        String outOfCharacterMessage = getFormattedTextAt(RESOURCE_BUNDLE, "babyBorn.message.ooc", parentFirstName);
+
+        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
+              getSpeaker(campaign),
+              parent,
+              inCharacterMessage,
+              getButtonLabels(parentFirstName),
+              outOfCharacterMessage,
+              true);
+
+        if (dialog.getDialogChoice() == SUPPRESS_DIALOG_RESPONSE_INDEX) {
+            CampaignOptions campaignOptions = campaign.getCampaignOptions();
+            campaignOptions.setShowLifeEventDialogBirths(false);
+        }
+    }
+
+    /**
+     * Generates the in-character message for a baby's birth announcement.
+     *
+     * <p>This method constructs the message using localized resource keys and various contextual details, such as
+     * the baby's gender, the number of babies born, the parent's details, and campaign-specific data (e.g., faction and
+     * personnel roles). Pronoun-specific and role-specific titles are dynamically incorporated into the message .</p>
+     *
+     * @param babyGender      The {@link Gender} of the baby-babies, used for gender-specific pronouns and titles.
+     * @param babyCount       The number of babies born, which determines the appropriate message key:
+     *                        <ul>
+     *                            <li>{@code 1}: Single baby message (randomly selects from 50 variants).</li>
+     *                            <li>{@code 2}: Twins message (randomly selects from 10 variants).</li>
+     *                            <li>{@code 3}: Triplets message (randomly selects from 5 variants).</li>
+     *                            <li>{@code 4+}: Quadruplets or more, using a generic message.</li>
+     *                        </ul>
+     * @param parentFirstName The first name of the parent, included in the message.
+     *
+     * @return A localized string containing the in-character birth announcement message.
+     */
+    private String getInCharacterMessage(Gender babyGender, int babyCount, String parentFirstName) {
+        // Campaign Data
+        Faction campaignFaction = campaign.getFaction();
+
+        // Parent Data
+        Gender parentGender = parent.getGender();
+        String parentFullTitle = parent.getHyperlinkedFullTitle();
+        PersonnelRole primaryRole = parent.getPrimaryRole();
+
+        PronounData parentPronounData = new PronounData(parentGender);
+        String parentTitle = getGenderedTitle("babyBorn.parentTitle.", parentGender);
+
+        // Child Data
+        PronounData childPronounData = new PronounData(babyGender);
+        String childTitle = getGenderedTitle("babyBorn.childTitle.", babyGender);
+        String lanceLabel = getLanceLabel(campaignFaction, primaryRole);
+
+        // Build the in character message
+        String resourceKey = switch (babyCount) {
+            case 1 -> "babyBorn.message." + randomInt(50) + ".ic";
+            case 2 -> "babyBorn.message." + randomInt(10) + ".twins.ic";
+            case 3 -> "babyBorn.message." + randomInt(5) + ".triplets.ic";
+            default -> "babyBorn.message.quadrupletsPlus.ic";
+        };
+
+        // {0} Parent Gender Neutral = 0, Otherwise 1 (used to determine whether to use plural case)
+        // {1} Delivery Time
+
+        // {2} Parent Full Name
+        // {3} Parent First Name
+        // {4} Parent Title (Capitalized)
+        // {5} Parent Title
+        // {6} Parent He/She/They
+        // {7} Parent he/she/they
+        // {8} Parent him/her/them
+        // {9} Parent his/her/their
+
+        // {10} Baby Gendered Title
+        // {11} Baby He/She/They
+        // {12} Baby he/she/they
+        // {13} Baby him/her/them
+        // {14} Baby his/her/their
+        // {15} Baby Weight
+        // {16} Baby Gender Neutral = 0, Otherwise 1 (used to determine whether to use plural case)
+
+        // {17} Faction Lance-Level label (lance, star, etc)
+        // {18} Baby Count
+        String inCharacterMessage = getFormattedTextAt(RESOURCE_BUNDLE,
+              resourceKey,
+              parentPronounData.pluralizer(),
+              getRandomTimeOfDay(),
+              parentFullTitle,
+              parentFirstName,
+              capitalize(parentTitle),
+              parentTitle,
+              parentPronounData.subjectPronoun(),
+              parentPronounData.subjectPronounLowerCase(),
+              parentPronounData.objectPronounLowerCase(),
+              parentPronounData.possessivePronounLowerCase(),
+              childTitle,
+              childPronounData.subjectPronoun(),
+              childPronounData.subjectPronounLowerCase(),
+              childPronounData.objectPronounLowerCase(),
+              childPronounData.possessivePronounLowerCase(),
+              getBabyWeightInOunces(),
+              childPronounData.pluralizer(),
+              lanceLabel,
+              babyCount);
+        return inCharacterMessage;
+    }
+
+    /**
+     * Retrieves the appropriate speaker for a campaign dialog based on {@link PersonnelRole}.
+     *
+     * <p>This method evaluates the active personnel within the campaign to determine the most suitable speaker.
+     * It prioritizes personnel with doctor roles, using rank and skills to select the optimal candidate. If no medical
+     * specialist is available, the method falls back to senior administrators with the "HR" or "COMMAND"
+     * specialization, ensuring a valid speaker is selected whenever possible.</p>
+     *
+     * <p>If there are no active personnel available, a fallback mechanism is employed to determine the speaker based
+     * on senior administrators.</p>
+     *
+     * @param campaign The {@link Campaign} instance providing access to personnel data.
+     *
+     * @return The {@link Person} designated as the speaker, prioritizing medical specialists, then senior
+     *       administrators with "HR" or "COMMAND" specializations. Returns {@code null} if no suitable speaker can be
+     *       found.
+     */
+    private @Nullable Person getSpeaker(Campaign campaign) {
+        List<Person> potentialSpeakers = campaign.getActivePersonnel(false);
+
+        if (potentialSpeakers.isEmpty()) {
+            return getFallbackSpeaker(campaign);
+        }
+
+        Person speaker = null;
+
+        for (Person person : potentialSpeakers) {
+            if (!person.isDoctor()) {
+                continue;
+            }
+
+            if (speaker == null) {
+                speaker = person;
+                continue;
+            }
+
+            if (person.outRanksUsingSkillTiebreaker(campaign, speaker)) {
+                speaker = person;
+            }
+        }
+
+        // First fallback
+        if (speaker == null) {
+            return getFallbackSpeaker(campaign);
+        } else {
+            return speaker;
+        }
+    }
+
+    /**
+     * Retrieves a fallback speaker based on senior administrators within the campaign.
+     *
+     * <p>This method attempts to retrieve a senior administrator with the "HR" specialization first.
+     * If no such administrator is available, it falls back to one with the "COMMAND" specialization.</p>
+     *
+     * @param campaign The {@link Campaign} instance providing access to administrator data.
+     *
+     * @return The {@link Person} designated as the fallback speaker. Returns {@code null} if no suitable administrator
+     *       is available.
+     */
+    private @Nullable Person getFallbackSpeaker(Campaign campaign) {
+        Person speaker = campaign.getSeniorAdminPerson(HR);
+
+        if (speaker == null) {
+            speaker = campaign.getSeniorAdminPerson(COMMAND);
+        } else {
+            return speaker;
+        }
+
+        return speaker;
+    }
+
+    /**
+     * Retrieves a gendered title based on the provided {@code titleKey} and {@code gender}.
+     *
+     * <p>The key is adjusted to a gender-specific version by appending "neutral", "male", or "female" based on the
+     * provided gender.</p>
+     *
+     * @param titleKey The base key for the title in the resource bundle.
+     * @param gender   The gender of the character, used to determine the gendered variation.
+     *
+     * @return The gendered title retrieved from the resource bundle.
+     */
+    private static String getGenderedTitle(String titleKey, Gender gender) {
+        if (gender.isGenderNeutral()) {
+            titleKey = titleKey + "neutral";
+        } else if (gender == FEMALE) {
+            titleKey = titleKey + "female";
+        } else if (gender == MALE) {
+            titleKey = titleKey + "male";
+        }
+        return getFormattedTextAt(RESOURCE_BUNDLE, titleKey);
+    }
+
+    /**
+     * Retrieves the label for a lance or equivalent formation for the given faction and role.
+     *
+     * <p>For infantry roles (e.g., soldier or battle armor), this method returns squad-related labels. Other roles
+     * return lance-related labels.</p>
+     *
+     * @param campaignFaction The faction of the campaign.
+     * @param primaryRole     The primary role of the parent.
+     *
+     * @return A localized label describing the lance (or equivalent unit) based on faction and role.
+     */
+    private static String getLanceLabel(Faction campaignFaction, PersonnelRole primaryRole) {
+        String formationKey;
+        if (primaryRole == SOLDIER || primaryRole == BATTLE_ARMOUR) {
+            formationKey = "squad";
+        } else {
+            formationKey = "lance";
+        }
+
+        String factionKey;
+        if (campaignFaction.isClan()) {
+            factionKey = "clan";
+        } else if (campaignFaction.isComStarOrWoB()) {
+            factionKey = "comStar";
+        } else {
+            factionKey = "innerSphere";
+        }
+
+        return getFormattedTextAt(RESOURCE_BUNDLE, formationKey + '.' + factionKey).toLowerCase();
+    }
+
+    /**
+     * Calculates and returns the weight of the newborn in pounds as a string. The value is rounded conditionally to 0,
+     * 1, or 2 decimal places based on the weight.
+     *
+     * @return A string representation of the newborn's weight in pounds with conditional decimal rounding.
+     */
+    private static String getBabyWeightInOunces() {
+        boolean isBabyHeavy = randomInt(2) == 0;
+        double weightVariance = (double) randomInt(10) / 10;
+
+        double weight = AVERAGE_BABY_WEIGHT_IN_KG;
+        if (isBabyHeavy) {
+            weight += weightVariance;
+        } else {
+            weight -= weightVariance;
+        }
+
+        return String.valueOf(weight);
+    }
+
+    /**
+     * <p>A random time will be generated with 24-hour format hours and minutes.</p>
+     *
+     * @return A string representing a random time of day.
+     */
+    private static String getRandomTimeOfDay() {
+        int randomHours = randomInt(24);
+        int randomMinutes = randomInt(60);
+
+        return String.format("%02d:%02d", randomHours, randomMinutes);
+    }
+
+    /**
+     * Retrieves a list of localized button labels for the birth announcement dialog.
+     *
+     * <p>The labels represent different user responses to the birth announcement, such as expressing
+     * a positive reaction, a neutral reaction incorporating the parent's first name, a negative reaction, or an option
+     * to suppress future dialogs of this type.</p>
+     *
+     * @param parentFirstName The first name of the parent, used in the neutral response button label.
+     *
+     * @return A {@link List} of localized strings containing the button labels.
+     */
+    private List<String> getButtonLabels(String parentFirstName) {
+        return List.of(getFormattedTextAt(RESOURCE_BUNDLE, "button.response.positive"),
+              getFormattedTextAt(RESOURCE_BUNDLE, "button.response.neutral", parentFirstName),
+              getFormattedTextAt(RESOURCE_BUNDLE, "button.response.negative"),
+              getFormattedTextAt(RESOURCE_BUNDLE, "button.response.suppress"));
+    }
+}

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/PersonalityController.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/PersonalityController.java
@@ -600,14 +600,6 @@ public class PersonalityController {
      *       on the context in which the pronoun data is used (e.g., 1 for singular, >1 for plural).</li>
      * </ul>
      *
-     * <h3>Example Usage</h3>
-     * <pre>
-     * PronounData pronounData = new PronounData("He", "he", "Him", "him", "His", "his", 1);
-     * System.out.println("Subject Pronoun: " + pronounData.subjectPronoun());
-     * System.out.println("Object Pronoun: " + pronounData.objectPronoun());
-     * System.out.println("Pluralizer: " + (pronounData.pluralizer() > 1 ? "Plural" : "Singular"));
-     * </pre>
-     *
      * @param subjectPronoun             The subject pronoun (e.g., "He", "She", "They").
      * @param subjectPronounLowerCase    The lowercased version of the subject pronoun.
      * @param objectPronoun              The object pronoun (e.g., "Him", "Her", "Them").

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/PersonalityController.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/PersonalityController.java
@@ -28,15 +28,6 @@
 
 package mekhq.campaign.randomEvents.personalities;
 
-import megamek.common.enums.Gender;
-import mekhq.campaign.personnel.Person;
-import mekhq.campaign.randomEvents.personalities.enums.*;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import static java.lang.Math.max;
 import static megamek.common.Compute.d6;
 import static megamek.common.Compute.randomInt;
@@ -45,10 +36,24 @@ import static mekhq.campaign.personnel.enums.GenderDescriptors.HIM_HER_THEM;
 import static mekhq.campaign.personnel.enums.GenderDescriptors.HIS_HER_THEIR;
 import static mekhq.campaign.randomEvents.personalities.enums.Intelligence.*;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import megamek.common.enums.Gender;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.randomEvents.personalities.enums.Aggression;
+import mekhq.campaign.randomEvents.personalities.enums.Ambition;
+import mekhq.campaign.randomEvents.personalities.enums.Greed;
+import mekhq.campaign.randomEvents.personalities.enums.Intelligence;
+import mekhq.campaign.randomEvents.personalities.enums.PersonalityQuirk;
+import mekhq.campaign.randomEvents.personalities.enums.Social;
+
 /**
- * This class is responsible for generating and managing personalities for characters. It assigns
- * traits such as aggression, ambition, greed, social behavior, intelligence, and personality
- * quirks to a person, and generates a descriptive personality summary.
+ * This class is responsible for generating and managing personalities for characters. It assigns traits such as
+ * aggression, ambition, greed, social behavior, intelligence, and personality quirks to a person, and generates a
+ * descriptive personality summary.
  *
  * <p>Additionally, this class includes methods for handling fallback personality logic, generating
  * trait values, and calculating a personality's overall value for campaign mechanics.
@@ -75,15 +80,15 @@ public class PersonalityController {
     }
 
     /**
-     * Generates a personality for the given person by assigning various personality characteristics
-     * such as aggression, ambition, greed, social behavior, intelligence, and optional quirks.
+     * Generates a personality for the given person by assigning various personality characteristics such as aggression,
+     * ambition, greed, social behavior, intelligence, and optional quirks.
      *
      * <p>The method ensures that each personality characteristic is generated with a specified
-     * probability (1 in 6 by default). If no characteristic is assigned, a fallback mechanism
-     * generates at least one characteristic to ensure a meaningful personality.
+     * probability (1 in 6 by default). If no characteristic is assigned, a fallback mechanism generates at least one
+     * characteristic to ensure a meaningful personality.
      *
-     * @param person the person for whom the personality will be generated; this person's
-     *               attributes will be updated based on generated traits
+     * @param person the person for whom the personality will be generated; this person's attributes will be updated
+     *               based on generated traits
      */
     public static void generatePersonality(Person person) {
         // AGGRESSION
@@ -145,8 +150,8 @@ public class PersonalityController {
      * Generates an expansive "big" personality for a major character, Ronin, or hero.
      *
      * <p>This method creates a detailed set of personality traits for the given person,
-     * selecting and assigning a combination of major traits, a quirk, and intelligence.
-     * It ensures the generated personality reflects a high degree of uniqueness and depth.</p>
+     * selecting and assigning a combination of major traits, a quirk, and intelligence. It ensures the generated
+     * personality reflects a high degree of uniqueness and depth.</p>
      *
      * <p>The method proceeds as follows:
      * <ul>
@@ -168,8 +173,7 @@ public class PersonalityController {
         person.setSocial(Social.NONE);
 
         // Then we generate a new personality
-        List<PersonalityTraitType> possibleTraits = new ArrayList<>(Arrays.asList(
-              PersonalityTraitType.AGGRESSION,
+        List<PersonalityTraitType> possibleTraits = new ArrayList<>(Arrays.asList(PersonalityTraitType.AGGRESSION,
               PersonalityTraitType.AMBITION,
               PersonalityTraitType.GREED,
               PersonalityTraitType.SOCIAL));
@@ -231,12 +235,11 @@ public class PersonalityController {
     }
 
     /**
-     * Generates and applies a personality quirk to the given person. This method ensures the quirk
-     * index is valid by rolling a random value between 1 and the number of quirk constants in the
-     * {@link PersonalityQuirk} enum.
+     * Generates and applies a personality quirk to the given person. This method ensures the quirk index is valid by
+     * rolling a random value between 1 and the number of quirk constants in the {@link PersonalityQuirk} enum.
      *
-     * @param person the person to whom the personality quirk will be applied; their quirk
-     *               attribute is updated based on the rolled quirk
+     * @param person the person to whom the personality quirk will be applied; their quirk attribute is updated based on
+     *               the rolled quirk
      */
     public static void generateAndApplyPersonalityQuirk(Person person) {
         // This ensures we're rolling a value between 1 and the maximum index in the enum
@@ -247,9 +250,9 @@ public class PersonalityController {
     }
 
     /**
-     * Fallback mechanism to ensure the person has at least one personality characteristic. If
-     * no characteristics were generated during the initial roll in {@link #generatePersonality},
-     * this method assigns one characteristic at random.
+     * Fallback mechanism to ensure the person has at least one personality characteristic. If no characteristics were
+     * generated during the initial roll in {@link #generatePersonality}, this method assigns one characteristic at
+     * random.
      *
      * @param person the person whose personality will be updated with a fallback characteristic
      */
@@ -281,10 +284,10 @@ public class PersonalityController {
      * Generates a trait index based on the provided starting index for major traits.
      *
      * <p>The method rolls a random integer between 0 and the provided index, and if the
-     * major traits index is rolled, it further rolls a value between 0 and 5 to cover the
-     * extended major traits range.
+     * major traits index is rolled, it further rolls a value between 0 and 5 to cover the extended major traits range.
      *
      * @param majorTraitsStartIndex the starting index for major traits in the enum
+     *
      * @return a {@link String} representation of a valid trait index within the trait range
      */
     private static String getTraitIndex(final int majorTraitsStartIndex) {
@@ -300,9 +303,9 @@ public class PersonalityController {
     }
 
     /**
-     * Generates and sets a descriptive personality summary for the given person based on their
-     * assigned personality traits and quirks. It combines descriptions for each non-default
-     * characteristic and formats them into paragraphs.
+     * Generates and sets a descriptive personality summary for the given person based on their assigned personality
+     * traits and quirks. It combines descriptions for each non-default characteristic and formats them into
+     * paragraphs.
      *
      * @param person the person whose personality description will be generated and updated
      */
@@ -310,11 +313,16 @@ public class PersonalityController {
         Gender gender = person.getGender();
         String givenName = person.getGivenName();
 
-        List<String> traitDescriptions = getTraitDescriptions(
-            gender, givenName, person.getAggression(), person.getAggressionDescriptionIndex(),
-            person.getAmbition(), person.getAmbitionDescriptionIndex(), person.getGreed(),
-            person.getGreedDescriptionIndex(), person.getSocial(), person.getSocialDescriptionIndex()
-        );
+        List<String> traitDescriptions = getTraitDescriptions(gender,
+              givenName,
+              person.getAggression(),
+              person.getAggressionDescriptionIndex(),
+              person.getAmbition(),
+              person.getAmbitionDescriptionIndex(),
+              person.getGreed(),
+              person.getGreedDescriptionIndex(),
+              person.getSocial(),
+              person.getSocialDescriptionIndex());
 
         // Intelligence and personality quirk are handled differently to general personality traits.
         // INTELLIGENCE
@@ -322,17 +330,19 @@ public class PersonalityController {
         String intelligenceDescription = "";
         if (!intelligence.isAverageType()) {
             intelligenceDescription = intelligence.getDescription(person.getIntelligenceDescriptionIndex(),
-                gender, givenName);
+                  gender,
+                  givenName);
         }
 
         // PERSONALITY QUIRK
         PersonalityQuirk personalityQuirk = person.getPersonalityQuirk();
         String quirkDescription = "";
         if (!personalityQuirk.isNone()) {
-            quirkDescription = personalityQuirk.getDescription(
-                person.getPrimaryRole(), person.getPersonalityQuirkDescriptionIndex(), gender,
-                person.getOriginFaction(), givenName
-            );
+            quirkDescription = personalityQuirk.getDescription(person.getPrimaryRole(),
+                  person.getPersonalityQuirkDescriptionIndex(),
+                  gender,
+                  person.getOriginFaction(),
+                  givenName);
         }
 
         // Build the description proper
@@ -379,45 +389,42 @@ public class PersonalityController {
     }
 
     /**
-     * Retrieves the descriptions of all personality traits (other than Intelligence and Quirks) for
-     * the given person. This method processes various personality traits such as aggression, ambition,
-     * greed, and social behavior, generating descriptions based on the specified indices, gender,
-     * and given name of the person.
+     * Retrieves the descriptions of all personality traits (other than Intelligence and Quirks) for the given person.
+     * This method processes various personality traits such as aggression, ambition, greed, and social behavior,
+     * generating descriptions based on the specified indices, gender, and given name of the person.
      *
      * <p>Descriptions for traits that are not assigned or are empty will be excluded from the
      * returned list. This ensures only meaningful and applicable descriptions are included.
      *
-     * @param gender the gender of the person, used for generating gender-specific pronouns in trait
-     *               descriptions
-     * @param givenName the given name of the person, used to personalize the descriptions
-     * @param aggression the {@link Aggression} trait assigned to the person; omitted if the trait
-     *                  is set to "none"
-     * @param aggressionDescriptionIndex the index used to determine the specific {@link Aggression}
-     *                                  description
-     * @param ambition the {@link Ambition} trait assigned to the person; omitted if the trait is set
-     *                to "none"
-     * @param ambitionDescriptionIndex the index used to determine the specific {@link Ambition}
-     *                                description
-     * @param greed the {@link Greed} trait assigned to the person; omitted if the trait is set to
-     *             "none"
-     * @param greedDescriptionIndex the index used to determine the specific {@link Greed} description
-     * @param social the {@link Social} behavior trait assigned to the person; omitted if the trait
-     *              is set to "none"
-     * @param socialDescriptionIndex the index used to determine the specific {@link Social} description
-     * @return a list of strings, where each string represents a detailed description of a personality
-     *         trait assigned to the given person; traits without meaningful descriptions are excluded
+     * @param gender                     the gender of the person, used for generating gender-specific pronouns in trait
+     *                                   descriptions
+     * @param givenName                  the given name of the person, used to personalize the descriptions
+     * @param aggression                 the {@link Aggression} trait assigned to the person; omitted if the trait is
+     *                                   set to "none"
+     * @param aggressionDescriptionIndex the index used to determine the specific {@link Aggression} description
+     * @param ambition                   the {@link Ambition} trait assigned to the person; omitted if the trait is set
+     *                                   to "none"
+     * @param ambitionDescriptionIndex   the index used to determine the specific {@link Ambition} description
+     * @param greed                      the {@link Greed} trait assigned to the person; omitted if the trait is set to
+     *                                   "none"
+     * @param greedDescriptionIndex      the index used to determine the specific {@link Greed} description
+     * @param social                     the {@link Social} behavior trait assigned to the person; omitted if the trait
+     *                                   is set to "none"
+     * @param socialDescriptionIndex     the index used to determine the specific {@link Social} description
+     *
+     * @return a list of strings, where each string represents a detailed description of a personality trait assigned to
+     *       the given person; traits without meaningful descriptions are excluded
      */
-    private static List<String> getTraitDescriptions(Gender gender, String givenName,
-                                                     Aggression aggression, int aggressionDescriptionIndex,
-                                                     Ambition ambition, int ambitionDescriptionIndex,
-                                                     Greed greed, int greedDescriptionIndex,
-                                                     Social social, int socialDescriptionIndex) {
+    private static List<String> getTraitDescriptions(Gender gender, String givenName, Aggression aggression,
+                                                     int aggressionDescriptionIndex, Ambition ambition,
+                                                     int ambitionDescriptionIndex, Greed greed,
+                                                     int greedDescriptionIndex, Social social,
+                                                     int socialDescriptionIndex) {
         List<String> traitDescriptions = new ArrayList<>();
 
         // AGGRESSION
         if (!aggression.isNone()) {
-            String traitDescription = aggression.getDescription(aggressionDescriptionIndex, gender,
-                givenName);
+            String traitDescription = aggression.getDescription(aggressionDescriptionIndex, gender, givenName);
 
             if (!traitDescription.isBlank()) {
                 traitDescriptions.add(traitDescription);
@@ -455,12 +462,14 @@ public class PersonalityController {
     }
 
     /**
-     * Generates an Intelligence enum value for a person based on a randomly rolled value. Each
-     * intelligence level is mapped to a specific range of values, with lower rolls producing less
-     * intelligent results and higher rolls producing more intelligent results.
+     * Generates an Intelligence enum value for a person based on a randomly rolled value. Each intelligence level is
+     * mapped to a specific range of values, with lower rolls producing less intelligent results and higher rolls
+     * producing more intelligent results.
      *
      * @param roll the random roll value used to determine the Intelligence enum value
+     *
      * @return the Intelligence enum value corresponding to the rolled range
+     *
      * @throws IllegalStateException if the roll exceeds the expected value range
      */
     private static Intelligence generateIntelligence(int roll) {
@@ -516,32 +525,31 @@ public class PersonalityController {
             return GENIUS;
         } else {
             throw new IllegalStateException(
-                    "Unexpected value in mekhq/campaign/personnel/randomEvents/PersonalityController.java/generateIntelligence: "
-                            + roll);
+                  "Unexpected value in mekhq/campaign/personnel/randomEvents/PersonalityController.java/generateIntelligence: " +
+                        roll);
         }
     }
 
     /**
-     * Calculates the total personality value for a person based on their assigned personality
-     * traits (aggression, ambition, greed, and social behavior) and whether personalities are
-     * enabled in the campaign options.
+     * Calculates the total personality value for a person based on their assigned personality traits (aggression,
+     * ambition, greed, and social behavior) and whether personalities are enabled in the campaign options.
      *
      * <p>The calculation assigns positive or negative values to each trait depending on whether it
-     * is considered positive or negative, with major traits contributing more heavily to the total
-     * value. If personality mechanics are disabled, the method will return 0.</p>
+     * is considered positive or negative, with major traits contributing more heavily to the total value. If
+     * personality mechanics are disabled, the method will return 0.</p>
      *
-     * @param isUseRandomPersonalities a flag indicating whether random personalities are enabled in
-     *                                 the campaign options; if false, the method will return 0
-     * @param aggression the {@link Aggression} trait assigned to the person
-     * @param ambition the {@link Ambition} trait assigned to the person
-     * @param greed the {@link Greed} trait assigned to the person
-     * @param social the {@link Social} trait assigned to the person
-     * @return the total personality value, which is the sum of values contributed by each trait,
-     *         or 0 if personalities are not enabled
+     * @param isUseRandomPersonalities a flag indicating whether random personalities are enabled in the campaign
+     *                                 options; if false, the method will return 0
+     * @param aggression               the {@link Aggression} trait assigned to the person
+     * @param ambition                 the {@link Ambition} trait assigned to the person
+     * @param greed                    the {@link Greed} trait assigned to the person
+     * @param social                   the {@link Social} trait assigned to the person
+     *
+     * @return the total personality value, which is the sum of values contributed by each trait, or 0 if personalities
+     *       are not enabled
      */
-    public static int getPersonalityValue(final boolean isUseRandomPersonalities,
-                                          final Aggression aggression, final Ambition ambition,
-                                          final Greed greed, final Social social) {
+    public static int getPersonalityValue(final boolean isUseRandomPersonalities, final Aggression aggression,
+                                          final Ambition ambition, final Greed greed, final Social social) {
         if (!isUseRandomPersonalities) {
             return 0;
         }
@@ -573,26 +581,57 @@ public class PersonalityController {
     }
 
     /**
-     * A record to encapsulate pronoun information and associated data based on a given gender.
+     * Represents a set of grammatical pronouns associated with a subject, object, and possessive form, along with their
+     * lowercased variations, and additional data for pluralization handling.
+     *
+     * <p>This record is intended to encapsulate information related to personal pronouns for use in
+     * linguistic or grammatical processing. It includes pronoun forms commonly required for sentence construction and
+     * supports pluralization when applicable.</p>
+     *
+     * <h3>Fields</h3>
+     * <ul>
+     *   <li><b>subjectPronoun</b>: The pronoun used as the subject of a sentence (e.g., "He", "She", "They").</li>
+     *   <li><b>subjectPronounLowerCase</b>: The lowercased version of the subject pronoun (e.g., "he", "she", "they").</li>
+     *   <li><b>objectPronoun</b>: The pronoun used as the object of a sentence (e.g., "Him", "Her", "Them").</li>
+     *   <li><b>objectPronounLowerCase</b>: The lowercased version of the object pronoun (e.g., "him", "her", "them").</li>
+     *   <li><b>possessivePronoun</b>: The pronoun used to indicate possession (e.g., "His", "Hers", "Theirs").</li>
+     *   <li><b>possessivePronounLowerCase</b>: The lowercased version of the possessive pronoun (e.g., "his", "hers", "theirs").</li>
+     *   <li><b>pluralizer</b>: An integer value used to determine pluralization behavior. The exact logic depends
+     *       on the context in which the pronoun data is used (e.g., 1 for singular, >1 for plural).</li>
+     * </ul>
+     *
+     * <h3>Example Usage</h3>
+     * <pre>
+     * PronounData pronounData = new PronounData("He", "he", "Him", "him", "His", "his", 1);
+     * System.out.println("Subject Pronoun: " + pronounData.subjectPronoun());
+     * System.out.println("Object Pronoun: " + pronounData.objectPronoun());
+     * System.out.println("Pluralizer: " + (pronounData.pluralizer() > 1 ? "Plural" : "Singular"));
+     * </pre>
+     *
+     * @param subjectPronoun             The subject pronoun (e.g., "He", "She", "They").
+     * @param subjectPronounLowerCase    The lowercased version of the subject pronoun.
+     * @param objectPronoun              The object pronoun (e.g., "Him", "Her", "Them").
+     * @param objectPronounLowerCase     The lowercased version of the object pronoun.
+     * @param possessivePronoun          The possessive pronoun (e.g., "His", "Hers", "Theirs").
+     * @param possessivePronounLowerCase The lowercased version of the possessive pronoun.
+     * @param pluralizer                 An integer value to represent singular (1) or plural (>1).
      */
     public record PronounData(String subjectPronoun, String subjectPronounLowerCase, String objectPronoun,
-                              String objectPronounLowerCase, String possessivePronoun, String possessivePronounLowerCase,
-                              int pluralizer) {
-
+          String objectPronounLowerCase, String possessivePronoun, String possessivePronounLowerCase, int pluralizer) {
         /**
          * Constructs a new {@code PronounData} record based on the specified gender.
          *
          * @param gender The gender used to determine the pronouns and pluralizer.
          */
         public PronounData(Gender gender) {
-            this(
-                HE_SHE_THEY.getDescriptorCapitalized(gender),
-                HE_SHE_THEY.getDescriptorCapitalized(gender).toLowerCase(),
-                HIM_HER_THEM.getDescriptorCapitalized(gender),
-                HIM_HER_THEM.getDescriptorCapitalized(gender).toLowerCase(),
-                HIS_HER_THEIR.getDescriptorCapitalized(gender),
-                HIS_HER_THEIR.getDescriptorCapitalized(gender).toLowerCase(),
-                gender.isGenderNeutral() ? 0 : 1 // Used to determine whether to use a plural case
+            this(HE_SHE_THEY.getDescriptorCapitalized(gender),
+                  HE_SHE_THEY.getDescriptorCapitalized(gender).toLowerCase(),
+                  HIM_HER_THEM.getDescriptorCapitalized(gender),
+                  HIM_HER_THEM.getDescriptorCapitalized(gender).toLowerCase(),
+                  HIS_HER_THEIR.getDescriptorCapitalized(gender),
+                  HIS_HER_THEIR.getDescriptorCapitalized(gender).toLowerCase(),
+                  gender.isGenderNeutral() ? 0 : 1
+                  // Used to determine whether to use a plural case
             );
         }
     }

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/PersonalityController.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/PersonalityController.java
@@ -588,7 +588,7 @@ public class PersonalityController {
      * linguistic or grammatical processing. It includes pronoun forms commonly required for sentence construction and
      * supports pluralization when applicable.</p>
      *
-     * <h3>Fields</h3>
+     * <b>Fields</b>
      * <ul>
      *   <li><b>subjectPronoun</b>: The pronoun used as the subject of a sentence (e.g., "He", "She", "They").</li>
      *   <li><b>subjectPronounLowerCase</b>: The lowercased version of the subject pronoun (e.g., "he", "she", "they").</li>

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -77,7 +77,7 @@ import mekhq.gui.panes.RankSystemsPane;
  *     <li>Random name generation and portrait assignment based on roles and factions.</li>
  *     <li>Rank and hierarchy management for campaign personnel.</li>
  * </ul>
- *
+ * <p>
  * The class includes methods to initialize, load, and configure settings while providing GUI tools to enable user
  * interaction. It also integrates with the current `Campaign` and `CampaignOptions` objects to synchronize settings.
  * This class serves as the backbone for displaying and managing the "Biography" tab in the campaign options dialog.
@@ -104,6 +104,8 @@ public class BiographyTab {
     private JCheckBox chkAnnounceBirthdays;
     private JCheckBox chkAnnounceChildBirthdays;
     private JCheckBox chkAnnounceRecruitmentAnniversaries;
+    private JPanel pnlLifeEvents;
+    private JCheckBox chkShowLifeEventDialogBirths;
     //end General Tab
 
     //start Backgrounds Tab
@@ -192,9 +194,9 @@ public class BiographyTab {
     /**
      * Constructs the `BiographyTab` and initializes the campaign and its dependent options.
      *
-     * @param campaign             The current `Campaign` object to which the BiographyTab is linked. The campaign
-     *                             options and origin options are derived from this object.
-     * @param generalTab           The currently active General Tab.
+     * @param campaign   The current `Campaign` object to which the BiographyTab is linked. The campaign options and
+     *                   origin options are derived from this object.
+     * @param generalTab The currently active General Tab.
      */
     public BiographyTab(Campaign campaign, GeneralTab generalTab) {
         this.campaign = campaign;
@@ -206,16 +208,16 @@ public class BiographyTab {
     }
 
     /**
-     * Initializes the various sections and settings tabs within the BiographyTab.
-     * This method organizes the following tabs:
+     * Initializes the various sections and settings tabs within the BiographyTab. This method organizes the following
+     * tabs:
      * <p>
-     *     <li>General Tab: Handles general campaign settings such as gender distribution and
-     *     relationship displays.</li>
-     *     <li>Background Tab: Configures randomized backgrounds for campaign characters.</li>
-     *     <li>Death Tab: Sets up random death rules and options.</li>
-     *     <li>Education Tab: Defines education-related gameplay settings.</li>
-     *     <li>Name and Portrait Tab: Configures rules for name and portrait generation.</li>
-     *     <li>Rank Tab: Manages the rank systems for campaign personnel.</li>
+     * <li>General Tab: Handles general campaign settings such as gender distribution and
+     * relationship displays.</li>
+     * <li>Background Tab: Configures randomized backgrounds for campaign characters.</li>
+     * <li>Death Tab: Sets up random death rules and options.</li>
+     * <li>Education Tab: Defines education-related gameplay settings.</li>
+     * <li>Name and Portrait Tab: Configures rules for name and portrait generation.</li>
+     * <li>Rank Tab: Manages the rank systems for campaign personnel.</li>
      * </p>
      */
     private void initialize() {
@@ -312,9 +314,9 @@ public class BiographyTab {
     /**
      * Initializes the Backgrounds tab, which handles:
      * <p>
-     *     <li>Randomized background settings for characters.</li>
-     *     <li>Options for specifying origins (e.g., faction-specific planetary systems).</li>
-     *     <li>Custom search radius and distance scaling for randomized origins.</li>
+     * <li>Randomized background settings for characters.</li>
+     * <li>Options for specifying origins (e.g., faction-specific planetary systems).</li>
+     * <li>Custom search radius and distance scaling for randomized origins.</li>
      * </p>
      */
     private void initializeBackgroundsTab() {
@@ -344,9 +346,9 @@ public class BiographyTab {
     /**
      * Initializes the General tab, which provides options for:
      * <p>
-     *     <li>General gameplay settings such as gender distribution sliders.</li>
-     *     <li>Configuration of familial display levels and other general campaign settings.</li>
-     *     <li>Annunciation of anniversaries, recruitment dates, and officer-related milestones.</li>
+     * <li>General gameplay settings such as gender distribution sliders.</li>
+     * <li>Configuration of familial display levels and other general campaign settings.</li>
+     * <li>Annunciation of anniversaries, recruitment dates, and officer-related milestones.</li>
      * </p>
      */
     private void initializeGeneralTab() {
@@ -357,13 +359,16 @@ public class BiographyTab {
         spnNonBinaryDiceSize = new JSpinner();
         lblFamilyDisplayLevel = new JLabel();
         comboFamilyDisplayLevel = new MMComboBox<>("comboFamilyDisplayLevel",
-            FamilialRelationshipDisplayLevel.values());
+              FamilialRelationshipDisplayLevel.values());
 
         pnlAnniversariesPanel = new JPanel();
         chkAnnounceOfficersOnly = new JCheckBox();
         chkAnnounceBirthdays = new JCheckBox();
         chkAnnounceChildBirthdays = new JCheckBox();
         chkAnnounceRecruitmentAnniversaries = new JCheckBox();
+
+        pnlLifeEvents = new JPanel();
+        chkShowLifeEventDialogBirths = new JCheckBox();
     }
 
     /**
@@ -392,7 +397,7 @@ public class BiographyTab {
     public JPanel createGeneralTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("BiographyGeneralTab",
-            getImageDirectory() + "logo_clan_blood_spirit.png");
+              getImageDirectory() + "logo_clan_blood_spirit.png");
 
         // Contents
         chkUseDylansRandomXP = new CampaignOptionsCheckBox("UseDylansRandomXP");
@@ -404,12 +409,13 @@ public class BiographyTab {
         sldGender.setPaintLabels(true);
 
         lblNonBinaryDiceSize = new CampaignOptionsLabel("NonBinaryDiceSize");
-        spnNonBinaryDiceSize = new CampaignOptionsSpinner("NonBinaryDiceSize",
-            60, 0, 100000, 1);
+        spnNonBinaryDiceSize = new CampaignOptionsSpinner("NonBinaryDiceSize", 60, 0, 100000, 1);
 
         lblFamilyDisplayLevel = new CampaignOptionsLabel("FamilyDisplayLevel");
 
         pnlAnniversariesPanel = createAnniversariesPanel();
+
+        pnlLifeEvents = createLifeEventsPanel();
 
         // Layout the Panel
         final JPanel panelLeft = new CampaignOptionsStandardPanel("BiographyGeneralTabLeft", true);
@@ -451,6 +457,10 @@ public class BiographyTab {
         layoutParent.gridx++;
         panelParent.add(pnlAnniversariesPanel, layoutParent);
 
+        layoutParent.gridx = 0;
+        layoutParent.gridy++;
+        panelParent.add(pnlLifeEvents, layoutParent);
+
         // Create Parent Panel and return
         return createParentPanel(panelParent, "BiographyGeneralTab");
     }
@@ -458,8 +468,8 @@ public class BiographyTab {
     /**
      * Creates the Anniversaries panel within the General tab for managing announcement-related settings:
      * <p>
-     *     <li>Enabling birthday and recruitment anniversary announcements.</li>
-     *     <li>Specifying whether such announcements should be limited to officers.</li>
+     * <li>Enabling birthday and recruitment anniversary announcements.</li>
+     * <li>Specifying whether such announcements should be limited to officers.</li>
      * </p>
      *
      * @return A `JPanel` containing the UI components for defining anniversary-related settings.
@@ -472,8 +482,7 @@ public class BiographyTab {
         chkAnnounceChildBirthdays = new CampaignOptionsCheckBox("AnnounceChildBirthdays");
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("AnniversariesPanel", true,
-            "AnniversariesPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("AnniversariesPanel", true, "AnniversariesPanel");
         final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
 
         layoutParent.gridwidth = 5;
@@ -494,6 +503,22 @@ public class BiographyTab {
         return panel;
     }
 
+    private JPanel createLifeEventsPanel() {
+        // Contents
+        chkShowLifeEventDialogBirths = new CampaignOptionsCheckBox("ShowLifeEventDialogBirths");
+
+        // Layout the Panel
+        final JPanel panel = new CampaignOptionsStandardPanel("LifeEventsPanel", true, "LifeEventsPanel");
+        final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
+
+        layoutParent.gridwidth = 5;
+        layoutParent.gridx = 0;
+        layoutParent.gridy = 0;
+        panel.add(chkShowLifeEventDialogBirths, layoutParent);
+
+        return panel;
+    }
+
     /**
      * Creates and lays out the Backgrounds tab, which includes:
      * <ul>
@@ -506,7 +531,7 @@ public class BiographyTab {
     public JPanel createBackgroundsTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("BackgroundsTab",
-            getImageDirectory() + "logo_nueva_castile.png");
+              getImageDirectory() + "logo_nueva_castile.png");
 
         // Contents
         pnlRandomOriginOptions = createRandomOriginOptionsPanel();
@@ -537,10 +562,10 @@ public class BiographyTab {
      * <p>
      * This includes controls to enable or disable features such as:
      * <p>
-     *     <li>Random personalities for characters.</li>
-     *     <li>Random personality reputation.</li>
-     *     <li>Intelligence XP multipliers.</li>
-     *     <li>Simulated relationships.</li>
+     * <li>Random personalities for characters.</li>
+     * <li>Random personality reputation.</li>
+     * <li>Intelligence XP multipliers.</li>
+     * <li>Simulated relationships.</li>
      * </p>
      *
      * @return A {@code JPanel} representing the random background configuration UI.
@@ -553,8 +578,7 @@ public class BiographyTab {
         chkUseSimulatedRelationships = new CampaignOptionsCheckBox("UseSimulatedRelationships");
 
         // Layout the Panels
-        final JPanel panel = new CampaignOptionsStandardPanel("RandomBackgroundsPanel", true,
-            "RandomBackgroundsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("RandomBackgroundsPanel", true, "RandomBackgroundsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridwidth = 1;
@@ -577,9 +601,9 @@ public class BiographyTab {
     /**
      * Creates and returns a panel for random origin options. This includes:
      * <p>
-     *     <li>Controls to enable or disable randomization of origins.</li>
-     *     <li>Options for selecting specific planetary systems or factions for origin determination.</li>
-     *     <li>Search radius and distance scaling fields to tweak origin calculations.</li>
+     * <li>Controls to enable or disable randomization of origins.</li>
+     * <li>Options for selecting specific planetary systems or factions for origin determination.</li>
+     * <li>Search radius and distance scaling fields to tweak origin calculations.</li>
      * </p>
      *
      * @return A `JPanel` for managing random origin settings.
@@ -596,13 +620,13 @@ public class BiographyTab {
 
 
         lblSpecifiedSystem = new CampaignOptionsLabel("SpecifiedSystem");
-        comboSpecifiedSystem.setModel(new DefaultComboBoxModel<>(getPlanetarySystems(
-              chkSpecifiedSystemFactionSpecific.isSelected() ? generalTab.getFaction() : null)));
+        comboSpecifiedSystem.setModel(new DefaultComboBoxModel<>(getPlanetarySystems(chkSpecifiedSystemFactionSpecific.isSelected() ?
+                                                                                           generalTab.getFaction() :
+                                                                                           null)));
         comboSpecifiedSystem.setRenderer(new DefaultListCellRenderer() {
             @Override
-            public Component getListCellRendererComponent(final JList<?> list, final Object value,
-                                                          final int index, final boolean isSelected,
-                                                          final boolean cellHasFocus) {
+            public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
+                                                          final boolean isSelected, final boolean cellHasFocus) {
                 super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof PlanetarySystem) {
                     setText(((PlanetarySystem) value).getName(generalTab.getDate()));
@@ -613,8 +637,7 @@ public class BiographyTab {
         comboSpecifiedSystem.addActionListener(evt -> {
             final PlanetarySystem planetarySystem = comboSpecifiedSystem.getSelectedItem();
             final Planet planet = comboSpecifiedPlanet.getSelectedItem();
-            if ((planetarySystem == null)
-                || ((planet != null) && !planet.getParentSystem().equals(planetarySystem))) {
+            if ((planetarySystem == null) || ((planet != null) && !planet.getParentSystem().equals(planetarySystem))) {
                 restoreComboSpecifiedPlanet();
             }
         });
@@ -622,13 +645,13 @@ public class BiographyTab {
         lblSpecifiedPlanet = new CampaignOptionsLabel("SpecifiedPlanet");
         final PlanetarySystem planetarySystem = comboSpecifiedSystem.getSelectedItem();
         if (planetarySystem != null) {
-            comboSpecifiedPlanet.setModel(new DefaultComboBoxModel<>(planetarySystem.getPlanets().toArray(new Planet[] { })));
+            comboSpecifiedPlanet.setModel(new DefaultComboBoxModel<>(planetarySystem.getPlanets()
+                                                                           .toArray(new Planet[] {})));
         }
         comboSpecifiedPlanet.setRenderer(new DefaultListCellRenderer() {
             @Override
-            public Component getListCellRendererComponent(final JList<?> list, final Object value,
-                                                          final int index, final boolean isSelected,
-                                                          final boolean cellHasFocus) {
+            public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
+                                                          final boolean isSelected, final boolean cellHasFocus) {
                 super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof Planet) {
                     setText(((Planet) value).getName(generalTab.getDate()));
@@ -638,20 +661,21 @@ public class BiographyTab {
         });
 
         lblOriginSearchRadius = new CampaignOptionsLabel("OriginSearchRadius");
-        spnOriginSearchRadius = new CampaignOptionsSpinner("OriginSearchRadius",
-            0, 0, 2000, 25);
+        spnOriginSearchRadius = new CampaignOptionsSpinner("OriginSearchRadius", 0, 0, 2000, 25);
 
         lblOriginDistanceScale = new CampaignOptionsLabel("OriginDistanceScale");
-        spnOriginDistanceScale = new CampaignOptionsSpinner("OriginDistanceScale",
-            0.6, 0.1, 2.0, 0.1);
+        spnOriginDistanceScale = new CampaignOptionsSpinner("OriginDistanceScale", 0.6, 0.1, 2.0, 0.1);
 
         chkAllowClanOrigins = new CampaignOptionsCheckBox("AllowClanOrigins");
         chkExtraRandomOrigin = new CampaignOptionsCheckBox("ExtraRandomOrigin");
 
         // Layout the Panel
         final JPanel panelSystemPlanetOrigins = new CampaignOptionsStandardPanel(
-            "RandomOriginOptionsPanelSystemPlanetOrigins", false, "");
-        final GridBagConstraints layoutSystemPlanetOrigins = new CampaignOptionsGridBagConstraints(panelSystemPlanetOrigins);
+              "RandomOriginOptionsPanelSystemPlanetOrigins",
+              false,
+              "");
+        final GridBagConstraints layoutSystemPlanetOrigins = new CampaignOptionsGridBagConstraints(
+              panelSystemPlanetOrigins);
 
         layoutSystemPlanetOrigins.gridwidth = 1;
         layoutSystemPlanetOrigins.gridx = 0;
@@ -674,8 +698,9 @@ public class BiographyTab {
         layoutSystemPlanetOrigins.gridx++;
         panelSystemPlanetOrigins.add(spnOriginDistanceScale, layoutSystemPlanetOrigins);
 
-        final JPanel panel = new CampaignOptionsStandardPanel("RandomOriginOptionsPanel", true,
-            "RandomOriginOptionsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("RandomOriginOptionsPanel",
+              true,
+              "RandomOriginOptionsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridwidth = 1;
@@ -709,13 +734,12 @@ public class BiographyTab {
      * Refreshes the planetary systems and planets displayed in the associated combo boxes.
      *
      * <p>This method first stores the currently selected planetary system and planet. It then
-     * restores the list of available planetary systems by repopulating the `comboSpecifiedSystem`.
-     * Finally, it reselects the previously selected planetary system and planet in their respective
-     * combo boxes.</p>
+     * restores the list of available planetary systems by repopulating the `comboSpecifiedSystem`. Finally, it
+     * reselects the previously selected planetary system and planet in their respective combo boxes.</p>
      *
      * <p>The method ensures that the user selection persists even after the combo boxes are refreshed.
-     * Any exceptions during the selection process are caught and ignored. As if we can't restore
-     * the selection, that's fine, we just use the fallback index of 0.</p>
+     * Any exceptions during the selection process are caught and ignored. As if we can't restore the selection, that's
+     * fine, we just use the fallback index of 0.</p>
      */
     private void refreshSystemsAndPlanets() {
         final PlanetarySystem planetarySystem = comboSpecifiedSystem.getSelectedItem();
@@ -726,7 +750,8 @@ public class BiographyTab {
         try {
             comboSpecifiedSystem.setSelectedItem(planetarySystem);
             comboSpecifiedPlanet.setSelectedItem(planet);
-        } catch (Exception ignored) {}
+        } catch (Exception ignored) {
+        }
     }
 
     /**
@@ -738,8 +763,8 @@ public class BiographyTab {
         if (planetarySystem == null) {
             comboSpecifiedPlanet.removeAllItems();
         } else {
-            comboSpecifiedPlanet.setModel(new DefaultComboBoxModel<>(
-                planetarySystem.getPlanets().toArray(new Planet[] {})));
+            comboSpecifiedPlanet.setModel(new DefaultComboBoxModel<>(planetarySystem.getPlanets()
+                                                                           .toArray(new Planet[] {})));
             comboSpecifiedPlanet.setSelectedItem(planetarySystem.getPrimaryPlanet());
         }
     }
@@ -750,8 +775,9 @@ public class BiographyTab {
     private void restoreComboSpecifiedSystem() {
         comboSpecifiedSystem.removeAllItems();
 
-        comboSpecifiedSystem.setModel(new DefaultComboBoxModel<>(getPlanetarySystems(
-            chkSpecifiedSystemFactionSpecific.isSelected() ? generalTab.getFaction() : null)));
+        comboSpecifiedSystem.setModel(new DefaultComboBoxModel<>(getPlanetarySystems(chkSpecifiedSystemFactionSpecific.isSelected() ?
+                                                                                           generalTab.getFaction() :
+                                                                                           null)));
 
         restoreComboSpecifiedPlanet();
     }
@@ -760,6 +786,7 @@ public class BiographyTab {
      * Filters planetary systems based on a given faction (if specified) and returns a sorted array of matches.
      *
      * @param faction The faction to filter planetary systems by (nullable). If `null`, all systems are included.
+     *
      * @return An array of `PlanetarySystem` objects meeting the filter criteria.
      */
     private PlanetarySystem[] getPlanetarySystems(final @Nullable Faction faction) {
@@ -793,12 +820,11 @@ public class BiographyTab {
     public JPanel createDeathTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("DeathTab",
-            getImageDirectory() + "logo_clan_fire_mandrills.png");
+              getImageDirectory() + "logo_clan_fire_mandrills.png");
 
         // Contents
         lblRandomDeathMultiplier = new CampaignOptionsLabel("RandomDeathMultiplier");
-        spnRandomDeathMultiplier = new CampaignOptionsSpinner("RandomDeathMultiplier",
-            1.0, 0, 100.0, 0.01);
+        spnRandomDeathMultiplier = new CampaignOptionsSpinner("RandomDeathMultiplier", 1.0, 0, 100.0, 0.01);
 
         chkUseRandomDeathSuicideCause = new CampaignOptionsCheckBox("UseRandomDeathSuicideCause");
 
@@ -841,7 +867,8 @@ public class BiographyTab {
     }
 
     /**
-     * Configures and creates a panel where users can enable or disable random death probabilities for specific age groups.
+     * Configures and creates a panel where users can enable or disable random death probabilities for specific age
+     * groups.
      *
      * @return A `JPanel` containing the random death age group options.
      */
@@ -849,8 +876,7 @@ public class BiographyTab {
         final AgeGroup[] ageGroups = AgeGroup.values();
 
         // Create the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("DeathAgeGroupsPanel", true,
-            "DeathAgeGroupsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("DeathAgeGroupsPanel", true, "DeathAgeGroupsPanel");
         panel.setLayout(new GridLayout((ageGroups.length / 2) + 1, 1));
 
         // Contents
@@ -882,18 +908,16 @@ public class BiographyTab {
     public JPanel createEducationTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("EducationTab",
-            getImageDirectory() + "logo_taurian_concordat.png");
+              getImageDirectory() + "logo_taurian_concordat.png");
 
         // Contents
         chkUseEducationModule = new CampaignOptionsCheckBox("UseEducationModule");
 
         lblCurriculumXpRate = new CampaignOptionsLabel("CurriculumXpRate");
-        spnCurriculumXpRate = new CampaignOptionsSpinner("CurriculumXpRate",
-            3, 1, 10, 1);
+        spnCurriculumXpRate = new CampaignOptionsSpinner("CurriculumXpRate", 3, 1, 10, 1);
 
         lblMaximumJumpCount = new CampaignOptionsLabel("MaximumJumpCount");
-        spnMaximumJumpCount = new CampaignOptionsSpinner("MaximumJumpCount",
-            5, 1, 200, 1);
+        spnMaximumJumpCount = new CampaignOptionsSpinner("MaximumJumpCount", 5, 1, 200, 1);
 
         chkUseReeducationCamps = new CampaignOptionsCheckBox("UseReeducationCamps");
 
@@ -902,8 +926,7 @@ public class BiographyTab {
         chkShowIneligibleAcademies = new CampaignOptionsCheckBox("ShowIneligibleAcademies");
 
         lblEntranceExamBaseTargetNumber = new CampaignOptionsLabel("EntranceExamBaseTargetNumber");
-        spnEntranceExamBaseTargetNumber = new CampaignOptionsSpinner("EntranceExamBaseTargetNumber",
-            14, 0, 20, 1);
+        spnEntranceExamBaseTargetNumber = new CampaignOptionsSpinner("EntranceExamBaseTargetNumber", 14, 0, 20, 1);
 
         pnlEnableStandardSets = createEnableStandardSetsPanel();
 
@@ -995,9 +1018,9 @@ public class BiographyTab {
      * <p>
      * This includes options to toggle various academy types:
      * <p>
-     *     <li>Local academies.</li>
-     *     <li>Prestigious academies.</li>
-     *     <li>Unit-based education academies.</li>
+     * <li>Local academies.</li>
+     * <li>Prestigious academies.</li>
+     * <li>Unit-based education academies.</li>
      * </p>
      *
      * @return A {@code JPanel} containing the Enable Standard Sets UI components.
@@ -1007,8 +1030,9 @@ public class BiographyTab {
         chkEnablePrestigiousAcademies = new CampaignOptionsCheckBox("EnablePrestigiousAcademies");
         chkEnableUnitEducation = new CampaignOptionsCheckBox("EnableUnitEducation");
 
-        final JPanel panel = new CampaignOptionsStandardPanel("EnableStandardSetsPanel", true,
-            "EnableStandardSetsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("EnableStandardSetsPanel",
+              true,
+              "EnableStandardSetsPanel");
 
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
@@ -1031,8 +1055,8 @@ public class BiographyTab {
      * <p>
      * This includes:
      * <p>
-     *     <li>Option to enable or disable bonuses.</li>
-     *     <li>Setting the faculty XP multiplier.</li>
+     * <li>Option to enable or disable bonuses.</li>
+     * <li>Setting the faculty XP multiplier.</li>
      * </p>
      *
      * @return A {@code JPanel} for managing XP rates and skill bonuses.
@@ -1041,12 +1065,10 @@ public class BiographyTab {
         // Contents
         chkEnableBonuses = new CampaignOptionsCheckBox("EnableBonuses");
         lblFacultyXpMultiplier = new CampaignOptionsLabel("FacultyXpMultiplier");
-        spnFacultyXpMultiplier = new CampaignOptionsSpinner("FacultyXpMultiplier",
-            1.00, 0.00, 10.00, 0.01);
+        spnFacultyXpMultiplier = new CampaignOptionsSpinner("FacultyXpMultiplier", 1.00, 0.00, 10.00, 0.01);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("XpAndSkillBonusesPanel", true,
-            "XpAndSkillBonusesPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("XpAndSkillBonusesPanel", true, "XpAndSkillBonusesPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridx = 0;
@@ -1068,8 +1090,8 @@ public class BiographyTab {
      * <p>
      * This includes:
      * <p>
-     *     <li>Setting the dropout chance for adults.</li>
-     *     <li>Setting the dropout chance for children.</li>
+     * <li>Setting the dropout chance for adults.</li>
+     * <li>Setting the dropout chance for children.</li>
      * </p>
      *
      * @return A {@code JPanel} for managing dropout chance settings.
@@ -1077,15 +1099,12 @@ public class BiographyTab {
     private JPanel createDropoutChancePanel() {
         // Contents
         lblAdultDropoutChance = new CampaignOptionsLabel("AdultDropoutChance");
-        spnAdultDropoutChance = new CampaignOptionsSpinner("AdultDropoutChance",
-            1000, 0, 100000, 1);
+        spnAdultDropoutChance = new CampaignOptionsSpinner("AdultDropoutChance", 1000, 0, 100000, 1);
         lblChildrenDropoutChance = new CampaignOptionsLabel("ChildrenDropoutChance");
-        spnChildrenDropoutChance = new CampaignOptionsSpinner("ChildrenDropoutChance",
-            10000, 0, 100000, 1);
+        spnChildrenDropoutChance = new CampaignOptionsSpinner("ChildrenDropoutChance", 10000, 0, 100000, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("DropoutChancePanel", true,
-            "DropoutChancePanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("DropoutChancePanel", true, "DropoutChancePanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridwidth = 1;
@@ -1109,8 +1128,8 @@ public class BiographyTab {
      * <p>
      * This includes:
      * <p>
-     *     <li>Toggling settings for all-age accidents.</li>
-     *     <li>Configuring the frequency of military academy accidents.</li>
+     * <li>Toggling settings for all-age accidents.</li>
+     * <li>Configuring the frequency of military academy accidents.</li>
      * </p>
      *
      * @return A {@code JPanel} containing the accidents and events configuration UI.
@@ -1119,12 +1138,12 @@ public class BiographyTab {
         // Contents
         chkAllAges = new CampaignOptionsCheckBox("AllAges");
         lblMilitaryAcademyAccidents = new CampaignOptionsLabel("MilitaryAcademyAccidents");
-        spnMilitaryAcademyAccidents = new CampaignOptionsSpinner("MilitaryAcademyAccidents",
-            10000, 0, 100000, 1);
+        spnMilitaryAcademyAccidents = new CampaignOptionsSpinner("MilitaryAcademyAccidents", 10000, 0, 100000, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("AccidentsAndEventsPanel", true,
-            "AccidentsAndEventsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("AccidentsAndEventsPanel",
+              true,
+              "AccidentsAndEventsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridx = 0;
@@ -1155,7 +1174,7 @@ public class BiographyTab {
     public JPanel createNameAndPortraitGenerationTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("NameAndPortraitGenerationTab",
-            getImageDirectory() + "logo_clan_nova_cat.png");
+              getImageDirectory() + "logo_clan_nova_cat.png");
 
         // Contents
         chkAssignPortraitOnRoleChange = new CampaignOptionsCheckBox("AssignPortraitOnRoleChange");
@@ -1213,8 +1232,8 @@ public class BiographyTab {
      * <p>
      * This includes:
      * <p>
-     *     <li>Options to enable or disable the use of role-specific portraits.</li>
-     *     <li>Buttons to toggle all or no portrait options collectively.</li>
+     * <li>Options to enable or disable the use of role-specific portraits.</li>
+     * <li>Buttons to toggle all or no portrait options collectively.</li>
      * </p>
      *
      * @return A {@code JPanel} containing the random portrait generation configuration UI.
@@ -1240,11 +1259,9 @@ public class BiographyTab {
         });
 
         // Layout the Panel
-        JPanel panel = new JPanel(
-            new GridLayout((int) Math.ceil((personnelRoles.length + 2) / 5.0), 5));
-        panel.setBorder(BorderFactory.createTitledBorder(
-            String.format(String.format("<html>%s</html>",
-                resources.getString("lblRandomPortraitPanel.text")))));
+        JPanel panel = new JPanel(new GridLayout((int) Math.ceil((personnelRoles.length + 2) / 5.0), 5));
+        panel.setBorder(BorderFactory.createTitledBorder(String.format(String.format("<html>%s</html>",
+              resources.getString("lblRandomPortraitPanel.text")))));
 
         panel.add(btnEnableAllPortraits);
         panel.add(btnDisableAllPortraits);
@@ -1274,7 +1291,8 @@ public class BiographyTab {
     public JPanel createRankTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("RankTab",
-            getImageDirectory() + "logo_umayyad_caliphate.png", true);
+              getImageDirectory() + "logo_umayyad_caliphate.png",
+              true);
 
         // Contents
         Component rankSystemsViewport = rankSystemsPane.getViewport().getView();
@@ -1305,9 +1323,10 @@ public class BiographyTab {
     /**
      * Loads values from campaign options, optionally integrating with presets for default settings.
      *
-     * @param presetCampaignOptions Optional preset campaign options, or `null` to use the campaign's active settings.
+     * @param presetCampaignOptions     Optional preset campaign options, or `null` to use the campaign's active
+     *                                  settings.
      * @param presetRandomOriginOptions Optional random origin options, or `null` to use the default origin settings.
-     * @param presetRankSystem Optional rank system, or `null` to use the default system.
+     * @param presetRankSystem          Optional rank system, or `null` to use the default system.
      */
     public void loadValuesFromCampaignOptions(@Nullable CampaignOptions presetCampaignOptions,
                                               @Nullable RandomOriginOptions presetRandomOriginOptions,
@@ -1336,6 +1355,7 @@ public class BiographyTab {
         chkAnnounceBirthdays.setSelected(options.isAnnounceBirthdays());
         chkAnnounceChildBirthdays.setSelected(options.isAnnounceChildBirthdays());
         chkAnnounceRecruitmentAnniversaries.setSelected(options.isAnnounceRecruitmentAnniversaries());
+        chkShowLifeEventDialogBirths.setSelected(options.isShowLifeEventDialogBirths());
 
         // Backgrounds
         chkUseRandomPersonalities.setSelected(options.isUseRandomPersonalities());
@@ -1396,15 +1416,14 @@ public class BiographyTab {
     }
 
     /**
-     * Applies the current settings from the market UI components back into
-     * the {@link CampaignOptions} of the associated campaign.
+     * Applies the current settings from the market UI components back into the {@link CampaignOptions} of the
+     * associated campaign.
      * <p>
-     * If a preset options object is provided, the changes are applied there.
-     * Otherwise, they are applied to the current campaign's options.
+     * If a preset options object is provided, the changes are applied there. Otherwise, they are applied to the current
+     * campaign's options.
      *
-     * @param presetCampaignOptions A {@link CampaignOptions} object to update
-     *                              with the current UI settings, or {@code null}
-     *                              to apply changes to the campaign's options directly.
+     * @param presetCampaignOptions A {@link CampaignOptions} object to update with the current UI settings, or
+     *                              {@code null} to apply changes to the campaign's options directly.
      */
     public void applyCampaignOptionsToCampaign(@Nullable CampaignOptions presetCampaignOptions) {
         CampaignOptions options = presetCampaignOptions;
@@ -1425,6 +1444,7 @@ public class BiographyTab {
         options.setAnnounceBirthdays(chkAnnounceBirthdays.isSelected());
         options.setAnnounceChildBirthdays(chkAnnounceChildBirthdays.isSelected());
         options.setAnnounceRecruitmentAnniversaries(chkAnnounceRecruitmentAnniversaries.isSelected());
+        options.setShowLifeEventDialogBirths(chkShowLifeEventDialogBirths.isSelected());
 
         // Backgrounds
         options.setUseRandomPersonalities(chkUseRandomPersonalities.isSelected());
@@ -1437,9 +1457,9 @@ public class BiographyTab {
         originOptions.setRandomizeAroundSpecifiedPlanet(chkRandomizeAroundSpecifiedPlanet.isSelected());
 
         Planet selectedPlanet = comboSpecifiedPlanet.getSelectedItem();
-        originOptions.setSpecifiedPlanet(selectedPlanet == null
-                                               ? Systems.getInstance().getSystemById("Terra").getPrimaryPlanet()
-                                               : selectedPlanet);
+        originOptions.setSpecifiedPlanet(selectedPlanet == null ?
+                                               Systems.getInstance().getSystemById("Terra").getPrimaryPlanet() :
+                                               selectedPlanet);
 
         originOptions.setOriginSearchRadius((int) spnOriginSearchRadius.getValue());
         originOptions.setOriginDistanceScale((double) spnOriginDistanceScale.getValue());
@@ -1451,8 +1471,8 @@ public class BiographyTab {
         options.setUseRandomDeathSuicideCause(chkUseRandomDeathSuicideCause.isSelected());
         options.setRandomDeathMultiplier((double) spnRandomDeathMultiplier.getValue());
         for (final AgeGroup ageGroup : AgeGroup.values()) {
-            options.getEnabledRandomDeathAgeGroups().put(ageGroup,
-                chkEnabledRandomDeathAgeGroups.get(ageGroup).isSelected());
+            options.getEnabledRandomDeathAgeGroups()
+                  .put(ageGroup, chkEnabledRandomDeathAgeGroups.get(ageGroup).isSelected());
         }
 
         // Education


### PR DESCRIPTION
- Introduced a new `BirthAnnouncement` class to handle birth event dialogs and messages, including both in-character and out-of-character announcements.
- Added localized properties and messages for various procreation-related scenarios in the new `AbstractProcreation.properties` resource file.
- Enhanced `AbstractProcreation` to include updated methods for procreation constraints and localized messaging.
- Introduced a new `showLifeEventDialogBirths` campaign option to allow users to toggle birth announcement dialogs.
- Updated the `CampaignOptions` class and XML persistence to accommodate the new `showLifeEventDialogBirths` option.

### Dev Notes
I didn't like how missable childbirth was in MekHQ. It made it really easy to miss and detracted from the 'generational campaign' experience. This PR tries to address that by triggering an Immersive Dialog whenever a child is born, turning childbirth into an event.

These dialogs can be disabled, either in the dialog, or in campaign options.

There are 50 variants for single child birthing; 10 for twins; 5 for triplets; and a single variant for quadruplets+.

<img width="774" alt="image" src="https://github.com/user-attachments/assets/2d211e61-5f01-43ab-8e1c-e5d37286d56e" />