### PR TITLE
Replaced Old Image Scaling Method with New

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -64,7 +64,7 @@ import static mekhq.campaign.stratcon.StratconContractDefinition.getContractDefi
 import static mekhq.campaign.universe.Factions.getFactionLogo;
 import static mekhq.campaign.universe.fameAndInfamy.BatchallFactions.BATCHALL_FACTIONS;
 import static mekhq.utilities.EntityUtilities.getEntityFromUnitId;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
 
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
@@ -154,48 +154,48 @@ public class AtBContract extends Contract {
     protected String enemyName;
 
     protected AtBContractType contractType;
-    protected SkillLevel      allySkill;
-    protected int             allyQuality;
-    protected SkillLevel      enemySkill;
-    protected int             enemyQuality;
-    protected String          allyBotName;
-    protected String          enemyBotName;
-    protected Camouflage      allyCamouflage;
-    protected PlayerColour    allyColour;
-    protected Camouflage      enemyCamouflage;
-    protected PlayerColour    enemyColour;
+    protected SkillLevel allySkill;
+    protected int allyQuality;
+    protected SkillLevel enemySkill;
+    protected int enemyQuality;
+    protected String allyBotName;
+    protected String enemyBotName;
+    protected Camouflage allyCamouflage;
+    protected PlayerColour allyColour;
+    protected Camouflage enemyCamouflage;
+    protected PlayerColour enemyColour;
 
     protected int extensionLength;
 
-    protected int            requiredCombatTeams;
+    protected int requiredCombatTeams;
     protected AtBMoraleLevel moraleLevel;
-    protected LocalDate      routEnd;
-    protected int            partsAvailabilityLevel;
-    protected int            sharesPct;
-    private   boolean        batchallAccepted;
+    protected LocalDate routEnd;
+    protected int partsAvailabilityLevel;
+    protected int sharesPct;
+    private boolean batchallAccepted;
 
     protected int playerMinorBreaches;
     protected int employerMinorBreaches;
     protected int contractScoreArbitraryModifier;
 
-    protected int   moraleMod    = 0;
-    private   Money routedPayout = null;
+    protected int moraleMod = 0;
+    private Money routedPayout = null;
 
     /* lasts for a month, then removed at next events roll */
-    protected boolean   priorLogisticsFailure;
+    protected boolean priorLogisticsFailure;
     /**
      * If the date is non-null, there will be a special scenario or big battle on that date, but the scenario is not
      * generated until the other battle rolls for the week.
      */
     protected LocalDate specialEventScenarioDate;
-    protected int       specialEventScenarioType;
+    protected int specialEventScenarioType;
     /* Lasts until end of contract */
-    protected int       battleTypeMod;
+    protected int battleTypeMod;
     /* Only applies to next week */
-    protected int       nextWeekBattleTypeMod;
+    protected int nextWeekBattleTypeMod;
 
     private StratconCampaignState stratconCampaignState;
-    private boolean               isAttacker;
+    private boolean isAttacker;
 
     private static final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.AtBContract",
           MekHQ.getMHQOptions().getLocale());
@@ -221,19 +221,19 @@ public class AtBContract extends Contract {
     public AtBContract(String name) {
         super(name, "Independent");
         employerCode = "IND";
-        enemyCode    = "IND";
-        enemyName    = "Independent";
+        enemyCode = "IND";
+        enemyName = "Independent";
 
-        parentContract  = null;
+        parentContract = null;
         mercSubcontract = false;
-        isAttacker      = false;
+        isAttacker = false;
 
         setContractType(AtBContractType.GARRISON_DUTY);
         setAllySkill(REGULAR);
         allyQuality = DRAGOON_C;
         setEnemySkill(REGULAR);
         enemyQuality = DRAGOON_C;
-        allyBotName  = "Ally";
+        allyBotName = "Ally";
         enemyBotName = "Enemy";
         setAllyCamouflage(new Camouflage(Camouflage.COLOUR_CAMOUFLAGE, PlayerColour.RED.name()));
         setAllyColour(PlayerColour.RED);
@@ -242,18 +242,18 @@ public class AtBContract extends Contract {
 
         extensionLength = 0;
 
-        sharesPct        = 0;
+        sharesPct = 0;
         batchallAccepted = true;
         setMoraleLevel(STALEMATE);
-        routEnd                  = null;
-        priorLogisticsFailure    = false;
+        routEnd = null;
+        priorLogisticsFailure = false;
         specialEventScenarioDate = null;
-        battleTypeMod            = 0;
-        nextWeekBattleTypeMod    = 0;
+        battleTypeMod = 0;
+        nextWeekBattleTypeMod = 0;
     }
 
     public void initContractDetails(Campaign campaign) {
-        int companySize   = getStandardForceSize(campaign.getFaction(), COMPANY.getDepth());
+        int companySize = getStandardForceSize(campaign.getFaction(), COMPANY.getDepth());
         int battalionSize = getStandardForceSize(campaign.getFaction(), BATTALION.getDepth());
 
         if (getEffectiveNumUnits(campaign) <= companySize) {
@@ -265,10 +265,10 @@ public class AtBContract extends Contract {
         }
 
         int currentYear = campaign.getGameYear();
-        allyBotName    = getEmployerName(currentYear);
+        allyBotName = getEmployerName(currentYear);
         allyCamouflage = pickRandomCamouflage(currentYear, employerCode);
 
-        enemyBotName    = getEnemyName(currentYear);
+        enemyBotName = getEnemyName(currentYear);
         enemyCamouflage = pickRandomCamouflage(currentYear, enemyCode);
     }
 
@@ -471,9 +471,8 @@ public class AtBContract extends Contract {
                 }
 
                 numUnits += switch (entity.getUnitType()) {
-                    case TANK, UnitType.VTOL, UnitType.NAVAL, UnitType.CONV_FIGHTER,
-                         AEROSPACEFIGHTER
-                        -> campaign.getFaction().isClan() ? 0.5 : 1;
+                    case TANK, UnitType.VTOL, UnitType.NAVAL, UnitType.CONV_FIGHTER, AEROSPACEFIGHTER ->
+                          campaign.getFaction().isClan() ? 0.5 : 1;
                     case UnitType.PROTOMEK -> 0.2;
                     case UnitType.BATTLE_ARMOR, UnitType.INFANTRY -> 0;
                     default -> 1; // All other unit types
@@ -545,7 +544,7 @@ public class AtBContract extends Contract {
                 }
 
                 moraleLevel = newMoraleLevel;
-                routEnd     = null;
+                routEnd = null;
 
                 if (contractType.isGarrisonDuty()) {
                     updateEnemy(campaign, today); // mix it up a little
@@ -590,8 +589,8 @@ public class AtBContract extends Contract {
         // Infantry == -1 (if unsupported)
 
         // Performance
-        int       victories = 0;
-        int       defeats   = 0;
+        int victories = 0;
+        int defeats = 0;
         LocalDate lastMonth = today.minusMonths(1);
 
         // Loop through scenarios, counting victories and defeats that fall within the target month
@@ -660,7 +659,7 @@ public class AtBContract extends Contract {
                 routEnd = today.plusMonths(max(1, d6() - 3)).minusDays(1);
             } else {
                 campaign.addReport("With the enemy routed, any remaining objectives have been" +
-                                   " successfully completed. The contract will conclude tomorrow.");
+                                         " successfully completed. The contract will conclude tomorrow.");
                 int remainingMonths = getMonthsLeft(campaign.getLocalDate().plusDays(1));
                 routedPayout = getMonthlyPayOut().multipliedBy(remainingMonths);
                 setEndDate(today.plusDays(1));
@@ -693,7 +692,7 @@ public class AtBContract extends Contract {
             enemyBotName = BackgroundsController.randomMercenaryCompanyNameGenerator(null);
         }
 
-        allyCamouflage  = pickRandomCamouflage(today.getYear(), employerCode);
+        allyCamouflage = pickRandomCamouflage(today.getYear(), employerCode);
         enemyCamouflage = pickRandomCamouflage(today.getYear(), enemyCode);
 
         // Update the Batchall information
@@ -740,8 +739,8 @@ public class AtBContract extends Contract {
     }
 
     public int getScore() {
-        int     score        = employerMinorBreaches - playerMinorBreaches;
-        int     battles      = 0;
+        int score = employerMinorBreaches - playerMinorBreaches;
+        int battles = 0;
         boolean earlySuccess = false;
         for (Scenario scenario : getCompletedScenarios()) {
             // Special Scenarios get no points for victory and only -1 for defeat.
@@ -773,9 +772,9 @@ public class AtBContract extends Contract {
             }
 
             if ((scenario instanceof AtBScenario atBScenario) &&
-                (atBScenario.getScenarioType() == AtBScenario.BASEATTACK) &&
-                atBScenario.isAttacker() &&
-                scenario.getStatus().isOverallVictory()) {
+                      (atBScenario.getScenarioType() == AtBScenario.BASEATTACK) &&
+                      atBScenario.isAttacker() &&
+                      scenario.getStatus().isOverallVictory()) {
                 earlySuccess = true;
             } else if (getMoraleLevel().isRouted() && !getContractType().isGarrisonType()) {
                 earlySuccess = true;
@@ -872,15 +871,16 @@ public class AtBContract extends Contract {
     /**
      * Generates a bonus unit for a given campaign and unit type.
      *
-     * @param campaign  the campaign object to add the bonus unit to
-     * @param unitType  the type of unit for the bonus
+     * @param campaign the campaign object to add the bonus unit to
+     * @param unitType the type of unit for the bonus
+     *
      * @deprecated deprecated as superceded by {@link MercenaryAuction}
      */
     @Deprecated(since = "0.50.04", forRemoval = true)
     private void addBonusUnit(Campaign campaign, int unitType) {
         // Determine faction and quality
         String faction = (randomInt(2) > 0) ? enemyCode : employerCode;
-        int    quality = (faction.equals(enemyCode)) ? enemyQuality : allyQuality;
+        int quality = (faction.equals(enemyCode)) ? enemyQuality : allyQuality;
 
         // Try to generate the new unit
         Entity newUnit = getEntity(faction, REGULAR, quality, unitType, UNIT_WEIGHT_UNSPECIFIED, null, campaign);
@@ -1117,7 +1117,7 @@ public class AtBContract extends Contract {
         }
 
         final int extension;
-        int       roll = d6();
+        int roll = d6();
 
         if (roll == 1) {
             extension = max(1, getLength() / 2);
@@ -1146,7 +1146,7 @@ public class AtBContract extends Contract {
         }
 
         moraleOrdinal = min(moraleOrdinal + roll, OVERWHELMING.ordinal());
-        moraleLevel   = AtBMoraleLevel.values()[moraleOrdinal];
+        moraleLevel = AtBMoraleLevel.values()[moraleOrdinal];
 
         campaign.addReport(moraleLevel.getToolTipText());
 
@@ -1290,7 +1290,7 @@ public class AtBContract extends Contract {
                     setEnemyColour(PlayerColour.parseFromString(wn2.getTextContent().trim()));
                     // <50.03 compatibility handler
                 } else if (wn2.getNodeName().equalsIgnoreCase("requiredLances") ||
-                           wn2.getNodeName().equalsIgnoreCase("requiredCombatTeams")) {
+                                 wn2.getNodeName().equalsIgnoreCase("requiredCombatTeams")) {
                     requiredCombatTeams = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("moraleLevel")) {
                     setMoraleLevel(AtBMoraleLevel.parseFromString(wn2.getTextContent().trim()));
@@ -1298,7 +1298,7 @@ public class AtBContract extends Contract {
                     routEnd = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("routedPayout")) {
                     String cleanValue = wn2.getTextContent().trim().replaceAll("[^0-9.]", "");
-                    double value      = Double.parseDouble(cleanValue);
+                    double value = Double.parseDouble(cleanValue);
                     routedPayout = Money.of(value);
                 } else if (wn2.getNodeName().equalsIgnoreCase("partsAvailabilityLevel")) {
                     partsAvailabilityLevel = Integer.parseInt(wn2.getTextContent());
@@ -1698,10 +1698,10 @@ public class AtBContract extends Contract {
         setPartsAvailabilityLevel(getContractType().calculatePartsAvailabilityLevel());
 
         int currentYear = campaign.getGameYear();
-        allyBotName    = getEmployerName(currentYear);
+        allyBotName = getEmployerName(currentYear);
         allyCamouflage = pickRandomCamouflage(currentYear, employerCode);
 
-        enemyBotName    = getEnemyName(currentYear);
+        enemyBotName = getEnemyName(currentYear);
         enemyCamouflage = pickRandomCamouflage(currentYear, enemyCode);
 
         clanTechSalvageOverride();
@@ -1756,9 +1756,9 @@ public class AtBContract extends Contract {
 
         // Set the commander's rank and use a name generator to generate the commander's
         // name
-        String              rank                = resources.getString("starColonel.text");
+        String rank = resources.getString("starColonel.text");
         RandomNameGenerator randomNameGenerator = new RandomNameGenerator();
-        String              commander           = randomNameGenerator.generate(Gender.RANDOMIZE, true, enemyCode);
+        String commander = randomNameGenerator.generate(Gender.RANDOMIZE, true, enemyCode);
         commander += ' ' + Bloodname.randomBloodname(enemyCode, Phenotype.MEKWARRIOR, campaign.getGameYear()).getName();
 
         // Construct the batchall message
@@ -1782,7 +1782,7 @@ public class AtBContract extends Contract {
         textPane.setEditable(false);
 
         // Create a panel to display the icon and the batchall message
-        JPanel panel      = new JPanel(new BorderLayout());
+        JPanel panel = new JPanel(new BorderLayout());
         JLabel imageLabel = new JLabel(icon);
         panel.add(imageLabel, BorderLayout.CENTER);
         panel.add(textPane, BorderLayout.SOUTH);
@@ -1975,8 +1975,8 @@ public class AtBContract extends Contract {
      * @return a {@link JPanel} with the difficulty skulls displayed
      */
     public JPanel getContractDifficultySkulls(Campaign campaign) {
-        final int ERROR      = -99;
-        int       difficulty = calculateContractDifficulty(campaign);
+        final int ERROR = -99;
+        int difficulty = calculateContractDifficulty(campaign);
 
         // Create a new JFrame
         JFrame frame = new JFrame();
@@ -1986,8 +1986,8 @@ public class AtBContract extends Contract {
         JPanel panel = new JPanel(new FlowLayout());
 
         // Load and scale the images
-        ImageIcon skullFull = scaleImageIconToWidth(new ImageIcon("data/images/misc/challenge_estimate_full.png"), 50);
-        ImageIcon skullHalf = scaleImageIconToWidth(new ImageIcon("data/images/misc/challenge_estimate_half.png"), 50);
+        ImageIcon skullFull = scaleImageIcon(new ImageIcon("data/images/misc/challenge_estimate_full.png"), 50, true);
+        ImageIcon skullHalf = scaleImageIcon(new ImageIcon("data/images/misc/challenge_estimate_half.png"), 50, true);
 
         int iterations = difficulty;
 
@@ -2062,11 +2062,11 @@ public class AtBContract extends Contract {
         final int ERROR = -99;
 
         // Estimate the power of the enemy forces
-        SkillLevel opposingSkill        = modifySkillLevelBasedOnFaction(enemyCode, enemySkill);
-        double     enemySkillMultiplier = getSkillMultiplier(opposingSkill);
-        int        gameYear             = campaign.getGameYear();
-        boolean    useGenericBV         = campaign.getCampaignOptions().isUseGenericBattleValue();
-        double     enemyPower           = estimateMekStrength(gameYear, useGenericBV, enemyCode, enemyQuality);
+        SkillLevel opposingSkill = modifySkillLevelBasedOnFaction(enemyCode, enemySkill);
+        double enemySkillMultiplier = getSkillMultiplier(opposingSkill);
+        int gameYear = campaign.getGameYear();
+        boolean useGenericBV = campaign.getCampaignOptions().isUseGenericBattleValue();
+        double enemyPower = estimateMekStrength(gameYear, useGenericBV, enemyCode, enemyQuality);
 
         // If we cannot calculate enemy power, abort.
         if (enemyPower == 0) {
@@ -2090,9 +2090,9 @@ public class AtBContract extends Contract {
         };
 
         if (allyRatio > 0) {
-            SkillLevel alliedSkill         = modifySkillLevelBasedOnFaction(employerCode, allySkill);
-            double     allySkillMultiplier = getSkillMultiplier(alliedSkill);
-            double     allyPower           = estimateMekStrength(gameYear, useGenericBV, employerCode, allyQuality);
+            SkillLevel alliedSkill = modifySkillLevelBasedOnFaction(employerCode, allySkill);
+            double allySkillMultiplier = getSkillMultiplier(alliedSkill);
+            double allyPower = estimateMekStrength(gameYear, useGenericBV, employerCode, allyQuality);
             allyPower = allyPower * allySkillMultiplier;
             // If we cannot calculate ally's power, use player power as a fallback.
             if (allyPower == 0) {
@@ -2103,7 +2103,7 @@ public class AtBContract extends Contract {
         }
 
         // Calculate difficulty based on the percentage difference between the two forces.
-        double difference        = enemyPower - playerPower;
+        double difference = enemyPower - playerPower;
         double percentDifference = (difference / playerPower) * 100;
 
         int mappedValue = (int) ceil(Math.abs(percentDifference) / 20);
@@ -2161,9 +2161,9 @@ public class AtBContract extends Contract {
         final int ERROR = -99;
 
         // Estimate the power of the enemy forces
-        SkillLevel opposingSkill        = modifySkillLevelBasedOnFaction(enemyCode, enemySkill);
-        double     enemySkillMultiplier = getSkillMultiplier(opposingSkill);
-        double     enemyPower           = estimateMekStrength(gameYear, useGenericBV, enemyCode, enemyQuality);
+        SkillLevel opposingSkill = modifySkillLevelBasedOnFaction(enemyCode, enemySkill);
+        double enemySkillMultiplier = getSkillMultiplier(opposingSkill);
+        double enemyPower = estimateMekStrength(gameYear, useGenericBV, enemyCode, enemyQuality);
 
         // If we cannot calculate enemy power, abort.
         if (enemyPower == 0) {
@@ -2187,9 +2187,9 @@ public class AtBContract extends Contract {
         };
 
         if (allyRatio > 0) {
-            SkillLevel alliedSkill         = modifySkillLevelBasedOnFaction(employerCode, allySkill);
-            double     allySkillMultiplier = getSkillMultiplier(alliedSkill);
-            double     allyPower           = estimateMekStrength(gameYear, useGenericBV, employerCode, allyQuality);
+            SkillLevel alliedSkill = modifySkillLevelBasedOnFaction(employerCode, allySkill);
+            double allySkillMultiplier = getSkillMultiplier(alliedSkill);
+            double allyPower = estimateMekStrength(gameYear, useGenericBV, employerCode, allyQuality);
             allyPower = allyPower * allySkillMultiplier;
             // If we cannot calculate ally's power, use player power as a fallback.
             if (allyPower == 0) {
@@ -2201,7 +2201,7 @@ public class AtBContract extends Contract {
 
         // Calculate difficulty based on the percentage difference between the two
         // forces.
-        double difference        = enemyPower - playerPower;
+        double difference = enemyPower - playerPower;
         double percentDifference = (difference / playerPower) * 100;
 
         int mappedValue = (int) ceil(Math.abs(percentDifference) / 20);
@@ -2246,8 +2246,8 @@ public class AtBContract extends Contract {
      */
     @Deprecated(since = "0.50.04")
     double estimatePlayerPower(Campaign campaign) {
-        int playerPower     = 0;
-        int playerGBV       = 0;
+        int playerPower = 0;
+        int playerGBV = 0;
         int playerUnitCount = 0;
         for (Force force : campaign.getAllForces()) {
             if (!force.isForceType(STANDARD)) {
@@ -2270,8 +2270,8 @@ public class AtBContract extends Contract {
     }
 
     double estimatePlayerPower(List<Entity> units, boolean useGenericBV) {
-        int playerPower     = 0;
-        int playerGBV       = 0;
+        int playerPower = 0;
+        int playerGBV = 0;
         int playerUnitCount = 0;
         for (Entity unit : units) {
             playerPower += unit.calculateBattleValue();
@@ -2320,8 +2320,8 @@ public class AtBContract extends Contract {
     double estimateMekStrength(int gameYear, boolean useGenericBV, String factionCode, int quality) {
         final double ERROR = 0;
 
-        RATGenerator  ratGenerator = Factions.getInstance().getRATGenerator();
-        FactionRecord faction      = ratGenerator.getFaction(factionCode);
+        RATGenerator ratGenerator = Factions.getInstance().getRATGenerator();
+        FactionRecord faction = ratGenerator.getFaction(factionCode);
 
         if (faction == null) {
             return ERROR;
@@ -2348,8 +2348,8 @@ public class AtBContract extends Contract {
         int entries = unitTable.getNumEntries();
 
         int totalBattleValue = 0;
-        int totalGBV         = 0;
-        int rollingCount     = 0;
+        int totalGBV = 0;
+        int rollingCount = 0;
 
         for (int i = 0; i < entries; i++) {
             int battleValue = unitTable.getBV(i); // 0 for salvage
@@ -2360,7 +2360,7 @@ public class AtBContract extends Contract {
             // TODO implement getGBV(int index) in UnitTable to simplify this?
             // getMekSummary(int index) is NULL for salvage.
             int genericBattleValue = unitTable.getMekSummary(i).loadEntity().getGenericBattleValue();
-            int weight             = unitTable.getEntryWeight(i); // NOT 0 for salvage
+            int weight = unitTable.getEntryWeight(i); // NOT 0 for salvage
 
             totalBattleValue += battleValue * weight;
             totalGBV += genericBattleValue * weight;

--- a/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQNagDialog.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/AbstractMHQNagDialog.java
@@ -29,7 +29,7 @@ package mekhq.gui.baseComponents;
 
 import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
 import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -132,7 +132,7 @@ public abstract class AbstractMHQNagDialog extends JDialog {
         // Add speaker image (icon)
         ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
         if (speakerIcon != null) {
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 100);
+            speakerIcon = scaleImageIcon(speakerIcon, 100, true);
         }
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
@@ -32,7 +32,7 @@ import static java.lang.Math.min;
 import static megamek.client.ui.WrapLayout.wordWrap;
 import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
 import static mekhq.campaign.force.Force.FORCE_NONE;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.awt.BorderLayout;
@@ -149,7 +149,10 @@ public class ImmersiveDialogCore extends JDialog {
      * @param spinnerPanel          An optional {@link JPanel} containing a spinner widget to be displayed in the center
      *                              panel; use {@code null} if not applicable.
      */
-    public ImmersiveDialogCore(Campaign campaign, @Nullable Person leftSpeaker, @Nullable Person rightSpeaker, String centerMessage, List<ButtonLabelTooltipPair> buttons, @Nullable String outOfCharacterMessage, @Nullable Integer centerWidth, boolean isVerticalLayout, @Nullable JPanel spinnerPanel, boolean isModal) {
+    public ImmersiveDialogCore(Campaign campaign, @Nullable Person leftSpeaker, @Nullable Person rightSpeaker,
+                               String centerMessage, List<ButtonLabelTooltipPair> buttons,
+                               @Nullable String outOfCharacterMessage, @Nullable Integer centerWidth,
+                               boolean isVerticalLayout, @Nullable JPanel spinnerPanel, boolean isModal) {
         // Initialize
         this.campaign = campaign;
         this.leftSpeaker = leftSpeaker;
@@ -255,7 +258,8 @@ public class ImmersiveDialogCore extends JDialog {
      *
      * @return A {@link JPanel} with the message displayed in the center and buttons at the bottom.
      */
-    private JPanel createCenterBox(String centerMessage, List<ButtonLabelTooltipPair> buttons, boolean isVerticalLayout, @Nullable JPanel spinnerPanel) {
+    private JPanel createCenterBox(String centerMessage, List<ButtonLabelTooltipPair> buttons, boolean isVerticalLayout,
+                                   @Nullable JPanel spinnerPanel) {
         northPanel = new JPanel(new BorderLayout());
 
         // Buttons panel
@@ -414,7 +418,8 @@ public class ImmersiveDialogCore extends JDialog {
      * @param isVerticalLayout A {@code boolean} value indicating the layout style: {@code true} for vertical stacking,
      *                         {@code false} for horizontal arrangement.
      */
-    protected JPanel populateButtonPanel(List<ButtonLabelTooltipPair> buttons, boolean isVerticalLayout, @Nullable JPanel spinnerPanel) {
+    protected JPanel populateButtonPanel(List<ButtonLabelTooltipPair> buttons, boolean isVerticalLayout,
+                                         @Nullable JPanel spinnerPanel) {
         final int padding = getPADDING();
 
         // Main container panel to hold the spinner and button panel
@@ -588,7 +593,7 @@ public class ImmersiveDialogCore extends JDialog {
         // Add speaker image (icon)
         ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
         if (speakerIcon != null) {
-            speakerIcon = scaleImageIconToWidth(speakerIcon, IMAGE_WIDTH);
+            speakerIcon = scaleImageIcon(speakerIcon, IMAGE_WIDTH, true);
         }
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);

--- a/MekHQ/src/mekhq/gui/campaignOptions/SelectPresetDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/SelectPresetDialog.java
@@ -28,7 +28,7 @@
 package mekhq.gui.campaignOptions;
 
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createGroupLayout;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -98,7 +98,7 @@ public class SelectPresetDialog extends JDialog {
         setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
 
         ImageIcon imageIcon = new ImageIcon("data/images/misc/megamek-splash.png");
-        imageIcon = scaleImageIconToWidth(imageIcon, UIUtil.scaleForGUI(400));
+        imageIcon = scaleImageIcon(imageIcon, 400, true);
 
         JLabel imageLabel = new JLabel(imageIcon);
         add(imageLabel, BorderLayout.NORTH);
@@ -124,7 +124,8 @@ public class SelectPresetDialog extends JDialog {
 
         DefaultListCellRenderer listRenderer = new DefaultListCellRenderer() {
             @Override
-            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected,
+                                                          boolean cellHasFocus) {
                 if (value instanceof CampaignPreset preset) {
                     setText(preset.getTitle());
                 }
@@ -241,7 +242,8 @@ public class SelectPresetDialog extends JDialog {
      *
      * @return The converted {@link DefaultComboBoxModel}.
      */
-    private DefaultComboBoxModel<CampaignPreset> convertPresetListModelToComboBoxModel(DefaultListModel<CampaignPreset> listModel) {
+    private DefaultComboBoxModel<CampaignPreset> convertPresetListModelToComboBoxModel(
+          DefaultListModel<CampaignPreset> listModel) {
 
         // Create a new DefaultComboBoxModel
         DefaultComboBoxModel<CampaignPreset> comboBoxModel = new DefaultComboBoxModel<>();

--- a/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsHeaderPanel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsHeaderPanel.java
@@ -27,22 +27,24 @@
  */
 package mekhq.gui.campaignOptions.components;
 
-import megamek.client.ui.swing.util.UIUtil;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.ResourceBundle;
-
 import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+
+import java.awt.GridBagConstraints;
+import java.util.ResourceBundle;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
+import megamek.client.ui.swing.util.UIUtil;
 
 /**
  * A specialized {@link JPanel} designed for headers in the campaign options dialog.
  * <p>
- * This panel includes a header label, an image, and optionally a body label for additional text.
- * The text for the labels is dynamically loaded from a resource bundle based on the provided name.
- * The image is scaled to fit the layout, and font scaling is applied to the labels to ensure
- * consistent appearance.
+ * This panel includes a header label, an image, and optionally a body label for additional text. The text for the
+ * labels is dynamically loaded from a resource bundle based on the provided name. The image is scaled to fit the
+ * layout, and font scaling is applied to the labels to ensure consistent appearance.
  */
 public class CampaignOptionsHeaderPanel extends JPanel {
     /**
@@ -56,12 +58,11 @@ public class CampaignOptionsHeaderPanel extends JPanel {
     static final ResourceBundle resources = ResourceBundle.getBundle(RESOURCE_PACKAGE);
 
     /**
-     * Constructs a new instance of {@link CampaignOptionsHeaderPanel} with a header label
-     * and an image.
+     * Constructs a new instance of {@link CampaignOptionsHeaderPanel} with a header label and an image.
      * <p>
-     * The panel is named {@code "pnl" + name + "HeaderPanel"}. The header label's text is
-     * fetched from a resource bundle using {@code "lbl" + name + ".text"}.
-     * The image is loaded from the specified file path and scaled appropriately.
+     * The panel is named {@code "pnl" + name + "HeaderPanel"}. The header label's text is fetched from a resource
+     * bundle using {@code "lbl" + name + ".text"}. The image is loaded from the specified file path and scaled
+     * appropriately.
      *
      * @param name         the name of the header panel, used to construct the resource bundle keys
      * @param imageAddress the file path of the image to be displayed in the panel
@@ -71,14 +72,13 @@ public class CampaignOptionsHeaderPanel extends JPanel {
     }
 
     /**
-     * Constructs a new instance of {@link CampaignOptionsHeaderPanel} with a header label,
-     * an image, and optionally a body label for descriptive text.
+     * Constructs a new instance of {@link CampaignOptionsHeaderPanel} with a header label, an image, and optionally a
+     * body label for descriptive text.
      * <p>
-     * The panel is named {@code "pnl" + name + "HeaderPanel"}. The header label's text is
-     * fetched from a resource bundle using {@code "lbl" + name + ".text"}. If {@code includeBodyText}
-     * is {@code true}, an additional body label is created using the resource key
-     * {@code "lbl" + name + "Body.text"}. The image is loaded from the specified file path
-     * and scaled appropriately.
+     * The panel is named {@code "pnl" + name + "HeaderPanel"}. The header label's text is fetched from a resource
+     * bundle using {@code "lbl" + name + ".text"}. If {@code includeBodyText} is {@code true}, an additional body label
+     * is created using the resource key {@code "lbl" + name + "Body.text"}. The image is loaded from the specified file
+     * path and scaled appropriately.
      *
      * @param name            the name of the header panel, used to construct the resource bundle keys
      * @param imageAddress    the file path of the image to be displayed in the panel
@@ -87,7 +87,7 @@ public class CampaignOptionsHeaderPanel extends JPanel {
     public CampaignOptionsHeaderPanel(String name, String imageAddress, boolean includeBodyText) {
         // Load and scale the image using the provided file path
         ImageIcon imageIcon = new ImageIcon(imageAddress);
-        imageIcon = scaleImageIconToWidth(imageIcon, UIUtil.scaleForGUI(100));
+        imageIcon = scaleImageIcon(imageIcon, 100, true);
 
         // Create a JLabel to display the image in the panel
         JLabel lblImage = new JLabel(imageIcon);
@@ -100,10 +100,9 @@ public class CampaignOptionsHeaderPanel extends JPanel {
         // Optionally create a body label with additional text, if includeBodyText is true
         JLabel lblBody = new JLabel();
         if (includeBodyText) {
-            lblBody = new JLabel(String.format(
-                    "<html><div style='width: %s; text-align:justify;'>%s</div></html>",
-                    UIUtil.scaleForGUI(750),
-                    resources.getString("lbl" + name + "Body.text")), SwingConstants.CENTER);
+            lblBody = new JLabel(String.format("<html><div style='width: %s; text-align:justify;'>%s</div></html>",
+                  UIUtil.scaleForGUI(750),
+                  resources.getString("lbl" + name + "Body.text")), SwingConstants.CENTER);
             lblBody.setName("lbl" + name + "Body");
             setFontScaling(lblBody, false, 1);
         }

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -30,7 +30,7 @@ package mekhq.gui.campaignOptions.contents;
 import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
 import static megamek.common.options.OptionsConstants.ALLOWED_YEAR;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createGroupLayout;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
 
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -72,8 +72,8 @@ import mekhq.gui.dialog.iconDialogs.UnitIconDialog;
 import mekhq.gui.displayWrappers.FactionDisplay;
 
 /**
- * Represents a tab within the campaign options UI that allows the user to configure
- * general campaign settings. This includes options for:
+ * Represents a tab within the campaign options UI that allows the user to configure general campaign settings. This
+ * includes options for:
  * <ul>
  *     <li>Configuring the campaign name</li>
  *     <li>Setting the faction and faction-related options</li>
@@ -81,7 +81,7 @@ import mekhq.gui.displayWrappers.FactionDisplay;
  *     <li>Specifying the campaign start date</li>
  *     <li>Choosing a camouflage pattern and unit icon</li>
  * </ul>
- *
+ * <p>
  * This class extends the user interface features provided by {@link AbstractMHQTabbedPane}.
  */
 public class GeneralTab {
@@ -120,8 +120,8 @@ public class GeneralTab {
      *
      * @param campaign The {@link Campaign} associated with this tab, which contains the core game data.
      * @param frame    The parent {@link JFrame} used to display this tab.
-     * @param mode     The {@link CampaignOptionsDialogMode} enum determining what state caused the
-     *                dialog to be triggered.
+     * @param mode     The {@link CampaignOptionsDialogMode} enum determining what state caused the dialog to be
+     *                 triggered.
      */
     public GeneralTab(Campaign campaign, JFrame frame, CampaignOptionsDialogMode mode) {
         // region Variable Declarations
@@ -149,7 +149,7 @@ public class GeneralTab {
      * <p>If no faction is selected, the method defaults to returning the "MERC" faction.</p>
      *
      * @return the {@link Faction} object representing the selected faction, or the "MERC" faction if no selection is
-     * made.
+     *       made.
      */
     public Faction getFaction() {
         if (comboFaction.getSelectedItem() == null) {
@@ -184,22 +184,20 @@ public class GeneralTab {
 
         // Generate new random campaign name
         btnNameGenerator = new CampaignOptionsButton("NameGenerator");
-        btnNameGenerator.addActionListener(e -> txtName.setText(BackgroundsController
-                .randomMercenaryCompanyNameGenerator(campaign.getFlaggedCommander())));
+        btnNameGenerator.addActionListener(e -> txtName.setText(BackgroundsController.randomMercenaryCompanyNameGenerator(
+              campaign.getFlaggedCommander())));
 
         // Campaign faction
         lblFaction = new CampaignOptionsLabel("Faction");
         comboFaction.setSelectedItem(new FactionDisplay(campaign.getFaction(), campaign.getLocalDate()));
-        comboFaction.setToolTipText(String.format("<html>%s</html>",
-            resources.getString("lblFaction.tooltip")));
+        comboFaction.setToolTipText(String.format("<html>%s</html>", resources.getString("lblFaction.tooltip")));
 
         // Reputation
         lblReputation = new CampaignOptionsLabel("Reputation");
         unitRatingMethodCombo.setToolTipText(String.format("<html>%s</html>",
-            resources.getString("lblReputation.tooltip")));
+              resources.getString("lblReputation.tooltip")));
         lblManualUnitRatingModifier = new CampaignOptionsLabel("ManualUnitRatingModifier");
-        manualUnitRatingModifier = new CampaignOptionsSpinner("ManualUnitRatingModifier",
-            0, -1000, 1000, 1);
+        manualUnitRatingModifier = new CampaignOptionsSpinner("ManualUnitRatingModifier", 0, -1000, 1000, 1);
         chkClampReputationPayMultiplier = new CampaignOptionsCheckBox("ClampReputationPayMultiplier");
         chkReduceReputationPerformanceModifier = new CampaignOptionsCheckBox("ReduceReputationPerformanceModifier");
         chkReputationPerformanceModifierCutOff = new CampaignOptionsCheckBox("ReputationPerformanceModifierCutOff");
@@ -210,8 +208,7 @@ public class GeneralTab {
         btnDate.setText(MekHQ.getMHQOptions().getDisplayFormattedDate(date));
         btnDate.addActionListener(this::btnDateActionPerformed);
 
-        if (mode != CampaignOptionsDialogMode.STARTUP
-            && mode != CampaignOptionsDialogMode.STARTUP_ABRIDGED) {
+        if (mode != CampaignOptionsDialogMode.STARTUP && mode != CampaignOptionsDialogMode.STARTUP_ABRIDGED) {
             lblDate.setEnabled(false);
             btnDate.setEnabled(false);
         }
@@ -230,7 +227,8 @@ public class GeneralTab {
 
         // Initialize the parent panel
         AbstractMHQScrollablePanel generalPanel = new DefaultMHQScrollablePanel(frame,
-            "generalPanel", new GridBagLayout());
+              "generalPanel",
+              new GridBagLayout());
 
         // Layout the Panel
         JPanel panel = new JPanel();
@@ -306,42 +304,40 @@ public class GeneralTab {
     /**
      * Creates a header panel for the general tab, which includes:
      * <p>
-     *     <li>An image representing the campaign options</li>
-     *     <li>A title for the general tab</li>
-     *     <li>A description of the general tab functionalities</li>
+     * <li>An image representing the campaign options</li>
+     * <li>A title for the general tab</li>
+     * <li>A description of the general tab functionalities</li>
      * </p>
      *
      * @return A {@link JPanel} containing the general tab header.
      */
     private static JPanel createGeneralHeader() {
         ImageIcon imageIcon = new ImageIcon("data/images/misc/MekHQ.png");
-        imageIcon = scaleImageIconToWidth(imageIcon, UIUtil.scaleForGUI(200));
+        imageIcon = scaleImageIcon(imageIcon, 200, true);
         JLabel imageLabel = new JLabel(imageIcon);
 
         final JLabel lblHeader = new JLabel(resources.getString("lblGeneral.text"), SwingConstants.CENTER);
         setFontScaling(lblHeader, true, 2);
         lblHeader.setName("lblGeneral");
 
-        JLabel lblBody = new JLabel(String.format("<html>%s</html>",
-            resources.getString("lblGeneralBody.text")), SwingConstants.CENTER);
+        JLabel lblBody = new JLabel(String.format("<html>%s</html>", resources.getString("lblGeneralBody.text")),
+              SwingConstants.CENTER);
         lblBody.setName("lblGeneralHeaderBody");
 
         final JPanel panel = new CampaignOptionsStandardPanel("pnlGeneralHeaderPanel");
         final GroupLayout layout = createGroupLayout(panel);
         panel.setLayout(layout);
 
-        layout.setVerticalGroup(
-            layout.createSequentialGroup()
-                .addComponent(lblHeader)
-                .addComponent(imageLabel)
-                .addComponent(lblBody)
-                .addGap(UIUtil.scaleForGUI(20)));
+        layout.setVerticalGroup(layout.createSequentialGroup()
+                                      .addComponent(lblHeader)
+                                      .addComponent(imageLabel)
+                                      .addComponent(lblBody)
+                                      .addGap(UIUtil.scaleForGUI(20)));
 
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(Alignment.CENTER)
-                .addComponent(lblHeader)
-                .addComponent(imageLabel)
-                .addComponent(lblBody));
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.CENTER)
+                                        .addComponent(lblHeader)
+                                        .addComponent(imageLabel)
+                                        .addComponent(lblBody));
 
         return panel;
     }
@@ -351,8 +347,8 @@ public class GeneralTab {
      * <p>
      * This method sets up the components for all editable campaign settings, including:
      * <p>
-     *     <li>Labels, text fields, dropdowns, and buttons for campaign settings</li>
-     *     <li>Default values fetched from the campaign instance</li>
+     * <li>Labels, text fields, dropdowns, and buttons for campaign settings</li>
+     * <li>Default values fetched from the campaign instance</li>
      * </p>
      */
     private void initialize() {
@@ -372,7 +368,7 @@ public class GeneralTab {
 
         chkClampReputationPayMultiplier = new JCheckBox();
         chkReduceReputationPerformanceModifier = new JCheckBox();
-         chkReputationPerformanceModifierCutOff = new JCheckBox();
+        chkReputationPerformanceModifierCutOff = new JCheckBox();
 
         lblDate = new JLabel();
         btnDate = new JButton();
@@ -395,23 +391,23 @@ public class GeneralTab {
     }
 
     /**
-     * Builds a {@link DefaultComboBoxModel} containing faction options based on the current campaign data.
-     * These options allow users to choose valid factions appropriate to the campaign's start date.
+     * Builds a {@link DefaultComboBoxModel} containing faction options based on the current campaign data. These
+     * options allow users to choose valid factions appropriate to the campaign's start date.
      *
      * @return A {@link DefaultComboBoxModel} populated with available {@link FactionDisplay} options.
      */
     private DefaultComboBoxModel<FactionDisplay> buildFactionDisplayOptions() {
         DefaultComboBoxModel<FactionDisplay> factionModel = new DefaultComboBoxModel<>();
 
-        factionModel.addAll(FactionDisplay.getSortedValidFactionDisplays(
-            Factions.getInstance().getChoosableFactions(), date));
+        factionModel.addAll(FactionDisplay.getSortedValidFactionDisplays(Factions.getInstance().getChoosableFactions(),
+              date));
 
         return factionModel;
     }
 
     /**
-     * Handles the "Date" button action, which triggers a date selection via a {@link DateChooser} dialog.
-     * If the user confirms their date choice, it updates the campaign's start date accordingly.
+     * Handles the "Date" button action, which triggers a date selection via a {@link DateChooser} dialog. If the user
+     * confirms their date choice, it updates the campaign's start date accordingly.
      *
      * @param actionEvent The {@link ActionEvent} triggered by the "Date" button.
      */
@@ -441,15 +437,15 @@ public class GeneralTab {
 
         final FactionDisplay factionDisplay = comboFaction.getSelectedItem();
         comboFaction.removeAllItems();
-        ((DefaultComboBoxModel<FactionDisplay>) comboFaction.getModel()).addAll(FactionDisplay
-            .getSortedValidFactionDisplays(Factions.getInstance().getChoosableFactions(), date));
+        ((DefaultComboBoxModel<FactionDisplay>) comboFaction.getModel()).addAll(FactionDisplay.getSortedValidFactionDisplays(
+              Factions.getInstance().getChoosableFactions(),
+              date));
         comboFaction.setSelectedItem(factionDisplay);
     }
 
     /**
-     * Handles the "Camouflage" button action, which opens a {@link CamoChooserDialog}.
-     * If the user confirms their camouflage selection, it updates the button icon to display the
-     * chosen camouflage.
+     * Handles the "Camouflage" button action, which opens a {@link CamoChooserDialog}. If the user confirms their
+     * camouflage selection, it updates the button icon to display the chosen camouflage.
      *
      * @param actionEvent The {@link ActionEvent} triggered by the "Camouflage" button.
      */
@@ -462,9 +458,8 @@ public class GeneralTab {
     }
 
     /**
-     * Handles the "Unit Icon" button action, which opens a {@link UnitIconDialog}.
-     * If the user selects a new unit icon and confirms, this method updates the button icon to
-     * reflect the selection.
+     * Handles the "Unit Icon" button action, which opens a {@link UnitIconDialog}. If the user selects a new unit icon
+     * and confirms, this method updates the button icon to reflect the selection.
      *
      * @param actionEvent The {@link ActionEvent} triggered by the "Unit Icon" button.
      */
@@ -477,32 +472,28 @@ public class GeneralTab {
     }
 
     /**
-     * Creates a "Further Reading" panel that provides links or additional details to guide users
-     * in understanding the campaign options.
+     * Creates a "Further Reading" panel that provides links or additional details to guide users in understanding the
+     * campaign options.
      * <p>
      * The panel may include references to:
      * <p>
-     *     <li>BattleMech Manual (BMM)</li>
-     *     <li>Total Warfare rules</li>
-     *     <li>Campaign Operations documentation</li>
+     * <li>BattleMech Manual (BMM)</li>
+     * <li>Total Warfare rules</li>
+     * <li>Campaign Operations documentation</li>
      * </p>
      *
      * @return A {@link JPanel} containing additional informational components.
      */
     private JPanel createFurtherReadingPanel() {
         // Contents
-        JPanel headerPanelBMM = new CampaignOptionsHeaderPanel("BMMPanel", "",
-            true);
+        JPanel headerPanelBMM = new CampaignOptionsHeaderPanel("BMMPanel", "", true);
 
-        JPanel headerPanelTotalWarfare = new CampaignOptionsHeaderPanel("TotalWarfarePanel",
-            "", true);
+        JPanel headerPanelTotalWarfare = new CampaignOptionsHeaderPanel("TotalWarfarePanel", "", true);
 
-        JPanel headerPanelCampaignOperations = new CampaignOptionsHeaderPanel("CampaignOperationsPanel",
-            "", true);
+        JPanel headerPanelCampaignOperations = new CampaignOptionsHeaderPanel("CampaignOperationsPanel", "", true);
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("FurtherReadingPanel",
-            true, "FurtherReadingPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("FurtherReadingPanel", true, "FurtherReadingPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
         layout.gridwidth = 5;
         layout.gridx = 0;
@@ -521,9 +512,10 @@ public class GeneralTab {
     /**
      * Loads the values from the current campaign's {@link CampaignOptions} and updates the user interface components.
      * <p>
-     * This is a convenience method that uses the default campaign options, default date, and default faction
-     * to populate the relevant data fields in the user interface. It essentially delegates the work to the overloaded
-     * method {@link #loadValuesFromCampaignOptions(CampaignOptions, LocalDate, Faction)} with all parameters set to {@code null}.
+     * This is a convenience method that uses the default campaign options, default date, and default faction to
+     * populate the relevant data fields in the user interface. It essentially delegates the work to the overloaded
+     * method {@link #loadValuesFromCampaignOptions(CampaignOptions, LocalDate, Faction)} with all parameters set to
+     * {@code null}.
      */
     public void loadValuesFromCampaignOptions() {
         loadValuesFromCampaignOptions(null, null, null);
@@ -546,16 +538,15 @@ public class GeneralTab {
      *     <li>Performing required UI updates (e.g., repainting date labels).</li>
      * </ul>
      *
-     * @param presetCampaignOptions Optional {@link CampaignOptions} used to populate values.
-     *                              If {@code null}, the current campaign options are used.
-     * @param presetDate Optional {@link LocalDate} to be used as the active date.
-     *                   If {@code null}, the campaign's current date is used.
-     * @param presetFaction Optional {@link Faction} to be used in the faction selection field.
-     *                      If {@code null}, the campaign's default faction is used.
+     * @param presetCampaignOptions Optional {@link CampaignOptions} used to populate values. If {@code null}, the
+     *                              current campaign options are used.
+     * @param presetDate            Optional {@link LocalDate} to be used as the active date. If {@code null}, the
+     *                              campaign's current date is used.
+     * @param presetFaction         Optional {@link Faction} to be used in the faction selection field. If {@code null},
+     *                              the campaign's default faction is used.
      */
     public void loadValuesFromCampaignOptions(@Nullable CampaignOptions presetCampaignOptions,
-                                              @Nullable LocalDate presetDate,
-                                              @Nullable Faction presetFaction) {
+                                              @Nullable LocalDate presetDate, @Nullable Faction presetFaction) {
         CampaignOptions options = presetCampaignOptions;
         if (presetCampaignOptions == null) {
             options = this.campaignOptions;
@@ -587,15 +578,16 @@ public class GeneralTab {
     }
 
     /**
-     * Applies the updated campaign options from the general tab's UI components to the {@link Campaign}.
-     * This method ensures that any changes made in the UI are reflected in the campaign's settings.
+     * Applies the updated campaign options from the general tab's UI components to the {@link Campaign}. This method
+     * ensures that any changes made in the UI are reflected in the campaign's settings.
      *
-     * @param presetCampaignOptions An optional {@link CampaignOptions} to apply instead of the campaign's current options.
+     * @param presetCampaignOptions An optional {@link CampaignOptions} to apply instead of the campaign's current
+     *                              options.
      * @param isStartUp             A boolean indicating if the campaign is in a startup state.
      * @param isSaveAction          A boolean indicating if this is a save action.
      */
-    public void applyCampaignOptionsToCampaign(@Nullable CampaignOptions presetCampaignOptions,
-                                               boolean isStartUp, boolean isSaveAction) {
+    public void applyCampaignOptionsToCampaign(@Nullable CampaignOptions presetCampaignOptions, boolean isStartUp,
+                                               boolean isSaveAction) {
         // First, we apply any updates to the campaign
         if (!isSaveAction) {
             campaign.setName(txtName.getText());
@@ -605,8 +597,8 @@ public class GeneralTab {
                 campaign.setLocalDate(date);
             }
 
-            if ((campaign.getCampaignStartDate() == null)
-                || (campaign.getCampaignStartDate().isAfter(campaign.getLocalDate()))) {
+            if ((campaign.getCampaignStartDate() == null) ||
+                      (campaign.getCampaignStartDate().isAfter(campaign.getLocalDate()))) {
                 campaign.setCampaignStartDate(date);
             }
             // Ensure that the MegaMek year GameOption matches the campaign year

--- a/MekHQ/src/mekhq/gui/dialog/ContractAutomationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractAutomationDialog.java
@@ -27,18 +27,31 @@
  */
 package mekhq.gui.dialog;
 
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.ResourceBundle;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import megamek.client.ui.swing.util.UIUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Campaign.AdministratorSpecialization;
 import mekhq.campaign.personnel.Person;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.ResourceBundle;
-
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
 
 public class ContractAutomationDialog extends JDialog {
     final int LEFT_WIDTH = UIUtil.scaleForGUI(200);
@@ -81,7 +94,7 @@ public class ContractAutomationDialog extends JDialog {
         // Add speaker image (icon)
         ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
         if (speakerIcon != null) {
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 100);
+            speakerIcon = scaleImageIcon(speakerIcon, 100, true);
         }
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);

--- a/MekHQ/src/mekhq/gui/dialog/NewsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewsDialog.java
@@ -27,19 +27,23 @@
  */
 package mekhq.gui.dialog;
 
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.util.List;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.NewsItem;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.List;
-
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * NewsDialog is a dialog window for displaying news items within the context of a campaign. It includes information
@@ -113,7 +117,7 @@ public class NewsDialog extends ImmersiveDialogCore {
         // Get Network image
         String networkImage = NETWORK.imageAddress;
         ImageIcon networkIcon = new ImageIcon(networkImage);
-        networkIcon = scaleImageIconToWidth(networkIcon, IMAGE_WIDTH);
+        networkIcon = scaleImageIcon(networkIcon, IMAGE_WIDTH, true);
 
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(networkIcon);

--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/GrayMondayDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/GrayMondayDialog.java
@@ -27,22 +27,26 @@
  */
 package mekhq.gui.dialog.randomEvents;
 
+import static mekhq.campaign.Campaign.AdministratorSpecialization.LOGISTICS;
+import static mekhq.campaign.randomEvents.GrayMonday.EVENT_DATE_GRAY_MONDAY;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.time.LocalDate;
+import java.util.List;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.Factions;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
-
-import javax.swing.*;
-import java.awt.*;
-import java.time.LocalDate;
-import java.util.List;
-
-import static mekhq.campaign.Campaign.AdministratorSpecialization.LOGISTICS;
-import static mekhq.campaign.randomEvents.GrayMonday.EVENT_DATE_GRAY_MONDAY;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 public class GrayMondayDialog extends ImmersiveDialogCore {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.GrayMonday";
@@ -136,7 +140,7 @@ public class GrayMondayDialog extends ImmersiveDialogCore {
         }
 
         if (speakerIcon != null) {
-            speakerIcon = scaleImageIconToWidth(speakerIcon, IMAGE_WIDTH);
+            speakerIcon = scaleImageIcon(speakerIcon, IMAGE_WIDTH, true);
         }
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogAbandonedConvoy.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogAbandonedConvoy.java
@@ -27,22 +27,34 @@
  */
 package mekhq.gui.dialog.resupplyAndCaches;
 
+import static megamek.common.Compute.randomInt;
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.UUID;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.UUID;
-
-import static megamek.common.Compute.randomInt;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * This class provides a utility method to display a custom dialog related to abandoned convoys in the MekHQ game. The
@@ -95,7 +107,7 @@ public class DialogAbandonedConvoy extends JDialog {
         // Add speaker image (icon)
         ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
         if (speakerIcon != null) {
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 100);
+            speakerIcon = scaleImageIcon(speakerIcon, 100, true);
         }
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogContractStart.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogContractStart.java
@@ -27,6 +27,31 @@
  */
 package mekhq.gui.dialog.resupplyAndCaches;
 
+import static mekhq.campaign.force.ForceType.CONVOY;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.isProhibitedUnitType;
+import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.estimateCargoRequirements;
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.UUID;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
 import mekhq.campaign.Campaign;
@@ -35,18 +60,6 @@ import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.UUID;
-
-import static mekhq.campaign.force.ForceType.CONVOY;
-import static mekhq.campaign.mission.resupplyAndCaches.Resupply.isProhibitedUnitType;
-import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.estimateCargoRequirements;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * This class provides utility methods to display dialogs related to the beginning of a contract. It generates
@@ -98,7 +111,7 @@ public class DialogContractStart extends JDialog {
         // Add speaker image (icon)
         ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
         if (speakerIcon != null) {
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 100);
+            speakerIcon = scaleImageIcon(speakerIcon, 100, true);
         }
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogInterception.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogInterception.java
@@ -27,6 +27,30 @@
  */
 package mekhq.gui.dialog.resupplyAndCaches;
 
+import static megamek.common.Compute.randomInt;
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.ResourceBundle;
+import java.util.UUID;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
@@ -34,17 +58,6 @@ import mekhq.campaign.force.Force;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply;
 import mekhq.campaign.personnel.Person;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.ResourceBundle;
-import java.util.UUID;
-
-import static megamek.common.Compute.randomInt;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * The {@code DialogInterception} class is responsible for displaying a UI dialog when an interception scenario occurs
@@ -116,7 +129,7 @@ public class DialogInterception extends JDialog {
         // Add speaker image (icon)
         ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
         if (speakerIcon != null) {
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 100);
+            speakerIcon = scaleImageIcon(speakerIcon, 100, true);
         }
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogItinerary.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogItinerary.java
@@ -27,21 +27,6 @@
  */
 package mekhq.gui.dialog.resupplyAndCaches;
 
-import megamek.client.ui.swing.util.UIUtil;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.Campaign.AdministratorSpecialization;
-import mekhq.campaign.mission.AtBContract;
-import mekhq.campaign.mission.enums.AtBMoraleLevel;
-import mekhq.campaign.mission.resupplyAndCaches.Resupply;
-import mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType;
-import mekhq.campaign.parts.Part;
-import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.enums.PersonnelRole;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.List;
-
 import static javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE;
 import static megamek.common.Compute.randomInt;
 import static mekhq.campaign.finances.enums.TransactionType.EQUIPMENT_PURCHASE;
@@ -57,8 +42,31 @@ import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getS
 import static mekhq.gui.dialog.resupplyAndCaches.ResupplyDialogUtilities.createPartsReport;
 import static mekhq.gui.dialog.resupplyAndCaches.ResupplyDialogUtilities.formatColumnData;
 import static mekhq.gui.dialog.resupplyAndCaches.ResupplyDialogUtilities.getEnemyFactionReference;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.BorderLayout;
+import java.util.List;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
+
+import megamek.client.ui.swing.util.UIUtil;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.Campaign.AdministratorSpecialization;
+import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.mission.enums.AtBMoraleLevel;
+import mekhq.campaign.mission.resupplyAndCaches.Resupply;
+import mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelRole;
 
 /**
  * The {@code DialogItinerary} class generates and displays dialogs related to resupply operations. These include normal
@@ -117,17 +125,17 @@ public class DialogItinerary {
             }
 
             speakerIcon = getSpeakerIcon(campaign, speaker);
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 100);
+            speakerIcon = scaleImageIcon(speakerIcon, 100, true);
         } else if (resupplyType.equals(RESUPPLY_SMUGGLER)) {
             speakerName = getFormattedTextAt(RESOURCE_BUNDLE, "guerrillaSpeaker.text");
 
             speakerIcon = getFactionLogo(campaign, "PIR", true);
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 200);
+            speakerIcon = scaleImageIcon(speakerIcon, 200, true);
         } else {
             speakerName = contract.getEmployerName(campaign.getGameYear());
 
             speakerIcon = getFactionLogo(campaign, contract.getEmployerCode(), true);
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 200);
+            speakerIcon = scaleImageIcon(speakerIcon, 200, true);
         }
 
         StringBuilder message = new StringBuilder(getInitialDescription(resupply));

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogPlayerConvoyOption.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogPlayerConvoyOption.java
@@ -27,21 +27,34 @@
  */
 package mekhq.gui.dialog.resupplyAndCaches;
 
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.WindowListener;
+import java.util.ResourceBundle;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import megamek.client.ui.swing.util.UIUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Campaign.AdministratorSpecialization;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply;
 import mekhq.campaign.personnel.Person;
-
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.WindowListener;
-import java.util.ResourceBundle;
-
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * The {@code DialogPlayerConvoyOption} class provides functionality to display a dialog that prompts the player to
@@ -123,7 +136,7 @@ public class DialogPlayerConvoyOption extends JDialog {
         // Add speaker image (icon)
         ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
         if (speakerIcon != null) {
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 100);
+            speakerIcon = scaleImageIcon(speakerIcon, 100, true);
         }
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogResupplyFocus.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogResupplyFocus.java
@@ -27,21 +27,34 @@
  */
 package mekhq.gui.dialog.resupplyAndCaches;
 
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.List;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import megamek.client.ui.swing.util.UIUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Campaign.AdministratorSpecialization;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.personnel.Person;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.List;
-
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * The {@code DialogResupplyFocus} class is responsible for displaying a dialog that allows the player to select their
@@ -120,7 +133,7 @@ public class DialogResupplyFocus extends JDialog {
         // Add speaker image (icon)
         ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
         if (speakerIcon != null) {
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 100);
+            speakerIcon = scaleImageIcon(speakerIcon, 100, true);
         }
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogRoleplayEvent.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogRoleplayEvent.java
@@ -27,19 +27,32 @@
  */
 package mekhq.gui.dialog.resupplyAndCaches;
 
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
+import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.UUID;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import megamek.client.ui.swing.util.UIUtil;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.UUID;
-
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * The {@code DialogRoleplayEvent} class handles the creation and display of roleplay event dialogs for convoy missions
@@ -118,7 +131,7 @@ public class DialogRoleplayEvent extends JDialog {
         // Add speaker image (icon)
         ImageIcon speakerIcon = getSpeakerIcon(campaign, speaker);
         if (speakerIcon != null) {
-            speakerIcon = scaleImageIconToWidth(speakerIcon, 100);
+            speakerIcon = scaleImageIcon(speakerIcon, 100, true);
         }
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogSwindled.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogSwindled.java
@@ -27,24 +27,37 @@
  */
 package mekhq.gui.dialog.resupplyAndCaches;
 
+import static mekhq.campaign.universe.Factions.getFactionLogo;
+import static mekhq.gui.dialog.resupplyAndCaches.ResupplyDialogUtilities.getEnemyFactionReference;
+import static mekhq.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Compute;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.resupplyAndCaches.Resupply;
 
-import javax.swing.*;
-import java.awt.*;
-
-import static mekhq.campaign.universe.Factions.getFactionLogo;
-import static mekhq.gui.dialog.resupplyAndCaches.ResupplyDialogUtilities.getEnemyFactionReference;
-import static mekhq.utilities.ImageUtilities.scaleImageIconToWidth;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
-
 /**
- * The {@code DialogSwindled} class provides functionality to display a dialog related to swindling events
- * during guerrilla contract missions. This dialog presents localized narrative content with
- * dynamic elements such as faction logos and contextual details about enemy factions.
+ * The {@code DialogSwindled} class provides functionality to display a dialog related to swindling events during
+ * guerrilla contract missions. This dialog presents localized narrative content with dynamic elements such as faction
+ * logos and contextual details about enemy factions.
  */
 public class DialogSwindled extends JDialog {
     final int LEFT_WIDTH = UIUtil.scaleForGUI(200);
@@ -54,9 +67,9 @@ public class DialogSwindled extends JDialog {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.Resupply";
 
     /**
-     * Displays a dialog notifying the player that they have been swindled during a resupply.
-     * The dialog includes details about the incident, a visual representation via a faction logo, and a confirmation
-     * button to allow the player to dismiss the dialog after reading it.
+     * Displays a dialog notifying the player that they have been swindled during a resupply. The dialog includes
+     * details about the incident, a visual representation via a faction logo, and a confirmation button to allow the
+     * player to dismiss the dialog after reading it.
      *
      * <p>This method performs the following tasks:</p>
      * <ol>
@@ -87,9 +100,9 @@ public class DialogSwindled extends JDialog {
      * <p>This dialog enhances the narrative immersion of being swindled in missions by presenting
      * visually and contextually rich content relevant to the player's situation.</p>
      *
-     * @param resupply the {@link Resupply} instance containing details about the current campaign, contract,
-     *                 and mission context. This object is used to retrieve dynamic elements such as the enemy
-     *                 faction and the player's information.
+     * @param resupply the {@link Resupply} instance containing details about the current campaign, contract, and
+     *                 mission context. This object is used to retrieve dynamic elements such as the enemy faction and
+     *                 the player's information.
      */
     public DialogSwindled(Resupply resupply) {
         final Campaign campaign = resupply.getCampaign();
@@ -115,15 +128,16 @@ public class DialogSwindled extends JDialog {
         String speakerName = String.format("<b>'%s'</b><br>%s", smugglerCallSign, smugglerTitle);
 
         ImageIcon speakerIcon = getFactionLogo(campaign, "PIR", true);
-        speakerIcon = scaleImageIconToWidth(speakerIcon, 100);
+        speakerIcon = scaleImageIcon(speakerIcon, 100, true);
         JLabel imageLabel = new JLabel();
         imageLabel.setIcon(speakerIcon);
         imageLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         // Speaker description (below the icon)
-        JLabel leftDescription = new JLabel(
-            String.format("<html><div style='width: %s; text-align:center;'>%s</div></html>",
-                LEFT_WIDTH, speakerName));
+        JLabel leftDescription = new JLabel(String.format(
+              "<html><div style='width: %s; text-align:center;'>%s</div></html>",
+              LEFT_WIDTH,
+              speakerName));
         leftDescription.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         // Add the image and description to the leftBox
@@ -143,13 +157,14 @@ public class DialogSwindled extends JDialog {
 
         String enemyFactionReference = getEnemyFactionReference(resupply);
         String message = getFormattedTextAt(RESOURCE_BUNDLE,
-            "guerrillaSwindled" + Compute.randomInt(25) + ".text",
-                campaign.getCommanderAddress(true),
-            enemyFactionReference);
+              "guerrillaSwindled" + Compute.randomInt(25) + ".text",
+              campaign.getCommanderAddress(true),
+              enemyFactionReference);
 
-        JLabel rightDescription = new JLabel(
-            String.format("<html><div style='width: %s; text-align:center;'>%s</div></html>",
-                RIGHT_WIDTH, message));
+        JLabel rightDescription = new JLabel(String.format(
+              "<html><div style='width: %s; text-align:center;'>%s</div></html>",
+              RIGHT_WIDTH,
+              message));
         rightBox.add(rightDescription);
 
         // Add rightBox to mainPanel
@@ -174,10 +189,9 @@ public class DialogSwindled extends JDialog {
 
         // New panel (to be added below the button panel)
         JPanel infoPanel = new JPanel(new BorderLayout());
-        JLabel lblInfo = new JLabel(
-            String.format("<html><div style='width: %s; text-align:center;'>%s</div></html>",
-                RIGHT_WIDTH + LEFT_WIDTH,
-                getFormattedTextAt(RESOURCE_BUNDLE, "documentation.prompt")));
+        JLabel lblInfo = new JLabel(String.format("<html><div style='width: %s; text-align:center;'>%s</div></html>",
+              RIGHT_WIDTH + LEFT_WIDTH,
+              getFormattedTextAt(RESOURCE_BUNDLE, "documentation.prompt")));
         lblInfo.setHorizontalAlignment(SwingConstants.CENTER);
         infoPanel.add(lblInfo, BorderLayout.CENTER);
         infoPanel.setBorder(BorderFactory.createEtchedBorder());

--- a/MekHQ/src/mekhq/utilities/ImageUtilities.java
+++ b/MekHQ/src/mekhq/utilities/ImageUtilities.java
@@ -38,40 +38,59 @@ import javax.swing.ImageIcon;
 
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
+import megamek.logging.MMLogger;
 
 public class ImageUtilities {
+    private static final MMLogger logger = MMLogger.create(ImageUtilities.class);
+
     /**
-     * Scales an {@link ImageIcon} to the specified width while maintaining its aspect ratio.
-     * The method dynamically determines the scaled height proportional to the original
-     * image dimensions to retain visual quality and appearance.
-     *
-     * <p>The scaling process follows these steps:</p>
-     * <ol>
-     *     <li>Adjusts the provided {@code width} to account for GUI scaling factors
-     *         by using {@link UIUtil#scaleForGUI(int)} to ensure consistent dimensions.</li>
-     *     <li>Calculates the new height required to maintain the image's original aspect ratio
-     *         using the formula {@code height = (width * originalHeight) / originalWidth}.</li>
-     *     <li>Uses {@link Image#getScaledInstance(int, int, int)} to create a resized image
-     *         with smooth scaling for better visual quality ({@code Image.SCALE_SMOOTH}).</li>
-     *     <li>Packages the resulting scaled image into a new {@link ImageIcon} object
-     *         and returns it.</li>
-     * </ol>
-     *
-     * <p>By dynamically scaling both width and height based on the GUI scaling factor,
-     * the method ensures that the resized icon adapts seamlessly across high-DPI displays
-     * and varying screen resolutions.</p>
-     *
-     * @param icon  the {@link ImageIcon} to be resized. This represents the source image
-     *              that requires scaling.
-     * @param width the desired width (in pixels) to scale the {@link ImageIcon} to.
-     *              The actual applied value will consider GUI scaling factors to ensure
-     *              consistent appearance across different display settings.
-     * @return a new {@link ImageIcon} instance representing the scaled image while
-     *         preserving the original aspect ratio.
+     * @deprecated use {@link #scaleImageIcon(ImageIcon, int, boolean)} instead.
      */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     public static ImageIcon scaleImageIconToWidth(ImageIcon icon, int width) {
-        width = UIUtil.scaleForGUI(width);
-        int height = (int) Math.ceil((double) width * icon.getIconHeight() / icon.getIconWidth());
+        return scaleImageIcon(icon, width, true);
+    }
+
+    /**
+     * Scales an {@link ImageIcon} proportionally based on either the specified width or height.
+     *
+     * <p>This method preserves the aspect ratio of the original image while resizing. The size to scale
+     * is determined by the {@code size} parameter, and whether scaling is based on width or height is controlled by the
+     * {@code scaleByWidth} flag.</p>
+     *
+     * <p>If the provided {@link ImageIcon} is {@code null}, an empty {@link ImageIcon} will be returned, and
+     * an error will be logged.</p>
+     *
+     * @param icon         The {@link ImageIcon} to be scaled. If {@code null}, an empty {@link ImageIcon} is returned.
+     * @param size         The target size to scale to, either width or height depending on the {@code scaleByWidth}
+     *                     flag. This value will be scaled for the GUI using {@link UIUtil#scaleForGUI(int)}.
+     * @param scaleByWidth A {@code boolean} flag to determine the scaling mode:
+     *                     <ul>
+     *                       <li>If {@code true}, scales the image by the given width, and calculates the height
+     *                           proportionally.</li>
+     *                       <li>If {@code false}, scales the image by the given height, and calculates the width
+     *                           proportionally.</li>
+     *                     </ul>
+     *
+     * @return A scaled {@link ImageIcon}, resized to the specified target dimension while maintaining the aspect ratio.
+     *       If the provided {@link ImageIcon} is {@code null}, returns an empty {@link ImageIcon}.
+     */
+    public static ImageIcon scaleImageIcon(ImageIcon icon, int size, boolean scaleByWidth) {
+        if (icon == null) {
+            logger.error(new NullPointerException(),
+                  "ImageIcon is null in scaleImageIcon(ImageIcon, int, boolean). Returning an empty ImageIcon.");
+            return new ImageIcon();
+        }
+
+        int width, height;
+
+        if (scaleByWidth) {
+            width = UIUtil.scaleForGUI(size);
+            height = (int) Math.ceil((double) width * icon.getIconHeight() / icon.getIconWidth());
+        } else {
+            height = UIUtil.scaleForGUI(size);
+            width = (int) Math.ceil((double) height * icon.getIconWidth() / icon.getIconHeight());
+        }
 
         Image image = icon.getImage();
         Image scaledImage = image.getScaledInstance(width, height, Image.SCALE_SMOOTH);
@@ -83,8 +102,7 @@ public class ImageUtilities {
      * Adds a default tint to the provided image with standard transparency settings.
      *
      * <p>This is a simplified utility method that applies a given tint color to only the
-     * non-transparent portions of an image, with a default transparency level of 75%
-     * (25% opaque).</p>
+     * non-transparent portions of an image, with a default transparency level of 75% (25% opaque).</p>
      *
      * @param image     the {@link Image} to which the tint will be applied.
      * @param tintColor the {@link Color} used for the tint.
@@ -98,33 +116,30 @@ public class ImageUtilities {
     }
 
     /**
-     * Adds a customizable tint to the given image, with options to control the transparency
-     * and the areas of the image affected by the tint.
+     * Adds a customizable tint to the given image, with options to control the transparency and the areas of the image
+     * affected by the tint.
      *
      * <p>This method processes the input {@link Image} and applies a tint (a blend of the
-     * given color and transparency) across the image. You may specify whether the tint should
-     * apply only to non-transparent areas or the entire image. Additionally, the transparency
-     * level can be customized or left as the default (50% transparency, 50% opaque).</p>
+     * given color and transparency) across the image. You may specify whether the tint should apply only to
+     * non-transparent areas or the entire image. Additionally, the transparency level can be customized or left as the
+     * default (50% transparency, 50% opaque).</p>
      *
-     * @param image              the {@link Image} to which the tint will be applied.
-     * @param tint               the {@link Color} used for the tint.
-     * @param nonTransparentOnly if {@code true}, applies the tint only to non-transparent areas of
-     *                           the image. Otherwise, it applies the tint globally.
-     * @param transparencyPercent an optional transparency level for the tint. If {@code null}, it
-     *                            defaults to 50% transparency (0.5). Must be between {@code 0.0}
-     *                            and {@code 1.0}.
+     * @param image               the {@link Image} to which the tint will be applied.
+     * @param tint                the {@link Color} used for the tint.
+     * @param nonTransparentOnly  if {@code true}, applies the tint only to non-transparent areas of the image.
+     *                            Otherwise, it applies the tint globally.
+     * @param transparencyPercent an optional transparency level for the tint. If {@code null}, it defaults to 50%
+     *                            transparency (0.5). Must be between {@code 0.0} and {@code 1.0}.
      *
      * @return an {@link ImageIcon} containing the image with the applied tint.
      *
      * @see #addTintToImageIcon(Image, Color) for default behavior.
      */
     public static ImageIcon addTintToImageIcon(Image image, Color tint, boolean nonTransparentOnly,
-                                           @Nullable Double transparencyPercent) {
-        BufferedImage tintedImage = new BufferedImage(
-              image.getWidth(null),
+                                               @Nullable Double transparencyPercent) {
+        BufferedImage tintedImage = new BufferedImage(image.getWidth(null),
               image.getHeight(null),
-              BufferedImage.TYPE_INT_ARGB
-        );
+              BufferedImage.TYPE_INT_ARGB);
 
         Graphics2D graphics = tintedImage.createGraphics();
         graphics.drawImage(image, 0, 0, null);
@@ -134,7 +149,9 @@ public class ImageUtilities {
             graphics.setComposite(AlphaComposite.SrcAtop);
         }
 
-        graphics.setColor(new Color(tint.getRed(), tint.getGreen(), tint.getBlue(),
+        graphics.setColor(new Color(tint.getRed(),
+              tint.getGreen(),
+              tint.getBlue(),
               getAlpha(transparencyPercent == null ? 0.5 : transparencyPercent)));
         graphics.fillRect(0, 0, tintedImage.getWidth(), tintedImage.getHeight());
 
@@ -178,7 +195,8 @@ public class ImageUtilities {
      *
      * @return A new {@link BufferedImage} with the specified tint applied.
      */
-    public static BufferedImage addTintToBufferedImage(BufferedImage image, Color tint, boolean nonTransparentOnly, @Nullable Double transparencyPercent) {
+    public static BufferedImage addTintToBufferedImage(BufferedImage image, Color tint, boolean nonTransparentOnly,
+                                                       @Nullable Double transparencyPercent) {
         // Create a new BufferedImage with the same dimensions and type as the original
         BufferedImage tintedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
 

--- a/MekHQ/src/mekhq/utilities/ImageUtilities.java
+++ b/MekHQ/src/mekhq/utilities/ImageUtilities.java
@@ -27,6 +27,7 @@
  */
 package mekhq.utilities;
 
+import static java.lang.Math.max;
 import static java.lang.Math.round;
 
 import java.awt.AlphaComposite;
@@ -85,10 +86,11 @@ public class ImageUtilities {
         int width, height;
 
         if (scaleByWidth) {
-            width = UIUtil.scaleForGUI(size);
+            // The uses of 'max' here are to prevent us risking a potential image with an illegal 0 px dimension.
+            width = max(1, UIUtil.scaleForGUI(size));
             height = (int) Math.ceil((double) width * icon.getIconHeight() / icon.getIconWidth());
         } else {
-            height = UIUtil.scaleForGUI(size);
+            height = max(1, UIUtil.scaleForGUI(size));
             width = (int) Math.ceil((double) height * icon.getIconWidth() / icon.getIconHeight());
         }
 


### PR DESCRIPTION
- Replaced usage of `scaleImageIconToWidth` with the new `scaleImageIcon` method across multiple classes.
- Marked `scaleImageIconToWidth` as deprecated with a warning to use `scaleImageIcon`.
- Ensured all affected image scaling operations now account for GUI scaling factors and maintain aspect ratios.

### Dev Notes
This just replaces the image scaling utility with something that's a bit more feature complete and safer to use.