### PR TITLE
Fix #6618: Implemented Pre-Tukayyid Clan Tech Restrictions to Force Generation

### DIFF
--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -340,4 +340,8 @@ public final class MHQConstants extends SuiteConstants {
     // endregion Backgrounds
 
     // endregion File Paths
+
+    // startregion Important Dates
+    public static final LocalDate BATTLE_OF_TUKAYYID = LocalDate.of(3052, 5, 21);
+    // endregion Important Dates
 }

--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AbstractUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AbstractUnitMarket.java
@@ -27,6 +27,15 @@
  */
 package mekhq.campaign.market.unitMarket;
 
+import static mekhq.MHQConstants.BATTLE_OF_TUKAYYID;
+
+import java.io.PrintWriter;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.ResourceBundle;
+
 import megamek.Version;
 import megamek.client.ratgenerator.MissionRole;
 import megamek.common.Compute;
@@ -43,13 +52,6 @@ import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import java.io.PrintWriter;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.ResourceBundle;
-
 public abstract class AbstractUnitMarket {
     private static final MMLogger logger = MMLogger.create(AbstractUnitMarket.class);
 
@@ -58,7 +60,7 @@ public abstract class AbstractUnitMarket {
     private List<UnitMarketOffer> offers;
 
     protected final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Market",
-            MekHQ.getMHQOptions().getLocale());
+          MekHQ.getMHQOptions().getLocale());
     // endregion Variable Declarations
 
     // region Constructors
@@ -83,20 +85,18 @@ public abstract class AbstractUnitMarket {
     // endregion Getters/Setters
 
     // region Process New Day
+
     /**
-     * This is the primary method for processing the Unit Market. It is executed as
-     * part of
-     * {@link Campaign#newDay()}
+     * This is the primary method for processing the Unit Market. It is executed as part of {@link Campaign#newDay()}
      *
      * @param campaign the campaign to process the Unit Market new day using
      */
     public abstract void processNewDay(Campaign campaign);
 
     // region Generate Offers
+
     /**
-     * This is the primary Unit Market generation method, which is how the market
-     * specified
-     * generates unit offers
+     * This is the primary Unit Market generation method, which is how the market specified generates unit offers
      *
      * @param campaign the campaign to generate the unit offers for
      */
@@ -109,15 +109,13 @@ public abstract class AbstractUnitMarket {
      * @param number      the number of units to generate
      * @param market      the unit market type the unit is part of
      * @param unitType    the unit type to generate
-     * @param faction     the faction to add the offers for, or null. If null, that
-     *                    must be handled within
-     *                    this method before any generated offers may be added to
-     *                    the market.
+     * @param faction     the faction to add the offers for, or null. If null, that must be handled within this method
+     *                    before any generated offers may be added to the market.
      * @param quality     the quality of the unit to generate
      * @param priceTarget the target number used to determine the percent
      */
     public abstract void addOffers(Campaign campaign, int number, UnitMarketType market, int unitType,
-            @Nullable Faction faction, int quality, int priceTarget);
+          @Nullable Faction faction, int quality, int priceTarget);
 
     /**
      * @param campaign the campaign to use to generate the unit
@@ -125,16 +123,20 @@ public abstract class AbstractUnitMarket {
      * @param unitType the unit type to generate the unit with
      * @param faction  the faction to generate the unit from
      * @param quality  the quality to generate the unit at
-     * @param percent  the percentage of the original unit cost the unit will be
-     *                 offered at
-     * @return the name of the unit that has been added to the market, or null if
-     *         none were added
+     * @param percent  the percentage of the original unit cost the unit will be offered at
+     *
+     * @return the name of the unit that has been added to the market, or null if none were added
      */
-    public @Nullable String addSingleUnit(final Campaign campaign, final UnitMarketType market,
-            final int unitType, final Faction faction,
-            final int quality, final int percent) {
-        return addSingleUnit(campaign, market, unitType, faction, quality, new ArrayList<>(),
-                new ArrayList<>(), percent);
+    public @Nullable String addSingleUnit(final Campaign campaign, final UnitMarketType market, final int unitType,
+          final Faction faction, final int quality, final int percent) {
+        return addSingleUnit(campaign,
+              market,
+              unitType,
+              faction,
+              quality,
+              new ArrayList<>(),
+              new ArrayList<>(),
+              percent);
     }
 
     /**
@@ -145,19 +147,22 @@ public abstract class AbstractUnitMarket {
      * @param quality       the quality to generate the unit at
      * @param movementModes the movement modes to generate for
      * @param missionRoles  the mission roles to generate for
-     * @param percent       the percentage of the original unit cost the unit will
-     *                      be offered at
-     * @return the name of the unit that has been added to the market, or null if
-     *         none were added
+     * @param percent       the percentage of the original unit cost the unit will be offered at
+     *
+     * @return the name of the unit that has been added to the market, or null if none were added
      */
-    public @Nullable String addSingleUnit(final Campaign campaign, final UnitMarketType market,
-            final int unitType, final Faction faction,
-            final int quality,
-            final Collection<EntityMovementMode> movementModes,
-            final Collection<MissionRole> missionRoles,
-            final int percent) {
-        return addSingleUnit(campaign, market, unitType, faction,
-                generateWeight(campaign, unitType, faction), quality, movementModes, missionRoles, percent);
+    public @Nullable String addSingleUnit(final Campaign campaign, final UnitMarketType market, final int unitType,
+          final Faction faction, final int quality, final Collection<EntityMovementMode> movementModes,
+          final Collection<MissionRole> missionRoles, final int percent) {
+        return addSingleUnit(campaign,
+              market,
+              unitType,
+              faction,
+              generateWeight(campaign, unitType, faction),
+              quality,
+              movementModes,
+              missionRoles,
+              percent);
     }
 
     /**
@@ -169,22 +174,30 @@ public abstract class AbstractUnitMarket {
      * @param quality       the quality to generate the unit at
      * @param movementModes the movement modes to generate for
      * @param missionRoles  the mission roles to generate for
-     * @param percent       the percentage of the original unit cost the unit will
-     *                      be offered at
-     * @return the name of the unit that has been added to the market, or null if
-     *         none were added
+     * @param percent       the percentage of the original unit cost the unit will be offered at
+     *
+     * @return the name of the unit that has been added to the market, or null if none were added
      */
-    protected @Nullable String addSingleUnit(final Campaign campaign, final UnitMarketType market,
-            final int unitType, final Faction faction,
-            final int weight, final int quality,
-            final Collection<EntityMovementMode> movementModes,
-            final Collection<MissionRole> missionRoles,
-            final int percent) {
-        final MekSummary mekSummary = campaign.getUnitGenerator().generate(faction.getShortName(),
-                unitType, weight, campaign.getGameYear(), quality, movementModes, missionRoles,
-                ms -> (!campaign.getCampaignOptions().isLimitByYear() || (campaign.getGameYear() > ms.getYear()))
-                        && (!ms.isClan() || campaign.getCampaignOptions().isAllowClanPurchases())
-                        && (ms.isClan() || campaign.getCampaignOptions().isAllowISPurchases()));
+    protected @Nullable String addSingleUnit(final Campaign campaign, final UnitMarketType market, final int unitType,
+          final Faction faction, final int weight, final int quality,
+          final Collection<EntityMovementMode> movementModes, final Collection<MissionRole> missionRoles,
+          final int percent) {
+        final MekSummary mekSummary = campaign.getUnitGenerator()
+                                            .generate(faction.getShortName(),
+                                                  unitType,
+                                                  weight,
+                                                  campaign.getGameYear(),
+                                                  quality,
+                                                  movementModes,
+                                                  missionRoles,
+                                                  ms -> (!campaign.getCampaignOptions().isLimitByYear() ||
+                                                               (campaign.getGameYear() > ms.getYear())) &&
+                                                              (!ms.isClan() ||
+                                                                     campaign.getCampaignOptions()
+                                                                           .isAllowClanPurchases()) &&
+                                                              (ms.isClan() ||
+                                                                     campaign.getCampaignOptions()
+                                                                           .isAllowISPurchases()));
         return (mekSummary == null) ? null : addSingleUnit(campaign, market, unitType, mekSummary, percent);
     }
 
@@ -193,14 +206,12 @@ public abstract class AbstractUnitMarket {
      * @param market     the market type the unit is being offered in
      * @param unitType   the unit type of the generated unit
      * @param mekSummary the generated mek summary
-     * @param percent    the percentage of the original unit cost the unit will be
-     *                   offered at
+     * @param percent    the percentage of the original unit cost the unit will be offered at
+     *
      * @return the name of the unit that has been added to the market
      */
-    public String addSingleUnit(final Campaign campaign, final UnitMarketType market,
-            final int unitType, final MekSummary mekSummary,
-            final int percent) {
-        final LocalDate BATTLE_OF_TUKAYYID = LocalDate.of(3052, 5, 21);
+    public String addSingleUnit(final Campaign campaign, final UnitMarketType market, final int unitType,
+          final MekSummary mekSummary, final int percent) {
 
         Faction campaignFaction = campaign.getFaction();
         LocalDate currentDate = campaign.getLocalDate();
@@ -211,8 +222,7 @@ public abstract class AbstractUnitMarket {
             }
         }
 
-        getOffers().add(new UnitMarketOffer(market, unitType, mekSummary, percent,
-                generateTransitDuration(campaign)));
+        getOffers().add(new UnitMarketOffer(market, unitType, mekSummary, percent, generateTransitDuration(campaign)));
 
         return mekSummary.getName();
     }
@@ -221,18 +231,20 @@ public abstract class AbstractUnitMarket {
      * @param campaign the campaign to generate the unit weight based on
      * @param unitType the unit type to determine the format of weight to generate
      * @param faction  the faction to generate the weight for
+     *
      * @return the generated weight
      */
-    protected abstract int generateWeight(Campaign campaign, int unitType,
-            Faction faction);
+    protected abstract int generateWeight(Campaign campaign, int unitType, Faction faction);
 
     /**
      * @param campaign the campaign to use to generate the transit duration
+     *
      * @return the generated transit duration
      */
     protected int generateTransitDuration(final Campaign campaign) {
-        return campaign.getCampaignOptions().isInstantUnitMarketDelivery() ? 0
-                : campaign.calculatePartTransitTime(Compute.d6(2) - 2);
+        return campaign.getCampaignOptions().isInstantUnitMarketDelivery() ?
+                     0 :
+                     campaign.calculatePartTransitTime(Compute.d6(2) - 2);
     }
 
     /**
@@ -246,10 +258,9 @@ public abstract class AbstractUnitMarket {
     // endregion Generate Offers
 
     // region Offer Removal
+
     /**
-     * This is the primary Unit Market removal method, which is how the market
-     * specified
-     * removes unit offers
+     * This is the primary Unit Market removal method, which is how the market specified removes unit offers
      *
      * @param campaign the campaign to use in determining the offers to remove
      */
@@ -258,6 +269,7 @@ public abstract class AbstractUnitMarket {
     // endregion Process New Day
 
     // region File I/O
+
     /**
      * This writes the Unit Market to XML
      *
@@ -271,9 +283,8 @@ public abstract class AbstractUnitMarket {
     }
 
     /**
-     * This is meant to be overridden so that a market can have additional elements
-     * added to it,
-     * albeit with this called by super.writeBodyToXML(pw, indent) first.
+     * This is meant to be overridden so that a market can have additional elements added to it, albeit with this called
+     * by super.writeBodyToXML(pw, indent) first.
      *
      * @param pw     the PrintWriter to write to
      * @param indent the base indent level to write at
@@ -285,9 +296,8 @@ public abstract class AbstractUnitMarket {
     }
 
     /**
-     * This method fills the market based on the supplied XML node. The market is
-     * initialized as
-     * empty before this is called.
+     * This method fills the market based on the supplied XML node. The market is initialized as empty before this is
+     * called.
      *
      * @param wn       the node to fill the market from
      * @param campaign the campaign the market is being parsed as part of
@@ -309,9 +319,8 @@ public abstract class AbstractUnitMarket {
     }
 
     /**
-     * This is meant to be overridden so that a market can have additional elements
-     * added to it,
-     * albeit with this called by super.parseXMLNode(wn) first.
+     * This is meant to be overridden so that a market can have additional elements added to it, albeit with this called
+     * by super.parseXMLNode(wn) first.
      *
      * @param wn       the node to parse from XML
      * @param campaign the campaign the market is being parsed as part of

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -46,6 +46,7 @@ import static megamek.common.enums.SkillLevel.REGULAR;
 import static megamek.common.enums.SkillLevel.parseFromInteger;
 import static megamek.common.enums.SkillLevel.parseFromString;
 import static megamek.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.MHQConstants.BATTLE_OF_TUKAYYID;
 import static mekhq.campaign.force.CombatTeam.getStandardForceSize;
 import static mekhq.campaign.force.ForceType.STANDARD;
 import static mekhq.campaign.force.FormationLevel.BATTALION;
@@ -1717,8 +1718,6 @@ public class AtBContract extends Contract {
      * </p>
      */
     public void clanTechSalvageOverride() {
-        final LocalDate BATTLE_OF_TUKAYYID = LocalDate.of(3052, 5, 21);
-
         if (getEnemy().isClan() && !getEmployerFaction().isClan()) {
             if (getStartDate().isBefore(BATTLE_OF_TUKAYYID)) {
                 setSalvageExchange(true);

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -33,6 +33,7 @@ import static java.lang.Math.min;
 import static java.lang.Math.round;
 import static megamek.common.MiscType.F_SPONSON_TURRET;
 import static megamek.common.enums.SkillLevel.NONE;
+import static mekhq.MHQConstants.BATTLE_OF_TUKAYYID;
 import static mekhq.campaign.force.CombatTeam.getStandardForceSize;
 import static mekhq.campaign.force.ForceType.CONVOY;
 import static mekhq.campaign.force.ForceType.STANDARD;
@@ -73,15 +74,13 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 
 /**
- * The {@code Resupply} class manages the resupply process during a campaign.
- * It calculates the required resupply resources, organizes parts pools (e.g., parts, armor, ammo),
- * and handles player convoy logistics and negotiation skills.
+ * The {@code Resupply} class manages the resupply process during a campaign. It calculates the required resupply
+ * resources, organizes parts pools (e.g., parts, armor, ammo), and handles player convoy logistics and negotiation
+ * skills.
  * <p>
- * It supports functionality such as
- * - Calculating target resupply tonnage based on combat unit weight and allowances.
- * - Building pools for parts (e.g., spare parts, ammo, and armor).
- * - Managing player convoy logistics.
- * - Handling procurement and negotiation results for administered resources.
+ * It supports functionality such as - Calculating target resupply tonnage based on combat unit weight and allowances. -
+ * Building pools for parts (e.g., spare parts, ammo, and armor). - Managing player convoy logistics. - Handling
+ * procurement and negotiation results for administered resources.
  */
 public class Resupply {
     private final Campaign campaign;
@@ -111,7 +110,6 @@ public class Resupply {
     public static final int CARGO_MINIMUM_WEIGHT = 4;
     public static final int RESUPPLY_AMMO_TONNAGE = 1;
     public static final int RESUPPLY_ARMOR_TONNAGE = 5;
-    final LocalDate BATTLE_OF_TUKAYYID = LocalDate.of(3052, 5, 21);
 
     private static final MMLogger logger = MMLogger.create(Resupply.class);
 
@@ -123,12 +121,11 @@ public class Resupply {
     }
 
     /**
-     * Constructs a new {@link Resupply} instance and initializes resupply parameters for the
-     * given campaign and contract. This includes setting faction data, calculating target cargo
-     * tonnage, and building parts pools.
+     * Constructs a new {@link Resupply} instance and initializes resupply parameters for the given campaign and
+     * contract. This includes setting faction data, calculating target cargo tonnage, and building parts pools.
      *
-     * @param campaign   The current campaign.
-     * @param contract   The specific contract under which the resupply process is conducted.
+     * @param campaign The current campaign.
+     * @param contract The specific contract under which the resupply process is conducted.
      */
     public Resupply(Campaign campaign, AtBContract contract, ResupplyType resupplyType) {
         this.campaign = campaign;
@@ -179,8 +176,8 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the current resupply type being used.
-     * The resupply type indicates the method by which supplies are obtained.
+     * Retrieves the current resupply type being used. The resupply type indicates the method by which supplies are
+     * obtained.
      *
      * @return A {@link ResupplyType} representing the current method of resupply.
      */
@@ -189,9 +186,8 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the target cargo tonnage calculated for the resupply process.
-     * This value represents the expected tonnage of supplies to be delivered
-     * based on the current campaign and contract conditions.
+     * Retrieves the target cargo tonnage calculated for the resupply process. This value represents the expected
+     * tonnage of supplies to be delivered based on the current campaign and contract conditions.
      *
      * @return The target cargo tonnage.
      */
@@ -207,6 +203,7 @@ public class Resupply {
     public double getFocusAmmo() {
         return focusAmmo;
     }
+
     /**
      * Sets the focus percentage allocated for ammunition resupply.
      *
@@ -224,6 +221,7 @@ public class Resupply {
     public double getFocusArmor() {
         return focusArmor;
     }
+
     /**
      * Sets the focus percentage allocated for armor resupply.
      *
@@ -241,6 +239,7 @@ public class Resupply {
     public double getFocusParts() {
         return focusParts;
     }
+
     /**
      * Sets the focus percentage allocated for general parts resupply.
      *
@@ -251,8 +250,8 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the pool of general parts available for resupply.
-     * This pool includes non-specific parts that have passed all eligibility checks.
+     * Retrieves the pool of general parts available for resupply. This pool includes non-specific parts that have
+     * passed all eligibility checks.
      *
      * @return A list of general parts available for resupply.
      */
@@ -261,8 +260,8 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the pool of armor parts available for resupply.
-     * This includes any eligible armor components that have been processed.
+     * Retrieves the pool of armor parts available for resupply. This includes any eligible armor components that have
+     * been processed.
      *
      * @return A list of armor parts available for resupply.
      */
@@ -271,8 +270,8 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the pool of ammo bins available for resupply.
-     * This includes eligible ammunition bins that have been processed.
+     * Retrieves the pool of ammo bins available for resupply. This includes eligible ammunition bins that have been
+     * processed.
      *
      * @return A list of ammo bins available for resupply.
      */
@@ -281,8 +280,8 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the negotiation skill level of the designated negotiator for the resupply process.
-     * This skill level is used to influence procurement outcomes and quality.
+     * Retrieves the negotiation skill level of the designated negotiator for the resupply process. This skill level is
+     * used to influence procurement outcomes and quality.
      *
      * @return The negotiation skill level of the negotiator.
      */
@@ -291,8 +290,8 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the target cargo tonnage used when the player is providing convoy units.
-     * This value represents the desired amount of cargo that the player's convoy aims to carry.
+     * Retrieves the target cargo tonnage used when the player is providing convoy units. This value represents the
+     * desired amount of cargo that the player's convoy aims to carry.
      *
      * @return The target cargo tonnage for the player's convoy.
      */
@@ -301,8 +300,8 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the total cargo capacity available in the player's convoy.
-     * This capacity indicates the maximum amount of cargo that the convoy can hold.
+     * Retrieves the total cargo capacity available in the player's convoy. This capacity indicates the maximum amount
+     * of cargo that the convoy can hold.
      *
      * @return The total cargo capacity of the player's convoy.
      */
@@ -311,17 +310,18 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the current list of parts in the convoy's inventory.
-     * This method provides access to the parts being transported by the convoy.
+     * Retrieves the current list of parts in the convoy's inventory. This method provides access to the parts being
+     * transported by the convoy.
      *
      * @return A list of parts contained within the convoy.
      */
     public List<Part> getConvoyContents() {
         return convoyContents;
     }
+
     /**
-     * Sets the list of parts to be included in the convoy's inventory.
-     * This method allows the assignment or modification of the parts being transported by the convoy.
+     * Sets the list of parts to be included in the convoy's inventory. This method allows the assignment or
+     * modification of the parts being transported by the convoy.
      *
      * @param convoyContents The list of parts to be assigned to the convoy.
      */
@@ -330,72 +330,74 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the base value of the contents in the convoy.
-     * This value typically represents the estimated or predetermined worth of the convoy's cargo.
+     * Retrieves the base value of the contents in the convoy. This value typically represents the estimated or
+     * predetermined worth of the convoy's cargo.
      *
      * @return A {@link Money} object representing the base value of the convoy contents.
      */
     public Money getConvoyContentsValueBase() {
         return convoyContentsValueBase;
     }
+
     /**
-     * Sets the base value of the contents in the convoy.
-     * This is used to define the predetermined or estimated worth of the convoy's cargo.
+     * Sets the base value of the contents in the convoy. This is used to define the predetermined or estimated worth of
+     * the convoy's cargo.
      *
-     * @param convoyContentsValueBase A {@link Money} object representing the base value of the
-     *                               convoy contents.
+     * @param convoyContentsValueBase A {@link Money} object representing the base value of the convoy contents.
      */
     public void setConvoyContentsValueBase(Money convoyContentsValueBase) {
         this.convoyContentsValueBase = convoyContentsValueBase;
     }
 
     /**
-     * Retrieves the calculated value of the convoy's contents.
-     * This value is typically dynamic and may include various adjustments based on gameplay scenarios.
+     * Retrieves the calculated value of the convoy's contents. This value is typically dynamic and may include various
+     * adjustments based on gameplay scenarios.
      *
      * @return A {@link Money} object representing the calculated value of the convoy contents.
      */
     public Money getConvoyContentsValueCalculated() {
         return convoyContentsValueCalculated;
     }
+
     /**
-     * Sets the calculated value of the convoy's contents.
-     * This value may be adjusted dynamically during the campaign or based on external factors.
+     * Sets the calculated value of the convoy's contents. This value may be adjusted dynamically during the campaign or
+     * based on external factors.
      *
-     * @param convoyContentsValueCalculated A {@link Money} object representing the calculated value
-     *                                     of the convoy contents.
+     * @param convoyContentsValueCalculated A {@link Money} object representing the calculated value of the convoy
+     *                                      contents.
      */
     public void setConvoyContentsValueCalculated(Money convoyContentsValueCalculated) {
         this.convoyContentsValueCalculated = convoyContentsValueCalculated;
     }
 
     /**
-     * Retrieves the player convoys and their corresponding cargo capacities.
-     * This method provides a mapping of player-controlled forces to their available cargo capacity.
+     * Retrieves the player convoys and their corresponding cargo capacities. This method provides a mapping of
+     * player-controlled forces to their available cargo capacity.
      *
-     * @return A {@link Map} where the key is a {@link Force} representing the player's convoy,
-     *         and the value is a {@link Double} indicating its cargo capacity.
+     * @return A {@link Map} where the key is a {@link Force} representing the player's convoy, and the value is a
+     *       {@link Double} indicating its cargo capacity.
      */
     public Map<Force, Double> getPlayerConvoys() {
         return playerConvoys;
     }
 
     /**
-     * Checks whether the player's convoy is set to be used for resupply purposes.
-     * This indicates if resupply operations take into account the player's convoy.
+     * Checks whether the player's convoy is set to be used for resupply purposes. This indicates if resupply operations
+     * take into account the player's convoy.
      *
-     * @return A {@code boolean} indicating whether the player's convoy is being used.
-     *         Returns {@code true} if the player's convoy is used, {@code false} otherwise.
+     * @return A {@code boolean} indicating whether the player's convoy is being used. Returns {@code true} if the
+     *       player's convoy is used, {@code false} otherwise.
      */
     public boolean getUsePlayerConvoy() {
         return usePlayerConvoy;
     }
+
     /**
-     * Sets whether the player's convoy should be used for resupply purposes.
-     * This determines if cargo and resupply operations will consider the player's convoy.
+     * Sets whether the player's convoy should be used for resupply purposes. This determines if cargo and resupply
+     * operations will consider the player's convoy.
      *
-     * @param usePlayerConvoy A {@code boolean} indicating whether the player's convoy should be used.
-     *                        {@code true} to use the player's convoy, {@code false} otherwise.
+     * @param usePlayerConvoy A {@code boolean} indicating whether the player's convoy should be used. {@code true} to
+     *                        use the player's convoy, {@code false} otherwise.
      */
     public void setUsePlayerConvoy(boolean usePlayerConvoy) {
         this.usePlayerConvoy = usePlayerConvoy;
@@ -451,17 +453,15 @@ public class Resupply {
     /**
      * Determines if the given entity is a prohibited unit type based on specific criteria.
      *
-     * @param entity the entity to check for prohibited unit type
-     * @param excludeDropShipsFromCheck if true, DropShip entities are excluded from being
-     *                                 considered prohibited
-     * @param excludeSuperHeaviesFromCheck if true, Super Heavy entities are excluded from being
-     *                                    considered prohibited
-     * @return {@code true} if the entity is a prohibited unit type such as Small Craft, Large
-     * Craft, or Conventional Infantry, and not excluded by the specified parameters; {@code false}
-     * otherwise
+     * @param entity                       the entity to check for prohibited unit type
+     * @param excludeDropShipsFromCheck    if true, DropShip entities are excluded from being considered prohibited
+     * @param excludeSuperHeaviesFromCheck if true, Super Heavy entities are excluded from being considered prohibited
+     *
+     * @return {@code true} if the entity is a prohibited unit type such as Small Craft, Large Craft, or Conventional
+     *       Infantry, and not excluded by the specified parameters; {@code false} otherwise
      */
     public static boolean isProhibitedUnitType(Entity entity, boolean excludeDropShipsFromCheck,
-                                               boolean excludeSuperHeaviesFromCheck) {
+          boolean excludeSuperHeaviesFromCheck) {
         if (entity.isDropShip() && excludeDropShipsFromCheck) {
             return false;
         }
@@ -470,16 +470,14 @@ public class Resupply {
             return false;
         }
 
-        return entity.isSmallCraft()
-            || entity.isLargeCraft()
-            || entity.isConventionalInfantry();
+        return entity.isSmallCraft() || entity.isLargeCraft() || entity.isConventionalInfantry();
     }
 
     /**
-     * Builds the pools of parts (e.g., general parts, ammo bins, and armor) for the resupply drop.
-     * Parts are procured, shuffled, and organized into their respective pools for distribution.
+     * Builds the pools of parts (e.g., general parts, ammo bins, and armor) for the resupply drop. Parts are procured,
+     * shuffled, and organized into their respective pools for distribution.
      *
-     * @param potentialParts   A map of potential parts to include in the supply drop, keyed by part name.
+     * @param potentialParts A map of potential parts to include in the supply drop, keyed by part name.
      */
     private void buildPartsPools(Map<Part, PartDetails> potentialParts) {
         partsPool = new ArrayList<>();
@@ -519,26 +517,24 @@ public class Resupply {
     }
 
     /**
-     * Collects all eligible parts from campaign units and organizes them into a map, where each part
-     * is associated with its corresponding details. The collection process considers various factors,
-     * including exclusion lists, location validation, and warehouse resources, to determine the
-     * eligibility and weight of each part.
+     * Collects all eligible parts from campaign units and organizes them into a map, where each part is associated with
+     * its corresponding details. The collection process considers various factors, including exclusion lists, location
+     * validation, and warehouse resources, to determine the eligibility and weight of each part.
      *
      * <p>This method leverages the campaign's existing parts in use, filters them based on specific
-     * criteria (e.g., unit exclusion, allowed quality levels), and applies warehouse-specific weight
-     * modifiers to calculate the resulting details.</p>
+     * criteria (e.g., unit exclusion, allowed quality levels), and applies warehouse-specific weight modifiers to
+     * calculate the resulting details.</p>
      *
      * @return A {@link Map} where:
-     *         <ul>
-     *             <li>The key is a {@link Part} object representing the eligible part.</li>
-     *             <li>The value is a {@link PartDetails} object that contains detailed information
-     *                 about the part, such as adjusted weight, based on warehouse modifiers.</li>
-     *         </ul>
+     *       <ul>
+     *           <li>The key is a {@link Part} object representing the eligible part.</li>
+     *           <li>The value is a {@link PartDetails} object that contains detailed information
+     *               about the part, such as adjusted weight, based on warehouse modifiers.</li>
+     *       </ul>
      */
 
     private Map<Part, PartDetails> collectParts() {
-        Set<PartInUse> partsInUse = campaign.getPartsInUse(true, true,
-            PartQuality.QUALITY_A);
+        Set<PartInUse> partsInUse = campaign.getPartsInUse(true, true, PartQuality.QUALITY_A);
 
         Faction campaignFaction = campaign.getFaction();
         LocalDate today = campaign.getLocalDate();
@@ -563,26 +559,27 @@ public class Resupply {
     }
 
     /**
-     * Checks if a part is ineligible for inclusion in the resupply process. Ineligibility is
-     * determined based on exclusion lists, unit structure compatibility, and transporter checks.
+     * Checks if a part is ineligible for inclusion in the resupply process. Ineligibility is determined based on
+     * exclusion lists, unit structure compatibility, and transporter checks.
      *
-     * @param part   The part being checked.
+     * @param part The part being checked.
+     *
      * @return {@code true} if the part is ineligible, {@code false} otherwise.
      */
     private boolean isIneligiblePart(Part part) {
-        return checkExclusionList(part)
-            || checkMekLocation(part)
-            || checkTankLocation(part)
-            || checkMotiveSystem(part)
-            || checkTransporter(part);
+        return checkExclusionList(part) ||
+                     checkMekLocation(part) ||
+                     checkTankLocation(part) ||
+                     checkMotiveSystem(part) ||
+                     checkTransporter(part);
     }
 
     /**
-     * Checks if a part is in the exclusion list and should not be considered for resupply.
-     * Equipment parts are evaluated for specific flags, such as {@code F_SPONSON_TURRET},
-     * which would disqualify them from inclusion.
+     * Checks if a part is in the exclusion list and should not be considered for resupply. Equipment parts are
+     * evaluated for specific flags, such as {@code F_SPONSON_TURRET}, which would disqualify them from inclusion.
      *
-     * @param part   The part to check.
+     * @param part The part to check.
+     *
      * @return {@code true} if the part is in the exclusion list, {@code false} otherwise.
      */
     private boolean checkExclusionList(Part part) {
@@ -596,6 +593,7 @@ public class Resupply {
      * Checks if the given part is an instance of {@code MotiveSystem}.
      *
      * @param part the {@link Part} to be checked.
+     *
      * @return {@code true} if the part is a {@link MotiveSystem}, {@code false} otherwise.
      */
     private boolean checkMotiveSystem(Part part) {
@@ -603,24 +601,23 @@ public class Resupply {
     }
 
     /**
-     * Checks if a part belonging to a 'Mek' unit is eligible for resupply, based on its location.
-     * For example, parts located in the center torso or parts from extinct units are deemed
-     * ineligible.
+     * Checks if a part belonging to a 'Mek' unit is eligible for resupply, based on its location. For example, parts
+     * located in the center torso or parts from extinct units are deemed ineligible.
      *
-     * @param part   The part to check.
-     * @return {@code true} if the part is ineligible due to its location or extinction,
-     * {@code false} otherwise.
+     * @param part The part to check.
+     *
+     * @return {@code true} if the part is ineligible due to its location or extinction, {@code false} otherwise.
      */
     private boolean checkMekLocation(Part part) {
-        return part instanceof MekLocation &&
-            (((MekLocation) part).getLoc() == Mek.LOC_CT);
+        return part instanceof MekLocation && (((MekLocation) part).getLoc() == Mek.LOC_CT);
     }
 
     /**
-     * Verifies if a vehicle part is eligible for resupply. Parts such as rotors
-     * and turrets are always eligible, while other tank locations may be disqualified.
+     * Verifies if a vehicle part is eligible for resupply. Parts such as rotors and turrets are always eligible, while
+     * other tank locations may be disqualified.
      *
-     * @param part   The part to check.
+     * @param part The part to check.
+     *
      * @return {@code true} if the part is ineligible for resupply, {@code false} otherwise.
      */
     private boolean checkTankLocation(Part part) {
@@ -628,10 +625,11 @@ public class Resupply {
     }
 
     /**
-     * Determines whether a part is a transporter-related part, such as a `TransportBayPart`,
-     * which makes it ineligible for consideration in the resupply process.
+     * Determines whether a part is a transporter-related part, such as a `TransportBayPart`, which makes it ineligible
+     * for consideration in the resupply process.
      *
-     * @param part   The part to check.
+     * @param part The part to check.
+     *
      * @return {@code true} if the part is a transporter part, {@code false} otherwise.
      */
     private boolean checkTransporter(Part part) {
@@ -639,22 +637,23 @@ public class Resupply {
     }
 
     /**
-     * Applies modifiers to adjust the weight of parts based on their usage and availability
-     * in the warehouse. This method calculates the adjusted weight for each part by taking
-     * into account its use count, store count, and a multiplier specific to the part.
+     * Applies modifiers to adjust the weight of parts based on their usage and availability in the warehouse. This
+     * method calculates the adjusted weight for each part by taking into account its use count, store count, and a
+     * multiplier specific to the part.
      *
      * <p>The resulting adjusted weight is used to determine the importance or priority of the part,
      * and only parts with a positive weight are included in the output map.</p>
      *
-     * @param partsInUse A {@link Set} of {@link PartInUse} objects containing information about
-     *                   parts currently in use and their quantities in the warehouse.
+     * @param partsInUse A {@link Set} of {@link PartInUse} objects containing information about parts currently in use
+     *                   and their quantities in the warehouse.
+     *
      * @return A {@link Map} where:
-     *         <ul>
-     *             <li>The key is a {@link Part} object representing the eligible part.</li>
-     *             <li>The value is a {@link PartDetails} object containing the adjusted weight of
-     *                 the part, calculated using its usage data and a multiplier.</li>
-     *         </ul>
-     *         Only parts with a positive adjusted weight are included in the resulting map.
+     *       <ul>
+     *           <li>The key is a {@link Part} object representing the eligible part.</li>
+     *           <li>The value is a {@link PartDetails} object containing the adjusted weight of
+     *               the part, calculated using its usage data and a multiplier.</li>
+     *       </ul>
+     *       Only parts with a positive adjusted weight are included in the resulting map.
      */
 
     private Map<Part, PartDetails> applyWarehouseWeightModifiers(Set<PartInUse> partsInUse) {
@@ -671,8 +670,7 @@ public class Resupply {
                 continue;
             }
 
-            if ((resupplyType != ResupplyType.RESUPPLY_LOOT)
-                && (resupplyType != ResupplyType.RESUPPLY_SMUGGLER)) {
+            if ((resupplyType != ResupplyType.RESUPPLY_LOOT) && (resupplyType != ResupplyType.RESUPPLY_SMUGGLER)) {
                 part.setBrandNew(true);
             }
 
@@ -691,11 +689,11 @@ public class Resupply {
     }
 
     /**
-     * Retrieves the multiplier value for a specific part type to calculate its priority
-     * in the resupply process. This multiplier affects how the part is weighted when
-     * included in the pool of available resupply resources.
+     * Retrieves the multiplier value for a specific part type to calculate its priority in the resupply process. This
+     * multiplier affects how the part is weighted when included in the pool of available resupply resources.
      *
-     * @param part   The part to determine the multiplier for.
+     * @param part The part to determine the multiplier for.
+     *
      * @return A multiplier value for the given part type.
      */
     private static double getPartMultiplier(Part part) {
@@ -708,10 +706,10 @@ public class Resupply {
             if (((MekLocation) part).getLoc() == Mek.LOC_HEAD) {
                 multiplier = 2;
             }
-        } else if (part instanceof MASC
-            || part instanceof MekGyro
-            || part instanceof EnginePart
-            || checkEquipmentSubType(part)) {
+        } else if (part instanceof MASC ||
+                         part instanceof MekGyro ||
+                         part instanceof EnginePart ||
+                         checkEquipmentSubType(part)) {
             multiplier = 0.5;
         } else if (part instanceof AmmoBin || part instanceof Armor) {
             multiplier = 5;
@@ -721,10 +719,11 @@ public class Resupply {
     }
 
     /**
-     * Determines whether a part is an eligible equipment subtype for the resupply process.
-     * Excludes certain types such as ammo, ammo storage, heat sinks, and jump jets.
+     * Determines whether a part is an eligible equipment subtype for the resupply process. Excludes certain types such
+     * as ammo, ammo storage, heat sinks, and jump jets.
      *
-     * @param part   The part to check.
+     * @param part The part to check.
+     *
      * @return {@code true} if the part is an eligible equipment subtype, {@code false} otherwise.
      */
     private static boolean checkEquipmentSubType(Part part) {
@@ -752,9 +751,9 @@ public class Resupply {
     }
 
     /**
-     * Calculates the negotiation skill level by selecting the most qualified negotiator
-     * in the current campaign. If the contract type is classified as guerrilla warfare, the
-     * flagged commander is prioritized. Otherwise, Admin/Logistics personnel are evaluated.
+     * Calculates the negotiation skill level by selecting the most qualified negotiator in the current campaign. If the
+     * contract type is classified as guerrilla warfare, the flagged commander is prioritized. Otherwise,
+     * Admin/Logistics personnel are evaluated.
      */
     private void calculateNegotiationSkill() {
         Person negotiator;
@@ -766,10 +765,9 @@ public class Resupply {
             negotiator = null;
 
             for (Person admin : campaign.getAdmins()) {
-                if (admin.getPrimaryRole().isAdministratorLogistics()
-                    || admin.getSecondaryRole().isAdministratorLogistics()) {
-                    if (negotiator == null
-                        || (admin.outRanksUsingSkillTiebreaker(campaign, negotiator))) {
+                if (admin.getPrimaryRole().isAdministratorLogistics() ||
+                          admin.getSecondaryRole().isAdministratorLogistics()) {
+                    if (negotiator == null || (admin.outRanksUsingSkillTiebreaker(campaign, negotiator))) {
                         negotiator = admin;
                     }
                 }
@@ -787,9 +785,8 @@ public class Resupply {
     }
 
     /**
-     * Calculates the total cargo capacity available in player-controlled convoys.
-     * Convoy forces and their units are evaluated for cargo capacity, and disabled,
-     * damaged, or uncrewed units are excluded from the totals.
+     * Calculates the total cargo capacity available in player-controlled convoys. Convoy forces and their units are
+     * evaluated for cargo capacity, and disabled, damaged, or uncrewed units are excluded from the totals.
      */
     private void calculatePlayerConvoyValues() {
         playerConvoys = new HashMap<>();
@@ -812,9 +809,7 @@ public class Resupply {
                     Unit unit = campaign.getUnit(unitId);
                     Entity entity = unit.getEntity();
 
-                    if (unit.isDamaged()
-                        || !unit.isFullyCrewed()
-                        || isProhibitedUnitType(entity, true, true)) {
+                    if (unit.isDamaged() || !unit.isFullyCrewed() || isProhibitedUnitType(entity, true, true)) {
                         continue;
                     }
 
@@ -841,8 +836,8 @@ public class Resupply {
     }
 
     /**
-     * Represents details about a part used during the collection and sorting process
-     * for resupply resources. Contains the part itself and its weight value.
+     * Represents details about a part used during the collection and sorting process for resupply resources. Contains
+     * the part itself and its weight value.
      */
     private static class PartDetails {
         private final Part part;
@@ -851,8 +846,8 @@ public class Resupply {
         /**
          * Constructs a new {@code PartDetails} instance.
          *
-         * @param part    The associated part.
-         * @param weight  The weight or priority of the part.
+         * @param part   The associated part.
+         * @param weight The weight or priority of the part.
          */
         public PartDetails(Part part, double weight) {
             this.part = part;
@@ -880,7 +875,7 @@ public class Resupply {
         /**
          * Sets the current weight of the part.
          *
-         * @param weight   The new weight to assign.
+         * @param weight The new weight to assign.
          */
         public void setWeight(double weight) {
             this.weight = weight;


### PR DESCRIPTION
- Added a new constant `BATTLE_OF_TUKAYYID`.
- Updated unit generation logic to restrict Clan technology in non-Clan forces before Tukayyid.

Fix #6618

### Dev Notes
Me and Hammer determined last year that Tukayyid would be the cut-off point after which the Houses started relaxing their tendency to hoard Clantech. Generally speaking, prior to this date you would occasionally see units in the Clan Invasion theatre rocking the odd bit of Clantech, however these unique situations are not something we can easily model so it's better to just bar non-Clan factions from accessing Clantech prior to the watershed.