### PR TITLE
Issue 6560: Fix for negative temporary prisoner capacity

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6407,7 +6407,7 @@ public class Campaign implements ITechManager {
     }
 
     public void setTemporaryPrisonerCapacity(int temporaryPrisonerCapacity) {
-        this.temporaryPrisonerCapacity = temporaryPrisonerCapacity;
+        this.temporaryPrisonerCapacity = max(PrisonerEventManager.MINIMUM_TEMPORARY_CAPACITY, temporaryPrisonerCapacity);
     }
 
     public RandomEventLibraries getRandomEventLibraries() {

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
@@ -91,6 +91,9 @@ public class PrisonerEventManager {
     private final int RESPONSE_TARGET_NUMBER = 7;
 
     public static final int DEFAULT_TEMPORARY_CAPACITY = 100;
+    // The temporary prisoner capacity should never go below 0.
+    // But the security forces should be able to guard some prisoners in all cases
+    public static final int MINIMUM_TEMPORARY_CAPACITY = 25;
     public static final double TEMPORARY_CAPACITY_DEGRADE_RATE = 0.1;
 
     // These values are based on CamOps. CamOps states a squad of CI or one squad of BA can

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
@@ -179,8 +179,8 @@ public class PrisonerEventManager {
         int newCapacity = 0;
 
         if (temporaryCapacityModifier != DEFAULT_TEMPORARY_CAPACITY) {
-        	int differendInTemporaryCapacity = abs(DEFAULT_TEMPORARY_CAPACITY-temporaryCapacityModifier);
-            int degreeOfChange = (int) max(1,round(differendInTemporaryCapacity * TEMPORARY_CAPACITY_DEGRADE_RATE));
+        	double differendInTemporaryCapacity = (double) abs(DEFAULT_TEMPORARY_CAPACITY-temporaryCapacityModifier);
+            int degreeOfChange = max(1,(int) round(differendInTemporaryCapacity * TEMPORARY_CAPACITY_DEGRADE_RATE));
 
             if (temporaryCapacityModifier < DEFAULT_TEMPORARY_CAPACITY) {
                 temporaryCapacityModifier += degreeOfChange;

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
@@ -27,6 +27,7 @@
  */
 package mekhq.campaign.randomEvents.prisoners;
 
+import static java.lang.Math.abs;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.round;
@@ -178,7 +179,8 @@ public class PrisonerEventManager {
         int newCapacity = 0;
 
         if (temporaryCapacityModifier != DEFAULT_TEMPORARY_CAPACITY) {
-            int degreeOfChange = (int) round(temporaryCapacityModifier * TEMPORARY_CAPACITY_DEGRADE_RATE);
+        	int differendInTemporaryCapacity = abs(DEFAULT_TEMPORARY_CAPACITY-temporaryCapacityModifier);
+            int degreeOfChange = (int) min(1,round(differendInTemporaryCapacity * TEMPORARY_CAPACITY_DEGRADE_RATE));
 
             if (temporaryCapacityModifier < DEFAULT_TEMPORARY_CAPACITY) {
                 temporaryCapacityModifier += degreeOfChange;

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
@@ -180,7 +180,7 @@ public class PrisonerEventManager {
 
         if (temporaryCapacityModifier != DEFAULT_TEMPORARY_CAPACITY) {
         	int differendInTemporaryCapacity = abs(DEFAULT_TEMPORARY_CAPACITY-temporaryCapacityModifier);
-            int degreeOfChange = (int) min(1,round(differendInTemporaryCapacity * TEMPORARY_CAPACITY_DEGRADE_RATE));
+            int degreeOfChange = (int) max(1,round(differendInTemporaryCapacity * TEMPORARY_CAPACITY_DEGRADE_RATE));
 
             if (temporaryCapacityModifier < DEFAULT_TEMPORARY_CAPACITY) {
                 temporaryCapacityModifier += degreeOfChange;

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/PrisonerEventManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/PrisonerEventManagerTest.java
@@ -35,6 +35,7 @@ import static mekhq.campaign.mission.enums.AtBMoraleLevel.STALEMATE;
 import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.DEFAULT_TEMPORARY_CAPACITY;
 import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.TEMPORARY_CAPACITY_DEGRADE_RATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -85,6 +86,7 @@ public class PrisonerEventManagerTest {
 
         // Assert
         assertEquals(expectedValue, actualValue);
+        assertNotEquals(INITIAL_TEMPORARY_CAPACITY, actualValue);
     }
 
     @Test
@@ -109,6 +111,7 @@ public class PrisonerEventManagerTest {
 
         // Assert
         assertEquals(expectedValue, actualValue);
+        assertNotEquals(INITIAL_TEMPORARY_CAPACITY, actualValue);
     }
 
     @Test
@@ -136,6 +139,7 @@ public class PrisonerEventManagerTest {
 
         // Assert
         assertEquals(expectedValue, actualValue);
+        assertNotEquals(INITIAL_TEMPORARY_CAPACITY, actualValue);
     }
 
     @Test
@@ -160,6 +164,7 @@ public class PrisonerEventManagerTest {
 
         // Assert
         assertEquals(expectedValue, actualValue);
+        assertNotEquals(INITIAL_TEMPORARY_CAPACITY, actualValue);
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/PrisonerEventManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/PrisonerEventManagerTest.java
@@ -27,6 +27,7 @@
  */
 package mekhq.campaign.randomEvents.prisoners;
 
+import static java.lang.Math.abs;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.round;
@@ -78,7 +79,8 @@ public class PrisonerEventManagerTest {
         // Act
         int actualValue = eventManager.degradeTemporaryCapacity();
 
-        int degreeOfChange = (int) round(INITIAL_TEMPORARY_CAPACITY * TEMPORARY_CAPACITY_DEGRADE_RATE);
+        int differendInTemporaryCapacity = abs(DEFAULT_TEMPORARY_CAPACITY-INITIAL_TEMPORARY_CAPACITY);
+        int degreeOfChange = (int) max(1,round(differendInTemporaryCapacity * TEMPORARY_CAPACITY_DEGRADE_RATE));
         int expectedValue = max(DEFAULT_TEMPORARY_CAPACITY, INITIAL_TEMPORARY_CAPACITY - degreeOfChange);
 
         // Assert
@@ -128,7 +130,8 @@ public class PrisonerEventManagerTest {
         // Act
         int actualValue = eventManager.degradeTemporaryCapacity();
 
-        int degreeOfChange = (int) round(INITIAL_TEMPORARY_CAPACITY * TEMPORARY_CAPACITY_DEGRADE_RATE);
+        int differendInTemporaryCapacity = abs(DEFAULT_TEMPORARY_CAPACITY-INITIAL_TEMPORARY_CAPACITY);
+        int degreeOfChange = (int) max(1,round(differendInTemporaryCapacity * TEMPORARY_CAPACITY_DEGRADE_RATE));
         int expectedValue = min(DEFAULT_TEMPORARY_CAPACITY, INITIAL_TEMPORARY_CAPACITY + degreeOfChange);
 
         // Assert


### PR DESCRIPTION
Fix for #6560 
- prevent temporaryPrisonerCapacity from going below MINIMUM_TEMPORARY_CAPACITY
  negative values should not be possible at all, but with 0% it would still be 
  impossible to contain the prisoners with any number of additional forces.
- MINIMUM_TEMPORARY_CAPACITY = 25 (25% normal prisoner capacity) 
  is an arbitrary number. I tried to balance being able to recover from an bad event
  and being to easy to recove. This value should be subject to further testing
- Changed the formular for degreeOfChange so that a lower value for temporaryPrisonerCapacity
  is not slower degrading than a higher temporaryPrisonerCapacity
- Updated the UnitTest to reflect the changes in degreeOfChange