### PR TITLE
Allow Dynamically Priced Parts to be Replaced in Repair Bay

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/EquipmentPart.java
@@ -30,9 +30,6 @@ package mekhq.campaign.parts.equipment;
 
 import java.io.PrintWriter;
 
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Compute;
 import megamek.common.CriticalSlot;
 import megamek.common.Entity;
@@ -50,15 +47,15 @@ import mekhq.campaign.finances.Money;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
- * This part covers most of the equipment types in WeaponType, AmmoType, and
- * MiscType It can robustly handle all equipment with static weights and costs.
- * It can also handle equipment whose only variability in terms of cost is the
- * equipment tonnage itself. More complicated variable weight/cost equipment
- * needs to be subclassed. Some examples of equipment that needs to be
- * subclasses: - MASC (depends on engine rating) - AES (depends on location and
- * cost is by unit tonnage)
+ * This part covers most of the equipment types in WeaponType, AmmoType, and MiscType It can robustly handle all
+ * equipment with static weights and costs. It can also handle equipment whose only variability in terms of cost is the
+ * equipment tonnage itself. More complicated variable weight/cost equipment needs to be subclassed. Some examples of
+ * equipment that needs to be subclasses: - MASC (depends on engine rating) - AES (depends on location and cost is by
+ * unit tonnage)
  *
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
@@ -98,6 +95,10 @@ public class EquipmentPart extends Part {
         if (null != type) {
             this.name = type.getName(size);
             this.typeName = type.getInternalName();
+
+            if (!unitTonnageMatters) {
+                this.unitTonnageMatters = type.isVariableCost();
+            }
         }
 
         this.equipmentNum = equipNum;
@@ -145,6 +146,11 @@ public class EquipmentPart extends Part {
             typeName = type.getName();
         } else {
             type = EquipmentType.get(typeName);
+
+            // This conditional is to handle <50.05 warehouses
+            if (!unitTonnageMatters) { // We don't want to accidentally overwrite this state if it's meant to be true
+                unitTonnageMatters = type.isVariableCost();
+            }
         }
 
         if (type == null) {
@@ -158,11 +164,12 @@ public class EquipmentPart extends Part {
         // they are not acceptable substitutes, so we need to check for that as
         // well
         // http://bg.battletech.com/forums/strategic-operations/(answered)-can-a-lance-for-a-35-ton-mech-be-used-on-a-40-ton-mech-and-so-on/
-        return (getClass() == part.getClass())
-                && getType().equals(((EquipmentPart) part).getType())
-                && getTonnage() == part.getTonnage() && getStickerPrice().equals(part.getStickerPrice())
-                && getSize() == ((EquipmentPart) part).getSize()
-                && isOmniPodded() == part.isOmniPodded();
+        return (getClass() == part.getClass()) &&
+                     getType().equals(((EquipmentPart) part).getType()) &&
+                     getTonnage() == part.getTonnage() &&
+                     getStickerPrice().equals(part.getStickerPrice()) &&
+                     getSize() == ((EquipmentPart) part).getSize() &&
+                     isOmniPodded() == part.isOmniPodded();
     }
 
     @Override
@@ -274,19 +281,22 @@ public class EquipmentPart extends Part {
 
         int priorHits = getHits();
 
-        int newHits = unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_EQUIPMENT, getEquipmentNum(),
-                mounted.getLocation());
+        int newHits = unit.getEntity()
+                            .getDamagedCriticals(CriticalSlot.TYPE_EQUIPMENT, getEquipmentNum(), mounted.getLocation());
         if (mounted.isSplit()) {
-            newHits += unit.getEntity().getDamagedCriticals(CriticalSlot.TYPE_EQUIPMENT, getEquipmentNum(),
-                    mounted.getSecondLocation());
+            newHits += unit.getEntity()
+                             .getDamagedCriticals(CriticalSlot.TYPE_EQUIPMENT,
+                                   getEquipmentNum(),
+                                   mounted.getSecondLocation());
         }
 
         setHits(newHits);
 
         omniPodded = mounted.isOmniPodMounted();
 
-        if (checkForDestruction && (getHits() > priorHits)
-                && (Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget())) {
+        if (checkForDestruction &&
+                  (getHits() > priorHits) &&
+                  (Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget())) {
             remove(false);
             return;
         }
@@ -439,8 +449,8 @@ public class EquipmentPart extends Part {
         final Unit unit = getUnit();
         final Mounted<?> mounted = getMounted();
         if ((unit != null) && (mounted != null)) {
-            return unit.isLocationDestroyed(mounted.getLocation())
-                    || (mounted.isSplit() && unit.isLocationDestroyed(mounted.getSecondLocation()));
+            return unit.isLocationDestroyed(mounted.getLocation()) ||
+                         (mounted.isSplit() && unit.isLocationDestroyed(mounted.getSecondLocation()));
         }
 
         return false;
@@ -451,17 +461,15 @@ public class EquipmentPart extends Part {
         final Unit unit = getUnit();
         final Mounted<?> mounted = getMounted();
         if ((unit != null) && (mounted != null)) {
-            return unit.hasBadHipOrShoulder(mounted.getLocation())
-                    || (mounted.isSplit() && unit.hasBadHipOrShoulder(mounted.getSecondLocation()));
+            return unit.hasBadHipOrShoulder(mounted.getLocation()) ||
+                         (mounted.isSplit() && unit.hasBadHipOrShoulder(mounted.getSecondLocation()));
         }
 
         return false;
     }
 
     /**
-     * Copied from megamek.common.Entity.getWeaponsAndEquipmentCost(StringBuffer
-     * detail, boolean ignoreAmmo)
-     *
+     * Copied from megamek.common.Entity.getWeaponsAndEquipmentCost(StringBuffer detail, boolean ignoreAmmo)
      */
     @Override
     public Money getStickerPrice() {
@@ -517,8 +525,10 @@ public class EquipmentPart extends Part {
                 varCost = Money.of(10000 * getTonnage());
             } else if (type.hasFlag(MiscType.F_OFF_ROAD)) {
                 varCost = Money.of(10 * getTonnage() * getTonnage());
-            } else if (type.hasFlag(MiscType.F_FLOTATION_HULL) || type.hasFlag(MiscType.F_VACUUM_PROTECTION)
-                    || type.hasFlag(MiscType.F_ENVIRONMENTAL_SEALING) || type.hasFlag(MiscType.F_OFF_ROAD)) {
+            } else if (type.hasFlag(MiscType.F_FLOTATION_HULL) ||
+                             type.hasFlag(MiscType.F_VACUUM_PROTECTION) ||
+                             type.hasFlag(MiscType.F_ENVIRONMENTAL_SEALING) ||
+                             type.hasFlag(MiscType.F_OFF_ROAD)) {
                 // ??
             } else if (type.hasFlag(MiscType.F_LIMITED_AMPHIBIOUS) || type.hasFlag((MiscType.F_FULLY_AMPHIBIOUS))) {
                 varCost = Money.of(getTonnage() * 10000);
@@ -527,8 +537,9 @@ public class EquipmentPart extends Part {
             } else if (type.hasFlag(MiscType.F_MASC) && type.hasFlag(MiscType.F_BA_EQUIPMENT)) {
                 // TODO: handle this one differently
                 // costValue = entity.getRunMP() * 75000;
-            } else if (type.hasFlag(MiscType.F_HEAD_TURRET) || type.hasFlag(MiscType.F_SHOULDER_TURRET)
-                    || type.hasFlag(MiscType.F_QUAD_TURRET)) {
+            } else if (type.hasFlag(MiscType.F_HEAD_TURRET) ||
+                             type.hasFlag(MiscType.F_SHOULDER_TURRET) ||
+                             type.hasFlag(MiscType.F_QUAD_TURRET)) {
                 varCost = Money.of(getTonnage() * 10000);
             } else if (type.hasFlag(MiscType.F_SPONSON_TURRET)) {
                 varCost = Money.of(getTonnage() * 4000);
@@ -544,8 +555,8 @@ public class EquipmentPart extends Part {
                 varCost = Money.of((getTonnage() * 10000) + 5000);
             } else if (type.hasFlag(MiscType.F_TARGCOMP)) {
                 varCost = Money.of(getTonnage() * 10000);
-            } else if (type.hasFlag(MiscType.F_CLUB)
-                    && (type.hasSubType(MiscType.S_HATCHET) || type.hasSubType(MiscType.S_MACE_THB))) {
+            } else if (type.hasFlag(MiscType.F_CLUB) &&
+                             (type.hasSubType(MiscType.S_HATCHET) || type.hasSubType(MiscType.S_MACE_THB))) {
                 varCost = Money.of(getTonnage() * 5000);
             } else if (type.hasFlag(MiscType.F_CLUB) && type.hasSubType(MiscType.S_SWORD)) {
                 varCost = Money.of(getTonnage() * 10000);
@@ -589,9 +600,10 @@ public class EquipmentPart extends Part {
      * item tonnage
      */
     public static boolean hasVariableTonnage(EquipmentType type) {
-        return (type instanceof MiscType)
-                && (type.hasFlag(MiscType.F_TARGCOMP) || type.hasFlag(MiscType.F_CLUB)
-                        || type.hasFlag(MiscType.F_TALON));
+        return (type instanceof MiscType) &&
+                     (type.hasFlag(MiscType.F_TARGCOMP) ||
+                            type.hasFlag(MiscType.F_CLUB) ||
+                            type.hasFlag(MiscType.F_TALON));
     }
 
     public static double getStartingTonnage(EquipmentType type) {
@@ -599,11 +611,12 @@ public class EquipmentPart extends Part {
     }
 
     public static double getMaxTonnage(EquipmentType type) {
-        if (type.hasFlag(MiscType.F_TALON) || (type.hasFlag(MiscType.F_CLUB)
-                && (type.hasSubType(MiscType.S_HATCHET) || type.hasSubType(MiscType.S_MACE_THB)))) {
+        if (type.hasFlag(MiscType.F_TALON) ||
+                  (type.hasFlag(MiscType.F_CLUB) &&
+                         (type.hasSubType(MiscType.S_HATCHET) || type.hasSubType(MiscType.S_MACE_THB)))) {
             return 7;
-        } else if (type.hasFlag(MiscType.F_CLUB)
-                && (type.hasSubType(MiscType.S_LANCE) || type.hasSubType(MiscType.S_SWORD))) {
+        } else if (type.hasFlag(MiscType.F_CLUB) &&
+                         (type.hasSubType(MiscType.S_LANCE) || type.hasSubType(MiscType.S_SWORD))) {
             return 5;
         } else if (type.hasFlag(MiscType.F_CLUB) && type.hasSubType(MiscType.S_MACE)) {
             return 10;
@@ -635,11 +648,13 @@ public class EquipmentPart extends Part {
             return false;
         }
         if (type instanceof MiscType) {
-            return type.hasFlag(MiscType.F_MEK_EQUIPMENT) || type.hasFlag(MiscType.F_TANK_EQUIPMENT)
-                    || type.hasFlag(MiscType.F_FIGHTER_EQUIPMENT);
+            return type.hasFlag(MiscType.F_MEK_EQUIPMENT) ||
+                         type.hasFlag(MiscType.F_TANK_EQUIPMENT) ||
+                         type.hasFlag(MiscType.F_FIGHTER_EQUIPMENT);
         } else if (type instanceof WeaponType) {
-            return (type.hasFlag(WeaponType.F_MEK_WEAPON) || type.hasFlag(WeaponType.F_TANK_WEAPON)
-                    || type.hasFlag(WeaponType.F_AERO_WEAPON)) && !((WeaponType) type).isCapital();
+            return (type.hasFlag(WeaponType.F_MEK_WEAPON) ||
+                          type.hasFlag(WeaponType.F_TANK_WEAPON) ||
+                          type.hasFlag(WeaponType.F_AERO_WEAPON)) && !((WeaponType) type).isCapital();
         }
         return true;
     }
@@ -662,23 +677,21 @@ public class EquipmentPart extends Part {
         }
 
         int location = unit.getEntity().getLocationFromAbbr(loc);
-        return (mounted.getLocation() == location)
-                || (mounted.isSplit() && (mounted.getSecondLocation() == location));
+        return (mounted.getLocation() == location) || (mounted.isSplit() && (mounted.getSecondLocation() == location));
     }
 
     /**
-     * This method will check for an existing weapon bay that this equipment belongs
-     * to and if there is one it will check the status of that weapon bay based on
-     * the equipment. If this equipment is functional, then it will clear any hits
-     * from the bay. If not, then it will check all the other equipment in the bay
-     * and if they are all damaged, then it will mark the bay as destroyed. This is
-     * designed to be used only by the fix and remove methods contained here in
-     * order to properly update weapon bay mounts on the entity
+     * This method will check for an existing weapon bay that this equipment belongs to and if there is one it will
+     * check the status of that weapon bay based on the equipment. If this equipment is functional, then it will clear
+     * any hits from the bay. If not, then it will check all the other equipment in the bay and if they are all damaged,
+     * then it will mark the bay as destroyed. This is designed to be used only by the fix and remove methods contained
+     * here in order to properly update weapon bay mounts on the entity
      */
     private static void checkWeaponBay(Unit unit, EquipmentType type, int equipmentNum) {
-        if ((unit == null) || (unit.getEntity() == null)
-                || !unit.getEntity().usesWeaponBays()
-                || !(type instanceof WeaponType)) {
+        if ((unit == null) ||
+                  (unit.getEntity() == null) ||
+                  !unit.getEntity().usesWeaponBays() ||
+                  !(type instanceof WeaponType)) {
             return;
         }
 


### PR DESCRIPTION
Fix #6515
Fix #6516

### Dev Notes
Basically, some parts have their value dynamically determined based on the tonnage of the unit they're being attached to. In those cases we were comparing sticker price -- basically the base price with no quality modifiers and so on. However, when a part is classified as 'missing' - for example, when it get blown to smithereens, or is scrapped - it has it's price fixed at 0 C-Bills.

CGL ruled that variable priced items could not be fitted to units of tonnage other than the tonnage they were designed for. A 35-ton 'Mek couldn't use a Lance designed for a 40-ton 'Mek, for example, even though the actual weight of the lance is identical for both.

Originally, we got around this issue by comparing the sticker price of each item. Which ultimately then led us to the problem I described above. Missing variable priced parts were completely prevented from being replaced, because those parts were comparing 0 C-Bills to `x` C-Bills (where `x` is whatever the item would be priced at, if it wasn't missing). As the two sticker prices didn't match, those repair couldn't proceed. No matter how many suitable replacement parts the player _actually_ had.

A few hours and one massive headache later I conjured a solution: now if the missing part is a part that has a variable price, we compare the tonnage of the unit the part was built for to the tonnage of the unit the replacement part was built for. If the two match, we're good, replace away. If they don't, then the player cannot use that replacement part to replace the missing part.

Parts that use fixed values are handled identically to how they have been for years. No functionality changes there.

What has changed, though, is that we now explicitly check to see if the 'podded' status of both the original part and the replacement. So that podded items can't replace unpodded items, and so forth. This check should have been included all along, based on the fact that we were testing for it, however that part of the test was a false positive. Now it works.

### Testing
I took @pheonixstorm's campaign and I stripped every unit down to the CT (or equivalent) and then manually repaired every... single... unit... It was a pain in the bum, but a necessary one.

Everything proceeded as expected.