### PR TITLE
Parts Fixes Grab Bag

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -229,7 +229,6 @@ import mekhq.campaign.universe.selectors.planetSelectors.RangedPlanetSelector;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
 import mekhq.gui.campaignOptions.enums.ProcurementPersonnelPick;
-import mekhq.gui.sorter.PersonTitleSorter;
 import mekhq.module.atb.AtBEventProcessor;
 import mekhq.service.AutosaveService;
 import mekhq.service.IAutosaveService;
@@ -3116,8 +3115,8 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Retrieves a list of active technicians, with options to include only those with time remaining,
-     * prioritize elite technicians, and expand the search to include technicians with additional roles.
+     * Retrieves a list of active technicians, with options to include only those with time remaining, prioritize elite
+     * technicians, and expand the search to include technicians with additional roles.
      *
      * <p>The resulting list includes {@link Person} objects who qualify as technicians ({@link Person#isTech()})
      * or, if specified, as expanded technicians ({@link Person#isTechExpanded()}). If the person is part of a
@@ -3140,11 +3139,11 @@ public class Campaign implements ITechManager {
      *
      * @param noZeroMinute If {@code true}, excludes technicians with no remaining available minutes.
      * @param eliteFirst   If {@code true}, sorts the list to place the most skilled technicians at the top.
-     * @param expanded     If {@code true}, includes technicians with expanded roles (e.g., those qualifying
-     *                     under {@link Person#isTechExpanded()}).
+     * @param expanded     If {@code true}, includes technicians with expanded roles (e.g., those qualifying under
+     *                     {@link Person#isTechExpanded()}).
      *
-     * @return A list of active {@link Person} objects who qualify as technicians or expanded technicians,
-     *         sorted by skill, available time, and rank as specified by the input parameters.
+     * @return A list of active {@link Person} objects who qualify as technicians or expanded technicians, sorted by
+     *       skill, available time, and rank as specified by the input parameters.
      */
     public List<Person> getTechsExpanded(final boolean noZeroMinute, final boolean eliteFirst, final boolean expanded) {
         final List<Person> techs = getActivePersonnel().stream()
@@ -3451,13 +3450,12 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Retrieves a list of eligible logistics personnel who can perform procurement actions
-     * based on the current campaign options. If acquisitions are set to automatically succeed,
-     * an empty list is returned.
+     * Retrieves a list of eligible logistics personnel who can perform procurement actions based on the current
+     * campaign options. If acquisitions are set to automatically succeed, an empty list is returned.
      *
      * <p>This method evaluates active personnel to determine who is eligible for procurement
-     * actions under the current campaign configuration. Personnel are filtered and sorted
-     * based on specific criteria:</p>
+     * actions under the current campaign configuration. Personnel are filtered and sorted based on specific
+     * criteria:</p>
      * <ul>
      *   <li><strong>Automatic Success:</strong> If the acquisition skill equals {@code S_AUTO},
      *       an empty list is immediately returned.</li>
@@ -3477,8 +3475,8 @@ public class Campaign implements ITechManager {
      *   </li>
      * </ul>
      *
-     * @return A {@link List} of {@link Person} objects who are eligible and sorted to perform
-     *         logistical actions, or an empty list if acquisitions automatically succeed.
+     * @return A {@link List} of {@link Person} objects who are eligible and sorted to perform logistical actions, or an
+     *       empty list if acquisitions automatically succeed.
      */
     public List<Person> getLogisticsPersonnel() {
         final String skill = getCampaignOptions().getAcquisitionSkill();
@@ -4204,11 +4202,11 @@ public class Campaign implements ITechManager {
     public Part fixWarehousePart(Part part, Person tech) {
         // get a new cloned part to work with and decrement original
         Part repairable = part.clone();
-        part.decrementQuantity();
+        part.changeQuantity(-1);
 
         fixPart(repairable, tech);
         if (!(repairable instanceof OmniPod)) {
-            getQuartermaster().addPart(repairable, 0);
+            getQuartermaster().addPart(repairable, 0, false);
         }
 
         // If there is at least one remaining unit of the part
@@ -5264,7 +5262,7 @@ public class Campaign implements ITechManager {
 
             // check to see if this part can now be combined with other spare parts
             if (part.isSpare() && (part.getQuantity() > 0)) {
-                getQuartermaster().addPart(part, 0);
+                getQuartermaster().addPart(part, 0, false);
             }
         }
 
@@ -7438,7 +7436,8 @@ public class Campaign implements ITechManager {
      * @return a {@link TargetRoll} object representing the roll required to successfully acquire the requested item, or
      *       an impossible/automatic result under specific circumstances.
      */
-    public TargetRoll getTargetForAcquisition(final IAcquisitionWork acquisition, final @Nullable Person person, final boolean checkDaysToWait) {
+    public TargetRoll getTargetForAcquisition(final IAcquisitionWork acquisition, final @Nullable Person person,
+                                              final boolean checkDaysToWait) {
         if (getCampaignOptions().getAcquisitionSkill().equals(S_AUTO)) {
             return new TargetRoll(TargetRoll.AUTOMATIC_SUCCESS, "Automatic Success");
         }
@@ -9430,7 +9429,7 @@ public class Campaign implements ITechManager {
             int toBuy = findStockUpAmount(partInUse);
             while (toBuy > 0) {
                 IAcquisitionWork partToBuy = partInUse.getPartToBuy();
-                getQuartermaster().addPart((Part) partToBuy.getNewEquipment(), 0);
+                getQuartermaster().addPart((Part) partToBuy.getNewEquipment(), 0, true);
                 --toBuy;
             }
         }

--- a/MekHQ/src/mekhq/campaign/mission/Loot.java
+++ b/MekHQ/src/mekhq/campaign/mission/Loot.java
@@ -28,6 +28,21 @@
  */
 package mekhq.campaign.mission;
 
+import static mekhq.campaign.mission.resupplyAndCaches.GenerateResupplyContents.RESUPPLY_MINIMUM_PART_WEIGHT;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_AMMO_TONNAGE;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_ARMOR_TONNAGE;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.UUID;
+
 import megamek.Version;
 import megamek.common.Entity;
 import megamek.common.MekFileParser;
@@ -50,15 +65,6 @@ import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import java.io.PrintWriter;
-import java.util.*;
-
-import static mekhq.campaign.mission.resupplyAndCaches.GenerateResupplyContents.RESUPPLY_MINIMUM_PART_WEIGHT;
-import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_AMMO_TONNAGE;
-import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_ARMOR_TONNAGE;
-import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
-import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
@@ -156,22 +162,20 @@ public class Loot {
     }
 
     /**
-     * Handles the looting process after a scenario is completed by adding loot to the campaign.
-     * The loot can include cash rewards, salvageable parts, and units, along with handling
-     * special scenarios like resupply interception.
+     * Handles the looting process after a scenario is completed by adding loot to the campaign. The loot can include
+     * cash rewards, salvageable parts, and units, along with handling special scenarios like resupply interception.
      *
      * <p>This method evaluates the loot based on the scenario type and unit statuses,
      * ensuring that captured, lost, or excess loot is appropriately managed.</p>
      *
-     * @param campaign              the campaign to which the looted resources (e.g., cash, parts, units) are added
-     * @param scenario              the specific scenario during which the loot was acquired
-     * @param unitsStatuses         a mapping of unit IDs to their respective status after the scenario
-     *                              (e.g., whether units are lost, captured, or operational)
+     * @param campaign      the campaign to which the looted resources (e.g., cash, parts, units) are added
+     * @param scenario      the specific scenario during which the loot was acquired
+     * @param unitsStatuses a mapping of unit IDs to their respective status after the scenario (e.g., whether units are
+     *                      lost, captured, or operational)
      */
-    public void getLoot(Campaign campaign, Scenario scenario,
-                        Hashtable<UUID, UnitStatus> unitsStatuses) {
+    public void getLoot(Campaign campaign, Scenario scenario, Hashtable<UUID, UnitStatus> unitsStatuses) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Loot",
-            MekHQ.getMHQOptions().getLocale());
+              MekHQ.getMHQOptions().getLocale());
 
         boolean isResupply = scenario.getStratConScenarioType() == ScenarioType.SPECIAL_RESUPPLY;
         double cargo = 0;
@@ -179,8 +183,7 @@ public class Loot {
         // If we're looting as the result of a StratCon Emergency Convoy Defence scenario,
         // we need to determine how much of the convoy survived
         if (isResupply) {
-            List<UUID> allUnitIds = new ArrayList<>(
-                scenario.getForces(campaign).getAllUnits(false));
+            List<UUID> allUnitIds = new ArrayList<>(scenario.getForces(campaign).getAllUnits(false));
 
             for (UUID unitId : allUnitIds) {
                 Unit unit = campaign.getUnit(unitId);
@@ -207,13 +210,16 @@ public class Loot {
         if (cash.isPositive()) {
             logger.debug("Looting cash: {}", cash);
 
-            campaign.getFinances().credit(TransactionType.MISCELLANEOUS, campaign.getLocalDate(), cash,
-                    "Reward for " + getName() + " during " + scenario.getName());
+            campaign.getFinances()
+                  .credit(TransactionType.MISCELLANEOUS,
+                        campaign.getLocalDate(),
+                        cash,
+                        "Reward for " + getName() + " during " + scenario.getName());
 
             campaign.addReport(String.format(resources.getString("looted.cash"),
-                cash.toAmountAndSymbolString(),
-                spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor()),
-                CLOSING_SPAN_TAG));
+                  cash.toAmountAndSymbolString(),
+                  spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor()),
+                  CLOSING_SPAN_TAG));
         }
 
         List<String> abandonedParts = new ArrayList<>();
@@ -244,59 +250,56 @@ public class Loot {
             logger.debug("Looting part: {}", part.getName());
 
             lootedParts.add("<br>- " + part.getName() + " (" + partWeight + " tons)");
-            campaign.getQuartermaster().addPart(part, 0);
+            campaign.getQuartermaster().addPart(part, 0, true);
 
             logger.debug("Looting parts complete");
         }
 
         if (!lootedParts.isEmpty()) {
-            String lootedPartsReport = lootedParts.toString()
-                .replace("[", "")
-                .replace("]", "");
+            String lootedPartsReport = lootedParts.toString().replace("[", "").replace("]", "");
             campaign.addReport(String.format(resources.getString("looted.successful.parts"),
-                spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor()),
-                CLOSING_SPAN_TAG, lootedPartsReport));
+                  spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor()),
+                  CLOSING_SPAN_TAG,
+                  lootedPartsReport));
         }
 
         if (!abandonedParts.isEmpty()) {
-            String abandonedPartsReport = abandonedParts.toString()
-                .replace("[", "")
-                .replace("]", "");
+            String abandonedPartsReport = abandonedParts.toString().replace("[", "").replace("]", "");
             campaign.addReport(String.format(resources.getString("looted.failed.parts"),
-                spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
-                CLOSING_SPAN_TAG, abandonedPartsReport));
+                  spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor()),
+                  CLOSING_SPAN_TAG,
+                  abandonedPartsReport));
         }
 
         // This only needs to be done once, so we do it outside the 'loot units' loop
         // for efficiency
-        HashMap<String, Integer> qualityAndModifier = getQualityAndModifier(
-                campaign.getMission(scenario.getMissionId()));
+        HashMap<String, Integer> qualityAndModifier = getQualityAndModifier(campaign.getMission(scenario.getMissionId()));
 
         for (Entity entity : units) {
             logger.debug("Looting unit: {}", entity.getDisplayName());
 
             if (campaign.getCampaignOptions().isUseRandomUnitQualities()) {
                 qualityAndModifier.put("quality",
-                    Unit.getRandomUnitQuality(qualityAndModifier.get("modifier")).toNumeric());
+                      Unit.getRandomUnitQuality(qualityAndModifier.get("modifier")).toNumeric());
             }
 
-            campaign.addNewUnit(entity, false, 0,
-                PartQuality.fromNumeric(qualityAndModifier.get("quality")));
+            campaign.addNewUnit(entity, false, 0, PartQuality.fromNumeric(qualityAndModifier.get("quality")));
 
             logger.debug("Looting units complete");
         }
     }
 
     /**
-     * Returns fixed quality values, and modifiers (for dynamic quality) used to
-     * generate a new unit
-     * with quality based on the equipment quality of the contract OpFor.
-     * If the contract isn't an instance of AtBContract we use fixed values.
+     * Returns fixed quality values, and modifiers (for dynamic quality) used to generate a new unit with quality based
+     * on the equipment quality of the contract OpFor. If the contract isn't an instance of AtBContract we use fixed
+     * values.
      *
      * @param contract the mission contract
+     *
      * @return a HashMap containing quality and modifier as key-value pairs:
-     * @throws IllegalStateException if the contract is an instance of AtBContract
-     *                               and the enemy quality is not recognized
+     *
+     * @throws IllegalStateException if the contract is an instance of AtBContract and the enemy quality is not
+     *                               recognized
      */
     private static HashMap<String, Integer> getQualityAndModifier(Mission contract) {
         HashMap<String, Integer> qualityAndModifier = new HashMap<>();
@@ -326,8 +329,8 @@ public class Loot {
                     break;
                 default:
                     throw new IllegalStateException(
-                            "Unexpected value in mekhq/campaign/mission/Loot.java/getQualityAndModifier: "
-                                    + ((AtBContract) contract).getEnemyQuality());
+                          "Unexpected value in mekhq/campaign/mission/Loot.java/getQualityAndModifier: " +
+                                ((AtBContract) contract).getEnemyQuality());
             }
         } else {
             qualityAndModifier.put("quality", PartQuality.QUALITY_D.toNumeric());

--- a/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
@@ -29,7 +29,6 @@ package mekhq.gui.adapter;
 
 import java.awt.event.ActionEvent;
 import java.util.Optional;
-
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -38,6 +37,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
 import megamek.common.TargetRoll;
+import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.event.PartChangedEvent;
 import mekhq.campaign.event.PartModeChangedEvent;
@@ -55,6 +55,7 @@ import mekhq.gui.model.PartsTableModel;
 import mekhq.service.enums.MRMSMode;
 
 public class PartsTableMouseAdapter extends JPopupMenuAdapter {
+    private static final MMLogger logger = MMLogger.create(PartsTableMouseAdapter.class);
 
     private CampaignGUI gui;
     private JTable partsTable;
@@ -67,8 +68,7 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
     }
 
     public static void connect(CampaignGUI gui, JTable partsTable, PartsTableModel partsModel) {
-        new PartsTableMouseAdapter(gui, partsTable, partsModel)
-                .connect(partsTable);
+        new PartsTableMouseAdapter(gui, partsTable, partsModel).connect(partsTable);
     }
 
     @Override
@@ -105,8 +105,12 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
                 if (selectedPart instanceof Armor) {
                     n = ((Armor) selectedPart).getAmount();
                 }
-                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(), true,
-                        "Sell How Many " + selectedPart.getName() + "s?", 1, 1, n);
+                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      "Sell How Many " + selectedPart.getName() + "s?",
+                      0,
+                      0,
+                      n);
                 pvcd.setVisible(true);
                 if (pvcd.getValue() < 0) {
                     return;
@@ -118,14 +122,20 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
             Money refundAmount = Money.zero();
             for (Part p : parts) {
                 if (null != p) {
-                    refundAmount = refundAmount.plus(p.getActualValue().multipliedBy(p.getQuantity())
-                            .multipliedBy(gui.getCampaign().getCampaignOptions().getCancelledOrderRefundMultiplier()));
+                    refundAmount = refundAmount.plus(p.getActualValue()
+                                                           .multipliedBy(p.getQuantity())
+                                                           .multipliedBy(gui.getCampaign()
+                                                                               .getCampaignOptions()
+                                                                               .getCancelledOrderRefundMultiplier()));
                     gui.getCampaign().getWarehouse().removePart(p);
                 }
             }
-            gui.getCampaign().getFinances().credit(TransactionType.EQUIPMENT_PURCHASE,
-                    gui.getCampaign().getLocalDate(), refundAmount,
-                    "refund for cancelled equipment sale");
+            gui.getCampaign()
+                  .getFinances()
+                  .credit(TransactionType.EQUIPMENT_PURCHASE,
+                        gui.getCampaign().getLocalDate(),
+                        refundAmount,
+                        "refund for cancelled equipment sale");
         } else if (command.equalsIgnoreCase("ARRIVE")) {
             for (Part p : parts) {
                 if (null != p) {
@@ -138,25 +148,57 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
                     gui.getCampaign().getWarehouse().removePart(p);
                 }
             }
+        } else if (command.equalsIgnoreCase("REMOVE_N")) {
+            if (null != selectedPart) {
+                int n = selectedPart.getQuantity();
+                if (selectedPart instanceof AmmoStorage) {
+                    n = ((AmmoStorage) selectedPart).getShots();
+                }
+                if (selectedPart instanceof Armor) {
+                    n = ((Armor) selectedPart).getAmount();
+                }
+                PopupValueChoiceDialog dialog = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      "Remove How Many " + selectedPart.getName() + "s?",
+                      0,
+                      0,
+                      n);
+                dialog.setVisible(true);
+                if (dialog.getValue() < 0) {
+                    return;
+                }
+                int quantity = dialog.getValue();
+                gui.getCampaign().getWarehouse().removePart(selectedPart, quantity);
+            }
         } else if (command.contains("SET_QUALITY")) {
             boolean reverse = gui.getCampaign().getCampaignOptions().isReverseQualityNames();
-            Object[] possibilities = {
-                    PartQuality.QUALITY_A.toName(reverse),
-                    PartQuality.QUALITY_B.toName(reverse),
-                    PartQuality.QUALITY_C.toName(reverse),
-                    PartQuality.QUALITY_D.toName(reverse),
-                    PartQuality.QUALITY_E.toName(reverse),
-                    PartQuality.QUALITY_F.toName(reverse)
-            };
-            String quality = (String) JOptionPane.showInputDialog(gui.getFrame(), "Choose the new quality level",
-                    "Set Quality", JOptionPane.PLAIN_MESSAGE, null, possibilities,
-                    PartQuality.QUALITY_D.toName(reverse));
+            Object[] possibilities = { PartQuality.QUALITY_A.toName(reverse), PartQuality.QUALITY_B.toName(reverse),
+                                       PartQuality.QUALITY_C.toName(reverse), PartQuality.QUALITY_D.toName(reverse),
+                                       PartQuality.QUALITY_E.toName(reverse), PartQuality.QUALITY_F.toName(reverse) };
 
-            PartQuality q = PartQuality.fromName(quality, reverse);
-            for (Part p : parts) {
-                if (null != p) {
-                    p.setQuality(q);
-                    MekHQ.triggerEvent(new PartChangedEvent(p));
+            String quality = (String) JOptionPane.showInputDialog(gui.getFrame(),
+                  "Choose the new quality level",
+                  "Set Quality",
+                  JOptionPane.PLAIN_MESSAGE,
+                  null,
+                  possibilities,
+                  PartQuality.QUALITY_D.toName(reverse));
+
+            if (quality != null) {
+                PartQuality partQuality = PartQuality.fromName(quality, reverse);
+
+                for (Part part : parts) {
+                    if (part != null) {
+                        part.setQuality(partQuality);
+                        MekHQ.triggerEvent(new PartChangedEvent(part));
+                    }
+                }
+            }
+        } else if (command.contains("SWITCH_NEWNESS")) {
+            for (Part part : parts) {
+                if (part != null) {
+                    part.setBrandNew(!part.isBrandNew());
+                    MekHQ.triggerEvent(new PartChangedEvent(part));
                 }
             }
         } else if (command.contains("CHANGE_MODE")) {
@@ -184,8 +226,12 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
         } else if (command.equalsIgnoreCase("DEPOD_N")) {
             if (null != selectedPart) {
                 int n = selectedPart.getQuantity();
-                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(), true,
-                        "Remove How Many Pods" + selectedPart.getName() + "s?", 1, 1, n);
+                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      "Remove How Many Pods" + selectedPart.getName() + "s?",
+                      1,
+                      1,
+                      n);
                 pvcd.setVisible(true);
                 if (pvcd.getValue() < 0) {
                     return;
@@ -201,15 +247,19 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
             }
         } else if (command.equalsIgnoreCase("BUY_N")) {
             if (null != selectedPart) {
-                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(), true,
-                        "Buy How Much " + selectedPart.getName(), 1, 1);
+                PopupValueChoiceDialog pvcd = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      "Buy How Much " + selectedPart.getName(),
+                      1,
+                      1);
                 pvcd.setVisible(true);
                 if (pvcd.getValue() < 1) {
                     return;
                 }
                 int q = pvcd.getValue();
-                gui.getCampaign().getShoppingList().addShoppingItem(selectedPart.getAcquisitionWork(), q,
-                        gui.getCampaign());
+                gui.getCampaign()
+                      .getShoppingList()
+                      .addShoppingItem(selectedPart.getAcquisitionWork(), q, gui.getCampaign());
             }
         }
     }
@@ -420,14 +470,24 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
                 menuItem.addActionListener(this);
                 menu.add(menuItem);
             }
-            // remove part
+            // remove parts
             menuItem = new JMenuItem("Remove Part");
             menuItem.setActionCommand("REMOVE");
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+
+            menuItem = new JMenuItem("Remove Parts...");
+            menuItem.setActionCommand("REMOVE_N");
             menuItem.addActionListener(this);
             menu.add(menuItem);
             // set part quality
             menuItem = new JMenuItem("Set Quality...");
             menuItem.setActionCommand("SET_QUALITY");
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+            // set part newness
+            menuItem = new JMenuItem("Switch Newness");
+            menuItem.setActionCommand("SWITCH_NEWNESS");
             menuItem.addActionListener(this);
             menu.add(menuItem);
             // end

--- a/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
@@ -74,34 +74,34 @@ public class PartsStoreDialog extends JDialog {
 
     // region Variable Declarations
     // parts filter groups
-    private static final int SG_ALL      = 0;
-    private static final int SG_ARMOR    = 1;
-    private static final int SG_SYSTEM   = 2;
-    private static final int SG_EQUIP    = 3;
-    private static final int SG_LOC      = 4;
-    private static final int SG_WEAP     = 5;
-    private static final int SG_AMMO     = 6;
-    private static final int SG_MISC     = 7;
-    private static final int SG_ENGINE   = 8;
-    private static final int SG_GYRO     = 9;
-    private static final int SG_ACT      = 10;
-    private static final int SG_COCKPIT  = 11;
-    private static final int SG_BA_SUIT  = 12;
+    private static final int SG_ALL = 0;
+    private static final int SG_ARMOR = 1;
+    private static final int SG_SYSTEM = 2;
+    private static final int SG_EQUIP = 3;
+    private static final int SG_LOC = 4;
+    private static final int SG_WEAP = 5;
+    private static final int SG_AMMO = 6;
+    private static final int SG_MISC = 7;
+    private static final int SG_ENGINE = 8;
+    private static final int SG_GYRO = 9;
+    private static final int SG_ACT = 10;
+    private static final int SG_COCKPIT = 11;
+    private static final int SG_BA_SUIT = 12;
     private static final int SG_OMNI_POD = 13;
-    private static final int SG_NUM      = 14;
+    private static final int SG_NUM = 14;
 
-    private Campaign                        campaign;
-    private CampaignGUI                     campaignGUI;
-    private PartsTableModel                 partsModel;
+    private Campaign campaign;
+    private CampaignGUI campaignGUI;
+    private PartsTableModel partsModel;
     private TableRowSorter<PartsTableModel> partsSorter;
-    private boolean                         addToCampaign;
-    private Part                            selectedPart;
-    private Person                          logisticsPerson;
+    private boolean addToCampaign;
+    private Part selectedPart;
+    private Person logisticsPerson;
 
-    private JTable            partsTable;
-    private JTextField        txtFilter;
+    private JTable partsTable;
+    private JTextField txtFilter;
     private JComboBox<String> choiceParts;
-    private JCheckBox         hideImpossible;
+    private JCheckBox hideImpossible;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.PartsStoreDialog",
           MekHQ.getMHQOptions().getLocale());
@@ -112,12 +112,13 @@ public class PartsStoreDialog extends JDialog {
         this(gui.getFrame(), modal, gui, gui.getCampaign(), true);
     }
 
-    public PartsStoreDialog(final JFrame frame, final boolean modal, final CampaignGUI gui, final Campaign campaign, final boolean add) {
+    public PartsStoreDialog(final JFrame frame, final boolean modal, final CampaignGUI gui, final Campaign campaign,
+                            final boolean add) {
         super(frame, modal);
-        this.campaignGUI   = gui;
-        this.campaign      = campaign;
+        this.campaignGUI = gui;
+        this.campaign = campaign;
         this.addToCampaign = add;
-        partsModel         = new PartsTableModel(campaign.getPartsStore().getInventory());
+        partsModel = new PartsTableModel(campaign.getPartsStore().getInventory());
         initComponents();
         filterParts();
         setLocationRelativeTo(frame);
@@ -150,9 +151,9 @@ public class PartsStoreDialog extends JDialog {
         scrollPartsTable.setViewportView(partsTable);
         getContentPane().add(scrollPartsTable, BorderLayout.CENTER);
 
-        GridBagConstraints           c               = new GridBagConstraints();
-        JPanel                       panFilter       = new JPanel();
-        JLabel                       lblPartsChoice  = new JLabel(resourceMap.getString("lblPartsChoice.text"));
+        GridBagConstraints c = new GridBagConstraints();
+        JPanel panFilter = new JPanel();
+        JLabel lblPartsChoice = new JLabel(resourceMap.getString("lblPartsChoice.text"));
         DefaultComboBoxModel<String> partsGroupModel = new DefaultComboBoxModel<>();
         for (int i = 0; i < SG_NUM; i++) {
             partsGroupModel.addElement(getPartsGroupName(i));
@@ -162,20 +163,20 @@ public class PartsStoreDialog extends JDialog {
         choiceParts.setSelectedIndex(0);
         choiceParts.addActionListener(evt -> filterParts());
         panFilter.setLayout(new GridBagLayout());
-        c.gridx   = 0;
-        c.gridy   = 0;
+        c.gridx = 0;
+        c.gridy = 0;
         c.weightx = 0.0;
-        c.anchor  = GridBagConstraints.WEST;
-        c.insets  = new Insets(5, 5, 5, 5);
+        c.anchor = GridBagConstraints.WEST;
+        c.insets = new Insets(5, 5, 5, 5);
         panFilter.add(lblPartsChoice, c);
-        c.gridx   = 1;
+        c.gridx = 1;
         c.weightx = 1.0;
         panFilter.add(choiceParts, c);
 
         JLabel lblFilter = new JLabel(resourceMap.getString("lblFilter.text"));
         lblFilter.setName("lblFilter");
-        c.gridx   = 0;
-        c.gridy   = 1;
+        c.gridx = 0;
+        c.gridy = 1;
         c.weightx = 0.0;
         panFilter.add(lblFilter, c);
         txtFilter = new JTextField();
@@ -199,8 +200,8 @@ public class PartsStoreDialog extends JDialog {
                 filterParts();
             }
         });
-        c.gridx   = 1;
-        c.gridy   = 1;
+        c.gridx = 1;
+        c.gridy = 1;
         c.weightx = 1.0;
         panFilter.add(txtFilter, c);
 
@@ -212,7 +213,7 @@ public class PartsStoreDialog extends JDialog {
 
         getContentPane().add(panFilter, BorderLayout.PAGE_START);
 
-        JPanel  panButtons = new JPanel();
+        JPanel panButtons = new JPanel();
         JButton btnAdd;
         JButton btnClose;
         if (addToCampaign) {
@@ -248,7 +249,7 @@ public class PartsStoreDialog extends JDialog {
                     int[] selectedRow = partsTable.getSelectedRows();
                     for (int i : selectedRow) {
                         PartProxy partProxy = partsModel.getPartProxyAt(partsTable.convertRowIndexToModel(i));
-                        int       quantity  = 1;
+                        int quantity = 1;
                         PopupValueChoiceDialog pcd = new PopupValueChoiceDialog(campaignGUI.getFrame(),
                               true,
                               "How Many " + partProxy.getName() + '?',
@@ -395,7 +396,7 @@ public class PartsStoreDialog extends JDialog {
             @Override
             public boolean include(Entry<? extends PartsTableModel, ? extends Integer> entry) {
                 PartsTableModel partsModel = entry.getModel();
-                Part            part       = partsModel.getPartAt(entry.getIdentifier());
+                Part part = partsModel.getPartAt(entry.getIdentifier());
 
                 if (hideImpossible.isSelected()) {
                     int target = partsModel.getPartProxyAt(entry.getIdentifier())
@@ -408,20 +409,20 @@ public class PartsStoreDialog extends JDialog {
                 } // This MUST NOT be an else if
 
                 if (!txtFilter.getText().isBlank() &&
-                    !part.getName().toLowerCase().contains(txtFilter.getText().toLowerCase()) &&
-                    !part.getDetails().toLowerCase().contains(txtFilter.getText().toLowerCase())) {
+                          !part.getName().toLowerCase().contains(txtFilter.getText().toLowerCase()) &&
+                          !part.getDetails().toLowerCase().contains(txtFilter.getText().toLowerCase())) {
                     return false;
                 } else if (((part.getTechBase() == Part.T_CLAN) || part.isClan()) &&
-                           !campaign.getCampaignOptions().isAllowClanPurchases()) {
+                                 !campaign.getCampaignOptions().isAllowClanPurchases()) {
                     return false;
                 } else if ((part.getTechBase() == Part.T_IS) &&
-                           !campaign.getCampaignOptions().isAllowISPurchases()
-                           // Hack to allow Clan access to SL tech but not post-Exodus tech
-                           // until 3050.
-                           &&
-                           !(campaign.useClanTechBase() &&
-                             (part.getIntroductionDate() > 2787) &&
-                             (part.getIntroductionDate() < 3050))) {
+                                 !campaign.getCampaignOptions().isAllowISPurchases()
+                                 // Hack to allow Clan access to SL tech but not post-Exodus tech
+                                 // until 3050.
+                                 &&
+                                 !(campaign.useClanTechBase() &&
+                                         (part.getIntroductionDate() > 2787) &&
+                                         (part.getIntroductionDate() < 3050))) {
                     return false;
                 } else if (!campaign.isLegal(part)) {
                     return false;
@@ -433,41 +434,41 @@ public class PartsStoreDialog extends JDialog {
                     return part instanceof Armor; // ProtoMekAmor and BaArmor are derived from Armor
                 } else if (nGroup == SG_SYSTEM) {
                     return (part instanceof MekLifeSupport) ||
-                           (part instanceof MekSensor) ||
-                           (part instanceof LandingGear) ||
-                           (part instanceof Avionics) ||
-                           (part instanceof FireControlSystem) ||
-                           (part instanceof AeroSensor) ||
-                           (part instanceof KfBoom) ||
-                           (part instanceof DropshipDockingCollar) ||
-                           (part instanceof JumpshipDockingCollar) ||
-                           (part instanceof BayDoor) ||
-                           (part instanceof Cubicle) ||
-                           (part instanceof GravDeck) ||
-                           (part instanceof VeeSensor) ||
-                           (part instanceof VeeStabilizer) ||
-                           (part instanceof ProtoMekSensor);
+                                 (part instanceof MekSensor) ||
+                                 (part instanceof LandingGear) ||
+                                 (part instanceof Avionics) ||
+                                 (part instanceof FireControlSystem) ||
+                                 (part instanceof AeroSensor) ||
+                                 (part instanceof KfBoom) ||
+                                 (part instanceof DropshipDockingCollar) ||
+                                 (part instanceof JumpshipDockingCollar) ||
+                                 (part instanceof BayDoor) ||
+                                 (part instanceof Cubicle) ||
+                                 (part instanceof GravDeck) ||
+                                 (part instanceof VeeSensor) ||
+                                 (part instanceof VeeStabilizer) ||
+                                 (part instanceof ProtoMekSensor);
                 } else if (nGroup == SG_EQUIP) {
                     return (part instanceof EquipmentPart) || (part instanceof ProtoMekJumpJet);
                 } else if (nGroup == SG_LOC) {
                     return (part instanceof MekLocation) ||
-                           (part instanceof TankLocation) ||
-                           (part instanceof ProtoMekLocation);
+                                 (part instanceof TankLocation) ||
+                                 (part instanceof ProtoMekLocation);
                 } else if (nGroup == SG_WEAP) {
                     return (part instanceof EquipmentPart) && (((EquipmentPart) part).getType() instanceof WeaponType);
                 } else if (nGroup == SG_AMMO) {
                     return part instanceof AmmoStorage;
                 } else if (nGroup == SG_MISC) {
                     return ((part instanceof EquipmentPart) && (((EquipmentPart) part).getType() instanceof MiscType) ||
-                            (part instanceof ProtoMekJumpJet));
+                                  (part instanceof ProtoMekJumpJet));
                 } else if (nGroup == SG_ENGINE) {
                     return part instanceof EnginePart;
                 } else if (nGroup == SG_GYRO) {
                     return part instanceof MekGyro;
                 } else if (nGroup == SG_ACT) {
                     return ((part instanceof MekActuator) ||
-                            (part instanceof ProtoMekArmActuator) ||
-                            (part instanceof ProtoMekLegActuator));
+                                  (part instanceof ProtoMekArmActuator) ||
+                                  (part instanceof ProtoMekLegActuator));
                 } else if (nGroup == SG_COCKPIT) {
                     return part instanceof MekCockpit;
                 } else if (nGroup == SG_BA_SUIT) {
@@ -482,12 +483,21 @@ public class PartsStoreDialog extends JDialog {
         partsSorter.setRowFilter(partsTypeFilter);
     }
 
+    /**
+     * Adds a part to the campaign, either by purchasing it or directly adding it to the quartermaster's inventory.
+     *
+     * @param purchase determines if the part should be purchased or directly added. If {@code true}, the part will be
+     *                 added to the shopping list. If {@code false}, the part will be cloned and added directly to the
+     *                 inventory.
+     * @param part     the {@link Part} to be added.
+     * @param quantity the number of parts to add.
+     */
     private void addPart(boolean purchase, Part part, int quantity) {
         if (purchase) {
             campaign.getShoppingList().addShoppingItem(part.getAcquisitionWork(), quantity, campaign);
         } else {
             while (quantity > 0) {
-                campaign.getQuartermaster().addPart(part.clone(), 0);
+                campaign.getQuartermaster().addPart(part.clone(), 0, true);
                 quantity--;
             }
         }
@@ -536,27 +546,27 @@ public class PartsStoreDialog extends JDialog {
      * A table model for displaying parts - similar to the one in CampaignGUI, but not exactly
      */
     public class PartsTableModel extends AbstractTableModel {
-        protected String[]             columnNames;
+        protected String[] columnNames;
         protected ArrayList<PartProxy> data;
 
-        public final static int COL_NAME      = 0;
-        public final static int COL_DETAIL    = 1;
+        public final static int COL_NAME = 0;
+        public final static int COL_DETAIL = 1;
         public final static int COL_TECH_BASE = 2;
-        public final static int COL_COST      = 3;
-        public final static int COL_TON       = 4;
-        public final static int COL_TARGET    = 5;
-        public final static int COL_SUPPLY    = 6;
-        public final static int COL_TRANSIT   = 7;
-        public final static int COL_QUEUE     = 8;
-        public final static int N_COL         = 9;
+        public final static int COL_COST = 3;
+        public final static int COL_TON = 4;
+        public final static int COL_TARGET = 5;
+        public final static int COL_SUPPLY = 6;
+        public final static int COL_TRANSIT = 7;
+        public final static int COL_QUEUE = 8;
+        public final static int N_COL = 9;
 
         /**
          * Provides a lazy view to a {@link TargetRoll} for use in a UI (e.g. sorting in a table).
          */
         public static class TargetProxy implements Comparable<TargetProxy> {
             private TargetRoll target;
-            private String     details;
-            private String     description;
+            private String details;
+            private String description;
 
             /**
              * Creates a new proxy object for a {@link TargetRoll}.
@@ -606,8 +616,8 @@ public class PartsStoreDialog extends JDialog {
                 if (null == details) {
                     details = target.getValueAsString();
                     if (target.getValue() != TargetRoll.IMPOSSIBLE &&
-                        target.getValue() != TargetRoll.AUTOMATIC_SUCCESS &&
-                        target.getValue() != TargetRoll.AUTOMATIC_FAIL) {
+                              target.getValue() != TargetRoll.AUTOMATIC_SUCCESS &&
+                              target.getValue() != TargetRoll.AUTOMATIC_FAIL) {
                         details += "+";
                     }
                 }
@@ -649,14 +659,14 @@ public class PartsStoreDialog extends JDialog {
          * Provides a container for a value formatted for display and the value itself for sorting.
          */
         public static class FormattedValue<T extends Comparable<T>> implements Comparable<FormattedValue<T>> {
-            private T      value;
+            private T value;
             private String formatted;
 
             /**
              * Creates a wrapper around a value and a formatted string representing the value.
              */
             public FormattedValue(T v, String f) {
-                value     = v;
+                value = v;
                 formatted = f;
             }
 
@@ -697,11 +707,11 @@ public class PartsStoreDialog extends JDialog {
          * Provides a lazy view to a {@link Part} for use in a UI (e.g. sorting in a table).
          */
         public class PartProxy {
-            private Part                    part;
-            private String                  details;
-            private TargetProxy             targetProxy;
-            private FormattedValue<Money>   cost;
-            private PartInventory           inventories;
+            private Part part;
+            private String details;
+            private TargetProxy targetProxy;
+            private FormattedValue<Money> cost;
+            private PartInventory inventories;
             private FormattedValue<Integer> ordered;
             private FormattedValue<Integer> supply;
             private FormattedValue<Integer> transit;
@@ -721,9 +731,9 @@ public class PartsStoreDialog extends JDialog {
             public void updateTargetAndInventories() {
                 targetProxy = null;
                 inventories = null;
-                ordered     = null;
-                supply      = null;
-                transit     = null;
+                ordered = null;
+                supply = null;
+                transit = null;
             }
 
             /**
@@ -994,7 +1004,8 @@ public class PartsStoreDialog extends JDialog {
 
         public class Renderer extends DefaultTableCellRenderer {
             @Override
-            public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+            public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+                                                           boolean hasFocus, int row, int column) {
                 super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
                 setOpaque(true);
                 int actualCol = table.convertColumnIndexToModel(column);


### PR DESCRIPTION
- Retired a number of uses of the deprecated `addPart` with its' replacement, also called `addPart`
- Added GM ability to reduce items in Warehouse by `n` rather than just 'remove all'
- Added GM ability to toggle the 'newness' of an item in the Warehouse
- Fixed 'change quality' GM ability in the Warehouse to no longer throw an error if canceled.

Fix #2368