### PR TITLE
Added Dedicated Skill Check Class Utility

### DIFF
--- a/MekHQ/resources/mekhq/resources/MarginOfSuccess.properties
+++ b/MekHQ/resources/mekhq/resources/MarginOfSuccess.properties
@@ -1,0 +1,10 @@
+# suppress inspection "UnusedProperty" for the whole file
+SPECTACULAR.label=<i>Spectacular!</i>
+EXTRAORDINARY.label=<i>Extraordinary!</i>
+GOOD.label=<i>Good</i>
+IT_WILL_DO.label=<i>It'll do...</i>
+BARELY_MADE_IT.label=<i>Barely made it!</i>
+ALMOST.label=<i>Almost...</i>
+BAD.label=<i>Bad</i>
+TERRIBLE.label=<i>Terrible!</i>
+DISASTROUS.label=<i>Disastrous</i>

--- a/MekHQ/resources/mekhq/resources/SkillCheckUtility.properties
+++ b/MekHQ/resources/mekhq/resources/SkillCheckUtility.properties
@@ -1,0 +1,3 @@
+skillCheck.results={0} {1}<b>failed</b>{2} {3} {4} check with a roll of <b>{5}</b> vs. a target number of <b>{6}</b>. {7}.{8}
+skillCheck.rerolled=\ {0} used a point of <b>Edge</b> when making this check.
+skillCheck.error=ERROR: Skill name is null. Please report this bug to the MegaMek team.

--- a/MekHQ/resources/mekhq/resources/SkillCheckUtility.properties
+++ b/MekHQ/resources/mekhq/resources/SkillCheckUtility.properties
@@ -1,3 +1,4 @@
 skillCheck.results={0} {1}<b>failed</b>{2} {3} {4} check with a roll of <b>{5}</b> vs. a target number of <b>{6}</b>. {7}.{8}
 skillCheck.rerolled=\ {0} used a point of <b>Edge</b> when making this check.
-skillCheck.error=ERROR: Skill name is null. Please report this bug to the MegaMek team.
+skillCheck.nullSkillName=ERROR: Skill name is null. Please report this bug to the MegaMek team.
+skillCheck.nullPerson=ERROR: Person is null. Please report this bug to the MegaMek team.

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
@@ -33,6 +33,7 @@ import java.io.PrintWriter;
 
 import megamek.codeUtilities.MathUtility;
 import megamek.logging.MMLogger;
+import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -113,6 +114,32 @@ public class Attributes {
     }
 
     // Getters and Setters
+
+    /**
+     * Retrieves the value of a specified attribute.
+     *
+     * <p>This method returns the score of the requested {@link SkillAttribute}.
+     * If the attribute does not match any of the defined attributes, the method returns {@code 0} as the default
+     * value.</p>
+     *
+     * @param attribute the {@link SkillAttribute} to retrieve the value for.
+     *
+     * @return the value of the specified attribute, or {@code 0} if the attribute is not valid or not recognized.
+     *
+     * @since 0.50.05
+     */
+    public int getAttribute(SkillAttribute attribute) {
+        return switch (attribute) {
+            case STRENGTH -> strength;
+            case BODY -> body;
+            case REFLEXES -> reflexes;
+            case DEXTERITY -> dexterity;
+            case INTELLIGENCE -> intelligence;
+            case WILLPOWER -> willpower;
+            case CHARISMA -> charisma;
+            default -> 0;
+        };
+    }
 
     /**
      * @return the current strength value.

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
@@ -113,6 +113,37 @@ public class Attributes {
         charisma = DEFAULT_ATTRIBUTE_SCORE;
     }
 
+    /**
+     * Constructs a new {@code Attributes} object with the specified attribute values.
+     *
+     * @param strength     the {@link SkillAttribute#STRENGTH} value of the character, representing physical power.
+     * @param body         the {@link SkillAttribute#BODY} value of the character, representing endurance and physical
+     *                     resilience.
+     * @param reflexes     the {@link SkillAttribute#REFLEXES} value of the character, representing reaction speed and
+     *                     agility.
+     * @param dexterity    the {@link SkillAttribute#DEXTERITY} value of the character, representing skillfulness and
+     *                     precision.
+     * @param intelligence the {@link SkillAttribute#INTELLIGENCE} value of the character, representing cognitive
+     *                     ability and reasoning.
+     * @param willpower    the {@link SkillAttribute#WILLPOWER} value of the character, representing mental strength and
+     *                     determination.
+     * @param charisma     the {@link SkillAttribute#CHARISMA} value of the character, representing persuasiveness and
+     *                     social skills.
+     *
+     * @author Illiani
+     * @since 0.50.5
+     */
+    public Attributes(int strength, int body, int reflexes, int dexterity, int intelligence, int willpower,
+          int charisma) {
+        this.strength = strength;
+        this.body = body;
+        this.reflexes = reflexes;
+        this.dexterity = dexterity;
+        this.intelligence = intelligence;
+        this.willpower = willpower;
+        this.charisma = charisma;
+    }
+
     // Getters and Setters
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -66,12 +66,12 @@ import org.w3c.dom.NodeList;
  * <p>
  * target - this is the baseline target number for the skill when level and bonus are zero.
  * <p>
- * countUp - this is a boolean that defines whether this skill's target is a "roll greater than or equal to" (false) or
- * an rpg-style bonus to a roll (true)
+ * isCountUp - this is a boolean that defines whether this skill's target is a "roll greater than or equal to" (false)
+ * or an rpg-style bonus to a roll (true)
  * <p>
  * The actual target number for a skill is given by
  * <p>
- * countUp: target + lvl + bonus !countUp: target - level - bonus
+ * isCountUp: target + lvl + bonus !isCountUp: target - level - bonus
  * <p>
  * by clever manipulation of these values and skill costs in campaignOptions, players should be able to recreate any of
  * the rpg versions or their own homebrew system. The default setup will follow the core rule books (not aToW).
@@ -79,8 +79,8 @@ import org.w3c.dom.NodeList;
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
 public class Skill {
-    private static int COUNT_UP_MAX_VALUE = 10;
-    private static int COUNT_DOWN_MIN_VALUE = 0;
+    public static int COUNT_UP_MAX_VALUE = 10;
+    public static int COUNT_DOWN_MIN_VALUE = 0;
 
     private static final MMLogger logger = MMLogger.create(Skill.class);
 
@@ -137,7 +137,7 @@ public class Skill {
      * @return {@code true} if the progression type is "count up", {@code false} otherwise.
      */
     private boolean isCountUp() {
-        return type.countUp();
+        return type.isCountUp();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
@@ -87,7 +87,7 @@ public class SkillCheckUtility {
      * target number and an optional use of edge.</p>
      *
      * <p><b>Usage:</b> This constructor gives you a lot of control over what information you need, but for most
-     * use-cases you can get away with using the lazy method: {@link #performQuickSkillCheck(Person, String)}.</p>
+     * use-cases you can get away with using the lazy method: {@link #performQuickSkillCheck(Person, String, int)}.</p>
      *
      * @param person       the {@link Person} performing the skill check
      * @param skillName    the name of the skill being used

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.campaign.personnel.skills;
+
+import static java.lang.Math.floor;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static megamek.codeUtilities.MathUtility.clamp;
+import static megamek.common.Compute.d6;
+import static mekhq.campaign.personnel.skills.Attributes.MAXIMUM_ATTRIBUTE_SCORE;
+import static mekhq.campaign.personnel.skills.Attributes.MINIMUM_ATTRIBUTE_SCORE;
+import static mekhq.campaign.personnel.skills.Skill.COUNT_DOWN_MIN_VALUE;
+import static mekhq.campaign.personnel.skills.Skill.COUNT_UP_MAX_VALUE;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessString;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginValue;
+
+import java.util.List;
+
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
+import mekhq.campaign.personnel.skills.enums.SkillAttribute;
+
+/**
+ * This class calculates the target number for a skill check based on the person's attributes, skills, and the
+ * associated skill type. It determines if the skill check succeeds or fails by rolling dice and calculates the
+ * resulting margin of success and corresponding text description.
+ *
+ * @since 0.50.5
+ */
+public class SkillCheckUtility {
+    /**
+     * The target number for an untrained skill check with one linked attribute.
+     */
+    private static final int UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE = 12; // ATOW pg 43
+
+    /**
+     * The target number for an untrained skill check with two linked attributes.
+     */
+    private static final int UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES = 18; // ATOW pg 43
+
+    private int marginOfSuccess;
+    private String resultsText;
+    private int targetNumber;
+    private int roll;
+    private boolean usedEdge;
+
+    /**
+     * Performs a skill check for the given person and skill.
+     *
+     * <p>This constructor performs a skill check by rolling dice and determining the outcome based on the person's
+     * target number and an optional use of edge.</p>
+     *
+     * <p><b>Usage:</b> This constructor gives you a lot of control over what information you need, but for most
+     * use-cases you can get away with using the lazy method: {@link #performQuickSkillCheck(Person, String)}.</p>
+     *
+     * @param person    the {@link Person} performing the skill check
+     * @param skillName the name of the skill being used
+     * @param useEdge   whether the person should use edge for a re-roll if the first attempt fails
+     *
+     * @since 0.50.5
+     */
+    public SkillCheckUtility(final Person person, final String skillName, final boolean useEdge) {
+        targetNumber = determineTargetNumber(person, skillName);
+        roll = d6(2);
+        int availableEdge = person.getCurrentEdge();
+
+        if (roll >= targetNumber || !useEdge || availableEdge < 1) {
+            marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(roll);
+            resultsText = getMarginOfSuccessString(marginOfSuccess);
+            return;
+        }
+
+        person.changeCurrentEdge(-1);
+        usedEdge = true;
+
+        roll = d6(2);
+        marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(roll);
+        resultsText = getMarginOfSuccessString(marginOfSuccess);
+    }
+
+    /**
+     * Performs a quick skill check for a person based on the specified skill name.
+     *
+     * <p>This method creates a {@link SkillCheckUtility} instance to evaluate whether the given person is successful
+     * in performing the specified skill.</p>
+     *
+     * <p><b>Usage:</b> This is a nice, quick lazy method for performing a skill check. For most use-cases across
+     * MekHQ this is the method you want to use. If you need more control use the class constructor, instead.</p>
+     *
+     * @param person    the {@link Person} performing the skill check
+     * @param skillName the name of the skill being checked
+     *
+     * @return {@code true} if the skill check is successful, {@code false} otherwise
+     *
+     * @since 0.50.5
+     */
+    public boolean performQuickSkillCheck(final Person person, final String skillName) {
+        SkillCheckUtility skillCheck = new SkillCheckUtility(person, skillName, false);
+        return skillCheck.isSuccess();
+    }
+
+    /**
+     * Gets the calculated margin of success for this skill check.
+     *
+     * <p>The margin of success represents how much better (or worse) the roll was compared to the target number.</p>
+     *
+     * <p><b>Usage:</b> You want to call this method whenever you care about how well a check was passed. Or how
+     * badly it was failed. If you only care whether the check was passed or failed use {@link #isSuccess()}
+     * instead.</p>
+     *
+     * @return the margin of success
+     *
+     * @since 0.50.5
+     */
+    public int getMarginOfSuccess() {
+        return marginOfSuccess;
+    }
+
+    /**
+     * Determines whether the skill check was successful.
+     *
+     * <p>A skill check is considered successful if the calculated margin of success is greater than or equal to the
+     * margin value of {@link MarginOfSuccess#BARELY_MADE_IT}.</p>
+     *
+     * <p><b>Usage:</b> You want to call this method whenever you only care whether the check was passed or failed.
+     * If you want to know how well the character did use {@link #getMarginOfSuccess()} instead.</p>
+     *
+     * @return {@code true} if the skill check succeeded, {@code false} otherwise
+     *
+     * @since 0.50.5
+     */
+    public boolean isSuccess() {
+        return marginOfSuccess >= getMarginValue(BARELY_MADE_IT);
+    }
+
+    /**
+     * Gets the results text for the margin of success.
+     *
+     * <p>This is a descriptive string representing the outcome of the skill check, based on the calculated margin of
+     * success.</p>
+     *
+     * @return the results text for the skill check
+     *
+     * @since 0.50.5
+     */
+    public String getResultsText() {
+        return resultsText;
+    }
+
+    /**
+     * Gets the target number for the skill check.
+     *
+     * <p>The target number represents the value that the rolled number must meet or exceed for the skill check to
+     * succeed.</p>
+     *
+     * @return the target number for the skill check
+     *
+     * @since 0.50.5
+     */
+    public int getTargetNumber() {
+        return targetNumber;
+    }
+
+
+    /**
+     * Gets the roll result for the skill check.
+     *
+     * <p>The roll is the result of the dice roll used to determine whether the skill check succeeded or failed.</p>
+     *
+     * @return the roll result for the skill check
+     *
+     * @since 0.50.5
+     */
+    public int getRoll() {
+        return roll;
+    }
+
+
+    /**
+     * Checks whether edge was used during the skill check.
+     *
+     * <p>Edge provides the opportunity to re-roll if the initial skill check fails, allowing a chance to improve the
+     * outcome.</p>
+     *
+     * @return {@code true} if edge was used during the skill check, {@code false} otherwise
+     *
+     * @since 0.50.5
+     */
+    public boolean isUsedEdge() {
+        return usedEdge;
+    }
+
+    /**
+     * Determines the target number for a skill check based on the person's attributes, skill type, and whether they are
+     * trained in the skill.
+     *
+     * <p>If the person is untrained, the target number is based on constants for untrained rolls and the number of
+     * linked attributes. Otherwise, it is based on the final skill value and attribute modifiers.</p>
+     *
+     * @param person    the {@link Person} performing the skill check
+     * @param skillName the name of the skill being used
+     *
+     * @return the target number for the skill check
+     *
+     * @since 0.50.5
+     */
+    private static int determineTargetNumber(Person person, String skillName) {
+        final SkillType skillType = SkillType.getType(skillName);
+        final Attributes characterAttributes = person.getATOWAttributes();
+
+        boolean isUntrained = person.hasSkill(skillName);
+        int linkedAttributeCount = skillType.getLinkedAttributeCount();
+
+        int targetNumber;
+        int attributeModifier;
+
+        if (isUntrained) {
+            targetNumber = switch (linkedAttributeCount) {
+                case 1 -> UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE;
+                case 2 -> UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES;
+                default -> 0;
+            };
+
+            attributeModifier = getTotalAttributeScoreForSkill(characterAttributes, skillType);
+        } else {
+            Skill skill = person.getSkill(skillName);
+            targetNumber = skill.getFinalSkillValue(person.getOptions(), person.getReputation());
+            attributeModifier = getTotalAttributeModifier(characterAttributes, skillType);
+        }
+
+        if (skillType.isCountUp()) {
+            targetNumber += attributeModifier;
+            return min(targetNumber, COUNT_UP_MAX_VALUE);
+        } else {
+            targetNumber -= attributeModifier;
+            return max(targetNumber, COUNT_DOWN_MIN_VALUE);
+        }
+    }
+
+    /**
+     * Calculates the total attribute modifier for a given skill type based on the character's attributes.
+     *
+     * <p>The modifier is determined by summing up the individual attribute modifiers for the skill's linked
+     * attributes.</p>
+     *
+     * @param characterAttributes the {@link Attributes} of the person performing the skill check
+     * @param skillType           the {@link SkillType} being checked
+     *
+     * @return the total attribute modifier for the skill check
+     *
+     * @since 0.50.5
+     */
+    public static int getTotalAttributeModifier(final Attributes characterAttributes, final SkillType skillType) {
+        List<SkillAttribute> linkedAttributes = List.of(skillType.getFirstAttribute(), skillType.getSecondAttribute());
+
+        int totalModifier = 0;
+        for (SkillAttribute attribute : linkedAttributes) {
+            int attributeScore = characterAttributes.getAttribute(attribute);
+            totalModifier += getIndividualAttributeModifier(attributeScore);
+        }
+
+        return totalModifier;
+    }
+
+    /**
+     * Calculates the individual attribute modifier for a given attribute score.
+     *
+     * <p>The modification is based on a predefined scale, with higher scores providing positive modifiers and lower
+     * scores providing negative modifiers.</p>
+     *
+     * @param attributeScore the score of the attribute
+     *
+     * @return the attribute modifier for the given score
+     *
+     * @since 0.50.5
+     */
+    public static int getIndividualAttributeModifier(int attributeScore) {
+        int actualScore = clamp(attributeScore, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+        return switch (actualScore) {
+            case 0 -> -4;
+            case 1 -> -2;
+            case 2, 3 -> -1;
+            case 4, 5, 6 -> 0;
+            case 7, 8, 9 -> 1;
+            case 10 -> 2;
+            default -> min(5, (int) floor((double) actualScore / 3)); // ATOW pg 41
+        };
+    }
+
+    /**
+     * Calculates the total score for all attributes linked to a given skill type.
+     *
+     * <p>This method sums the raw values of the attributes linked to the skill, without applying any modifiers.</p>
+     *
+     * @param characterAttributes the {@link Attributes} of the person performing the skill check
+     * @param skillType           the {@link SkillType} being checked
+     *
+     * @return the total raw attribute score for the given skill type
+     *
+     * @since 0.50.5
+     */
+    public static int getTotalAttributeScoreForSkill(final Attributes characterAttributes, final SkillType skillType) {
+        List<SkillAttribute> linkedAttributes = List.of(skillType.getFirstAttribute(), skillType.getSecondAttribute());
+
+        int totalScore = 0;
+        for (SkillAttribute attribute : linkedAttributes) {
+            totalScore += characterAttributes.getAttribute(attribute);
+        }
+        return totalScore;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
@@ -149,7 +149,7 @@ public class SkillCheckUtility {
                                " Auto-failing check with bogus results so the bug stands out.");
 
             marginOfSuccess = getMarginValue(DISASTROUS);
-            resultsText = generateResultsText();
+            resultsText = getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.nullPerson");
             targetNumber = Integer.MAX_VALUE;
             roll = Integer.MIN_VALUE;
             return true;
@@ -185,7 +185,7 @@ public class SkillCheckUtility {
      */
     private String generateResultsText() {
         if (skillName == null) {
-            return getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.error");
+            return getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.nullSkillName");
         }
 
         String fullTitle = person.getHyperlinkedFullTitle();

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -320,20 +320,22 @@ public class SkillType {
      * Default constructor for the {@code SkillType} class.
      *
      * <p>Initializes a default skill type with placeholder values, primarily for testing or fallback purposes.</p>
+     *
+     * <p><b>Usage:</b> Generally you don't want to be calling this, outside of loading from xml or in Unit Tests.
+     * Instead, you want to use the full constructor.</p>
      */
     public SkillType() {
-        new SkillType("MISSING_NAME",
-              7,
-              false,
-              COMBAT_GUNNERY,
-              REFLEXES,
-              DEXTERITY,
-              1,
-              3,
-              4,
-              5,
-              new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL });
+        this.name = "MISSING_NAME";
+        this.target = 7;
+        this.countUp = false;
+        this.subType = COMBAT_GUNNERY;
+        this.firstAttribute = REFLEXES;
+        this.secondAttribute = DEXTERITY;
+        this.greenLvl = 1;
+        this.regLvl = 3;
+        this.vetLvl = 4;
+        this.eliteLvl = 5;
+        this.costs = new Integer[11];
     }
 
     /**
@@ -375,10 +377,10 @@ public class SkillType {
      *
      *                        <p>For example:</p>
      *                        <pre>
-     *                                                                                                                                                                  Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
-     *                                                                                                                                                                  SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
-     *                                                                                                                                                                         SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
-     *                                                                                                                                                                  </pre>
+     *                                                                                                                                                                                                                                                              Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
+     *                                                                                                                                                                                                                                                              SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
+     *                                                                                                                                                                                                                                                                     SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
+     *                                                                                                                                                                                                                                                              </pre>
      *
      * @author Illiani
      * @since 0.50.05

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -375,10 +375,10 @@ public class SkillType {
      *
      *                        <p>For example:</p>
      *                        <pre>
-     *                                                                                             Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
-     *                                                                                             SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
-     *                                                                                                    SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
-     *                                                                                             </pre>
+     *                                                                                                                                                                  Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
+     *                                                                                                                                                                  SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
+     *                                                                                                                                                                         SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
+     *                                                                                                                                                                  </pre>
      *
      * @author Illiani
      * @since 0.50.05
@@ -900,6 +900,12 @@ public class SkillType {
                     skillType.secondAttribute = SkillAttribute.fromString(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("costs")) {
                     String[] values = wn2.getTextContent().split(",");
+                    if (skillType.costs == null) {
+                        skillType.costs = new Integer[11];
+                        // Fill with default values, this protects us from NPEs
+                        Arrays.fill(skillType.costs, DISABLED_SKILL_LEVEL);
+                    }
+
                     for (int i = 0; i < values.length; i++) {
                         skillType.costs[i] = MathUtility.parseInt(values[i], skillType.costs[i]);
                     }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -322,7 +322,18 @@ public class SkillType {
      * <p>Initializes a default skill type with placeholder values, primarily for testing or fallback purposes.</p>
      */
     public SkillType() {
-        new SkillType("MISSING_NAME", 7, false, COMBAT_GUNNERY, REFLEXES, DEXTERITY, 1, 3, 4, 5, new ArrayList<>());
+        new SkillType("MISSING_NAME",
+              7,
+              false,
+              COMBAT_GUNNERY,
+              REFLEXES,
+              DEXTERITY,
+              1,
+              3,
+              4,
+              5,
+              new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL });
     }
 
     /**
@@ -330,39 +341,51 @@ public class SkillType {
      *
      * <p>If certain parameters are {@code null}, default values will be used.</p>
      *
-     * <p>The {@code costs} parameter is validated to ensure that it has exactly 11 entries (corresponding to skill
-     * levels 0 through 10 inclusive). If the provided list has fewer than 11 entries, additional entries with a value
-     * of {@link #DISABLED_SKILL_LEVEL} will be appended until the size reaches 11. If an error occurs when setting the
-     * {@code costs}, it will be logged, and the {@code costs} array will not be set.</p>
+     * <p>The {@code costs} parameter is validated to ensure it contains exactly 11 entries,
+     * corresponding to skill levels 0 through 10 inclusive. If the provided array is {@code null} or has fewer than 11
+     * elements, a new array will be created with missing entries filled with {@link #DISABLED_SKILL_LEVEL}. If the
+     * array has more than 11 entries, it will be trimmed to size. Additionally, the input array is copied to prevent
+     * accidental external changes to the internal state of the instance.</p>
      *
      * @param name            The name of the skill type. <b>Cannot</b> be {@code null}.
-     * @param target          The target value of the skill used for achievement or comparison purposes. If
-     *                        {@code null}, the default value is {@code 7}.
+     * @param target          The target value representing a threshold or goal for the skill. If {@code null}, the
+     *                        default value is {@code 7}.
      * @param isCountUp       {@code true} if the skill counts up toward a goal, {@code false} otherwise. If
      *                        {@code null}, the default value is {@code false}.
-     * @param subType         The {@code SkillSubType} category of the skill. <b>Cannot</b> be {@code null}.
-     * @param firstAttribute  The first associated skill attribute. <b>Cannot</b> be {@code null}.
-     * @param secondAttribute The second associated skill attribute. If {@code null}, the default value is
-     *                        {@code NONE}.
-     * @param greenLvl        The value representing the green skill level. If {@code null}, the default value is
-     *                        {@code 1}.
-     * @param regLvl          The value representing the regular skill level. If {@code null}, the default value is
-     *                        {@code 3}.
-     * @param vetLvl          The value representing the veteran skill level. If {@code null}, the default value is
-     *                        {@code 4}.
-     * @param eliteLvl        The value representing the elite skill level. If {@code null}, the default value is
-     *                        {@code 5}.
-     * @param costs           A {@code List<Integer>} representing costs associated with the skill's progression. The
-     *                        list should ideally contain exactly 11 values, one for each skill level (0-10, inclusive).
-     *                        If fewer than 11 values are provided, additional entries with the value
-     *                        {@link #DISABLED_SKILL_LEVEL} will be  added until the size is 11.
+     * @param subType         The {@link SkillSubType} category of the skill. This indicates the broader classification
+     *                        of the skill (e.g., combat-related, role-playing).
+     *                        <b>Cannot</b> be {@code null}.
+     * @param firstAttribute  The primary {@link SkillAttribute} associated with the skill, influencing its calculation
+     *                        or behavior. <b>Cannot</b> be {@code null}.
+     * @param secondAttribute The secondary {@link SkillAttribute} associated with the skill. If {@code null}, the
+     *                        default value is {@link SkillAttribute#NONE}.
+     * @param greenLvl        The value representing the skill's "Green" proficiency level. If {@code null}, the default
+     *                        value is {@code 1}.
+     * @param regLvl          The value representing the skill's "Regular" proficiency level. If {@code null}, the
+     *                        default value is {@code 3}.
+     * @param vetLvl          The value representing the skill's "Veteran" proficiency level. If {@code null}, the
+     *                        default value is {@code 4}.
+     * @param eliteLvl        The value representing the skill's "Elite" proficiency level. If {@code null}, the default
+     *                        value is {@code 5}.
+     * @param costs           An {@code Integer[]} array representing the skill's progression costs for each level from
+     *                        0 to 10 inclusive. If the array is {@code null} or its length is not exactly 11, a new
+     *                        array is created with default values. Missing entries are filled with
+     *                        {@link #DISABLED_SKILL_LEVEL}, and extra entries beyond the 11th are ignored. A clean copy
+     *                        of the array is always used to ensure the integrity of the internal state.
+     *
+     *                        <p>For example:</p>
+     *                        <pre>
+     *                                                                                             Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
+     *                                                                                             SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
+     *                                                                                                    SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
+     *                                                                                             </pre>
      *
      * @author Illiani
      * @since 0.50.05
      */
     public SkillType(String name, @Nullable Integer target, @Nullable Boolean isCountUp, SkillSubType subType,
           SkillAttribute firstAttribute, @Nullable SkillAttribute secondAttribute, @Nullable Integer greenLvl,
-          @Nullable Integer regLvl, @Nullable Integer vetLvl, @Nullable Integer eliteLvl, List<Integer> costs) {
+          @Nullable Integer regLvl, @Nullable Integer vetLvl, @Nullable Integer eliteLvl, Integer[] costs) {
         this.name = name;
         this.target = target == null ? 7 : target;
         this.countUp = isCountUp != null && isCountUp;
@@ -376,19 +399,21 @@ public class SkillType {
 
         // This validates the length of costs to ensure that valid entries exist for all possible skill levels (0-10,
         // inclusive)
-        int costsLength = costs.size();
-        if (costsLength != 11) {
-            while (costsLength < 11) {
-                costs.add(DISABLED_SKILL_LEVEL);
-                costsLength++;
-            }
-        }
+        if (costs == null || costs.length != 11) {
+            logger.warn(
+                  "The costs array is null or does not have exactly 11 entries. Filling missing levels with default values.");
+            Integer[] validCosts = new Integer[11];
+            Arrays.fill(validCosts, DISABLED_SKILL_LEVEL);
 
-        try {
-            this.costs = costs.toArray(new Integer[11]);
-        } catch (Exception e) {
-            logger.error("Error setting costs for skill type: {}. Array has {} entries." +
-                               "  Skipping setting of costs.", name, costsLength);
+            // If costs is not null, copy in existing elements
+            if (costs != null) {
+                System.arraycopy(costs, 0, validCosts, 0, Math.min(costs.length, 11));
+            }
+
+            this.costs = validCosts;
+        } else {
+            // Ensure a clean copy of the given array so we can't accidentally make dirty edits.
+            this.costs = Arrays.copyOf(costs, 11);
         }
     }
 
@@ -1098,7 +1123,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createGunneryMek() {
@@ -1112,7 +1137,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createPilotingAero() {
@@ -1126,7 +1152,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createGunneryAero() {
@@ -1140,7 +1166,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createPilotingJet() {
@@ -1154,7 +1181,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createGunneryJet() {
@@ -1168,7 +1195,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createPilotingSpace() {
@@ -1182,7 +1210,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createGunnerySpace() {
@@ -1196,7 +1224,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createPilotingGroundVee() {
@@ -1210,7 +1239,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createPilotingNavalVee() {
@@ -1224,7 +1253,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createPilotingVTOL() {
@@ -1238,7 +1267,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createGunneryVehicle() {
@@ -1252,7 +1281,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createArtillery() {
@@ -1266,7 +1296,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createGunneryBA() {
@@ -1280,7 +1311,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createGunneryProto() {
@@ -1294,7 +1326,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createSmallArms() {
@@ -1308,7 +1341,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createAntiMek() {
@@ -1325,7 +1358,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(12, 6, 6, 6, 6, 6, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createTechMek() {
@@ -1340,17 +1373,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(12,
-                    6,
-                    0,
-                    6,
-                    6,
-                    6,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL));
+              new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createTechMechanic() {
@@ -1365,17 +1389,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(12,
-                    6,
-                    0,
-                    6,
-                    6,
-                    6,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL));
+              new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createTechAero() {
@@ -1390,17 +1405,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(12,
-                    6,
-                    0,
-                    6,
-                    6,
-                    6,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL));
+              new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createTechBA() {
@@ -1415,17 +1421,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(12,
-                    6,
-                    0,
-                    6,
-                    6,
-                    6,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL));
+              new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createTechVessel() {
@@ -1440,17 +1437,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(12,
-                    6,
-                    0,
-                    6,
-                    6,
-                    6,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL));
+              new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createAstech() {
@@ -1465,17 +1453,9 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(12,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL));
+              new Integer[] { 12, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createDoctor() {
@@ -1490,17 +1470,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(16,
-                    8,
-                    0,
-                    8,
-                    8,
-                    8,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL));
+              new Integer[] { 16, 8, 0, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createMedTech() {
@@ -1514,17 +1485,9 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(16,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL));
+              new Integer[] { 16, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createNav() {
@@ -1539,7 +1502,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createTactics() {
@@ -1553,7 +1516,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6));
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 });
     }
 
     public static SkillType createStrategy() {
@@ -1567,7 +1530,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6));
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 });
     }
 
     public static SkillType createAdmin() {
@@ -1581,17 +1544,8 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8,
-                    4,
-                    0,
-                    4,
-                    4,
-                    4,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL,
-                    DISABLED_SKILL_LEVEL));
+              new Integer[] { 8, 4, 0, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
     }
 
     public static SkillType createLeadership() {
@@ -1605,7 +1559,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6));
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 });
     }
 
     public static SkillType createNegotiation() {
@@ -1619,7 +1573,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 });
     }
 
     public static SkillType createScrounge() {
@@ -1634,7 +1588,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4));
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 });
     }
 
     public static SkillType createAcrobatics() {
@@ -1648,7 +1602,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createActing() {
@@ -1662,7 +1616,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createAnimalHandling() {
@@ -1676,7 +1630,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createAppraisal() {
@@ -1690,7 +1644,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createArchery() {
@@ -1704,7 +1658,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createArtDancing() {
@@ -1718,7 +1672,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createArtDrawing() {
@@ -1732,7 +1686,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createArtPainting() {
@@ -1746,7 +1700,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createArtWriting() {
@@ -1760,7 +1714,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createClimbing() {
@@ -1774,7 +1728,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createCommunications() {
@@ -1788,7 +1742,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createComputers() {
@@ -1802,7 +1756,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createCryptography() {
@@ -1816,7 +1770,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createDemolitions() {
@@ -1830,7 +1784,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createDisguise() {
@@ -1844,7 +1798,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createEscapeArtist() {
@@ -1858,7 +1812,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createForgery() {
@@ -1872,7 +1826,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createInterestHistory() {
@@ -1886,7 +1840,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createInterestLiterature() {
@@ -1900,7 +1854,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createInterestHoloGames() {
@@ -1914,7 +1868,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createInterestSports() {
@@ -1928,7 +1882,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createInterrogation() {
@@ -1942,7 +1896,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createInvestigation() {
@@ -1956,7 +1910,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createLanguages() {
@@ -1970,7 +1924,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createMartialArts() {
@@ -1984,7 +1938,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createPerception() {
@@ -1998,7 +1952,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createSleightOfHand() {
@@ -2014,7 +1968,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createProtocols() {
@@ -2028,7 +1982,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createScienceBiology() {
@@ -2042,7 +1996,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createScienceChemistry() {
@@ -2056,7 +2010,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createScienceMathematics() {
@@ -2070,7 +2024,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createSciencePhysics() {
@@ -2084,7 +2038,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createSecuritySystemsElectronic() {
@@ -2098,7 +2052,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createSecuritySystemsMechanical() {
@@ -2112,7 +2066,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createSensorOperations() {
@@ -2126,7 +2080,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createStealth() {
@@ -2140,7 +2094,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createStreetwise() {
@@ -2154,7 +2108,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createSurvival() {
@@ -2168,7 +2122,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createTracking() {
@@ -2182,7 +2136,7 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 
     public static SkillType createTraining() {
@@ -2196,6 +2150,6 @@ public class SkillType {
               null,
               null,
               null,
-              Arrays.asList(20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100));
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -335,7 +335,15 @@ public class SkillType {
         target = t;
     }
 
+    /**
+     * @deprecated replaced by {@link #isCountUp()}
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     public boolean countUp() {
+        return countUp;
+    }
+
+    public boolean isCountUp() {
         return countUp;
     }
 
@@ -361,6 +369,21 @@ public class SkillType {
 
     public SkillAttribute getSecondAttribute() {
         return secondAttribute;
+    }
+
+    /**
+     * Calculates the number of linked attributes.
+     *
+     * <p>This method checks the primary and secondary attributes to determine how many are valid (i.e., not {@code
+     * null} and not {@code NONE}). It returns the total count of linked attributes.</p>
+     *
+     * @return the number of linked attributes, which can be 0, 1, or 2 depending on the validity of the attributes.
+     */
+    public int getLinkedAttributeCount() {
+        int count = 0;
+        count += (firstAttribute != null && firstAttribute != NONE) ? 1 : 0;
+        count += (secondAttribute != null && secondAttribute != NONE) ? 1 : 0;
+        return count;
     }
 
     public int getLevelFromExperience(int expLvl) {
@@ -690,7 +713,7 @@ public class SkillType {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "skillType");
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "name", name);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "target", target);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "countUp", countUp);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "isCountUp", countUp);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "subType", subType.toString());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "firstAttribute", firstAttribute.toString());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "secondAttribute", secondAttribute.toString());
@@ -741,7 +764,7 @@ public class SkillType {
                     skillType.vetLvl = MathUtility.parseInt(wn2.getTextContent(), skillType.vetLvl);
                 } else if (wn2.getNodeName().equalsIgnoreCase("eliteLvl")) {
                     skillType.eliteLvl = MathUtility.parseInt(wn2.getTextContent(), skillType.eliteLvl);
-                } else if (wn2.getNodeName().equalsIgnoreCase("countUp")) {
+                } else if (wn2.getNodeName().equalsIgnoreCase("isCountUp")) {
                     skillType.countUp = Boolean.parseBoolean(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("subType")) {
                     skillType.subType = SkillSubType.fromString(wn2.getTextContent().trim());
@@ -789,7 +812,7 @@ public class SkillType {
                     skillType.vetLvl = MathUtility.parseInt(wn2.getTextContent(), skillType.vetLvl);
                 } else if (wn2.getNodeName().equalsIgnoreCase("eliteLvl")) {
                     skillType.eliteLvl = MathUtility.parseInt(wn2.getTextContent(), skillType.eliteLvl);
-                } else if (wn2.getNodeName().equalsIgnoreCase("countUp")) {
+                } else if (wn2.getNodeName().equalsIgnoreCase("isCountUp")) {
                     skillType.countUp = Boolean.parseBoolean(wn2.getTextContent().trim());
                 } else if (wn2.getNodeName().equalsIgnoreCase("subType")) {
                     skillType.subType = SkillSubType.fromString(wn2.getTextContent().trim());

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -316,6 +316,12 @@ public class SkillType {
 
     /** Creates new SkillType */
     public SkillType() {
+        name = "MISSING_NAME";
+        target = 7;
+        countUp = false;
+        subType = COMBAT_GUNNERY;
+        firstAttribute = REFLEXES;
+        secondAttribute = DEXTERITY;
         greenLvl = 1;
         regLvl = 3;
         vetLvl = 4;
@@ -429,6 +435,42 @@ public class SkillType {
 
     public void setEliteLevel(int l) {
         eliteLvl = l;
+    }
+
+    /**
+     * Sets the first {@link SkillAttribute} associated with the skill type.
+     *
+     * <p>If {@code firstAttribute} is {@code null}, no action is taken, and the current value of the first attribute
+     * remains unchanged.
+     *
+     * @param firstAttribute the {@link SkillAttribute} to be used as the second attribute. If {@code null}, the
+     *                       existing value is preserved.
+     *
+     * @author Illiani
+     * @since 0.50.05
+     */
+    public void setFirstAttribute(SkillAttribute firstAttribute) {
+        if (secondAttribute != null) {
+            this.firstAttribute = firstAttribute;
+        }
+    }
+
+    /**
+     * Sets the second {@link SkillAttribute} associated with the skill type.
+     *
+     * <p>If {@code secondAttribute} is {@code null}, no action is taken, and the current value of the second
+     * attribute remains unchanged.
+     *
+     * @param secondAttribute the {@link SkillAttribute} to be used as the second attribute. If {@code null}, the
+     *                        existing value is preserved.
+     *
+     * @author Illiani
+     * @since 0.50.05
+     */
+    public void setSecondAttribute(SkillAttribute secondAttribute) {
+        if (secondAttribute != null) {
+            this.secondAttribute = secondAttribute;
+        }
     }
 
     public int getCost(int lvl) {

--- a/MekHQ/src/mekhq/campaign/personnel/skills/enums/MarginOfSuccess.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/enums/MarginOfSuccess.java
@@ -38,15 +38,17 @@ import megamek.logging.MMLogger;
  * <p>It is used to categorize results such as skill checks into predefined ranges and retrieve associated values or
  * labels for those results.</p>
  *
- * <p>Each enum constant represents a performance level and is associated with:
+ * <p>Each enum constant represents a performance level and is associated with:</p>
  * <ul>
  *     <li>A lower bound (inclusive),</li>
  *     <li>An upper bound (inclusive),</li>
  *     <li>A margin of success value.</li>
+ * </ul>
  *
  * <p>For example, {@link #SPECTACULAR} represents a margin of success in the range of 7 to {@link Integer#MAX_VALUE},
  * while {@link #DISASTROUS} represents a margin of success in the range of {@link Integer#MIN_VALUE} to -7.</p>
  *
+ * @author Illiani
  * @since 0.50.5
  */
 public enum MarginOfSuccess {
@@ -74,6 +76,7 @@ public enum MarginOfSuccess {
      * @param upperBound the upper inclusive bound for this margin of success
      * @param margin     the margin value associated with this range
      *
+     * @author Illiani
      * @since 0.50.5
      */
     MarginOfSuccess(int lowerBound, int upperBound, int margin) {
@@ -92,6 +95,7 @@ public enum MarginOfSuccess {
      *
      * @return the margin value associated with the given {@link MarginOfSuccess}
      *
+     * @author Illiani
      * @since 0.50.5
      */
     public static int getMarginValue(MarginOfSuccess marginOfSuccess) {
@@ -109,6 +113,7 @@ public enum MarginOfSuccess {
      * @return the margin (calculated as {@code roll - lowerBound}) corresponding to the matching
      *       {@link MarginOfSuccess} range, or the margin for {@link #DISASTROUS} if no matching range is found
      *
+     * @author Illiani
      * @since 0.50.5
      */
     public static int getMarginOfSuccess(int roll) {
@@ -133,6 +138,7 @@ public enum MarginOfSuccess {
      *
      * @return the localized string representing the given margin of success
      *
+     * @author Illiani
      * @since 0.50.5
      */
     public static String getMarginOfSuccessString(int marginOfSuccess) {

--- a/MekHQ/src/mekhq/campaign/personnel/skills/enums/MarginOfSuccess.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/enums/MarginOfSuccess.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.campaign.personnel.skills.enums;
+
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import megamek.logging.MMLogger;
+
+/**
+ * Represents margins of success (mos) that define ranges of roll results with an associated integer margin, lower
+ * bound, and upper bound.
+ *
+ * <p>It is used to categorize results such as skill checks into predefined ranges and retrieve associated values or
+ * labels for those results.</p>
+ *
+ * <p>Each enum constant represents a performance level and is associated with:
+ * <ul>
+ *     <li>A lower bound (inclusive),</li>
+ *     <li>An upper bound (inclusive),</li>
+ *     <li>A margin of success value.</li>
+ *
+ * <p>For example, {@link #SPECTACULAR} represents a margin of success in the range of 7 to {@link Integer#MAX_VALUE},
+ * while {@link #DISASTROUS} represents a margin of success in the range of {@link Integer#MIN_VALUE} to -7.</p>
+ *
+ * @since 0.50.5
+ */
+public enum MarginOfSuccess {
+    SPECTACULAR(7, Integer.MAX_VALUE, 4),
+    EXTRAORDINARY(5, 6, 3),
+    GOOD(3, 4, 2),
+    IT_WILL_DO(1, 2, 1),
+    BARELY_MADE_IT(0, 0, 0),
+    ALMOST(-2, -1, -1),
+    BAD(-4, -3, -2),
+    TERRIBLE(-6, -5, -3),
+    DISASTROUS(Integer.MIN_VALUE, -7, -4);
+
+    private static final MMLogger logger = MMLogger.create(MarginOfSuccess.class);
+    private static final String RESOURCE_BUNDLE = "mekhq.resources." + MarginOfSuccess.class.getSimpleName();
+
+    private final int lowerBound;
+    private final int upperBound;
+    private final int margin;
+
+    /**
+     * Constructs a {@link MarginOfSuccess} enum constant with the specified bounds and margin value.
+     *
+     * @param lowerBound the lower inclusive bound for this margin of success
+     * @param upperBound the upper inclusive bound for this margin of success
+     * @param margin     the margin value associated with this range
+     *
+     * @since 0.50.5
+     */
+    MarginOfSuccess(int lowerBound, int upperBound, int margin) {
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+        this.margin = margin;
+    }
+
+    /**
+     * Retrieves the margin value associated with the specified {@link MarginOfSuccess}.
+     *
+     * <p>The margin value represents the numerical value tied to a specific margin of success, typically used to
+     * measure the degree of success or failure of a skill check.</p>
+     *
+     * @param marginOfSuccess the {@link MarginOfSuccess} whose margin value is to be retrieved
+     *
+     * @return the margin value associated with the given {@link MarginOfSuccess}
+     *
+     * @since 0.50.5
+     */
+    public static int getMarginValue(MarginOfSuccess marginOfSuccess) {
+        return marginOfSuccess.margin;
+    }
+
+    /**
+     * Retrieves the margin of success for the specified roll value.
+     *
+     * <p>This method matches the provided roll value against the bounds of each {@link MarginOfSuccess} constant to
+     * determine the appropriate range and calculate the roll's margin.</p>
+     *
+     * @param roll the roll value to evaluate
+     *
+     * @return the margin (calculated as {@code roll - lowerBound}) corresponding to the matching
+     *       {@link MarginOfSuccess} range, or the margin for {@link #DISASTROUS} if no matching range is found
+     *
+     * @since 0.50.5
+     */
+    public static int getMarginOfSuccess(int roll) {
+        for (MarginOfSuccess mos : MarginOfSuccess.values()) {
+            if (roll >= mos.lowerBound && roll <= mos.upperBound) {
+                return roll - mos.lowerBound;
+            }
+        }
+
+        logger.error("Unknown MarginOfSuccess value: {} - returning {}.", roll, DISASTROUS);
+
+        return DISASTROUS.margin;
+    }
+
+    /**
+     * Retrieves the localized string label for a given margin of success.
+     *
+     * <p>This method looks up the label from the associated resource bundle, using the specified margin of success
+     * as a key, suffixed with {@code .label}.</p>
+     *
+     * @param marginOfSuccess the margin of success for which to retrieve the label
+     *
+     * @return the localized string representing the given margin of success
+     *
+     * @since 0.50.5
+     */
+    public static String getMarginOfSuccessString(int marginOfSuccess) {
+        return getFormattedTextAt(RESOURCE_BUNDLE, marginOfSuccess + ".label");
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -1436,7 +1436,7 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
         int level = (Integer) skillLvls.get(type).getModel().getValue();
         int bonus = (Integer) skillBonus.get(type).getModel().getValue();
 
-        if (skillType.countUp()) {
+        if (skillType.isCountUp()) {
             int target = min(getCountUpMaxValue(), skillType.getTarget() + level + bonus);
             skillValues.get(type).setText("+" + target);
         } else {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1741,7 +1741,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
               skillType.getFirstAttribute(),
               skillType.getSecondAttribute());
 
-        if (skillType.countUp()) {
+        if (skillType.isCountUp()) {
             int target = min(getCountUpMaxValue(), skillType.getTarget() + level + bonus + ageModifier);
             skillValues.get(type).setText("+" + target);
         } else {

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
@@ -77,7 +77,7 @@ import org.mockito.Mockito;
 class SkillCheckUtilityTest {
     @Test
     void testIsPersonNull_EdgeDisallowed() {
-        SkillCheckUtility checkUtility = new SkillCheckUtility(null, S_GUN_MEK, false);
+        SkillCheckUtility checkUtility = new SkillCheckUtility(null, S_GUN_MEK, 0, false);
 
         int expectedMarginOfSuccess = getMarginValue(DISASTROUS);
         assertEquals(expectedMarginOfSuccess, checkUtility.getMarginOfSuccess());
@@ -95,7 +95,7 @@ class SkillCheckUtilityTest {
 
     @Test
     void testIsPersonNull_EdgeAllowed() {
-        SkillCheckUtility checkUtility = new SkillCheckUtility(null, S_GUN_MEK, true);
+        SkillCheckUtility checkUtility = new SkillCheckUtility(null, S_GUN_MEK, 0, true);
 
         int expectedMarginOfSuccess = getMarginValue(DISASTROUS);
         assertEquals(expectedMarginOfSuccess, checkUtility.getMarginOfSuccess());
@@ -113,7 +113,7 @@ class SkillCheckUtilityTest {
 
     @Test
     void testIsPersonNull_PerformQuickSkillCheck() {
-        boolean results = performQuickSkillCheck(null, S_GUN_MEK);
+        boolean results = performQuickSkillCheck(null, S_GUN_MEK, 0);
         assertFalse(results);
     }
 
@@ -305,7 +305,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType(S_GUN_MEK)).thenReturn(testSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(person, S_GUN_MEK);
+            int targetNumber = SkillCheckUtility.determineTargetNumber(person, S_GUN_MEK, 0);
 
             // Assert
             int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE -
@@ -326,7 +326,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType(S_GUN_MEK)).thenReturn(testSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(person, S_GUN_MEK);
+            int targetNumber = SkillCheckUtility.determineTargetNumber(person, S_GUN_MEK, 0);
 
             // Assert
             int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES -
@@ -364,7 +364,7 @@ class SkillCheckUtilityTest {
                 mockSkillType.when(() -> SkillType.getType(S_GUN_MEK)).thenReturn(testSkillType);
 
                 // Act
-                int targetNumber = SkillCheckUtility.determineTargetNumber(mockPerson, S_GUN_MEK);
+                int targetNumber = SkillCheckUtility.determineTargetNumber(mockPerson, S_GUN_MEK, 0);
 
                 // Assert
                 int skillTargetNumber = skill.getFinalSkillValue(new PersonnelOptions(), 0);
@@ -403,7 +403,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType(S_GUN_MEK)).thenReturn(testSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(mockPerson, S_GUN_MEK);
+            int targetNumber = SkillCheckUtility.determineTargetNumber(mockPerson, S_GUN_MEK, 0);
 
             // Assert
             int skillTargetNumber = skill.getFinalSkillValue(new PersonnelOptions(), 0);
@@ -439,7 +439,7 @@ class SkillCheckUtilityTest {
                 mockSkillType.when(() -> SkillType.getType(S_GUN_MEK)).thenReturn(testSkillType);
 
                 // Act
-                int targetNumber = SkillCheckUtility.determineTargetNumber(mockPerson, S_GUN_MEK);
+                int targetNumber = SkillCheckUtility.determineTargetNumber(mockPerson, S_GUN_MEK, 0);
 
                 // Assert
                 int skillTargetNumber = skill.getFinalSkillValue(new PersonnelOptions(), 0);
@@ -468,7 +468,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType(S_GUN_MEK)).thenReturn(testSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(person, S_GUN_MEK);
+            int targetNumber = SkillCheckUtility.determineTargetNumber(person, S_GUN_MEK, 0);
 
             // Assert
             int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES -
@@ -494,7 +494,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType(S_GUN_MEK)).thenReturn(edgeCaseSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(person, S_GUN_MEK);
+            int targetNumber = SkillCheckUtility.determineTargetNumber(person, S_GUN_MEK, 0);
 
             // Assert
             assertEquals(UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE, targetNumber);
@@ -523,7 +523,7 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType(S_GUN_MEK)).thenReturn(testSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(person, S_GUN_MEK);
+            int targetNumber = SkillCheckUtility.determineTargetNumber(person, S_GUN_MEK, 0);
 
             // Assert
             int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES -

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
@@ -37,11 +37,11 @@ import static mekhq.campaign.personnel.skills.SkillCheckUtility.getTotalAttribut
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.performQuickSkillCheck;
 import static mekhq.campaign.personnel.skills.SkillType.S_GUN_MEK;
 import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.DISASTROUS;
-import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessString;
 import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginValue;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.DEXTERITY;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.NONE;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.REFLEXES;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
@@ -82,7 +82,8 @@ class SkillCheckUtilityTest {
         int expectedMarginOfSuccess = getMarginValue(DISASTROUS);
         assertEquals(expectedMarginOfSuccess, checkUtility.getMarginOfSuccess());
 
-        String expectedResultsText = getMarginOfSuccessString(expectedMarginOfSuccess);
+        String RESOURCE_BUNDLE = "mekhq.resources." + SkillCheckUtility.class.getSimpleName();
+        String expectedResultsText = getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.nullPerson");
         assertEquals(expectedResultsText, checkUtility.getResultsText());
 
         int expectedTargetNumber = Integer.MAX_VALUE;
@@ -99,7 +100,8 @@ class SkillCheckUtilityTest {
         int expectedMarginOfSuccess = getMarginValue(DISASTROUS);
         assertEquals(expectedMarginOfSuccess, checkUtility.getMarginOfSuccess());
 
-        String expectedResultsText = getMarginOfSuccessString(expectedMarginOfSuccess);
+        String RESOURCE_BUNDLE = "mekhq.resources." + SkillCheckUtility.class.getSimpleName();
+        String expectedResultsText = getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.nullPerson");
         assertEquals(expectedResultsText, checkUtility.getResultsText());
 
         int expectedTargetNumber = Integer.MAX_VALUE;


### PR DESCRIPTION
### Dev Notes
#### The Problem
Under our current implementation to perform a skill check a developer needs to perform the following actions:

- Check whether the character even has the skill. Failing to do this will result in an NPE.
- Determine what the final target number is, manually adding modifiers as necessary.
- Make the actual roll.
- Manually check whether the check was passed or failed. If necessary, add handler code so we can factor in Margins of Success.
- Determine whether Edge is used and if so, manually factor that in.

Speaking from extensive experience, this is a right pain in the bum and fraught with easy to make mistakes. Not checking whether the character _has_ the skill being the biggest.

All of this becomes exacerbated as characters become increasingly more complex. With interactions between ATOW Attributes, and SPAs, and other such similar exceptions and special rules.

#### Introducing `SkillCheckUtility`
The Skill Check Utility class allows you to pass in the character, the skill name, and any special modifiers and it will handle all of the above for you. Either returning a binary pass/fail, or a more nuanced 'margin of success', as desired. It's also possible to pass in a boolean dictating whether Edge should be rolled in the event of a failure.

Finally, this class will generate a skill check string showing who made the check, what the target number, and roll were, and finally what the margin of success was.

This is fully supported with a margin of success enum, ensuring things are kept consistent.

#### Testing & Integration
This class is not currently integrated into any other classes, so currently isn't accessed. My next challenge will be going through current skill checks and moving them to use `SkillCheckUtility`, if appropriate.

As this is a new feature and liable to be fairly critical, I went ahead and added 31 new Unit Tests to ensure the class works as intended.

#### ATOW & Attributes
`SkillCheckUtility` is fully set up so that skill checks made through it will incorporate any modifiers from that skill's linked attributes. It also implements ATOW's 'untrained' skill check functionality. Both of these follow the official rules outlined in ATOW. I went with the ATOW implementation here as it has a fairly robust margin of success system and clear interaction with attributes in the event a skill is untrained.

#### A Living Class
I'm not expecting this class to be perfect out the gate. There will be use-cases I didn't account for and implementations that need expanding or adjusting. Much like my Immersive Dialog pet classes, `SkillCheckUtility` will be expanded and improved as it's used.