### PR TITLE
Show engine tonnage in parts-in-use table

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/MissingEnginePart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingEnginePart.java
@@ -30,9 +30,6 @@ package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
 
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.common.Aero;
 import megamek.common.CriticalSlot;
 import megamek.common.Engine;
@@ -48,6 +45,8 @@ import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.parts.enums.PartRepairType;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
@@ -239,7 +238,7 @@ public class MissingEnginePart extends MissingPart {
 
     @Override
     public String getAcquisitionName() {
-        return getPartName() + ",  " + getTonnage() + " tons";
+        return getPartName() + ",  " + getUnitTonnage() + " tons";
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/PartInUse.java
+++ b/MekHQ/src/mekhq/campaign/parts/PartInUse.java
@@ -28,7 +28,11 @@
 
 package mekhq.campaign.parts;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import megamek.common.AmmoType;
@@ -92,7 +96,7 @@ public class PartInUse {
         if (null != partToBuy) {
             this.cost = partToBuy.getBuyCost();
             String descString = partToBuy.getAcquisitionName();
-            if( !(descString.contains("(") && descString.contains(")"))) {
+            if( !(descString.contains("(") && descString.contains(")")) && !(part instanceof EnginePart)) {
                 descString = descString.split(",")[0];
                 descString = descString.split("<")[0];
             }


### PR DESCRIPTION
Engines with the same rating but different unit tonnages cost different and are not interchangeable. This updates the parts in use table to reflect that. Prior to this change it only showed engine tonnage for Clan engines. It now shows & differentiates for IS engines too. 

An engine's actual tonnage doesn't matter when differentiating two engines, it's the unit's tonnage that matters.

![image](https://github.com/user-attachments/assets/332fc60b-c09a-490e-a554-bf5f03e39531)
