### PR TITLE
Fix #2183, #3819, #4788: Corrected Hydrogen-Based Fuel Cost Calculation

### DIFF
--- a/MekHQ/src/mekhq/campaign/finances/Accountant.java
+++ b/MekHQ/src/mekhq/campaign/finances/Accountant.java
@@ -27,7 +27,15 @@
  */
 package mekhq.campaign.finances;
 
+import static mekhq.campaign.force.Force.FORCE_NONE;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import megamek.common.Entity;
+import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.Hangar;
@@ -37,15 +45,11 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.Unit;
 
-import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 /**
  * Provides accounting for a Campaign.
  */
 public record Accountant(Campaign campaign) {
+    private static final MMLogger logger = MMLogger.create(Accountant.class);
 
     public CampaignOptions getCampaignOptions() {
         return campaign().getCampaignOptions();
@@ -77,20 +81,22 @@ public record Accountant(Campaign campaign) {
         }
 
         // And pay our pool
-        salaries = salaries.plus(campaign().getCampaignOptions().getRoleBaseSalaries()
-            [PersonnelRole.ASTECH.ordinal()].getAmount().doubleValue()
-            * campaign().getAstechPool());
-        salaries = salaries.plus(campaign().getCampaignOptions().getRoleBaseSalaries()
-            [PersonnelRole.MEDIC.ordinal()].getAmount().doubleValue()
-            * campaign().getMedicPool());
+        salaries = salaries.plus(campaign().getCampaignOptions()
+                                       .getRoleBaseSalaries()[PersonnelRole.ASTECH.ordinal()].getAmount()
+                                       .doubleValue() * campaign().getAstechPool());
+        salaries = salaries.plus(campaign().getCampaignOptions()
+                                       .getRoleBaseSalaries()[PersonnelRole.MEDIC.ordinal()].getAmount().doubleValue() *
+                                       campaign().getMedicPool());
 
         return salaries;
     }
 
     public Money getMaintenanceCosts() {
         if (getCampaignOptions().isPayForMaintain()) {
-            return getHangar().getUnitsStream().filter(u -> u.requiresMaintenance()
-                && (null != u.getTech())).map(Unit::getMaintenanceCost).reduce(Money.zero(), Money::plus);
+            return getHangar().getUnitsStream()
+                         .filter(u -> u.requiresMaintenance() && (null != u.getTech()))
+                         .map(Unit::getMaintenanceCost)
+                         .reduce(Money.zero(), Money::plus);
         }
         return Money.zero();
     }
@@ -121,15 +127,13 @@ public record Accountant(Campaign campaign) {
      * <p>
      * This can be used to ensure salaries are not double counted.
      *
-     * @param includeSalaries A value indicating whether or not salaries
-     *                        should be included in peacetime cost calculations.
+     * @param includeSalaries A value indicating whether or not salaries should be included in peacetime cost
+     *                        calculations.
+     *
      * @return The peacetime costs of the campaign, optionally including salaries.
      */
     public Money getPeacetimeCost(boolean includeSalaries) {
-        Money peaceTimeCosts = Money.zero()
-            .plus(getMonthlySpareParts())
-            .plus(getMonthlyFuel())
-            .plus(getMonthlyAmmo());
+        Money peaceTimeCosts = Money.zero().plus(getMonthlySpareParts()).plus(getMonthlyFuel()).plus(getMonthlyAmmo());
         if (includeSalaries) {
             peaceTimeCosts = peaceTimeCosts.plus(getPayRoll(getCampaignOptions().isInfantryDontCount()));
         }
@@ -142,7 +146,36 @@ public record Accountant(Campaign campaign) {
     }
 
     public Money getMonthlyFuel() {
-        return getHangar().getUnitCosts(u -> !u.isMothballed(), Unit::getFuelCost);
+        int daysInMonth = 28; // we use a 28-day month so we don't need to bring in and process the exact date
+        int dailyHydrogenProduction = 10;
+        int monthlyHydrogenProduction = daysInMonth * dailyHydrogenProduction;
+
+        int totalFusionEngines = 0;
+        for (Unit unit : getHangar().getUnits()) {
+            if (unit.isMothballed()) {
+                continue;
+            }
+
+            Entity entity = unit.getEntity();
+
+            if (entity == null) {
+                logger.info("(getMonthlyFuel) entity is null for {}", unit);
+                continue;
+            }
+
+            // While there will be times when a unit is unavailable, we don't check for that as we also don't track
+            // hydrogen stored, and we don't want to unfairly penalize the player.
+            if (entity.getEngine().isFusion()) {
+                totalFusionEngines++;
+            }
+        }
+
+        // Calculate total hydrogen production based on the number of fusion engines
+        int hydrogenProduction = totalFusionEngines * monthlyHydrogenProduction;
+
+        return getHangar().getUnitCosts(
+              // Is it in the TO&E and by extension in use?
+              unit -> unit.getForceId() != FORCE_NONE, unit -> unit.getFuelCost(hydrogenProduction));
     }
 
     public Money getMonthlyAmmo() {
@@ -150,10 +183,9 @@ public record Accountant(Campaign campaign) {
     }
 
     /**
-     * Calculates the total monetary value of all units in the current campaign's forces,
-     * applying specific percentage adjustments based on unit types. Units such as DropShips,
-     * WarShips, JumpShips, Space Stations, infantry, and others are calculated according
-     * to the provided contract percentages and rules.
+     * Calculates the total monetary value of all units in the current campaign's forces, applying specific percentage
+     * adjustments based on unit types. Units such as DropShips, WarShips, JumpShips, Space Stations, infantry, and
+     * others are calculated according to the provided contract percentages and rules.
      *
      * <p>This method iterates over all units in the campaign's forces and computes their
      * total value by checking each unit's type and applying the appropriate adjustments.</p>
@@ -161,22 +193,22 @@ public record Accountant(Campaign campaign) {
      * <p>The value of each unit is based on the {@code useEquipmentSaleValue} flag, which
      * determines whether to use the equipment's sale value during the calculation.</p>
      *
-     * @param excludeInfantry         A {@code boolean} flag specifying whether conventional
-     *                                infantry units (non-Battle Armor) should be excluded.
-     * @param dropShipContractPercent The percentage adjustment applied specifically to DropShips.
-     *                                If set to {@code 0}, DropShips are excluded from the calculation.
-     * @param warShipContractPercent  The percentage adjustment applied specifically to WarShips.
-     *                                If set to {@code 0}, WarShips are excluded from the calculation.
-     * @param jumpShipContractPercent The percentage adjustment applied specifically to JumpShips
-     *                                and Space Stations. If set to {@code 0}, these units are excluded.
-     * @param useEquipmentSaleValue   A {@code boolean} flag that determines whether to use the
-     *                                equipment's sale value in the calculation.
-     * @return A {@link Money} object representing the total force value of the campaign's units
-     * after applying the provided rules and percentages.
+     * @param excludeInfantry         A {@code boolean} flag specifying whether conventional infantry units (non-Battle
+     *                                Armor) should be excluded.
+     * @param dropShipContractPercent The percentage adjustment applied specifically to DropShips. If set to {@code 0},
+     *                                DropShips are excluded from the calculation.
+     * @param warShipContractPercent  The percentage adjustment applied specifically to WarShips. If set to {@code 0},
+     *                                WarShips are excluded from the calculation.
+     * @param jumpShipContractPercent The percentage adjustment applied specifically to JumpShips and Space Stations. If
+     *                                set to {@code 0}, these units are excluded.
+     * @param useEquipmentSaleValue   A {@code boolean} flag that determines whether to use the equipment's sale value
+     *                                in the calculation.
+     *
+     * @return A {@link Money} object representing the total force value of the campaign's units after applying the
+     *       provided rules and percentages.
      */
-    public Money getForceValue(boolean excludeInfantry, double dropShipContractPercent,
-                               double warShipContractPercent, double jumpShipContractPercent,
-                               boolean useEquipmentSaleValue) {
+    public Money getForceValue(boolean excludeInfantry, double dropShipContractPercent, double warShipContractPercent,
+          double jumpShipContractPercent, boolean useEquipmentSaleValue) {
         Money value = Money.zero();
 
         for (UUID uuid : campaign().getForces().getAllUnits(true)) {
@@ -234,8 +266,10 @@ public record Accountant(Campaign campaign) {
 
     public Money getTotalEquipmentValue() {
         Money unitsSellValue = getHangar().getUnitCosts(Unit::getSellValue);
-        return campaign().getWarehouse().streamSpareParts().map(Part::getActualValue)
-            .reduce(unitsSellValue, Money::plus);
+        return campaign().getWarehouse()
+                     .streamSpareParts()
+                     .map(Part::getActualValue)
+                     .reduce(unitsSellValue, Money::plus);
     }
 
     public Money getEquipmentContractValue(Unit u, boolean useSaleValue) {
@@ -249,35 +283,31 @@ public record Accountant(Campaign campaign) {
         }
 
         if (u.getEntity().hasETypeFlag(Entity.ETYPE_DROPSHIP)) {
-            percentValue = value.multipliedBy(getCampaignOptions().getDropShipContractPercent())
-                .dividedBy(100);
+            percentValue = value.multipliedBy(getCampaignOptions().getDropShipContractPercent()).dividedBy(100);
         } else if (u.getEntity().hasETypeFlag(Entity.ETYPE_WARSHIP)) {
-            percentValue = value.multipliedBy(getCampaignOptions().getWarShipContractPercent())
-                .dividedBy(100);
-        } else if (u.getEntity().hasETypeFlag(Entity.ETYPE_JUMPSHIP) || u.getEntity().hasETypeFlag(Entity.ETYPE_SPACE_STATION)) {
-            percentValue = value.multipliedBy(getCampaignOptions().getJumpShipContractPercent())
-                .dividedBy(100);
+            percentValue = value.multipliedBy(getCampaignOptions().getWarShipContractPercent()).dividedBy(100);
+        } else if (u.getEntity().hasETypeFlag(Entity.ETYPE_JUMPSHIP) ||
+                         u.getEntity().hasETypeFlag(Entity.ETYPE_SPACE_STATION)) {
+            percentValue = value.multipliedBy(getCampaignOptions().getJumpShipContractPercent()).dividedBy(100);
         } else {
-            percentValue = value.multipliedBy(getCampaignOptions().getEquipmentContractPercent())
-                .dividedBy(100);
+            percentValue = value.multipliedBy(getCampaignOptions().getEquipmentContractPercent()).dividedBy(100);
         }
 
         return percentValue;
     }
 
     /**
-     * Calculates the base monetary value for contracts in the campaign based on the specified
-     * campaign options. The calculation considers whether peacetime costs, equipment contracts,
-     * or theoretical payroll costs should be used as the base value.
+     * Calculates the base monetary value for contracts in the campaign based on the specified campaign options. The
+     * calculation considers whether peacetime costs, equipment contracts, or theoretical payroll costs should be used
+     * as the base value.
      *
      * <p>This method retrieves relevant options from the campaign's {@link CampaignOptions}
-     * to control how the base contract value is computed. Based on the campaign settings, it
-     * takes into account factors such as infantry exclusion, contract percentages for different
-     * types of units (DropShips, WarShips, JumpShips), and whether to use the equipment's
-     * sale value in the calculations.</p>
+     * to control how the base contract value is computed. Based on the campaign settings, it takes into account factors
+     * such as infantry exclusion, contract percentages for different types of units (DropShips, WarShips, JumpShips),
+     * and whether to use the equipment's sale value in the calculations.</p>
      *
-     * @return A {@link Money} object representing the calculated base contract value, adjusted
-     * according to the campaign's configuration.
+     * @return A {@link Money} object representing the calculated base contract value, adjusted according to the
+     *       campaign's configuration.
      */
     public Money getContractBase() {
         final CampaignOptions options = getCampaignOptions();
@@ -289,15 +319,21 @@ public record Accountant(Campaign campaign) {
         final boolean useEquipmentSalveValue = options.isEquipmentContractSaleValue();
 
         if (getCampaignOptions().isUsePeacetimeCost()) {
-            final Money forceValue = getForceValue(excludeInfantry, dropShipContractPercent,
-                warShipContractPercent, jumpShipContractPercent, useEquipmentSalveValue);
+            final Money forceValue = getForceValue(excludeInfantry,
+                  dropShipContractPercent,
+                  warShipContractPercent,
+                  jumpShipContractPercent,
+                  useEquipmentSalveValue);
 
             return getPeacetimeCost().multipliedBy(0.75).plus(forceValue);
         }
 
         if (getCampaignOptions().isEquipmentContractBase()) {
-            return getForceValue(excludeInfantry, dropShipContractPercent, warShipContractPercent,
-                jumpShipContractPercent, useEquipmentSalveValue);
+            return getForceValue(excludeInfantry,
+                  dropShipContractPercent,
+                  warShipContractPercent,
+                  jumpShipContractPercent,
+                  useEquipmentSalveValue);
         }
 
         return getTheoreticalPayroll(getCampaignOptions().isInfantryDontCount());
@@ -307,6 +343,7 @@ public record Accountant(Campaign campaign) {
      * Returns a map of every Person and their salary.
      *
      * @return map of personnel to their pay, including pool as a null key
+     *
      * @see Finances#debit(TransactionType, LocalDate, Money, String, Map, boolean)
      */
     public Map<Person, Money> getPayRollSummary() {
@@ -315,13 +352,13 @@ public record Accountant(Campaign campaign) {
             payRollSummary.put(person, person.getSalary(campaign()));
         }
         // And pay our pool
-        payRollSummary.put(null, Money.of((
-            campaign().getCampaignOptions().getRoleBaseSalaries()
-                [PersonnelRole.ASTECH.ordinal()].getAmount().doubleValue()
-                * campaign().getAstechPool())
-            + (campaign().getCampaignOptions().getRoleBaseSalaries()
-            [PersonnelRole.MEDIC.ordinal()].getAmount().doubleValue()
-            * campaign().getMedicPool())));
+        payRollSummary.put(null,
+              Money.of((campaign().getCampaignOptions()
+                              .getRoleBaseSalaries()[PersonnelRole.ASTECH.ordinal()].getAmount().doubleValue() *
+                              campaign().getAstechPool()) +
+                             (campaign().getCampaignOptions()
+                                    .getRoleBaseSalaries()[PersonnelRole.MEDIC.ordinal()].getAmount().doubleValue() *
+                                    campaign().getMedicPool())));
 
         return payRollSummary;
     }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -6506,8 +6506,8 @@ public class Unit implements ITechnology {
                      "<b>Ammunition</b>: " +
                      getAmmoCost().toAmountAndSymbolString() +
                      "<br>" +
-                     "<b>Fuel</b>: " +
-                     getFuelCost().toAmountAndSymbolString() +
+                     "<b>Fuel</b>: ~" +
+                     getFuelCost(0).toAmountAndSymbolString() +
                      "<br>";
     }
 
@@ -6616,21 +6616,62 @@ public class Unit implements ITechnology {
         return ammoCost.multipliedBy(0.25);
     }
 
+    /**
+     * @deprecated use {@link #getFuelCost(int)} instead.
+     */
+    @Deprecated(since = "0.50.04", forRemoval = true)
     public Money getFuelCost() {
-        Money fuelCost = Money.zero();
+        return getFuelCost(0);
+    }
 
-        if ((entity instanceof Warship) || (entity instanceof SmallCraft)) {
-            fuelCost = fuelCost.plus(getTonsBurnDay(entity));
-        } else if (entity instanceof Jumpship) {
-            fuelCost = fuelCost.plus(getTonsBurnDay(entity));// * 3 * 15000;
-        } else if (entity instanceof ConvFighter) {
+    /**
+     * Calculates the monthly fuel cost for this unit, applying any available hydrogen production credits.
+     *
+     * <p>Different entity types have different fuel requirements:</p>
+     * <ul>
+     *   <li>Large Craft and Small Craft: Calculated based on tons burned per day</li>
+     *   <li>Conventional Fighters: Use fighter-specific fuel cost calculation</li>
+     *   <li>Aerospace Fighters: Based on fuel tonnage multiplied by a factor of 4</li>
+     *   <li>Vehicles and Mechs: Use vehicle-specific fuel cost calculation</li>
+     *   <li>Infantry: Use infantry-specific fuel cost calculation</li>
+     * </ul>
+     *
+     * <p>Hydrogen produced by fusion engines is credited against the unit's hydrogen usage, reducing the overall
+     * fuel cost.</p>
+     *
+     * @param hydrogenProduction The amount of hydrogen produced by fusion engines, which offsets hydrogen usage costs
+     *
+     * @return The calculated fuel cost as a Money object, always non-negative
+     */
+    public Money getFuelCost(int hydrogenProduction) {
+        final int FUEL_COST_PER_HYDROGEN = 15000;
+
+        Money fuelCost = Money.zero();
+        double hydrogenUsage = 0;
+
+        // Calculate base fuel costs by entity type
+        if (entity.isLargeCraft() || entity.isSmallCraft()) {
+            hydrogenUsage = getTonsBurnDay(entity);
+        } else if (entity.isConventionalFighter()) {
             fuelCost = fuelCost.plus(getFighterFuelCost(entity));
-        } else if (entity instanceof Aero) {
-            fuelCost = fuelCost.plus(((Aero) entity).getFuelTonnage() * 4.0 * 15000.0);
-        } else if ((entity instanceof Tank) || (entity instanceof Mek)) {
+        } else if (entity.isAerospaceFighter()) {
+            try {
+                hydrogenUsage = ((AeroSpaceFighter) entity).getFuelTonnage() * 4.0;
+            } catch (ClassCastException e) {
+                logger.error("{} was thought to be an AeroSpace Fighter, but actually it isn't." +
+                                   " This should be looked into.", getName());
+            }
+        } else if (entity.isVehicle() || entity.isMek()) {
             fuelCost = fuelCost.plus(getVehicleFuelCost(entity));
-        } else if (entity instanceof Infantry) {
+        } else if (entity.isInfantry()) {
             fuelCost = fuelCost.plus(getInfantryFuelCost(entity));
+        }
+
+        // Apply hydrogen production credit if there is any hydrogen usage
+        if (hydrogenUsage > 0) {
+            // Ensure hydrogen usage doesn't go negative after applying production credit
+            double actualHydrogenUsage = Math.max(0, hydrogenUsage - hydrogenProduction);
+            fuelCost = fuelCost.plus(Money.of(actualHydrogenUsage * FUEL_COST_PER_HYDROGEN));
         }
 
         return fuelCost;


### PR DESCRIPTION
- Replaced `getFuelCost()` with a new `getFuelCost(int hydrogenProduction)` method to account for hydrogen production offsets.
- Units not in the TO&E no longer incur monthly fuel costs (they're not in use)

Fix #2183
Fix #3819
Fix #4788

### Dev Notes
We don't currently track hydrogen stockpiles and it would be a pain to implement, so instead we assume all non-mothballed fusion engine having units are producing hydrogen in their spare time. This is done at the rates listed in SO.

While there will be times when a unit is unavailable, without stockpile tracking there is no way for the user to benefit from stocking up before a contract. So we employ a bit of handwavium and run under the assumption that the player stockpiled enough to mitigate fusion engines being at times unavailable.