### PR TITLE
Issue 6548: PersonnelTableModelColumn's cell value should be a date to allow proper sorting

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -30,6 +30,7 @@ package mekhq.gui.dialog;
 import static java.lang.Math.round;
 
 import java.awt.BorderLayout;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridLayout;
@@ -39,6 +40,7 @@ import java.util.Objects;
 import java.util.ResourceBundle;
 import javax.swing.*;
 import javax.swing.RowSorter.SortKey;
+import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
@@ -137,7 +139,7 @@ public final class BatchXPDialog extends JDialog {
             }
 
             tableColumn.setPreferredWidth(column.getWidth());
-            tableColumn.setCellRenderer(new MekHqTableCellRenderer());
+            tableColumn.setCellRenderer(getRenderer());
             columnModel.setColumnVisible(tableColumn, true);
 
             personnelSorter.setComparator(column.ordinal(), column.getComparator(campaign));
@@ -154,6 +156,28 @@ public final class BatchXPDialog extends JDialog {
         final JScrollPane pane = new JScrollPaneWithSpeed(personnelTable);
         pane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
         return pane;
+    }
+
+    private TableCellRenderer getRenderer() {
+        return new Renderer();
+    }
+
+    private class Renderer extends MekHqTableCellRenderer {
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+              boolean hasFocus, int row, int column) {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            final int modelRow = table.convertRowIndexToModel(row);
+            final PersonnelTableModelColumn personnelColumn = batchXPColumns.get(column);
+            Person person = personnelModel.getPerson(modelRow);
+            String displayText = personnelColumn.getDisplayText(campaign, person);
+            if (displayText != null) {
+                setText(displayText);
+            }
+
+            return this;
+        }
     }
 
     private JComponent getButtonPanel() {

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -30,7 +30,6 @@ package mekhq.gui.dialog;
 import static java.lang.Math.round;
 
 import java.awt.BorderLayout;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridLayout;
@@ -60,7 +59,6 @@ import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.gui.enums.PersonnelTableModelColumn;
 import mekhq.gui.model.PersonnelTableModel;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
-import mekhq.gui.utilities.MekHqTableCellRenderer;
 
 public final class BatchXPDialog extends JDialog {
     private static final MMLogger logger = MMLogger.create(BatchXPDialog.class);
@@ -159,25 +157,7 @@ public final class BatchXPDialog extends JDialog {
     }
 
     private TableCellRenderer getRenderer() {
-        return new Renderer();
-    }
-
-    private class Renderer extends MekHqTableCellRenderer {
-
-        @Override
-        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
-              boolean hasFocus, int row, int column) {
-            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-            final int modelRow = table.convertRowIndexToModel(row);
-            final PersonnelTableModelColumn personnelColumn = batchXPColumns.get(column);
-            Person person = personnelModel.getPerson(modelRow);
-            String displayText = personnelColumn.getDisplayText(campaign, person);
-            if (displayText != null) {
-                setText(displayText);
-            }
-
-            return this;
-        }
+        return personnelModel.new Renderer();
     }
 
     private JComponent getButtonPanel() {

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -536,8 +536,7 @@ public enum PersonnelTableModelColumn {
                 return person.getPostNominal();
             case CALLSIGN:
                 return person.getCallsign();
-            case AGE:
-                return String.valueOf(person.getAge(campaign.getLocalDate()));
+            case AGE: //Age's cell value must return birthday to allow sorting
             case BIRTHDAY:
                 return MekHQ.getMHQOptions().getDisplayFormattedDate(person.getDateOfBirth());
             case PERSONNEL_STATUS:


### PR DESCRIPTION
Fixes #6548 

On the Personnel table, Age was recently updated to show a person's Age instead of birthday. However, the sort wasn't changed. Unfortunately, the sort won't work properly without the full birthday, otherwise people of the same age-year won't be sorted within their age. 

To fix this I set Age back to having a date as a cell value and updated the Mass Personnel Training (`BatchXPDialoig`) to use `getDisplayValue` from the `PersonnelTableModelColumn`.

![image](https://github.com/user-attachments/assets/5da3a244-81cd-4fd7-9343-e7dbad942503)
