### PR TITLE
Fix #6544: Restored Ability to Salvage Turrets

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -417,12 +417,6 @@ public class ResolveScenarioTracker {
                     }
                 }
             } else if (wreck.getOwner().isEnemyOf(client.getLocalPlayer())) {
-                // MekHQ doesn't support gun emplacements, so we don't want the player salvaging them
-                if (wreck instanceof GunEmplacement) {
-                    appendKillCredit(wreck);
-                    continue;
-                }
-
                 if (wreck.isDropShip() && scenario.getBoardType() != T_SPACE) {
                     double dropShipBonusPercentage = (double) campaign.getCampaignOptions()
                                                                     .getDropShipBonusPercentage() / 100;


### PR DESCRIPTION
- Removed code that prevented players from salvaging turrets, specifically gun emplacements.

Fix #6544

### Dev Notes
This was leftover code from 50.03 when we first prevented the player from acquiring gun emplacements, prior to us implementing the Unsupported Unit class.