### PR TITLE
Fixes Compatibility for AC Ammo in MHQ

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -31,9 +31,6 @@ package mekhq.campaign.parts;
 import java.io.PrintWriter;
 import java.util.Objects;
 
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.AmmoType;
 import megamek.common.ITechnology;
 import megamek.common.TargetRoll;
@@ -48,6 +45,8 @@ import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * This will be a special type of part that will only exist as spares
@@ -152,6 +151,8 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
      * is compatible with this instance's ammo.
      *
      * @param otherAmmoType The other {@code AmmoType}.
+     * @return False if the ammo does not support "compatibility" or is not compatible, true if the ammo type
+     * supports compatibility and is compatible
      */
     public boolean isCompatibleAmmo(AmmoType otherAmmoType) {
         return getType().isCompatibleWith(otherAmmoType);

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -490,8 +490,9 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         // AmmoType and number of rounds of ammo (i.e. they are the same
         // irrespective of "munition type" or "bomb type").
         return (getClass() == part.getClass()) &&
-               getType().isCompatibleWith(((AmmoBin) part).getType()) &&
-               (((AmmoBin) part).getFullShots() == getFullShots());
+            ((getType().isCompatibleWith(((AmmoBin) part).getType())) ||
+                   (getType().equals(((AmmoBin) part).getType()))) &&
+            (((AmmoBin) part).getFullShots() == getFullShots());
     }
 
     @Override


### PR DESCRIPTION
In MekHQ, `AmmoBin::isSamePartType` does not properly recognize AC ammo as being the same part type. Two AC/5 ammo bins, for example. This led to any refit in MHQ for a unit that had AC ammo would show as needing changed in the refit even if nothing was changed. 


In the below screenshots, nothing was changed for this unit. I right clicked the unit in the Hangar and selected customize > customize in mek lab. I made no changes to the unit before taking the screenshots.
Before Fix:
![image](https://github.com/user-attachments/assets/3521c6d6-fd7b-49a6-ae7b-d7055487fc74)


After Fix:
![image](https://github.com/user-attachments/assets/eb1e5e45-0619-47cb-b701-5b41ddaa8336)
