### PR TITLE
Added Tint To Campaign Options Tab Images

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsHeaderPanel.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/components/CampaignOptionsHeaderPanel.java
@@ -27,7 +27,9 @@
  */
 package mekhq.gui.campaignOptions.components;
 
+import static java.awt.Color.BLACK;
 import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
+import static megamek.utilities.ImageUtilities.addTintToImageIcon;
 import static megamek.utilities.ImageUtilities.scaleImageIcon;
 
 import java.awt.GridBagConstraints;
@@ -88,6 +90,7 @@ public class CampaignOptionsHeaderPanel extends JPanel {
         // Load and scale the image using the provided file path
         ImageIcon imageIcon = new ImageIcon(imageAddress);
         imageIcon = scaleImageIcon(imageIcon, 100, true);
+        imageIcon = addTintToImageIcon(imageIcon.getImage(), BLACK);
 
         // Create a JLabel to display the image in the panel
         JLabel lblImage = new JLabel(imageIcon);


### PR DESCRIPTION
- Applied a black tint to the Campaign Options Header Panel image using `addTintToImageIcon`.

#### Before
<img width="504" alt="image" src="https://github.com/user-attachments/assets/e003491c-7588-4b34-8798-c3bfd6114375" />


#### After
<img width="507" alt="image" src="https://github.com/user-attachments/assets/1faa96b5-6b1a-4fca-909f-1f754a9386bb" />