### PR TITLE
Fixed Error On Loading Campaign That Predates Combat Teams

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -28,6 +28,23 @@
  */
 package mekhq.campaign.force;
 
+import static megamek.common.Entity.ETYPE_AEROSPACEFIGHTER;
+import static megamek.common.Entity.ETYPE_MEK;
+import static megamek.common.Entity.ETYPE_PROTOMEK;
+import static megamek.common.Entity.ETYPE_TANK;
+import static megamek.common.EntityWeightClass.WEIGHT_ULTRA_LIGHT;
+import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_NONE;
+import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_TRUE;
+import static mekhq.campaign.force.ForceType.STANDARD;
+import static mekhq.campaign.force.FormationLevel.LANCE;
+
+import java.io.PrintWriter;
+import java.time.LocalDate;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.UUID;
+
+import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
@@ -46,31 +63,13 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
 import mekhq.utilities.MHQXMLUtility;
-import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import java.io.PrintWriter;
-import java.time.LocalDate;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.UUID;
-
-import static megamek.common.Entity.ETYPE_AEROSPACEFIGHTER;
-import static megamek.common.Entity.ETYPE_MEK;
-import static megamek.common.Entity.ETYPE_PROTOMEK;
-import static megamek.common.Entity.ETYPE_TANK;
-import static megamek.common.EntityWeightClass.WEIGHT_ULTRA_LIGHT;
-import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_NONE;
-import static mekhq.campaign.force.Force.COMBAT_TEAM_OVERRIDE_TRUE;
-import static mekhq.campaign.force.ForceType.STANDARD;
-import static mekhq.campaign.force.FormationLevel.LANCE;
-
 /**
- * Used by Against the Bot &amp; StratCon to track additional information about each force
- * on the TO&amp;E that has at least one unit assigned. Extra info includes whether
- * the force counts as a Combat Team eligible for assignment to a scenario role
- * and what the assignment is on which contract.
+ * Used by Against the Bot &amp; StratCon to track additional information about each force on the TO&amp;E that has at
+ * least one unit assigned. Extra info includes whether the force counts as a Combat Team eligible for assignment to a
+ * scenario role and what the assignment is on which contract.
  *
  * @author Neoancient
  */
@@ -90,11 +89,11 @@ public class CombatTeam {
     private UUID commanderId;
 
     /**
-     * Determines the standard size for a given faction. The size varies depending on whether the
-     * faction is a Clan, ComStar/WoB, or others (Inner Sphere). This overloaded method defaults to
-     * Lance/Star/Level II
+     * Determines the standard size for a given faction. The size varies depending on whether the faction is a Clan,
+     * ComStar/WoB, or others (Inner Sphere). This overloaded method defaults to Lance/Star/Level II
      *
      * @param faction The {@link Faction} object for which the standard force size is to be calculated.
+     *
      * @return The standard force size, at the provided formation level, for the provided faction
      */
     public static int getStandardForceSize(Faction faction) {
@@ -102,12 +101,13 @@ public class CombatTeam {
     }
 
     /**
-     * Determines the standard size for a given faction. The size varies depending on whether the
-     * faction is a Clan, ComStar/WoB, or others (Inner Sphere).
+     * Determines the standard size for a given faction. The size varies depending on whether the faction is a Clan,
+     * ComStar/WoB, or others (Inner Sphere).
      *
-     * @param faction The {@link Faction} object for which the standard force size is to be calculated.
-     * @param formationLevelDepth The {@link FormationLevel} {@code Depth} from which the standard
-     *                           force size is to be calculated.
+     * @param faction             The {@link Faction} object for which the standard force size is to be calculated.
+     * @param formationLevelDepth The {@link FormationLevel} {@code Depth} from which the standard force size is to be
+     *                            calculated.
+     *
      * @return The standard force size, at the provided formation level, for the provided faction
      */
     public static int getStandardForceSize(Faction faction, int formationLevelDepth) {
@@ -141,16 +141,15 @@ public class CombatTeam {
     /**
      * Default constructor
      */
-    public CombatTeam() {}
+    public CombatTeam() {
+    }
 
     public CombatTeam(int forceId, Campaign campaign) {
         this.forceId = forceId;
         role = CombatRole.RESERVE;
         missionId = -1;
         for (AtBContract contract : campaign.getActiveAtBContracts()) {
-            missionId = ((contract.getParentContract() == null)
-                    ? contract
-                    : contract.getParentContract()).getId();
+            missionId = ((contract.getParentContract() == null) ? contract : contract.getParentContract()).getId();
         }
         commanderId = findCommander(this.forceId, campaign);
     }
@@ -327,14 +326,14 @@ public class CombatTeam {
         if (campaign.getCampaignOptions().isLimitLanceNumUnits()) {
             int size = getSize(campaign);
             if (size < getStandardForceSize(campaign.getFaction()) - 1 ||
-                    size > getStandardForceSize(campaign.getFaction()) + 2) {
+                      size > getStandardForceSize(campaign.getFaction()) + 2) {
                 force.setCombatTeamStatus(false);
                 return false;
             }
         }
 
         if (campaign.getCampaignOptions().isLimitLanceWeight() &&
-                getWeightClass(campaign) > EntityWeightClass.WEIGHT_ASSAULT) {
+                  getWeightClass(campaign) > EntityWeightClass.WEIGHT_ASSAULT) {
             force.setCombatTeamStatus(false);
             return false;
         }
@@ -399,22 +398,24 @@ public class CombatTeam {
 
     public AtBScenario checkForBattle(Campaign campaign) {
         // Make sure there is a battle first
-        if ((campaign.getCampaignOptions().getAtBBattleChance(role, true) == 0)
-                || (Compute.randomInt(100) > campaign.getCampaignOptions().getAtBBattleChance(role, true))) {
+        if ((campaign.getCampaignOptions().getAtBBattleChance(role, true) == 0) ||
+                  (Compute.randomInt(100) > campaign.getCampaignOptions().getAtBBattleChance(role, true))) {
             // No battle
             return null;
         }
 
         // if we are using StratCon, don't *also* generate legacy scenarios
         if (campaign.getCampaignOptions().isUseStratCon() &&
-                (getContract(campaign).getStratconCampaignState() != null)) {
+                  (getContract(campaign).getStratconCampaignState() != null)) {
             return null;
         }
 
         int roll;
         // thresholds are coded from charts with 1-100 range, so we add 1 to mod to
         // adjust 0-based random int
-        int battleTypeMod = 1 + (AtBMoraleLevel.STALEMATE.ordinal() - getContract(campaign).getMoraleLevel().ordinal()) * 5;
+        int battleTypeMod = 1 +
+                                  (AtBMoraleLevel.STALEMATE.ordinal() -
+                                         getContract(campaign).getMoraleLevel().ordinal()) * 5;
         battleTypeMod += getContract(campaign).getBattleTypeMod();
 
         // debugging code that will allow you to force the generation of a particular
@@ -436,144 +437,204 @@ public class CombatTeam {
             case MANEUVER: {
                 roll = Compute.randomInt(40) + battleTypeMod;
                 if (roll < 1) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.BASEATTACK, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.BASEATTACK,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 9) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.BREAKTHROUGH, true,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.BREAKTHROUGH,
+                          true,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 17) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.STANDUP, true,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.STANDUP,
+                          true,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 25) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.STANDUP, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.STANDUP,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 33) {
                     if (campaign.getCampaignOptions().isGenerateChases()) {
-                        return AtBScenarioFactory.createScenario(campaign, this,
-                                AtBScenario.CHASE, false,
-                                getBattleDate(campaign.getLocalDate()));
+                        return AtBScenarioFactory.createScenario(campaign,
+                              this,
+                              AtBScenario.CHASE,
+                              false,
+                              getBattleDate(campaign.getLocalDate()));
                     } else {
-                        return AtBScenarioFactory.createScenario(campaign, this,
-                                AtBScenario.HOLDTHELINE, false,
-                                getBattleDate(campaign.getLocalDate()));
+                        return AtBScenarioFactory.createScenario(campaign,
+                              this,
+                              AtBScenario.HOLDTHELINE,
+                              false,
+                              getBattleDate(campaign.getLocalDate()));
                     }
                 } else if (roll < 41) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.HOLDTHELINE, true,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.HOLDTHELINE,
+                          true,
+                          getBattleDate(campaign.getLocalDate()));
                 } else {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.BASEATTACK, true,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.BASEATTACK,
+                          true,
+                          getBattleDate(campaign.getLocalDate()));
                 }
             }
             case PATROL: {
                 roll = Compute.randomInt(60) + battleTypeMod;
                 if (roll < 1) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.BASEATTACK, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.BASEATTACK,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 11) {
                     if (campaign.getCampaignOptions().isGenerateChases()) {
-                        return AtBScenarioFactory.createScenario(campaign, this,
-                                AtBScenario.CHASE, true,
-                                getBattleDate(campaign.getLocalDate()));
+                        return AtBScenarioFactory.createScenario(campaign,
+                              this,
+                              AtBScenario.CHASE,
+                              true,
+                              getBattleDate(campaign.getLocalDate()));
                     } else {
-                        return AtBScenarioFactory.createScenario(campaign, this,
-                                AtBScenario.HIDEANDSEEK, false,
-                                getBattleDate(campaign.getLocalDate()));
+                        return AtBScenarioFactory.createScenario(campaign,
+                              this,
+                              AtBScenario.HIDEANDSEEK,
+                              false,
+                              getBattleDate(campaign.getLocalDate()));
                     }
                 } else if (roll < 21) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.HIDEANDSEEK, true,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.HIDEANDSEEK,
+                          true,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 31) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.PROBE, true,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.PROBE,
+                          true,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 41) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.PROBE, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.PROBE,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 51) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.EXTRACTION, true,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.EXTRACTION,
+                          true,
+                          getBattleDate(campaign.getLocalDate()));
                 } else {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.RECONRAID, true,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.RECONRAID,
+                          true,
+                          getBattleDate(campaign.getLocalDate()));
                 }
             }
             case FRONTLINE: {
                 roll = Compute.randomInt(20) + battleTypeMod;
                 if (roll < 1) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.BASEATTACK, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.BASEATTACK,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 5) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.HOLDTHELINE, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.HOLDTHELINE,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 9) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.RECONRAID, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.RECONRAID,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 13) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.EXTRACTION, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.EXTRACTION,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 17) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.HIDEANDSEEK, true,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.HIDEANDSEEK,
+                          true,
+                          getBattleDate(campaign.getLocalDate()));
                 } else {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.BREAKTHROUGH, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.BREAKTHROUGH,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 }
             }
             case TRAINING: {
                 roll = Compute.randomInt(10) + battleTypeMod;
                 if (roll < 1) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.BASEATTACK, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.BASEATTACK,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 3) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.HOLDTHELINE, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.HOLDTHELINE,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 5) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.BREAKTHROUGH, true,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.BREAKTHROUGH,
+                          true,
+                          getBattleDate(campaign.getLocalDate()));
                 } else if (roll < 7) {
                     if (campaign.getCampaignOptions().isGenerateChases()) {
-                        return AtBScenarioFactory.createScenario(campaign, this,
-                                AtBScenario.CHASE, true,
-                                getBattleDate(campaign.getLocalDate()));
+                        return AtBScenarioFactory.createScenario(campaign,
+                              this,
+                              AtBScenario.CHASE,
+                              true,
+                              getBattleDate(campaign.getLocalDate()));
                     } else {
-                        return AtBScenarioFactory.createScenario(campaign, this,
-                                AtBScenario.BREAKTHROUGH, false,
-                                getBattleDate(campaign.getLocalDate()));
+                        return AtBScenarioFactory.createScenario(campaign,
+                              this,
+                              AtBScenario.BREAKTHROUGH,
+                              false,
+                              getBattleDate(campaign.getLocalDate()));
                     }
                 } else if (roll < 9) {
-                    return AtBScenarioFactory.createScenario(campaign, this,
-                            AtBScenario.HIDEANDSEEK, false,
-                            getBattleDate(campaign.getLocalDate()));
+                    return AtBScenarioFactory.createScenario(campaign,
+                          this,
+                          AtBScenario.HIDEANDSEEK,
+                          false,
+                          getBattleDate(campaign.getLocalDate()));
                 } else {
                     if (campaign.getCampaignOptions().isGenerateChases()) {
-                        return AtBScenarioFactory.createScenario(campaign, this,
-                                AtBScenario.CHASE, false,
-                                getBattleDate(campaign.getLocalDate()));
+                        return AtBScenarioFactory.createScenario(campaign,
+                              this,
+                              AtBScenario.CHASE,
+                              false,
+                              getBattleDate(campaign.getLocalDate()));
                     } else {
-                        return AtBScenarioFactory.createScenario(campaign, this,
-                                AtBScenario.HOLDTHELINE, false,
-                                getBattleDate(campaign.getLocalDate()));
+                        return AtBScenarioFactory.createScenario(campaign,
+                              this,
+                              AtBScenario.HOLDTHELINE,
+                              false,
+                              getBattleDate(campaign.getLocalDate()));
                     }
                 }
             }
@@ -594,20 +655,19 @@ public class CombatTeam {
 
     public static CombatTeam generateInstanceFromXML(Node wn) {
         CombatTeam retVal = null;
-        NamedNodeMap attrs = wn.getAttributes();
-        Node classNameNode = attrs.getNamedItem("type");
-        String className = classNameNode.getTextContent();
         try {
-            retVal = (CombatTeam) Class.forName(className).newInstance();
+            retVal = new CombatTeam();
             NodeList nl = wn.getChildNodes();
 
             for (int x = 0; x < nl.getLength(); x++) {
                 Node wn2 = nl.item(x);
 
                 if (wn2.getNodeName().equalsIgnoreCase("forceId")) {
+                    // We're not using MathUtility here because there is no good fallback value.
+                    // If this breaks, we need it to break loudly so we immediately notice
                     retVal.forceId = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("missionId")) {
-                    retVal.missionId = Integer.parseInt(wn2.getTextContent());
+                    retVal.missionId = MathUtility.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("role")) {
                     retVal.setRole(CombatRole.parseFromString(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("commanderId")) {
@@ -623,8 +683,9 @@ public class CombatTeam {
     /**
      * Worker function that calculates the total weight of a force with the given ID
      *
-     * @param campaign       Campaign in which the force resides
-     * @param forceId        Force for which to calculate weight
+     * @param campaign Campaign in which the force resides
+     * @param forceId  Force for which to calculate weight
+     *
      * @return Total force weight
      */
     public static double calculateTotalWeight(Campaign campaign, int forceId) {
@@ -662,9 +723,8 @@ public class CombatTeam {
     }
 
     /**
-     * This static method updates the combat teams across the campaign.
-     * It starts at the top level force, and calculates the combat teams for each sub-force.
-     * It keeps only the eligible combat teams and imports them into the campaign.
+     * This static method updates the combat teams across the campaign. It starts at the top level force, and calculates
+     * the combat teams for each sub-force. It keeps only the eligible combat teams and imports them into the campaign.
      * After every formation is processed, an 'OrganizationChangedEvent' is triggered by that force.
      *
      * @param campaign the current campaign.
@@ -683,7 +743,7 @@ public class CombatTeam {
             }
 
             force.setCombatTeamStatus(isEligible);
-        // Otherwise, create a new formation and then add it to the table, if appropriate
+            // Otherwise, create a new formation and then add it to the table, if appropriate
         } else {
             combatTeam = new CombatTeam(0, campaign);
             boolean isEligible = combatTeam.isEligible(campaign);
@@ -701,21 +761,17 @@ public class CombatTeam {
     }
 
     /**
-     * This method is used to update the combat teams for the campaign working downwards
-     * from a specified node, through all of its sub-forces.
-     * It creates a new {@link CombatTeam} for each sub-force and checks its eligibility.
-     * Eligible formations are imported into the campaign, and the combat team status of
-     * the respective force is set to {@code true}.
-     * After every force is processed, an 'OrganizationChangedEvent' is triggered.
-     * This function runs recursively on each sub-force, effectively traversing the complete TO&E.
+     * This method is used to update the combat teams for the campaign working downwards from a specified node, through
+     * all of its sub-forces. It creates a new {@link CombatTeam} for each sub-force and checks its eligibility.
+     * Eligible formations are imported into the campaign, and the combat team status of the respective force is set to
+     * {@code true}. After every force is processed, an 'OrganizationChangedEvent' is triggered. This function runs
+     * recursively on each sub-force, effectively traversing the complete TO&E.
      *
-     * @param campaign the current {@link Campaign}.
-     * @param workingNode the {@link Force} node from which the method starts working down through
-     *                   all its sub-forces.
+     * @param campaign    the current {@link Campaign}.
+     * @param workingNode the {@link Force} node from which the method starts working down through all its sub-forces.
      */
     private static void recalculateSubForceStrategicStatus(Campaign campaign,
-                                                           Hashtable<Integer, CombatTeam> combatTeamsTable,
-                                                           Force workingNode) {
+          Hashtable<Integer, CombatTeam> combatTeamsTable, Force workingNode) {
 
         for (Force force : workingNode.getSubForces()) {
             int forceId = force.getId();
@@ -730,7 +786,7 @@ public class CombatTeam {
                 }
 
                 force.setCombatTeamStatus(isEligible);
-            // Otherwise, create a new formation and then add it to the table, if appropriate
+                // Otherwise, create a new formation and then add it to the table, if appropriate
             } else {
                 combatTeam = new CombatTeam(forceId, campaign);
                 boolean isEligible = combatTeam.isEligible(campaign);
@@ -752,12 +808,12 @@ public class CombatTeam {
      * Retrieves the force associated with the given campaign using the stored force ID.
      *
      * <p>
-     * This method returns a {@link Force} object corresponding to the stored {@code forceId},
-     * if it exists within the specified campaign. If no matching force is found, {@code null}
-     * is returned.
+     * This method returns a {@link Force} object corresponding to the stored {@code forceId}, if it exists within the
+     * specified campaign. If no matching force is found, {@code null} is returned.
      * </p>
      *
      * @param campaign the campaign containing the forces to search for the specified {@code forceId}
+     *
      * @return the {@link Force} object associated with the {@code forceId}, or {@code null} if not found
      */
     public @Nullable Force getForce(Campaign campaign) {


### PR DESCRIPTION
- Removed reflection-based `Class.forName` usage in `generateInstanceFromXML` for `CombatTeam` creation.
- Replaced with direct instantiation of `CombatTeam` to remove runtime errors.

### Dev Notes
This just fixes the loading of combat teams in campaigns that predate Combat Teams as a _thing_. The failure didn't actually cause any problems, but it did throw up all over the log so with us hoping 50.05 will make Milestone I figured it was worth tidying up.