### PR TITLE
Issue 6178: [RFE] Improved Display for in stock parts while salvaging

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -450,19 +450,27 @@ public abstract class Part implements IPartWork, ITechnology {
         String details = getDetails();
 
         if (details != null && !details.isBlank()) {
-            toReturn.append("</b><br/>").append(getDetails()).append("<br/>");
+            toReturn.append("</b><br>").append(getDetails()).append("<br>");
         }
 
-        if (this instanceof mekhq.campaign.parts.equipment.AmmoBin ammoBin) {
-            if (campaign.getQuartermaster() != null) {
-                toReturn.append("<br> <b>In Warehouse:</b> ")
-                      .append(campaign.getQuartermaster().getAmmoAvailable(ammoBin.getType()))
-                      .append(' ');
+        if (this.isSalvaging()) {
+            int inStock = 0;
+            if (this instanceof mekhq.campaign.parts.equipment.AmmoBin ammoBin) {
+                if (campaign.getQuartermaster() != null) {
+                    inStock = campaign.getQuartermaster().getAmmoAvailable(ammoBin.getType());
+                }
+            } else if (campaign.getWarehouse() != null) {
+                inStock = campaign.getWarehouse().getSparePartsCount(this);
             }
-        } else if (campaign.getWarehouse() != null) {
-            toReturn.append("<br> <b>In Warehouse:</b> ")
-                  .append(campaign.getWarehouse().getSparePartsCount(this))
-                  .append(' ');
+            String inStockText = inStock == 0 ?
+                ReportingUtilities.messageSurroundedBySpanWithColor(MekHQ.getMHQOptions()
+                    .getFontColorNegativeHexColor(), "None in stock") :
+               ReportingUtilities.messageSurroundedBySpanWithColor(MekHQ.getMHQOptions()
+                    .getFontColorPositiveHexColor(), String.valueOf(inStock) + " in stock");
+
+            toReturn.append(inStockText).append("<br>");
+        } else {
+            toReturn.append("<br>");
         }
 
         if (getSkillMin() <= SkillType.EXP_ELITE) {


### PR DESCRIPTION
Improved the display for in stock parts when salvaging: 
![image](https://github.com/user-attachments/assets/65c123ae-8214-4c54-b2fa-b4aff7d0f717)

Relates to #6178 and #6527 