### PR TITLE
Fix #4828, #6476: Updated Maintenance Handling and Tech Assignment Display

### DIFF
--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -1,23 +1,15 @@
 # This is used to store any mekhq/campaign Resources
-
 #### General Campaign Resources
-
 ## Classes
 # CampaignPreset Class
 CampaignPresetSaveFailure.title=Campaign Preset Creation Failure
 CampaignPresetSaveFailure.text=Oh no! The program was unable to correctly export your campaign options. We know this \nis annoying and apologize. Please help us out and submit a bug with the \nmekhq.log file from this game so we can prevent this from happening in the future.
-
-
-
 ## Enums
 # PlanetaryAcquisitionFactionLimit Enum
 PlanetaryAcquisitionFactionLimit.ALL.text=All Factions
 PlanetaryAcquisitionFactionLimit.NEUTRAL.text=Neutral or Allied Factions
 PlanetaryAcquisitionFactionLimit.ALLIED.text=Allied Factions
 PlanetaryAcquisitionFactionLimit.SELF.text=Own Faction Only
-
-
-
 #### Icons
 ### Enums
 ## LayeredForceIconLayer Enum
@@ -37,14 +29,11 @@ LayeredForceIconLayer.FRAME.text=Frames
 LayeredForceIconLayer.FRAME.toolTipText=This tab contains frames, which are the outer layer of the force icon.
 LayeredForceIconLayer.LOGO.text=Logos
 LayeredForceIconLayer.LOGO.toolTipText=This tab contains canon faction logos that can be added to the center of a force icon.
-
 #### Anniversaries
 anniversaryBirthday.text=%s is <b>%s%s%s</b> today!
 anniversaryRecruitment.text=%s celebrates <b>%s%s%s</b> years with %s!
-
 #### Personnel Removal
 personnelRemoval.text=Old personnel records have been tidied away.
-
 #### Personnel Recruitment
 personnelRecruitmentFinancesReason.text=Recruitment of %s
 personnelRecruitmentInsufficientFunds.text=<font color='%s'><b>Insufficient funds to recruit %s</b></font>
@@ -52,23 +41,19 @@ personnelRecruitmentFormerSurname.text=(Formerly %s)
 personnelRecruitmentBondsman.text=as a bondsman
 personnelRecruitmentPrisoner.text=as a prisoner
 personnelRecruitmentAddedToRoster.text=%s%s has been added to the personnel roster%s.
-
 #### Turnover and Retention
 turnoverJointDeparture.text=departed with their spouse.
 turnoverJointDepartureChild.text=departed with a parent.
 orphaned.text=has been orphaned.
-
 turnoverEmployeeTurnoverDialog.text=Continue
 turnoverAdvanceRegardless=Ignore Check
 turnoverCancel.text=Cancel
-
 turnoverRollRequired.text=Employee Turnover Check Required
 turnoverDialogDescription.text=<html>It is time for an Employee Turnover Check.\
   <br>\
   <br>If this is your first time using this screen, please read the documentation in <i>docs/personnel modules</i>.\
   <br>\
   <br>Seeing high target numbers? Select individual personnel to see how the target number was calculated!</html>
-
 turnoverFinalPayments.text=Unresolved Final Payments
 turnoverPersonnelKilled.text=<html>You have personnel who have left the unit or been killed in action and have not received their final payout.\
   <br>\
@@ -78,10 +63,9 @@ turnoverPersonnelKilled.text=<html>You have personnel who have left the unit or 
   <ul><li>Sell off equipment to generate funds.</li>\
   <li>Pay one or more personnel in equipment.</li>\
   <li>Use GM mode to edit the settlement.</li></ul></html>
-
 divorce.text=%s has divorced %s.
-
 #### Unsorted Campaign Resources
+maintenanceNotAvailable.text=Unable to perform maintenance on %s as its assigned tech did not have sufficient minutes remaining.
 dependentJoinsForce.text=%s has started traveling with the force.
 relativeJoinsForce.text=%s has started traveling with the force. They are %s's %s.
 relativeJoinsForceSpouse.text=spouse

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1011,7 +1011,7 @@ navigatorMenu.text=Navigator
 miUnassignCrew.text=Unassign Crew
 #### AssignUnitToTechMenu Class
 AssignUnitToTechMenu.title=Tech
-miAssignTech.text=%s (%sm)
+miAssignTech.text=%s (%s available minutes)
 miUnassignTech.text=Unassign Tech
 #### ExportUnitSpriteMenu Class
 ExportUnitSpriteMenu.title=Export Unit Sprite

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5189,22 +5189,22 @@ public class Campaign implements ITechManager {
         // the second time to do whatever else. Otherwise, maintenance minutes might
         // get sucked up by other stuff. This is also a good place to ensure that a
         // unit's engineer gets reset and updated.
-        for (Unit u : getUnits()) {
+        for (Unit unit : getUnits()) {
             // do maintenance checks
             try {
-                u.resetEngineer();
-                if (null != u.getEngineer()) {
-                    u.getEngineer().resetMinutesLeft(campaignOptions.isTechsUseAdministration());
+                unit.resetEngineer();
+                if (null != unit.getEngineer()) {
+                    unit.getEngineer().resetMinutesLeft(campaignOptions.isTechsUseAdministration());
                 }
 
-                doMaintenance(u);
+                doMaintenance(unit);
             } catch (Exception ex) {
                 logger.error(ex,
                       "Unable to perform maintenance on {} ({}) due to an error",
-                      u.getName(),
-                      u.getId().toString());
+                      unit.getName(),
+                      unit.getId().toString());
                 addReport(String.format("ERROR: An error occurred performing maintenance on %s, check the log",
-                      u.getName()));
+                      unit.getName()));
             }
         }
 
@@ -6407,7 +6407,8 @@ public class Campaign implements ITechManager {
     }
 
     public void setTemporaryPrisonerCapacity(int temporaryPrisonerCapacity) {
-        this.temporaryPrisonerCapacity = max(PrisonerEventManager.MINIMUM_TEMPORARY_CAPACITY, temporaryPrisonerCapacity);
+        this.temporaryPrisonerCapacity = max(PrisonerEventManager.MINIMUM_TEMPORARY_CAPACITY,
+              temporaryPrisonerCapacity);
     }
 
     public RandomEventLibraries getRandomEventLibraries() {
@@ -8751,49 +8752,64 @@ public class Campaign implements ITechManager {
         return false;
     }
 
-    public void doMaintenance(Unit u) {
-        if (!u.requiresMaintenance() || !campaignOptions.isCheckMaintenance()) {
+    public void doMaintenance(Unit unit) {
+        if (!unit.requiresMaintenance() || !campaignOptions.isCheckMaintenance()) {
             return;
         }
         // let's start by checking times
-        Person tech = u.getTech();
-        int minutesUsed = u.getMaintenanceTime();
-        int asTechsUsed = getAvailableAstechs(minutesUsed, false);
-        boolean maintained = ((tech != null) && (tech.getMinutesLeft() >= minutesUsed) && !tech.isMothballing());
+        int minutesUsed = unit.getMaintenanceTime();
+        int asTechsUsed = 0;
+        boolean maintained = false;
         boolean paidMaintenance = true;
-        if (maintained) {
-            // use the time
-            tech.setMinutesLeft(tech.getMinutesLeft() - minutesUsed);
-            astechPoolMinutes -= asTechsUsed * minutesUsed;
-        }
-        u.incrementDaysSinceMaintenance(this, maintained, asTechsUsed);
+
+        unit.incrementDaysSinceMaintenance(this, maintained, asTechsUsed);
 
         int ruggedMultiplier = 1;
-        if (u.getEntity().hasQuirk(OptionsConstants.QUIRK_POS_RUGGED_1)) {
+        if (unit.getEntity().hasQuirk(OptionsConstants.QUIRK_POS_RUGGED_1)) {
             ruggedMultiplier = 2;
         }
 
-        if (u.getEntity().hasQuirk(OptionsConstants.QUIRK_POS_RUGGED_2)) {
+        if (unit.getEntity().hasQuirk(OptionsConstants.QUIRK_POS_RUGGED_2)) {
             ruggedMultiplier = 3;
         }
 
-        if (u.getDaysSinceMaintenance() >= (getCampaignOptions().getMaintenanceCycleDays() * ruggedMultiplier)) {
+        if (unit.getDaysSinceMaintenance() >= (getCampaignOptions().getMaintenanceCycleDays() * ruggedMultiplier)) {
+            Person tech = unit.getTech();
+            if (tech != null) {
+                int availableMinutes = tech.getMinutesLeft();
+
+                maintained = (availableMinutes >= minutesUsed);
+
+                if (!maintained) {
+                    // At this point, insufficient minutes is the only reason why this would be failed.
+                    addReport(String.format(resources.getString("maintenanceNotAvailable.text"), unit.getName()));
+                } else {
+                    maintained = !tech.isMothballing();
+                }
+
+                if (maintained) {
+                    tech.setMinutesLeft(availableMinutes - minutesUsed);
+                    asTechsUsed = getAvailableAstechs(minutesUsed, false);
+                    astechPoolMinutes -= asTechsUsed * minutesUsed;
+                }
+            }
+
             // maybe use the money
             if (campaignOptions.isPayForMaintain()) {
                 if (!(finances.debit(TransactionType.MAINTENANCE,
                       getLocalDate(),
-                      u.getMaintenanceCost(),
-                      "Maintenance for " + u.getName()))) {
+                      unit.getMaintenanceCost(),
+                      "Maintenance for " + unit.getName()))) {
                     addReport("<font color='" +
                                     MekHQ.getMHQOptions().getFontColorNegativeHexColor() +
                                     "'><b>You cannot afford to pay maintenance costs for " +
-                                    u.getHyperlinkedName() +
+                                    unit.getHyperlinkedName() +
                                     "!</b></font>");
                     paidMaintenance = false;
                 }
             }
             // it is time for a maintenance check
-            PartQuality qualityOrig = u.getQuality();
+            PartQuality qualityOrig = unit.getQuality();
             String techName = "Nobody";
             String techNameLinked = techName;
             if (null != tech) {
@@ -8807,9 +8823,9 @@ public class Campaign implements ITechManager {
             StringBuilder maintenanceReport = new StringBuilder("<strong>" +
                                                                       techName +
                                                                       " performing maintenance</strong><br><br>");
-            for (Part p : u.getParts()) {
+            for (Part p : unit.getParts()) {
                 try {
-                    String partReport = doMaintenanceOnUnitPart(u, p, partsToDamage, paidMaintenance);
+                    String partReport = doMaintenanceOnUnitPart(unit, p, partsToDamage, paidMaintenance);
                     if (partReport != null) {
                         maintenanceReport.append(partReport).append("<br>");
                     }
@@ -8818,12 +8834,12 @@ public class Campaign implements ITechManager {
                           "Could not perform maintenance on part {} ({}) for {} ({}) due to an error",
                           p.getName(),
                           p.getId(),
-                          u.getName(),
-                          u.getId().toString());
+                          unit.getName(),
+                          unit.getId().toString());
                     addReport(String.format(
                           "ERROR: An error occurred performing maintenance on %s for unit %s, check the log",
                           p.getName(),
-                          u.getName()));
+                          unit.getName()));
                 }
             }
 
@@ -8840,13 +8856,13 @@ public class Campaign implements ITechManager {
                 }
             }
 
-            u.setLastMaintenanceReport(maintenanceReport.toString());
+            unit.setLastMaintenanceReport(maintenanceReport.toString());
 
             if (getCampaignOptions().isLogMaintenance()) {
                 logger.info(maintenanceReport.toString());
             }
 
-            PartQuality quality = u.getQuality();
+            PartQuality quality = unit.getQuality();
             String qualityString;
             boolean reverse = getCampaignOptions().isReverseQualityNames();
             if (quality.toNumeric() > qualityOrig.toNumeric()) {
@@ -8879,7 +8895,7 @@ public class Campaign implements ITechManager {
                                      "'>" +
                                      damageString +
                                      "</b></font> [<a href='REPAIR|" +
-                                     u.getId() +
+                                     unit.getId() +
                                      "'>Repair bay</a>]";
             }
             String paidString = "";
@@ -8890,17 +8906,17 @@ public class Campaign implements ITechManager {
             }
             addReport(techNameLinked +
                             " performs maintenance on " +
-                            u.getHyperlinkedName() +
+                            unit.getHyperlinkedName() +
                             ". " +
                             paidString +
                             qualityString +
                             ". " +
                             damageString +
                             " [<a href='MAINTENANCE|" +
-                            u.getId() +
+                            unit.getId() +
                             "'>Get details</a>]");
 
-            u.resetDaysSinceMaintenance();
+            unit.resetDaysSinceMaintenance();
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4384,32 +4384,31 @@ public class Person {
     }
 
     /**
-     * Calculates and retrieves the person's current daily available tech time. This does NOT account for any expended
-     * time, but it factors in administrative adjustments if specified.
+     * Calculates and retrieves the current daily available tech time for the person.
      *
-     * <p>The returned value is determined based on the person's role:</p>
+     * <p>This calculation does not account for any expended time but incorporates potential administrative
+     * adjustments if specified.</p>
+     *
+     * <p>The calculation follows these rules:</p>
      * <ul>
-     *   <li>If the primary role is a technician, the primary role's base support
-     *       time is used.</li>
-     *   <li>Otherwise, the secondary role's base support time is used.</li>
+     *   <li>If the person's primary role is a technician, the base support time is determined from the primary
+     *   role.</li>
+     *   <li>Otherwise, the base support time is taken from the secondary role.</li>
      * </ul>
      *
-     * <p>The base time is then adjusted by a multiplier if administrative adjustments
-     * are enabled (via the {@code isTechsUseAdministration} parameter). Maintenance
-     * time is also deducted from the result.</p>
+     * <p>If administrative adjustments are enabled (via the {@code isTechsUseAdministration} parameter),
+     * the support time is multiplied by an administrative adjustment multiplier.</p>
      *
-     * @param isTechsUseAdministration Determines whether administrative adjustments should be applied when calculating
-     *                                 the person's time.
+     * @param isTechsUseAdministration A boolean flag indicating whether administrative adjustments should be applied in
+     *                                 the calculation.
      *
-     * @return The person's current daily available tech time, after applying the multiplier for administrative
-     *       adjustments (if applicable) and deducting maintenance time.
+     * @return The adjusted daily available tech time for the person, after factoring in the appropriate role support
+     *       time, applying the administrative multiplier (if enabled), and deducting maintenance time.
      */
     public int getDailyAvailableTechTime(final boolean isTechsUseAdministration) {
         int baseTime = (getPrimaryRole().isTech() ? PRIMARY_ROLE_SUPPORT_TIME : SECONDARY_ROLE_SUPPORT_TIME);
 
-        // TODO maintenance time should only be deducted when we make a maintenance check
-        return (int) round(baseTime * calculateTechTimeMultiplier(isTechsUseAdministration)) -
-                     getMaintenanceTimeUsing();
+        return (int) round(baseTime * calculateTechTimeMultiplier(isTechsUseAdministration));
     }
 
     public int getMaintenanceTimeUsing() {

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToTechMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToTechMenu.java
@@ -27,6 +27,9 @@
  */
 package mekhq.gui.menus;
 
+import java.util.stream.Stream;
+import javax.swing.JMenuItem;
+
 import megamek.codeUtilities.StringUtility;
 import megamek.common.enums.SkillLevel;
 import mekhq.campaign.Campaign;
@@ -34,16 +37,13 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.baseComponents.JScrollableMenu;
 
-import javax.swing.*;
-import java.util.stream.Stream;
-
 /**
- * This is a standard menu that takes either a unit or multiple units, and
- * allows the user to
- * assign or remove a tech from them.
+ * This is a standard menu that takes either a unit or multiple units, and allows the user to assign or remove a tech
+ * from them.
  */
 public class AssignUnitToTechMenu extends JScrollableMenu {
     // region Constructors
+
     /**
      * @param campaign the campaign the unit is a part of
      * @param units    the units in question
@@ -69,9 +69,10 @@ public class AssignUnitToTechMenu extends JScrollableMenu {
         // Initial Parsing Values
         final int maintenanceTime = Stream.of(units).mapToInt(Unit::getMaintenanceTime).sum();
         final String skillName = units[0].determineUnitTechSkillType();
-        final boolean assign = (maintenanceTime < Person.PRIMARY_ROLE_SUPPORT_TIME)
-                && !StringUtility.isNullOrBlank(skillName)
-                && Stream.of(units).allMatch(unit -> skillName.equalsIgnoreCase(unit.determineUnitTechSkillType()));
+        final boolean assign = (maintenanceTime < Person.PRIMARY_ROLE_SUPPORT_TIME) &&
+                                     !StringUtility.isNullOrBlank(skillName) &&
+                                     Stream.of(units)
+                                           .allMatch(unit -> skillName.equalsIgnoreCase(unit.determineUnitTechSkillType()));
 
         if (assign) {
             // Person Assignment Menus
@@ -82,56 +83,44 @@ public class AssignUnitToTechMenu extends JScrollableMenu {
             final JScrollableMenu regularMenu = new JScrollableMenu("regularMenu", SkillLevel.REGULAR.toString());
             final JScrollableMenu greenMenu = new JScrollableMenu("greenMenu", SkillLevel.GREEN.toString());
             final JScrollableMenu ultraGreenMenu = new JScrollableMenu("ultraGreenMenu",
-                    SkillLevel.ULTRA_GREEN.toString());
+                  SkillLevel.ULTRA_GREEN.toString());
 
             // Boolean Parsing Values
-            final boolean allShareTech = Stream.of(units).allMatch(unit -> (units[0].getTech() == null)
-                    ? (unit.getTech() == null)
-                    : units[0].getTech().equals(unit.getTech()));
+            final boolean allShareTech = Stream.of(units)
+                                               .allMatch(unit -> (units[0].getTech() == null) ?
+                                                                       (unit.getTech() == null) :
+                                                                       units[0].getTech().equals(unit.getTech()));
 
             for (final Person tech : campaign.getTechs()) {
                 if (allShareTech && tech.equals(units[0].getTech())) {
                     continue;
                 }
 
-                if (tech.hasSkill(skillName)
-                        && ((tech.getMaintenanceTimeUsing() + maintenanceTime) <= Person.PRIMARY_ROLE_SUPPORT_TIME)) {
-                    final SkillLevel skillLevel = (tech.getSkillForWorkingOn(units[0]) == null)
-                            ? SkillLevel.NONE
-                            : tech.getSkillForWorkingOn(units[0]).getSkillLevel();
+                if (tech.hasSkill(skillName) &&
+                          ((tech.getMaintenanceTimeUsing() + maintenanceTime) <= Person.PRIMARY_ROLE_SUPPORT_TIME)) {
+                    final SkillLevel skillLevel = (tech.getSkillForWorkingOn(units[0]) == null) ?
+                                                        SkillLevel.NONE :
+                                                        tech.getSkillForWorkingOn(units[0]).getSkillLevel();
 
-                    final JScrollableMenu subMenu;
-                    switch (skillLevel) {
-                        case LEGENDARY:
-                            subMenu = legendaryMenu;
-                            break;
-                        case HEROIC:
-                            subMenu = heroicMenu;
-                            break;
-                        case ELITE:
-                            subMenu = eliteMenu;
-                            break;
-                        case VETERAN:
-                            subMenu = veteranMenu;
-                            break;
-                        case REGULAR:
-                            subMenu = regularMenu;
-                            break;
-                        case GREEN:
-                            subMenu = greenMenu;
-                            break;
-                        case ULTRA_GREEN:
-                            subMenu = ultraGreenMenu;
-                            break;
-                        default:
-                            subMenu = null;
-                            break;
-                    }
+                    final JScrollableMenu subMenu = switch (skillLevel) {
+                        case LEGENDARY -> legendaryMenu;
+                        case HEROIC -> heroicMenu;
+                        case ELITE -> eliteMenu;
+                        case VETERAN -> veteranMenu;
+                        case REGULAR -> regularMenu;
+                        case GREEN -> greenMenu;
+                        case ULTRA_GREEN -> ultraGreenMenu;
+                        default -> null;
+                    };
 
                     if (subMenu != null) {
-                        final JMenuItem miAssignTech = new JMenuItem(String.format(
-                                resources.getString("miAssignTech.text"), tech.getFullTitle(),
-                                tech.getMaintenanceTimeUsing()));
+                        int dailyTime = tech.getDailyAvailableTechTime(campaign.getCampaignOptions()
+                                                                             .isTechsUseAdministration());
+                        int dailyTimeUsing = tech.getMaintenanceTimeUsing();
+                        int available = dailyTime - dailyTimeUsing;
+
+                        final JMenuItem miAssignTech = new JMenuItem(String.format(resources.getString(
+                              "miAssignTech.text"), tech.getFullTitle(), available));
                         miAssignTech.setName("miAssignTech");
                         miAssignTech.addActionListener(evt -> {
                             for (final Unit unit : units) {
@@ -160,8 +149,8 @@ public class AssignUnitToTechMenu extends JScrollableMenu {
         if (Stream.of(units).anyMatch(unit -> unit.getTech() != null)) {
             final JMenuItem miUnassignTech = new JMenuItem(resources.getString("miUnassignTech.text"));
             miUnassignTech.setName("miUnassignTech");
-            miUnassignTech
-                    .addActionListener(evt -> Stream.of(units).forEach(unit -> unit.remove(unit.getTech(), true)));
+            miUnassignTech.addActionListener(evt -> Stream.of(units)
+                                                          .forEach(unit -> unit.remove(unit.getTech(), true)));
             add(miUnassignTech);
         }
     }


### PR DESCRIPTION
- Refactored `doMaintenance` logic so that maintenance time is only deducted on the day maintenance takes place - to match current errata.
- Added failure reporting when a tech lacks sufficient minutes for maintenance, with a localized message update.
- Revised `Person.getDailyAvailableTechTime` to exclude maintenance time.
- Updated `AssignUnitToTechMenu` to display available minutes for tech assignment using recalculated logic.

Fix #4828
Fix #6476 

### Dev Notes
This PR does two things: one, it changes maintenance time deductions to match current errata which states that maintenance time is only deducted on the day in which the maintenance takes place. This will be a game changer, I suspect.

Second, when assigning a character to a unit you now see the amount of minutes they have available (minus time reserved for maintenance, but excluding time spent on that specific day); rather than just the amount of time reserved for maintenance. I'm not sure if this is the best implementation, but we had an issue report requesting it, so I went ahead and made the change. We can switch it out easily, should user feedback warrant it.