### PR TITLE
 Fixed Facility Capacities Display Logic In Command Center Tab

### DIFF
--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -373,7 +373,9 @@ public final class CommandCenterTab extends CampaignGuiTab {
         gridBagConstraints.weightx = 1.0;
         panInfo.add(lblCargoSummary, gridBagConstraints);
 
-        if ((getCampaignOptions().isUseFatigue()) || (getCampaignOptions().isUseAdvancedMedical())) {
+        if ((getCampaignOptions().isUseFatigue()) ||
+                  (getCampaignOptions().isUseAdvancedMedical() ||
+                         (!getCampaignOptions().getPrisonerCaptureStyle().isNone()))) {
             JLabel lblFacilityCapacitiesHead = new JLabel(resourceMap.getString("lblFacilityCapacities.text"));
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 0;
@@ -648,11 +650,9 @@ public final class CommandCenterTab extends CampaignGuiTab {
             }
         }
 
-        if (campaignOptions.isUseFatigue()) {
-            try {
-                lblFacilityCapacities.setText(campaignSummary.getFacilityReport());
-            } catch (Exception ignored) {
-            }
+        try {
+            lblFacilityCapacities.setText(campaignSummary.getFacilityReport());
+        } catch (Exception ignored) {
         }
     }
 


### PR DESCRIPTION
- Modified the condition to show facility capacities to include checks for prisoner capture style settings.
- Removed redundant fatigue-specific logic for setting the facility report.