### PR TITLE
Fix #4717: Added Display Of Days Till Next Maintenance Check To Hangar Table

### DIFF
--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -79,16 +79,16 @@ public final class HangarTab extends CampaignGuiTab {
     private static final int UV_GRAPHIC = 0;
     private static final int UV_GENERAL = 1;
     private static final int UV_DETAILS = 2;
-    private static final int UV_STATUS  = 3;
-    private static final int UV_NUM     = 4;
+    private static final int UV_STATUS = 3;
+    private static final int UV_NUM = 4;
 
-    private JSplitPane        splitUnit;
-    private JTable            unitTable;
+    private JSplitPane splitUnit;
+    private JTable unitTable;
     private JComboBox<String> choiceUnit;
     private JComboBox<String> choiceUnitView;
-    private JScrollPane       scrollUnitView;
+    private JScrollPane scrollUnitView;
 
-    private UnitTableModel                 unitModel;
+    private UnitTableModel unitModel;
     private TableRowSorter<UnitTableModel> unitSorter;
 
     private final IPreferenceChangeListener scalingChangeListener = e -> changeUnitView();
@@ -120,11 +120,11 @@ public final class HangarTab extends CampaignGuiTab {
         setLayout(new GridBagLayout());
 
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx   = 0;
-        gridBagConstraints.gridy   = 0;
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 0;
         gridBagConstraints.weightx = 0.0;
-        gridBagConstraints.anchor  = GridBagConstraints.WEST;
-        gridBagConstraints.insets  = new Insets(5, 5, 0, 0);
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         add(new JLabel(resourceMap.getString("lblUnitChoice.text")), gridBagConstraints);
 
         DefaultComboBoxModel<String> unitGroupModel = new DefaultComboBoxModel<>();
@@ -138,18 +138,18 @@ public final class HangarTab extends CampaignGuiTab {
         choiceUnit = new JComboBox<>(unitGroupModel);
         choiceUnit.setSelectedIndex(0);
         choiceUnit.addActionListener(ev -> filterUnits());
-        gridBagConstraints         = new GridBagConstraints();
-        gridBagConstraints.gridx   = 1;
-        gridBagConstraints.gridy   = 0;
-        gridBagConstraints.fill    = GridBagConstraints.NONE;
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.weightx = 0.0;
-        gridBagConstraints.anchor  = GridBagConstraints.WEST;
-        gridBagConstraints.insets  = new Insets(5, 5, 0, 0);
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         add(choiceUnit, gridBagConstraints);
 
-        gridBagConstraints        = new GridBagConstraints();
-        gridBagConstraints.gridx  = 2;
-        gridBagConstraints.gridy  = 0;
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 0;
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         add(new JLabel(resourceMap.getString("lblUnitView.text")), gridBagConstraints);
@@ -161,13 +161,13 @@ public final class HangarTab extends CampaignGuiTab {
         choiceUnitView = new JComboBox<>(unitViewModel);
         choiceUnitView.setSelectedIndex(UV_GENERAL);
         choiceUnitView.addActionListener(ev -> changeUnitView());
-        gridBagConstraints         = new GridBagConstraints();
-        gridBagConstraints.gridx   = 3;
-        gridBagConstraints.gridy   = 0;
-        gridBagConstraints.fill    = GridBagConstraints.NONE;
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 3;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.anchor  = GridBagConstraints.WEST;
-        gridBagConstraints.insets  = new Insets(5, 5, 0, 0);
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(5, 5, 0, 0);
         add(choiceUnitView, gridBagConstraints);
 
         unitModel = new UnitTableModel(getCampaign());
@@ -214,12 +214,12 @@ public final class HangarTab extends CampaignGuiTab {
         splitUnit.setOneTouchExpandable(true);
         splitUnit.setResizeWeight(1.0);
         splitUnit.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, pce -> refreshUnitView());
-        gridBagConstraints.gridx     = 0;
-        gridBagConstraints.gridy     = 1;
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 1;
         gridBagConstraints.gridwidth = 6;
-        gridBagConstraints.fill      = GridBagConstraints.BOTH;
-        gridBagConstraints.weightx   = 1.0;
-        gridBagConstraints.weighty   = 1.0;
+        gridBagConstraints.fill = GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 1.0;
         add(splitUnit, gridBagConstraints);
 
         UnitTableMouseAdapter.connect(getCampaignGui(), unitTable, unitModel, splitUnit);
@@ -273,11 +273,11 @@ public final class HangarTab extends CampaignGuiTab {
                     return true;
                 }
                 UnitTableModel unitModel = entry.getModel();
-                Unit           unit      = unitModel.getUnit(entry.getIdentifier());
+                Unit unit = unitModel.getUnit(entry.getIdentifier());
 
                 if (nGroup < UnitType.SIZE) {
-                    Entity en   = unit.getEntity();
-                    int    type = -1;
+                    Entity en = unit.getEntity();
+                    int type = -1;
                     if (en != null) {
                         type = en.getUnitType();
                     }
@@ -311,7 +311,7 @@ public final class HangarTab extends CampaignGuiTab {
     }
 
     public void changeUnitView() {
-        int               view        = choiceUnitView.getSelectedIndex();
+        int view = choiceUnitView.getSelectedIndex();
         XTableColumnModel columnModel = (XTableColumnModel) unitTable.getColumnModel();
         unitTable.setRowHeight(UIUtil.scaleForGUI(15));
 
@@ -416,6 +416,8 @@ public final class HangarTab extends CampaignGuiTab {
             columnModel.setColumnVisible(columnModel.getColumnByModelIndex(UnitTableModel.COL_TECH_CRW), false);
             columnModel.setColumnVisible(columnModel.getColumnByModelIndex(UnitTableModel.COL_MAINTAIN),
                   getCampaign().getCampaignOptions().isPayForMaintain());
+            columnModel.setColumnVisible(columnModel.getColumnByModelIndex(UnitTableModel.COL_MAINTAIN_CYCLE),
+                  getCampaign().getCampaignOptions().isCheckMaintenance());
             columnModel.setColumnVisible(columnModel.getColumnByModelIndex(UnitTableModel.COL_BV), false);
             columnModel.setColumnVisible(columnModel.getColumnByModelIndex(UnitTableModel.COL_REPAIR), true);
             columnModel.setColumnVisible(columnModel.getColumnByModelIndex(UnitTableModel.COL_PARTS), true);
@@ -473,7 +475,7 @@ public final class HangarTab extends CampaignGuiTab {
 
     public void refreshUnitList() {
         UUID selectedUUID = null;
-        int  selectedRow  = unitTable.getSelectedRow();
+        int selectedRow = unitTable.getSelectedRow();
         if (selectedRow != -1) {
             Unit u = unitModel.getUnit(unitTable.convertRowIndexToModel(selectedRow));
             if (null != u) {
@@ -493,7 +495,7 @@ public final class HangarTab extends CampaignGuiTab {
         getCampaignGui().refreshLab();
     }
 
-    private ActionScheduler unitListScheduler   = new ActionScheduler(this::refreshUnitList);
+    private ActionScheduler unitListScheduler = new ActionScheduler(this::refreshUnitList);
     private ActionScheduler filterUnitScheduler = new ActionScheduler(this::filterUnits);
 
     @Subscribe

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -27,8 +27,23 @@
  */
 package mekhq.gui.model;
 
-import megamek.common.*;
+import java.awt.Component;
+import java.awt.Image;
+import java.util.ArrayList;
+import javax.swing.JTable;
+import javax.swing.SwingConstants;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
+
+import megamek.common.Entity;
+import megamek.common.Infantry;
+import megamek.common.Jumpship;
+import megamek.common.SmallCraft;
+import megamek.common.SpaceStation;
+import megamek.common.TechConstants;
+import megamek.common.UnitType;
 import megamek.common.annotations.Nullable;
+import megamek.common.options.OptionsConstants;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
@@ -36,40 +51,36 @@ import mekhq.campaign.unit.Unit;
 import mekhq.gui.BasicInfo;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
 
-import javax.swing.*;
-import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.TableCellRenderer;
-import java.awt.*;
-import java.util.ArrayList;
-
 /**
  * A table Model for displaying information about units
+ *
  * @author Jay lawson
  */
 public class UnitTableModel extends DataTableModel {
     //region Variable Declarations
-    public static final int COL_NAME    =    0;
-    public static final int COL_TYPE    =    1;
-    public static final int COL_WCLASS    =  2;
-    public static final int COL_TECH     =   3;
-    public static final int COL_WEIGHT =     4;
-    public static final int COL_COST    =    5;
-    public static final int COL_STATUS   =   6;
-    public static final int COL_CONDITION  = 7;
+    public static final int COL_NAME = 0;
+    public static final int COL_TYPE = 1;
+    public static final int COL_WCLASS = 2;
+    public static final int COL_TECH = 3;
+    public static final int COL_WEIGHT = 4;
+    public static final int COL_COST = 5;
+    public static final int COL_STATUS = 6;
+    public static final int COL_CONDITION = 7;
     public static final int COL_CREW_STATE = 8;
-    public static final int COL_QUALITY  =   9;
-    public static final int COL_PILOT    =   10;
-    public static final int COL_FORCE    =   11;
-    public static final int COL_CREW     =   12;
-    public static final int COL_TECH_CRW =   13;
-    public static final int COL_MAINTAIN  =  14;
-    public static final int COL_BV        =  15;
-    public static final int COL_REPAIR  =    16;
-    public static final int COL_PARTS    =   17;
-    public static final int COL_SITE     =   18;
-    public static final int COL_QUIRKS   =   19;
-    public static final int COL_RSTATUS   =  20;
-    public static final int N_COL =          21;
+    public static final int COL_QUALITY = 9;
+    public static final int COL_PILOT = 10;
+    public static final int COL_FORCE = 11;
+    public static final int COL_CREW = 12;
+    public static final int COL_TECH_CRW = 13;
+    public static final int COL_MAINTAIN = 14;
+    public static final int COL_MAINTAIN_CYCLE = 15;
+    public static final int COL_BV = 16;
+    public static final int COL_REPAIR = 17;
+    public static final int COL_PARTS = 18;
+    public static final int COL_SITE = 19;
+    public static final int COL_QUIRKS = 20;
+    public static final int COL_RSTATUS = 21;
+    public static final int N_COL = 22;
 
     private Campaign campaign;
     //endregion Variable Declarations
@@ -106,7 +117,8 @@ public class UnitTableModel extends DataTableModel {
             case COL_FORCE -> "Force";
             case COL_CREW -> "Crew";
             case COL_TECH_CRW -> "Tech Crew";
-            case COL_MAINTAIN -> "Maintenance";
+            case COL_MAINTAIN -> "Maint. Cost";
+            case COL_MAINTAIN_CYCLE -> "Next Maint.";
             case COL_BV -> "BV";
             case COL_REPAIR -> "# Repairs";
             case COL_PARTS -> "# Parts";
@@ -129,7 +141,8 @@ public class UnitTableModel extends DataTableModel {
 
     public int getAlignment(int col) {
         return switch (col) {
-            case COL_WEIGHT, COL_COST, COL_MAINTAIN, COL_BV, COL_REPAIR, COL_PARTS -> SwingConstants.RIGHT;
+            case COL_WEIGHT, COL_COST, COL_MAINTAIN, COL_MAINTAIN_CYCLE, COL_BV, COL_REPAIR, COL_PARTS ->
+                  SwingConstants.RIGHT;
             case COL_QUALITY, COL_CREW, COL_QUIRKS, COL_RSTATUS -> SwingConstants.CENTER;
             default -> SwingConstants.LEFT;
         };
@@ -140,6 +153,7 @@ public class UnitTableModel extends DataTableModel {
      *
      * @param rowIndex    the index of the row
      * @param columnIndex the index of the column
+     *
      * @return the tooltip for the specified row and column, or {@code null} if no tooltip is available
      */
     public @Nullable String getTooltip(int rowIndex, int columnIndex) {
@@ -162,6 +176,7 @@ public class UnitTableModel extends DataTableModel {
      * Returns the tooltip for the crew status of a given unit.
      *
      * @param unit the unit for which to get the crew tooltip
+     *
      * @return the crew tooltip as an HTML string
      */
     static String getCrewTooltip(Unit unit) {
@@ -216,10 +231,10 @@ public class UnitTableModel extends DataTableModel {
     /**
      * Appends a crew report line to the provided StringBuilder.
      *
-     * @param report the {@link StringBuilder} to append to
-     * @param title the title of the crew role (e.g., "Driver", "Gunner")
+     * @param report   the {@link StringBuilder} to append to
+     * @param title    the title of the crew role (e.g., "Driver", "Gunner")
      * @param assigned the number of crew members assigned to the role
-     * @param needed the number of crew members needed for the role
+     * @param needed   the number of crew members needed for the role
      */
     private static void appendReport(StringBuilder report, String title, int assigned, int needed) {
         report.append(String.format("<b>%s: </b>%d/%d", title, assigned, needed));
@@ -270,6 +285,25 @@ public class UnitTableModel extends DataTableModel {
             case COL_CREW -> unit.getActiveCrew().size() + "/" + unit.getFullCrewSize();
             case COL_TECH_CRW -> (unit.getTech() != null) ? unit.getTech().getHTMLTitle() : "-";
             case COL_MAINTAIN -> unit.getMaintenanceCost().toAmountAndSymbolString();
+            case COL_MAINTAIN_CYCLE -> {
+                boolean needsMaintenance = unit.requiresMaintenance();
+
+                if (!needsMaintenance) {
+                    yield '-';
+                }
+
+                double daysSinceLastMaintenance = unit.getDaysSinceMaintenance();
+                int cycleLength = campaign.getCampaignOptions().getMaintenanceCycleDays();
+                int ruggedMultiplier = 1;
+                if (entity.hasQuirk(OptionsConstants.QUIRK_POS_RUGGED_1)) {
+                    ruggedMultiplier = 2;
+                }
+                if (entity.hasQuirk(OptionsConstants.QUIRK_POS_RUGGED_2)) {
+                    ruggedMultiplier = 3;
+                }
+
+                yield daysSinceLastMaintenance + " / " + (cycleLength * ruggedMultiplier) + " days";
+            }
             case COL_BV -> entity.calculateBattleValue(true, unit.getEntity().getCrew() == null);
             case COL_REPAIR -> unit.getPartsNeedingFixing().size();
             case COL_PARTS -> unit.getPartsNeeded().size();
@@ -290,8 +324,8 @@ public class UnitTableModel extends DataTableModel {
 
     public class Renderer extends DefaultTableCellRenderer {
         @Override
-        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
-                                                       boolean hasFocus, int row, int column) {
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus,
+              int row, int column) {
             super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
             setOpaque(true);
             int actualCol = table.convertColumnIndexToModel(column);
@@ -314,8 +348,8 @@ public class UnitTableModel extends DataTableModel {
         }
 
         @Override
-        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
-                                                       boolean hasFocus, int row, int column) {
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus,
+              int row, int column) {
             Component c = this;
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
@@ -353,8 +387,7 @@ public class UnitTableModel extends DataTableModel {
                 case COL_FORCE: {
                     Force force = getCampaign().getForceFor(u);
                     if (force != null) {
-                        StringBuilder desc = new StringBuilder("<html><b>").append(force.getName())
-                                .append("</b>");
+                        StringBuilder desc = new StringBuilder("<html><b>").append(force.getName()).append("</b>");
                         Force parent = force.getParentForce();
                         // cut off after three lines and don't include the top level
                         int lines = 1;


### PR DESCRIPTION
- Added `COL_MAINTAIN_CYCLE` to `UnitTableModel` for tracking the maintenance check cycle.
- Adjusted related methods to calculate and display the days since the last maintenance vs. the maintenance cycle length, considering ruggedness quirks.
- Updated `HangarTab` to toggle the visibility of the new "Next Maint." column based on campaign options.

Fix #4717