### PR TITLE
Adjusted Missing Team Fallback Logging

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -1097,7 +1097,7 @@ public class Scenario implements IPlayerSettings {
                     Node team = wn2.getAttributes().getNamedItem("team");
                     if (team != null) {
                         teamValue = Integer.parseInt(MHQXMLUtility.unEscape(team.getTextContent()));
-                    } else {
+                    } else if (retVal.getStatus().isCurrent()) {
                         // Campaigns <50.05 won't have 'team' recorded, so we need to use a fallback value.
                         // The value is equal to 'Allied' which means the scenario will inherit the pre-change behavior
                         logger.info("Scenario {} predates Blind Drop changes. Using fallback team of 1.",


### PR DESCRIPTION
- Adjusted logic to apply fallback team value only for scenarios with a current status. Stops it spamming up `mekhq.log`