### PR TITLE
When restoring techs time, Large Vessel Crews should be considered techs.

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4651,7 +4651,7 @@ public class Person {
         final double TECH_ADMINISTRATION_MULTIPLIER = 0.05;
         final int REGULAR_EXPERIENCE_LEVEL = REGULAR.getExperienceLevel();
 
-        if (!isTech()) {
+        if (!isTechExpanded()) {
             return 0;
         }
 


### PR DESCRIPTION
When resetting a tech's time, this was causing Large Vessel Crewmembers to not be considered a tech, which is incorrect.