### PR TITLE
Added Support for Optional Image Icons in Immersive Dialogs

### DIFF
--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -358,6 +358,7 @@ public class CurrentLocation {
                       inCharacterMessage,
                       null,
                       outOfCharacterMessage,
+                      null,
                       false);
                 break;
             }

--- a/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillDeprecationTool.java
@@ -178,6 +178,7 @@ public class SkillDeprecationTool {
                   getInCharacterMessage(skillName),
                   getButtonLabels(),
                   getOutOfCharacterMessage(skillName, refundValue),
+                  null,
                   true);
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/BirthAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/BirthAnnouncement.java
@@ -86,6 +86,7 @@ public class BirthAnnouncement {
               inCharacterMessage,
               getButtonLabels(parentFirstName),
               outOfCharacterMessage,
+              null,
               true);
 
         if (dialog.getDialogChoice() == SUPPRESS_DIALOG_RESPONSE_INDEX) {

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/ComingOfAgeAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/ComingOfAgeAnnouncement.java
@@ -106,6 +106,7 @@ public class ComingOfAgeAnnouncement {
               inCharacterMessage,
               getButtonLabels(birthdayHaverFirstName),
               outOfCharacterMessage,
+              null,
               true);
 
         if (dialog.getDialogChoice() == SUPPRESS_DIALOG_RESPONSE_INDEX) {

--- a/MekHQ/src/mekhq/campaign/randomEvents/MercenaryAuction.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/MercenaryAuction.java
@@ -27,13 +27,6 @@
  */
 package mekhq.campaign.randomEvents;
 
-import megamek.common.Entity;
-import megamek.logging.MMLogger;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.stratcon.StratconCampaignState;
-import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
-import mekhq.gui.dialog.MercenaryAuctionDialog;
-
 import static java.lang.Math.max;
 import static megamek.common.Compute.d6;
 import static megamek.common.Compute.randomInt;
@@ -43,6 +36,13 @@ import static mekhq.campaign.mission.AtBDynamicScenarioFactory.getEntity;
 import static mekhq.campaign.mission.BotForceRandomizer.UNIT_WEIGHT_UNSPECIFIED;
 import static mekhq.campaign.unit.Unit.getRandomUnitQuality;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import megamek.common.Entity;
+import megamek.logging.MMLogger;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.stratcon.StratconCampaignState;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+import mekhq.gui.dialog.MercenaryAuctionDialog;
 
 /**
  * This class handles the logic for determining auction eligibility based on the player's resources and provides the
@@ -66,7 +66,8 @@ public class MercenaryAuction {
      * @param campaign The current {@link Campaign} instance where the auction takes place.
      * @param unitType The type of unit being auctioned (e.g., `MECH`, `VEHICLE`).
      */
-    public MercenaryAuction(Campaign campaign, int requiredCombatTeams, StratconCampaignState campaignState, int unitType) {
+    public MercenaryAuction(Campaign campaign, int requiredCombatTeams, StratconCampaignState campaignState,
+                            int unitType) {
         String faction = campaign.getFaction().getShortName();
 
         Entity entity = getEntity(faction,
@@ -112,6 +113,7 @@ public class MercenaryAuction {
                   inCharacterMessage,
                   null,
                   outOfCharacterMessage,
+                  null,
                   true);
             return;
         }
@@ -148,6 +150,7 @@ public class MercenaryAuction {
                       getFormattedTextAt(RESOURCE_BUNDLE, "auction.successful", entity.getChassis(), deliveryTime),
                       null,
                       null,
+                      null,
                       true);
             } else {
                 // This dialog informs the player their bid was unsuccessful
@@ -155,6 +158,7 @@ public class MercenaryAuction {
                       campaign.getSeniorAdminPerson(TRANSPORT),
                       null,
                       getFormattedTextAt(RESOURCE_BUNDLE, "auction.failure", entity.getChassis()),
+                      null,
                       null,
                       null,
                       true);

--- a/MekHQ/src/mekhq/campaign/randomEvents/RoninOffer.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/RoninOffer.java
@@ -28,6 +28,28 @@
  */
 package mekhq.campaign.randomEvents;
 
+import static megamek.common.Compute.randomInt;
+import static megamek.common.enums.SkillLevel.VETERAN;
+import static megamek.common.options.PilotOptions.LVL3_ADVANTAGES;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
+import static mekhq.campaign.finances.enums.TransactionType.RECRUITMENT;
+import static mekhq.campaign.personnel.PersonUtility.overrideSkills;
+import static mekhq.campaign.personnel.PersonUtility.reRollAdvantages;
+import static mekhq.campaign.personnel.PersonUtility.reRollLoyalty;
+import static mekhq.campaign.personnel.enums.PersonnelRole.AEROSPACE_PILOT;
+import static mekhq.campaign.personnel.enums.PersonnelRole.MEKWARRIOR;
+import static mekhq.campaign.randomEvents.personalities.PersonalityController.PersonalityTraitType.AGGRESSION;
+import static mekhq.campaign.randomEvents.personalities.PersonalityController.PersonalityTraitType.AMBITION;
+import static mekhq.campaign.randomEvents.personalities.PersonalityController.PersonalityTraitType.GREED;
+import static mekhq.campaign.randomEvents.personalities.PersonalityController.PersonalityTraitType.SOCIAL;
+import static mekhq.campaign.randomEvents.personalities.PersonalityController.generateBigPersonality;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.codeUtilities.ObjectUtility;
 import megamek.common.annotations.Nullable;
@@ -47,28 +69,6 @@ import mekhq.campaign.randomEvents.personalities.enums.Greed;
 import mekhq.campaign.randomEvents.personalities.enums.Social;
 import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-
-import static megamek.common.Compute.randomInt;
-import static megamek.common.enums.SkillLevel.VETERAN;
-import static megamek.common.options.PilotOptions.LVL3_ADVANTAGES;
-import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
-import static mekhq.campaign.finances.enums.TransactionType.RECRUITMENT;
-import static mekhq.campaign.personnel.PersonUtility.overrideSkills;
-import static mekhq.campaign.personnel.PersonUtility.reRollAdvantages;
-import static mekhq.campaign.personnel.PersonUtility.reRollLoyalty;
-import static mekhq.campaign.personnel.enums.PersonnelRole.AEROSPACE_PILOT;
-import static mekhq.campaign.personnel.enums.PersonnelRole.MEKWARRIOR;
-import static mekhq.campaign.randomEvents.personalities.PersonalityController.PersonalityTraitType.AGGRESSION;
-import static mekhq.campaign.randomEvents.personalities.PersonalityController.PersonalityTraitType.AMBITION;
-import static mekhq.campaign.randomEvents.personalities.PersonalityController.PersonalityTraitType.GREED;
-import static mekhq.campaign.randomEvents.personalities.PersonalityController.PersonalityTraitType.SOCIAL;
-import static mekhq.campaign.randomEvents.personalities.PersonalityController.generateBigPersonality;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * Represents a dialog and associated logic for presenting the player with a Ronin offer. The Ronin offer involves
@@ -131,7 +131,8 @@ public class RoninOffer {
      * @param campaignState       The optional {@link StratconCampaignState} providing strategic information.
      * @param requiredCombatTeams The number of combat teams required for the recruitment.
      */
-    private void displayAndProcessConversation(Campaign campaign, Person ronin, StratconCampaignState campaignState, int requiredCombatTeams) {
+    private void displayAndProcessConversation(Campaign campaign, Person ronin, StratconCampaignState campaignState,
+                                               int requiredCombatTeams) {
         String commanderAddress = campaign.getCommanderAddress(false);
         int response = displayInitialMessage(commanderAddress, ronin.getCallsign());
         if (response != ACCEPT_DIALOG_CHOICE_INDEX) {
@@ -188,6 +189,7 @@ public class RoninOffer {
               centerMessage,
               buttonLabels,
               null,
+              null,
               true);
 
         return initialMessage.getDialogChoice();
@@ -207,7 +209,8 @@ public class RoninOffer {
      *
      * @return An integer representing the player's choice from the dialog.
      */
-    private int displayRoninMessage(Person ronin, String commanderAddress, boolean useFallbackHiringFee, int requiredCombatTeams, @Nullable Integer availableSupportPoints) {
+    private int displayRoninMessage(Person ronin, String commanderAddress, boolean useFallbackHiringFee,
+                                    int requiredCombatTeams, @Nullable Integer availableSupportPoints) {
         String centerMessage = createRoninMessage(ronin, commanderAddress);
 
         List<String> buttonLabels = new ArrayList<>();
@@ -227,6 +230,7 @@ public class RoninOffer {
               centerMessage,
               buttonLabels,
               outOfCharacterMessage,
+              null,
               true);
 
         return initialMessage.getDialogChoice();
@@ -322,7 +326,8 @@ public class RoninOffer {
      *
      * @return A {@link String} containing formatted out-of-character details for the player.
      */
-    private String createRoninOutOfCharacterMessage(Person ronin, boolean useFallbackHiringFee, int requiredCombatTeams, @Nullable Integer availableSupportPoints) {
+    private String createRoninOutOfCharacterMessage(Person ronin, boolean useFallbackHiringFee, int requiredCombatTeams,
+                                                    @Nullable Integer availableSupportPoints) {
         StringBuilder report = new StringBuilder();
 
         report.append(buildCostString(useFallbackHiringFee, requiredCombatTeams, availableSupportPoints));
@@ -378,7 +383,8 @@ public class RoninOffer {
      *
      * @return A {@link String} containing the formatted cost information.
      */
-    private String buildCostString(boolean useFallbackHiringFee, int requiredCombatTeams, @Nullable Integer availableSupportPoints) {
+    private String buildCostString(boolean useFallbackHiringFee, int requiredCombatTeams,
+                                   @Nullable Integer availableSupportPoints) {
         String addendumKey = useFallbackHiringFee ? "message.ooc.cBills" : "message.ooc.supportPoints";
         String addendum = getFormattedTextAt(RESOURCE_BUNDLE, addendumKey);
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1662,19 +1662,19 @@ public class CampaignGUI extends JPanel {
                 }
 
                 name = "<html>" +
-                       tech.getFullName() +
-                       ", <b>" +
-                       SkillType.getColoredExperienceLevelName(tech.getSkillLevel(getCampaign(), false)) +
-                       "</b> " +
-                       tech.getPrimaryRoleDesc() +
-                       " (" +
-                       getCampaign().getTargetFor(r, tech).getValueAsString() +
-                       "+), " +
-                       tech.getMinutesLeft() +
-                       '/' +
+                             tech.getFullName() +
+                             ", <b>" +
+                             SkillType.getColoredExperienceLevelName(tech.getSkillLevel(getCampaign(), false)) +
+                             "</b> " +
+                             tech.getPrimaryRoleDesc() +
+                             " (" +
+                             getCampaign().getTargetFor(r, tech).getValueAsString() +
+                             "+), " +
+                             tech.getMinutesLeft() +
+                             '/' +
                              tech.getDailyAvailableTechTime(getCampaign().getCampaignOptions()
                                                                   .isTechsUseAdministration()) +
-                       " minutes</html>";
+                             " minutes</html>";
                 techHash.put(name, tech);
                 if (tech.isRightTechTypeFor(r)) {
                     techList.add(lastRightTech++, name);
@@ -2594,6 +2594,7 @@ public class CampaignGUI extends JPanel {
                   inCharacterMessage,
                   null,
                   outOfCharacterMessage,
+                  null,
                   false);
 
             dayEndingEvent.cancel();
@@ -2635,6 +2636,7 @@ public class CampaignGUI extends JPanel {
                   inCharacterMessage,
                   null,
                   outOfCharacterMessage,
+                  null,
                   false);
 
             dayEndingEvent.cancel();

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
@@ -267,17 +267,6 @@ public class ImmersiveDialogCore extends JDialog {
         // Buttons panel
         JPanel buttonPanel = populateButtonPanel(buttons, isVerticalLayout, spinnerPanel);
 
-        // Create a JLabel for the image above the JEditorPane
-        JLabel imageLabel = new JLabel();
-        if (imageIcon != null) {
-            if (imageIcon.getIconWidth() > IMAGE_WIDTH) {
-                imageIcon = ImageUtilities.scaleImageIconToWidth(imageIcon, CENTER_WIDTH);
-            }
-            imageLabel.setIcon(imageIcon);
-            imageLabel.setHorizontalAlignment(SwingConstants.CENTER);
-            imageLabel.setBorder(BorderFactory.createEmptyBorder(PADDING, 0, PADDING, 0));
-        }
-
         // Create a JEditorPane for the center message
         JEditorPane editorPane = new JEditorPane();
         editorPane.setContentType("text/html");
@@ -307,6 +296,23 @@ public class ImmersiveDialogCore extends JDialog {
         JPanel scrollPaneContainer = new JPanel(new BorderLayout());
         scrollPaneContainer.setBorder(BorderFactory.createEmptyBorder(PADDING, 0, PADDING, 0));
         scrollPaneContainer.add(scrollPane, BorderLayout.CENTER);
+
+        // Create a JLabel for the image above the JEditorPane
+        JLabel imageLabel = new JLabel();
+        if (imageIcon != null) {
+            if (imageIcon.getIconWidth() > CENTER_WIDTH) {
+                imageIcon = ImageUtilities.scaleImageIcon(imageIcon, CENTER_WIDTH, true);
+            }
+
+            int heightLimit = max(1, CENTER_WIDTH / 3); // I went with 3 because that provided the best feel
+            if (imageIcon.getIconHeight() > heightLimit) {
+                imageIcon = ImageUtilities.scaleImageIcon(imageIcon, heightLimit, false);
+            }
+
+            imageLabel.setIcon(imageIcon);
+            imageLabel.setHorizontalAlignment(SwingConstants.CENTER);
+            imageLabel.setBorder(BorderFactory.createEmptyBorder(PADDING, 0, PADDING, 0));
+        }
 
         // Create a panel for the image and editorPane
         JPanel contentPanel = new JPanel();

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
@@ -60,6 +60,7 @@ import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.GlossaryDialog;
+import mekhq.utilities.ImageUtilities;
 
 /**
  * An immersive dialog used in MekHQ to display interactions between speakers, messages, and actions. The dialog
@@ -149,7 +150,11 @@ public class ImmersiveDialogCore extends JDialog {
      * @param spinnerPanel          An optional {@link JPanel} containing a spinner widget to be displayed in the center
      *                              panel; use {@code null} if not applicable.
      */
-    public ImmersiveDialogCore(Campaign campaign, @Nullable Person leftSpeaker, @Nullable Person rightSpeaker, String centerMessage, List<ButtonLabelTooltipPair> buttons, @Nullable String outOfCharacterMessage, @Nullable Integer centerWidth, boolean isVerticalLayout, @Nullable JPanel spinnerPanel, boolean isModal) {
+    public ImmersiveDialogCore(Campaign campaign, @Nullable Person leftSpeaker, @Nullable Person rightSpeaker,
+                               String centerMessage, List<ButtonLabelTooltipPair> buttons,
+                               @Nullable String outOfCharacterMessage, @Nullable Integer centerWidth,
+                               boolean isVerticalLayout, @Nullable JPanel spinnerPanel, @Nullable ImageIcon imageIcon,
+                               boolean isModal) {
         // Initialize
         this.campaign = campaign;
         this.leftSpeaker = leftSpeaker;
@@ -184,7 +189,7 @@ public class ImmersiveDialogCore extends JDialog {
         }
 
         // Center box for the message
-        JPanel pnlCenter = createCenterBox(centerMessage, buttons, isVerticalLayout, spinnerPanel);
+        JPanel pnlCenter = createCenterBox(centerMessage, buttons, isVerticalLayout, spinnerPanel, imageIcon);
         constraints.gridx = gridx;
         constraints.gridy = 0;
         constraints.weightx = 2;
@@ -255,12 +260,23 @@ public class ImmersiveDialogCore extends JDialog {
      *
      * @return A {@link JPanel} with the message displayed in the center and buttons at the bottom.
      */
-    private JPanel createCenterBox(String centerMessage, List<ButtonLabelTooltipPair> buttons, boolean isVerticalLayout, @Nullable JPanel spinnerPanel) {
+    private JPanel createCenterBox(String centerMessage, List<ButtonLabelTooltipPair> buttons, boolean isVerticalLayout,
+                                   @Nullable JPanel spinnerPanel, @Nullable ImageIcon imageIcon) {
         northPanel = new JPanel(new BorderLayout());
 
         // Buttons panel
         JPanel buttonPanel = populateButtonPanel(buttons, isVerticalLayout, spinnerPanel);
 
+        // Create a JLabel for the image above the JEditorPane
+        JLabel imageLabel = new JLabel();
+        if (imageIcon != null) {
+            if (imageIcon.getIconWidth() > IMAGE_WIDTH) {
+                imageIcon = ImageUtilities.scaleImageIconToWidth(imageIcon, CENTER_WIDTH);
+            }
+            imageLabel.setIcon(imageIcon);
+            imageLabel.setHorizontalAlignment(SwingConstants.CENTER);
+            imageLabel.setBorder(BorderFactory.createEmptyBorder(PADDING, 0, PADDING, 0));
+        }
 
         // Create a JEditorPane for the center message
         JEditorPane editorPane = new JEditorPane();
@@ -276,10 +292,9 @@ public class ImmersiveDialogCore extends JDialog {
               fontStyle,
               centerMessage));
         setFontScaling(editorPane, false, 1.1);
+
         // Add a HyperlinkListener to capture hyperlink clicks
-        editorPane.addHyperlinkListener(evt -> {
-            hyperlinkEventListenerActions(evt);
-        });
+        editorPane.addHyperlinkListener(this::hyperlinkEventListenerActions);
 
         // Wrap the JEditorPane in a JScrollPane
         JScrollPane scrollPane = new JScrollPane(editorPane);
@@ -293,12 +308,18 @@ public class ImmersiveDialogCore extends JDialog {
         scrollPaneContainer.setBorder(BorderFactory.createEmptyBorder(PADDING, 0, PADDING, 0));
         scrollPaneContainer.add(scrollPane, BorderLayout.CENTER);
 
-        // Add the scrollPane with padding to the northPanel
-        northPanel.add(scrollPaneContainer, BorderLayout.CENTER);
+        // Create a panel for the image and editorPane
+        JPanel contentPanel = new JPanel();
+        contentPanel.setLayout(new BorderLayout());
+        if (imageIcon != null) {
+            contentPanel.add(imageLabel, BorderLayout.NORTH);
+        }
+        contentPanel.add(scrollPaneContainer, BorderLayout.CENTER);
 
-        // Ensure the scrollbars default to the top-left position
-        SwingUtilities.invokeLater(() -> scrollPane.getViewport().setViewPosition(new Point(0, 0)));
+        // Add the contentPanel to the northPanel
+        northPanel.add(contentPanel, BorderLayout.CENTER);
 
+        // Add the buttons panel to the northPanel
         northPanel.add(buttonPanel, BorderLayout.SOUTH);
 
         return northPanel;
@@ -414,7 +435,8 @@ public class ImmersiveDialogCore extends JDialog {
      * @param isVerticalLayout A {@code boolean} value indicating the layout style: {@code true} for vertical stacking,
      *                         {@code false} for horizontal arrangement.
      */
-    protected JPanel populateButtonPanel(List<ButtonLabelTooltipPair> buttons, boolean isVerticalLayout, @Nullable JPanel spinnerPanel) {
+    protected JPanel populateButtonPanel(List<ButtonLabelTooltipPair> buttons, boolean isVerticalLayout,
+                                         @Nullable JPanel spinnerPanel) {
         final int padding = getPADDING();
 
         // Main container panel to hold the spinner and button panel

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogNag.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogNag.java
@@ -112,7 +112,8 @@ public class ImmersiveDialogNag {
      * @param messageKey     A {@code String} key to retrieve localized text for the in-character and out-of-character
      *                       messages from the resource bundle.
      */
-    public ImmersiveDialogNag(final Campaign campaign, final @Nullable AdministratorSpecialization specialization, final String nagConstant, final String messageKey) {
+    public ImmersiveDialogNag(final Campaign campaign, final @Nullable AdministratorSpecialization specialization,
+                              final String nagConstant, final String messageKey) {
         ImmersiveDialogCore dialog = constructDialog(campaign, specialization, messageKey);
         processDialogChoice(dialog.getDialogChoice(), nagConstant);
     }
@@ -133,7 +134,8 @@ public class ImmersiveDialogNag {
      * @return The constructed {@link ImmersiveDialogSimple} instance containing the specified speaker, messages, and
      *       button labels.
      */
-    protected ImmersiveDialogCore constructDialog(Campaign campaign, AdministratorSpecialization specialization, String messageKey) {
+    protected ImmersiveDialogCore constructDialog(Campaign campaign, AdministratorSpecialization specialization,
+                                                  String messageKey) {
         return new ImmersiveDialogCore(campaign,
               getSpeaker(campaign, specialization),
               null,
@@ -142,6 +144,7 @@ public class ImmersiveDialogNag {
               getOutOfCharacterMessage(messageKey),
               null,
               true,
+              null,
               null,
               true);
     }

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogNag.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogNag.java
@@ -145,7 +145,7 @@ public class ImmersiveDialogNag {
               null,
               true,
               null,
-              null,
+              campaign.getCampaignFactionIcon(),
               true);
     }
 

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogSimple.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogSimple.java
@@ -27,14 +27,15 @@
  */
 package mekhq.gui.baseComponents.immersiveDialogs;
 
-import megamek.common.annotations.Nullable;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.Person;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.ImageIcon;
 
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import megamek.common.annotations.Nullable;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
 
 /**
  * A generic immersive message dialog for providing information to the player in the campaign.
@@ -51,25 +52,37 @@ public class ImmersiveDialogSimple extends ImmersiveDialogCore {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.GUI";
 
     /**
-     * Constructs a {@code GenericImmersiveMessageDialog} with the specified campaign and message details.
+     * Constructs a {@code GenericImmersiveMessageDialog} with the specified campaign, message details, and optional
+     * image and layout configuration.
      *
-     * <p>This dialog represents an immersive interaction, typically involving the appearance
-     * of one or two characters "speaking" to the player. The dialog is modal by default, and it provides customizable
-     * button labels for user interaction, with the commonly used button being "Understood" for closing the dialog.</p>
+     * <p>This dialog represents an immersive interaction, typically involving one or two characters
+     * "speaking" to the player. It provides a central message area, optional image display above the content, and
+     * customizable buttons for user interaction. The dialog is modal by default, blocking other interactions until it
+     * is closed.</p>
      *
      * @param campaign              The current game state, providing relevant campaign data.
      * @param leftSpeaker           The {@link Person} appearing as the left speaker, or {@code null} if no speaker is
-     *                              present on the left side.
+     *                              displayed on the left side.
      * @param rightSpeaker          The {@link Person} appearing as the right speaker, or {@code null} if no speaker is
-     *                              present on the right side.
-     * @param centerMessage         The primary message to be displayed in the center of the dialog.
+     *                              displayed on the right side.
+     * @param centerMessage         The primary message to be displayed in the center of the dialog. This typically
+     *                              conveys the main information or narrative of the dialog.
      * @param buttonLabels          A {@link List} of custom button labels to display in the dialog. If the list is
      *                              {@code null}, a default "Understood" button is displayed.
      * @param outOfCharacterMessage An optional out-of-character (OOC) message, or {@code null} if not applicable. This
-     *                              message is displayed in a non-character context, usually to provide additional
-     *                              information or context to the player.
+     *                              message is displayed outside the dialog's in-character context, usually to provide
+     *                              additional explanation or game-related information to the player.
+     * @param imageIcon             An optional {@link ImageIcon}, or {@code null} if not applicable. If specified, the
+     *                              image will appear above the center message to highlight or visually support the
+     *                              dialog's content. For example, it can represent a symbol, character, or important
+     *                              visual cue.
+     * @param useVerticalLayout     A boolean flag indicating whether to use a vertical layout. If {@code true}, the
+     *                              buttons are stacked vertically; otherwise, they are arranged side-by-side.
      */
-    public ImmersiveDialogSimple(Campaign campaign, @Nullable Person leftSpeaker, @Nullable Person rightSpeaker, String centerMessage, @Nullable List<String> buttonLabels, @Nullable String outOfCharacterMessage, boolean useVerticalLayout) {
+    public ImmersiveDialogSimple(Campaign campaign, @Nullable Person leftSpeaker, @Nullable Person rightSpeaker,
+                                 String centerMessage, @Nullable List<String> buttonLabels,
+                                 @Nullable String outOfCharacterMessage, @Nullable ImageIcon imageIcon,
+                                 boolean useVerticalLayout) {
         super(campaign,
               leftSpeaker,
               rightSpeaker,
@@ -79,6 +92,7 @@ public class ImmersiveDialogSimple extends ImmersiveDialogCore {
               null,
               useVerticalLayout,
               null,
+              imageIcon,
               true);
     }
 

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogSimple.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogSimple.java
@@ -92,7 +92,7 @@ public class ImmersiveDialogSimple extends ImmersiveDialogCore {
               null,
               useVerticalLayout,
               null,
-              imageIcon,
+              imageIcon == null ? campaign.getCampaignFactionIcon() : imageIcon,
               true);
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/CampaignHasProblemOnLoad.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignHasProblemOnLoad.java
@@ -27,17 +27,17 @@
  */
 package mekhq.gui.dialog;
 
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.campaign.CampaignFactory.CampaignProblemType.CANT_LOAD_FROM_NEWER_VERSION;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.List;
+
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignFactory.CampaignProblemType;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import java.util.List;
-
-import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
-import static mekhq.campaign.CampaignFactory.CampaignProblemType.CANT_LOAD_FROM_NEWER_VERSION;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * Dialog to inform and handle campaign-loading problems within MekHQ.
@@ -72,6 +72,7 @@ public class CampaignHasProblemOnLoad extends ImmersiveDialogCore {
               createOutOfCharacterMessage(problemType),
               null,
               false,
+              null,
               null,
               true);
     }

--- a/MekHQ/src/mekhq/gui/dialog/DefectionOffer.java
+++ b/MekHQ/src/mekhq/gui/dialog/DefectionOffer.java
@@ -27,14 +27,14 @@
  */
 package mekhq.gui.dialog;
 
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.Person;
-import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.util.List;
 
-import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
 
 /**
  * Represents a dialog created when a prisoner wants to defect to the player's force.
@@ -64,6 +64,7 @@ public class DefectionOffer extends ImmersiveDialogCore {
               createOutOfCharacterMessage(isBondsman),
               null,
               false,
+              null,
               null,
               true);
     }

--- a/MekHQ/src/mekhq/gui/dialog/MercenaryAuctionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MercenaryAuctionDialog.java
@@ -76,7 +76,8 @@ public class MercenaryAuctionDialog extends ImmersiveDialogCore {
      * @param percentPerStep The percentage increment for the bid adjustments.
      * @param stepSize       The step size for each spinner adjustment.
      */
-    public MercenaryAuctionDialog(Campaign campaign, Entity entity, int minimumBid, int maximumBid, int percentPerStep, int stepSize) {
+    public MercenaryAuctionDialog(Campaign campaign, Entity entity, int minimumBid, int maximumBid, int percentPerStep,
+                                  int stepSize) {
         super(campaign,
               campaign.getSeniorAdminPerson(TRANSPORT),
               null,
@@ -86,6 +87,7 @@ public class MercenaryAuctionDialog extends ImmersiveDialogCore {
               null,
               false,
               createJSpinnerPanel(minimumBid, minimumBid, maximumBid, stepSize),
+              null,
               false);
 
         // This setup ensures the dialogs both operate as modal and also assign the entity being
@@ -169,7 +171,8 @@ public class MercenaryAuctionDialog extends ImmersiveDialogCore {
      *
      * @return The JPanel containing the spinner, or {@code null} if the default value is invalid.
      */
-    private static @Nullable JPanel createJSpinnerPanel(int defaultValue, int minimumValue, int maximumValue, int stepSize) {
+    private static @Nullable JPanel createJSpinnerPanel(int defaultValue, int minimumValue, int maximumValue,
+                                                        int stepSize) {
         JSpinner spinner = new JSpinner(new SpinnerNumberModel(defaultValue, minimumValue, maximumValue, stepSize));
         JLabel label = new JLabel(getFormattedTextAt(RESOURCE_BUNDLE, "spinner.label.auction"));
 

--- a/MekHQ/src/mekhq/gui/dialog/MissionEndPrisonerDefectorDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MissionEndPrisonerDefectorDialog.java
@@ -27,14 +27,14 @@
  */
 package mekhq.gui.dialog;
 
-import mekhq.campaign.Campaign;
-import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import mekhq.campaign.Campaign;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
 
 /**
  * Represents a dialog triggered at the end of a mission when the player has Prisoner Defectors they can recruit.
@@ -62,6 +62,7 @@ public class MissionEndPrisonerDefectorDialog extends ImmersiveDialogCore {
               createOutOfCharacterMessage(),
               null,
               false,
+              null,
               null,
               true);
     }

--- a/MekHQ/src/mekhq/gui/dialog/MissionEndPrisonerDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MissionEndPrisonerDialog.java
@@ -52,7 +52,8 @@ public class MissionEndPrisonerDialog extends ImmersiveDialogCore {
      * @param isSuccess   Indicates whether the mission was successful.
      * @param isGoodEvent Indicates whether the event is positive.
      */
-    public MissionEndPrisonerDialog(Campaign campaign, Money ransom, boolean isAllied, boolean isSuccess, boolean isGoodEvent) {
+    public MissionEndPrisonerDialog(Campaign campaign, Money ransom, boolean isAllied, boolean isSuccess,
+                                    boolean isGoodEvent) {
         super(campaign,
               getSpeaker(campaign),
               null,
@@ -61,6 +62,7 @@ public class MissionEndPrisonerDialog extends ImmersiveDialogCore {
               createOutOfCharacterMessage(isAllied, isSuccess, isGoodEvent),
               null,
               false,
+              null,
               null,
               true);
     }
@@ -79,7 +81,8 @@ public class MissionEndPrisonerDialog extends ImmersiveDialogCore {
      *
      * @return A list of button-label and tooltip pairs to be displayed on the dialog.
      */
-    private static List<ButtonLabelTooltipPair> createButtons(boolean isAllied, boolean isSuccess, boolean isGoodEvent) {
+    private static List<ButtonLabelTooltipPair> createButtons(boolean isAllied, boolean isSuccess,
+                                                              boolean isGoodEvent) {
         List<ButtonLabelTooltipPair> buttons = new ArrayList<>();
 
         boolean isRansom = (!isAllied && isSuccess && isGoodEvent) ||
@@ -133,7 +136,8 @@ public class MissionEndPrisonerDialog extends ImmersiveDialogCore {
      *
      * @return A formatted string containing the in-character dialog message.
      */
-    private static String createInCharacterMessage(Campaign campaign, Money ransomSum, boolean isAllied, boolean isSuccess, boolean isGoodEvent) {
+    private static String createInCharacterMessage(Campaign campaign, Money ransomSum, boolean isAllied,
+                                                   boolean isSuccess, boolean isGoodEvent) {
         String key = "prisoners." +
                            (isAllied ? "player" : "enemy") +
                            '.' +
@@ -172,7 +176,8 @@ public class MissionEndPrisonerDialog extends ImmersiveDialogCore {
      *
      * @return A formatted string containing the OOC dialog message, or {@code null} if no message is required.
      */
-    private static @Nullable String createOutOfCharacterMessage(boolean isAllied, boolean isSuccess, boolean isGoodEvent) {
+    private static @Nullable String createOutOfCharacterMessage(boolean isAllied, boolean isSuccess,
+                                                                boolean isGoodEvent) {
         boolean showMessage = (isAllied && !isSuccess && isGoodEvent);
 
         if (showMessage) {

--- a/MekHQ/src/mekhq/gui/dialog/NewsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewsDialog.java
@@ -27,19 +27,23 @@
  */
 package mekhq.gui.dialog;
 
+import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.util.List;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.NewsItem;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.List;
-
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * NewsDialog is a dialog window for displaying news items within the context of a campaign. It includes information
@@ -72,6 +76,7 @@ public class NewsDialog extends ImmersiveDialogCore {
               null,
               UIUtil.scaleForGUI(400),
               false,
+              null,
               null,
               true);
     }

--- a/MekHQ/src/mekhq/gui/dialog/ReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ReplacementLimbDialog.java
@@ -27,17 +27,17 @@
  */
 package mekhq.gui.dialog;
 
-import mekhq.campaign.Campaign;
-import mekhq.campaign.finances.Money;
-import mekhq.campaign.personnel.Person;
-import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
+import static mekhq.campaign.mod.am.InjuryTypes.REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
-import static mekhq.campaign.mod.am.InjuryTypes.REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.personnel.Person;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
 
 /**
  * A dialog for managing the replacement of limbs in a campaign. This immersive dialog provides an in-character message
@@ -75,6 +75,7 @@ public class ReplacementLimbDialog extends ImmersiveDialogCore {
               null,
               false,
               null,
+              null,
               true);
     }
 
@@ -97,7 +98,8 @@ public class ReplacementLimbDialog extends ImmersiveDialogCore {
      *
      * @return A {@link List} of {@link ButtonLabelTooltipPair} objects representing the dialog buttons.
      */
-    private static List<ButtonLabelTooltipPair> createButtons(boolean hasQualifiedDoctor, boolean isPlanetside, boolean hasSufficientFunds) {
+    private static List<ButtonLabelTooltipPair> createButtons(boolean hasQualifiedDoctor, boolean isPlanetside,
+                                                              boolean hasSufficientFunds) {
         List<ButtonLabelTooltipPair> buttons = new ArrayList<>();
 
         if (!hasSufficientFunds || (!hasQualifiedDoctor && !isPlanetside)) {
@@ -131,7 +133,9 @@ public class ReplacementLimbDialog extends ImmersiveDialogCore {
      *
      * @return A {@link String} containing the localized in-character message for the dialog.
      */
-    private static String createInCharacterMessage(boolean isPlanetside, boolean hasQualifiedDoctors, String commanderAddress, Person patient, Money cost, boolean hasSufficientFunds) {
+    private static String createInCharacterMessage(boolean isPlanetside, boolean hasQualifiedDoctors,
+                                                   String commanderAddress, Person patient, Money cost,
+                                                   boolean hasSufficientFunds) {
         String keyAddendum = "normal";
 
         if (!hasQualifiedDoctors && hasSufficientFunds) {

--- a/MekHQ/src/mekhq/gui/dialog/VocationalExperienceAwardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/VocationalExperienceAwardDialog.java
@@ -27,17 +27,17 @@
  */
 package mekhq.gui.dialog;
 
+import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.List;
+
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import java.util.List;
-
-import static mekhq.campaign.Campaign.AdministratorSpecialization.HR;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * A dialog that displays a notification to the commander about personnel who have advanced via vocational experience
@@ -70,6 +70,7 @@ public class VocationalExperienceAwardDialog extends ImmersiveDialogCore {
               createOutOfCharacterMessage(campaign),
               null,
               false,
+              null,
               null,
               true);
 

--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/GrayMondayDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/GrayMondayDialog.java
@@ -27,22 +27,26 @@
  */
 package mekhq.gui.dialog.randomEvents;
 
+import static mekhq.campaign.Campaign.AdministratorSpecialization.LOGISTICS;
+import static mekhq.campaign.randomEvents.GrayMonday.EVENT_DATE_GRAY_MONDAY;
+import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.time.LocalDate;
+import java.util.List;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.Factions;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import javax.swing.*;
-import java.awt.*;
-import java.time.LocalDate;
-import java.util.List;
-
-import static mekhq.campaign.Campaign.AdministratorSpecialization.LOGISTICS;
-import static mekhq.campaign.randomEvents.GrayMonday.EVENT_DATE_GRAY_MONDAY;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 public class GrayMondayDialog extends ImmersiveDialogCore {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.GrayMonday";
@@ -56,6 +60,7 @@ public class GrayMondayDialog extends ImmersiveDialogCore {
               createOutOfCharacterMessage(),
               null,
               false,
+              null,
               null,
               true);
     }

--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerEscapeeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerEscapeeScenarioDialog.java
@@ -27,15 +27,15 @@
  */
 package mekhq.gui.dialog.randomEvents.prisonerDialogs;
 
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.List;
+
 import mekhq.campaign.Campaign;
 import mekhq.campaign.stratcon.StratconCoords;
 import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import java.util.List;
-
-import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * Represents a dialog triggered after prisoners have been tracked down, culminating in a special scenario.
@@ -63,6 +63,7 @@ public class PrisonerEscapeeScenarioDialog extends ImmersiveDialogCore {
               createOutOfCharacterMessage(),
               null,
               false,
+              null,
               null,
               true);
     }

--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerEventDialog.java
@@ -27,16 +27,16 @@
  */
 package mekhq.gui.dialog.randomEvents.prisonerDialogs;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.randomEvents.prisoners.enums.PrisonerEvent;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * Represents a dialog triggered when a random prisoner event occurs, asking the player how they would like to resolve
@@ -74,6 +74,7 @@ public class PrisonerEventDialog extends ImmersiveDialogCore {
               createOutOfCharacterMessage(),
               null,
               true,
+              null,
               null,
               true);
     }

--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerEventResultsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerEventResultsDialog.java
@@ -27,15 +27,15 @@
  */
 package mekhq.gui.dialog.randomEvents.prisonerDialogs;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.List;
+
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.randomEvents.prisoners.enums.PrisonerEvent;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import java.util.List;
-
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * Represents a dialog triggered after a random prisoner event to communicate its results to the player.
@@ -62,7 +62,8 @@ public class PrisonerEventResultsDialog extends ImmersiveDialogCore {
      * @param isSuccessful {@code true} if the event concluded successfully, {@code false} if the event failed.
      * @param eventReport  A detailed report of the event's outcome, presented out-of-character for additional clarity.
      */
-    public PrisonerEventResultsDialog(Campaign campaign, @Nullable Person speaker, PrisonerEvent event, int choiceIndex, boolean isSuccessful, String eventReport) {
+    public PrisonerEventResultsDialog(Campaign campaign, @Nullable Person speaker, PrisonerEvent event, int choiceIndex,
+                                      boolean isSuccessful, String eventReport) {
         super(campaign,
               speaker,
               null,
@@ -71,6 +72,7 @@ public class PrisonerEventResultsDialog extends ImmersiveDialogCore {
               eventReport,
               null,
               false,
+              null,
               null,
               true);
     }
@@ -108,7 +110,8 @@ public class PrisonerEventResultsDialog extends ImmersiveDialogCore {
      *
      * @return A formatted string containing the in-character message describing the event results.
      */
-    private static String createInCharacterMessage(Campaign campaign, PrisonerEvent event, int choiceIndex, boolean isSuccessful) {
+    private static String createInCharacterMessage(Campaign campaign, PrisonerEvent event, int choiceIndex,
+                                                   boolean isSuccessful) {
         String suffix = isSuccessful ? SUFFIX_SUCCESS : SUFFIX_FAILURE;
         String commanderAddress = campaign.getCommanderAddress(false);
         return getFormattedTextAt(RESOURCE_BUNDLE,

--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerRansomEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerRansomEventDialog.java
@@ -27,15 +27,15 @@
  */
 package mekhq.gui.dialog.randomEvents.prisonerDialogs;
 
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.List;
+
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import java.util.List;
-
-import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * Represents a dialog triggered when the enemy offers a ransom deal for prisoners.
@@ -66,6 +66,7 @@ public class PrisonerRansomEventDialog extends ImmersiveDialogCore {
               createOutOfCharacterMessage(isFriendlyPOWs),
               null,
               false,
+              null,
               null,
               false);
 
@@ -110,7 +111,8 @@ public class PrisonerRansomEventDialog extends ImmersiveDialogCore {
      *
      * @return A formatted HTML string containing the narrative in-character message for the dialog.
      */
-    private static String createInCharacterMessage(Campaign campaign, Money payment, List<Person> prisoners, boolean isFriendlyPOWs) {
+    private static String createInCharacterMessage(Campaign campaign, Money payment, List<Person> prisoners,
+                                                   boolean isFriendlyPOWs) {
         String commanderAddress = campaign.getCommanderAddress(false);
         StringBuilder message = new StringBuilder();
         String key = isFriendlyPOWs ? "pows" : "prisoners";

--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerWarningDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerWarningDialog.java
@@ -27,14 +27,14 @@
  */
 package mekhq.gui.dialog.randomEvents.prisonerDialogs;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.List;
+
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import java.util.List;
-
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * Represents a dialog prompted when the player has dangerously low prisoner capacity, risking a negative event.
@@ -66,6 +66,7 @@ public class PrisonerWarningDialog extends ImmersiveDialogCore {
               createOutOfCharacterMessage(),
               null,
               true,
+              null,
               null,
               true);
     }

--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerWarningResultsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerWarningResultsDialog.java
@@ -27,15 +27,15 @@
  */
 package mekhq.gui.dialog.randomEvents.prisonerDialogs;
 
+import static megamek.common.Compute.randomInt;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.util.List;
+
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import java.util.List;
-
-import static megamek.common.Compute.randomInt;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * Represents a dialog triggered as a result of the player responding to a warning about exceeding Prisoner Capacity.
@@ -66,6 +66,7 @@ public class PrisonerWarningResultsDialog extends ImmersiveDialogCore {
               createOutOfCharacterMessage(),
               null,
               false,
+              null,
               null,
               true);
     }


### PR DESCRIPTION
- Refactored `ImmersiveDialogCore` to include an optional `ImageIcon` parameter for enhanced visual support in dialogs.
- Modified `createCenterBox` method to display the image above the message if provided.
- Updated all constructors of immersive dialog classes to handle the new `ImageIcon` parameter (defaulting to null where not applicable).
- Improved documentation for dialog-related classes to reflect the changes and clarify parameter purposes.
- Rearranged imports for consistency across impacted files.

### Requirements
Requires #6494

### Dev Notes
This expands what we can do with immersive dialogs in a cool new direction, making it effortless to add images to the dialog. The below is just an example, using the ACAR splash image.

<img width="586" alt="image" src="https://github.com/user-attachments/assets/00d2e532-40aa-472d-8205-d0009bc25e0a" />