### PR TITLE
Bay package move, instanceof chain removal

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -28,6 +28,30 @@
  */
 package mekhq;
 
+import static java.lang.Math.max;
+import static mekhq.campaign.personnel.skills.SkillType.EXP_ELITE;
+import static mekhq.campaign.personnel.skills.SkillType.EXP_GREEN;
+import static mekhq.campaign.personnel.skills.SkillType.EXP_NONE;
+import static mekhq.campaign.personnel.skills.SkillType.EXP_REGULAR;
+import static mekhq.campaign.personnel.skills.SkillType.EXP_ULTRA_GREEN;
+import static mekhq.campaign.personnel.skills.SkillType.EXP_VETERAN;
+
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FilenameFilter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+import javax.swing.JTable;
+import javax.swing.table.TableModel;
+
 import megamek.client.Client;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.codeUtilities.MathUtility;
@@ -35,6 +59,13 @@ import megamek.codeUtilities.ObjectUtility;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
+import megamek.common.bays.ASFBay;
+import megamek.common.bays.Bay;
+import megamek.common.bays.HeavyVehicleBay;
+import megamek.common.bays.InfantryBay;
+import megamek.common.bays.LightVehicleBay;
+import megamek.common.bays.SmallCraftBay;
+import megamek.common.bays.SuperHeavyVehicleBay;
 import megamek.common.enums.Gender;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.options.IOption;
@@ -45,9 +76,9 @@ import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.mission.IPlayerSettings;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.Phenotype;
+import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.unit.CrewType;
 import mekhq.campaign.unit.ITransportAssignment;
 import mekhq.campaign.unit.Unit;
@@ -55,21 +86,6 @@ import mekhq.campaign.unit.UnitTechProgression;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.w3c.dom.Node;
-
-import javax.swing.*;
-import javax.swing.table.TableModel;
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.function.Consumer;
-
-import static java.lang.Math.max;
-import static mekhq.campaign.personnel.skills.SkillType.*;
 
 public class Utilities {
     private static final MMLogger logger = MMLogger.create(Utilities.class);
@@ -79,7 +95,7 @@ public class Utilities {
     }
 
     private static final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.Utilities",
-            MekHQ.getMHQOptions().getLocale());
+          MekHQ.getMHQOptions().getLocale());
 
     // A couple of arrays for use in the getLevelName() method
     private static final int[] arabicNumbers = { 1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1 };
@@ -116,8 +132,9 @@ public class Utilities {
         final Vector<AmmoType> munitions = AmmoType.getMunitionsFor(currentAmmoType.getAmmoType());
         if (munitions == null) {
             String message = String.format(
-                    "Cannot getMunitions for %s because of a null munitions list for ammo type %d",
-                    entity.getDisplayName(), currentAmmoType.getAmmoType());
+                  "Cannot getMunitions for %s because of a null munitions list for ammo type %d",
+                  entity.getDisplayName(),
+                  currentAmmoType.getAmmoType());
             logger.error(message);
             return Collections.emptyList();
         }
@@ -127,9 +144,10 @@ public class Utilities {
             // this is an abbreviated version of setupMunitions in the CustomMekDialog
             // TODO : clan/IS limitations?
 
-            if ((entity instanceof Aero)
-                    && !ammoType.canAeroUse(entity.getGame().getOptions()
-                            .booleanOption(OptionsConstants.ADVAERORULES_AERO_ARTILLERY_MUNITIONS))) {
+            if ((entity instanceof Aero) &&
+                      !ammoType.canAeroUse(entity.getGame()
+                                                 .getOptions()
+                                                 .booleanOption(OptionsConstants.ADVAERORULES_AERO_ARTILLERY_MUNITIONS))) {
                 continue;
             }
 
@@ -139,36 +157,37 @@ public class Utilities {
             }
 
             if ((techLvl < Utilities.getSimpleTechLevel(lvl)) ||
-                    (TechConstants.isClan(currentAmmoType.getTechLevel(entity.getTechLevelYear())) != TechConstants
-                            .isClan(lvl))) {
+                      (TechConstants.isClan(currentAmmoType.getTechLevel(entity.getTechLevelYear())) !=
+                             TechConstants.isClan(lvl))) {
                 continue;
             }
 
-            // Only Protos can use Proto-specific ammo
+            // Only ProtoMeks can use Proto-specific ammo
             if (ammoType.hasFlag(AmmoType.F_PROTOMEK) && !(entity instanceof ProtoMek)) {
                 continue;
             }
 
-            // When dealing with machine guns, Protos can only use proto-specific machine
+            // When dealing with machine guns, ProtoMeks can only use proto-specific machine
             // gun ammo
-            if ((entity instanceof ProtoMek)
-                    && ammoType.hasFlag(AmmoType.F_MG)
-                    && !ammoType.hasFlag(AmmoType.F_PROTOMEK)) {
+            if ((entity instanceof ProtoMek) &&
+                      ammoType.hasFlag(AmmoType.F_MG) &&
+                      !ammoType.hasFlag(AmmoType.F_PROTOMEK)) {
                 continue;
             }
 
-            if (ammoType.hasFlag(AmmoType.F_NUCLEAR) && ammoType.hasFlag(AmmoType.F_CAP_MISSILE)
-                    && !entity.getGame().getOptions().booleanOption(OptionsConstants.ADVAERORULES_AT2_NUKES)) {
+            if (ammoType.hasFlag(AmmoType.F_NUCLEAR) &&
+                      ammoType.hasFlag(AmmoType.F_CAP_MISSILE) &&
+                      !entity.getGame().getOptions().booleanOption(OptionsConstants.ADVAERORULES_AT2_NUKES)) {
                 continue;
             }
 
             // Battle Armor ammo can't be selected at all.
             // All other ammo types need to match on rack size and tech.
-            if ((ammoType.getRackSize() == currentAmmoType.getRackSize())
-                    && (ammoType.hasFlag(AmmoType.F_BATTLEARMOR) == currentAmmoType.hasFlag(AmmoType.F_BATTLEARMOR))
-                    && (ammoType.hasFlag(AmmoType.F_ENCUMBERING) == currentAmmoType.hasFlag(AmmoType.F_ENCUMBERING))
-                    && ((ammoType.getTonnage(entity) == currentAmmoType.getTonnage(entity))
-                            || ammoType.hasFlag(AmmoType.F_CAP_MISSILE))) {
+            if ((ammoType.getRackSize() == currentAmmoType.getRackSize()) &&
+                      (ammoType.hasFlag(AmmoType.F_BATTLEARMOR) == currentAmmoType.hasFlag(AmmoType.F_BATTLEARMOR)) &&
+                      (ammoType.hasFlag(AmmoType.F_ENCUMBERING) == currentAmmoType.hasFlag(AmmoType.F_ENCUMBERING)) &&
+                      ((ammoType.getTonnage(entity) == currentAmmoType.getTonnage(entity)) ||
+                             ammoType.hasFlag(AmmoType.F_CAP_MISSILE))) {
                 ammoTypes.add(ammoType);
             }
         }
@@ -176,11 +195,11 @@ public class Utilities {
     }
 
     /**
-     * Returns the last file modified in a directory and all subdirectories
-     * that conforms to a FilenameFilter
+     * Returns the last file modified in a directory and all subdirectories that conforms to a FilenameFilter
      *
      * @param dir    direction name
      * @param filter filter for the file's name
+     *
      * @return the last file modified in that dir that fits the filter
      */
     public static @Nullable File lastFileModified(String dir, FilenameFilter filter) {
@@ -221,6 +240,10 @@ public class Utilities {
         return choice;
     }
 
+    /**
+     * @deprecated no indicated uses.
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     public static File[] getAllFiles(String dir, FilenameFilter filter) {
         File fl = new File(dir);
         return fl.listFiles(filter);
@@ -231,13 +254,13 @@ public class Utilities {
 
         for (MekSummary summary : MekSummaryCache.getInstance().getAllMeks()) {
             // If this isn't the same chassis, is our current unit, we continue
-            if (!en.getChassis().equalsIgnoreCase(summary.getChassis())
-                    || en.getModel().equalsIgnoreCase(summary.getModel())
-                    || !summary.getUnitType().equals(UnitType.getTypeName(en.getUnitType()))) {
+            if (!en.getChassis().equalsIgnoreCase(summary.getChassis()) ||
+                      en.getModel().equalsIgnoreCase(summary.getModel()) ||
+                      !summary.getUnitType().equals(UnitType.getTypeName(en.getUnitType()))) {
                 continue;
             }
 
-            // Weight of the two units must match or we continue, but BA weight gets checked
+            // Weight of the two units must match, or we continue, but BA weight gets checked
             // differently
             if (en instanceof BattleArmor battleArmor) {
                 if (battleArmor.getTroopers() != (int) summary.getTWweight()) {
@@ -256,8 +279,8 @@ public class Utilities {
                 // calculating the progression. In such a case we will log it and take the least
                 // restrictive action, which is to let it through.
                 String message = String.format(
-                        "Could not determine tech progression for %s, including among available refits.",
-                        summary.getName());
+                      "Could not determine tech progression for %s, including among available refits.",
+                      summary.getName());
                 logger.warn(message);
             } else if (!campaign.isLegal(techProg)) {
                 continue;
@@ -275,9 +298,9 @@ public class Utilities {
             return false;
         } else if (entity1.getClass() != entity2.getClass()) {
             return false;
-        } else if ((entity1.getEngine().getRating() != entity2.getEngine().getRating())
-                || (entity1.getEngine().getEngineType() != entity2.getEngine().getEngineType())
-                || (entity1.getEngine().getFlags() != entity2.getEngine().getFlags())) {
+        } else if ((entity1.getEngine().getRating() != entity2.getEngine().getRating()) ||
+                         (entity1.getEngine().getEngineType() != entity2.getEngine().getEngineType()) ||
+                         (entity1.getEngine().getFlags() != entity2.getEngine().getFlags())) {
             return false;
         } else if (entity1.getStructureType() != entity2.getStructureType()) {
             return false;
@@ -300,38 +323,37 @@ public class Utilities {
         }
         List<EquipmentType> fixedEquipment = new ArrayList<>();
         for (int loc = 0; loc < entity1.locations(); loc++) {
-            if ((entity1.getArmorType(loc) != entity2.getArmorType(loc))
-                    || (entity1.getOArmor(loc) != entity2.getOArmor(loc))) {
+            if ((entity1.getArmorType(loc) != entity2.getArmorType(loc)) ||
+                      (entity1.getOArmor(loc) != entity2.getOArmor(loc))) {
                 return false;
             }
             // Go through the base entity and make a list of all fixed equipment in this
             // location.
             for (int slot = 0; slot < entity1.getNumberOfCriticals(loc); slot++) {
-                CriticalSlot crit = entity1.getCritical(loc, slot);
-                if ((null != crit) && (crit.getType() == CriticalSlot.TYPE_EQUIPMENT)
-                        && (null != crit.getMount())) {
-                    if (!crit.getMount().isOmniPodMounted()) {
-                        fixedEquipment.add(crit.getMount().getType());
-                        if (null != crit.getMount2()) {
-                            fixedEquipment.add(crit.getMount2().getType());
+                CriticalSlot criticalSlot = entity1.getCritical(loc, slot);
+                if ((null != criticalSlot) &&
+                          (criticalSlot.getType() == CriticalSlot.TYPE_EQUIPMENT) &&
+                          (null != criticalSlot.getMount())) {
+                    if (!criticalSlot.getMount().isOmniPodMounted()) {
+                        fixedEquipment.add(criticalSlot.getMount().getType());
+                        if (null != criticalSlot.getMount2()) {
+                            fixedEquipment.add(criticalSlot.getMount2().getType());
                         }
                     }
                 }
             }
-            // Go through the critical slots in this location for the second entity and
-            // remove all
-            // fixed equipment from the list. If not found or something is left over, there
-            // is a
-            // fixed equipment difference.
+            // Go through the critical slots in this location for the second entity and remove all fixed equipment
+            // from the list. If not found or something is left over, there is a fixed equipment difference.
             for (int slot = 0; slot < entity2.getNumberOfCriticals(loc); slot++) {
-                CriticalSlot crit = entity1.getCritical(loc, slot);
-                if ((crit != null) && (crit.getType() == CriticalSlot.TYPE_EQUIPMENT)
-                        && (crit.getMount() != null)) {
-                    if (!crit.getMount().isOmniPodMounted()) {
-                        if (!fixedEquipment.remove(crit.getMount().getType())) {
+                CriticalSlot criticalSlot = entity1.getCritical(loc, slot);
+                if ((criticalSlot != null) &&
+                          (criticalSlot.getType() == CriticalSlot.TYPE_EQUIPMENT) &&
+                          (criticalSlot.getMount() != null)) {
+                    if (!criticalSlot.getMount().isOmniPodMounted()) {
+                        if (!fixedEquipment.remove(criticalSlot.getMount().getType())) {
                             return false;
-                        } else if ((crit.getMount2() != null)
-                                && !fixedEquipment.remove(crit.getMount2().getType())) {
+                        } else if ((criticalSlot.getMount2() != null) &&
+                                         !fixedEquipment.remove(criticalSlot.getMount2().getType())) {
                             return false;
                         }
                     }
@@ -346,11 +368,12 @@ public class Utilities {
     }
 
     /**
-     * Generates an experience level based on a 2d6 roll modified by the bonus
-     * value.
+     * Generates an experience level based on a 2d6 roll modified by the bonus value.
      *
      * @param bonus the bonus value to be added to the roll
+     *
      * @return the generated experience level
+     *
      * @throws IllegalStateException if the roll is not within the expected range
      */
     public static int generateExpLevel(int bonus) {
@@ -362,20 +385,14 @@ public class Utilities {
             case 6, 7, 8, 9 -> EXP_REGULAR;
             case 10, 11 -> EXP_VETERAN;
             case 12 -> EXP_ELITE;
-            default -> throw new IllegalStateException("Unexpected value in mekhq/Utilities.java/generateExpLevel: "
-                    + roll);
+            default ->
+                  throw new IllegalStateException("Unexpected value in mekhq/Utilities.java/generateExpLevel: " + roll);
         };
     }
 
     /**
-     * Simple utility function to take a specified number and randomize it a little
-     * bit
-     * roll 1d6 results in:
-     * 1: target - 2
-     * 2: target - 1
-     * 3 &amp; 4: target
-     * 5: target + 1
-     * 6: target + 2
+     * Simple utility function to take a specified number and randomize it a little bit roll 1d6 results in: 1: target -
+     * 2 2: target - 1 3 &amp; 4: target 5: target + 1 6: target + 2
      */
     public static int randomSkillFromTarget(int target) {
         int dice = Compute.d6();
@@ -391,9 +408,8 @@ public class Utilities {
         return max(target, 0);
     }
 
-    public static Map<CrewType, Collection<Person>> genRandomCrewWithCombinedSkill(Campaign c,
-            Unit u,
-            String factionCode) {
+    public static Map<CrewType, Collection<Person>> genRandomCrewWithCombinedSkill(Campaign c, Unit u,
+          String factionCode) {
         Objects.requireNonNull(c);
         Objects.requireNonNull(u);
         Objects.requireNonNull(u.getEntity(), "Unit needs to have a valid Entity attached");
@@ -418,49 +434,64 @@ public class Utilities {
             Person p;
             if (u.getEntity() instanceof LandAirMek) {
                 p = c.newPerson(PersonnelRole.LAM_PILOT, factionCode, oldCrew.getGender());
-                p.addSkill(SkillType.S_PILOT_MEK, SkillType.getType(SkillType.S_PILOT_MEK).getTarget()
-                        - oldCrew.getPiloting(), 0);
-                p.addSkill(SkillType.S_GUN_MEK, SkillType.getType(SkillType.S_GUN_MEK).getTarget()
-                        - oldCrew.getGunnery(), 0);
-                p.addSkill(SkillType.S_PILOT_AERO, SkillType.getType(SkillType.S_PILOT_AERO).getTarget()
-                        - oldCrew.getPiloting(), 0);
-                p.addSkill(SkillType.S_GUN_AERO, SkillType.getType(SkillType.S_GUN_AERO).getTarget()
-                        - oldCrew.getGunnery(), 0);
+                p.addSkill(SkillType.S_PILOT_MEK,
+                      SkillType.getType(SkillType.S_PILOT_MEK).getTarget() - oldCrew.getPiloting(),
+                      0);
+                p.addSkill(SkillType.S_GUN_MEK,
+                      SkillType.getType(SkillType.S_GUN_MEK).getTarget() - oldCrew.getGunnery(),
+                      0);
+                p.addSkill(SkillType.S_PILOT_AERO,
+                      SkillType.getType(SkillType.S_PILOT_AERO).getTarget() - oldCrew.getPiloting(),
+                      0);
+                p.addSkill(SkillType.S_GUN_AERO,
+                      SkillType.getType(SkillType.S_GUN_AERO).getTarget() - oldCrew.getGunnery(),
+                      0);
             } else if (u.getEntity() instanceof Mek) {
                 p = c.newPerson(PersonnelRole.MEKWARRIOR, factionCode, oldCrew.getGender());
-                p.addSkill(SkillType.S_PILOT_MEK, SkillType.getType(SkillType.S_PILOT_MEK).getTarget()
-                        - oldCrew.getPiloting(), 0);
-                p.addSkill(SkillType.S_GUN_MEK, SkillType.getType(SkillType.S_GUN_MEK).getTarget()
-                        - oldCrew.getGunnery(), 0);
+                p.addSkill(SkillType.S_PILOT_MEK,
+                      SkillType.getType(SkillType.S_PILOT_MEK).getTarget() - oldCrew.getPiloting(),
+                      0);
+                p.addSkill(SkillType.S_GUN_MEK,
+                      SkillType.getType(SkillType.S_GUN_MEK).getTarget() - oldCrew.getGunnery(),
+                      0);
             } else if (u.getEntity() instanceof Aero) {
                 p = c.newPerson(PersonnelRole.AEROSPACE_PILOT, factionCode, oldCrew.getGender());
-                p.addSkill(SkillType.S_PILOT_AERO, SkillType.getType(SkillType.S_PILOT_AERO).getTarget()
-                        - oldCrew.getPiloting(), 0);
-                p.addSkill(SkillType.S_GUN_AERO, SkillType.getType(SkillType.S_GUN_AERO).getTarget()
-                        - oldCrew.getGunnery(), 0);
+                p.addSkill(SkillType.S_PILOT_AERO,
+                      SkillType.getType(SkillType.S_PILOT_AERO).getTarget() - oldCrew.getPiloting(),
+                      0);
+                p.addSkill(SkillType.S_GUN_AERO,
+                      SkillType.getType(SkillType.S_GUN_AERO).getTarget() - oldCrew.getGunnery(),
+                      0);
             } else if (u.getEntity() instanceof ConvFighter) {
                 p = c.newPerson(PersonnelRole.CONVENTIONAL_AIRCRAFT_PILOT, factionCode, oldCrew.getGender());
-                p.addSkill(SkillType.S_PILOT_JET, SkillType.getType(SkillType.S_PILOT_JET).getTarget()
-                        - oldCrew.getPiloting(), 0);
-                p.addSkill(SkillType.S_GUN_JET, SkillType.getType(SkillType.S_GUN_JET).getTarget()
-                        - oldCrew.getPiloting(), 0);
+                p.addSkill(SkillType.S_PILOT_JET,
+                      SkillType.getType(SkillType.S_PILOT_JET).getTarget() - oldCrew.getPiloting(),
+                      0);
+                p.addSkill(SkillType.S_GUN_JET,
+                      SkillType.getType(SkillType.S_GUN_JET).getTarget() - oldCrew.getPiloting(),
+                      0);
             } else if (u.getEntity() instanceof ProtoMek) {
                 p = c.newPerson(PersonnelRole.PROTOMEK_PILOT, factionCode, oldCrew.getGender());
-                p.addSkill(SkillType.S_GUN_PROTO, SkillType.getType(SkillType.S_GUN_PROTO).getTarget()
-                        - oldCrew.getGunnery(), 0);
+                p.addSkill(SkillType.S_GUN_PROTO,
+                      SkillType.getType(SkillType.S_GUN_PROTO).getTarget() - oldCrew.getGunnery(),
+                      0);
             } else if (u.getEntity() instanceof VTOL) {
                 p = c.newPerson(PersonnelRole.VTOL_PILOT, factionCode, oldCrew.getGender());
-                p.addSkill(SkillType.S_PILOT_VTOL, SkillType.getType(SkillType.S_PILOT_VTOL).getTarget()
-                        - oldCrew.getPiloting(), 0);
-                p.addSkill(SkillType.S_GUN_VEE, SkillType.getType(SkillType.S_GUN_VEE).getTarget()
-                        - oldCrew.getGunnery(), 0);
+                p.addSkill(SkillType.S_PILOT_VTOL,
+                      SkillType.getType(SkillType.S_PILOT_VTOL).getTarget() - oldCrew.getPiloting(),
+                      0);
+                p.addSkill(SkillType.S_GUN_VEE,
+                      SkillType.getType(SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery(),
+                      0);
             } else {
                 // assume tanker if we got here
                 p = c.newPerson(PersonnelRole.GROUND_VEHICLE_DRIVER, factionCode, oldCrew.getGender());
-                p.addSkill(SkillType.S_PILOT_GVEE, SkillType.getType(SkillType.S_PILOT_GVEE).getTarget()
-                        - oldCrew.getPiloting(), 0);
-                p.addSkill(SkillType.S_GUN_VEE, SkillType.getType(SkillType.S_GUN_VEE).getTarget()
-                        - oldCrew.getGunnery(), 0);
+                p.addSkill(SkillType.S_PILOT_GVEE,
+                      SkillType.getType(SkillType.S_PILOT_GVEE).getTarget() - oldCrew.getPiloting(),
+                      0);
+                p.addSkill(SkillType.S_GUN_VEE,
+                      SkillType.getType(SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery(),
+                      0);
             }
 
             migrateCrewData(p, oldCrew, 0, true);
@@ -473,16 +504,20 @@ public class Utilities {
                     Person p = null;
                     if (u.getEntity() instanceof Mek) {
                         p = c.newPerson(PersonnelRole.MEKWARRIOR, factionCode, oldCrew.getGender(slot));
-                        p.addSkill(SkillType.S_PILOT_MEK, SkillType.getType(SkillType.S_PILOT_MEK).getTarget()
-                                - oldCrew.getPiloting(slot), 0);
-                        p.addSkill(SkillType.S_GUN_MEK, SkillType.getType(SkillType.S_GUN_MEK).getTarget()
-                                - oldCrew.getGunnery(slot), 0);
+                        p.addSkill(SkillType.S_PILOT_MEK,
+                              SkillType.getType(SkillType.S_PILOT_MEK).getTarget() - oldCrew.getPiloting(slot),
+                              0);
+                        p.addSkill(SkillType.S_GUN_MEK,
+                              SkillType.getType(SkillType.S_GUN_MEK).getTarget() - oldCrew.getGunnery(slot),
+                              0);
                     } else if (u.getEntity() instanceof Aero) {
                         p = c.newPerson(PersonnelRole.AEROSPACE_PILOT, factionCode, oldCrew.getGender(slot));
-                        p.addSkill(SkillType.S_PILOT_AERO, SkillType.getType(SkillType.S_PILOT_AERO).getTarget()
-                                - oldCrew.getPiloting(slot), 0);
-                        p.addSkill(SkillType.S_GUN_AERO, SkillType.getType(SkillType.S_GUN_AERO).getTarget()
-                                - oldCrew.getGunnery(slot), 0);
+                        p.addSkill(SkillType.S_PILOT_AERO,
+                              SkillType.getType(SkillType.S_PILOT_AERO).getTarget() - oldCrew.getPiloting(slot),
+                              0);
+                        p.addSkill(SkillType.S_GUN_AERO,
+                              SkillType.getType(SkillType.S_GUN_AERO).getTarget() - oldCrew.getGunnery(slot),
+                              0);
                     }
                     if (null != p) {
                         if (!oldCrew.getExternalIdAsString(numberPeopleGenerated).equals("-1")) {
@@ -509,11 +544,9 @@ public class Utilities {
             else {
                 // Generate drivers for multi-crewed vehicles and vessels
 
-                // Uggh, BA are a nightmare. The getTotalDriverNeeds will adjust for
-                // missing/destroyed suits
-                // but we can't change that because lots of other stuff needs that to be right,
-                // so we will hack
-                // it here to make it the starting squad size
+                // BA are a nightmare. The getTotalDriverNeeds will adjust for missing/destroyed suits, but we can't
+                // change that because lots of other stuff needs that to be right, so we will hack it here to make it
+                // the starting squad size
                 int driversNeeded = u.getTotalDriverNeeds();
                 if (u.getEntity() instanceof BattleArmor) {
                     driversNeeded = ((BattleArmor) u.getEntity()).getSquadSize();
@@ -522,53 +555,58 @@ public class Utilities {
                 for (int slot = 0; slot < driversNeeded; slot++) {
                     Person p;
                     if (u.getEntity() instanceof SmallCraft || u.getEntity() instanceof Jumpship) {
-                        p = c.newPerson(PersonnelRole.VESSEL_PILOT, factionCode,
-                                oldCrew.getGender(numberPeopleGenerated));
-                        p.addSkill(SkillType.S_PILOT_SPACE, randomSkillFromTarget(
-                                SkillType.getType(SkillType.S_PILOT_SPACE).getTarget()
-                                        - oldCrew.getPiloting()),
-                                0);
+                        p = c.newPerson(PersonnelRole.VESSEL_PILOT,
+                              factionCode,
+                              oldCrew.getGender(numberPeopleGenerated));
+                        p.addSkill(SkillType.S_PILOT_SPACE,
+                              randomSkillFromTarget(SkillType.getType(SkillType.S_PILOT_SPACE).getTarget() -
+                                                          oldCrew.getPiloting()),
+                              0);
                     } else if (u.getEntity() instanceof BattleArmor) {
-                        p = c.newPerson(PersonnelRole.BATTLE_ARMOUR, factionCode,
-                                oldCrew.getGender(numberPeopleGenerated));
-                        p.addSkill(SkillType.S_GUN_BA, randomSkillFromTarget(
-                                SkillType.getType(SkillType.S_GUN_BA).getTarget()
-                                        - oldCrew.getGunnery()),
-                                0);
+                        p = c.newPerson(PersonnelRole.BATTLE_ARMOUR,
+                              factionCode,
+                              oldCrew.getGender(numberPeopleGenerated));
+                        p.addSkill(SkillType.S_GUN_BA,
+                              randomSkillFromTarget(SkillType.getType(SkillType.S_GUN_BA).getTarget() -
+                                                          oldCrew.getGunnery()),
+                              0);
                     } else if (u.getEntity() instanceof Infantry) {
-                        p = c.newPerson(PersonnelRole.SOLDIER, factionCode,
-                                oldCrew.getGender(numberPeopleGenerated));
-                        p.addSkill(SkillType.S_SMALL_ARMS, randomSkillFromTarget(
-                                SkillType.getType(SkillType.S_SMALL_ARMS).getTarget() - oldCrew.getGunnery()),
-                                0);
+                        p = c.newPerson(PersonnelRole.SOLDIER, factionCode, oldCrew.getGender(numberPeopleGenerated));
+                        p.addSkill(SkillType.S_SMALL_ARMS,
+                              randomSkillFromTarget(SkillType.getType(SkillType.S_SMALL_ARMS).getTarget() -
+                                                          oldCrew.getGunnery()),
+                              0);
                     } else if (u.getEntity() instanceof VTOL) {
-                        p = c.newPerson(PersonnelRole.VTOL_PILOT, factionCode,
-                                oldCrew.getGender(numberPeopleGenerated));
-                        p.addSkill(SkillType.S_PILOT_VTOL, SkillType.getType(
-                                SkillType.S_PILOT_VTOL).getTarget() - oldCrew.getPiloting(),
-                                0);
-                        p.addSkill(SkillType.S_GUN_VEE, SkillType.getType(
-                                SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery(),
-                                0);
+                        p = c.newPerson(PersonnelRole.VTOL_PILOT,
+                              factionCode,
+                              oldCrew.getGender(numberPeopleGenerated));
+                        p.addSkill(SkillType.S_PILOT_VTOL,
+                              SkillType.getType(SkillType.S_PILOT_VTOL).getTarget() - oldCrew.getPiloting(),
+                              0);
+                        p.addSkill(SkillType.S_GUN_VEE,
+                              SkillType.getType(SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery(),
+                              0);
                     } else if (u.getEntity() instanceof Mek) {
-                        p = c.newPerson(PersonnelRole.MEKWARRIOR, factionCode,
-                                oldCrew.getGender(numberPeopleGenerated));
-                        p.addSkill(SkillType.S_PILOT_MEK, SkillType.getType(
-                                SkillType.S_PILOT_MEK).getTarget() - oldCrew.getPiloting(),
-                                0);
-                        p.addSkill(SkillType.S_GUN_MEK, SkillType.getType(
-                                SkillType.S_GUN_MEK).getTarget() - oldCrew.getGunnery(),
-                                0);
+                        p = c.newPerson(PersonnelRole.MEKWARRIOR,
+                              factionCode,
+                              oldCrew.getGender(numberPeopleGenerated));
+                        p.addSkill(SkillType.S_PILOT_MEK,
+                              SkillType.getType(SkillType.S_PILOT_MEK).getTarget() - oldCrew.getPiloting(),
+                              0);
+                        p.addSkill(SkillType.S_GUN_MEK,
+                              SkillType.getType(SkillType.S_GUN_MEK).getTarget() - oldCrew.getGunnery(),
+                              0);
                     } else {
                         // assume tanker if we got here
-                        p = c.newPerson(PersonnelRole.GROUND_VEHICLE_DRIVER, factionCode,
-                                oldCrew.getGender(numberPeopleGenerated));
-                        p.addSkill(SkillType.S_PILOT_GVEE, SkillType.getType(
-                                SkillType.S_PILOT_GVEE).getTarget() - oldCrew.getPiloting(),
-                                0);
-                        p.addSkill(SkillType.S_GUN_VEE, SkillType.getType(
-                                SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery(),
-                                0);
+                        p = c.newPerson(PersonnelRole.GROUND_VEHICLE_DRIVER,
+                              factionCode,
+                              oldCrew.getGender(numberPeopleGenerated));
+                        p.addSkill(SkillType.S_PILOT_GVEE,
+                              SkillType.getType(SkillType.S_PILOT_GVEE).getTarget() - oldCrew.getPiloting(),
+                              0);
+                        p.addSkill(SkillType.S_GUN_VEE,
+                              SkillType.getType(SkillType.S_GUN_VEE).getTarget() - oldCrew.getGunnery(),
+                              0);
                     }
 
                     migrateCrewData(p, oldCrew, numberPeopleGenerated++, true);
@@ -578,11 +616,11 @@ public class Utilities {
                 // Re-balance as needed to balance
                 if (!drivers.isEmpty()) {
                     if (u.getEntity() instanceof SmallCraft || u.getEntity() instanceof Jumpship) {
-                        rebalanceCrew(oldCrew.getPiloting(), drivers, SkillType.S_PILOT_SPACE);
+                        reBalanceCrew(oldCrew.getPiloting(), drivers, SkillType.S_PILOT_SPACE);
                     } else if (u.getEntity() instanceof BattleArmor) {
-                        rebalanceCrew(oldCrew.getGunnery(), drivers, SkillType.S_GUN_BA);
+                        reBalanceCrew(oldCrew.getGunnery(), drivers, SkillType.S_GUN_BA);
                     } else if (u.getEntity() instanceof Infantry) {
-                        rebalanceCrew(oldCrew.getGunnery(), drivers, SkillType.S_SMALL_ARMS);
+                        reBalanceCrew(oldCrew.getGunnery(), drivers, SkillType.S_SMALL_ARMS);
                     }
                 }
 
@@ -591,31 +629,32 @@ public class Utilities {
                     for (int slot = 0; slot < u.getTotalGunnerNeeds(); slot++) {
                         Person p;
                         if (u.getEntity() instanceof SmallCraft || u.getEntity() instanceof Jumpship) {
-                            p = c.newPerson(PersonnelRole.VESSEL_GUNNER, factionCode,
-                                    oldCrew.getGender(numberPeopleGenerated));
-                            p.addSkill(SkillType.S_GUN_SPACE, randomSkillFromTarget(
-                                    SkillType.getType(SkillType.S_GUN_SPACE).getTarget()
-                                            - oldCrew.getGunnery()),
-                                    0);
+                            p = c.newPerson(PersonnelRole.VESSEL_GUNNER,
+                                  factionCode,
+                                  oldCrew.getGender(numberPeopleGenerated));
+                            p.addSkill(SkillType.S_GUN_SPACE,
+                                  randomSkillFromTarget(SkillType.getType(SkillType.S_GUN_SPACE).getTarget() -
+                                                              oldCrew.getGunnery()),
+                                  0);
                         } else if (u.getEntity() instanceof Mek) {
-                            p = c.newPerson(PersonnelRole.MEKWARRIOR, factionCode,
-                                    oldCrew.getGender(numberPeopleGenerated));
+                            p = c.newPerson(PersonnelRole.MEKWARRIOR,
+                                  factionCode,
+                                  oldCrew.getGender(numberPeopleGenerated));
                             p.addSkill(SkillType.S_PILOT_MEK,
-                                    SkillType.getType(SkillType.S_PILOT_MEK).getTarget()
-                                            - oldCrew.getPiloting(),
-                                    0);
+                                  SkillType.getType(SkillType.S_PILOT_MEK).getTarget() - oldCrew.getPiloting(),
+                                  0);
                             p.addSkill(SkillType.S_GUN_MEK,
-                                    SkillType.getType(SkillType.S_GUN_MEK).getTarget()
-                                            - oldCrew.getGunnery(),
-                                    0);
+                                  SkillType.getType(SkillType.S_GUN_MEK).getTarget() - oldCrew.getGunnery(),
+                                  0);
                         } else {
                             // assume tanker if we got here
-                            p = c.newPerson(PersonnelRole.VEHICLE_GUNNER, factionCode,
-                                    oldCrew.getGender(numberPeopleGenerated));
-                            p.addSkill(SkillType.S_GUN_VEE, randomSkillFromTarget(
-                                    SkillType.getType(SkillType.S_GUN_VEE).getTarget()
-                                            - oldCrew.getGunnery()),
-                                    0);
+                            p = c.newPerson(PersonnelRole.VEHICLE_GUNNER,
+                                  factionCode,
+                                  oldCrew.getGender(numberPeopleGenerated));
+                            p.addSkill(SkillType.S_GUN_VEE,
+                                  randomSkillFromTarget(SkillType.getType(SkillType.S_GUN_VEE).getTarget() -
+                                                              oldCrew.getGunnery()),
+                                  0);
                         }
 
                         migrateCrewData(p, oldCrew, numberPeopleGenerated++, true);
@@ -625,33 +664,36 @@ public class Utilities {
                     // Regenerate gunners as needed to balance
                     if (!gunners.isEmpty()) {
                         if (u.getEntity() instanceof Tank) {
-                            rebalanceCrew(oldCrew.getGunnery(), gunners, SkillType.S_GUN_VEE);
+                            reBalanceCrew(oldCrew.getGunnery(), gunners, SkillType.S_GUN_VEE);
                         } else if (u.getEntity() instanceof SmallCraft || u.getEntity() instanceof Jumpship) {
-                            rebalanceCrew(oldCrew.getGunnery(), gunners, SkillType.S_GUN_SPACE);
+                            reBalanceCrew(oldCrew.getGunnery(), gunners, SkillType.S_GUN_SPACE);
                         }
                     }
                 }
             }
 
             for (int slot = 0; slot < u.getTotalCrewNeeds(); slot++) {
-                Person p = c.newPerson(u.getEntity().isSupportVehicle()
-                        ? PersonnelRole.VEHICLE_CREW
-                        : PersonnelRole.VESSEL_CREW,
-                        factionCode, oldCrew.getGender(numberPeopleGenerated));
+                Person p = c.newPerson(u.getEntity().isSupportVehicle() ?
+                                             PersonnelRole.VEHICLE_CREW :
+                                             PersonnelRole.VESSEL_CREW,
+                      factionCode,
+                      oldCrew.getGender(numberPeopleGenerated));
 
                 migrateCrewData(p, oldCrew, numberPeopleGenerated++, false);
                 vesselCrew.add(p);
             }
 
             if (u.canTakeNavigator()) {
-                navigator = c.newPerson(PersonnelRole.VESSEL_NAVIGATOR, factionCode,
-                        oldCrew.getGender(numberPeopleGenerated));
+                navigator = c.newPerson(PersonnelRole.VESSEL_NAVIGATOR,
+                      factionCode,
+                      oldCrew.getGender(numberPeopleGenerated));
                 migrateCrewData(navigator, oldCrew, numberPeopleGenerated++, false);
             }
 
             if (u.canTakeTechOfficer()) {
-                consoleCmdr = c.newPerson(PersonnelRole.VEHICLE_GUNNER, factionCode,
-                        oldCrew.getGender(numberPeopleGenerated));
+                consoleCmdr = c.newPerson(PersonnelRole.VEHICLE_GUNNER,
+                      factionCode,
+                      oldCrew.getGender(numberPeopleGenerated));
                 migrateCrewData(consoleCmdr, oldCrew, numberPeopleGenerated, false);
             }
         }
@@ -684,11 +726,10 @@ public class Utilities {
     }
 
     /**
-     * Adjusts the skill levels of the given list of people in the given skill
-     * until the average skill level matches the given desired skill level
-     * (desiredSkill)
+     * Adjusts the skill levels of the given list of people in the given skill until the average skill level matches the
+     * given desired skill level (desiredSkill)
      */
-    private static void rebalanceCrew(int desiredSkill, List<Person> people, String skillType) {
+    private static void reBalanceCrew(int desiredSkill, List<Person> people, String skillType) {
         int totalGunnery = 0;
         int targetNum = SkillType.getType(skillType).getTarget();
 
@@ -716,11 +757,11 @@ public class Utilities {
             boolean skillCannotChange = true;
             while (skillCannotChange) {
                 if ((skillLevel < 0) && (skillIncrement == -1) ||
-                        (skillLevel >= SkillType.NUM_LEVELS) && (skillIncrement == 1)) {
+                          (skillLevel >= SkillType.NUM_LEVELS) && (skillIncrement == 1)) {
                     eligiblePeople.remove(person);
                     person = ObjectUtility.getRandomItem(eligiblePeople);
 
-                    // if we can't drop anyone's skill any lower or raise it any higher then forget
+                    // if we can't drop anyone's skill any lower or raise it any higher than forget
                     // it
                     if (person == null) {
                         return;
@@ -740,16 +781,14 @@ public class Utilities {
     }
 
     /**
-     * Function that determines what name should be used by a person that is created
-     * through crew
-     * And then assigns them a pre-selected portrait, provided one is to their index
-     * Additionally, any extraData parameters should be migrated here
+     * Function that determines what name should be used by a person that is created through crew And then assigns them
+     * a pre-selected portrait, provided one is to their index Additionally, any extraData parameters should be migrated
+     * here
      *
      * @param p           the person to be renamed, if applicable
      * @param oldCrew     the crew object they were a part of
      * @param crewIndex   the index of the person in the crew
-     * @param crewOptions whether or not to run the populateOptionsFromCrew for this
-     *                    person
+     * @param crewOptions whether to run the populateOptionsFromCrew for this person
      */
     private static void migrateCrewData(Person p, Crew oldCrew, int crewIndex, boolean crewOptions) {
         if (crewOptions) {
@@ -768,8 +807,8 @@ public class Utilities {
             if (StringUtility.isNullOrBlank(givenName)) {
                 String name = oldCrew.getName(crewIndex);
 
-                if (!(name.equalsIgnoreCase(RandomNameGenerator.UNNAMED)
-                        || name.equalsIgnoreCase(RandomNameGenerator.UNNAMED_FULL_NAME))) {
+                if (!(name.equalsIgnoreCase(RandomNameGenerator.UNNAMED) ||
+                            name.equalsIgnoreCase(RandomNameGenerator.UNNAMED_FULL_NAME))) {
                     p.migrateName(name);
                 }
             } else {
@@ -795,9 +834,8 @@ public class Utilities {
     }
 
     /**
-     * Worker function that takes the PersonnelOptions (SPAs, in other words) from
-     * the given
-     * "old crew" and sets them for a person.
+     * Worker function that takes the PersonnelOptions (SPAs, in other words) from the given "old crew" and sets them
+     * for a person.
      *
      * @param p       The person whose SPAs to populate
      * @param oldCrew The entity the SPAs of whose crew we're importing
@@ -844,10 +882,9 @@ public class Utilities {
      * Calculates the age based on the experience level and clan status.
      *
      * <p>This method computes the age of a character by rolling a given number of exploding
-     * six-sided dice (d6) depending on the specified experience level. It starts with a base age
-     * and adds results of the rolls. If the character is part of a Clan, the dice rolls are halved
-     * (rounded up). Additionally, for all experience levels other than {@code EXP_NONE}, the final
-     * result is clamped to a minimum of 18.</p>
+     * six-sided dice (d6) depending on the specified experience level. It starts with a base age and adds results of
+     * the rolls. If the character is part of a Clan, the dice rolls are halved (rounded up). Additionally, for all
+     * experience levels other than {@code EXP_NONE}, the final result is clamped to a minimum of 18.</p>
      *
      * <p>An exploding die roll occurs if the roll is 6. In such cases, another die is rolled, and
      * the result is added to the previous roll (minus one).</p>
@@ -888,10 +925,11 @@ public class Utilities {
      *   </tr>
      * </table>
      *
-     * @param experienceLevel The experience level of the character. Must be one of the constants
-     *                       defined in {@code SkillType}.
-     * @param isClan {@code true} if the character is part of a Clan, in which case dice rolls are
-     *                          halved (rounded up), {@code false} otherwise.
+     * @param experienceLevel The experience level of the character. Must be one of the constants defined in
+     *                        {@code SkillType}.
+     * @param isClan          {@code true} if the character is part of a Clan, in which case dice rolls are halved
+     *                        (rounded up), {@code false} otherwise.
+     *
      * @return The calculated age of the character based on the input parameters.
      */
     public static int getAgeByExpLevel(int experienceLevel, boolean isClan) {
@@ -954,6 +992,10 @@ public class Utilities {
         return joiner.toString();
     }
 
+    /**
+     * @deprecated no indicated uses
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     public static Money[] readMoneyArray(Node node) {
         return readMoneyArray(node, 0);
     }
@@ -975,12 +1017,13 @@ public class Utilities {
 
     public static int getSimpleTechLevel(int level) {
         return switch (level) {
-            case TechConstants.T_IS_TW_NON_BOX, TechConstants.T_CLAN_TW, TechConstants.T_IS_TW_ALL,
-                    TechConstants.T_TW_ALL ->
-                CampaignOptions.TECH_STANDARD;
+            case TechConstants.T_IS_TW_NON_BOX,
+                 TechConstants.T_CLAN_TW,
+                 TechConstants.T_IS_TW_ALL,
+                 TechConstants.T_TW_ALL -> CampaignOptions.TECH_STANDARD;
             case TechConstants.T_IS_ADVANCED, TechConstants.T_CLAN_ADVANCED -> CampaignOptions.TECH_ADVANCED;
             case TechConstants.T_IS_EXPERIMENTAL, TechConstants.T_CLAN_EXPERIMENTAL ->
-                CampaignOptions.TECH_EXPERIMENTAL;
+                  CampaignOptions.TECH_EXPERIMENTAL;
             case TechConstants.T_IS_UNOFFICIAL, TechConstants.T_CLAN_UNOFFICIAL -> CampaignOptions.TECH_UNOFFICIAL;
             case TechConstants.T_TECH_UNKNOWN -> CampaignOptions.TECH_UNKNOWN;
             default -> CampaignOptions.TECH_INTRO;
@@ -992,21 +1035,19 @@ public class Utilities {
      *
      * @param inFile  the existing input file
      * @param outFile the new file to copy into
+     *
      * @see <a href="http://www.roseindia.net/java/beginners/copyfile.shtml">Rose
-     *      India's tutorial</a>
-     *      for the original code source
+     *       India's tutorial</a> for the original code source
      */
     public static void copyfile(final File inFile, final File outFile) {
-        try (FileInputStream fis = new FileInputStream(inFile);
-                FileOutputStream fos = new FileOutputStream(outFile)) {
+        try (FileInputStream fis = new FileInputStream(inFile); FileOutputStream fos = new FileOutputStream(outFile)) {
             byte[] buf = new byte[1024];
             int len;
             while ((len = fis.read(buf)) > 0) {
                 fos.write(buf, 0, len);
             }
 
-            logger
-                    .info(String.format("Copied file %s to file %s", inFile.getPath(), outFile.getPath()));
+            logger.info("Copied file {} to file {}", inFile.getPath(), outFile.getPath());
         } catch (Exception ex) {
             logger.error("", ex);
         }
@@ -1017,6 +1058,7 @@ public class Utilities {
      *
      * @param table the table to save to csv
      * @param file  the file to save to
+     *
      * @return a csv formatted export of the table
      */
     public static String exportTableToCSV(JTable table, File file) {
@@ -1028,7 +1070,7 @@ public class Utilities {
 
         String report;
         try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(file.getPath()));
-                CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(columns))) {
+              CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader(columns))) {
             for (int i = 0; i < model.getRowCount(); i++) {
                 Object[] toWrite = new String[model.getColumnCount()];
                 for (int j = 0; j < model.getColumnCount(); j++) {
@@ -1149,18 +1191,19 @@ public class Utilities {
     }
 
     /**
-     * Run through the directory and call parser.parse(fis) for each XML file found.
-     * Don't recurse.
+     * Run through the directory and call parser.parse(fis) for each XML file found. Don't recurse.
+     *
+     * @deprecated No indicated uses.
      */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     public static void parseXMLFiles(String dirName, Consumer<FileInputStream> parser) {
         parseXMLFiles(dirName, parser, false);
     }
 
     /**
-     * Run through the directory and call parser.parse(fis) for each XML file found.
-     * This was originally used to read in the planetary system data, but we are now doing that
-     * with YML code in Systems.java#loadDefault. Leaving this here, in case it is useful for
-     * something in the future.
+     * Run through the directory and call parser.parse(fis) for each XML file found. This was originally used to read in
+     * the planetary system data, but we are now doing that with YML code in Systems.java#loadDefault. Leaving this
+     * here, in case it is useful for something in the future.
      */
     public static void parseXMLFiles(String dirName, Consumer<FileInputStream> parser, boolean recurse) {
         if ((null == dirName) || (null == parser)) {
@@ -1179,9 +1222,7 @@ public class Utilities {
                             parser.accept(fis);
                         } catch (Exception ex) {
                             // Ignore this file then
-                            logger.error(
-                                    String.format("Exception trying to parse %s - ignoring.", file.getPath()),
-                                    ex);
+                            logger.error("Exception trying to parse {} - ignoring.", file.getPath(), ex);
                         }
                     }
                 }
@@ -1209,6 +1250,7 @@ public class Utilities {
      * Converts a given Image into a BufferedImage
      *
      * @param img The Image to be converted
+     *
      * @return The converted BufferedImage
      */
     public static BufferedImage toBufferedImage(Image img) {
@@ -1229,26 +1271,22 @@ public class Utilities {
     }
 
     /**
-     * Handles loading a player's transported units onto their transports once a
-     * megamek scenario has actually started.
-     * This separates loading air and ground units, since map type and planetary
-     * conditions may prohibit ground unit deployment
-     * while the player wants fighters launched to defend the transport
+     * Handles loading a player's transported units onto their transports once a megamek scenario has actually started.
+     * This separates loading air and ground units, since map type and planetary conditions may prohibit ground unit
+     * deployment while the player wants fighters launched to defend the transport
      *
      * @param trnId          - The MM id of the transport entity we want to load
-     * @param toLoad         - List of Entity ids for the units we want to load into
-     *                       this transport
+     * @param toLoad         - List of Entity ids for the units we want to load into this transport
      * @param client         - the player's Client instance
      * @param loadDropShips  - Should DropShip units be loaded?
      * @param loadSmallCraft - Should Small Craft units be loaded?
      * @param loadFighters   - Should aero type units be loaded?
      * @param loadGround     - should ground units be loaded?
      */
-    public static void loadPlayerTransports(int trnId, Set<Integer> toLoad, Client client,
-            boolean loadDropShips, boolean loadSmallCraft,
-            boolean loadFighters, boolean loadGround) {
+    public static void loadPlayerTransports(int trnId, Set<Integer> toLoad, Client client, boolean loadDropShips,
+          boolean loadSmallCraft, boolean loadFighters, boolean loadGround) {
         if (!loadDropShips && !loadSmallCraft && !loadFighters && !loadGround) {
-            // Nothing to do. Get outta here!
+            // Nothing to do. Get out of here!
             return;
         }
         Entity transport = client.getEntity(trnId);
@@ -1293,24 +1331,23 @@ public class Utilities {
     }
 
     /**
-     * Handles loading a player's transported units onto their transports once a
-     * megamek scenario has actually started.
-     *
+     * Handles loading a player's transported units onto their transports once a megamek scenario has actually started.
      *
      * @param trnId          - The MM id of the transport entity we want to load
      * @param toLoad         - Map of entity ids and transport assignments for the units we want to load
      * @param client         - the player's Client instance
-     * @param loadTactical  - Should "tactical"-ly transported units be loaded?
+     * @param loadTactical   - Should "tactical"-ly transported units be loaded?
      * @param isAlreadyReset - transports loaded via "Ship" will have been reset once, don't do it again here
+     *
      * @see mekhq.campaign.enums.CampaignTransportType#TACTICAL_TRANSPORT
      * @see ITransportAssignment
      */
-    public static void loadPlayerTransports(int trnId, Map<Integer, ? extends ITransportAssignment> toLoad, Client client,
-                                            boolean loadTactical, boolean isAlreadyReset) {
+    public static void loadPlayerTransports(int trnId, Map<Integer, ? extends ITransportAssignment> toLoad,
+          Client client, boolean loadTactical, boolean isAlreadyReset) {
         Set<Entity> alreadyTransportedEntities = new HashSet<>();
 
         if (!loadTactical) {
-            // Nothing to do. Get outta here!
+            // Nothing to do. Get out of here!
             return;
         }
         Entity transport = client.getEntity(trnId);
@@ -1387,22 +1424,21 @@ public class Utilities {
     }
 
     /**
-     * Handles towing a player's trailers by their tractors once a
-     * megamek scenario has actually started.
+     * Handles towing a player's trailers by their tractors once a megamek scenario has actually started.
      *
-     *
-     * @param tractorId          - The MM id of the tractor entity we want to tow with
-     * @param trailerId         - Entity id for the unit we want to tow
+     * @param tractorId      - The MM id of the tractor entity we want to tow with
+     * @param trailerId      - Entity id for the unit we want to tow
      * @param client         - the player's Client instance
      * @param isAlreadyReset - transports loaded via "Ship" will have been reset once, don't do it again here
+     *
      * @see mekhq.campaign.enums.CampaignTransportType#TOW_TRANSPORT
      * @see ITransportAssignment
      */
-    public static void towPlayerTrailers(int tractorId, int trailerId, Client client,
-                                            boolean towTrailers, boolean isAlreadyReset) {
+    public static void towPlayerTrailers(int tractorId, int trailerId, Client client, boolean towTrailers,
+          boolean isAlreadyReset) {
         Set<Entity> alreadyTransportedEntities = new HashSet<>();
         if (!towTrailers) {
-            // Nothing to do. Get outta here!
+            // Nothing to do. Get out of here!
             return;
         }
         Entity tractor = client.getEntity(tractorId);
@@ -1443,15 +1479,14 @@ public class Utilities {
     }
 
     /**
-     * Method that loops through a Transport ship's bays and finds one with enough
-     * available space to load the Cargo unit
-     * Helps assign a bay number to the Unit record so that transport bays can be
-     * automatically filled once a game of MegaMek is started
+     * Method that loops through a Transport ship's bays and finds one with enough available space to load the Cargo
+     * unit Helps assign a bay number to the Unit record so that transport bays can be automatically filled once a game
+     * of MegaMek is started
      *
      * @param cargo     The Entity we wish to load into a bay
      * @param transport The Bay-equipped Entity we want to load Cargo aboard
-     * @return integer representing the (lowest) bay number on Transport that has
-     *         space to carry Cargo
+     *
+     * @return integer representing the (lowest) bay number on Transport that has space to carry Cargo
      */
     public static int selectBestBayFor(Entity cargo, Entity transport) {
         if (cargo.getUnitType() == UnitType.DROPSHIP) {
@@ -1536,6 +1571,7 @@ public class Utilities {
 
     /**
      * @param shortNameRaw complete Entity name as returned by getShortNameRaw()
+     *
      * @throws EntityLoadingException
      */
     public static MekSummary retrieveUnit(String shortNameRaw) throws EntityLoadingException {
@@ -1543,8 +1579,7 @@ public class Utilities {
 
         // If we got this far with no summary loaded, give up
         if (null == summary) {
-            throw new EntityLoadingException(String.format("Could not load %s from the mek cache",
-                    shortNameRaw));
+            throw new EntityLoadingException(String.format("Could not load %s from the mek cache", shortNameRaw));
         }
 
         return summary;
@@ -1554,31 +1589,38 @@ public class Utilities {
         List<String> stub = new ArrayList<>();
         for (Entity en : entities) {
             if (null == en) {
-                stub.add("<html><font color='" + MekHQ.getMHQOptions().getFontColorNegativeHexColor()
-                        + "'>No random assignment table found for faction</font></html>");
+                stub.add("<html><font color='" +
+                               MekHQ.getMHQOptions().getFontColorNegativeHexColor() +
+                               "'>No random assignment table found for faction</font></html>");
             } else {
-                stub.add("<html>" + en.getCrew().getName() + " (" +
-                        en.getCrew().getGunnery() + '/' +
-                        en.getCrew().getPiloting() + "), " +
-                        "<i>" + en.getShortName() + "</i>" +
-                        "</html>");
+                stub.add("<html>" +
+                               en.getCrew().getName() +
+                               " (" +
+                               en.getCrew().getGunnery() +
+                               '/' +
+                               en.getCrew().getPiloting() +
+                               "), " +
+                               "<i>" +
+                               en.getShortName() +
+                               "</i>" +
+                               "</html>");
             }
         }
         return stub;
     }
 
     /**
-     * Display a descriptive character string for the deployment parameters in an
-     * object that implements IPlayerSettings
+     * Display a descriptive character string for the deployment parameters in an object that implements
+     * IPlayerSettings
      *
      * @param player object that implements IPlayerSettings
+     *
      * @return A character string
      */
     public static String getDeploymentString(Player player) {
         StringBuilder result = new StringBuilder();
 
-        if (player.getStartingPos() >= 0
-                && player.getStartingPos() <= IStartingPositions.START_LOCATION_NAMES.length) {
+        if (player.getStartingPos() >= 0 && player.getStartingPos() <= IStartingPositions.START_LOCATION_NAMES.length) {
             result.append(IStartingPositions.START_LOCATION_NAMES[player.getStartingPos()]);
         }
 
@@ -1588,8 +1630,15 @@ public class Utilities {
             int SEx = player.getStartingAnySEx() + 1;
             int SEy = player.getStartingAnySEy() + 1;
             if ((NWx + NWy + SEx + SEy) > 0) {
-                result.append(" (").append(NWx).append(", ").append(NWy).append(")-(").append(SEx).append(", ")
-                        .append(SEy).append(')');
+                result.append(" (")
+                      .append(NWx)
+                      .append(", ")
+                      .append(NWy)
+                      .append(")-(")
+                      .append(SEx)
+                      .append(", ")
+                      .append(SEy)
+                      .append(')');
             }
         }
         int so = player.getStartOffset();
@@ -1607,10 +1656,10 @@ public class Utilities {
     }
 
     /**
-     * Create a Player object from IPlayerSettings parameters. Useful for tracking
-     * these variables in dialogs.
+     * Create a Player object from IPlayerSettings parameters. Useful for tracking these variables in dialogs.
      *
      * @param settings an object that implements IPlayerSettings
+     *
      * @return A Player object
      */
     public static Player createPlayer(IPlayerSettings settings) {
@@ -1627,8 +1676,7 @@ public class Utilities {
     }
 
     /**
-     * Update values of an object that implements IPlayerSettings from a player
-     * object
+     * Update values of an object that implements IPlayerSettings from a player object
      *
      * @param settings An object that implements IPlayerSettings
      * @param player   A Player object from which to read values

--- a/MekHQ/src/mekhq/campaign/enums/CampaignTransportType.java
+++ b/MekHQ/src/mekhq/campaign/enums/CampaignTransportType.java
@@ -1,14 +1,14 @@
-/**
+/*
  * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of MekHQ.
+ * This file is part of MegaMekLab.
  *
- * MekHQ is free software: you can redistribute it and/or modify
+ * MegaMekLab is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * MekHQ is distributed in the hope that it will be useful,
+ * MegaMekLab is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -28,16 +28,23 @@
 
 package mekhq.campaign.enums;
 
-import megamek.common.*;
-import mekhq.campaign.unit.*;
+import megamek.common.BattleArmorHandles;
+import megamek.common.DockingCollar;
+import megamek.common.InfantryCompartment;
+import megamek.common.bays.Bay;
+import mekhq.campaign.unit.AbstractTransportedUnitsSummary;
+import mekhq.campaign.unit.ITransportAssignment;
+import mekhq.campaign.unit.ShipTransportedUnitsSummary;
+import mekhq.campaign.unit.TacticalTransportedUnitsSummary;
+import mekhq.campaign.unit.TowTransportedUnitsSummary;
+import mekhq.campaign.unit.TransportAssignment;
+import mekhq.campaign.unit.TransportShipAssignment;
+import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.enums.TransporterType;
 
 /**
- * Enum for the different transport types used in MekHQ.
- * Campaign Transports allow a unit to be
- * assigned a transport (another unit).
- * The different transport types primarily differ
- * in the Transporters they allow.
+ * Enum for the different transport types used in MekHQ. Campaign Transports allow a unit to be assigned a transport
+ * (another unit). The different transport types primarily differ in the Transporters they allow.
  *
  * @see Unit
  * @see TransporterType
@@ -48,24 +55,19 @@ public enum CampaignTransportType {
     // which transport assignment should be used when loading
     // units in the MegaMek lobby.
     /**
-     * Units assigned a ship transport, if both units are in the battle
-     * the unit will attempt to load onto the transport when deployed into battle.
-     * Ship transports are intended to be used for long-term travel or space combat
-     * and only allow units to be transported in long-term Transporters like Bays or
-     * Docking Collars.
+     * Units assigned a ship transport, if both units are in the battle the unit will attempt to load onto the transport
+     * when deployed into battle. Ship transports are intended to be used for long-term travel or space combat and only
+     * allow units to be transported in long-term Transporters like Bays or Docking Collars.
      *
      * @see Bay
      * @see DockingCollar
      */
     SHIP_TRANSPORT(TransportShipAssignment.class, ShipTransportedUnitsSummary.class),
     /**
-     * Units assigned a tactical transport, if both units are in the battle
-     * the unit will attempt to load onto the transport when deployed into battle.
-     * Tactical Transporters are meant to represent short-term transport - Infantry
-     * in
-     * an Infantry compartment, or Battle Armor on Battle Armor Handles. It still
-     * allows
-     * units to be loaded into bays though for tactical Dropship assaults.
+     * Units assigned a tactical transport, if both units are in the battle the unit will attempt to load onto the
+     * transport when deployed into battle. Tactical Transporters are meant to represent short-term transport - Infantry
+     * in an Infantry compartment, or Battle Armor on Battle Armor Handles. It still allows units to be loaded into bays
+     * though for tactical Dropship assaults.
      *
      * @see InfantryCompartment
      * @see BattleArmorHandles
@@ -73,9 +75,7 @@ public enum CampaignTransportType {
     TACTICAL_TRANSPORT(TransportAssignment.class, TacticalTransportedUnitsSummary.class),
 
     /**
-     * Units assigned a tow transports will, if both deployed to battle,
-     * automatically
-     * set the unit as being towed.
+     * Units assigned a tow transports will, if both deployed to battle, automatically set the unit as being towed.
      */
     TOW_TRANSPORT(TransportAssignment.class, TowTransportedUnitsSummary.class);
     // endregion Enum declarations
@@ -87,7 +87,7 @@ public enum CampaignTransportType {
 
     // region Constructors
     CampaignTransportType(Class<? extends ITransportAssignment> transportAssignmentType,
-            Class<? extends AbstractTransportedUnitsSummary> transportedUnitsSummaryType) {
+          Class<? extends AbstractTransportedUnitsSummary> transportedUnitsSummaryType) {
         this.transportAssignmentType = transportAssignmentType;
         this.transportedUnitsSummaryType = transportedUnitsSummaryType;
     }

--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import megamek.common.*;
+import megamek.common.bays.BayType;
 import megamek.common.equipment.ArmorType;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.verifier.TestEntity;
@@ -50,13 +51,11 @@ import mekhq.campaign.parts.equipment.JumpJet;
 import mekhq.campaign.parts.equipment.MASC;
 
 /**
- * This is a parts store which will contain one copy of every possible
- * part that might be needed as well as a variety of helper functions to
- * acquire parts.
- *
- * We could in the future extend this to different types of stores that have
- * different finite numbers of
- * parts in inventory
+ * This is a parts store which will contain one copy of every possible part that might be needed as well as a variety of
+ * helper functions to acquire parts.
+ * <p>
+ * We could in the future extend this to different types of stores that have different finite numbers of parts in
+ * inventory
  *
  * @author Jay Lawson (jaylawson39 at yahoo.com)
  */
@@ -125,26 +124,32 @@ public class PartsStore {
                 logger.error("", e);
             }
             if (null != newEntity) {
-                BattleArmorSuit ba = new BattleArmorSuit(summary.getChassis(), summary.getModel(),
-                        (int) summary.getTons(), 1, summary.getWeightClass(), summary.getWalkMp(), summary.getJumpMp(),
-                        newEntity.entityIsQuad(), summary.isClan(), newEntity.getMovementMode(), c);
+                BattleArmorSuit ba = new BattleArmorSuit(summary.getChassis(),
+                      summary.getModel(),
+                      (int) summary.getTons(),
+                      1,
+                      summary.getWeightClass(),
+                      summary.getWalkMp(),
+                      summary.getJumpMp(),
+                      newEntity.entityIsQuad(),
+                      summary.isClan(),
+                      newEntity.getMovementMode(),
+                      c);
                 parts.add(ba);
             }
         }
     }
 
     private void stockWeaponsAmmoAndEquipment(Campaign c) {
-        for (Enumeration<EquipmentType> e = EquipmentType.getAllTypes(); e.hasMoreElements();) {
+        for (Enumeration<EquipmentType> e = EquipmentType.getAllTypes(); e.hasMoreElements(); ) {
             EquipmentType et = e.nextElement();
-            if (!et.isHittable() &&
-                    !(et instanceof MiscType && ((MiscType) et).hasFlag(MiscType.F_BA_MANIPULATOR))) {
+            if (!et.isHittable() && !(et instanceof MiscType && ((MiscType) et).hasFlag(MiscType.F_BA_MANIPULATOR))) {
                 continue;
             }
             // TODO: we are still adding a lot of non-hittable equipment
             if (et instanceof AmmoType) {
                 AmmoType ammoType = (AmmoType) et;
-                if (ammoType.hasFlag(AmmoType.F_BATTLEARMOR)
-                        && (ammoType.getKgPerShot() > 0)) {
+                if (ammoType.hasFlag(AmmoType.F_BATTLEARMOR) && (ammoType.getKgPerShot() > 0)) {
                     // BA ammo has one shot listed as the amount. Do it as 1 ton blocks if using
                     // kg/shot.
                     int shots = (int) Math.floor(1000.0 / ammoType.getKgPerShot());
@@ -152,8 +157,9 @@ public class PartsStore {
                 } else {
                     parts.add(new AmmoStorage(0, ammoType, ammoType.getShots(), c));
                 }
-            } else if (et instanceof MiscType && (((MiscType) et).hasFlag(MiscType.F_HEAT_SINK)
-                    || ((MiscType) et).hasFlag(MiscType.F_DOUBLE_HEAT_SINK))) {
+            } else if (et instanceof MiscType &&
+                             (((MiscType) et).hasFlag(MiscType.F_HEAT_SINK) ||
+                                    ((MiscType) et).hasFlag(MiscType.F_DOUBLE_HEAT_SINK))) {
                 Part p = new HeatSink(0, et, -1, false, c);
                 parts.add(p);
                 parts.add(new OmniPod(p, c));
@@ -168,13 +174,15 @@ public class PartsStore {
                         parts.add(new JumpJet(ton, et, -1, true, c));
                     }
                 }
-            } else if ((et instanceof MiscType && ((MiscType) et).hasFlag(MiscType.F_TANK_EQUIPMENT)
-                    && ((MiscType) et).hasFlag(MiscType.F_CHASSIS_MODIFICATION))
-                    || et instanceof BayWeapon
-                    || et instanceof InfantryAttack) {
+            } else if ((et instanceof MiscType &&
+                              ((MiscType) et).hasFlag(MiscType.F_TANK_EQUIPMENT) &&
+                              ((MiscType) et).hasFlag(MiscType.F_CHASSIS_MODIFICATION)) ||
+                             et instanceof BayWeapon ||
+                             et instanceof InfantryAttack) {
                 continue;
-            } else if (et instanceof MiscType && ((MiscType) et).hasFlag(MiscType.F_BA_EQUIPMENT)
-                    && !((MiscType) et).hasFlag(MiscType.F_BA_MANIPULATOR)) {
+            } else if (et instanceof MiscType &&
+                             ((MiscType) et).hasFlag(MiscType.F_BA_EQUIPMENT) &&
+                             !((MiscType) et).hasFlag(MiscType.F_BA_MANIPULATOR)) {
                 continue;
             } else if (et instanceof MiscType && ((MiscType) et).hasFlag(MiscType.F_MASC)) {
                 if (et.hasSubType(MiscType.S_SUPERCHARGER)) {
@@ -184,11 +192,11 @@ public class PartsStore {
                             double eton = i * 0.5;
                             double weight = Engine.ENGINE_RATINGS[(int) Math.ceil(rating / 5.0)];
                             double minweight = weight * 0.5;
-                            minweight = Math.ceil(
-                                    (TestEntity.ceilMaxHalf(minweight, TestEntity.Ceil.HALFTON) / 10.0) * 2.0) / 2.0;
+                            minweight = Math.ceil((TestEntity.ceilMaxHalf(minweight, TestEntity.Ceil.HALFTON) / 10.0) *
+                                                        2.0) / 2.0;
                             double maxweight = weight * 2.0;
-                            maxweight = Math.ceil(
-                                    (TestEntity.ceilMaxHalf(maxweight, TestEntity.Ceil.HALFTON) / 10.0) * 2.0) / 2.0;
+                            maxweight = Math.ceil((TestEntity.ceilMaxHalf(maxweight, TestEntity.Ceil.HALFTON) / 10.0) *
+                                                        2.0) / 2.0;
                             if (eton < minweight || eton > maxweight) {
                                 continue;
                             }
@@ -218,19 +226,19 @@ public class PartsStore {
             } else {
                 boolean poddable = !et.isOmniFixedOnly();
                 if (et instanceof MiscType) {
-                    poddable &= et.hasFlag(MiscType.F_MEK_EQUIPMENT)
-                            || et.hasFlag(MiscType.F_TANK_EQUIPMENT)
-                            || et.hasFlag(MiscType.F_FIGHTER_EQUIPMENT);
+                    poddable &= et.hasFlag(MiscType.F_MEK_EQUIPMENT) ||
+                                      et.hasFlag(MiscType.F_TANK_EQUIPMENT) ||
+                                      et.hasFlag(MiscType.F_FIGHTER_EQUIPMENT);
                 } else if (et instanceof WeaponType) {
-                    poddable &= (et.hasFlag(WeaponType.F_MEK_WEAPON)
-                            || et.hasFlag(Weapon.F_TANK_WEAPON)
-                            || et.hasFlag(WeaponType.F_AERO_WEAPON))
-                            && !((WeaponType) et).isCapital();
+                    poddable &= (et.hasFlag(WeaponType.F_MEK_WEAPON) ||
+                                       et.hasFlag(Weapon.F_TANK_WEAPON) ||
+                                       et.hasFlag(WeaponType.F_AERO_WEAPON)) && !((WeaponType) et).isCapital();
                 }
                 if (EquipmentPart.hasVariableTonnage(et)) {
                     EquipmentPart epart;
-                    for (double ton = EquipmentPart.getStartingTonnage(et); ton <= EquipmentPart
-                            .getMaxTonnage(et); ton += EquipmentPart.getTonnageIncrement(et)) {
+                    for (double ton = EquipmentPart.getStartingTonnage(et);
+                          ton <= EquipmentPart.getMaxTonnage(et);
+                          ton += EquipmentPart.getTonnageIncrement(et)) {
                         epart = new EquipmentPart(0, et, -1, 1.0, false, c);
                         epart.setEquipTonnage(ton);
                         parts.add(epart);

--- a/MekHQ/src/mekhq/campaign/parts/BayDoor.java
+++ b/MekHQ/src/mekhq/campaign/parts/BayDoor.java
@@ -33,7 +33,7 @@ import megamek.common.annotations.Nullable;
 import mekhq.campaign.finances.Money;
 import org.w3c.dom.Node;
 
-import megamek.common.Bay;
+import megamek.common.bays.Bay;
 import megamek.common.Entity;
 import megamek.common.SimpleTechLevel;
 import megamek.common.TechAdvancement;
@@ -182,8 +182,8 @@ public class BayDoor extends Part {
     @Override
     public TechAdvancement getTechAdvancement() {
         return new TechAdvancement(TECH_BASE_ALL).setAdvancement(DATE_PS, DATE_PS, DATE_PS)
-                .setTechRating(RATING_A)
-                .setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD);
+                     .setTechRating(RATING_A)
+                     .setAvailability(RATING_A, RATING_A, RATING_A, RATING_A)
+                     .setStaticTechLevel(SimpleTechLevel.STANDARD);
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/Cubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/Cubicle.java
@@ -27,7 +27,7 @@
  */
 package mekhq.campaign.parts;
 
-import megamek.common.BayType;
+import megamek.common.bays.BayType;
 import megamek.common.Entity;
 import megamek.common.ITechnology;
 import megamek.common.annotations.Nullable;
@@ -42,8 +42,7 @@ import java.io.PrintWriter;
 import java.util.Objects;
 
 /**
- * A transport bay cubicle for a Mek, ProtoMek, vehicle, fighter, or small
- * craft.
+ * A transport bay cubicle for a Mek, ProtoMek, vehicle, fighter, or small craft.
  *
  * @author Neoancient
  */
@@ -155,8 +154,7 @@ public class Cubicle extends Part {
 
     @Override
     public boolean isSamePartType(Part part) {
-        return (part instanceof Cubicle)
-                && (((Cubicle) part).getBayType() == bayType);
+        return (part instanceof Cubicle) && (((Cubicle) part).getBayType() == bayType);
     }
 
     @Override
@@ -187,7 +185,7 @@ public class Cubicle extends Part {
                 bayType = BayType.parse(bayRawValue);
                 if (null == bayType) {
                     logger.error(String.format("Could not parse bay type %s treating as BayType.Mek",
-                        wn2.getTextContent()));
+                          wn2.getTextContent()));
                     bayType = BayType.MEK;
                 }
                 name = bayType.getDisplayName() + " Cubicle";

--- a/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingCubicle.java
@@ -27,18 +27,18 @@
  */
 package mekhq.campaign.parts;
 
-import megamek.common.BayType;
+import java.io.PrintWriter;
+import java.util.Objects;
+
 import megamek.common.Entity;
 import megamek.common.ITechnology;
 import megamek.common.annotations.Nullable;
+import megamek.common.bays.BayType;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import java.io.PrintWriter;
-import java.util.Objects;
 
 /**
  * @author Neoancient
@@ -112,8 +112,7 @@ public class MissingCubicle extends MissingPart {
 
     @Override
     public boolean isAcceptableReplacement(Part part, boolean refit) {
-        return (part instanceof Cubicle)
-                && (((Cubicle) part).getBayType() == bayType);
+        return (part instanceof Cubicle) && (((Cubicle) part).getBayType() == bayType);
     }
 
     @Override
@@ -147,7 +146,7 @@ public class MissingCubicle extends MissingPart {
                 bayType = BayType.parse(bayRawValue);
                 if (null == bayType) {
                     logger.error(String.format("Could not parse bay type %s treating as BayType.Mek",
-                        wn2.getTextContent()));
+                          wn2.getTextContent()));
                     bayType = BayType.MEK;
                 }
                 name = bayType.getDisplayName() + " Cubicle";

--- a/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
@@ -29,19 +29,17 @@ package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import megamek.common.annotations.Nullable;
-import mekhq.campaign.finances.Money;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import megamek.common.Bay;
 import megamek.common.Compute;
 import megamek.common.Entity;
 import megamek.common.TechAdvancement;
-import mekhq.utilities.MHQXMLUtility;
+import megamek.common.annotations.Nullable;
+import megamek.common.bays.Bay;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * @author Neoancient
@@ -50,6 +48,10 @@ public class TransportBayPart extends Part {
     private int bayNumber;
     private double size;
 
+    /**
+     * @deprecated no indicated uses.
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     public TransportBayPart() {
         this(0, 0, 0, null);
     }
@@ -95,8 +97,7 @@ public class TransportBayPart extends Part {
             hits = (int) bay.getBayDamage();
             int prevDoorHits = 0;
             for (Part p : getChildParts()) {
-                if ((p instanceof MissingBayDoor)
-                        || ((p instanceof BayDoor) && p.needsFixing())) {
+                if ((p instanceof MissingBayDoor) || ((p instanceof BayDoor) && p.needsFixing())) {
                     prevDoorHits++;
                 }
             }
@@ -105,11 +106,10 @@ public class TransportBayPart extends Part {
                 // exceptions from removing destroyed doors. We might as well filter anything that's
                 // not an undamaged door at the same time.
                 List<Part> doors = getChildParts().stream()
-                        .filter(p -> (p instanceof BayDoor) && !p.needsFixing())
-                        .collect(Collectors.toList());
+                                         .filter(p -> (p instanceof BayDoor) && !p.needsFixing())
+                                         .toList();
                 for (Part door : doors) {
-                    if (checkForDestruction
-                            && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
+                    if (checkForDestruction && Compute.d6(2) < campaign.getCampaignOptions().getDestroyPartTarget()) {
                         door.remove(false);
                     } else {
                         door.hits = 1;
@@ -123,9 +123,7 @@ public class TransportBayPart extends Part {
             // If checking for destruction we need to remove a number of cubicles (if any)
             // equal to the increase in damage.
             if ((hits > prevHits) && checkForDestruction) {
-                List<Part> cubicles = getChildParts().stream()
-                        .filter(p -> p instanceof Cubicle)
-                        .collect(Collectors.toList());
+                List<Part> cubicles = getChildParts().stream().filter(p -> p instanceof Cubicle).toList();
                 while ((hits > prevHits) && !cubicles.isEmpty()) {
                     Part cubicle = cubicles.get(Compute.randomInt(cubicles.size()));
                     cubicle.remove(false);

--- a/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/AbstractUnitRating.java
@@ -35,7 +35,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import megamek.common.*;
+import megamek.common.BattleArmor;
+import megamek.common.Dropship;
+import megamek.common.Entity;
+import megamek.common.Infantry;
+import megamek.common.Jumpship;
+import megamek.common.SpaceStation;
+import megamek.common.UnitType;
+import megamek.common.bays.*;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
@@ -170,8 +177,7 @@ public abstract class AbstractUnitRating implements IUnitRating {
      * Returns the average experience level for all combat personnel.
      */
     protected BigDecimal calcAverageExperience() {
-        return hasUnits() ? getTotalSkillLevels().divide(getNumberUnits(), PRECISION, HALF_EVEN)
-                : BigDecimal.ZERO;
+        return hasUnits() ? getTotalSkillLevels().divide(getNumberUnits(), PRECISION, HALF_EVEN) : BigDecimal.ZERO;
     }
 
     /**
@@ -302,17 +308,12 @@ public abstract class AbstractUnitRating implements IUnitRating {
         setTransportPercent(getTransportPercent());
 
         // Compute the score.
-        BigDecimal scoredPercent = getTransportPercent().subtract(
-                new BigDecimal(50));
+        BigDecimal scoredPercent = getTransportPercent().subtract(new BigDecimal(50));
         if (scoredPercent.compareTo(BigDecimal.ZERO) < 0) {
             return value;
         }
-        BigDecimal percentageScore = scoredPercent.divide(new BigDecimal(10),
-                0,
-                RoundingMode.DOWN);
-        value += percentageScore.multiply(new BigDecimal(5))
-                .setScale(0, RoundingMode.DOWN)
-                .intValue();
+        BigDecimal percentageScore = scoredPercent.divide(new BigDecimal(10), 0, RoundingMode.DOWN);
+        value += percentageScore.multiply(new BigDecimal(5)).setScale(0, RoundingMode.DOWN).intValue();
         value = Math.min(value, 25);
 
         // Only the highest of these values should be used, regardless of how
@@ -347,22 +348,15 @@ public abstract class AbstractUnitRating implements IUnitRating {
 
     @Override
     public String getUnitRatingName(int rating) {
-        switch (rating) {
-            case DRAGOON_F:
-                return "F";
-            case DRAGOON_D:
-                return "D";
-            case DRAGOON_C:
-                return "C";
-            case DRAGOON_B:
-                return "B";
-            case DRAGOON_A:
-                return "A";
-            case DRAGOON_ASTAR:
-                return "A*";
-            default:
-                return "Unrated";
-        }
+        return switch (rating) {
+            case DRAGOON_F -> "F";
+            case DRAGOON_D -> "D";
+            case DRAGOON_C -> "C";
+            case DRAGOON_B -> "B";
+            case DRAGOON_A -> "A";
+            case DRAGOON_ASTAR -> "A*";
+            default -> "Unrated";
+        };
     }
 
     @Override
@@ -387,8 +381,7 @@ public abstract class AbstractUnitRating implements IUnitRating {
     }
 
     /**
-     * Calculates the weighted value of the unit based on if it is Infantry,
-     * Battle Armor or something else.
+     * Calculates the weighted value of the unit based on if it is Infantry, Battle Armor or something else.
      *
      * @param u The {@code Unit} to be evaluated.
      */
@@ -410,7 +403,7 @@ public abstract class AbstractUnitRating implements IUnitRating {
     /**
      * Returns the sum of all experience rating for all combat units.
      *
-     * @param canInit Whether or not this method may initialize the values
+     * @param canInit Whether this method may initialize the values
      */
     BigDecimal getTotalSkillLevels(boolean canInit) {
         if (canInit && !isInitialized()) {
@@ -439,8 +432,7 @@ public abstract class AbstractUnitRating implements IUnitRating {
     protected abstract int calculateUnitRatingScore();
 
     /**
-     * Recalculates the dragoons rating. If this has already been done, the
-     * initialized flag should already be set true
+     * Recalculates the dragoons rating. If this has already been done, the initialized flag should already be set true
      * and this method will immediately exit.
      */
     protected void initValues() {
@@ -490,11 +482,10 @@ public abstract class AbstractUnitRating implements IUnitRating {
     }
 
     /**
-     * Updates the count of storage bays that may be used in Interstellar transport
-     * (part of transport capacity calculations)
+     * Updates the count of storage bays that may be used in Interstellar transport (part of transport capacity
+     * calculations)
      *
-     * @param e is the unit that may or may not contain bays that need to be
-     *          included in the count
+     * @param e is the unit that may or may not contain bays that need to be included in the count
      */
     void updateBayCount(Entity e) {
         if (((e instanceof Jumpship) || (e instanceof Dropship)) && !(e instanceof SpaceStation)) {
@@ -516,13 +507,18 @@ public abstract class AbstractUnitRating implements IUnitRating {
                 } else if (bay instanceof BattleArmorBay) {
                     setBaBayCount(getBaBayCount() + (int) bay.getCapacity());
                 } else if (bay instanceof InfantryBay) {
-                    setInfantryBayCount(getInfantryBayCount()
-                            + (int) Math.floor(bay.getCapacity() / ((InfantryBay) bay).getPlatoonType().getWeight()));
+                    setInfantryBayCount(getInfantryBayCount() +
+                                              (int) Math.floor(bay.getCapacity() /
+                                                                     ((InfantryBay) bay).getPlatoonType().getWeight()));
                 }
             }
         }
     }
 
+    /**
+     * @deprecated no indicated uses.
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     void updateDockingCollarCount(Jumpship jumpShip) {
         setDockingCollarCount(getDockingCollarCount() + jumpShip.getDockingCollars().size());
     }
@@ -592,6 +588,10 @@ public abstract class AbstractUnitRating implements IUnitRating {
         infantryUnitCount++;
     }
 
+    /**
+     * @deprecated no indicated uses
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     public int getInfantryUnitCount() {
         return infantryUnitCount;
     }
@@ -693,11 +693,8 @@ public abstract class AbstractUnitRating implements IUnitRating {
     }
 
     /**
-     * Calculate the number of infantry "platoons" present in the company, based on
-     * the numbers
-     * of various infantry present. Per CamOps, the simplification is that an
-     * infantry cube can
-     * house 28 infantry.
+     * Calculate the number of infantry "platoons" present in the company, based on the numbers of various infantry
+     * present. Per CamOps, the simplification is that an infantry cube can house 28 infantry.
      *
      * @return Number of infantry "platoons" in the company.
      */
@@ -894,16 +891,16 @@ public abstract class AbstractUnitRating implements IUnitRating {
         if (u.isMothballed()) {
             return;
         }
-        logger.debug("Adding " + u.getName() + " to unit counts.");
+        logger.debug("Adding {} to unit counts.", u.getName());
 
         Entity e = u.getEntity();
         if (null == e) {
-            logger.debug("Unit " + u.getName() + " is not an Entity.  Skipping.");
+            logger.debug("Unit {} is not an Entity. Skipping.", u.getName());
             return;
         }
 
         int unitType = e.getUnitType();
-        logger.debug("Unit " + u.getName() + " is a " + UnitType.getTypeDisplayableName(unitType));
+        logger.debug("Unit {} is a {}", u.getName(), UnitType.getTypeDisplayableName(unitType));
         // TODO : Add Airship when MegaMek supports it.
         switch (unitType) {
             case UnitType.MEK:
@@ -915,7 +912,7 @@ public abstract class AbstractUnitRating implements IUnitRating {
             case UnitType.GUN_EMPLACEMENT:
             case UnitType.VTOL:
             case UnitType.TANK:
-                logger.debug("Unit " + u.getName() + " weight is " + e.getWeight());
+                logger.debug("Unit {} weight is {}", u.getName(), e.getWeight());
                 if (e.getWeight() <= 50f) {
                     incrementLightVeeCount();
                 } else if (e.getWeight() <= 100f) {

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/TransportationRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/TransportationRating.java
@@ -28,6 +28,7 @@
 package mekhq.campaign.rating.CamOpsReputation;
 
 import megamek.common.*;
+import megamek.common.bays.*;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.Unit;
@@ -48,10 +49,10 @@ public class TransportationRating {
     /**
      * Calculates the transportation rating for the given campaign.
      *
-     * @param campaign The campaign for which to calculate the transportation
-     *                 rating.
-     * @return A list containing maps of transportation capacities and requirements,
-     *         including the transportation rating.
+     * @param campaign The campaign for which to calculate the transportation rating.
+     *
+     * @return A list containing maps of transportation capacities and requirements, including the transportation
+     *       rating.
      */
     public static List<Map<String, Integer>> calculateTransportationRating(Campaign campaign) {
         // Calculate transportation capacities and requirements for the campaign
@@ -182,8 +183,7 @@ public class TransportationRating {
         // Docking Collar Requirements
         int dockingCollarCount = transportationCapacities.get("dockingCollars");
 
-        if ((dockingCollarCount >= 0)
-            && (dockingCollarCount >= transportationRequirements.get("dropShipCount"))) {
+        if ((dockingCollarCount >= 0) && (dockingCollarCount >= transportationRequirements.get("dropShipCount"))) {
             transportationRating += 5;
             logger.debug("Exceeding docking collar requirements: +5");
         }
@@ -205,8 +205,9 @@ public class TransportationRating {
     /**
      * Returns capacity rating based on provided rating and capacityRating parameters.
      *
-     * @param rating the input rating
+     * @param rating         the input rating
      * @param capacityRating the current capacity rating
+     *
      * @return the determined capacity rating
      */
     private static int getCapacityRating(int rating, int capacityRating) {
@@ -224,11 +225,11 @@ public class TransportationRating {
     }
 
     /**
-     * Calculates the transportation rating adjustment based on capacity and
-     * requirements.
+     * Calculates the transportation rating adjustment based on capacity and requirements.
      *
      * @param capacity     the transport bay capacity
      * @param requirements the transport bay usage
+     *
      * @return the rating calculated based on the capacity and requirements
      */
     protected static int calculateRating(int capacity, int requirements) {
@@ -250,20 +251,17 @@ public class TransportationRating {
     /**
      * Retrieves the transportation bays and passenger capacity for a campaign.
      *
-     * @param campaign the campaign to retrieve the transportation bays and
-     *                 passenger capacity for
-     * @return a map containing the transportation bays and passenger capacity,
-     *         where each key represents
-     *         a bay type and its corresponding value represents the count or
-     *         capacity
+     * @param campaign the campaign to retrieve the transportation bays and passenger capacity for
+     *
+     * @return a map containing the transportation bays and passenger capacity, where each key represents a bay type and
+     *       its corresponding value represents the count or capacity
      */
     private static Map<String, Integer> calculateTransportationCapacities(Campaign campaign) {
         int uncrewedUnits = 0;
         int dockingCollars = 0;
         int hasJumpShipOrWarShip = 0;
 
-        int smallCraftBays = 0, mekBays = 0, asfBays = 0, superHeavyVehicleBays = 0, heavyVehicleBays = 0,
-                lightVehicleBays = 0, protoMekBays = 0, battleArmorBays = 0, infantryBays = 0, passengerCapacity = 0;
+        int smallCraftBays = 0, mekBays = 0, asfBays = 0, superHeavyVehicleBays = 0, heavyVehicleBays = 0, lightVehicleBays = 0, protoMekBays = 0, battleArmorBays = 0, infantryBays = 0, passengerCapacity = 0;
 
         // Iterating through each unit in the campaign
         for (Unit unit : campaign.getActiveUnits()) {
@@ -306,8 +304,8 @@ public class TransportationRating {
                 } else if (bay instanceof BattleArmorBay) {
                     battleArmorBays += (int) bay.getCapacity();
                 } else if (bay instanceof InfantryBay) {
-                    infantryBays += (int) Math
-                            .floor(bay.getCapacity() / ((InfantryBay) bay).getPlatoonType().getWeight());
+                    infantryBays += (int) Math.floor(bay.getCapacity() /
+                                                           ((InfantryBay) bay).getPlatoonType().getWeight());
                 }
 
                 passengerCapacity += bay.getPersonnel(entity.isClan());
@@ -317,17 +315,26 @@ public class TransportationRating {
         }
 
         // Map the capacity of each bay type
-        Map<String, Integer> transportationCapacities = new HashMap<>(Map.of(
-                "smallCraftBays", smallCraftBays,
-                "mekBays", mekBays,
-                "asfBays", asfBays,
-                "superHeavyVehicleBays", superHeavyVehicleBays,
-                "heavyVehicleBays", heavyVehicleBays,
-                "lightVehicleBays", lightVehicleBays,
-                "protoMekBays", protoMekBays,
-                "battleArmorBays", battleArmorBays,
-                "infantryBays", infantryBays,
-                "passengerCapacity", passengerCapacity));
+        Map<String, Integer> transportationCapacities = new HashMap<>(Map.of("smallCraftBays",
+              smallCraftBays,
+              "mekBays",
+              mekBays,
+              "asfBays",
+              asfBays,
+              "superHeavyVehicleBays",
+              superHeavyVehicleBays,
+              "heavyVehicleBays",
+              heavyVehicleBays,
+              "lightVehicleBays",
+              lightVehicleBays,
+              "protoMekBays",
+              protoMekBays,
+              "battleArmorBays",
+              battleArmorBays,
+              "infantryBays",
+              infantryBays,
+              "passengerCapacity",
+              passengerCapacity));
 
         // add the supplemental information to the map
         transportationCapacities.put("hasJumpShipOrWarShip", hasJumpShipOrWarShip);
@@ -336,9 +343,10 @@ public class TransportationRating {
 
         // log the stored information to aid debugging
         logger.debug("Transportation Capacities = {}",
-                transportationCapacities.entrySet().stream()
-                        .map(entry -> entry.getKey() + ": " + entry.getValue() + '\n')
-                        .collect(Collectors.joining()));
+              transportationCapacities.entrySet()
+                    .stream()
+                    .map(entry -> entry.getKey() + ": " + entry.getValue() + '\n')
+                    .collect(Collectors.joining()));
 
         // return the map
         return transportationCapacities;
@@ -347,15 +355,13 @@ public class TransportationRating {
     /**
      * Calculates the transport requirements for the given campaign.
      *
-     * @param campaign the campaign for which to calculate the transport
-     *                 requirements
+     * @param campaign the campaign for which to calculate the transport requirements
+     *
      * @return a map containing the count for each type of entity in the campaign
      */
     private static Map<String, Integer> calculateTransportRequirements(Campaign campaign) {
         // Initialize variables to store counts of different unit types
-        int dropShipCount = 0, smallCraftCount = 0, mekCount = 0, asfCount = 0, superHeavyVehicleCount = 0,
-                heavyVehicleCount = 0, lightVehicleCount = 0, protoMekCount = 0, battleArmorCount = 0,
-                infantryCount = 0;
+        int dropShipCount = 0, smallCraftCount = 0, mekCount = 0, asfCount = 0, superHeavyVehicleCount = 0, heavyVehicleCount = 0, lightVehicleCount = 0, protoMekCount = 0, battleArmorCount = 0, infantryCount = 0;
 
         // Iterate through each unit in the campaign
         for (Unit unit : campaign.getActiveUnits()) {
@@ -393,33 +399,45 @@ public class TransportationRating {
         }
 
         // Count the number of passengers by filtering the personnel list
-        int passengerCount = (int) campaign.getPersonnel().stream()
-                .filter(person -> !person.getStatus().isAbsent() && !person.getStatus().isDepartedUnit())
-                .filter(person -> person.getUnit() == null)
-                .count();
+        int passengerCount = (int) campaign.getPersonnel()
+                                         .stream()
+                                         .filter(person -> !person.getStatus().isAbsent() &&
+                                                                 !person.getStatus().isDepartedUnit())
+                                         .filter(person -> person.getUnit() == null)
+                                         .count();
 
         // Map each unit count to its type
-        Map<String, Integer> transportRequirements = new HashMap<>(Map.of(
-                "dropShipCount", dropShipCount,
-                "smallCraftCount", smallCraftCount,
-                "mekCount", mekCount,
-                "asfCount", asfCount,
-                "superHeavyVehicleCount", superHeavyVehicleCount,
-                "heavyVehicleCount", heavyVehicleCount,
-                "lightVehicleCount", lightVehicleCount,
-                "protoMekCount", protoMekCount,
-                "battleArmorCount", battleArmorCount,
-                "infantryCount", infantryCount));
+        Map<String, Integer> transportRequirements = new HashMap<>(Map.of("dropShipCount",
+              dropShipCount,
+              "smallCraftCount",
+              smallCraftCount,
+              "mekCount",
+              mekCount,
+              "asfCount",
+              asfCount,
+              "superHeavyVehicleCount",
+              superHeavyVehicleCount,
+              "heavyVehicleCount",
+              heavyVehicleCount,
+              "lightVehicleCount",
+              lightVehicleCount,
+              "protoMekCount",
+              protoMekCount,
+              "battleArmorCount",
+              battleArmorCount,
+              "infantryCount",
+              infantryCount));
 
         transportRequirements.put("totalVehicleCount",
-                (superHeavyVehicleCount + heavyVehicleCount + lightVehicleCount));
+              (superHeavyVehicleCount + heavyVehicleCount + lightVehicleCount));
         transportRequirements.put("passengerCount", passengerCount);
 
         // Log the calculated transport requirements
         logger.debug("Transportation Requirements = {}",
-                transportRequirements.entrySet().stream()
-                        .map(entry -> entry.getKey() + ": " + entry.getValue() + '\n')
-                        .collect(Collectors.joining()));
+              transportRequirements.entrySet()
+                    .stream()
+                    .map(entry -> entry.getKey() + ": " + entry.getValue() + '\n')
+                    .collect(Collectors.joining()));
 
         // Returns a map with calculated counts for each unit type
         return transportRequirements;

--- a/MekHQ/src/mekhq/campaign/unit/ITransportAssignment.java
+++ b/MekHQ/src/mekhq/campaign/unit/ITransportAssignment.java
@@ -28,14 +28,16 @@
 
 package mekhq.campaign.unit;
 
+import java.util.Optional;
+
 import megamek.common.Transporter;
+import megamek.common.bays.Bay;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.unit.enums.TransporterType;
 
-import java.util.Optional;
-
 /**
- * Represents an assignment on a transport.
+ * Represents an assignment on transport.
+ *
  * @see ITransportedUnitsSummary
  * @see mekhq.campaign.enums.CampaignTransportType
  */
@@ -43,6 +45,7 @@ public interface ITransportAssignment {
 
     /**
      * The transport that is assigned
+     *
      * @return
      */
     Unit getTransport();
@@ -55,37 +58,43 @@ public interface ITransportAssignment {
 
     /**
      * Where is this unit being transported?
+     *
      * @return The transporter this unit is in
      */
     Transporter getTransportedLocation();
 
     /**
      * Is this unit in a specific location?
+     *
      * @return true if it is
      */
     boolean hasTransportedLocation();
 
     /**
      * Convert location to hash to assist with saving/loading
+     *
      * @return hash int, or null if none
      */
     Optional<Integer> hashTransportedLocation();
 
     /**
      * After loading UnitRefs need converted to Units
-     * @see Unit#fixReferences(Campaign campaign)
+     *
      * @param campaign Campaign we need to fix references for
-     * @param unit Unit we need to fix references for
+     * @param unit     Unit we need to fix references for
+     *
+     * @see Unit#fixReferences(Campaign campaign)
      */
     void fixReferences(Campaign campaign, Unit unit);
 
     /**
-     * Bays have some extra functionality other transporters don't have, like
-     * having a tech crew, which will matter for boarding actions against
-     * dropships and other Ship Transports. This method determines if this
-     * transport assignment is for a Bay.
+     * Bays have some extra functionality other transporters don't have, like having a tech crew, which will matter for
+     * boarding actions against dropships and other Ship Transports. This method determines if this transport assignment
+     * is for a Bay.
+     *
      * @return true if the unit is transported in a Bay or a subclass
-     * @see megamek.common.Bay
+     *
+     * @see Bay
      */
     boolean isTransportedInBay();
 

--- a/MekHQ/src/mekhq/campaign/unit/TransportAssignment.java
+++ b/MekHQ/src/mekhq/campaign/unit/TransportAssignment.java
@@ -1,45 +1,40 @@
 /**
  * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
- *
+ * <p>
  * This file is part of MekHQ.
- *
- * MekHQ is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License (GPL),
- * version 3 or (at your option) any later version,
- * as published by the Free Software Foundation.
- *
- * MekHQ is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty
- * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
- *
- * A copy of the GPL should have been included with this project;
- * if not, see <https://www.gnu.org/licenses/>.
- *
- * NOTICE: The MegaMek organization is a non-profit group of volunteers
- * creating free software for the BattleTech community.
- *
- * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
- * of The Topps Company, Inc. All Rights Reserved.
- *
- * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
- * InMediaRes Productions, LLC.
+ * <p>
+ * MekHQ is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * (GPL), version 3 or (at your option) any later version, as published by the Free Software Foundation.
+ * <p>
+ * MekHQ is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <p>
+ * A copy of the GPL should have been included with this project; if not, see <https://www.gnu.org/licenses/>.
+ * <p>
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers creating free software for the BattleTech
+ * community.
+ * <p>
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks of The Topps Company, Inc. All Rights
+ * Reserved.
+ * <p>
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Productions, LLC.
  */
 package mekhq.campaign.unit;
 
-import megamek.common.Bay;
+import java.util.Optional;
+
 import megamek.common.Transporter;
 import megamek.common.annotations.Nullable;
+import megamek.common.bays.Bay;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.unit.enums.TransporterType;
 
-import java.util.Optional;
-
 /**
- * Represents an assignment on a transport. Currently only used by TACTICAL_TRANSPORT
- * but this could be used by other transport types.
+ * Represents an assignment on transport. Currently only used by TACTICAL_TRANSPORT but this could be used by other
+ * transport types.
+ *
  * @see TacticalTransportedUnitsSummary
  * @see CampaignTransportType#TACTICAL_TRANSPORT
  */
@@ -62,7 +57,9 @@ public class TransportAssignment implements ITransportAssignment {
     public TransportAssignment(Unit transport, @Nullable Transporter transportedLocation) {
         setTransport(transport);
         setTransportedLocation(transportedLocation);
-        setTransporterType(hasTransportedLocation() ? TransporterType.getTransporterType(getTransportedLocation()) : null);
+        setTransporterType(hasTransportedLocation() ?
+                                 TransporterType.getTransporterType(getTransportedLocation()) :
+                                 null);
     }
 
     public TransportAssignment(Unit transport, int hashedTransportedLocation) {
@@ -78,9 +75,7 @@ public class TransportAssignment implements ITransportAssignment {
 
 
     /**
-     * The transport that is assigned
-     *
-     * @return
+     * @return The transport that is assigned
      */
     @Override
     public Unit getTransport() {
@@ -96,11 +91,10 @@ public class TransportAssignment implements ITransportAssignment {
      * Change the transport assignment to have a new transport
      *
      * @param newTransport transport, or null if none
-     * @return true if a unit was provided, false if it was null
      */
-    protected boolean setTransport(Unit newTransport) {
+    protected void setTransport(Unit newTransport) {
         this.transport = newTransport;
-        return hasTransport();
+        hasTransport();
     }
 
     @Override
@@ -113,9 +107,9 @@ public class TransportAssignment implements ITransportAssignment {
         return transporterType != null;
     }
 
-    protected boolean setTransporterType(TransporterType transporterType) {
+    protected void setTransporterType(TransporterType transporterType) {
         this.transporterType = transporterType;
-        return hasTransporterType();
+        hasTransporterType();
     }
 
     @Override
@@ -135,12 +129,10 @@ public class TransportAssignment implements ITransportAssignment {
 
     /**
      * Set where this unit should be transported
-     *
-     * @return true if a location was provided, false if it was null
      */
-    protected boolean setTransportedLocation(@Nullable Transporter transportedLocation) {
+    protected void setTransportedLocation(@Nullable Transporter transportedLocation) {
         this.transportedLocation = transportedLocation;
-        return hasTransportedLocation();
+        hasTransportedLocation();
     }
 
     /**
@@ -160,12 +152,13 @@ public class TransportAssignment implements ITransportAssignment {
      * After loading UnitRefs need converted to Units
      *
      * @param campaign Campaign we need to fix references for
-     * @param unit the unit that needs references fixed
+     * @param unit     the unit that needs references fixed
+     *
      * @see Unit#fixReferences(Campaign campaign)
      */
     @Override
     public void fixReferences(Campaign campaign, Unit unit) {
-            if (getTransport() instanceof Unit.UnitRef) {
+        if (getTransport() instanceof Unit.UnitRef) {
             Unit transport = campaign.getHangar().getUnit(getTransport().getId());
             if (transport != null) {
                 if (hasTransportedLocation()) {
@@ -173,18 +166,19 @@ public class TransportAssignment implements ITransportAssignment {
 
                 } else if (hasTransporterType()) {
                     setTransport(transport);
-                }
-                else {
+                } else {
                     setTransport(transport);
                     logger.warn(
-                        String.format("Unit %s ('%s') is missing a transportedLocation " +
-                                "and transporterType for tactical transport %s",
-                            unit.getId(), unit.getName(), getTransport().getId()));
+                          "Unit {} ('{}') is missing a transportedLocation and transporterType for tactical transport {}",
+                          unit.getId(),
+                          unit.getName(),
+                          getTransport().getId());
                 }
             } else {
-                logger.error(
-                    String.format("Unit %s ('%s') references missing transport %s",
-                        unit.getId(), unit.getName(), getTransport().getId()));
+                logger.error("Unit {} ('{}') references missing transport {}",
+                      unit.getId(),
+                      unit.getName(),
+                      getTransport().getId());
 
                 unit.setTacticalTransportAssignment(null);
             }
@@ -192,12 +186,12 @@ public class TransportAssignment implements ITransportAssignment {
     }
 
     /**
-     * Bays have some extra functionality other transporters don't have, like
-     * having a tech crew, which will matter for boarding actions against
-     * dropships and other Ship Transports. This method determines if this
-     * transport assignment is for a Bay.
+     * Bays have some extra functionality other transporters don't have, like having a tech crew, which will matter for
+     * boarding actions against dropships and other Ship Transports. This method determines if this transport assignment
+     * is for a Bay.
      *
      * @return true if the unit is transported in a Bay or a subclass
+     *
      * @see Bay
      */
     @Override

--- a/MekHQ/src/mekhq/campaign/unit/enums/TransporterType.java
+++ b/MekHQ/src/mekhq/campaign/unit/enums/TransporterType.java
@@ -1,14 +1,14 @@
-/**
+/*
  * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of MekHQ.
+ * This file is part of MegaMekLab.
  *
- * MekHQ is free software: you can redistribute it and/or modify
+ * MegaMekLab is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * MekHQ is distributed in the hope that it will be useful,
+ * MegaMekLab is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -28,16 +28,22 @@
 
 package mekhq.campaign.unit.enums;
 
-import megamek.common.*;
+import megamek.common.BattleArmorHandles;
+import megamek.common.BattleArmorHandlesTank;
+import megamek.common.ClampMountMek;
+import megamek.common.ClampMountTank;
+import megamek.common.DockingCollar;
+import megamek.common.InfantryCompartment;
+import megamek.common.ProtoMekClampMount;
+import megamek.common.TankTrailerHitch;
+import megamek.common.Transporter;
+import megamek.common.bays.*;
 import mekhq.campaign.enums.CampaignTransportType;
 
 /**
- * Entities are equipped with different Transporters.
- * TransporterTypes are the different kinds of
- * transporters from MegaMek that are implemented
- * to be used with CampaignTransportTypes, like
- * Mek Bays, Docking Collars, Battle Armor Handles,
- * or Infantry Compartments.
+ * Entities are equipped with different Transporters. TransporterTypes are the different kinds of transporters from
+ * MegaMek that are implemented to be used with CampaignTransportTypes, like Mek Bays, Docking Collars, Battle Armor
+ * Handles, or Infantry Compartments.
  *
  * @see Transporter
  * @see CampaignTransportType
@@ -49,7 +55,7 @@ public enum TransporterType {
     HEAVY_VEHICLE_BAY(HeavyVehicleBay.class),
     NAVAL_REPAIR_FACILITY(NavalRepairFacility.class),
     REINFORCED_REPAIR_FACILITY(ReinforcedRepairFacility.class),
-    DROPSHUTTLE_BAY(DropshuttleBay.class),
+    DROPSHUTTLE_BAY(DropShuttleBay.class),
     LIGHT_VEHICLE_BAY(LightVehicleBay.class),
     SUPER_HEAVY_VEHICLE_BAY(SuperHeavyVehicleBay.class),
     MEK_BAY(MekBay.class),
@@ -81,15 +87,15 @@ public enum TransporterType {
     // endregion Constructor
 
     /**
-     * An Entity's Transporters need to be mapped to their
-     * TransporterTypes. For the provided Transporter,
-     * this returns its corresponding TransporterType,
-     * or null if it's not found.
+     * An Entity's Transporters need to be mapped to their TransporterTypes. For the provided Transporter, this returns
+     * its corresponding TransporterType, or null if it's not found.
+     *
+     * @param transporter specific transporter to return the type of
+     * @param <T>         extends Transporter
+     *
+     * @return TransporterType (enum) of the provided transporter, or null
      *
      * @see Transporter
-     * @param transporter specific transporter to return the type of
-     * @return TransporterType (enum) of the provided transporter, or null
-     * @param <T> extends Transporter
      */
     public static <T extends Transporter> TransporterType getTransporterType(T transporter) {
         for (TransporterType transporterType : TransporterType.values()) {
@@ -102,7 +108,10 @@ public enum TransporterType {
 
     /**
      * The specific Class of Transporter that corresponds to this TransporterType
+     *
      * @return Class that extends Transporter
      */
-    public Class<? extends Transporter> getTransporterClass() { return transporterClass; }
+    public Class<? extends Transporter> getTransporterClass() {
+        return transporterClass;
+    }
 }

--- a/MekHQ/src/mekhq/campaign/utilities/CampaignTransportUtilities.java
+++ b/MekHQ/src/mekhq/campaign/utilities/CampaignTransportUtilities.java
@@ -1,14 +1,14 @@
-/**
+/*
  * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of MekHQ.
+ * This file is part of MegaMekLab.
  *
- * MekHQ is free software: you can redistribute it and/or modify
+ * MegaMekLab is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * MekHQ is distributed in the hope that it will be useful,
+ * MegaMekLab is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -28,15 +28,19 @@
 
 package mekhq.campaign.utilities;
 
+import static mekhq.campaign.unit.enums.TransporterType.*;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Vector;
+
 import megamek.common.*;
+import megamek.common.bays.InfantryBay;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.utilities.MHQInternationalization;
 import org.apache.commons.math3.util.Pair;
-
-import java.util.*;
-
-import static mekhq.campaign.unit.enums.TransporterType.*;
 
 public class CampaignTransportUtilities {
     // region Static Helpers
@@ -48,46 +52,48 @@ public class CampaignTransportUtilities {
     }
 
     /**
-     * Helps the menus need to check less when generating Transports. Let's get a list of
-     * TransporterTypes that this Entity could potentially be transported in. This will make
-     * it much easier to determine what Transporters we should even look at.
-     * In addition, CampaignTransportTypes that can't use certain TransporterTypes is handled,
-     * like Ship Transports not being able to use InfantryCompartments or BattleArmorHandles.
-     * Use a Bay! Or DockingCollar.
+     * Helps the menus need to check less when generating Transports. Let's get a list of TransporterTypes that this
+     * Entity could potentially be transported in. This will make it much easier to determine what Transporters we
+     * should even look at. In addition, CampaignTransportTypes that can't use certain TransporterTypes is handled, like
+     * Ship Transports not being able to use InfantryCompartments or BattleArmorHandles. Use a Bay! Or DockingCollar.
+     *
+     * @param campaignTransportType type (enum) of campaign transport - some transport types can't use certain
+     *                              transporters
+     * @param unit                  unit we want to get the Transporter types that could potentially hold it
+     *
+     * @return Transporter types that could potentially transport this entity
      *
      * @see TransporterType
-     * @param campaignTransportType type (enum) of campaign transport - some transport types can't use certain transporters
-     * @param unit unit we want to get the Transporter types that could potentially hold it
-     * @return Transporter types that could potentially transport this entity
      */
-    public static EnumSet<TransporterType> mapEntityToTransporters(CampaignTransportType campaignTransportType, Entity unit) {
+    public static EnumSet<TransporterType> mapEntityToTransporters(CampaignTransportType campaignTransportType,
+          Entity unit) {
         if (campaignTransportType.isTowTransport()) {
             if (unit.isTrailer()) {
                 return EnumSet.of(TANK_TRAILER_HITCH);
-            }
-            else {
+            } else {
                 return EnumSet.noneOf(TransporterType.class);
             }
         }
-        return getTransportTypeClassifier(unit).map(v -> v.getTransporterTypes(unit, campaignTransportType)).orElse(EnumSet.noneOf(TransporterType.class));
+        return getTransportTypeClassifier(unit).map(v -> v.getTransporterTypes(unit, campaignTransportType))
+                     .orElse(EnumSet.noneOf(TransporterType.class));
     }
 
 
     /**
-     * Most slots are 1:1, infantry use their tonnage in some cases
-     * TANK_TRAILER_HITCH use the maximum pulling capacity of its
-     * tractor so return the transported unit's weight
+     * Most slots are 1:1, infantry use their tonnage in some cases TANK_TRAILER_HITCH use the maximum pulling capacity
+     * of its tractor so return the transported unit's weight
      *
      * @param transporterType type (Enum) of Transporter
      * @param transportedUnit Entity we want the capacity usage of
+     *
      * @return how much capacity this unit uses when being transported in this kind of transporter
      */
     public static double transportCapacityUsage(TransporterType transporterType, Entity transportedUnit) {
         if (transportedUnit instanceof Infantry) {
-            if (transporterType == INFANTRY_BAY || transporterType == CARGO_BAY) { // TODO from MekHQ#5928: Add Cargo Container
+            if (transporterType == INFANTRY_BAY ||
+                      transporterType == CARGO_BAY) { // TODO from MekHQ#5928: Add Cargo Container
                 return calcInfantryBayWeight(transportedUnit);
-            }
-            else if (transporterType == INFANTRY_COMPARTMENT) {
+            } else if (transporterType == INFANTRY_COMPARTMENT) {
                 return calcInfantryCompartmentWeight(transportedUnit);
             }
         } else if (transporterType == TANK_TRAILER_HITCH) {
@@ -97,10 +103,11 @@ public class CampaignTransportUtilities {
     }
 
     /**
-     * Calculates transport bay space required by an infantry platoon,
-     * which is not the same as the flat weight of that platoon
+     * Calculates transport bay space required by an infantry platoon, which is not the same as the flat weight of that
+     * platoon
      *
      * @param entity The Entity that we need the weight for
+     *
      * @return Capacity in tons needed to transport this entity
      */
     private static double calcInfantryBayWeight(Entity entity) {
@@ -117,6 +124,7 @@ public class CampaignTransportUtilities {
      * Calculates transport space required for an infantry compartment
      *
      * @param entity The Entity that we need the weight for
+     *
      * @return Capacity in tons needed to transport this entity
      */
     private static double calcInfantryCompartmentWeight(Entity entity) {
@@ -126,155 +134,160 @@ public class CampaignTransportUtilities {
 
     private static final List<Visitor> visitors = List.of(
 
-        new Visitor<ProtoMek>() {
-            @Override
-            public boolean isInterestedIn(Entity entity) {
-                return entity instanceof ProtoMek;
-            }
+          new Visitor<ProtoMek>() {
+              @Override
+              public boolean isInterestedIn(Entity entity) {
+                  return entity instanceof ProtoMek;
+              }
 
-            @Override
-            public EnumSet<TransporterType> getTransporterTypes(ProtoMek entity, CampaignTransportType campaignTransportType) {
-                EnumSet<TransporterType> transporters = EnumSet.noneOf(TransporterType.class);
-                transporters.add(PROTO_MEK_BAY);
+              @Override
+              public EnumSet<TransporterType> getTransporterTypes(ProtoMek entity,
+                    CampaignTransportType campaignTransportType) {
+                  EnumSet<TransporterType> transporters = EnumSet.noneOf(TransporterType.class);
+                  transporters.add(PROTO_MEK_BAY);
 
-                //Ship transports can't use some transport types
-                if (!(campaignTransportType.isShipTransport())) {
-                    transporters.add(PROTO_MEK_CLAMP_MOUNT);
-                }
+                  //Ship transports can't use some transport types
+                  if (!(campaignTransportType.isShipTransport())) {
+                      transporters.add(PROTO_MEK_CLAMP_MOUNT);
+                  }
 
-                return transporters;
-            }
-        },
-        new Visitor<Aero>() {
+                  return transporters;
+              }
+          }, new Visitor<Aero>() {
 
-            @Override
-            public boolean isInterestedIn(Entity entity) {
-                return entity instanceof Aero;
-            }
+              @Override
+              public boolean isInterestedIn(Entity entity) {
+                  return entity instanceof Aero;
+              }
 
-            @Override
-            public EnumSet<TransporterType> getTransporterTypes(Aero entity, CampaignTransportType campaignTransportType) {
-                EnumSet<TransporterType> transporters = EnumSet.noneOf(TransporterType.class);
-                if (entity.isFighter()) {
-                    transporters.add(ASF_BAY);
-                }
-                if ((entity.isFighter()) || entity.isSmallCraft()) {
-                    transporters.add(SMALL_CRAFT_BAY);
-                }
-                if (entity.hasETypeFlag(Entity.ETYPE_DROPSHIP) && (entity.getWeight() <= 5000)) {
-                    transporters.add(DROPSHUTTLE_BAY);
-                }
-                if (entity.hasETypeFlag(Entity.ETYPE_DROPSHIP) || entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
-                    transporters.add(NAVAL_REPAIR_FACILITY);
-                    transporters.add(REINFORCED_REPAIR_FACILITY);
-                }
-                if (entity instanceof Dropship && !((Dropship) entity).isDockCollarDamaged()) {
-                    transporters.add(DOCKING_COLLAR);
-                }
+              @Override
+              public EnumSet<TransporterType> getTransporterTypes(Aero entity,
+                    CampaignTransportType campaignTransportType) {
+                  EnumSet<TransporterType> transporters = EnumSet.noneOf(TransporterType.class);
+                  if (entity.isFighter()) {
+                      transporters.add(ASF_BAY);
+                  }
+                  if ((entity.isFighter()) || entity.isSmallCraft()) {
+                      transporters.add(SMALL_CRAFT_BAY);
+                  }
+                  if (entity.hasETypeFlag(Entity.ETYPE_DROPSHIP) && (entity.getWeight() <= 5000)) {
+                      transporters.add(DROPSHUTTLE_BAY);
+                  }
+                  if (entity.hasETypeFlag(Entity.ETYPE_DROPSHIP) || entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+                      transporters.add(NAVAL_REPAIR_FACILITY);
+                      transporters.add(REINFORCED_REPAIR_FACILITY);
+                  }
+                  if (entity instanceof Dropship && !((Dropship) entity).isDockCollarDamaged()) {
+                      transporters.add(DOCKING_COLLAR);
+                  }
 
-                return transporters;
-            }
-        },
-        new Visitor<Tank>() {
+                  return transporters;
+              }
+          }, new Visitor<Tank>() {
 
-            @Override
-            public boolean isInterestedIn(Entity entity) {
-                return entity instanceof Tank;
-            }
+              @Override
+              public boolean isInterestedIn(Entity entity) {
+                  return entity instanceof Tank;
+              }
 
-            @Override
-            public EnumSet<TransporterType> getTransporterTypes(Tank entity, CampaignTransportType campaignTransportType) {
+              @Override
+              public EnumSet<TransporterType> getTransporterTypes(Tank entity,
+                    CampaignTransportType campaignTransportType) {
 
-                EnumSet<TransporterType> transporters = EnumSet.noneOf(TransporterType.class);
+                  EnumSet<TransporterType> transporters = EnumSet.noneOf(TransporterType.class);
 
-                if (entity.getWeight() <= 50) {
-                    transporters.add(LIGHT_VEHICLE_BAY);
-                }
+                  if (entity.getWeight() <= 50) {
+                      transporters.add(LIGHT_VEHICLE_BAY);
+                  }
 
-                if (entity.getWeight() <= 100) {
-                    transporters.add(HEAVY_VEHICLE_BAY);
-                }
+                  if (entity.getWeight() <= 100) {
+                      transporters.add(HEAVY_VEHICLE_BAY);
+                  }
 
-                if (entity.getWeight() <= 150) {
-                    transporters.add(SUPER_HEAVY_VEHICLE_BAY);
-                }
-                return transporters;
-            }
-        },
-        new Visitor<Mek>() {
+                  if (entity.getWeight() <= 150) {
+                      transporters.add(SUPER_HEAVY_VEHICLE_BAY);
+                  }
+                  return transporters;
+              }
+          }, new Visitor<Mek>() {
 
-            @Override
-            public boolean isInterestedIn(Entity entity) {
-                return entity instanceof Mek;
-            }
+              @Override
+              public boolean isInterestedIn(Entity entity) {
+                  return entity instanceof Mek;
+              }
 
-            @Override
-            public EnumSet<TransporterType> getTransporterTypes(Mek entity, CampaignTransportType campaignTransportType) {
-                EnumSet<TransporterType> transporters = EnumSet.noneOf(TransporterType.class);
-                boolean loadableQuadVee = (entity instanceof QuadVee) && (entity.getConversionMode() == QuadVee.CONV_MODE_MEK);
-                boolean loadableLAM = (entity instanceof LandAirMek) && (entity.getConversionMode() != LandAirMek.CONV_MODE_FIGHTER);
-                boolean loadableOtherMek = (entity != null) && !(entity instanceof QuadVee) && !(entity instanceof LandAirMek);
-                if (loadableQuadVee || loadableLAM || loadableOtherMek) {
-                    transporters.add(MEK_BAY);
+              @Override
+              public EnumSet<TransporterType> getTransporterTypes(Mek entity,
+                    CampaignTransportType campaignTransportType) {
+                  EnumSet<TransporterType> transporters = EnumSet.noneOf(TransporterType.class);
+                  boolean loadableQuadVee = (entity instanceof QuadVee) &&
+                                                  (entity.getConversionMode() == QuadVee.CONV_MODE_MEK);
+                  boolean loadableLAM = (entity instanceof LandAirMek) &&
+                                              (entity.getConversionMode() != LandAirMek.CONV_MODE_FIGHTER);
+                  boolean loadableOtherMek = (entity != null) &&
+                                                   !(entity instanceof QuadVee) &&
+                                                   !(entity instanceof LandAirMek);
+                  if (loadableQuadVee || loadableLAM || loadableOtherMek) {
+                      transporters.add(MEK_BAY);
 
-                } else {
-                    if ((entity instanceof QuadVee) && (entity.getConversionMode() == QuadVee.CONV_MODE_VEHICLE)) {
-                        if (entity.getWeight() <= 50) {
-                            transporters.add(LIGHT_VEHICLE_BAY);
-                        }
+                  } else {
+                      if ((entity instanceof QuadVee) && (entity.getConversionMode() == QuadVee.CONV_MODE_VEHICLE)) {
+                          if (entity.getWeight() <= 50) {
+                              transporters.add(LIGHT_VEHICLE_BAY);
+                          }
 
-                        if (entity.getWeight() <= 100) {
-                            transporters.add(HEAVY_VEHICLE_BAY);
-                        }
+                          if (entity.getWeight() <= 100) {
+                              transporters.add(HEAVY_VEHICLE_BAY);
+                          }
 
-                        if (entity.getWeight() <= 100) {
-                            transporters.add(SUPER_HEAVY_VEHICLE_BAY);
-                        }
-                    }
-                }
-                return transporters;
-            }
-        },
-        new Visitor<Infantry>() {
+                          if (entity.getWeight() <= 100) {
+                              transporters.add(SUPER_HEAVY_VEHICLE_BAY);
+                          }
+                      }
+                  }
+                  return transporters;
+              }
+          }, new Visitor<Infantry>() {
 
-            @Override
-            public boolean isInterestedIn(Entity entity) {
-                return entity instanceof Infantry;
-            }
+              @Override
+              public boolean isInterestedIn(Entity entity) {
+                  return entity instanceof Infantry;
+              }
 
-            @Override
-            public EnumSet<TransporterType> getTransporterTypes(Infantry entity, CampaignTransportType campaignTransportType) {
-                EnumSet<TransporterType> transporters = EnumSet.noneOf(TransporterType.class);
+              @Override
+              public EnumSet<TransporterType> getTransporterTypes(Infantry entity,
+                    CampaignTransportType campaignTransportType) {
+                  EnumSet<TransporterType> transporters = EnumSet.noneOf(TransporterType.class);
 
-                //Ship transports can't use some transport types
-                if (!(campaignTransportType.isShipTransport())) {
-                    transporters.add(INFANTRY_COMPARTMENT);
-                    transporters.add(CARGO_BAY);
-                    // TODO from MekHQ#5928: Add Cargo Container
-                }
+                  //Ship transports can't use some transport types
+                  if (!(campaignTransportType.isShipTransport())) {
+                      transporters.add(INFANTRY_COMPARTMENT);
+                      transporters.add(CARGO_BAY);
+                      // TODO from MekHQ#5928: Add Cargo Container
+                  }
 
-                if (entity instanceof BattleArmor baEntity) {
-                    transporters.add(BATTLE_ARMOR_BAY);
+                  if (entity instanceof BattleArmor baEntity) {
+                      transporters.add(BATTLE_ARMOR_BAY);
 
-                    //Ship transports can't use some transport types
-                    if (baEntity.canDoMechanizedBA() && !campaignTransportType.isShipTransport()) {
-                        transporters.add(BATTLE_ARMOR_HANDLES);
-                        transporters.add(BATTLE_ARMOR_HANDLES_TANK);
+                      //Ship transports can't use some transport types
+                      if (baEntity.canDoMechanizedBA() && !campaignTransportType.isShipTransport()) {
+                          transporters.add(BATTLE_ARMOR_HANDLES);
+                          transporters.add(BATTLE_ARMOR_HANDLES_TANK);
 
-                        if (baEntity.hasMagneticClamps()) {
-                            transporters.add(CLAMP_MOUNT_MEK);
-                            transporters.add(CLAMP_MOUNT_TANK);
-                        }
+                          if (baEntity.hasMagneticClamps()) {
+                              transporters.add(CLAMP_MOUNT_MEK);
+                              transporters.add(CLAMP_MOUNT_TANK);
+                          }
 
-                    }
+                      }
 
-                } else {
-                    transporters.add(INFANTRY_BAY);
-                }
+                  } else {
+                      transporters.add(INFANTRY_BAY);
+                  }
 
-                return transporters;
-            }
-        });
+                  return transporters;
+              }
+          });
 
     private static Optional<Visitor> getTransportTypeClassifier(Entity entity) {
         return visitors.stream().filter(v -> v.isInterestedIn(entity)).findFirst();
@@ -282,13 +295,18 @@ public class CampaignTransportUtilities {
 
     /**
      * Return "None" in the first position
+     *
      * @return vector of transport options, with none first
      */
     public static Vector<Pair<String, CampaignTransportType>> getLeadershipDropdownVectorPair() {
         Vector<Pair<String, CampaignTransportType>> retVal = new Vector<>();
-        retVal.add(new Pair<>(MHQInternationalization.getTextAt("mekhq.resources.AssignForceToTransport", "CampaignTransportUtilities.selectTransport.null.text"), null));
-        retVal.add(new Pair<>(MHQInternationalization.getTextAt("mekhq.resources.AssignForceToTransport", "CampaignTransportUtilities.selectTransport.TACTICAL_TRANSPORT.text"), CampaignTransportType.TACTICAL_TRANSPORT));
-        retVal.add(new Pair<>(MHQInternationalization.getTextAt("mekhq.resources.AssignForceToTransport", "CampaignTransportUtilities.selectTransport.SHIP_TRANSPORT.text"), CampaignTransportType.SHIP_TRANSPORT));
+        retVal.add(new Pair<>(MHQInternationalization.getTextAt("mekhq.resources.AssignForceToTransport",
+              "CampaignTransportUtilities.selectTransport.null.text"), null));
+        retVal.add(new Pair<>(MHQInternationalization.getTextAt("mekhq.resources.AssignForceToTransport",
+              "CampaignTransportUtilities.selectTransport.TACTICAL_TRANSPORT.text"),
+              CampaignTransportType.TACTICAL_TRANSPORT));
+        retVal.add(new Pair<>(MHQInternationalization.getTextAt("mekhq.resources.AssignForceToTransport",
+              "CampaignTransportUtilities.selectTransport.SHIP_TRANSPORT.text"), CampaignTransportType.SHIP_TRANSPORT));
 
         return retVal;
     }

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -30,7 +30,7 @@ package mekhq.campaign;
 
 import static mekhq.campaign.unit.enums.TransporterType.ASF_BAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -39,24 +39,25 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import java.util.*;
-
-import megamek.common.Bay;
-import mekhq.campaign.enums.CampaignTransportType;
-import mekhq.campaign.unit.AbstractTransportedUnitsSummary;
-import org.apache.logging.log4j.LogManager;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
 
 import megamek.common.Dropship;
 import megamek.common.EquipmentType;
 import megamek.common.enums.SkillLevel;
+import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.ranks.Ranks;
+import mekhq.campaign.unit.AbstractTransportedUnitsSummary;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Systems;
+import org.apache.logging.log4j.LogManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -143,7 +144,7 @@ public class CampaignTest {
 
         Campaign testCampaign = mock(Campaign.class);
         when(testCampaign.getPersonnel()).thenReturn(testPersonList);
-        when(testCampaign.getActivePersonnel()).thenReturn(testActivePersonList);
+        when(testCampaign.getActivePersonnel(true)).thenReturn(testActivePersonList);
         when(testCampaign.getTechs()).thenCallRealMethod();
         when(testCampaign.getTechs(anyBoolean())).thenCallRealMethod();
         when(testCampaign.getTechs(anyBoolean(), anyBoolean())).thenCallRealMethod();
@@ -210,26 +211,26 @@ public class CampaignTest {
     }
 
     @Test
-    void testIniative() {
+    void testInitiative() {
         Campaign campaign = new Campaign();
 
         campaign.applyInitiativeBonus(6);
         // should increase bonus to 6 and max to 6
-        assertTrue(campaign.getInitiativeBonus() == 6);
-        assertTrue(campaign.getInitiativeMaxBonus() == 6);
+        assertEquals(6, campaign.getInitiativeBonus());
+        assertEquals(6, campaign.getInitiativeMaxBonus());
         // Should not be able to increment over max of 6
         campaign.initiativeBonusIncrement(true);
-        assertFalse(campaign.getInitiativeBonus() == 7);
+        assertNotEquals(7, campaign.getInitiativeBonus());
         campaign.applyInitiativeBonus(2);
-        assertEquals(campaign.getInitiativeBonus(), 6);
+        assertEquals(6, campaign.getInitiativeBonus());
         // But should be able to decrease below max
         campaign.initiativeBonusIncrement(false);
-        assertEquals(campaign.getInitiativeBonus(), 5);
-        // After setting lower Max Bonus any appied bonus thats less then max should set
+        assertEquals(5, campaign.getInitiativeBonus());
+        // After setting lower Max Bonus any applied bonus that's less than max should set
         // bonus to max
         campaign.setInitiativeMaxBonus(3);
         campaign.applyInitiativeBonus(2);
-        assertEquals(campaign.getInitiativeBonus(), 3);
+        assertEquals(3, campaign.getInitiativeBonus());
 
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
@@ -44,13 +44,22 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import megamek.common.*;
+import megamek.common.Aero;
+import megamek.common.BipedMek;
+import megamek.common.Crew;
+import megamek.common.Dropship;
+import megamek.common.Entity;
+import megamek.common.EntityMovementMode;
+import megamek.common.Jumpship;
+import megamek.common.Tank;
+import megamek.common.TechConstants;
+import megamek.common.bays.ASFBay;
+import megamek.common.bays.Bay;
+import megamek.common.bays.MekBay;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.Hangar;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.skills.Skill;
-import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.skills.Skill;
@@ -70,10 +79,8 @@ public class FieldManualMercRevDragoonsRatingTest {
     private List<Person> mockPersonnelList;
     private List<Person> mockActivePersonnelList;
 
-    private Skill mockDoctorSkillRegular;
     private Skill mockDoctorSkillGreen;
     private Skill mockMedicSkill;
-    private Skill mockMekTechSkillVeteran;
     private Skill mockMekTechSkillRegular;
     private Skill mockAstechSkill;
 
@@ -89,10 +96,10 @@ public class FieldManualMercRevDragoonsRatingTest {
         Person mockDoctor = mock(Person.class);
         Person mockTech = mock(Person.class);
 
-        mockDoctorSkillRegular = mock(Skill.class);
+        Skill mockDoctorSkillRegular = mock(Skill.class);
         mockDoctorSkillGreen = mock(Skill.class);
         mockMedicSkill = mock(Skill.class);
-        mockMekTechSkillVeteran = mock(Skill.class);
+        Skill mockMekTechSkillVeteran = mock(Skill.class);
         mockMekTechSkillRegular = mock(Skill.class);
         mockAstechSkill = mock(Skill.class);
 
@@ -131,7 +138,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         mockActivePersonnelList.add(mockTech);
 
         when(mockCampaign.getPersonnel()).thenReturn(mockPersonnelList);
-        when(mockCampaign.getActivePersonnel()).thenReturn(mockActivePersonnelList);
+        when(mockCampaign.getActivePersonnel(true)).thenReturn(mockActivePersonnelList);
         when(mockCampaign.getNumberMedics()).thenCallRealMethod();
         when(mockCampaign.getNumberAstechs()).thenCallRealMethod();
         when(mockCampaign.getNumberPrimaryAstechs()).thenCallRealMethod();
@@ -333,25 +340,25 @@ public class FieldManualMercRevDragoonsRatingTest {
         // Regular Doctor = 40 hours.
         // + 4 Medics = 20 * 4 = 80 hours.
         // Total = 120 hours.
-        FieldManualMercRevDragoonsRating testFieldManuMercRevDragoonsRating =
-                new FieldManualMercRevDragoonsRating(mockCampaign);
+        FieldManualMercRevDragoonsRating testFieldManuMercRevDragoonsRating = new FieldManualMercRevDragoonsRating(
+              mockCampaign);
         testFieldManuMercRevDragoonsRating.updateAvailableSupport();
         int expectedHours = 120;
         when(mockCampaign.getMedicPool()).thenReturn(4);
         assertEquals(expectedHours, testFieldManuMercRevDragoonsRating.getMedicalSupportAvailable());
 
-        // Add a mekwarrior who doubles as a back-up medic of Green skill.  This should add another 15 hours.
+        // Add a MekWarrior who doubles as a back-up medic of Green skill.  This should add another 15 hours.
         testFieldManuMercRevDragoonsRating = new FieldManualMercRevDragoonsRating(mockCampaign);
-        Person mockMekwarrior = mock(Person.class);
-        when(mockMekwarrior.getPrimaryRole()).thenReturn(PersonnelRole.MEKWARRIOR);
-        when(mockMekwarrior.getSecondaryRole()).thenReturn(PersonnelRole.DOCTOR);
-        when(mockMekwarrior.isDoctor()).thenReturn(true);
-        doReturn(PersonnelStatus.ACTIVE).when(mockMekwarrior).getStatus();
-        when(mockMekwarrior.isDeployed()).thenReturn(false);
-        when(mockMekwarrior.getSkill(eq(SkillType.S_DOCTOR))).thenReturn(mockDoctorSkillGreen);
-        when(mockMekwarrior.hasSkill(eq(SkillType.S_DOCTOR))).thenReturn(true);
-        mockPersonnelList.add(mockMekwarrior);
-        mockActivePersonnelList.add(mockMekwarrior);
+        Person mockMekWarrior = mock(Person.class);
+        when(mockMekWarrior.getPrimaryRole()).thenReturn(PersonnelRole.MEKWARRIOR);
+        when(mockMekWarrior.getSecondaryRole()).thenReturn(PersonnelRole.DOCTOR);
+        when(mockMekWarrior.isDoctor()).thenReturn(true);
+        doReturn(PersonnelStatus.ACTIVE).when(mockMekWarrior).getStatus();
+        when(mockMekWarrior.isDeployed()).thenReturn(false);
+        when(mockMekWarrior.getSkill(eq(SkillType.S_DOCTOR))).thenReturn(mockDoctorSkillGreen);
+        when(mockMekWarrior.hasSkill(eq(SkillType.S_DOCTOR))).thenReturn(true);
+        mockPersonnelList.add(mockMekWarrior);
+        mockActivePersonnelList.add(mockMekWarrior);
         expectedHours += 15;
         testFieldManuMercRevDragoonsRating.updateAvailableSupport();
         assertEquals(expectedHours, testFieldManuMercRevDragoonsRating.getMedicalSupportAvailable());
@@ -380,8 +387,8 @@ public class FieldManualMercRevDragoonsRatingTest {
         // Regular Tech = 45 hours.
         // + 6 Astechs = 20 * 4 = 120 hours.
         // Total = 165 hours.
-        FieldManualMercRevDragoonsRating testFieldManuMercRevDragoonsRating =
-                new FieldManualMercRevDragoonsRating(mockCampaign);
+        FieldManualMercRevDragoonsRating testFieldManuMercRevDragoonsRating = new FieldManualMercRevDragoonsRating(
+              mockCampaign);
         testFieldManuMercRevDragoonsRating.updateAvailableSupport();
         int expectedHours = 165;
         when(mockCampaign.getAstechPool()).thenReturn(6);
@@ -473,39 +480,41 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(BigDecimal.ZERO).when(testRating).getTransportPercent();
         doReturn(4).when(testRating).getHeavyVeeCount();
         doReturn(4).when(testRating).getLightVeeCount();
-        String expected = "Transportation      -10\n" +
-                          "    DropShip Capacity:       0%\n" +
-                          "        #BattleMek Bays:              0 needed /   0 available\n" +
-                          "        #Fighter Bays:                0 needed /   0 available (plus 0 excess Small Craft)\n" +
-                          "        #Small Craft Bays:            0 needed /   0 available\n" +
-                          "        #ProtoMek Bays:               0 needed /   0 available\n" +
-                          "        #Super Heavy Vehicle Bays:    0 needed /   0 available\n" +
-                          "        #Heavy Vehicle Bays:          4 needed /   0 available (plus 0 excess Super Heavy)\n" +
-                          "        #Light Vehicle Bays:          4 needed /   0 available (plus 0 excess Heavy and 0 excess Super Heavy)\n" +
-                          "        #Battle Armor Bays:           0 needed /   0 available\n" +
-                          "        #Infantry Bays:               0 needed /   0 available\n" +
-                          "    JumpShip?                No\n" +
-                          "    WarShip w/out Collar?    No\n" +
-                          "    WarShip w/ Collar?       No";
+        String expected = """
+              Transportation      -10
+                  DropShip Capacity:       0%
+                      #BattleMek Bays:              0 needed /   0 available
+                      #Fighter Bays:                0 needed /   0 available (plus 0 excess Small Craft)
+                      #Small Craft Bays:            0 needed /   0 available
+                      #ProtoMek Bays:               0 needed /   0 available
+                      #Super Heavy Vehicle Bays:    0 needed /   0 available
+                      #Heavy Vehicle Bays:          4 needed /   0 available (plus 0 excess Super Heavy)
+                      #Light Vehicle Bays:          4 needed /   0 available (plus 0 excess Heavy and 0 excess Super Heavy)
+                      #Battle Armor Bays:           0 needed /   0 available
+                      #Infantry Bays:               0 needed /   0 available
+                  JumpShip?                No
+                  WarShip w/out Collar?    No
+                  WarShip w/ Collar?       No""";
         assertEquals(expected, testRating.getTransportationDetails());
         // Add some heavy vee bays.
         doReturn(0).when(testRating).getTransportValue();
         doReturn(BigDecimal.valueOf(100)).when(testRating).getTransportPercent();
         doReturn(8).when(testRating).getHeavyVeeBayCount();
-        expected = "Transportation        0\n" +
-                   "    DropShip Capacity:      100%\n" +
-                   "        #BattleMek Bays:              0 needed /   0 available\n" +
-                   "        #Fighter Bays:                0 needed /   0 available (plus 0 excess Small Craft)\n" +
-                   "        #Small Craft Bays:            0 needed /   0 available\n" +
-                   "        #ProtoMek Bays:               0 needed /   0 available\n" +
-                   "        #Super Heavy Vehicle Bays:    0 needed /   0 available\n" +
-                   "        #Heavy Vehicle Bays:          4 needed /   8 available (plus 0 excess Super Heavy)\n" +
-                   "        #Light Vehicle Bays:          4 needed /   0 available (plus 4 excess Heavy and 0 excess Super Heavy)\n" +
-                   "        #Battle Armor Bays:           0 needed /   0 available\n" +
-                   "        #Infantry Bays:               0 needed /   0 available\n" +
-                   "    JumpShip?                No\n" +
-                   "    WarShip w/out Collar?    No\n" +
-                   "    WarShip w/ Collar?       No";
+        expected = """
+              Transportation        0
+                  DropShip Capacity:      100%
+                      #BattleMek Bays:              0 needed /   0 available
+                      #Fighter Bays:                0 needed /   0 available (plus 0 excess Small Craft)
+                      #Small Craft Bays:            0 needed /   0 available
+                      #ProtoMek Bays:               0 needed /   0 available
+                      #Super Heavy Vehicle Bays:    0 needed /   0 available
+                      #Heavy Vehicle Bays:          4 needed /   8 available (plus 0 excess Super Heavy)
+                      #Light Vehicle Bays:          4 needed /   0 available (plus 4 excess Heavy and 0 excess Super Heavy)
+                      #Battle Armor Bays:           0 needed /   0 available
+                      #Infantry Bays:               0 needed /   0 available
+                  JumpShip?                No
+                  WarShip w/out Collar?    No
+                  WarShip w/ Collar?       No""";
         assertEquals(expected, testRating.getTransportationDetails());
     }
 
@@ -520,7 +529,6 @@ public class FieldManualMercRevDragoonsRatingTest {
         doReturn(0).when(testRating).getHeavyVeeCount();
         doReturn(5).when(testRating).getLightVeeCount();
 
-        assertEquals(BigDecimal.valueOf(100.0).setScale(0, RoundingMode.HALF_EVEN),
-                testRating.getTransportPercent());
+        assertEquals(BigDecimal.valueOf(100.0).setScale(0, RoundingMode.HALF_EVEN), testRating.getTransportPercent());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/unit/LegacyUnitShipTransportTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/LegacyUnitShipTransportTest.java
@@ -28,6 +28,8 @@
 package mekhq.campaign.unit;
 
 import megamek.common.*;
+import megamek.common.bays.ASFBay;
+import megamek.common.bays.Bay;
 import mekhq.campaign.Campaign;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -45,6 +47,7 @@ import static org.mockito.Mockito.*;
 
 /**
  * Psi - Transport has been split into Ship & Tactical transport.
+ *
  * @see UnitTransportTest
  */
 public class LegacyUnitShipTransportTest {
@@ -65,7 +68,6 @@ public class LegacyUnitShipTransportTest {
         Unit transport = new Unit();
         when(mockCampaign.getGame()).thenReturn(mockGame);
         mockCampaign.importUnit(transport);
-
 
 
         // We start with empty transport bays
@@ -175,8 +177,8 @@ public class LegacyUnitShipTransportTest {
 
         // Create a fake entity to back the real transport Unit
         Dropship mockVengeance = mock(Dropship.class);
-        Unit transport = new Unit(mockVengeance,campaign);
-        ASFBay mockASFBay = new ASFBay(100, 1 ,0);
+        Unit transport = new Unit(mockVengeance, campaign);
+        ASFBay mockASFBay = new ASFBay(100, 1, 0);
 
         // Initialize bays
         Vector<Bay> bays = new Vector<>();
@@ -213,8 +215,7 @@ public class LegacyUnitShipTransportTest {
         verify(randomUnit, times(0)).setTransportShipAssignment(eq(null));
 
         // And we should not have had our bay space recalculated.
-        verify(transport, times(0)).updateBayCapacity(anyInt(), anyDouble(),
-                anyBoolean(), anyInt());
+        verify(transport, times(0)).updateBayCapacity(anyInt(), anyDouble(), anyBoolean(), anyInt());
     }
 
     @Test
@@ -235,7 +236,6 @@ public class LegacyUnitShipTransportTest {
         verify(randomUnit, times(0)).setTransportShipAssignment(eq(null));
 
         // And we should not have had our bay space recalculated.
-        verify(transport0, times(0)).updateBayCapacity(anyInt(), anyDouble(),
-                anyBoolean(), anyInt());
+        verify(transport0, times(0)).updateBayCapacity(anyInt(), anyDouble(), anyBoolean(), anyInt());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/unit/UnitTransportTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/UnitTransportTest.java
@@ -27,26 +27,41 @@
  */
 package mekhq.campaign.unit;
 
-import megamek.common.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import java.util.Vector;
+
+import megamek.common.Aero;
+import megamek.common.AeroSpaceFighter;
+import megamek.common.Dropship;
+import megamek.common.Entity;
+import megamek.common.EquipmentType;
+import megamek.common.Game;
+import megamek.common.Mek;
+import megamek.common.Transporter;
+import megamek.common.bays.ASFBay;
+import megamek.common.bays.Bay;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.enums.CampaignTransportType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.UUID;
-import java.util.Vector;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
 public class UnitTransportTest {
 
     @BeforeAll
     static void before() {
         EquipmentType.initializeTypes();
-
-
     }
 
     @ParameterizedTest
@@ -59,7 +74,6 @@ public class UnitTransportTest {
         Unit transport = new Unit();
         when(mockCampaign.getGame()).thenReturn(mockGame);
         mockCampaign.importUnit(transport);
-
 
 
         // We start with empty transport bays
@@ -163,8 +177,8 @@ public class UnitTransportTest {
 
         // Create a fake entity to back the real transport Unit
         Dropship mockVengeance = mock(Dropship.class);
-        Unit transport = new Unit(mockVengeance,campaign);
-        ASFBay mockASFBay = new ASFBay(100, 1 ,0);
+        Unit transport = new Unit(mockVengeance, campaign);
+        ASFBay mockASFBay = new ASFBay(100, 1, 0);
 
         // Initialize bays
         Vector<Bay> bays = new Vector<>();


### PR DESCRIPTION
This is a fix for the chain of InstanceOf on BayTypes and BayData, related classes.

With this, moved all Bay data to their own package which... caused the rest of the files to get impacted as well. In addition to this, performed general IDEA clean up, updated the Copyright headers, and the license file for all impacted files.

In addition to the above, deprecated additional methods showing no usages, removed private deprecated/non-used/non-overrode methods as they aren't in use.