### PR TITLE
Fix #6545: Prevented Self-Crewed Unit Crew from Going on Maternity Leave Mid-Refit, Mid-Repair, or Mid-Mothballing

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4436,7 +4436,7 @@ public class Person {
      *     <li>If the personnel is a technician, by reviewing their current tech assignments,
      *         such as units being mothballed, refitted, or repaired.</li>
      *     <li>If the personnel has a unit assignment and whether that unit is currently deployed.</li>
-     * </li>
+     * </ol>
      *
      * @return {@code true} if the person is deemed busy due to one of the above conditions; {@code false} otherwise.
      */

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -335,7 +335,7 @@ public abstract class AbstractProcreation {
      * @param isNoReport true if no message should be posted to the daily report
      */
     public void addPregnancy(final Campaign campaign, final LocalDate today, final Person mother, final int size,
-                             boolean isNoReport) {
+          boolean isNoReport) {
         if (size < 1) {
             return;
         }
@@ -506,7 +506,7 @@ public abstract class AbstractProcreation {
      * @param father   the father of the baby, null if unknown
      */
     private static void logAndUpdateFamily(Campaign campaign, LocalDate today, Person mother, Person baby,
-                                           Person father) {
+          Person father) {
         if (campaign.getCampaignOptions().isLogProcreation()) {
             MedicalLogger.deliveredBaby(mother, baby, today);
             if (father != null) {
@@ -537,7 +537,7 @@ public abstract class AbstractProcreation {
      * @return the babies
      */
     public List<Person> birthHistoric(final Campaign campaign, final LocalDate today, final Person mother,
-                                      @Nullable final Person father) {
+          @Nullable final Person father) {
         List<Person> babies = new ArrayList<>();
 
         // Determine the number of children
@@ -668,7 +668,7 @@ public abstract class AbstractProcreation {
             }
 
             if (campaign.getCampaignOptions().isUseMaternityLeave()) {
-                if (person.getStatus().isActive() && (person.getDueDate().minusWeeks(20).isBefore(today))) {
+                if (!person.isBusy() && (person.getDueDate().minusWeeks(20).isBefore(today))) {
                     person.changeStatus(campaign, today, PersonnelStatus.ON_MATERNITY_LEAVE);
                 }
             }
@@ -690,7 +690,7 @@ public abstract class AbstractProcreation {
      * @param isNoReport true, if the player shouldn't be informed, otherwise false
      */
     public void processRandomProcreationCheck(final Campaign campaign, final LocalDate today, final Person person,
-                                              boolean isNoReport) {
+          boolean isNoReport) {
         if (randomlyProcreates(today, person)) {
             addPregnancy(campaign, today, person, isNoReport);
         }


### PR DESCRIPTION
- Replaced `isActive` check with the new `isBusy` method in maternity leave eligibility logic.
- Added `isBusy` method in `Person` class to determine personnel activity based on status, unit assignments, and tasks.
  - Includes checks for self-crewed units, technicians, unit deployments, and various task states (mothballing, refitting, repairing).

Fix #6545