### PR TITLE
Fixed Infinite Loop in `getAvailableForceIDs` (Sentry)

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -2412,7 +2412,7 @@ public class StratconRulesManager {
             }
         }
 
-        if (suitableForces.isEmpty()) {
+        if (suitableForces.isEmpty() && !bypassRoleRestrictions) {
             suitableForces = getAvailableForceIDs(campaign, contract, true);
         }
 

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -2412,8 +2412,14 @@ public class StratconRulesManager {
             }
         }
 
-        if (suitableForces.isEmpty() && !bypassRoleRestrictions) {
-            suitableForces = getAvailableForceIDs(campaign, contract, true);
+        if (suitableForces.isEmpty()) {
+            if (!bypassRoleRestrictions) {
+                logger.info("No suitable combat teams found for contract {}. Relaxing restrictions", contract.getId());
+                suitableForces = getAvailableForceIDs(campaign, contract, true);
+            } else {
+                logger.info("No suitable combat teams found for contract {} despite relaxed restrictions." +
+                                  " Scenario generation will likely be skipped.", contract.getId());
+            }
         }
 
         return suitableForces;


### PR DESCRIPTION
- Updated the condition in `StratconRulesManager` to include a check for the `bypassRoleRestrictions` flag when determining if suitable forces are empty.
- Prevented unintended infinite fallback to `getAvailableForceIDs` in the event no suitable forces exist, even with restrictions relaxed.
- Added detailed logging to indicate when no suitable combat teams are found. So we don't have to guess what happened if we get player reports that no scenarios are spawning.

Fix [Sentry Report](https://sentry.tapenvy.us/organizations/tapenvyus/issues/4224/?alert_rule_id=13&alert_type=issue&notification_uuid=7d506ef2-4432-4f64-93db-5fe078ff5a2a&project=10&referrer=discord)