### PR TITLE
Fix #6616: Fixed Convoys Not Deploying to Scenarios

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -899,7 +899,7 @@ public class Scenario implements IPlayerSettings {
         if (!getStatus().isCurrent()) {
             return false;
         }
-        if (getForces(c).getAllUnits(true).isEmpty()) {
+        if (getForces(c).getAllUnits(false).isEmpty()) {
             return false;
         }
         if (!includesRequiredPersonnel(c)) {

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -78,7 +78,6 @@ import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
 import mekhq.campaign.mission.enums.MissionStatus;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.skills.SkillType;
@@ -829,7 +828,7 @@ public final class BriefingTab extends CampaignGuiTab {
         if (scenario == null) {
             return;
         }
-        Vector<UUID> uids = scenario.getForces(getCampaign()).getAllUnits(true);
+        Vector<UUID> uids = scenario.getForces(getCampaign()).getAllUnits(false);
         if (uids.isEmpty()) {
             return;
         }


### PR DESCRIPTION
- Updated `getAllUnits` calls to use `false` instead of `true` for filtering unit lists.

Fix #6616