### PR TITLE
Issue 6481: Personnel that are both the tech and crew for a unit will now be properly removed from both

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -53,8 +53,8 @@ import javax.swing.UIManager;
 import megamek.Version;
 import megamek.client.ui.swing.tileset.EntityImage;
 import megamek.codeUtilities.MathUtility;
-import megamek.common.*;
 import megamek.common.CrewType;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.ArmorType;
@@ -5558,22 +5558,33 @@ public class Unit implements ITechnology {
         ensurePersonIsRegistered(person);
         if (person.equals(tech)) {
             removeTech();
-        } else {
+        }
+
+        boolean wasCrew = false;
+
+        if (this.equals(person.getUnit())) {
+            wasCrew = true;
             person.setUnit(null);
-            drivers.remove(person);
-            gunners.remove(person);
-            vesselCrew.remove(person);
-            if (person.equals(navigator)) {
-                navigator = null;
-            }
+        }
+        wasCrew |= drivers.remove(person);
+        wasCrew |= gunners.remove(person);
+        wasCrew |= vesselCrew.remove(person);
+        if (person.equals(navigator)) {
+            wasCrew = true;
+            navigator = null;
+        }
 
-            if (person.equals(techOfficer)) {
-                techOfficer = null;
-            }
+        if (person.equals(techOfficer)) {
+            wasCrew = true;
+            techOfficer = null;
+        }
 
-            if (person.equals(engineer)) {
-                engineer = null;
-            }
+        if (person.equals(engineer)) {
+            wasCrew = true;
+            engineer = null;
+        }
+
+        if (wasCrew) {
             resetPilotAndEntity();
             MekHQ.triggerEvent(new PersonCrewAssignmentEvent(campaign, person, this));
         }

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitPersonTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitPersonTest.java
@@ -27,20 +27,26 @@
  */
 package mekhq.campaign.unit;
 
-import megamek.common.Entity;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.personnel.Person;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.*;
+import megamek.common.Entity;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import org.junit.jupiter.api.Test;
 
 public class UnitPersonTest {
     @Test
@@ -190,6 +196,7 @@ public class UnitPersonTest {
         Person mockTech = mock(Person.class);
         when(mockTech.getId()).thenReturn(id);
         when(mockCampaign.getPerson(eq(id))).thenReturn(mockTech);
+        when(mockTech.getUnit()).thenReturn(null);
 
         // Set the tech
         unit.setTech(mockTech);
@@ -239,6 +246,7 @@ public class UnitPersonTest {
         Person mockDriver = mock(Person.class);
         when(mockDriver.getId()).thenReturn(id);
         when(mockCampaign.getPerson(eq(id))).thenReturn(mockDriver);
+        when(mockDriver.getUnit()).thenReturn(unit);
 
         // This person is NOT a driver (yet)
         assertFalse(unit.isDriver(mockDriver));
@@ -297,6 +305,7 @@ public class UnitPersonTest {
         Person mockGunner = mock(Person.class);
         when(mockGunner.getId()).thenReturn(id);
         when(mockCampaign.getPerson(eq(id))).thenReturn(mockGunner);
+        when(mockGunner.getUnit()).thenReturn(unit);
 
         // This person is NOT a gunner (yet)
         assertFalse(unit.isGunner(mockGunner));
@@ -355,6 +364,7 @@ public class UnitPersonTest {
         Person mockVesselCrew = mock(Person.class);
         when(mockVesselCrew.getId()).thenReturn(id);
         when(mockCampaign.getPerson(eq(id))).thenReturn(mockVesselCrew);
+        when(mockVesselCrew.getUnit()).thenReturn(unit);
 
         // Add the vessel crew
         unit.addVesselCrew(mockVesselCrew);
@@ -402,6 +412,7 @@ public class UnitPersonTest {
         Person mockTechOfficer = mock(Person.class);
         when(mockTechOfficer.getId()).thenReturn(id);
         when(mockCampaign.getPerson(eq(id))).thenReturn(mockTechOfficer);
+         when(mockTechOfficer.getUnit()).thenReturn(unit);
 
         // This person is NOT a tech officer (yet)
         assertFalse(unit.isTechOfficer(mockTechOfficer));
@@ -459,6 +470,7 @@ public class UnitPersonTest {
         Person mockNavigator = mock(Person.class);
         when(mockNavigator.getId()).thenReturn(id);
         when(mockCampaign.getPerson(eq(id))).thenReturn(mockNavigator);
+        when(mockNavigator.getUnit()).thenReturn(unit);
 
         // This person is NOT a navigator (yet)
         assertFalse(unit.isNavigator(mockNavigator));


### PR DESCRIPTION
Fixes #6481 

For history.txt:
```+ Fix #6481: Soldiers getting "stuck" to previous unit```

If a person was a tech for a unit, it would stop processing. It is possible for a person to be both a tech and crew - for infantry, the leader fills that role. That was the issue here - the unit's leader was also the tech. When removing personnel from the unit, it would remove the leader from the vehicle's tech and then stop, leaving the unit to still have that person as a crew. 