### PR TITLE
Removed Redundant Artillery Role Entries in Scenario Templates

### DIFF
--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -4,14 +4,15 @@
     <shortBriefing>Defend grounded DropShip from raid.</shortBriefing>
     <detailedBriefing>The enemy has launched a deep strike behind our lines, targeting one of our DropShips before it can take off. This is a calculated assault meant to cripple our logistics and deny us critical mobility. Your mission is to defend the DropShip until it can launch or eliminate at least 50% of the attacking force to force their retreat.
 
-Expect long-range bombardment. The enemy is likely to deploy artillery strikes to weaken our defenses before engaging directly. You must counter their firepower while maintaining a strong perimeter around the DropShip. Close the distance where possible, neutralize their artillery assets, and prevent them from overwhelming our position before liftoff.
+        Expect long-range bombardment. The enemy is likely to deploy artillery strikes to weaken our defenses before engaging directly. You must counter their firepower while maintaining a strong perimeter around the DropShip. Close the distance where possible, neutralize their artillery assets, and prevent them from overwhelming our position before liftoff.
 
-We will control the battlefield at the end of the engagement, ensuring access to salvage and preventing any lingering enemy forces from regrouping. Hold the line, protect the DropShip, and make the enemy pay dearly for their incursion.</detailedBriefing>
+        We will control the battlefield at the end of the engagement, ensuring access to salvage and preventing any lingering enemy forces from regrouping. Hold the line, protect the DropShip, and make the enemy pay dearly for their incursion.
+    </detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes/>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
@@ -53,7 +54,7 @@ We will control the battlefield at the end of the engagement, ensuring access to
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
-                <objectiveLinkedForces />
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -92,21 +93,15 @@ We will control the battlefield at the end of the engagement, ensuring access to
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>2</minWeightClass>
-                <objectiveLinkedForces />
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>ARTILLERY</forceRole>
-                    <forceRole>MISSILE_ARTILLERY</forceRole>
-                    <forceRole>MIXED_ARTILLERY</forceRole>
                     <forceRole>FIRE_SUPPORT</forceRole>
                     <forceRole>FIRE_SUPPORT</forceRole>
-                    <forceRole>FIRE_SUPPORT</forceRole>
-                    <forceRole>FIRE_SUPPORT</forceRole>
-                    <forceRole>SR_FIRE_SUPPORT</forceRole>
-                    <forceRole>SR_FIRE_SUPPORT</forceRole>
                     <forceRole>SR_FIRE_SUPPORT</forceRole>
                     <forceRole>SR_FIRE_SUPPORT</forceRole>
                 </roleChoices>
@@ -136,7 +131,7 @@ We will control the battlefield at the end of the engagement, ensuring access to
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
-                <objectiveLinkedForces />
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -158,7 +153,7 @@ We will control the battlefield at the end of the engagement, ensuring access to
             <associatedForceNames>
                 <associatedForceName>DropShip</associatedForceName>
             </associatedForceNames>
-            <associatedUnitIDs />
+            <associatedUnitIDs/>
             <successEffects>
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
@@ -188,7 +183,7 @@ We will control the battlefield at the end of the engagement, ensuring access to
             <associatedForceNames>
                 <associatedForceName>OpFor</associatedForceName>
             </associatedForceNames>
-            <associatedUnitIDs />
+            <associatedUnitIDs/>
             <successEffects>
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
@@ -203,7 +198,7 @@ We will control the battlefield at the end of the engagement, ensuring access to
                     <howMuch>1</howMuch>
                 </failureEffect>
             </failureEffects>
-            <additionalDetails />
+            <additionalDetails/>
             <description>Destroy, cripple or force to withdraw 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>

--- a/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -4,14 +4,15 @@
     <shortBriefing>Defend isolated DropShip from interception.</shortBriefing>
     <detailedBriefing>An allied DropShip has been isolated behind enemy lines, and hostile forces are closing in fast. Your mission is to defend the DropShip until it can lift off or, if necessary, destroy at least 50% of the enemy forces to break their assault. If the DropShip fails to escape and the enemy remains intact, our strategic situation will be severely compromised.
 
-Expect a relentless assault from multiple directions, with enemy units prioritizing disabling the DropShip before it can launch. They may attempt to immobilize it, breach its hull, or delay its departure long enough for reinforcements to arrive. You must hold the line, intercept high-threat targets, and keep the DropShip secure until it achieves liftoff. If the situation demands it, eliminating half of the enemy force will force them to retreat, buying the DropShip a chance to escape.
+        Expect a relentless assault from multiple directions, with enemy units prioritizing disabling the DropShip before it can launch. They may attempt to immobilize it, breach its hull, or delay its departure long enough for reinforcements to arrive. You must hold the line, intercept high-threat targets, and keep the DropShip secure until it achieves liftoff. If the situation demands it, eliminating half of the enemy force will force them to retreat, buying the DropShip a chance to escape.
 
-The enemy will control the field at the end of the engagement, meaning no salvage or recovery will be possible. This is a battle of survival—ensure the DropShip gets out or cripple the enemy so thoroughly that they can no longer threaten it.</detailedBriefing>
+        The enemy will control the field at the end of the engagement, meaning no salvage or recovery will be possible. This is a battle of survival—ensure the DropShip gets out or cripple the enemy so thoroughly that they can no longer threaten it.
+    </detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
-        <allowedTerrainTypes />
+        <allowedTerrainTypes/>
         <allowRotation>false</allowRotation>
         <baseHeight>0</baseHeight>
         <baseWidth>0</baseWidth>
@@ -53,7 +54,7 @@ The enemy will control the field at the end of the engagement, meaning no salvag
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
-                <objectiveLinkedForces />
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -92,21 +93,15 @@ The enemy will control the field at the end of the engagement, meaning no salvag
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
-                <objectiveLinkedForces />
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>ARTILLERY</forceRole>
-                    <forceRole>MISSILE_ARTILLERY</forceRole>
-                    <forceRole>MIXED_ARTILLERY</forceRole>
                     <forceRole>FIRE_SUPPORT</forceRole>
                     <forceRole>FIRE_SUPPORT</forceRole>
-                    <forceRole>FIRE_SUPPORT</forceRole>
-                    <forceRole>FIRE_SUPPORT</forceRole>
-                    <forceRole>SR_FIRE_SUPPORT</forceRole>
-                    <forceRole>SR_FIRE_SUPPORT</forceRole>
                     <forceRole>SR_FIRE_SUPPORT</forceRole>
                     <forceRole>SR_FIRE_SUPPORT</forceRole>
                 </roleChoices>
@@ -136,7 +131,7 @@ The enemy will control the field at the end of the engagement, meaning no salvag
                 <generationOrder>3</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
-                <objectiveLinkedForces />
+                <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
@@ -158,7 +153,7 @@ The enemy will control the field at the end of the engagement, meaning no salvag
             <associatedForceNames>
                 <associatedForceName>DropShip</associatedForceName>
             </associatedForceNames>
-            <associatedUnitIDs />
+            <associatedUnitIDs/>
             <successEffects>
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
@@ -188,7 +183,7 @@ The enemy will control the field at the end of the engagement, meaning no salvag
             <associatedForceNames>
                 <associatedForceName>OpFor</associatedForceName>
             </associatedForceNames>
-            <associatedUnitIDs />
+            <associatedUnitIDs/>
             <successEffects>
                 <successEffect>
                     <effectType>ScenarioVictory</effectType>
@@ -203,7 +198,7 @@ The enemy will control the field at the end of the engagement, meaning no salvag
                     <howMuch>1</howMuch>
                 </failureEffect>
             </failureEffects>
-            <additionalDetails />
+            <additionalDetails/>
             <description>Destroy, cripple or force to withdraw 50% of the following forces. +1 SVP if succeeded, -1 SVP if failed.</description>
             <destinationEdge>NONE</destinationEdge>
             <objectiveCriterion>ForceWithdraw</objectiveCriterion>


### PR DESCRIPTION
- Eliminated redundant roles such as `MISSILE_ARTILLERY` and `MIXED_ARTILLERY`.

### Dev Note
This was a consequence of me misunderstanding how the `ARTILLERY`, `MISSILE_ARTILLERY`, and `MIXED_ARTILLERY` roles were configured.

Switching up the roles should help reduce the spam of specific artillery units when these scenarios are generated.