### PR TITLE
Fixed Minimum Bid Calculation in Mercenary Auction

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/MercenaryAuction.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/MercenaryAuction.java
@@ -27,13 +27,6 @@
  */
 package mekhq.campaign.randomEvents;
 
-import megamek.common.Entity;
-import megamek.logging.MMLogger;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.stratcon.StratconCampaignState;
-import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
-import mekhq.gui.dialog.MercenaryAuctionDialog;
-
 import static java.lang.Math.max;
 import static megamek.common.Compute.d6;
 import static megamek.common.Compute.randomInt;
@@ -43,6 +36,13 @@ import static mekhq.campaign.mission.AtBDynamicScenarioFactory.getEntity;
 import static mekhq.campaign.mission.BotForceRandomizer.UNIT_WEIGHT_UNSPECIFIED;
 import static mekhq.campaign.unit.Unit.getRandomUnitQuality;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import megamek.common.Entity;
+import megamek.logging.MMLogger;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.stratcon.StratconCampaignState;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+import mekhq.gui.dialog.MercenaryAuctionDialog;
 
 /**
  * This class handles the logic for determining auction eligibility based on the player's resources and provides the
@@ -66,7 +66,8 @@ public class MercenaryAuction {
      * @param campaign The current {@link Campaign} instance where the auction takes place.
      * @param unitType The type of unit being auctioned (e.g., `MECH`, `VEHICLE`).
      */
-    public MercenaryAuction(Campaign campaign, int requiredCombatTeams, StratconCampaignState campaignState, int unitType) {
+    public MercenaryAuction(Campaign campaign, int requiredCombatTeams, StratconCampaignState campaignState,
+                            int unitType) {
         String faction = campaign.getFaction().getShortName();
 
         Entity entity = getEntity(faction,
@@ -90,7 +91,7 @@ public class MercenaryAuction {
         }
 
         int maximumBid = campaignState.getSupportPoints();
-        int minimumBid = maximumBid * requiredCombatTeams;
+        int minimumBid = requiredCombatTeams;
         boolean cannotAffordOpeningBid = (maximumBid < minimumBid) || (maximumBid == 0);
 
         // If the player can't afford the minimum bid, we just tell them about the opportunity and
@@ -123,7 +124,7 @@ public class MercenaryAuction {
               maximumBid,
               AUCTION_TIER_SUCCESS_PERCENT,
               max(requiredCombatTeams, 1));
-        int finalBid = mercenaryAuctionDialog.getSpinnerValue() * AUCTION_TIER_SUCCESS_PERCENT;
+        int finalBid = (mercenaryAuctionDialog.getSpinnerValue() / minimumBid) * AUCTION_TIER_SUCCESS_PERCENT;
 
         // If the player confirmed the auction (option 0) then check whether they were successful,
         // deliver the unit, and deduct funds.


### PR DESCRIPTION
- Corrected the minimum bid logic by removing its dependency on support points, ensuring it now scales accurately with the required combat teams.
- Adjusted the final bid computation to account for the updated minimum bid calculation.

### Dev Notes
Marking this as 'high' as it prevented use of this system.