### PR TITLE
Added ATOW Attribute Tracking and Utility Methods

### DIFF
--- a/MekHQ/resources/mekhq/resources/SkillAttribute.properties
+++ b/MekHQ/resources/mekhq/resources/SkillAttribute.properties
@@ -1,0 +1,25 @@
+# suppress inspection "UnusedProperty" for whole file
+NONE.label=None
+NONE.shortName=None
+NONE.description=THIS SHOULDN''T BE VISIBLE
+STRENGTH.label=Strength
+STRENGTH.shortName=STR
+STRENGTH.description=Represents the character''s physical strength or power.
+BODY.label=Body
+BODY.shortName=BOD
+BODY.description=Represents the character''s overall physical condition and health.
+REFLEXES.label=Reflexes
+REFLEXES.shortName=RFL
+REFLEXES.description=Represents the character''s reflexes or reaction time.
+DEXTERITY.label=Dexterity
+DEXTERITY.shortName=DEX
+DEXTERITY.description=Represents the character''s coordination and fine motor skills.
+INTELLIGENCE.label=Intelligence
+INTELLIGENCE.shortName=INT
+INTELLIGENCE.description=Represents the character''s cognitive ability and problem-solving skills.
+WILLPOWER.label=Willpower
+WILLPOWER.shortName=WIL
+WILLPOWER.description=Represents the character''s mental willpower and determination.
+CHARISMA.label=Charisma
+CHARISMA.shortName=CHA
+CHARISMA.description=Represents the character''s social skills and personal magnetism.

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -90,9 +90,11 @@ import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.personnel.ranks.RankValidator;
 import mekhq.campaign.personnel.ranks.Ranks;
+import mekhq.campaign.personnel.skills.Attributes;
 import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.skills.Skills;
+import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 import mekhq.campaign.randomEvents.personalities.enums.Aggression;
 import mekhq.campaign.randomEvents.personalities.enums.Ambition;
 import mekhq.campaign.randomEvents.personalities.enums.Greed;
@@ -199,6 +201,7 @@ public class Person {
     private int wealth;
     private int reputation;
     private int unlucky;
+    private Attributes atowAttributes;
 
     private PersonnelStatus status;
     private int xp;
@@ -427,6 +430,7 @@ public class Person {
         wealth = 0;
         reputation = 0;
         unlucky = 0;
+        atowAttributes = new Attributes();
         dateOfDeath = null;
         recruitment = null;
         joinedCampaign = null;
@@ -2339,6 +2343,10 @@ public class Person {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "unlucky", unlucky);
             }
 
+            MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "atowAttributes");
+            atowAttributes.writeAttributesToXML(pw, indent);
+            MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "atowAttributes");
+
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "minutesLeft", minutesLeft);
 
             if (overtimeLeft > 0) {
@@ -2748,6 +2756,8 @@ public class Person {
                     person.reputation = MathUtility.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("unlucky")) {
                     person.unlucky = MathUtility.parseInt(wn2.getTextContent());
+                } else if (wn2.getNodeName().equalsIgnoreCase("atowAttributes")) {
+                    person.atowAttributes = new Attributes().generateAttributesFromXML(wn2);
                 } else if (wn2.getNodeName().equalsIgnoreCase("pilotHits")) {
                     person.hits = MathUtility.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("skill")) {
@@ -3493,18 +3503,18 @@ public class Person {
                              SkillType.EXP_NONE;
             case MECHANIC:
                 if (isTechsHaveAdministration) {
-                    if (hasSkill(SkillType.S_TECH_MECHANIC) && hasSkill(SkillType.S_ADMIN)) {
+                    if (hasSkill(SkillType.S_TECH_MECHANIC) && hasSkill(S_ADMIN)) {
                         if (isAlternativeQualityAveraging) {
                             int rawScore = (int) Math.floor((getSkill(SkillType.S_TECH_MECHANIC).getLevel() +
-                                                                   getSkill(SkillType.S_ADMIN).getLevel()) / 2.0);
+                                                                   getSkill(S_ADMIN).getLevel()) / 2.0);
                             if (getSkill(SkillType.S_TECH_MECHANIC).getType().getExperienceLevel(rawScore) ==
-                                      getSkill(SkillType.S_ADMIN).getType().getExperienceLevel(rawScore)) {
+                                      getSkill(S_ADMIN).getType().getExperienceLevel(rawScore)) {
                                 return getSkill(SkillType.S_TECH_MECHANIC).getType().getExperienceLevel(rawScore);
                             }
                         }
 
                         return (int) Math.floor((getSkill(SkillType.S_TECH_MECHANIC).getExperienceLevel() +
-                                                       getSkill(SkillType.S_ADMIN).getExperienceLevel()) / 2.0);
+                                                       getSkill(S_ADMIN).getExperienceLevel()) / 2.0);
                     } else {
                         return SkillType.EXP_NONE;
                     }
@@ -3579,18 +3589,18 @@ public class Person {
                              SkillType.EXP_NONE;
             case VESSEL_CREW:
                 if (isTechsHaveAdministration) {
-                    if (hasSkill(SkillType.S_TECH_VESSEL) && hasSkill(SkillType.S_ADMIN)) {
+                    if (hasSkill(SkillType.S_TECH_VESSEL) && hasSkill(S_ADMIN)) {
                         if (isAlternativeQualityAveraging) {
                             int rawScore = (int) Math.floor((getSkill(SkillType.S_TECH_VESSEL).getLevel() +
-                                                                   getSkill(SkillType.S_ADMIN).getLevel()) / 2.0);
+                                                                   getSkill(S_ADMIN).getLevel()) / 2.0);
                             if (getSkill(SkillType.S_TECH_VESSEL).getType().getExperienceLevel(rawScore) ==
-                                      getSkill(SkillType.S_ADMIN).getType().getExperienceLevel(rawScore)) {
+                                      getSkill(S_ADMIN).getType().getExperienceLevel(rawScore)) {
                                 return getSkill(SkillType.S_TECH_VESSEL).getType().getExperienceLevel(rawScore);
                             }
                         }
 
                         return (int) Math.floor((getSkill(SkillType.S_TECH_VESSEL).getExperienceLevel() +
-                                                       getSkill(SkillType.S_ADMIN).getExperienceLevel()) / 2.0);
+                                                       getSkill(S_ADMIN).getExperienceLevel()) / 2.0);
                     } else {
                         return SkillType.EXP_NONE;
                     }
@@ -3603,18 +3613,18 @@ public class Person {
                 return hasSkill(SkillType.S_NAV) ? getSkill(SkillType.S_NAV).getExperienceLevel() : SkillType.EXP_NONE;
             case MEK_TECH:
                 if (isTechsHaveAdministration) {
-                    if (hasSkill(SkillType.S_TECH_MEK) && hasSkill(SkillType.S_ADMIN)) {
+                    if (hasSkill(SkillType.S_TECH_MEK) && hasSkill(S_ADMIN)) {
                         if (isAlternativeQualityAveraging) {
                             int rawScore = (int) Math.floor((getSkill(SkillType.S_TECH_MEK).getLevel() +
-                                                                   getSkill(SkillType.S_ADMIN).getLevel()) / 2.0);
+                                                                   getSkill(S_ADMIN).getLevel()) / 2.0);
                             if (getSkill(SkillType.S_TECH_MEK).getType().getExperienceLevel(rawScore) ==
-                                      getSkill(SkillType.S_ADMIN).getType().getExperienceLevel(rawScore)) {
+                                      getSkill(S_ADMIN).getType().getExperienceLevel(rawScore)) {
                                 return getSkill(SkillType.S_TECH_MEK).getType().getExperienceLevel(rawScore);
                             }
                         }
 
                         return (int) Math.floor((getSkill(SkillType.S_TECH_MEK).getExperienceLevel() +
-                                                       getSkill(SkillType.S_ADMIN).getExperienceLevel()) / 2.0);
+                                                       getSkill(S_ADMIN).getExperienceLevel()) / 2.0);
                     } else {
                         return SkillType.EXP_NONE;
                     }
@@ -3625,18 +3635,18 @@ public class Person {
                 }
             case AERO_TEK:
                 if (isTechsHaveAdministration) {
-                    if (hasSkill(SkillType.S_TECH_AERO) && hasSkill(SkillType.S_ADMIN)) {
+                    if (hasSkill(SkillType.S_TECH_AERO) && hasSkill(S_ADMIN)) {
                         if (isAlternativeQualityAveraging) {
                             int rawScore = (int) Math.floor((getSkill(SkillType.S_TECH_AERO).getLevel() +
-                                                                   getSkill(SkillType.S_ADMIN).getLevel()) / 2.0);
+                                                                   getSkill(S_ADMIN).getLevel()) / 2.0);
                             if (getSkill(SkillType.S_TECH_AERO).getType().getExperienceLevel(rawScore) ==
-                                      getSkill(SkillType.S_ADMIN).getType().getExperienceLevel(rawScore)) {
+                                      getSkill(S_ADMIN).getType().getExperienceLevel(rawScore)) {
                                 return getSkill(SkillType.S_TECH_AERO).getType().getExperienceLevel(rawScore);
                             }
                         }
 
                         return (int) Math.floor((getSkill(SkillType.S_TECH_AERO).getExperienceLevel() +
-                                                       getSkill(SkillType.S_ADMIN).getExperienceLevel()) / 2.0);
+                                                       getSkill(S_ADMIN).getExperienceLevel()) / 2.0);
                     } else {
                         return SkillType.EXP_NONE;
                     }
@@ -3647,18 +3657,18 @@ public class Person {
                 }
             case BA_TECH:
                 if (isTechsHaveAdministration) {
-                    if (hasSkill(SkillType.S_TECH_BA) && hasSkill(SkillType.S_ADMIN)) {
+                    if (hasSkill(SkillType.S_TECH_BA) && hasSkill(S_ADMIN)) {
                         if (isAlternativeQualityAveraging) {
                             int rawScore = (int) Math.floor((getSkill(SkillType.S_TECH_BA).getLevel() +
-                                                                   getSkill(SkillType.S_ADMIN).getLevel()) / 2.0);
+                                                                   getSkill(S_ADMIN).getLevel()) / 2.0);
                             if (getSkill(SkillType.S_TECH_BA).getType().getExperienceLevel(rawScore) ==
-                                      getSkill(SkillType.S_ADMIN).getType().getExperienceLevel(rawScore)) {
+                                      getSkill(S_ADMIN).getType().getExperienceLevel(rawScore)) {
                                 return getSkill(SkillType.S_TECH_BA).getType().getExperienceLevel(rawScore);
                             }
                         }
 
                         return (int) Math.floor((getSkill(SkillType.S_TECH_BA).getExperienceLevel() +
-                                                       getSkill(SkillType.S_ADMIN).getExperienceLevel()) / 2.0);
+                                                       getSkill(S_ADMIN).getExperienceLevel()) / 2.0);
                     } else {
                         return SkillType.EXP_NONE;
                     }
@@ -3673,18 +3683,18 @@ public class Person {
                              SkillType.EXP_NONE;
             case DOCTOR:
                 if (isDoctorsHaveAdministration) {
-                    if (hasSkill(SkillType.S_DOCTOR) && hasSkill(SkillType.S_ADMIN)) {
+                    if (hasSkill(SkillType.S_DOCTOR) && hasSkill(S_ADMIN)) {
                         if (isAlternativeQualityAveraging) {
                             int rawScore = (int) Math.floor((getSkill(SkillType.S_DOCTOR).getLevel() +
-                                                                   getSkill(SkillType.S_ADMIN).getLevel()) / 2.0);
+                                                                   getSkill(S_ADMIN).getLevel()) / 2.0);
                             if (getSkill(SkillType.S_DOCTOR).getType().getExperienceLevel(rawScore) ==
-                                      getSkill(SkillType.S_ADMIN).getType().getExperienceLevel(rawScore)) {
+                                      getSkill(S_ADMIN).getType().getExperienceLevel(rawScore)) {
                                 return getSkill(SkillType.S_DOCTOR).getType().getExperienceLevel(rawScore);
                             }
                         }
 
                         return (int) Math.floor((getSkill(SkillType.S_DOCTOR).getExperienceLevel() +
-                                                       getSkill(SkillType.S_ADMIN).getExperienceLevel()) / 2.0);
+                                                       getSkill(S_ADMIN).getExperienceLevel()) / 2.0);
                     } else {
                         return SkillType.EXP_NONE;
                     }
@@ -4619,7 +4629,7 @@ public class Person {
 
         double administrationMultiplier = 1.0 - (TECH_ADMINISTRATION_MULTIPLIER * REGULAR_EXPERIENCE_LEVEL);
 
-        Skill administration = skills.getSkill(SkillType.S_ADMIN);
+        Skill administration = skills.getSkill(S_ADMIN);
         int experienceLevel = SkillLevel.NONE.getExperienceLevel();
 
         if (administration != null) {
@@ -4667,7 +4677,7 @@ public class Person {
 
         double administrationMultiplier = 1.0 - (DOCTOR_ADMINISTRATION_MULTIPLIER * REGULAR_EXPERIENCE_LEVEL);
 
-        Skill administration = skills.getSkill(SkillType.S_ADMIN);
+        Skill administration = skills.getSkill(S_ADMIN);
         int experienceLevel = SkillLevel.NONE.getExperienceLevel();
 
         if (administration != null) {
@@ -4899,6 +4909,99 @@ public class Person {
 
     public void setUnlucky(final int unlucky) {
         this.unlucky = unlucky;
+    }
+
+    /**
+     * Retrieves the character's {@link Attributes} object containing the character's attribute scores.
+     *
+     * <p><b>Usage:</b> In most cases you'll want to use {@link #getAttributeScore(SkillAttribute)} instead, as that
+     * will allow you to jump straight to the exact score you need.</p>
+     *
+     * @return the character's {@link Attributes} object.
+     *
+     * @since 0.50.5
+     */
+    public Attributes getATOWAttributes() {
+        return atowAttributes;
+    }
+
+    /**
+     * Retrieves the score of a specified attribute.
+     *
+     * <p>The method maps the provided {@link SkillAttribute} to its corresponding attribute in
+     * the {@link Attributes} object and returns its value. If the {@link SkillAttribute} is {@code NONE}, the method
+     * returns a score of 0. If the {@code attribute} is {@code null}, an error is logged, and the method returns a
+     * score of 0.</p>
+     *
+     * @param attribute the {@link SkillAttribute} to retrieve the score for.
+     *
+     * @return the score of the specified attribute, or 0 if the attribute is {@code NONE} or {@code null}.
+     *
+     * @since 0.50.5
+     */
+    public int getAttributeScore(final SkillAttribute attribute) {
+        if (attribute == null) {
+            logger.error("(getAttributeScore) SkillAttribute is null.");
+            return 0;
+        }
+
+        return switch (attribute) {
+            case NONE -> 0;
+            case STRENGTH -> atowAttributes.getStrength();
+            case BODY -> atowAttributes.getBody();
+            case REFLEXES -> atowAttributes.getReflexes();
+            case DEXTERITY -> atowAttributes.getDexterity();
+            case INTELLIGENCE -> atowAttributes.getIntelligence();
+            case WILLPOWER -> atowAttributes.getWillpower();
+            case CHARISMA -> atowAttributes.getCharisma();
+        };
+    }
+
+    /**
+     * Sets the character's {@link Attributes} object which contains their ATOW Attribute scores.
+     *
+     * <p><b>Usage:</b> This completely wipes the character's attribute scores and is likely not the method you're
+     * looking for. Consider{@link #changeAttributeScore(SkillAttribute, int)} if you just want to increment or
+     * decrement a specific attribute by a certain value.</p>
+     *
+     * @param atowAttributes the {@link Attributes} object to set.
+     *
+     * @since 0.50.5
+     */
+    public void setATOWAttributes(final Attributes atowAttributes) {
+        this.atowAttributes = atowAttributes;
+    }
+
+    /**
+     * Modifies the score of a specified attribute by applying a delta value.
+     *
+     * <p>This method maps the provided {@link SkillAttribute} to its corresponding attribute in the
+     * {@link Attributes} object and adjusts its value by the specified delta. If the {@code attribute} is {@code NONE},
+     * the method does nothing. If {@code attribute} is {@code null}, an error is logged, and the method returns without
+     * performing any operation.</p>
+     *
+     * @param attribute the {@link SkillAttribute} to modify the score for.
+     * @param delta     the value to add to (or subtract from) the current score of the specified attribute.
+     *
+     * @since 0.50.5
+     */
+    public void changeAttributeScore(final SkillAttribute attribute, final int delta) {
+        if (attribute == null) {
+            logger.error("(changeAttributeScore) SkillAttribute is null.");
+            return;
+        }
+
+        switch (attribute) {
+            case NONE -> {
+            }
+            case STRENGTH -> atowAttributes.changeStrength(delta);
+            case BODY -> atowAttributes.changeBody(delta);
+            case REFLEXES -> atowAttributes.changeReflexes(delta);
+            case DEXTERITY -> atowAttributes.changeDexterity(delta);
+            case INTELLIGENCE -> atowAttributes.changeIntelligence(delta);
+            case WILLPOWER -> atowAttributes.changeWillpower(delta);
+            case CHARISMA -> atowAttributes.changeCharisma(delta);
+        }
     }
 
     public void resetSkillTypes() {

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.campaign.personnel.skills;
+
+import static megamek.codeUtilities.MathUtility.clamp;
+
+import java.io.PrintWriter;
+
+import megamek.codeUtilities.MathUtility;
+import megamek.logging.MMLogger;
+import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * The {@code Attributes} class represents a set of core attributes for a character.
+ *
+ * <p>Each attribute has a defined minimum, maximum, and default score. Helper methods provide functionality to get,
+ * set, adjust, and serialize these attributes.</p>
+ *
+ * <p>The attributes and their meanings are as follows:</p>
+ * <ul>
+ *     <li><b>Strength:</b> Physical strength of the entity.</li>
+ *     <li><b>Body:</b> Overall fitness and physical endurance.</li>
+ *     <li><b>Reflexes:</b> Reaction speed and agility.</li>
+ *     <li><b>Dexterity:</b> Fine motor skills and coordination.</li>
+ *     <li><b>Intelligence:</b> Cognitive abilities and reasoning capacity.</li>
+ *     <li><b>Willpower:</b> Mental determination and perseverance.</li>
+ *     <li><b>Charisma:</b> Social skills and personal magnetism.</li>
+ * </ul>
+ *
+ * <p>The class also provides XML serialization and deserialization methods to read/write attributes from/to external
+ * storage.</p>
+ *
+ * @since 0.50.5
+ */
+public class Attributes {
+    private static final MMLogger logger = MMLogger.create(Attributes.class);
+
+    private int strength;
+    private int body;
+    private int reflexes;
+    private int dexterity;
+    private int intelligence;
+    private int willpower;
+    private int charisma;
+
+    /**
+     * The default score assigned to all attributes during initialization.
+     */
+    public static int DEFAULT_ATTRIBUTE_SCORE = 5;
+
+    /**
+     * The minimum allowable score for any attribute.
+     *
+     * <p>Attribute values cannot be set below this limit, and any attempts to do so will result in clamping to this
+     * value.</p>
+     *
+     * <p><b>Note:</b> ATOW allows attribute scores of 0. However, at that point the character is effectively dead
+     * and outside the scope of MekHQ tracking (for now).</p>
+     */
+    public static int MINIMUM_ATTRIBUTE_SCORE = 1;
+
+    /**
+     * The maximum allowable score for any attribute.
+     *
+     * <p>Attribute values cannot be set above this limit, and any attempts to do so will result in clamping to this
+     * value.</p>
+     */
+    public static int MAXIMUM_ATTRIBUTE_SCORE = 10;
+
+    // Constructor
+
+    /**
+     * Constructs an {@code Attributes} object with all attributes initialized to their default value
+     * {@link #DEFAULT_ATTRIBUTE_SCORE}.
+     *
+     * @since 0.50.5
+     */
+    public Attributes() {
+        strength = DEFAULT_ATTRIBUTE_SCORE;
+        body = DEFAULT_ATTRIBUTE_SCORE;
+        reflexes = DEFAULT_ATTRIBUTE_SCORE;
+        dexterity = DEFAULT_ATTRIBUTE_SCORE;
+        intelligence = DEFAULT_ATTRIBUTE_SCORE;
+        willpower = DEFAULT_ATTRIBUTE_SCORE;
+        charisma = DEFAULT_ATTRIBUTE_SCORE;
+    }
+
+    // Getters and Setters
+
+    /**
+     * @return the current strength value.
+     *
+     * @since 0.50.5
+     */
+    public int getStrength() {
+        return strength;
+    }
+
+    /**
+     * Sets the strength attribute, ensuring it is clamped between the defined minimum and maximum values.
+     *
+     * @param strength the new strength value.
+     *
+     * @see #MINIMUM_ATTRIBUTE_SCORE
+     * @see #MAXIMUM_ATTRIBUTE_SCORE
+     * @since 0.50.5
+     */
+    public void setStrength(int strength) {
+        this.strength = clamp(strength, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+    /**
+     * @return the current body value.
+     *
+     * @since 0.50.5
+     */
+    public int getBody() {
+        return body;
+    }
+
+
+    /**
+     * Sets the body attribute, ensuring it is clamped between the defined minimum and maximum values.
+     *
+     * @param body the new body value.
+     *
+     * @see #MINIMUM_ATTRIBUTE_SCORE
+     * @see #MAXIMUM_ATTRIBUTE_SCORE
+     * @since 0.50.5
+     */
+    public void setBody(int body) {
+        this.body = clamp(body, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+    /**
+     * @return the current reflexes value.
+     *
+     * @since 0.50.5
+     */
+    public int getReflexes() {
+        return reflexes;
+    }
+
+
+    /**
+     * Sets the reflexes attribute, ensuring it is clamped between the defined minimum and maximum values.
+     *
+     * @param reflexes the new reflexes value.
+     *
+     * @see #MINIMUM_ATTRIBUTE_SCORE
+     * @see #MAXIMUM_ATTRIBUTE_SCORE
+     * @since 0.50.5
+     */
+    public void setReflexes(int reflexes) {
+        this.reflexes = clamp(reflexes, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+    /**
+     * @return the current dexterity value.
+     *
+     * @since 0.50.5
+     */
+    public int getDexterity() {
+        return dexterity;
+    }
+
+
+    /**
+     * Sets the dexterity attribute, ensuring it is clamped between the defined minimum and maximum values.
+     *
+     * @param dexterity the new dexterity value.
+     *
+     * @see #MINIMUM_ATTRIBUTE_SCORE
+     * @see #MAXIMUM_ATTRIBUTE_SCORE
+     * @since 0.50.5
+     */
+    public void setDexterity(int dexterity) {
+        this.dexterity = clamp(dexterity, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+    /**
+     * @return the current intelligence value.
+     *
+     * @since 0.50.5
+     */
+    public int getIntelligence() {
+        return intelligence;
+    }
+
+    /**
+     * Sets the intelligence attribute, ensuring it is clamped between the defined minimum and maximum values.
+     *
+     * @param intelligence the new intelligence value.
+     *
+     * @see #MINIMUM_ATTRIBUTE_SCORE
+     * @see #MAXIMUM_ATTRIBUTE_SCORE
+     * @since 0.50.5
+     */
+    public void setIntelligence(int intelligence) {
+        this.intelligence = clamp(intelligence, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+    /**
+     * @return the current willpower value.
+     *
+     * @since 0.50.5
+     */
+    public int getWillpower() {
+        return willpower;
+    }
+
+    /**
+     * Sets the willpower attribute, ensuring it is clamped between the defined minimum and maximum values.
+     *
+     * @param willpower the new willpower value.
+     *
+     * @see #MINIMUM_ATTRIBUTE_SCORE
+     * @see #MAXIMUM_ATTRIBUTE_SCORE
+     * @since 0.50.5
+     */
+    public void setWillpower(int willpower) {
+        this.willpower = clamp(willpower, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+    /**
+     * @return the current charisma value.
+     *
+     * @since 0.50.5
+     */
+    public int getCharisma() {
+        return charisma;
+    }
+
+    /**
+     * Sets the charisma attribute, ensuring it is clamped between the defined minimum and maximum values.
+     *
+     * @param charisma the new charisma value.
+     *
+     * @see #MINIMUM_ATTRIBUTE_SCORE
+     * @see #MAXIMUM_ATTRIBUTE_SCORE
+     * @since 0.50.5
+     */
+    public void setCharisma(int charisma) {
+        this.charisma = clamp(charisma, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+    // Utility Methods
+
+    /**
+     * Applies a delta to all attributes, incrementing or decrementing their values by the specified amount while
+     * clamping results within bounds.
+     *
+     * @param delta the value to add to each attribute. A positive delta will increase the attribute scores, while a
+     *              negative delta will decrease them.
+     *
+     * @since 0.50.5
+     */
+    public void changeAllAttributes(int delta) {
+        changeStrength(delta);
+        changeBody(delta);
+        changeReflexes(delta);
+        changeDexterity(delta);
+        changeIntelligence(delta);
+        changeWillpower(delta);
+        changeCharisma(delta);
+    }
+
+    /**
+     * Changes the strength attribute by a delta.
+     *
+     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
+     *
+     * @param delta the value to add to the current strength. A positive delta will increase the attribute score, while
+     *              a negative delta will decrease it.
+     *
+     * @since 0.50.5
+     */
+    public void changeStrength(int delta) {
+        strength += delta;
+        strength = clamp(strength, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+
+    /**
+     * Changes the body attribute by a delta.
+     *
+     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
+     *
+     * @param delta the value to add to the current body. A positive delta will increase the attribute score, while a
+     *              negative delta will decrease it.
+     *
+     * @since 0.50.5
+     */
+    public void changeBody(int delta) {
+        body += delta;
+        body = clamp(body, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+
+    /**
+     * Changes the reflexes attribute by a delta.
+     *
+     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
+     *
+     * @param delta the value to add to the current reflexes. A positive delta will increase the attribute score, while
+     *              a negative delta will decrease it.
+     *
+     * @since 0.50.5
+     */
+    public void changeReflexes(int delta) {
+        reflexes += delta;
+        reflexes = clamp(reflexes, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+
+    /**
+     * Changes the dexterity attribute by a delta.
+     *
+     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
+     *
+     * @param delta the value to add to the current dexterity. A positive delta will increase the attribute score, while
+     *              a negative delta will decrease it.
+     *
+     * @since 0.50.5
+     */
+    public void changeDexterity(int delta) {
+        dexterity += delta;
+        dexterity = clamp(dexterity, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+
+    /**
+     * Changes the intelligence attribute by a delta.
+     *
+     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
+     *
+     * @param delta the value to add to the current intelligence. A positive delta will increase the attribute score,
+     *              while a negative delta will decrease it.
+     *
+     * @since 0.50.5
+     */
+    public void changeIntelligence(int delta) {
+        intelligence += delta;
+        intelligence = clamp(intelligence, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+
+    /**
+     * Changes the willpower attribute by a delta.
+     *
+     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
+     *
+     * @param delta the value to add to the current willpower. A positive delta will increase the attribute score, while
+     *              a negative delta will decrease it.
+     *
+     * @since 0.50.5
+     */
+    public void changeWillpower(int delta) {
+        willpower += delta;
+        willpower = clamp(willpower, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+
+    /**
+     * Changes the charisma attribute by a delta.
+     *
+     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
+     *
+     * @param delta the value to add to the current charisma. A positive delta will increase the attribute score, while
+     *              a negative delta will decrease it.
+     *
+     * @since 0.50.5
+     */
+    public void changeCharisma(int delta) {
+        charisma += delta;
+        charisma = clamp(charisma, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+    // Reading and Writing
+
+    /**
+     * Writes the current attributes to an XML format.
+     *
+     * <p>The method generates simple XML tags, writing each attribute as a named element containing its current
+     * value.</p>
+     *
+     * <pre>{@code
+     * <Attributes>
+     *     <strength>5</strength>
+     *     <body>5</body>
+     *     <reflexes>5</reflexes>
+     *     ...
+     * </Attributes>
+     * }</pre>
+     *
+     * @param printWriter the writer used to write the XML.
+     * @param indent      the number of spaces to indent each XML tag.
+     *
+     * @since 0.50.5
+     */
+    public void writeAttributesToXML(final PrintWriter printWriter, int indent) {
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "strength", strength);
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "body", body);
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "reflexes", reflexes);
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "dexterity", dexterity);
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "intelligence", intelligence);
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "willpower", willpower);
+        MHQXMLUtility.writeSimpleXMLTag(printWriter, indent, "charisma", charisma);
+    }
+
+    /**
+     * Reads attributes from an XML {@link Node}.
+     *
+     * <p>The method parses child nodes of the given XML node to set the values of attributes. If parsing fails for
+     * any reason, default attribute values are used.</p>
+     *
+     * @param workingNode the XML node containing attribute data.
+     *
+     * @return the current {@code Attributes} object with updated values.
+     *
+     * @author Illiani
+     * @since 0.50.5
+     */
+    public Attributes generateAttributesFromXML(final Node workingNode) {
+        NodeList newLine = workingNode.getChildNodes();
+
+        try {
+            for (int i = 0; i < newLine.getLength(); i++) {
+                Node workingNode2 = newLine.item(i);
+
+                if (workingNode2.getNodeName().equalsIgnoreCase("strength")) {
+                    this.strength = MathUtility.parseInt(workingNode2.getTextContent(), DEFAULT_ATTRIBUTE_SCORE);
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("body")) {
+                    this.body = MathUtility.parseInt(workingNode2.getTextContent(), DEFAULT_ATTRIBUTE_SCORE);
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("reflexes")) {
+                    this.reflexes = MathUtility.parseInt(workingNode2.getTextContent(), DEFAULT_ATTRIBUTE_SCORE);
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("dexterity")) {
+                    this.dexterity = MathUtility.parseInt(workingNode2.getTextContent(), DEFAULT_ATTRIBUTE_SCORE);
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("intelligence")) {
+                    this.intelligence = MathUtility.parseInt(workingNode2.getTextContent(), DEFAULT_ATTRIBUTE_SCORE);
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("willpower")) {
+                    this.willpower = MathUtility.parseInt(workingNode2.getTextContent(), DEFAULT_ATTRIBUTE_SCORE);
+                } else if (workingNode2.getNodeName().equalsIgnoreCase("charisma")) {
+                    this.charisma = MathUtility.parseInt(workingNode2.getTextContent(), DEFAULT_ATTRIBUTE_SCORE);
+                }
+            }
+        } catch (Exception ex) {
+            logger.error("Could not parse Attributes: ", ex);
+        }
+
+        return this;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/personnel/skills/enums/SkillAttribute.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/enums/SkillAttribute.java
@@ -27,6 +27,9 @@
  */
 package mekhq.campaign.personnel.skills.enums;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import megamek.codeUtilities.MathUtility;
 import megamek.logging.MMLogger;
 
 /**
@@ -78,6 +81,117 @@ public enum SkillAttribute {
 
     public static int NO_SKILL_ATTRIBUTE = -1;
 
+    final private static String RESOURCE_BUNDLE = "mekhq.resources." + SkillAttribute.class.getSimpleName();
+
+
+    /**
+     * Retrieves the label associated with this {@link SkillAttribute}.
+     *
+     * <p>The label is determined by looking up a resource bundle key associated with the enum's name in the format
+     * <code>{name}.label</code>.</p>
+     *
+     * @return The localized label for this {@link SkillAttribute}.
+     *
+     * @see #getLabel(SkillAttribute)
+     * @since 0.50.05
+     */
+    public String getLabel() {
+        final String RESOURCE_KEY = name() + ".label";
+
+        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+    }
+
+    /**
+     * Retrieves the label associated with the given {@link SkillAttribute}.
+     *
+     * <p>The label is determined by looking up a resource bundle key associated with the attribute's name in the
+     * format <code>{name}.label</code>.</p>
+     *
+     * @param attribute The {@link SkillAttribute} whose label is to be retrieved.
+     *
+     * @return The localized label for the provided {@link SkillAttribute}.
+     *
+     * @see #getLabel()
+     * @since 0.50.05
+     */
+    public static String getLabel(SkillAttribute attribute) {
+        final String RESOURCE_KEY = attribute.name() + ".label";
+
+        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+    }
+
+    /**
+     * Retrieves the short name associated with this {@link SkillAttribute}.
+     *
+     * <p>The short name is determined by looking up a resource bundle key associated with the enum's name in the
+     * format <code>{name}.shortName</code>.</p>
+     *
+     * @return The localized short name for this {@link SkillAttribute}.
+     *
+     * @see #getShortName(SkillAttribute)
+     * @since 0.50.05
+     */
+    public String getShortName() {
+        final String RESOURCE_KEY = name() + ".shortName";
+
+        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+    }
+
+    /**
+     * Retrieves the short name associated with the given {@link SkillAttribute}.
+     *
+     * <p>The short name is determined by looking up a resource bundle key associated with the attribute's name in
+     * the format <code>{name}.shortName</code>.</p>
+     *
+     * @param attribute The {@link SkillAttribute} whose short name is to be retrieved.
+     *
+     * @return The localized short name for the provided {@link SkillAttribute}.
+     *
+     * @see #getShortName()
+     * @since 0.50.05
+     */
+    public static String getShortName(SkillAttribute attribute) {
+        final String RESOURCE_KEY = attribute.name() + ".shortName";
+
+        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+    }
+
+    /**
+     * Retrieves the description associated with this {@link SkillAttribute}.
+     *
+     * <p>The description is determined by looking up a resource bundle key associated with the enum's name in the
+     * format <code>{name}.description</code>.</p>
+     *
+     * @return The localized description for this {@link SkillAttribute}.
+     *
+     * @see #getDescription(SkillAttribute)
+     * @since 0.50.05
+     */
+    public String getDescription() {
+        final String RESOURCE_KEY = name() + ".description";
+
+        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+    }
+
+    /**
+     * Retrieves the description associated with the given {@link SkillAttribute}.
+     *
+     * <p>The description is determined by looking up a resource bundle key associated with the attribute's name in
+     * the format <code>{name}.description</code>.</p>
+     *
+     * @param attribute The {@link SkillAttribute} whose description is to be retrieved.
+     *
+     * @return The localized description for the provided {@link SkillAttribute}.
+     *
+     * @see #getDescription()
+     * @since 0.50.05
+     */
+    public static String getDescription(SkillAttribute attribute) {
+        final String RESOURCE_KEY = attribute.name() + ".description";
+
+        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+    }
+
     /**
      * Converts a string or integer input to its corresponding {@link SkillAttribute}.
      *
@@ -105,9 +219,7 @@ public enum SkillAttribute {
 
         try {
             // Attempt to parse as an integer and use as ordinal.
-            // We're using Integer.parseInt() here and not MathUtility.parseInt as we want to have a log in the event
-            // parsing fails, rather than just silently failing.
-            return SkillAttribute.values()[Integer.parseInt(text)];
+            return SkillAttribute.values()[MathUtility.parseInt(text)];
         } catch (Exception ignored) {
         }
 

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/AttributesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/AttributesTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.campaign.personnel.skills;
+
+import static mekhq.campaign.personnel.skills.Attributes.DEFAULT_ATTRIBUTE_SCORE;
+import static mekhq.campaign.personnel.skills.Attributes.MAXIMUM_ATTRIBUTE_SCORE;
+import static mekhq.campaign.personnel.skills.Attributes.MINIMUM_ATTRIBUTE_SCORE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class AttributesTest {
+    @Test
+    public void testDefaultConstructor() {
+        Attributes attributes = new Attributes();
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getStrength());
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getBody());
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getReflexes());
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getDexterity());
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getIntelligence());
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getWillpower());
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getCharisma());
+    }
+
+    @Test
+    public void testSetStrength() {
+        Attributes attributes = new Attributes();
+
+        attributes.setStrength(MAXIMUM_ATTRIBUTE_SCORE + 1);
+        assertEquals(MAXIMUM_ATTRIBUTE_SCORE, attributes.getStrength());
+
+        attributes.setStrength(MINIMUM_ATTRIBUTE_SCORE - 1);
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getStrength());
+
+        for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
+            attributes.setStrength(i);
+            assertEquals(i, attributes.getStrength());
+        }
+    }
+
+    @Test
+    public void testSetBody() {
+        Attributes attributes = new Attributes();
+
+        attributes.setBody(MAXIMUM_ATTRIBUTE_SCORE + 1);
+        assertEquals(MAXIMUM_ATTRIBUTE_SCORE, attributes.getBody());
+
+        attributes.setBody(MINIMUM_ATTRIBUTE_SCORE - 1);
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getBody());
+
+        for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
+            attributes.setBody(i);
+            assertEquals(i, attributes.getBody());
+        }
+    }
+
+    @Test
+    public void testSetReflexes() {
+        Attributes attributes = new Attributes();
+
+        attributes.setReflexes(MAXIMUM_ATTRIBUTE_SCORE + 1);
+        assertEquals(MAXIMUM_ATTRIBUTE_SCORE, attributes.getReflexes());
+
+        attributes.setReflexes(MINIMUM_ATTRIBUTE_SCORE - 1);
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getReflexes());
+
+        for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
+            attributes.setReflexes(i);
+            assertEquals(i, attributes.getReflexes());
+        }
+    }
+
+    @Test
+    public void testSetDexterity() {
+        Attributes attributes = new Attributes();
+
+        attributes.setDexterity(MAXIMUM_ATTRIBUTE_SCORE + 1);
+        assertEquals(MAXIMUM_ATTRIBUTE_SCORE, attributes.getDexterity());
+
+        attributes.setDexterity(MINIMUM_ATTRIBUTE_SCORE - 1);
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getDexterity());
+
+        for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
+            attributes.setDexterity(i);
+            assertEquals(i, attributes.getDexterity());
+        }
+    }
+
+    @Test
+    public void testSetIntelligence() {
+        Attributes attributes = new Attributes();
+
+        attributes.setIntelligence(MAXIMUM_ATTRIBUTE_SCORE + 1);
+        assertEquals(MAXIMUM_ATTRIBUTE_SCORE, attributes.getIntelligence());
+
+        attributes.setIntelligence(MINIMUM_ATTRIBUTE_SCORE - 1);
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getIntelligence());
+
+        for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
+            attributes.setIntelligence(i);
+            assertEquals(i, attributes.getIntelligence());
+        }
+    }
+
+    @Test
+    public void testSetWillpower() {
+        Attributes attributes = new Attributes();
+
+        attributes.setWillpower(MAXIMUM_ATTRIBUTE_SCORE + 1);
+        assertEquals(MAXIMUM_ATTRIBUTE_SCORE, attributes.getWillpower());
+
+        attributes.setWillpower(MINIMUM_ATTRIBUTE_SCORE - 1);
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getWillpower());
+
+        for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
+            attributes.setWillpower(i);
+            assertEquals(i, attributes.getWillpower());
+        }
+    }
+
+    @Test
+    public void testSetCharisma() {
+        Attributes attributes = new Attributes();
+
+        attributes.setCharisma(MAXIMUM_ATTRIBUTE_SCORE + 1);
+        assertEquals(MAXIMUM_ATTRIBUTE_SCORE, attributes.getCharisma());
+
+        attributes.setCharisma(MINIMUM_ATTRIBUTE_SCORE - 1);
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getCharisma());
+
+        for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
+            attributes.setCharisma(i);
+            assertEquals(i, attributes.getCharisma());
+        }
+    }
+
+    @Test
+    public void testChangeAllAttributes_BelowMinimum() {
+        Attributes attributes = new Attributes();
+        attributes.changeAllAttributes(-999);
+        assertEqualsAllAttributes(MINIMUM_ATTRIBUTE_SCORE, attributes);
+    }
+
+    @Test
+    public void testChangeAllAttributes_AboveMaximum() {
+        Attributes attributes = new Attributes();
+        attributes.changeAllAttributes(999);
+        assertEqualsAllAttributes(MAXIMUM_ATTRIBUTE_SCORE, attributes);
+    }
+
+    @Test
+    public void testChangeAllAttributes_AllPossibleValues() {
+        int minimum = MINIMUM_ATTRIBUTE_SCORE - DEFAULT_ATTRIBUTE_SCORE;
+        int maximum = MAXIMUM_ATTRIBUTE_SCORE - DEFAULT_ATTRIBUTE_SCORE;
+
+        for (int i = minimum; i <= maximum; i++) {
+            Attributes attributes = new Attributes();
+            int expectation = DEFAULT_ATTRIBUTE_SCORE + i;
+
+            attributes.changeAllAttributes(i);
+            assertEqualsAllAttributes(expectation, attributes);
+        }
+    }
+
+    /**
+     * Asserts that all attributes of the given {@link Attributes} object are equal to the expected value.
+     *
+     * <p>This utility method performs assertions on the following attributes:</p>
+     * <ul>
+     *     <li>Strength</li>
+     *     <li>Body</li>
+     *     <li>Reflexes</li>
+     *     <li>Dexterity</li>
+     *     <li>Intelligence</li>
+     *     <li>Willpower</li>
+     *     <li>Charisma</li>
+     * </ul>
+     * <p>If any attribute does not match the expected value, an assertion error will be thrown.</p>
+     *
+     * @param expectation the expected value for all attributes.
+     * @param attributes  the {@link Attributes} object whose attributes are being tested.
+     *
+     * @throws AssertionError if any attribute does not match the expected value.
+     * @since 0.50.5
+     */
+    private static void assertEqualsAllAttributes(int expectation, Attributes attributes) {
+        assertEquals(expectation, attributes.getStrength());
+        assertEquals(expectation, attributes.getBody());
+        assertEquals(expectation, attributes.getReflexes());
+        assertEquals(expectation, attributes.getDexterity());
+        assertEquals(expectation, attributes.getIntelligence());
+        assertEquals(expectation, attributes.getWillpower());
+        assertEquals(expectation, attributes.getCharisma());
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/enums/SkillAttributeTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/enums/SkillAttributeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.campaign.personnel.skills.enums;
+
+import static mekhq.campaign.personnel.skills.enums.SkillAttribute.DEXTERITY;
+import static mekhq.campaign.personnel.skills.enums.SkillAttribute.NONE;
+import static mekhq.utilities.MHQInternationalization.isResourceKeyValid;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class SkillAttributeTest {
+    @Test
+    public void testFromString_ValidStatus() {
+        SkillAttribute status = SkillAttribute.fromString(DEXTERITY.name());
+        assertEquals(DEXTERITY, status);
+    }
+
+    @Test
+    public void testFromString_InvalidStatus() {
+        SkillAttribute status = SkillAttribute.fromString("INVALID_STATUS");
+
+        assertEquals(NONE, status);
+    }
+
+    @Test
+    public void testFromString_NullStatus() {
+        SkillAttribute status = SkillAttribute.fromString(null);
+
+        assertEquals(NONE, status);
+    }
+
+    @Test
+    public void testFromString_EmptyString() {
+        SkillAttribute status = SkillAttribute.fromString("");
+
+        assertEquals(NONE, status);
+    }
+
+    @Test
+    public void testFromString_FromOrdinal() {
+        SkillAttribute status = SkillAttribute.fromString(DEXTERITY.ordinal() + "");
+
+        assertEquals(DEXTERITY, status);
+    }
+
+    @Test
+    public void testGetLabel_notInvalid() {
+        for (SkillAttribute attribute : SkillAttribute.values()) {
+            String label = attribute.getLabel();
+
+            String results = "";
+            if (!isResourceKeyValid(label)) {
+                results = "Found Error in: " + label;
+            }
+
+            assertEquals("", results);
+        }
+    }
+
+    @Test
+    public void testGetShortName_notInvalid() {
+        for (SkillAttribute attribute : SkillAttribute.values()) {
+            String label = attribute.getShortName();
+
+            String results = "";
+            if (!isResourceKeyValid(label)) {
+                results = "Found Error in: " + label;
+            }
+
+            assertEquals("", results);
+        }
+    }
+
+    @Test
+    public void testGetDescription_notInvalid() {
+        for (SkillAttribute attribute : SkillAttribute.values()) {
+            String label = attribute.getDescription();
+
+            String results = "";
+            if (!isResourceKeyValid(label)) {
+                results = "Found Error in: " + label;
+            }
+
+            assertEquals("", results);
+        }
+    }
+}


### PR DESCRIPTION
- Introduced localized label, short name, and description retrieval methods in `SkillAttribute`.
- Implemented `Attributes` in `Person` to track character attribute scores with getter, setter, and modifier methods.
- Updated XML read/write functionality in `Person` to handle `Attributes` persistence.
- Added comprehensive unit tests for `SkillAttribute` and `Attributes` classes to ensure new methods' correctness.

### Dev Notes
This PR doesn't really do much on its' own and is more setup for future stuff. Essentially all it does is process and store a character's Attribute scores. There is no way to access, or influence these. Characters just get assigned the default of `5` in every attribute, which is stored and loaded alongside the rest of their stats.

Of special note, mhq handles Edge very differently and I really have no interest in implementing an ATOW-accurate Edge system, frankly I'm not sure it's possible without a _lot_ of work. So the Edge attribute isn't tracked by mhq and probably won't be.

TLDR: Edge remains unchanged from its current implementation.