### PR TITLE
Updated Edge Handling and GUI Support

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4914,7 +4914,7 @@ public class Campaign implements ITechManager {
                     processWeeklyRelationshipEvents(person);
                 }
 
-                processWeeklyEdgeResets(person);
+                person.resetCurrentEdge();
 
                 if (!person.getStatus().isMIA()) {
                     processFatigueRecovery(this, person);
@@ -4990,14 +4990,11 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Process weekly Edge resets for a given person.
-     *
-     * @param person the person for whom weekly Edge resets will be processed
+     * @deprecated use {@link Person#resetCurrentEdge()} instead
      */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     private void processWeeklyEdgeResets(Person person) {
-        if ((person.hasSupportRole(true) || person.isEngineer())) {
-            person.resetCurrentEdge();
-        }
+        person.resetCurrentEdge();
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -215,7 +215,7 @@ public class Person {
 
     // Supports edge usage by a ship's engineer composite crewman
     private int edgeUsedThisRound;
-    // To track how many edge points support personnel have left until next refresh
+    // To track how many edge points personnel have left until next refresh
     private int currentEdge;
 
     // phenotype and background
@@ -2411,10 +2411,7 @@ public class Person {
                       indent,
                       "edge",
                       getOptionList("::", PersonnelOptions.EDGE_ADVANTAGES));
-                // For support personnel, write an available edge value
-                if (hasSupportRole(true) || isEngineer()) {
-                    MHQXMLUtility.writeSimpleXMLTag(pw, indent, "edgeAvailable", getCurrentEdge());
-                }
+                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "edgeAvailable", getCurrentEdge());
             }
 
             if (countOptions(PersonnelOptions.MD_ADVANTAGES) > 0) {
@@ -4226,14 +4223,14 @@ public class Person {
     }
 
     /**
-     * Resets support personnel edge points to the purchased level. Used for weekly refresh.
+     * Resets edge points to the purchased level. Used for weekly refresh.
      */
     public void resetCurrentEdge() {
         setCurrentEdge(getEdge());
     }
 
     /**
-     * Sets support personnel edge points to the value 'currentEdge'. Used for weekly refresh.
+     * Sets edge points to the value 'currentEdge'. Used for weekly refresh.
      *
      * @param currentEdge - integer used to track this person's edge points available for the current week
      */

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1614,7 +1614,7 @@ public class PersonViewPanel extends JScrollablePanel {
 
             lblEdge2.setName("lblEdge2");
             lblEdge1.setLabelFor(lblEdge2);
-            lblEdge2.setText(Integer.toString(person.getEdge()));
+            lblEdge2.setText("" + person.getCurrentEdge() + '/' + person.getEdge());
             lblEdge2.setToolTipText(person.getEdgeTooltip());
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 1;
@@ -1625,27 +1625,6 @@ public class PersonViewPanel extends JScrollablePanel {
             gridBagConstraints.fill = GridBagConstraints.NONE;
             gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
             pnlSkills.add(lblEdge2, gridBagConstraints);
-
-            if (campaign.getCampaignOptions().isUseSupportEdge() && person.hasSupportRole(true)) {
-                // Add the Edge Available field for support personnel only
-                lblEdgeAvail1.setName("lblEdgeAvail1");
-                lblEdgeAvail1.setText(resourceMap.getString("lblEdgeAvail1.text"));
-                gridBagConstraints = new GridBagConstraints();
-                gridBagConstraints.gridx = 2;
-                gridBagConstraints.gridy = firsty;
-                gridBagConstraints.fill = GridBagConstraints.NONE;
-                gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-                pnlSkills.add(lblEdgeAvail1, gridBagConstraints);
-
-                lblEdgeAvail2.setName("lblEdgeAvail2");
-                lblEdgeAvail1.setLabelFor(lblEdgeAvail2);
-                lblEdgeAvail2.setText(Integer.toString(person.getCurrentEdge()));
-                gridBagConstraints.gridx = 3;
-                gridBagConstraints.gridwidth = 1;
-                gridBagConstraints.weightx = 1.0;
-                gridBagConstraints.insets = new Insets(0, 10, 0, 0);
-                pnlSkills.add(lblEdgeAvail2, gridBagConstraints);
-            }
             firsty++;
         }
 


### PR DESCRIPTION
- Refactored `PersonViewPanel` to display current and total edge without support role-specific logic.
- Updated `resetCurrentEdge` logic in `Person` to apply universally instead of being restricted to support roles.
- Marked `processWeeklyEdgeResets` in `Campaign` as deprecated, consolidating its usage into `resetCurrentEdge`.
- Removed check that prevented non-support characters from having their current Edge levels stored on save.

### Dev Notes
Historically, the expectation was that only techs could use their Edge outside of scenarios. Therefore only techs had their current Edge levels stored in the save file. Everyone else had their current Edge reset to 0 on load.

Furthermore, previously Edge and Current Edge (for techs, nobody else displayed current edge) were displayed on separate lines of the View Person pane. I condensed those into the same line so it appears as shown below. 

<img width="335" alt="image" src="https://github.com/user-attachments/assets/2b1209f1-c0cf-4993-87b9-dbaddee2ebfe" />