### PR TITLE
Fix #4710: Added Ad-Hoc Maintenance Option

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -308,6 +308,10 @@ deleteUnitsCount.text=%d units
 removeQ.title=Remove?
 confirmRemove.text=Do you really want to remove %s?
 hireMinimumComplement.text=Hire minimum complement
+maintenanceExtraTime.text=Set Maintenance Extra Time
+maintenanceAdHoc.text=Immediately Perform Maintenance
+maintenanceAdHoc.noNeed=%s doesn't require maintenance.
+maintenanceAdHoc.unable=%s has insufficient time to perform maintenance on %s.
 ##### Base Components - These may originate in MM, but are in active use
 #### AbstractMHQNagDialog
 chkIgnore.text=Don't bother me again


### PR DESCRIPTION
- Updated the unit right-click menu to include an option to immediately perform maintenance.

Fix #4710

### Dev Notes
This gives players much more control over when maintenance checks are made, allowing them to change up the tempo as they see fit.