### PR TITLE
Implemented Graceful Failure when Loading Random Procreation Settings from Older Versions

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -6019,7 +6019,7 @@ public class CampaignOptions {
                 } else if (nodeName.equalsIgnoreCase("logProcreation")) {
                     retVal.setLogProcreation(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("randomProcreationMethod")) {
-                    retVal.setRandomProcreationMethod(RandomProcreationMethod.valueOf(wn2.getTextContent().trim()));
+                    retVal.setRandomProcreationMethod(RandomProcreationMethod.fromString(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("useRelationshiplessRandomProcreation")) {
                     retVal.setUseRelationshiplessRandomProcreation(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("useRandomClanPersonnelProcreation")) {

--- a/MekHQ/src/mekhq/campaign/personnel/enums/RandomProcreationMethod.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/RandomProcreationMethod.java
@@ -27,20 +27,21 @@
  */
 package mekhq.campaign.personnel.enums;
 
+import java.util.ResourceBundle;
+
+import megamek.codeUtilities.MathUtility;
+import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.procreation.AbstractProcreation;
 import mekhq.campaign.personnel.procreation.DisabledRandomProcreation;
 import mekhq.campaign.personnel.procreation.RandomProcreation;
 
-import java.util.ResourceBundle;
-
 /**
  * The {@link RandomProcreationMethod} enum represents different methods of getting random procreation.
  * <p>
- * The available methods are:
- * - {@code NONE}: No random procreation method.
- * - {@code DICE_ROLL}: Random procreation method using dice roll.
+ * The available methods are: - {@code NONE}: No random procreation method. - {@code DICE_ROLL}: Random procreation
+ * method using dice roll.
  */
 public enum RandomProcreationMethod {
     //region Enum Declarations
@@ -48,28 +49,32 @@ public enum RandomProcreationMethod {
     DICE_ROLL("RandomProcreationMethod.DICE_ROLL.text", "RandomProcreationMethod.DICE_ROLL.toolTipText");
     //endregion Enum Declarations
 
+    private static final MMLogger logger = MMLogger.create(RandomProcreationMethod.class);
+
     //region Variable Declarations
     private final String name;
     private final String toolTipText;
     //endregion Variable Declarations
 
     //region Constructors
+
     /**
-     * Constructor for the {@link RandomProcreationMethod} class.
-     * Initializes the name and toolTipText variables using the specified name and toolTipText resources.
+     * Constructor for the {@link RandomProcreationMethod} class. Initializes the name and toolTipText variables using
+     * the specified name and toolTipText resources.
      *
-     * @param name          the name resource key used to retrieve the name from the resource bundle
-     * @param toolTipText   the tooltip text resource key used to retrieve the tool tip text from the resource bundle
+     * @param name        the name resource key used to retrieve the name from the resource bundle
+     * @param toolTipText the tooltip text resource key used to retrieve the tool tip text from the resource bundle
      */
     RandomProcreationMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale());
+              MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }
     //endregion Constructors
 
     //region Getters
+
     /**
      * @return The tooltip text associated with the current instance of the class.
      */
@@ -79,11 +84,11 @@ public enum RandomProcreationMethod {
     //endregion Getters
 
     //region Boolean Comparison Methods
+
     /**
      * Checks if the current {@link RandomProcreationMethod} is {@code NONE}.
      *
-     * @return {@code true} if the current {@link RandomProcreationMethod} is {@code NONE},
-     * {@code false} otherwise.
+     * @return {@code true} if the current {@link RandomProcreationMethod} is {@code NONE}, {@code false} otherwise.
      */
     public boolean isNone() {
         return this == NONE;
@@ -92,8 +97,8 @@ public enum RandomProcreationMethod {
     /**
      * Checks if the current {@link RandomProcreationMethod} is {@code DICE_ROLL}.
      *
-     * @return {@code true} if the current {@link RandomProcreationMethod} is {@code DICE_ROLL},
-     * {@code false} otherwise.
+     * @return {@code true} if the current {@link RandomProcreationMethod} is {@code DICE_ROLL}, {@code false}
+     *       otherwise.
      */
     public boolean isDiceRoll() {
         return this == DICE_ROLL;
@@ -102,6 +107,7 @@ public enum RandomProcreationMethod {
 
     /**
      * @param options the {@link CampaignOptions} object used to initialize the {@link AbstractProcreation} instance
+     *
      * @return an instance of {@link AbstractProcreation} based on the {@link RandomProcreationMethod}
      */
     public AbstractProcreation getMethod(final CampaignOptions options) {
@@ -111,6 +117,66 @@ public enum RandomProcreationMethod {
             return new DisabledRandomProcreation(options);
         }
     }
+
+    /**
+     * Converts a string representation to a {@link RandomProcreationMethod} enum value.
+     *
+     * <p>This method attempts to parse the input string in several different ways:</p>
+     * <ul>
+     *   <li>First, it tries to match the string as an enum constant (converting to uppercase
+     *       and replacing spaces with underscores)</li>
+     *   <li>Next, it checks if the string matches any enum name directly (case-insensitive)</li>
+     *   <li>Finally, it attempts to parse the string as an integer ordinal value</li>
+     * </ul>
+     *
+     * <p>If all conversion attempts fail, it returns the {@link #NONE} value.</p>
+     *
+     * @param text the string to convert, which may be the enum name (with or without spaces), or its ordinal value as a
+     *             string
+     *
+     * @return the corresponding {@link RandomProcreationMethod}, or {@link #NONE} if the string could not be converted
+     *
+     * @author Illiani
+     * @since 0.50.05
+     */
+    public static RandomProcreationMethod fromString(String text) {
+        // Return NONE for null or empty strings
+        if ((text == null) || text.isEmpty()) {
+            logger.error("Null or empty string passed to RandomProcreationMethod.fromString: {}", text);
+            return NONE;
+        }
+
+        // String value (uppercase with underscores)
+        try {
+            return RandomProcreationMethod.valueOf(text.toUpperCase().replace(" ", "_"));
+        } catch (Exception ignored) {
+        }
+
+        // Display name matching
+        for (RandomProcreationMethod method : RandomProcreationMethod.values()) {
+            if (method.toString().equalsIgnoreCase(text)) {
+                return method;
+            }
+        }
+
+        // Name comparison
+        for (RandomProcreationMethod method : RandomProcreationMethod.values()) {
+            if (method.name().equalsIgnoreCase(text)) {
+                return method;
+            }
+        }
+
+        // Ordinal value
+        try {
+            return RandomProcreationMethod.values()[MathUtility.parseInt(text.trim())];
+        } catch (Exception ignored) {
+        }
+
+        // Log error and return default
+        logger.error("Unknown RandomProcreationMethod: {} - returning {}.", text, NONE);
+        return NONE;
+    }
+
 
     @Override
     public String toString() {

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomProcreationMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomProcreationMethodTest.java
@@ -27,14 +27,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import mekhq.MekHQ;
-import mekhq.campaign.CampaignOptions;
-import mekhq.campaign.personnel.procreation.DisabledRandomProcreation;
-import mekhq.campaign.personnel.procreation.RandomProcreation;
-import org.junit.jupiter.api.Test;
-
-import java.util.ResourceBundle;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -42,21 +34,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ResourceBundle;
+
+import mekhq.MekHQ;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.personnel.procreation.DisabledRandomProcreation;
+import mekhq.campaign.personnel.procreation.RandomProcreation;
+import org.junit.jupiter.api.Test;
+
 public class RandomProcreationMethodTest {
     //region Variable Declarations
     private static final RandomProcreationMethod[] methods = RandomProcreationMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale());
+          MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters
     @Test
     public void testGetToolTipText() {
         assertEquals(resources.getString("RandomProcreationMethod.NONE.toolTipText"),
-                RandomProcreationMethod.NONE.getToolTipText());
+              RandomProcreationMethod.NONE.getToolTipText());
         assertEquals(resources.getString("RandomProcreationMethod.DICE_ROLL.toolTipText"),
-                RandomProcreationMethod.DICE_ROLL.getToolTipText());
+              RandomProcreationMethod.DICE_ROLL.getToolTipText());
     }
     //endregion Getters
 
@@ -101,9 +101,24 @@ public class RandomProcreationMethodTest {
 
     @Test
     public void testToStringOverride() {
-        assertEquals(resources.getString("RandomProcreationMethod.NONE.text"),
-                RandomProcreationMethod.NONE.toString());
+        assertEquals(resources.getString("RandomProcreationMethod.NONE.text"), RandomProcreationMethod.NONE.toString());
         assertEquals(resources.getString("RandomProcreationMethod.DICE_ROLL.text"),
-                RandomProcreationMethod.DICE_ROLL.toString());
+              RandomProcreationMethod.DICE_ROLL.toString());
+    }
+
+    @Test
+    public void testFromString() {
+        assertEquals(RandomProcreationMethod.NONE, RandomProcreationMethod.fromString("NONE"));
+        assertEquals(RandomProcreationMethod.DICE_ROLL, RandomProcreationMethod.fromString("DICE_ROLL"));
+        assertEquals(RandomProcreationMethod.NONE, RandomProcreationMethod.fromString("none"));
+        assertEquals(RandomProcreationMethod.DICE_ROLL, RandomProcreationMethod.fromString("dice_roll"));
+    }
+
+    @Test
+    public void testFromStringInvalidInput() {
+        assertEquals(RandomProcreationMethod.NONE, RandomProcreationMethod.fromString(null));
+        assertEquals(RandomProcreationMethod.NONE, RandomProcreationMethod.fromString(""));
+        assertEquals(RandomProcreationMethod.NONE, RandomProcreationMethod.fromString("INVALID_VALUE"));
+        assertEquals(RandomProcreationMethod.NONE, RandomProcreationMethod.fromString("123"));
     }
 }


### PR DESCRIPTION
- Implemented a `fromString` method in `RandomProcreationMethod` for parsing string input into the corresponding enum value.
  - Supports matching by enum constant, case-insensitive alias, or ordinal value.
  - Defaults to `NONE` for unrecognized input.
  - Logs a warning when an unknown method is encountered.
- Updated `CampaignOptions` to use `fromString` for safer parsing of `randomProcreationMethod`.

### Dev Notes
Fixes a log error when loading old campaigns with `RandomProcreationMethod ` set to a value that no longer exists.