### PR TITLE
Added "Coming of Age" Life Event Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -690,6 +690,11 @@ lblAnnounceChildBirthdays.text=Always Announce 18th Birthdays \u26A0
 lblAnnounceChildBirthdays.tooltip=If enabled, 18th birthdays will always be announced.\
   <br>\
   <br><b>Warning:</b> Enabling this option will override any other settings.
+# createLifeEventsPanel
+lblLifeEventsPanel.text=Life Events \uD83C\uDF1F
+lblShowLifeEventDialogComingOfAge.text=Children Coming of Age
+lblShowLifeEventDialogComingOfAge.tooltip=Whenever a child turns 16, an in character dialog will appear announcing the\
+  \ event and informing you that they can now be assigned to a profession.
 # createBackgroundsTab
 lblBackgroundsTab.text=Background Options \u270E
 # createRandomBackgroundsPanel

--- a/MekHQ/resources/mekhq/resources/ComingOfAgeAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/ComingOfAgeAnnouncement.properties
@@ -1,0 +1,503 @@
+# suppress inspection "UnusedMessageFormatParameter" for whole file
+# suppress inspection "UnusedProperty" for whole file
+# Buttons
+button.response.positive=I hope {0} likes my present.
+button.response.neutral=I''ll send a card.
+button.response.negative=Do I look like I care?
+button.response.suppress=I''m not interested in this kind of update.
+# Data
+title.female=woman
+title.male=man
+title.neutral=adult
+lance.innerSphere=Lance
+lance.clan=Star
+lance.comStar=Level II
+# OOC
+comingOfAge.message.ooc={0} can now be assigned to a profession.\
+  <p>If you select the final option, all future announcements of this type will be disabled. They can be re-enabled in\
+  \ Campaign Options.</p>
+# IC
+## From Parent
+comingOfAge.message.0.fromParent.ic={8}, I just wanted to share some personal news - today, my child {2} turns <b>16</b>.\
+  <p>It''s a big moment for {6} and for me as well. I still remember when {5} {0, choice, 0#were|1#was} just a kid, constantly tagging along\
+  \ during downtime, asking questions about ''Meks and how they worked. Now {5}''{0, choice, 0#re|1#s} growing into a thoughtful, determined\
+  \ young {3}, and it''s honestly a little overwhelming to see how far {5}''{0, choice, 0#ve|1#s} come.</p>\
+  <p>Raising a kid while on duty here isn''t easy, but {2}''s always shown a remarkable ability to adapt.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} taken on more responsibilities at home without being asked, and I''ve caught {6} offering to help out around\
+  \ the hangar, even if it''s just fetching tools. It''s good to see that sense of duty taking root.</p>\
+  <p>I just wanted to take a moment to acknowledge how proud I am of {6}. Sometimes it''s easy to get lost in the grind,\
+  \ but today, I''m reminded of why we keep pushing forward.</p>\
+  <p>Thank you for understanding.</p>
+comingOfAge.message.1.fromParent.ic={8}, well, it''s official - {2} turned <b>16</b> today, and I think {5}''{0, choice, 0#ve|1#s} already outgrown me both physically\
+  \ and in attitude.\
+  <p>{4}''{0, choice, 0#ve|1#s} been walking around like {5} owns the place, and I swear {5}''{0, choice, 0#ve|1#s} been eyeing the cockpit of the ''Meks like it''s\
+  \ {7} next project.</p>\
+  <p>{5}''{0, choice, 0#re|1#s} a good kid, though - doesn''t take shortcuts, and {5}''{0, choice, 0#ve|1#s} got that stubborn streak that probably comes from me.\
+  \ Just yesterday, {5} {0, choice, 0#were|1#was} helping me organize some old maintenance logs and managed to find a mistake I''d missed. I''ll\
+  \ never hear the end of it, but I''m proud of {6}.</p>\
+  <p>Anyway, I figured you''d get a kick out of knowing that our newest "adult" is already planning how to take\
+  \ over. I''ll keep {6} grounded... as much as I can.</p>
+comingOfAge.message.2.fromParent.ic={8}, today {2} turned <b>16</b>, and it''s hitting me harder than I expected.\
+  <p>Raising {6} out here has been challenging, but it''s also been a privilege. Seeing {6} grow up, learn to navigate\
+  \ this life, and still keep {7} spirit intact - it''s not something I take for granted.</p>\
+  <p>There have been days when I worried about the kind of life I''m giving {6} - always on the move, surrounded by\
+  \ conflict. But seeing the way {5}''{0, choice, 0#ve|1#s} turned out, I know {5}''{0, choice, 0#re|1#s} stronger for it. {4}''{0, choice, 0#re|1#s} resilient, sharp, and starting to\
+  \ understand what it means to support the people around {6}.</p>\
+  <p>I just wanted to share this moment. Sometimes, in the middle of everything, it''s good to remember that there''s more\
+  \ to life than just surviving.</p>
+comingOfAge.message.3.fromParent.ic={8}, {2} hit <b>16</b> today, and to be honest, it caught me off guard.\
+  <p>{4}''{0, choice, 0#ve|1#s} been helping out more lately - whether it''s cleaning up around the barracks or trying to fix that old comms \
+  unit {5} found. {4}''{0, choice, 0#ve|1#s} got this curiosity about how things work, and sometimes I catch {6} tinkering with spare parts.</p>\
+  <p>It''s not easy balancing this life with being a parent, but {5}''{0, choice, 0#ve|1#s} been handling it better than I could have asked for.\
+  \ Sometimes I wonder if {5} even realizes how proud I am of {6}.</p>\
+  <p>I guess I just wanted to share that {5}''{0, choice, 0#re|1#s} growing into a pretty capable young {3}, and it''s a bit surreal to see.</p>\
+  <p>Thanks for giving me the moment to reflect.</p>
+comingOfAge.message.4.fromParent.ic={8}, today marked a special moment - {2} turned <b>16</b>.\
+  <p>It''s hard to put into words how proud I am. Despite everything - the deployments, the unpredictability - {5}''{0, choice, 0#ve|1#s} grown\
+  \ into someone I can genuinely look up to. It''s funny how your own kid can surprise you like that.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} been talking a lot about the future lately. {4}''{0, choice, 0#re|1#s} curious, driven, and already thinking about how {5} can make a\
+  \ difference. I can see {6} wanting to follow in our footsteps, and while that thought''s a little daunting, it also\
+  \ makes me feel like I''ve done something right.</p>\
+  <p>Just wanted to share a bit of good news. We don''t get enough of that these days.</p>
+comingOfAge.message.5.fromParent.ic={8}, today marks a big day for me - {2} turned <b>16</b>.\
+  <p>It''s hard to believe how quickly time has passed. Feels like just yesterday {5} {0, choice, 0#were|1#was} that little kid running around\
+  \ the hangar, wide-eyed at the sight of a ''Mek powering up. Now {5}''{0, choice, 0#re|1#s} taller, stronger, and asking tougher questions\
+  \ about life and duty.</p>\
+  <p>I can''t help but feel a bit emotional. Raising {6} out here hasn''t been easy, but seeing {6} grow into someone\
+  \ thoughtful and resilient makes me proud. It''s moments like this that remind me why I keep pushing forward.</p>\
+  <p>Thanks for allowing me a moment to reflect.</p>
+comingOfAge.message.6.fromParent.ic={8}, I don''t know how it happened, but {2} turned <b>16</b> today.\
+  <p>{5}''{0, choice, 0#re|1#s} taller than me now and never misses a chance to point it out. Spends half {7} time trying to outdo me at\
+  \ everything from lifting crates to fixing that old power coupler.</p>\
+  <p>{5}''{0, choice, 0#re|1#s} a good kid - got {7} heart in the right place and a stubborn streak a mile wide. Sometimes I wonder where {5}\
+  \ gets it from.</p>\
+  <p>Just wanted to share a little bit of good news. Kids grow up too fast, don''t they?</p>
+comingOfAge.message.7.fromParent.ic={8}, today''s one of those rare days when I feel truly grateful.\
+  <p>{2} turned <b>16</b>, and despite everything life''s thrown at us, {5}''{0, choice, 0#ve|1#s} grown into someone I respect and admire. Sometimes\
+  \ I catch myself wondering how I got so lucky.</p>\
+  <p>Raising a kid while on duty isn''t easy, but {2}''s adapted better than I ever could''ve imagined. {4}''{0, choice, 0#re|1#s} curious about\
+  \ everything - always asking questions and trying to help out. I''m proud of the person {5}''{0, choice, 0#re|1#s} becoming.</p>\
+  <p>Just wanted to share that bit of happiness.</p>
+comingOfAge.message.8.fromParent.ic={8}, somehow, {2} made it to <b>16</b> without giving me too many gray hairs.\
+  <p>Though {5} has hit that age where {5} thinks {5} knows better than me, especially when it comes to maintenance work. I\
+  \ caught {6} trying to "improve" the diagnostic system on one of the ''Meks. Didn''t go as planned, but at least {5}''{0, choice, 0#ve|1#s} got\
+  \ ambition.</p>\
+  <p>Thought you''d get a kick out of hearing that my own personal Astech is still in training.</p>
+comingOfAge.message.9.fromParent.ic={8}, I just wanted to take a moment to share that Today {2} turned <b>16</b>.\
+  <p>It''s a milestone that I can''t help but feel grateful for. Watching {6} grow up while juggling duty has been a\
+  \ challenge, but {5}''{0, choice, 0#ve|1#s} never complained. {4} just keeps going - learning, helping, and figuring things out.</p>\
+  <p>{5}''{0, choice, 0#re|1#s} growing into a fine young {3}, and I couldn''t be prouder. Thank you for supporting families like mine while\
+  \ we''re out here. It means more than you know.</p>
+comingOfAge.message.10.fromParent.ic={8}, I''d like to file a formal complaint - {2} just turned <b>16</b>, and I wasn''t consulted about how\
+  \ fast time was allowed to fly.\
+  <p>{5}''{0, choice, 0#re|1#s} now taller than me, smarter than me (at least in {7} own mind), and has developed an affinity for arguing about\
+  \ engine specs.</p>\
+  <p>I''m pretty sure {5}''{0, choice, 0#re|1#s} plotting to take over my duties next. At least {5}''{0, choice, 0#re|1#s} putting that stubbornness to good use.</p>\
+  <p>Just wanted to share the news - mostly because I could use some backup keeping {7} ego in check.</p>
+comingOfAge.message.11.fromParent.ic={8}, today {2} turned <b>16</b>. It''s a big moment for {6} and for me as well.\
+  <p>Despite the challenges we face out here, {5}''{0, choice, 0#ve|1#s} grown into someone I can genuinely admire. {4}''{0, choice, 0#ve|1#s} taken to helping\
+  \ out, always asking how things work and wanting to pitch in.</p>\
+  <p>Seeing {6} take on new challenges without hesitation gives me hope. Sometimes, in the chaos of duty, we forget that\
+  \ we''re also building something worth protecting. {2} reminds me of that.</p>
+comingOfAge.message.12.fromParent.ic={8}, {2} turned <b>16</b> today, and it''s got me thinking about how much {5}''{0, choice, 0#ve|1#s} grown.\
+  <p>Life out here hasn''t always been easy for {6} - missing friends, moving between bases - but {5}''{0, choice, 0#ve|1#s} taken it in stride.\
+  \ {4}''{0, choice, 0#ve|1#s} learned to make the most of it, even finding ways to help out where {5} can.</p>\
+  <p>Sometimes I wonder if {5}''{0, choice, 0#ve|1#s} had to grow up faster than {5} should. I just hope I''m giving {6} enough of a childhood\
+  \ in between the responsibilities.</p>\
+  <p>Figured I''d take a moment to share - can''t always keep the personal stuff bottled up.</p>
+comingOfAge.message.13.fromParent.ic={8}, today {2} turned <b>16</b>, and it got me thinking about how fast life moves when you''re on duty.\
+  <p>I''ve done my best to raise {6} right, but sometimes I wonder if I''m doing enough. Seeing {6} today - confident,\
+  \ curious, and ready to tackle new challenges - I realized {5}''{0, choice, 0#ve|1#s} become {7} own person, and that''s something to be\
+  \ proud of.</p>\
+  <p>It''s a good reminder that even when life feels like an endless grind, there''s growth happening in the quiet\
+  \ moments.</p>
+comingOfAge.message.14.fromParent.ic={8}, today''s a special one - {2} just turned <b>16</b>.\
+  <p>{4}''{0, choice, 0#ve|1#s} been helping out around more than ever, trying to learn from anyone who''s willing to teach {6}. I ca\
+  n see the drive in {6} to make a difference, and it''s honestly inspiring.</p>\
+  <p>Raising {6} while balancing duty hasn''t always been easy, but seeing the young {3} {5}''{0, choice, 0#re|1#s} becoming makes it all worth\
+  \ it. Just wanted to share this bit of good news - feels good to acknowledge it out loud.</p>
+comingOfAge.message.15.fromParent.ic={8}, today {2} turned <b>16</b>, and it''s got me reminiscing.\
+  <p>I still remember when {5}''d sit by the hangar door, fascinated by every ''Mek that passed by. Back then, {5}''d ask\
+  \ endless questions about how the machines worked, and I''d do my best to explain without laughing at {7} wild\
+  \ theories.</p>\
+  <p>Now {5}''{0, choice, 0#re|1#s} talking about engineering like it''s second nature. It''s hard to believe how much {5}''{0, choice, 0#ve|1#s} grown - not just\
+  \ physically but in the way {5} thinks and approaches problems. I''m proud of {6}, even if {5} sometimes acts like\
+  \ {5} knows more than I do.</p>
+comingOfAge.message.16.fromParent.ic={8}, well, it''s official - {2} hit <b>16</b> today, and I''m pretty sure {5} grew another inch overnight\
+  \ just to rub it in.\
+  <p>{4}''{0, choice, 0#ve|1#s} been giving me grief about how {5}''{0, choice, 0#re|1#s} taller now, as if that somehow means {5}''{0, choice, 0#re|1#s} in charge. I told {6} being tall\
+  \ doesn''t make you any better at cleaning up the gear room, and {5} just rolled {7} eyes.</p>\
+  <p>Thought you''d appreciate knowing that at least one of us is still growing.</p>
+comingOfAge.message.17.fromParent.ic={8}, today {2} turned <b>16</b>. It''s an important moment for {6}, and I couldn''t be prouder.\
+  <p>{4}''{0, choice, 0#ve|1#s} taken on more responsibilities lately - whether it''s helping organize supplies or learning basic maintenance.\
+  \ {4}''{0, choice, 0#ve|1#s} got a good heart and a willingness to help wherever {5} can.</p>\
+  <p>Sometimes I wonder how {5} stays so grounded in the middle of all this, but I''m grateful for it. Just wanted to take\
+  \ a moment to acknowledge how far {5}''{0, choice, 0#ve|1#s} come.</p>
+comingOfAge.message.18.fromParent.ic={8}, today {2} hit <b>16</b>, and I can''t help but feel a sense of pride.\
+  <p>{4}''{0, choice, 0#ve|1#s} been showing more interest in how things work around here - fixing minor issues, lending a hand where {5} can.\
+  \ I see that same spark of curiosity in {6} that first got me into this line of work.</p>\
+  <p>It''s moments like these that remind me why we''re fighting - to give our kids a future where they can keep growing,\
+  \ keep learning, and make something of themselves. {2}''s already well on {7} way.</p>
+comingOfAge.message.19.fromParent.ic={8}, just thought I''d let you know - {2} turned <b>16</b> today, and I''ve officially lost the height\
+  \ race.<p>\
+  {5}''{0, choice, 0#re|1#s} taller, louder, and more convinced than ever that {5} knows better than me about almost everything. The latest\
+  \ debate was about which coolant system works best on the heavier ''Meks.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} got that typical teenage confidence, but at least {5}''{0, choice, 0#re|1#s} putting {7} energy into learning. I''ll call it a win as\
+  \ long as {5} doesn''t start trying to pilot without permission. Again.</p>
+comingOfAge.message.20.fromParent.ic={8}, {2} turned <b>16</b> today, and it got me thinking about how much things have changed since {5} {0, choice, 0#were|1#was}\
+  \ a kid.\
+  <p>Watching {6} grow up in the midst of all this - it makes you pause and wonder what kind of world we''re shaping for\
+  \ the next generation.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} got a good head on {7} shoulders, despite the chaos around {6}. It''s humbling to see {6} developing {7} own\
+  \ sense of purpose, even when the future feels uncertain. Sometimes, it''s the little milestones that give you hope.</p>
+comingOfAge.message.21.fromParent.ic={8}, {2} turned <b>16</b> today, and I couldn''t be prouder.\
+  <p>{4}''{0, choice, 0#ve|1#s} been stepping up more lately - offering to help with maintenance, asking more questions about duty and\
+  \ responsibility. It''s good to see that kind of initiative, and it reminds me that maybe we''re raising the next\
+  \ generation right.</p>\
+  <p>It''s not easy balancing duty with parenthood, but {2} makes it worthwhile. Just wanted to share the good news.</p>
+comingOfAge.message.22.fromParent.ic={8}, {2} turned <b>16</b> today, and I''m half convinced {5} thinks it means {5}''{0, choice, 0#re|1#s} in charge now.\
+  <p>{4}''{0, choice, 0#ve|1#s} been asking to shadow the tech crew more often, claiming {5}''{0, choice, 0#re|1#s} "old enough to learn the real stuff." I caught\
+  \ {6} practicing maintenance drills with the older guys, and {5}''{0, choice, 0#ve|1#s} got that look like {5}''{0, choice, 0#re|1#s} ready to take on the world.</p>\
+  <p>It''s good seeing {6} push {6}self. I''ll let {6} enjoy {7} newfound "authority" for a day or two before reminding\
+  \ {6} who''s still got the rank.</p>
+comingOfAge.message.23.fromParent.ic={8}, today {2} hit <b>16</b>, and it''s been making me think about how fast {5}''{0, choice, 0#ve|1#s} grown up.\
+  <p>Sometimes I worry about how this life has shaped {6} - always on the move, surrounded by conflict. But {5}''{0, choice, 0#ve|1#s} handled\
+  \ it better than I could''ve expected. {4}''{0, choice, 0#re|1#s} resilient, adaptable, and never loses that spark of curiosity.</p>\
+  <p>I''m proud of the person {5}''{0, choice, 0#re|1#s} becoming, even if it feels like I blinked and missed half of it. Just thought I''d take\
+  \ a moment to share.</p>
+comingOfAge.message.24.fromParent.ic={8}, today {2} turned <b>16</b>, and I took a second to just watch {6} tinker with that busted-up cooling\
+  \ unit.\
+  <p>{4}''{0, choice, 0#ve|1#s} grown into a pretty capable young {3}, and it''s not often I get a chance to really appreciate it.</p>\
+  <p>Sometimes I get caught up in worrying about how much {5}''{0, choice, 0#ve|1#s} missed out on, but then I see {6} solving problems on {7}\
+  \ own, and it gives me hope.</p>\
+  <p>I guess seeing {6} turn <b>16</b> made me realize that despite everything, {5}''{0, choice, 0#re|1#s} doing alright. Just wanted to share that.</p>
+comingOfAge.message.25.fromParent.ic={8}, I just wanted to share that today my child {2} turned <b>16</b>.\
+  <p>It''s one of those moments where I can''t help but feel a little overwhelmed.</p>\
+  <p>Sometimes I look at {6} and see that same kid who used to follow me around, wide-eyed and full of questions. Now,\
+  \ {5}''{0, choice, 0#re|1#s} taller than me and eager to prove {6}self, whether it''s fixing equipment or learning from the tech crew.</p>\
+  <p>I just wanted to take a moment to share a bit of good news. Thanks for your continued support.</p>
+comingOfAge.message.26.fromParent.ic={8}, just wanted to give you a heads-up - {2} hit <b>16</b> today, and I swear {5}''{0, choice, 0#ve|1#s} convinced it makes\
+  \ {6} my equal now.\
+  <p>{4}''{0, choice, 0#ve|1#s} been strutting around like {5}''{0, choice, 0#re|1#s} in charge, trying to outdo me in everything from wrenching on the cooling units\
+  \ to arguing about the best way to maintain the gyro systems.</p>\
+  <p>It''s hard not to laugh at how serious {5}''{0, choice, 0#re|1#s} taking it. {4}''{0, choice, 0#ve|1#s} got the enthusiasm, that''s for sure. I guess I''ll let\
+  \ {6} think {5}''{0, choice, 0#re|1#s} winning for a little while longer.</p>\
+  <p>Just thought you''d appreciate the update on our "Junior MekTech."</p>
+comingOfAge.message.27.fromParent.ic={8}, today {2} turned <b>16</b>.\
+  <p>It''s been one of those days where I can''t help but feel grateful. Despite everything we''ve been through, {5}''{0, choice, 0#re|1#s} growing\
+  \ into a responsible, curious young {3}. Sometimes I catch {6} helping the maintenance crew without even being asked\
+  \ - just because {5} wants to learn.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} been asking a lot about what it means to serve and why we do what we do. I can see {6} trying to figure out\
+  \ {7} place in all this, and it''s honestly impressive. Watching {6} grow up in the middle of this life isn''t easy, but\
+  \ it''s moments like these that remind me why we fight to make things better.</p>
+comingOfAge.message.28.fromParent.ic={8}, today {2} turned <b>16</b>, and it''s a bit surreal to think about how quickly time has passed.\
+  <p>One minute {5}''{0, choice, 0#re|1#s} that little kid helping sort bolts in the ''Mek bay, and now {5}''{0, choice, 0#re|1#s} giving advice on how to better\
+  \ secure the coolant lines. {4}''{0, choice, 0#ve|1#s} got that mix of confidence and curiosity that keeps me on my toes.</p>\
+  <p>It''s not all smooth sailing, though. {4}''{0, choice, 0#ve|1#s} hit that age where {5} challenges just about everything I say. Part of me\
+  \ is proud to see {6} thinking for {6}self, but it also means a few more debates than I bargained for. Still, I wouldn''t\
+  \ trade it for anything.</p>\
+  <p>Figured I''d share this little milestone - feels good to see {6} becoming {7} own person.</p>
+comingOfAge.message.29.fromParent.ic={8}, {2} turned <b>16</b> today, and it hit me harder than I expected.\
+  <p>It''s one of those moments where I had to stop and really think about how much {5}''{0, choice, 0#ve|1#s} grown. Raising {6} while being\
+  \ in the line of fire hasn''t been easy.</p>\
+  <p>There were days I worried about {6} feeling isolated or growing up too fast. But seeing {6} today - tall, confident,\
+  \ and talking about {7} plans for the future - I couldn''t help but feel proud.</p>\
+  <p>{5}''{0, choice, 0#re|1#s} not just surviving out here; {5}''{0, choice, 0#re|1#s} thriving. {4}''{0, choice, 0#re|1#s} curious, motivated, and quick to lend a hand.</p>\
+  <p>I know it''s just a birthday, but it feels like a milestone for both of us.</p>
+comingOfAge.message.30.fromParent.ic={8}, {2} hit <b>16</b> today, and to be honest, it''s a bit of a reality check.\
+  <p>{4}''{0, choice, 0#ve|1#s} gotten taller, stronger, and way more opinionated, and {5}''{0, choice, 0#ve|1#s} been asking a lot of tough questions lately - about\
+  \ duty, about why we do what we do. I guess I shouldn''t be surprised that {5}''{0, choice, 0#re|1#s} looking for answers, given everything\
+  \ {5}''{0, choice, 0#ve|1#s} seen.</p>\
+  <p>Sometimes I worry that {5}''{0, choice, 0#ve|1#s} had to grow up too fast, but I guess that''s just part of life out here. {4}''{0, choice, 0#ve|1#s} got a good\
+  \ head on {7} shoulders, and {5}''{0, choice, 0#re|1#s} not afraid to speak {7} mind. I''m proud of {6} for that, even if it means a few more\
+  \ late-night talks than I bargained for.</p>
+comingOfAge.message.31.fromParent.ic={8}, today {2} turned <b>16</b>, and I''ve been thinking a lot about {7} future.\
+  <p>{4}''{0, choice, 0#ve|1#s} been more involved in our duties these days, helping wherever {5} can and soaking up knowledge like a sponge. {4}''{0, choice, 0#ve|1#s} got\
+  \ that drive to understand how things work, whether it''s machinery or people.</p>\
+  <p>It''s good to see {6} wanting to be part of something bigger. Sometimes I forget just how resilient {5} is. {4}''{0, choice, 0#ve|1#s} been\
+  \ talking about what {5} can do to help more, and it makes me proud to see {6} thinking that way. Just wanted to share\
+  \ a bit of good news - feels good to acknowledge it.</p>
+comingOfAge.message.32.fromParent.ic={8}, today {2} turned <b>16</b>.\
+  <p>It''s been a long journey raising {6} while balancing duty, but seeing the young {3} {5}''{0, choice, 0#re|1#s} becoming makes me feel like\
+  \ we''re doing something right. {4}''{0, choice, 0#re|1#s} resilient, thoughtful, and never hesitates to help out.</p>\
+  <p>I know not everyone gets to watch their kids grow up out here, and I don''t take it for granted. Sometimes I feel\
+  \ like I owe it to {6} to make sure {5} knows how proud I am.</p>\
+  <p>Just wanted to share this moment - it''s one of the good ones.</p>
+comingOfAge.message.33.fromParent.ic={8}, today {2} turned <b>16</b>, and I can''t help but feel a mix of pride and amazement.\
+  <p>It feels like just yesterday {5} {0, choice, 0#were|1#was} helping me clean gear, barely tall enough to reach the workbench.</p>\
+  <p>Now, {5}''{0, choice, 0#re|1#s} practically running {7} own projects, asking questions about engineering techniques I didn''t even think\
+  \ to teach {6}.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} grown into a responsible young {3}, always eager to help and never one to back down from a challenge. I''m\
+  \ proud of the way {5}''{0, choice, 0#ve|1#s} turned out, especially considering the life we''ve had out here. Just thought I''d take a moment\
+  \ to share some good news.</p>
+comingOfAge.message.34.fromParent.ic={8}, so, {2} just hit <b>16</b>, and I''m pretty sure {5}''{0, choice, 0#ve|1#s} convinced it means {5}''{0, choice, 0#re|1#s} ready to take over my\
+  \ duties.\
+  <p>{4}''{0, choice, 0#ve|1#s} been testing {7} boundaries, arguing with me about how to properly calibrate the targeting systems, and I swear\
+  \ {5}''{0, choice, 0#ve|1#s} got more opinions than I remember having at that age.</p>\
+  <p>It''s good to see {6} so confident, even if it comes with a side of teenage attitude. {4}''{0, choice, 0#ve|1#s} been spending more time\
+  \ in the hangar, asking the techs to teach {6} the finer points of repairs. I guess I''ll let {6} keep thinking {5}''{0, choice, 0#re|1#s} in\
+  \ charge for a bit - it''s nice seeing {6} find {7} place.</p>\
+  <p>Just wanted to share the update - looks like I''ve got competition now.</p>
+comingOfAge.message.35.fromParent.ic={8}, today {2} turned <b>16</b>, and it hit me just how fast time moves out here.\
+  <p>Seeing {6} grow into someone strong, curious, and resilient - it''s honestly a little overwhelming. {4}''{0, choice, 0#ve|1#s} taken on\
+  \ more responsibility without me even asking, helping the tech crew with simple maintenance and always eager to learn\
+  \ something new.</p>\
+  <p>Sometimes I wonder if I''ve given {6} enough of a childhood, but seeing {6} take on challenges with determination\
+  \ makes me think we''re doing alright. I just wanted to take a moment to share this personal milestone - it feels good\
+  \ to see {6} thriving.</p>
+comingOfAge.message.36.fromParent.ic={8}, {2} just hit <b>16</b> today, and I''m pretty sure {5}''{0, choice, 0#ve|1#s} grown another foot overnight.\
+  <p>{4}''{0, choice, 0#ve|1#s} been walking around like {5}''{0, choice, 0#ve|1#s} got all the answers, especially when it comes to fixing the coolant leaks. I''m\
+  \ not sure where {5} got {7} sudden confidence, but it''s definitely keeping me on my toes.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} been hanging around the ''Mek bay more, trying to figure out how everything works, and offering advice like {5}''{0, choice, 0#ve|1#s}\
+  \ been doing it for years. I guess I can''t complain - it''s good to see {6} take initiative. Just thought I''d share that\
+  \ my own kid''s now my biggest critic.</p>
+comingOfAge.message.37.fromParent.ic={8}, today marked an important day for me - {2} turned <b>16</b>.\
+  <p>It''s hard to put into words how proud I am of {6}. Growing up in the middle of all this isn''t easy, but {5}''{0, choice, 0#ve|1#s} faced\
+  \ it with a quiet determination that honestly impresses me.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} grown into someone reliable and thoughtful, never hesitating to offer a hand when it''s needed.</p>\
+  <p>Raising {6} while on duty hasn''t been easy, but every time I see {6} step up, I know we''re doing something right.\
+  \ I appreciate the unit''s support - it means a lot.</p>
+comingOfAge.message.38.fromParent.ic={8}, today''s a big day - {2} turned <b>16</b>.\
+  <p>{4}''{0, choice, 0#ve|1#s} been stepping up more lately, whether it''s helping out with small repairs or figuring out logistics for supply\
+  \ runs. {4}''{0, choice, 0#ve|1#s} got a good head on {7} shoulders, and it''s been rewarding to see {6} find ways to pitch in.</p>\
+  <p>It''s moments like these that remind me why we''re doing what we do - making sure the next generation has a shot at\
+  \ something better. {2}''s showing signs of leadership already, and I couldn''t be prouder.</p>\
+  <p>Thanks for letting me share.</p>
+comingOfAge.message.39.fromParent.ic={8}, {2} turned <b>16</b> today, and it made me think about how much {5}''{0, choice, 0#ve|1#s} changed over the years.\
+  <p>It''s strange - life moves so fast when you''re always on duty. Sometimes I worry about whether {5}''{0, choice, 0#ve|1#s} had enough time\
+  \ to just be a kid, but seeing {7} confidence grow reassures me.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} been asking deeper questions lately - about purpose, about why we fight. I suppose it''s natural at {7} age,\
+  \ but it still catches me off guard. {4}''{0, choice, 0#re|1#s} growing up right before my eyes, and it makes me hopeful for {7} future, \
+  despite everything.</p>\
+  <p>Just thought I''d take a moment to reflect.</p>
+comingOfAge.message.40.fromParent.ic={8}, today {2} turned <b>16</b>.\
+  <p>It''s one of those moments that makes you pause and think about what really matters.</p>\
+  <p>{5}''{0, choice, 0#re|1#s} growing into someone I genuinely admire - thoughtful, hardworking, and curious about the world around {6}.\
+  \ Despite the challenges of our lifestyle, {5}''{0, choice, 0#ve|1#s} adapted better than I could have hoped.</p>\
+  <p>Sometimes I feel like I''m the one learning from {6}.</p>
+comingOfAge.message.41.fromParent.ic={8}, today {2} hit <b>16</b>, and I couldn''t be prouder of {6}.\
+  <p>Despite the hardships, {5}''{0, choice, 0#ve|1#s} grown into someone with purpose.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} been more focused lately - helping where {5} can and always asking how {5} can contribute. It''s good to see that\
+  \ spark in {6}, a reminder of why we keep going.</p>\
+  <p>In a life like ours, seeing {6} thrive feels like a victory in itself.</p>
+comingOfAge.message.42.fromParent.ic=So, {2} turned <b>16</b> today, and I''m still trying to process how {5} went from being the little\
+  \ kid who asked a million questions, to the teenager who tells me how to fix a coolant leak.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} been more hands-on lately, learning from the techs and trying to prove {5}''{0, choice, 0#ve|1#s} got what it takes.</p>\
+  <p>It''s good to see {6} growing up, even if it means a few more debates about how to properly wire a power conduit. \
+  I guess I''ll just have to get used to {6} being right more often than not.</p>\
+  <p>Just wanted to share - feels like a big day for both of us.</p>
+comingOfAge.message.43.fromParent.ic={8}, today is a special day for me - {2} turned <b>16</b>.\
+  <p>Sometimes it''s hard to believe how fast {5}''{0, choice, 0#ve|1#s} grown. I still remember when {5}''d sit by the hangar, just watching the\
+  \ ''Meks and asking endless questions. Now, {5}''{0, choice, 0#re|1#s} the one showing me new tricks with maintenance and running around\
+  \ trying to make {6}self useful wherever {5} can.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} got that fire in {6} - the kind that doesn''t let go of a problem until it''s fixed. I can''t help but feel proud\
+  \ seeing how {5}''{0, choice, 0#re|1#s} turning out.</p>\
+  <p>Raising {6} in the middle of this life hasn''t been easy, but {5}''{0, choice, 0#ve|1#s} made it worthwhile.</p>
+comingOfAge.message.44.fromParent.ic={8}, well, {2} turned <b>16</b> today, and I swear {5}''{0, choice, 0#re|1#s} already acting like {5}''{0, choice, 0#re|1#s} the new chief engineer.\
+  <p>{4}''{0, choice, 0#ve|1#s} been sticking {7} nose in the tech bay more often, trying to "improve efficiency" with the coolant systems. I\
+  \ had to remind {6} that just because you can quote a manual doesn''t mean you know everything.</p>\
+  <p>Still, it''s good to see {6} so motivated. {4}''{0, choice, 0#re|1#s} growing up faster than I expected, and I guess that''s a good problem\
+  \ to have. Just thought I''d share that I might have some competition in the problem-solving department.</p>
+comingOfAge.message.45.fromParent.ic={8}, {2} turned <b>16</b> today, and it''s got me thinking about how far we''ve come.\
+  <p>Raising {6} in the middle of all this chaos has never been simple, but somehow {5}''{0, choice, 0#ve|1#s} managed to thrive. {4}''{0, choice, 0#re|1#s} curious,\
+  \ thoughtful, and more responsible than I sometimes give {6} credit for.</p>\
+  <p>Sometimes I worry that I''m pushing {6} too hard, but {5} seems to embrace the challenge. I''m proud of the young {3}\
+  \ {5}''{0, choice, 0#re|1#s} becoming, even if it means letting go a little bit.</p>\
+  <p>Just wanted to take a moment to share that.</p>
+comingOfAge.message.46.fromParent.ic={8}, today''s the day - {2} hit <b>16</b>, and I''m starting to think {5}''{0, choice, 0#re|1#s} convinced {5}''{0, choice, 0#ve|1#s} got me all\
+  \ figured out.\
+  <p>{4}''{0, choice, 0#ve|1#s} been challenging me on maintenance protocols and even told the tech crew they were doing the diagnostic checks\
+  \ "the slow way."</p>\
+  <p>It''s good to see {6} stepping up, even if it means I''m getting called out on outdated methods. {4}''{0, choice, 0#ve|1#s} got a sharp\
+  \ mind and isn''t afraid to use it. I''ll just have to get used to being corrected by my own kid.</p>
+comingOfAge.message.47.fromParent.ic={8}, today {2} turned <b>16</b>, and it''s been making me think about how much {5}''{0, choice, 0#ve|1#s} had to adapt growing\
+  \ up in this environment.\
+  <p>It''s not the life I would''ve chosen for {6}, but {5}''{0, choice, 0#ve|1#s} handled it better than I could have imagined. {4}''{0, choice, 0#ve|1#s} got a natural\
+  \ curiosity and a way of finding the bright side, even when things are tough.</p>\
+  <p>I know not everyone gets the chance to watch their kid grow up out here, and I don''t take that for granted. Sometimes\
+  \ it''s the little moments, like seeing {6} help a tech with a jammed component, that make me realize how resilient\
+  \ {5}''{0, choice, 0#ve|1#s} become.</p>
+comingOfAge.message.48.fromParent.ic={8}, today {2} turned <b>16</b>, and I can''t help but feel a renewed sense of hope.\
+  <p>{4}''{0, choice, 0#ve|1#s} been more driven lately - fixing things without being asked, helping out wherever {5} sees a need. It''s good to\
+  \ see that spirit of wanting to make a difference.</p>\
+  <p>In a world where everything feels uncertain, seeing {6} take charge of small tasks gives me confidence that we''re\
+  \ building something worthwhile. It''s a reminder that even amid the chaos, the next generation is preparing to step\
+  \ up.</p>\
+  <p>Thanks for listening.</p>
+comingOfAge.message.49.fromParent.ic={8}, just wanted to share a quick personal update - {2} turned <b>16</b> today.\
+  <p>{4}''{0, choice, 0#ve|1#s} been showing a lot more interest in the engineering side of things lately, asking the tech crew to teach {6}\
+  \ some of the more complex maintenance routines. I can tell {5}''{0, choice, 0#ve|1#s} got a knack for problem-solving.</p>\
+  <p>It''s been good seeing {6} develop {7} own interests and skills. Growing up out here isn''t easy, but {5}''{0, choice, 0#re|1#s} making the\
+  \ most of it. Just figured I''d take a moment to reflect on it.</p>
+## No Parents
+comingOfAge.message.0.noParents.ic={8}, I wanted to inform you that {1} turned <b>16</b> today.\
+  <p>As you know, {2} doesn''t have any family present within the unit, so the team decided to step up and make sure it\
+  \ didn''t go unnoticed.</p>\
+  <p>We''ve put together a small celebration to mark the occasion - a bit of food, some decorations, and a chance for\
+  \ everyone to show their support.</p>\
+  <p>If you''d like to stop by, I''m sure it would mean a lot to {6}. We''ll keep things low-key but heartfelt. Just wanted\
+  \ to let you know that we''re making sure {2} feels appreciated on {7} special day.</p>
+comingOfAge.message.1.noParents.ic={8}, today is {1}''s 16th birthday.\
+  <p>Since {5} doesn''t have family around, the unit has come together to make sure {5} feels valued and supported. We''re\
+  \ throwing {6} a small party - nothing too elaborate, just some food, a few decorations, and plenty of well-wishes.</p>\
+  <p>The crew''s really pulled together to make this happen, and it''s been uplifting to see.</p>\
+  <p>If you have a moment to stop by, it would mean a lot to {2}.</p>
+comingOfAge.message.2.noParents.ic={8}, just a quick update - {2} turned <b>16</b> today, and since {5} doesn''t have family here,\
+  \ the unit''s taken it upon themselves to make sure {7} day doesn''t go uncelebrated.\
+  <p>We''ve thrown together a small party - nothing fancy, but it''s got all the essentials: mystery meat cake, a few\
+  \ decorations, and some well-deserved attention.</p>\
+  <p>Would be great if you could make an appearance - it''d really make {7} day.</p>
+comingOfAge.message.3.noParents.ic={8}, today, {1} turns <b>16</b>.\
+  <p>Since {2} doesn''t have any family here, the unit has decided to come together to make sure {5} doesn''t feel alone\
+  \ on {7} special day. We''ve arranged a small gathering to let {6} know that {5}''{0, choice, 0#re|1#s} valued and appreciated as part of our\
+  \ team.</p>\
+  <p>It''s been heartening to see everyone contribute - bringing snacks, decorating the common area, and making sure {2}\
+  \ knows {5}''{0, choice, 0#re|1#s} part of our extended family.</p>\
+  <p>If you can spare a moment to join us, it would really make a difference.</p>
+comingOfAge.message.4.noParents.ic={8}, turns out {1} hit the big 1-6 today!\
+  <p>Since {5} doesn''t have family around, the unit decided to step up and make sure {7} day feels special. We''ve thrown\
+  \ together a bit of a celebration - cake, a few streamers, and a whole lot of good cheer.</p>\
+  <p>If you can swing by, it''d mean a lot to {2} - and to the team.</p>
+comingOfAge.message.5.noParents.ic={8}, {1} turned <b>16</b> today, and since {5} doesn''t have family present, the unit has\
+  \ taken it upon themselves to make sure {5}''{0, choice, 0#re|1#s} not alone on {7} birthday. We''ve arranged a small gathering, just to let\
+  \ {6} know how much {5} means to the team.</p>\
+  <p>It would be great if you could stop by to show your support.</p>
+comingOfAge.message.6.noParents.ic={8}, just letting you know - {1} turned <b>16</b> today, and since {5} doesn''t have any\
+  \ family with {6}, the unit decided to make it special. We put together a small party - nothing too fancy, but\
+  \ definitely enough to remind {6} {5}''{0, choice, 0#ve|1#s} got people who care.</p>\
+  <p>If you''re available, your presence would really lift {7} spirits.</p>
+comingOfAge.message.7.noParents.ic={8}, today marks {1}''s 16th birthday.\
+  <p>Since {5} doesn''t have family here, the unit decided to step in and make sure {5} felt celebrated. We''ve organized a\
+  \ small party, and the turnout''s been impressive - everyone wanted to show their support.</p>\
+  <p>Your presence would really make the day even more special.</p>
+comingOfAge.message.8.noParents.ic={8}, today {1} turned <b>16</b>, and without family around, the unit decided to throw {6}\
+  \ a little party.\
+  <p>It''s been a while since we had something to celebrate, and everyone really stepped up - food, decorations, and a\
+  \ lot of good energy.</p>\
+  <p>If you can join, it''d mean a lot to {6} and to everyone here.</p>
+comingOfAge.message.9.noParents.ic={8}, {1} turned <b>16</b> today.\
+  <p>Since {5} doesn''t have family here, the unit has taken the initiative to organize a small party.</p>\
+  <p>It''s been amazing to see everyone come together to make sure {2} knows {5}''{0, choice, 0#re|1#s} not alone. There''s food, some\
+  \ decorations, and plenty of well-wishes going around.</p>\
+  <p>Your presence would really add to the celebration if you''re available.</p>
+## Commander is the Parent, from Other Parent
+comingOfAge.message.0.reminder.ic=Just wanted to give you a quick heads-up - today''s {2}''s 16th birthday. Can you\
+  \ believe it?\
+  <p>Feels like just yesterday {5} {0, choice, 0#were|1#was} that little kid trying to fit into your boots. Now {5}''{0, choice, 0#re|1#s} practically taller than\
+  \ both of us and acting like {5}''{0, choice, 0#ve|1#s} got the world figured out.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} been talking about {7} plans for the day, mostly involving spending time in the hangar and seeing if {5} can\
+  \ sweet-talk the techs into letting {6} help out. You know how {5} gets when {5}''{0, choice, 0#re|1#s} set on something.</p>\
+  <p>I''m planning to pull {6} aside for a little celebration later - nothing too fancy, just some cake and a chance to\
+  \ remind {6} that even in the middle of all this, we''re proud of {6}.</p>\
+  <p>If you can make it, I know it would mean the world to {6}.</p>\
+  <p>Let me know if you''ll be able to swing by.</p>
+comingOfAge.message.1.reminder.ic=Just a quick reminder - {2} turns <b>16</b> today!\
+  <p>I know things have been hectic lately, but I didn''t want the day to slip by without at least giving {6} a bit of a\
+  \ celebration.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} been talking a lot about trying to get more involved with the tech crew, so you might want to brace yourself\
+  \ for some ambitious project ideas.</p>\
+  <p>I figured we could surprise {6} later with a little cake and just spend some time together.</p>\
+  <p>Let me know if you can swing by.</p>
+comingOfAge.message.2.reminder.ic=Just wanted to remind you - today''s {2}''s 16th, and it''s hitting me a little harder\
+  \ than I thought it would.\
+  <p>I guess it''s just one of those milestones where you look back and wonder how {5} grew up so fast. {4}''{0, choice, 0#ve|1#s} been in a good\
+  \ mood today, but I can tell {5}''{0, choice, 0#re|1#s} hoping to see you at some point.</p>\
+  <p>I''m planning a small get-together later. Nothing big, just some cake. If you can make it, I know it would really\
+  \ make {7} day. {4}''{0, choice, 0#ve|1#s} been practicing that maintenance routine you showed {6}, trying to get it just right. You''d be\
+  \ proud.</p>\
+  <p>Let me know if you''ll be there.</p>
+comingOfAge.message.3.reminder.ic=So, {2} officially hit <b>16</b> today!\
+  <p>{4}''{0, choice, 0#ve|1#s} been acting like it makes {6} a full-grown adult now - talking about responsibility and how {5}''{0, choice, 0#re|1#s} ready to take\
+  \ on more duties. I can''t help but laugh, but it''s good to see {6} so motivated.</p>\
+  <p>I''m planning to pull {6} away from the hangar for a little while this evening. Just some cake and maybe a few\
+  \ stories about when {5} {0, choice, 0#were|1#was} younger - {5} loves hearing your side of things. I know it would mean a lot to {6} if you\
+  \ joined us.</p>\
+  <p>Let me know if you can make it.</p>
+comingOfAge.message.4.reminder.ic=Just a quick reminder - {2}''s turning <b>16</b> today.\
+  <p>{4}''{0, choice, 0#ve|1#s} been hinting that {5}''d love to spend some time with you, maybe pick your brain about some new ideas {5}''{0, choice, 0#ve|1#s} been\
+  \ working on. You know how {5} gets when {5}''{0, choice, 0#re|1#s} onto something - doesn''t stop talking until {5}''{0, choice, 0#ve|1#s} got it all figured\
+  \ out.</p>\
+  <p>I thought we''d surprise {6} with a little cake and some downtime later. I know it''s not much, but {5} deserves to\
+  \ feel a bit special today. It would really mean a lot if you could be there.</p>\
+  <p>Let me know if you''ll join.</p>
+comingOfAge.message.5.reminder.ic=I just wanted to remind you - {2}''s turning <b>16</b> today.\
+  <p>It feels like just yesterday we were teaching {6} how to tie {7} boots. Now {5}''{0, choice, 0#re|1#s} taller than me and telling me how\
+  \ to properly calibrate a cooling system. I''m proud of how much {5}''{0, choice, 0#ve|1#s} grown, even if {5} sometimes acts like {5} knows it\
+  \ all.</p>\
+  <p>I thought we could put together something small for {6} later - a little cake and maybe some stories. I know {5}''{0, choice, 0#ve|1#s}\
+  \ been itching to hear more about your first assignment. {4} loves those stories, even if {5} pretends not to be\
+  \ impressed.</p>\
+  <p>Hope you can make it.</p>
+comingOfAge.message.6.reminder.ic=Just giving you a heads-up - {2}''s officially <b>16</b> today.\
+  <p>{4}''{0, choice, 0#ve|1#s} been strutting around like {5}''{0, choice, 0#re|1#s} in charge of the hangar now. I caught {6} giving pointers to the tech crew,\
+  \ and they just played along like {5} {0, choice, 0#were|1#was} the new supervisor.</p>\
+  <p>I guess we''ll have to manage {7} growing confidence carefully.</p>\
+  <p>I''m planning a little get-together later - nothing too big, just some cake. {4}''{0, choice, 0#ve|1#s} been hinting that {5}''d like to see\
+  \ you.</p>\
+  <p>Let me know if you''ll join.</p>
+comingOfAge.message.7.reminder.ic=Just wanted to remind you - {2}''s <b>16</b> today.\
+  <p>{4}''{0, choice, 0#ve|1#s} been pretty upbeat, talking about new ideas for helping out. I thought we could take a little break\
+  \ this evening and celebrate, just so {5} knows we didn''t forget.</p>\
+  <p>It doesn''t have to be anything fancy - just cake, a few laughs, and a chance to let {6} know we''re proud of {6}. I\
+  \ know {5}''d love to see you there.</p>\
+  <p>Let me know if you can make it.</p>
+comingOfAge.message.8.reminder.ic=I can''t believe it, but {2}''s <b>16</b> today. {4}''{0, choice, 0#re|1#s} growing up way too fast.\
+  <p>I keep thinking about when {5} used to follow us around, trying to copy everything we did. Now {5}''{0, choice, 0#re|1#s} trying to come\
+  \ up with {7} own maintenance protocols and acting like {5}''{0, choice, 0#ve|1#s} got it all figured out.</p>\
+  <p>I''m putting together a small celebration later - nothing fancy, just a little cake and some downtime. It''d mean a\
+  \ lot if you could be there.</p>\
+  <p>Hope you can make it.</p>
+comingOfAge.message.9.reminder.ic=Just wanted to remind you - {2}''s officially <b>16</b> today.\
+  <p>{4}''{0, choice, 0#ve|1#s} been bouncing around the hangar like {5}''{0, choice, 0#ve|1#s} got something to prove, and honestly, it''s kind of nice to see {6}\
+  \ so full of energy. {4}''{0, choice, 0#ve|1#s} been working hard lately, trying to learn as much as {5} can.</p>\
+  <p>I''m planning to slow {6} down for a bit later, just to make sure {5} knows we didn''t forget. A little cake, a few\
+  \ laughs - it''s not much, but I think it''ll mean a lot to {6}. If you can make it, I know it''d really make {7} day.</p>\
+  <p>Let me know.</p>
+## Commander is the Parent, from HR
+comingOfAge.message.0.hrReminder.ic={8}, just wanted to make sure it''s on your radar - today is {2}''s 16th birthday.\
+  <p>I know things can get hectic around here, but I thought I''d drop a quick note to remind you. It''s a big milestone,\
+  \ and I''m sure it would mean a lot to {2} to have you acknowledge it.</p>\
+  <p>{4}''{0, choice, 0#ve|1#s} been in good spirits today - busy around the hangar as usual. The team has noticed {5}''{0, choice, 0#ve|1#s} been pretty energetic,\
+  \ and I think {5}''{0, choice, 0#re|1#s} hoping for a bit of recognition. If you can make a moment to check in with {6}, I know it would\
+  \ make {7} day.</p>\
+  <p>Let me know if you''d like me to help arrange anything special.</p>
+comingOfAge.message.1.hrReminder.ic={8}, just a quick note to remind you - today''s {2}''s 16th birthday.\
+  <p>I know your schedule''s packed, so I thought it''d be good to make sure it doesn''t slip by unnoticed.</p>\
+  <p>{2}''s been in a great mood today, and I''m sure {5}''d really appreciate hearing from you.</p>\
+  <p>If you need any help setting something up or finding a few minutes in your schedule, lemme know.</p>
+comingOfAge.message.2.hrReminder.ic={8}, just wanted to give you a heads-up - {2}''s turning <b>16</b> today!\
+  <p>I know you''ve got a lot on your plate, but I wanted to make sure you knew. I''m sure {5}''d love to see you today,\
+  \ even if it''s just for a quick chat.</p>\
+  <p>Let me know if you''d like any help making it a bit special.</p>
+comingOfAge.message.3.hrReminder.ic={8}, I wanted to make sure you''re aware that today is {2}''s 16th birthday.\
+  <p>I know your duties keep you busy, but I thought it would be good to ensure it''s on your radar. Birthdays can be\
+  \ important milestones, especially for someone {7} age.</p>\
+  <p>If you''d like assistance in planning something small to mark the occasion, I''m happy to help.</p>
+comingOfAge.message.4.hrReminder.ic={8}, I just wanted to make sure you know that {2} turns <b>16</b> today.\
+  <p>{4}''{0, choice, 0#ve|1#s} been in good spirits, but I can tell {5}''{0, choice, 0#re|1#s} hoping for a little acknowledgment. If you can find a moment in your\
+  \ schedule to check in with {6}, I know it would mean a lot.</p>\
+  <p>Let me know if I can assist with anything.</p>
+comingOfAge.message.5.hrReminder.ic={8}, just wanted to make sure you didn''t miss this - {2}''s 16th birthday is today.\
+  <p>I know how busy things get, but it''s a pretty big day for {6}, and I wanted to make sure it was on your radar. A\
+  \ little recognition would go a long way.</p>\
+  <p>If you''d like any help making it a bit more special, just let me know.</p>
+comingOfAge.message.6.hrReminder.ic={8}, I just wanted to gently remind you that today is {2}''s 16th birthday.\
+  <p>{4}''{0, choice, 0#ve|1#s} been {7} usual upbeat self, but I know {5}''d really appreciate a little acknowledgment from you. Even a few\
+  \ words would mean the world to {6}.</p>\
+  <p>If you''d like any help planning something quick and simple, just let me know.</p>
+comingOfAge.message.7.hrReminder.ic={8}, I just wanted to make sure you were aware - {2} turns <b>16</b> today.\
+  <p>I know things have been busy lately, so I thought it would be good to make sure you knew. A quick word from you\
+  \ would really make {7} day.</p>\
+  <p>Let me know if there''s anything I can do to help.</p>
+comingOfAge.message.8.hrReminder.ic={8}, just wanted to make sure you didn''t forget - today''s {2}''s 16th birthday.\
+  <pPHe''s been keeping busy as usual, but I can tell {5}''{0, choice, 0#re|1#s} hoping to hear from you. Even just a few words\
+  \ would mean a lot to {6} today.</p>\
+  <p>If you''ve got a spare moment, it''d be great for {6} to know you''re thinking of {6}. Let me know if I can help\
+  \ coordinate anything.</p>
+comingOfAge.message.9.hrReminder.ic={8}, just wanted to touch base and make sure you know that {2} turns <b>16</b> today.\
+  <p>It''s a big milestone, and even though {5}''{0, choice, 0#ve|1#s} been keeping busy like usual, I know {5}''d appreciate a bit of your\
+  \ time.</p>\
+  <p>If you''re able to drop by and say a few words, it would really make a difference. Let me know if you need any\
+  \ assistance with arrangements.</p>
+
+

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -171,6 +171,7 @@ import mekhq.campaign.personnel.generator.AbstractSpecialAbilityGenerator;
 import mekhq.campaign.personnel.generator.DefaultPersonnelGenerator;
 import mekhq.campaign.personnel.generator.DefaultSpecialAbilityGenerator;
 import mekhq.campaign.personnel.generator.RandomPortraitGenerator;
+import mekhq.campaign.personnel.lifeEvents.ComingOfAgeAnnouncement;
 import mekhq.campaign.personnel.marriage.AbstractMarriage;
 import mekhq.campaign.personnel.marriage.DisabledRandomMarriage;
 import mekhq.campaign.personnel.procreation.AbstractProcreation;
@@ -4957,9 +4958,9 @@ public class Campaign implements ITechManager {
      * @param person The {@link Person} for whom the anniversaries will be processed
      */
     private void processAnniversaries(Person person) {
+        LocalDate birthday = person.getBirthday(getGameYear());
         if ((person.getRank().isOfficer()) || (!getCampaignOptions().isAnnounceOfficersOnly())) {
-            if ((person.getBirthday(getGameYear()).isEqual(getLocalDate())) &&
-                      (campaignOptions.isAnnounceBirthdays())) {
+            if (birthday.isEqual(currentDay) && campaignOptions.isAnnounceBirthdays()) {
                 addReport(String.format(resources.getString("anniversaryBirthday.text"),
                       person.getHyperlinkedFullTitle(),
                       ReportingUtilities.spanOpeningWithCustomColor(MekHQ.getMHQOptions()
@@ -4973,7 +4974,7 @@ public class Campaign implements ITechManager {
                 LocalDate recruitmentAnniversary = recruitmentDate.withYear(getGameYear());
                 int yearsOfEmployment = (int) ChronoUnit.YEARS.between(recruitmentDate, currentDay);
 
-                if ((recruitmentAnniversary.isEqual(getLocalDate())) &&
+                if ((recruitmentAnniversary.isEqual(currentDay)) &&
                           (campaignOptions.isAnnounceRecruitmentAnniversaries())) {
                     addReport(String.format(resources.getString("anniversaryRecruitment.text"),
                           person.getHyperlinkedFullTitle(),
@@ -4985,13 +4986,19 @@ public class Campaign implements ITechManager {
                 }
             }
         } else if ((person.getAge(getLocalDate()) == 18) && (campaignOptions.isAnnounceChildBirthdays())) {
-            if (person.getBirthday(getGameYear()).isEqual(getLocalDate())) {
+            if (birthday.isEqual(currentDay)) {
                 addReport(String.format(resources.getString("anniversaryBirthday.text"),
                       person.getHyperlinkedFullTitle(),
                       ReportingUtilities.spanOpeningWithCustomColor(MekHQ.getMHQOptions()
                                                                           .getFontColorPositiveHexColor()),
                       person.getAge(getLocalDate()),
                       CLOSING_SPAN_TAG));
+            }
+        }
+
+        if (campaignOptions.isShowLifeEventDialogComingOfAge()) {
+            if ((person.getAge(currentDay) == 16) && (birthday.isEqual(currentDay))) {
+                new ComingOfAgeAnnouncement(this, person);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -312,6 +312,9 @@ public class CampaignOptions {
     private boolean announceOfficersOnly;
     private boolean announceChildBirthdays;
 
+    // Life Events
+    private boolean showLifeEventDialogComingOfAge;
+
     // Marriage
     private boolean useManualMarriages;
     private boolean useClanPersonnelMarriages;
@@ -882,6 +885,9 @@ public class CampaignOptions {
         setAnnounceRecruitmentAnniversaries(true);
         setAnnounceOfficersOnly(true);
         setAnnounceChildBirthdays(true);
+
+        // Life Events
+        setShowLifeEventDialogComingOfAge(true);
 
         // Marriage
         setUseManualMarriages(true);
@@ -2252,6 +2258,16 @@ public class CampaignOptions {
         this.announceChildBirthdays = announceChildBirthdays;
     }
     // endregion anniversaries
+
+    //startregion Life Events
+    public boolean isShowLifeEventDialogComingOfAge() {
+        return showLifeEventDialogComingOfAge;
+    }
+
+    public void setShowLifeEventDialogComingOfAge(final boolean showLifeEventDialogComingOfAge) {
+        this.showLifeEventDialogComingOfAge = showLifeEventDialogComingOfAge;
+    }
+    //endregion Life Events
 
     // region Dependents
     public boolean isUseRandomDependentAddition() {
@@ -4974,6 +4990,13 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "announceChildBirthdays", isAnnounceChildBirthdays());
         // endregion Announcements
 
+        // region Life Events
+        MHQXMLUtility.writeSimpleXMLTag(pw,
+              indent,
+              "showLifeEventDialogComingOfAge",
+              isShowLifeEventDialogComingOfAge());
+        // endregion Life Events
+
         // region Marriage
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useManualMarriages", isUseManualMarriages());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useClanPersonnelMarriages", isUseClanPersonnelMarriages());
@@ -5351,8 +5374,7 @@ public class CampaignOptions {
                     retVal.mistakeXP = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("vocationalXP")
                                  // <50.03 compatibility handler
-                                 ||
-                                 wn2.getNodeName().equalsIgnoreCase("idleXP")) {
+                                 || wn2.getNodeName().equalsIgnoreCase("idleXP")) {
                     retVal.vocationalXP = Integer.parseInt(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("vocationalXPTargetNumber")
                                  // <50.03 compatibility handler
@@ -5720,6 +5742,8 @@ public class CampaignOptions {
                     retVal.setAnnounceOfficersOnly(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("announceChildBirthdays")) {
                     retVal.setAnnounceChildBirthdays(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("showLifeEventDialogComingOfAge")) {
+                    retVal.setShowLifeEventDialogComingOfAge(Boolean.parseBoolean(wn2.getTextContent().trim()));
                     // endregion anniversaries
 
                     // region Marriage
@@ -5788,8 +5812,9 @@ public class CampaignOptions {
                         if (wn3.getNodeType() != Node.ELEMENT_NODE) {
                             continue;
                         }
-                        retVal.getDivorceSurnameWeights().put(SplittingSurnameStyle.valueOf(wn3.getNodeName().trim()),
-                              Integer.parseInt(wn3.getTextContent().trim()));
+                        retVal.getDivorceSurnameWeights()
+                              .put(SplittingSurnameStyle.valueOf(wn3.getNodeName().trim()),
+                                    Integer.parseInt(wn3.getTextContent().trim()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("randomDivorceMethod")) {
                     retVal.setRandomDivorceMethod(RandomDivorceMethod.valueOf(wn2.getTextContent().trim()));

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/ComingOfAgeAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/ComingOfAgeAnnouncement.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.campaign.personnel.lifeEvents;
+
+import static megamek.codeUtilities.ObjectUtility.getRandomItem;
+import static megamek.common.Compute.randomInt;
+import static megamek.common.enums.Gender.FEMALE;
+import static megamek.common.enums.Gender.MALE;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import megamek.common.annotations.Nullable;
+import megamek.common.enums.Gender;
+import megamek.logging.MMLogger;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelStatus;
+import mekhq.campaign.personnel.familyTree.Genealogy;
+import mekhq.campaign.randomEvents.personalities.PersonalityController.PronounData;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+
+public class ComingOfAgeAnnouncement {
+    private static final MMLogger logger = MMLogger.create(ComingOfAgeAnnouncement.class);
+
+    private static String RESOURCE_BUNDLE = "mekhq.resources." + ComingOfAgeAnnouncement.class.getSimpleName();
+
+    private final Campaign campaign;
+    private final Person birthdayHaver;
+    private SpeakerType speakerType;
+
+    private final static int SUPPRESS_DIALOG_RESPONSE_INDEX = 3;
+
+    private enum SpeakerType {
+        PARENT, OTHER_PARENT, HR_REMINDER, HR_ORPHAN
+    }
+
+    public ComingOfAgeAnnouncement(Campaign campaign, Person birthdayHaver) {
+        this.campaign = campaign;
+        this.birthdayHaver = birthdayHaver;
+
+        Person speaker = getSpeaker();
+        String birthdayHaverFirstName = birthdayHaver.getFirstName();
+        String inCharacterMessage = getInCharacterMessage(birthdayHaverFirstName);
+        String outOfCharacterMessage = getFormattedTextAt(RESOURCE_BUNDLE,
+              "comingOfAge.message.ooc",
+              birthdayHaver.getHyperlinkedFullTitle());
+
+        ImmersiveDialogSimple dialog = new ImmersiveDialogSimple(campaign,
+              speaker,
+              birthdayHaver,
+              inCharacterMessage,
+              getButtonLabels(birthdayHaverFirstName),
+              outOfCharacterMessage,
+              true);
+
+        //        if (dialog.getDialogChoice() == SUPPRESS_DIALOG_RESPONSE_INDEX) {
+        //            CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        //            campaignOptions.setShowLifeEventDialogBirths(false);
+        //        }
+    }
+
+    private String getInCharacterMessage(String birthdayHaverFirstName) {
+        // Birthday Haver Data
+        Gender birthdayHaverGender = birthdayHaver.getGender();
+        PronounData birthdayHaverPronounData = new PronounData(birthdayHaverGender);
+        String birthdayHaverTitle = getGenderedTitle(birthdayHaverGender);
+        String birthdayHaverFullTitle = birthdayHaver.getFullTitle();
+
+        // Build the in character message
+        String resourceKey = "comingOfAge.message." + switch (speakerType) {
+            case PARENT -> randomInt(50) + ".fromParent.ic";
+            case OTHER_PARENT -> randomInt(10) + ".reminder.ic";
+            case HR_REMINDER -> randomInt(10) + ".hrReminder.ic";
+            case HR_ORPHAN -> randomInt(10) + ".noParents.ic";
+        };
+
+        // {0} Gender Neutral = 0, Otherwise 1 (used to determine whether to use plural case)
+        // {1} Full name
+        // {2} First name
+        // {3} Gendered Title
+        // {4} He/She/They
+        // {5} he/she/they
+        // {6} him/her/them
+        // {7} his/her/their
+        // {8} commander address
+        return getFormattedTextAt(RESOURCE_BUNDLE,
+              resourceKey,
+              birthdayHaverPronounData.pluralizer(),
+              birthdayHaverFullTitle,
+              birthdayHaverFirstName,
+              birthdayHaverTitle,
+              birthdayHaverPronounData.subjectPronoun(),
+              birthdayHaverPronounData.subjectPronounLowerCase(),
+              birthdayHaverPronounData.objectPronounLowerCase(),
+              birthdayHaverPronounData.possessivePronounLowerCase(),
+              campaign.getCommanderAddress(false));
+    }
+
+    private @Nullable Person getSpeaker() {
+        Genealogy genealogy = birthdayHaver.getGenealogy();
+        Person commander = campaign.getFlaggedCommander();
+
+        if (genealogy == null) {
+            logger.debug("No genealogy found for {}. Using fallback speaker.", birthdayHaver.getFullName());
+            return getFallbackSpeaker();
+        }
+
+        List<Person> parents = genealogy.getParents();
+        List<Person> presentParents = new ArrayList<>();
+
+        for (Person parent : parents) {
+            if (parent == null) {
+                logger.debug("Null parent found for {}. Skipping.", birthdayHaver.getFullName());
+                continue;
+            }
+
+            PersonnelStatus parentStatus = parent.getStatus();
+
+            if (parentStatus.isDepartedUnit() || parentStatus.isAbsent()) {
+                continue;
+            }
+
+            presentParents.add(parent);
+        }
+
+        if (presentParents.isEmpty()) {
+            speakerType = SpeakerType.HR_ORPHAN;
+            return getFallbackSpeaker();
+        } else {
+            if (commander != null) {
+                if (commander.equals(presentParents.get(0))) {
+                    speakerType = SpeakerType.OTHER_PARENT;
+                    return presentParents.get(0);
+                } else if ((presentParents.size() > 1) && commander.equals(presentParents.get(1))) {
+                    speakerType = SpeakerType.OTHER_PARENT;
+                    return presentParents.get(1);
+                }
+            }
+        }
+
+        Person speaker = getRandomItem(presentParents);
+
+        // This means only one object is in the pool, and it's the campaign commander. They shouldn't message
+        // themselves, so instead HR (or COMMAND) sends them a reminder.
+        if (Objects.equals(speaker, commander)) {
+            speakerType = SpeakerType.HR_ORPHAN;
+            return getFallbackSpeaker();
+        }
+
+        speakerType = SpeakerType.PARENT;
+        return speaker;
+    }
+
+    private @Nullable Person getFallbackSpeaker() {
+        Person speaker = campaign.getSeniorAdminPerson(HR);
+
+        if (speaker == null) {
+            speaker = campaign.getSeniorAdminPerson(COMMAND);
+        } else {
+            return speaker;
+        }
+
+        return speaker;
+    }
+
+    private static String getGenderedTitle(Gender gender) {
+        String titleKey = "title.";
+
+        if (gender.isGenderNeutral()) {
+            titleKey = titleKey + "neutral";
+        } else if (gender == FEMALE) {
+            titleKey = titleKey + "female";
+        } else if (gender == MALE) {
+            titleKey = titleKey + "male";
+        }
+        return getFormattedTextAt(RESOURCE_BUNDLE, titleKey);
+    }
+
+    private List<String> getButtonLabels(String birthdayHaverFirstName) {
+        return List.of(getFormattedTextAt(RESOURCE_BUNDLE, "button.response.positive", birthdayHaverFirstName),
+              getFormattedTextAt(RESOURCE_BUNDLE, "button.response.neutral"),
+              getFormattedTextAt(RESOURCE_BUNDLE, "button.response.negative"),
+              getFormattedTextAt(RESOURCE_BUNDLE, "button.response.suppress"));
+    }
+}

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -507,22 +507,6 @@ public class BiographyTab {
 
     private JPanel createLifeEventsPanel() {
         // Contents
-        chkShowLifeEventDialogBirths = new CampaignOptionsCheckBox("ShowLifeEventDialogBirths");
-
-        // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("LifeEventsPanel", true, "LifeEventsPanel");
-        final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
-
-        layoutParent.gridwidth = 5;
-        layoutParent.gridx = 0;
-        layoutParent.gridy = 0;
-        panel.add(chkShowLifeEventDialogBirths, layoutParent);
-
-        return panel;
-    }
-
-    private JPanel createLifeEventsPanel() {
-        // Contents
         chkShowLifeEventDialogComingOfAge = new CampaignOptionsCheckBox("ShowLifeEventDialogComingOfAge");
 
         // Layout the Panel
@@ -532,6 +516,7 @@ public class BiographyTab {
         layoutParent.gridwidth = 1;
         layoutParent.gridx = 0;
         layoutParent.gridy = 0;
+        panel.add(chkShowLifeEventDialogBirths, layoutParent);
         layoutParent.gridx++;
         panel.add(chkShowLifeEventDialogComingOfAge, layoutParent);
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -507,6 +507,7 @@ public class BiographyTab {
 
     private JPanel createLifeEventsPanel() {
         // Contents
+        chkShowLifeEventDialogBirths = new CampaignOptionsCheckBox("ShowLifeEventDialogBirths");
         chkShowLifeEventDialogComingOfAge = new CampaignOptionsCheckBox("ShowLifeEventDialogComingOfAge");
 
         // Layout the Panel

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -77,7 +77,7 @@ import mekhq.gui.panes.RankSystemsPane;
  *     <li>Random name generation and portrait assignment based on roles and factions.</li>
  *     <li>Rank and hierarchy management for campaign personnel.</li>
  * </ul>
- *
+ * <p>
  * The class includes methods to initialize, load, and configure settings while providing GUI tools to enable user
  * interaction. It also integrates with the current `Campaign` and `CampaignOptions` objects to synchronize settings.
  * This class serves as the backbone for displaying and managing the "Biography" tab in the campaign options dialog.
@@ -104,6 +104,8 @@ public class BiographyTab {
     private JCheckBox chkAnnounceBirthdays;
     private JCheckBox chkAnnounceChildBirthdays;
     private JCheckBox chkAnnounceRecruitmentAnniversaries;
+    private JPanel pnlLifeEvents;
+    private JCheckBox chkShowLifeEventDialogComingOfAge;
     //end General Tab
 
     //start Backgrounds Tab
@@ -192,9 +194,9 @@ public class BiographyTab {
     /**
      * Constructs the `BiographyTab` and initializes the campaign and its dependent options.
      *
-     * @param campaign             The current `Campaign` object to which the BiographyTab is linked. The campaign
-     *                             options and origin options are derived from this object.
-     * @param generalTab           The currently active General Tab.
+     * @param campaign   The current `Campaign` object to which the BiographyTab is linked. The campaign options and
+     *                   origin options are derived from this object.
+     * @param generalTab The currently active General Tab.
      */
     public BiographyTab(Campaign campaign, GeneralTab generalTab) {
         this.campaign = campaign;
@@ -206,16 +208,16 @@ public class BiographyTab {
     }
 
     /**
-     * Initializes the various sections and settings tabs within the BiographyTab.
-     * This method organizes the following tabs:
+     * Initializes the various sections and settings tabs within the BiographyTab. This method organizes the following
+     * tabs:
      * <p>
-     *     <li>General Tab: Handles general campaign settings such as gender distribution and
-     *     relationship displays.</li>
-     *     <li>Background Tab: Configures randomized backgrounds for campaign characters.</li>
-     *     <li>Death Tab: Sets up random death rules and options.</li>
-     *     <li>Education Tab: Defines education-related gameplay settings.</li>
-     *     <li>Name and Portrait Tab: Configures rules for name and portrait generation.</li>
-     *     <li>Rank Tab: Manages the rank systems for campaign personnel.</li>
+     * <li>General Tab: Handles general campaign settings such as gender distribution and
+     * relationship displays.</li>
+     * <li>Background Tab: Configures randomized backgrounds for campaign characters.</li>
+     * <li>Death Tab: Sets up random death rules and options.</li>
+     * <li>Education Tab: Defines education-related gameplay settings.</li>
+     * <li>Name and Portrait Tab: Configures rules for name and portrait generation.</li>
+     * <li>Rank Tab: Manages the rank systems for campaign personnel.</li>
      * </p>
      */
     private void initialize() {
@@ -312,9 +314,9 @@ public class BiographyTab {
     /**
      * Initializes the Backgrounds tab, which handles:
      * <p>
-     *     <li>Randomized background settings for characters.</li>
-     *     <li>Options for specifying origins (e.g., faction-specific planetary systems).</li>
-     *     <li>Custom search radius and distance scaling for randomized origins.</li>
+     * <li>Randomized background settings for characters.</li>
+     * <li>Options for specifying origins (e.g., faction-specific planetary systems).</li>
+     * <li>Custom search radius and distance scaling for randomized origins.</li>
      * </p>
      */
     private void initializeBackgroundsTab() {
@@ -344,9 +346,9 @@ public class BiographyTab {
     /**
      * Initializes the General tab, which provides options for:
      * <p>
-     *     <li>General gameplay settings such as gender distribution sliders.</li>
-     *     <li>Configuration of familial display levels and other general campaign settings.</li>
-     *     <li>Annunciation of anniversaries, recruitment dates, and officer-related milestones.</li>
+     * <li>General gameplay settings such as gender distribution sliders.</li>
+     * <li>Configuration of familial display levels and other general campaign settings.</li>
+     * <li>Annunciation of anniversaries, recruitment dates, and officer-related milestones.</li>
      * </p>
      */
     private void initializeGeneralTab() {
@@ -357,13 +359,16 @@ public class BiographyTab {
         spnNonBinaryDiceSize = new JSpinner();
         lblFamilyDisplayLevel = new JLabel();
         comboFamilyDisplayLevel = new MMComboBox<>("comboFamilyDisplayLevel",
-            FamilialRelationshipDisplayLevel.values());
+              FamilialRelationshipDisplayLevel.values());
 
         pnlAnniversariesPanel = new JPanel();
         chkAnnounceOfficersOnly = new JCheckBox();
         chkAnnounceBirthdays = new JCheckBox();
         chkAnnounceChildBirthdays = new JCheckBox();
         chkAnnounceRecruitmentAnniversaries = new JCheckBox();
+
+        pnlLifeEvents = new JPanel();
+        chkShowLifeEventDialogComingOfAge = new JCheckBox();
     }
 
     /**
@@ -392,7 +397,7 @@ public class BiographyTab {
     public JPanel createGeneralTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("BiographyGeneralTab",
-            getImageDirectory() + "logo_clan_blood_spirit.png");
+              getImageDirectory() + "logo_clan_blood_spirit.png");
 
         // Contents
         chkUseDylansRandomXP = new CampaignOptionsCheckBox("UseDylansRandomXP");
@@ -404,12 +409,13 @@ public class BiographyTab {
         sldGender.setPaintLabels(true);
 
         lblNonBinaryDiceSize = new CampaignOptionsLabel("NonBinaryDiceSize");
-        spnNonBinaryDiceSize = new CampaignOptionsSpinner("NonBinaryDiceSize",
-            60, 0, 100000, 1);
+        spnNonBinaryDiceSize = new CampaignOptionsSpinner("NonBinaryDiceSize", 60, 0, 100000, 1);
 
         lblFamilyDisplayLevel = new CampaignOptionsLabel("FamilyDisplayLevel");
 
         pnlAnniversariesPanel = createAnniversariesPanel();
+
+        pnlLifeEvents = createLifeEventsPanel();
 
         // Layout the Panel
         final JPanel panelLeft = new CampaignOptionsStandardPanel("BiographyGeneralTabLeft", true);
@@ -451,6 +457,10 @@ public class BiographyTab {
         layoutParent.gridx++;
         panelParent.add(pnlAnniversariesPanel, layoutParent);
 
+        layoutParent.gridx = 0;
+        layoutParent.gridy++;
+        panelParent.add(pnlLifeEvents, layoutParent);
+
         // Create Parent Panel and return
         return createParentPanel(panelParent, "BiographyGeneralTab");
     }
@@ -458,8 +468,8 @@ public class BiographyTab {
     /**
      * Creates the Anniversaries panel within the General tab for managing announcement-related settings:
      * <p>
-     *     <li>Enabling birthday and recruitment anniversary announcements.</li>
-     *     <li>Specifying whether such announcements should be limited to officers.</li>
+     * <li>Enabling birthday and recruitment anniversary announcements.</li>
+     * <li>Specifying whether such announcements should be limited to officers.</li>
      * </p>
      *
      * @return A `JPanel` containing the UI components for defining anniversary-related settings.
@@ -472,8 +482,7 @@ public class BiographyTab {
         chkAnnounceChildBirthdays = new CampaignOptionsCheckBox("AnnounceChildBirthdays");
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("AnniversariesPanel", true,
-            "AnniversariesPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("AnniversariesPanel", true, "AnniversariesPanel");
         final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
 
         layoutParent.gridwidth = 5;
@@ -494,6 +503,23 @@ public class BiographyTab {
         return panel;
     }
 
+    private JPanel createLifeEventsPanel() {
+        // Contents
+        chkShowLifeEventDialogComingOfAge = new CampaignOptionsCheckBox("ShowLifeEventDialogComingOfAge");
+
+        // Layout the Panel
+        final JPanel panel = new CampaignOptionsStandardPanel("LifeEventsPanel", true, "LifeEventsPanel");
+        final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
+
+        layoutParent.gridwidth = 1;
+        layoutParent.gridx = 0;
+        layoutParent.gridy = 0;
+        layoutParent.gridx++;
+        panel.add(chkShowLifeEventDialogComingOfAge, layoutParent);
+
+        return panel;
+    }
+
     /**
      * Creates and lays out the Backgrounds tab, which includes:
      * <ul>
@@ -506,7 +532,7 @@ public class BiographyTab {
     public JPanel createBackgroundsTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("BackgroundsTab",
-            getImageDirectory() + "logo_nueva_castile.png");
+              getImageDirectory() + "logo_nueva_castile.png");
 
         // Contents
         pnlRandomOriginOptions = createRandomOriginOptionsPanel();
@@ -537,10 +563,10 @@ public class BiographyTab {
      * <p>
      * This includes controls to enable or disable features such as:
      * <p>
-     *     <li>Random personalities for characters.</li>
-     *     <li>Random personality reputation.</li>
-     *     <li>Intelligence XP multipliers.</li>
-     *     <li>Simulated relationships.</li>
+     * <li>Random personalities for characters.</li>
+     * <li>Random personality reputation.</li>
+     * <li>Intelligence XP multipliers.</li>
+     * <li>Simulated relationships.</li>
      * </p>
      *
      * @return A {@code JPanel} representing the random background configuration UI.
@@ -553,8 +579,7 @@ public class BiographyTab {
         chkUseSimulatedRelationships = new CampaignOptionsCheckBox("UseSimulatedRelationships");
 
         // Layout the Panels
-        final JPanel panel = new CampaignOptionsStandardPanel("RandomBackgroundsPanel", true,
-            "RandomBackgroundsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("RandomBackgroundsPanel", true, "RandomBackgroundsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridwidth = 1;
@@ -577,9 +602,9 @@ public class BiographyTab {
     /**
      * Creates and returns a panel for random origin options. This includes:
      * <p>
-     *     <li>Controls to enable or disable randomization of origins.</li>
-     *     <li>Options for selecting specific planetary systems or factions for origin determination.</li>
-     *     <li>Search radius and distance scaling fields to tweak origin calculations.</li>
+     * <li>Controls to enable or disable randomization of origins.</li>
+     * <li>Options for selecting specific planetary systems or factions for origin determination.</li>
+     * <li>Search radius and distance scaling fields to tweak origin calculations.</li>
      * </p>
      *
      * @return A `JPanel` for managing random origin settings.
@@ -596,13 +621,13 @@ public class BiographyTab {
 
 
         lblSpecifiedSystem = new CampaignOptionsLabel("SpecifiedSystem");
-        comboSpecifiedSystem.setModel(new DefaultComboBoxModel<>(getPlanetarySystems(
-              chkSpecifiedSystemFactionSpecific.isSelected() ? generalTab.getFaction() : null)));
+        comboSpecifiedSystem.setModel(new DefaultComboBoxModel<>(getPlanetarySystems(chkSpecifiedSystemFactionSpecific.isSelected() ?
+                                                                                           generalTab.getFaction() :
+                                                                                           null)));
         comboSpecifiedSystem.setRenderer(new DefaultListCellRenderer() {
             @Override
-            public Component getListCellRendererComponent(final JList<?> list, final Object value,
-                                                          final int index, final boolean isSelected,
-                                                          final boolean cellHasFocus) {
+            public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
+                                                          final boolean isSelected, final boolean cellHasFocus) {
                 super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof PlanetarySystem) {
                     setText(((PlanetarySystem) value).getName(generalTab.getDate()));
@@ -613,8 +638,7 @@ public class BiographyTab {
         comboSpecifiedSystem.addActionListener(evt -> {
             final PlanetarySystem planetarySystem = comboSpecifiedSystem.getSelectedItem();
             final Planet planet = comboSpecifiedPlanet.getSelectedItem();
-            if ((planetarySystem == null)
-                || ((planet != null) && !planet.getParentSystem().equals(planetarySystem))) {
+            if ((planetarySystem == null) || ((planet != null) && !planet.getParentSystem().equals(planetarySystem))) {
                 restoreComboSpecifiedPlanet();
             }
         });
@@ -622,13 +646,13 @@ public class BiographyTab {
         lblSpecifiedPlanet = new CampaignOptionsLabel("SpecifiedPlanet");
         final PlanetarySystem planetarySystem = comboSpecifiedSystem.getSelectedItem();
         if (planetarySystem != null) {
-            comboSpecifiedPlanet.setModel(new DefaultComboBoxModel<>(planetarySystem.getPlanets().toArray(new Planet[] { })));
+            comboSpecifiedPlanet.setModel(new DefaultComboBoxModel<>(planetarySystem.getPlanets()
+                                                                           .toArray(new Planet[] {})));
         }
         comboSpecifiedPlanet.setRenderer(new DefaultListCellRenderer() {
             @Override
-            public Component getListCellRendererComponent(final JList<?> list, final Object value,
-                                                          final int index, final boolean isSelected,
-                                                          final boolean cellHasFocus) {
+            public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
+                                                          final boolean isSelected, final boolean cellHasFocus) {
                 super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
                 if (value instanceof Planet) {
                     setText(((Planet) value).getName(generalTab.getDate()));
@@ -638,20 +662,21 @@ public class BiographyTab {
         });
 
         lblOriginSearchRadius = new CampaignOptionsLabel("OriginSearchRadius");
-        spnOriginSearchRadius = new CampaignOptionsSpinner("OriginSearchRadius",
-            0, 0, 2000, 25);
+        spnOriginSearchRadius = new CampaignOptionsSpinner("OriginSearchRadius", 0, 0, 2000, 25);
 
         lblOriginDistanceScale = new CampaignOptionsLabel("OriginDistanceScale");
-        spnOriginDistanceScale = new CampaignOptionsSpinner("OriginDistanceScale",
-            0.6, 0.1, 2.0, 0.1);
+        spnOriginDistanceScale = new CampaignOptionsSpinner("OriginDistanceScale", 0.6, 0.1, 2.0, 0.1);
 
         chkAllowClanOrigins = new CampaignOptionsCheckBox("AllowClanOrigins");
         chkExtraRandomOrigin = new CampaignOptionsCheckBox("ExtraRandomOrigin");
 
         // Layout the Panel
         final JPanel panelSystemPlanetOrigins = new CampaignOptionsStandardPanel(
-            "RandomOriginOptionsPanelSystemPlanetOrigins", false, "");
-        final GridBagConstraints layoutSystemPlanetOrigins = new CampaignOptionsGridBagConstraints(panelSystemPlanetOrigins);
+              "RandomOriginOptionsPanelSystemPlanetOrigins",
+              false,
+              "");
+        final GridBagConstraints layoutSystemPlanetOrigins = new CampaignOptionsGridBagConstraints(
+              panelSystemPlanetOrigins);
 
         layoutSystemPlanetOrigins.gridwidth = 1;
         layoutSystemPlanetOrigins.gridx = 0;
@@ -674,8 +699,9 @@ public class BiographyTab {
         layoutSystemPlanetOrigins.gridx++;
         panelSystemPlanetOrigins.add(spnOriginDistanceScale, layoutSystemPlanetOrigins);
 
-        final JPanel panel = new CampaignOptionsStandardPanel("RandomOriginOptionsPanel", true,
-            "RandomOriginOptionsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("RandomOriginOptionsPanel",
+              true,
+              "RandomOriginOptionsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridwidth = 1;
@@ -709,13 +735,12 @@ public class BiographyTab {
      * Refreshes the planetary systems and planets displayed in the associated combo boxes.
      *
      * <p>This method first stores the currently selected planetary system and planet. It then
-     * restores the list of available planetary systems by repopulating the `comboSpecifiedSystem`.
-     * Finally, it reselects the previously selected planetary system and planet in their respective
-     * combo boxes.</p>
+     * restores the list of available planetary systems by repopulating the `comboSpecifiedSystem`. Finally, it
+     * reselects the previously selected planetary system and planet in their respective combo boxes.</p>
      *
      * <p>The method ensures that the user selection persists even after the combo boxes are refreshed.
-     * Any exceptions during the selection process are caught and ignored. As if we can't restore
-     * the selection, that's fine, we just use the fallback index of 0.</p>
+     * Any exceptions during the selection process are caught and ignored. As if we can't restore the selection, that's
+     * fine, we just use the fallback index of 0.</p>
      */
     private void refreshSystemsAndPlanets() {
         final PlanetarySystem planetarySystem = comboSpecifiedSystem.getSelectedItem();
@@ -726,7 +751,8 @@ public class BiographyTab {
         try {
             comboSpecifiedSystem.setSelectedItem(planetarySystem);
             comboSpecifiedPlanet.setSelectedItem(planet);
-        } catch (Exception ignored) {}
+        } catch (Exception ignored) {
+        }
     }
 
     /**
@@ -738,8 +764,8 @@ public class BiographyTab {
         if (planetarySystem == null) {
             comboSpecifiedPlanet.removeAllItems();
         } else {
-            comboSpecifiedPlanet.setModel(new DefaultComboBoxModel<>(
-                planetarySystem.getPlanets().toArray(new Planet[] {})));
+            comboSpecifiedPlanet.setModel(new DefaultComboBoxModel<>(planetarySystem.getPlanets()
+                                                                           .toArray(new Planet[] {})));
             comboSpecifiedPlanet.setSelectedItem(planetarySystem.getPrimaryPlanet());
         }
     }
@@ -750,8 +776,9 @@ public class BiographyTab {
     private void restoreComboSpecifiedSystem() {
         comboSpecifiedSystem.removeAllItems();
 
-        comboSpecifiedSystem.setModel(new DefaultComboBoxModel<>(getPlanetarySystems(
-            chkSpecifiedSystemFactionSpecific.isSelected() ? generalTab.getFaction() : null)));
+        comboSpecifiedSystem.setModel(new DefaultComboBoxModel<>(getPlanetarySystems(chkSpecifiedSystemFactionSpecific.isSelected() ?
+                                                                                           generalTab.getFaction() :
+                                                                                           null)));
 
         restoreComboSpecifiedPlanet();
     }
@@ -760,6 +787,7 @@ public class BiographyTab {
      * Filters planetary systems based on a given faction (if specified) and returns a sorted array of matches.
      *
      * @param faction The faction to filter planetary systems by (nullable). If `null`, all systems are included.
+     *
      * @return An array of `PlanetarySystem` objects meeting the filter criteria.
      */
     private PlanetarySystem[] getPlanetarySystems(final @Nullable Faction faction) {
@@ -793,12 +821,11 @@ public class BiographyTab {
     public JPanel createDeathTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("DeathTab",
-            getImageDirectory() + "logo_clan_fire_mandrills.png");
+              getImageDirectory() + "logo_clan_fire_mandrills.png");
 
         // Contents
         lblRandomDeathMultiplier = new CampaignOptionsLabel("RandomDeathMultiplier");
-        spnRandomDeathMultiplier = new CampaignOptionsSpinner("RandomDeathMultiplier",
-            1.0, 0, 100.0, 0.01);
+        spnRandomDeathMultiplier = new CampaignOptionsSpinner("RandomDeathMultiplier", 1.0, 0, 100.0, 0.01);
 
         chkUseRandomDeathSuicideCause = new CampaignOptionsCheckBox("UseRandomDeathSuicideCause");
 
@@ -841,7 +868,8 @@ public class BiographyTab {
     }
 
     /**
-     * Configures and creates a panel where users can enable or disable random death probabilities for specific age groups.
+     * Configures and creates a panel where users can enable or disable random death probabilities for specific age
+     * groups.
      *
      * @return A `JPanel` containing the random death age group options.
      */
@@ -849,8 +877,7 @@ public class BiographyTab {
         final AgeGroup[] ageGroups = AgeGroup.values();
 
         // Create the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("DeathAgeGroupsPanel", true,
-            "DeathAgeGroupsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("DeathAgeGroupsPanel", true, "DeathAgeGroupsPanel");
         panel.setLayout(new GridLayout((ageGroups.length / 2) + 1, 1));
 
         // Contents
@@ -882,18 +909,16 @@ public class BiographyTab {
     public JPanel createEducationTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("EducationTab",
-            getImageDirectory() + "logo_taurian_concordat.png");
+              getImageDirectory() + "logo_taurian_concordat.png");
 
         // Contents
         chkUseEducationModule = new CampaignOptionsCheckBox("UseEducationModule");
 
         lblCurriculumXpRate = new CampaignOptionsLabel("CurriculumXpRate");
-        spnCurriculumXpRate = new CampaignOptionsSpinner("CurriculumXpRate",
-            3, 1, 10, 1);
+        spnCurriculumXpRate = new CampaignOptionsSpinner("CurriculumXpRate", 3, 1, 10, 1);
 
         lblMaximumJumpCount = new CampaignOptionsLabel("MaximumJumpCount");
-        spnMaximumJumpCount = new CampaignOptionsSpinner("MaximumJumpCount",
-            5, 1, 200, 1);
+        spnMaximumJumpCount = new CampaignOptionsSpinner("MaximumJumpCount", 5, 1, 200, 1);
 
         chkUseReeducationCamps = new CampaignOptionsCheckBox("UseReeducationCamps");
 
@@ -902,8 +927,7 @@ public class BiographyTab {
         chkShowIneligibleAcademies = new CampaignOptionsCheckBox("ShowIneligibleAcademies");
 
         lblEntranceExamBaseTargetNumber = new CampaignOptionsLabel("EntranceExamBaseTargetNumber");
-        spnEntranceExamBaseTargetNumber = new CampaignOptionsSpinner("EntranceExamBaseTargetNumber",
-            14, 0, 20, 1);
+        spnEntranceExamBaseTargetNumber = new CampaignOptionsSpinner("EntranceExamBaseTargetNumber", 14, 0, 20, 1);
 
         pnlEnableStandardSets = createEnableStandardSetsPanel();
 
@@ -995,9 +1019,9 @@ public class BiographyTab {
      * <p>
      * This includes options to toggle various academy types:
      * <p>
-     *     <li>Local academies.</li>
-     *     <li>Prestigious academies.</li>
-     *     <li>Unit-based education academies.</li>
+     * <li>Local academies.</li>
+     * <li>Prestigious academies.</li>
+     * <li>Unit-based education academies.</li>
      * </p>
      *
      * @return A {@code JPanel} containing the Enable Standard Sets UI components.
@@ -1007,8 +1031,9 @@ public class BiographyTab {
         chkEnablePrestigiousAcademies = new CampaignOptionsCheckBox("EnablePrestigiousAcademies");
         chkEnableUnitEducation = new CampaignOptionsCheckBox("EnableUnitEducation");
 
-        final JPanel panel = new CampaignOptionsStandardPanel("EnableStandardSetsPanel", true,
-            "EnableStandardSetsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("EnableStandardSetsPanel",
+              true,
+              "EnableStandardSetsPanel");
 
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
@@ -1031,8 +1056,8 @@ public class BiographyTab {
      * <p>
      * This includes:
      * <p>
-     *     <li>Option to enable or disable bonuses.</li>
-     *     <li>Setting the faculty XP multiplier.</li>
+     * <li>Option to enable or disable bonuses.</li>
+     * <li>Setting the faculty XP multiplier.</li>
      * </p>
      *
      * @return A {@code JPanel} for managing XP rates and skill bonuses.
@@ -1041,12 +1066,10 @@ public class BiographyTab {
         // Contents
         chkEnableBonuses = new CampaignOptionsCheckBox("EnableBonuses");
         lblFacultyXpMultiplier = new CampaignOptionsLabel("FacultyXpMultiplier");
-        spnFacultyXpMultiplier = new CampaignOptionsSpinner("FacultyXpMultiplier",
-            1.00, 0.00, 10.00, 0.01);
+        spnFacultyXpMultiplier = new CampaignOptionsSpinner("FacultyXpMultiplier", 1.00, 0.00, 10.00, 0.01);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("XpAndSkillBonusesPanel", true,
-            "XpAndSkillBonusesPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("XpAndSkillBonusesPanel", true, "XpAndSkillBonusesPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridx = 0;
@@ -1068,8 +1091,8 @@ public class BiographyTab {
      * <p>
      * This includes:
      * <p>
-     *     <li>Setting the dropout chance for adults.</li>
-     *     <li>Setting the dropout chance for children.</li>
+     * <li>Setting the dropout chance for adults.</li>
+     * <li>Setting the dropout chance for children.</li>
      * </p>
      *
      * @return A {@code JPanel} for managing dropout chance settings.
@@ -1077,15 +1100,12 @@ public class BiographyTab {
     private JPanel createDropoutChancePanel() {
         // Contents
         lblAdultDropoutChance = new CampaignOptionsLabel("AdultDropoutChance");
-        spnAdultDropoutChance = new CampaignOptionsSpinner("AdultDropoutChance",
-            1000, 0, 100000, 1);
+        spnAdultDropoutChance = new CampaignOptionsSpinner("AdultDropoutChance", 1000, 0, 100000, 1);
         lblChildrenDropoutChance = new CampaignOptionsLabel("ChildrenDropoutChance");
-        spnChildrenDropoutChance = new CampaignOptionsSpinner("ChildrenDropoutChance",
-            10000, 0, 100000, 1);
+        spnChildrenDropoutChance = new CampaignOptionsSpinner("ChildrenDropoutChance", 10000, 0, 100000, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("DropoutChancePanel", true,
-            "DropoutChancePanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("DropoutChancePanel", true, "DropoutChancePanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridwidth = 1;
@@ -1109,8 +1129,8 @@ public class BiographyTab {
      * <p>
      * This includes:
      * <p>
-     *     <li>Toggling settings for all-age accidents.</li>
-     *     <li>Configuring the frequency of military academy accidents.</li>
+     * <li>Toggling settings for all-age accidents.</li>
+     * <li>Configuring the frequency of military academy accidents.</li>
      * </p>
      *
      * @return A {@code JPanel} containing the accidents and events configuration UI.
@@ -1119,12 +1139,12 @@ public class BiographyTab {
         // Contents
         chkAllAges = new CampaignOptionsCheckBox("AllAges");
         lblMilitaryAcademyAccidents = new CampaignOptionsLabel("MilitaryAcademyAccidents");
-        spnMilitaryAcademyAccidents = new CampaignOptionsSpinner("MilitaryAcademyAccidents",
-            10000, 0, 100000, 1);
+        spnMilitaryAcademyAccidents = new CampaignOptionsSpinner("MilitaryAcademyAccidents", 10000, 0, 100000, 1);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("AccidentsAndEventsPanel", true,
-            "AccidentsAndEventsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("AccidentsAndEventsPanel",
+              true,
+              "AccidentsAndEventsPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
 
         layout.gridx = 0;
@@ -1155,7 +1175,7 @@ public class BiographyTab {
     public JPanel createNameAndPortraitGenerationTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("NameAndPortraitGenerationTab",
-            getImageDirectory() + "logo_clan_nova_cat.png");
+              getImageDirectory() + "logo_clan_nova_cat.png");
 
         // Contents
         chkAssignPortraitOnRoleChange = new CampaignOptionsCheckBox("AssignPortraitOnRoleChange");
@@ -1213,8 +1233,8 @@ public class BiographyTab {
      * <p>
      * This includes:
      * <p>
-     *     <li>Options to enable or disable the use of role-specific portraits.</li>
-     *     <li>Buttons to toggle all or no portrait options collectively.</li>
+     * <li>Options to enable or disable the use of role-specific portraits.</li>
+     * <li>Buttons to toggle all or no portrait options collectively.</li>
      * </p>
      *
      * @return A {@code JPanel} containing the random portrait generation configuration UI.
@@ -1240,11 +1260,9 @@ public class BiographyTab {
         });
 
         // Layout the Panel
-        JPanel panel = new JPanel(
-            new GridLayout((int) Math.ceil((personnelRoles.length + 2) / 5.0), 5));
-        panel.setBorder(BorderFactory.createTitledBorder(
-            String.format(String.format("<html>%s</html>",
-                resources.getString("lblRandomPortraitPanel.text")))));
+        JPanel panel = new JPanel(new GridLayout((int) Math.ceil((personnelRoles.length + 2) / 5.0), 5));
+        panel.setBorder(BorderFactory.createTitledBorder(String.format(String.format("<html>%s</html>",
+              resources.getString("lblRandomPortraitPanel.text")))));
 
         panel.add(btnEnableAllPortraits);
         panel.add(btnDisableAllPortraits);
@@ -1274,7 +1292,8 @@ public class BiographyTab {
     public JPanel createRankTab() {
         // Header
         JPanel headerPanel = new CampaignOptionsHeaderPanel("RankTab",
-            getImageDirectory() + "logo_umayyad_caliphate.png", true);
+              getImageDirectory() + "logo_umayyad_caliphate.png",
+              true);
 
         // Contents
         Component rankSystemsViewport = rankSystemsPane.getViewport().getView();
@@ -1305,9 +1324,10 @@ public class BiographyTab {
     /**
      * Loads values from campaign options, optionally integrating with presets for default settings.
      *
-     * @param presetCampaignOptions Optional preset campaign options, or `null` to use the campaign's active settings.
+     * @param presetCampaignOptions     Optional preset campaign options, or `null` to use the campaign's active
+     *                                  settings.
      * @param presetRandomOriginOptions Optional random origin options, or `null` to use the default origin settings.
-     * @param presetRankSystem Optional rank system, or `null` to use the default system.
+     * @param presetRankSystem          Optional rank system, or `null` to use the default system.
      */
     public void loadValuesFromCampaignOptions(@Nullable CampaignOptions presetCampaignOptions,
                                               @Nullable RandomOriginOptions presetRandomOriginOptions,
@@ -1336,6 +1356,7 @@ public class BiographyTab {
         chkAnnounceBirthdays.setSelected(options.isAnnounceBirthdays());
         chkAnnounceChildBirthdays.setSelected(options.isAnnounceChildBirthdays());
         chkAnnounceRecruitmentAnniversaries.setSelected(options.isAnnounceRecruitmentAnniversaries());
+        chkShowLifeEventDialogComingOfAge.setSelected(options.isShowLifeEventDialogComingOfAge());
 
         // Backgrounds
         chkUseRandomPersonalities.setSelected(options.isUseRandomPersonalities());
@@ -1396,15 +1417,14 @@ public class BiographyTab {
     }
 
     /**
-     * Applies the current settings from the market UI components back into
-     * the {@link CampaignOptions} of the associated campaign.
+     * Applies the current settings from the market UI components back into the {@link CampaignOptions} of the
+     * associated campaign.
      * <p>
-     * If a preset options object is provided, the changes are applied there.
-     * Otherwise, they are applied to the current campaign's options.
+     * If a preset options object is provided, the changes are applied there. Otherwise, they are applied to the current
+     * campaign's options.
      *
-     * @param presetCampaignOptions A {@link CampaignOptions} object to update
-     *                              with the current UI settings, or {@code null}
-     *                              to apply changes to the campaign's options directly.
+     * @param presetCampaignOptions A {@link CampaignOptions} object to update with the current UI settings, or
+     *                              {@code null} to apply changes to the campaign's options directly.
      */
     public void applyCampaignOptionsToCampaign(@Nullable CampaignOptions presetCampaignOptions) {
         CampaignOptions options = presetCampaignOptions;
@@ -1425,6 +1445,7 @@ public class BiographyTab {
         options.setAnnounceBirthdays(chkAnnounceBirthdays.isSelected());
         options.setAnnounceChildBirthdays(chkAnnounceChildBirthdays.isSelected());
         options.setAnnounceRecruitmentAnniversaries(chkAnnounceRecruitmentAnniversaries.isSelected());
+        options.setShowLifeEventDialogComingOfAge(chkShowLifeEventDialogComingOfAge.isSelected());
 
         // Backgrounds
         options.setUseRandomPersonalities(chkUseRandomPersonalities.isSelected());
@@ -1437,9 +1458,9 @@ public class BiographyTab {
         originOptions.setRandomizeAroundSpecifiedPlanet(chkRandomizeAroundSpecifiedPlanet.isSelected());
 
         Planet selectedPlanet = comboSpecifiedPlanet.getSelectedItem();
-        originOptions.setSpecifiedPlanet(selectedPlanet == null
-                                               ? Systems.getInstance().getSystemById("Terra").getPrimaryPlanet()
-                                               : selectedPlanet);
+        originOptions.setSpecifiedPlanet(selectedPlanet == null ?
+                                               Systems.getInstance().getSystemById("Terra").getPrimaryPlanet() :
+                                               selectedPlanet);
 
         originOptions.setOriginSearchRadius((int) spnOriginSearchRadius.getValue());
         originOptions.setOriginDistanceScale((double) spnOriginDistanceScale.getValue());
@@ -1451,8 +1472,8 @@ public class BiographyTab {
         options.setUseRandomDeathSuicideCause(chkUseRandomDeathSuicideCause.isSelected());
         options.setRandomDeathMultiplier((double) spnRandomDeathMultiplier.getValue());
         for (final AgeGroup ageGroup : AgeGroup.values()) {
-            options.getEnabledRandomDeathAgeGroups().put(ageGroup,
-                chkEnabledRandomDeathAgeGroups.get(ageGroup).isSelected());
+            options.getEnabledRandomDeathAgeGroups()
+                  .put(ageGroup, chkEnabledRandomDeathAgeGroups.get(ageGroup).isSelected());
         }
 
         // Education


### PR DESCRIPTION
- Introduced the `ComingOfAgeAnnouncement` class to handle life event dialogs when characters come of age in campaigns.
- Updated the `CampaignOptions` to include a setting (`showLifeEventDialogComingOfAge`) enabling players to toggle the feature.
- Integrated the life event dialog into the `processAnniversaries` logic for characters turning 16.
- Added a new panel in the campaign options UI to manage life events preferences.
- Updated resource files to include labels and tooltips related to the "Coming of Age" setting.
- Ensured proper serialization of the new setting in campaign save/load behavior.

### Dev Notes
Characters 'coming of age' (turning 16) is an important event in MekHQ, as it marks the point in which the character can be assigned a Profession - such as MekWarrior. Previously it was nearly impossible to keep track of this, unless you were watching the daily log like a hawk.

This PR turns such moments into an event with 80 possible narrative Immersive Dialogs: 50 variants, where a parent contacts their 'commander' (the player); 10 variants for if the child has no parents; 10 variants for if the campaign commander is the parent and they're being contacted by the other parent; 10 variants for if the campaign commander is the parent and there is no other parent.

![image](https://github.com/user-attachments/assets/e516fcb6-7b9d-4743-9ac3-d36a69c3820d)
