### PR TITLE
Fixed 24-hour Work Day in Refit Display

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -266,11 +266,10 @@ public class Unit implements ITechnology {
         } else if (!isPresent()) {
             return "In transit (" + getDaysToArrival() + " days)";
         } else if (isRefitting()) {
-            int minutesInHour = 60;
-            int hoursInDay = 24;
-            int minutesInDay = hoursInDay * minutesInHour;
-            int days = (int) ceil((double) getRefit().getTimeLeft() / minutesInDay);
-            return "Refitting" + " (" + days + " days)";
+            int days = (int) ceil((double) getRefit().getTimeLeft() / TECH_WORK_DAY);
+            String dayString = days == 1 ? "day" : "days";
+
+            return "Refitting" + " (" + days + ' ' + dayString + ')';
         } else {
             return getCondition();
         }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -266,10 +266,19 @@ public class Unit implements ITechnology {
         } else if (!isPresent()) {
             return "In transit (" + getDaysToArrival() + " days)";
         } else if (isRefitting()) {
-            int days = (int) ceil((double) getRefit().getTimeLeft() / TECH_WORK_DAY);
-            String dayString = days == 1 ? "day" : "days";
+            double timeLeft = refit.getTimeLeft();
+            Person refitTech = refit.getTech();
 
-            return "Refitting" + " (" + days + ' ' + dayString + ')';
+            double minutesInWorkDay = TECH_WORK_DAY;
+            if (refitTech != null) {
+                boolean isTechsUseAdmin = getCampaign().getCampaignOptions().isTechsUseAdministration();
+                minutesInWorkDay = refitTech.getDailyAvailableTechTime(isTechsUseAdmin);
+            }
+
+            int daysLeft = (int) Math.ceil(timeLeft / minutesInWorkDay);
+            String dayString = daysLeft == 1 ? "day" : "days";
+
+            return "Refitting" + " (" + daysLeft + ' ' + dayString + ')';
         } else {
             return getCondition();
         }


### PR DESCRIPTION
- Replaced hardcoded time calculations with the `TECH_WORK_DAY`.
- Added singular/plural handling for "day" in the refit status message.