### PR TITLE
Implemented Graceful Failure when Loading Random Divorce Settings from Older Versions

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -6041,7 +6041,7 @@ public class CampaignOptions {
                                     Integer.parseInt(wn3.getTextContent().trim()));
                     }
                 } else if (nodeName.equalsIgnoreCase("randomDivorceMethod")) {
-                    retVal.setRandomDivorceMethod(RandomDivorceMethod.valueOf(wn2.getTextContent().trim()));
+                    retVal.setRandomDivorceMethod(RandomDivorceMethod.fromString(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("useRandomOppositeSexDivorce")) {
                     retVal.setUseRandomOppositeSexDivorce(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("useRandomSameSexDivorce")) {
@@ -6542,11 +6542,11 @@ public class CampaignOptions {
                 } else if (nodeName.equalsIgnoreCase("originSearchRadius")) { // Legacy, 0.49.7 Removal
                     retVal.getRandomOriginOptions().setOriginSearchRadius(Integer.parseInt(wn2.getTextContent()));
                 } else if (nodeName.equalsIgnoreCase("extraRandomOrigin")) { // Legacy, 0.49.7 Removal
-                    retVal.getRandomOriginOptions().setExtraRandomOrigin(Boolean.parseBoolean(wn2.getTextContent()
-                                                                                                    .trim()));
+                    retVal.getRandomOriginOptions()
+                          .setExtraRandomOrigin(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("originDistanceScale")) { // Legacy, 0.49.7 Removal
-                    retVal.getRandomOriginOptions().setOriginDistanceScale(Double.parseDouble(wn2.getTextContent()
-                                                                                                    .trim()));
+                    retVal.getRandomOriginOptions()
+                          .setOriginDistanceScale(Double.parseDouble(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("dependentsNeverLeave")) { // Legacy - 0.49.7 Removal
                     retVal.setUseRandomDependentRemoval(!Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("marriageAgeRange")) { // Legacy - 0.49.6 Removal

--- a/MekHQ/src/mekhq/campaign/personnel/enums/RandomDivorceMethod.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/RandomDivorceMethod.java
@@ -27,22 +27,24 @@
  */
 package mekhq.campaign.personnel.enums;
 
+import java.util.ResourceBundle;
+
+import megamek.codeUtilities.MathUtility;
+import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.divorce.AbstractDivorce;
 import mekhq.campaign.personnel.divorce.DisabledRandomDivorce;
 import mekhq.campaign.personnel.divorce.RandomDivorce;
 
-import java.util.ResourceBundle;
-
 /**
  * An enumeration representing the available random divorce methods.
  * <p>
- * The {@link RandomDivorceMethod} enum is used to specify the method of randomly generating a divorce.
- * It supports two methods: {@code NONE} and {@code DICE_ROLL}.
+ * The {@link RandomDivorceMethod} enum is used to specify the method of randomly generating a divorce. It supports two
+ * methods: {@code NONE} and {@code DICE_ROLL}.
  * <p>
- * The {@code NONE} method represents no random divorce generation, and the {@code DICE_ROLL} method
- * represents randomly generated divorce using dice rolls.
+ * The {@code NONE} method represents no random divorce generation, and the {@code DICE_ROLL} method represents randomly
+ * generated divorce using dice rolls.
  */
 public enum RandomDivorceMethod {
     //region Enum Declarations
@@ -50,28 +52,32 @@ public enum RandomDivorceMethod {
     DICE_ROLL("RandomDivorceMethod.DICE_ROLL.text", "RandomDivorceMethod.DICE_ROLL.toolTipText");
     //endregion Enum Declarations
 
+    private static final MMLogger logger = MMLogger.create(RandomDivorceMethod.class);
+
     //region Variable Declarations
     private final String name;
     private final String toolTipText;
     //endregion Variable Declarations
 
     //region Constructors
+
     /**
-     * Constructor for the {@link RandomDivorceMethod} class.
-     * Initializes the name and toolTipText variables using the specified name and toolTipText resources.
+     * Constructor for the {@link RandomDivorceMethod} class. Initializes the name and toolTipText variables using the
+     * specified name and toolTipText resources.
      *
-     * @param name          the name resource key used to retrieve the name from the resource bundle
-     * @param toolTipText   the tooltip text resource key used to retrieve the tool tip text from the resource bundle
+     * @param name        the name resource key used to retrieve the name from the resource bundle
+     * @param toolTipText the tooltip text resource key used to retrieve the tool tip text from the resource bundle
      */
     RandomDivorceMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-                MekHQ.getMHQOptions().getLocale());
+              MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }
     //endregion Constructors
 
     //region Getters
+
     /**
      * @return the tooltip text for the current object
      */
@@ -81,11 +87,11 @@ public enum RandomDivorceMethod {
     //endregion Getters
 
     //region Boolean Comparisons
+
     /**
      * Checks if the current {@link RandomDivorceMethod} is {@code NONE}.
      *
-     * @return {@code true} if the current {@link RandomDivorceMethod} is {@code NONE},
-     * {@code false} otherwise.
+     * @return {@code true} if the current {@link RandomDivorceMethod} is {@code NONE}, {@code false} otherwise.
      */
     public boolean isNone() {
         return this == NONE;
@@ -94,8 +100,7 @@ public enum RandomDivorceMethod {
     /**
      * Checks if the current {@link RandomDivorceMethod} is {@code DICE_ROLL}.
      *
-     * @return {@code true} if the current {@link RandomDivorceMethod} is {@code DICE_ROLL},
-     * {@code false} otherwise.
+     * @return {@code true} if the current {@link RandomDivorceMethod} is {@code DICE_ROLL}, {@code false} otherwise.
      */
     public boolean isDiceRoll() {
         return this == DICE_ROLL;
@@ -104,6 +109,7 @@ public enum RandomDivorceMethod {
 
     /**
      * @param options the {@link CampaignOptions} object used to initialize the {@link AbstractDivorce} instance
+     *
      * @return an instance of {@link AbstractDivorce} based on the {@link RandomDivorceMethod}
      */
     public AbstractDivorce getMethod(final CampaignOptions options) {
@@ -112,6 +118,65 @@ public enum RandomDivorceMethod {
         } else {
             return new DisabledRandomDivorce(options);
         }
+    }
+
+    /**
+     * Converts a string representation to a {@link RandomDivorceMethod} enum value.
+     *
+     * <p>This method attempts to parse the input string in several different ways:</p>
+     * <ul>
+     *   <li>First, it tries to match the string as an enum constant (converting to uppercase and replacing spaces
+     *   with underscores)</li>
+     *   <li>Next, it checks if the string matches any enum name directly (case-insensitive)</li>
+     *   <li>Finally, it attempts to parse the string as an integer ordinal value</li>
+     * </ul>
+     *
+     * <p>If all conversion attempts fail, it returns the {@link #NONE} value.</p>
+     *
+     * @param text the string to convert, which may be the enum name (with or without spaces), or its ordinal value as a
+     *             string
+     *
+     * @return the corresponding {@link RandomDivorceMethod}, or {@link #NONE} if the string could not be converted
+     *
+     * @author Illiani
+     * @since 0.50.05
+     */
+    public static RandomDivorceMethod fromString(String text) {
+        // Return NONE for null or empty strings
+        if ((text == null) || text.isEmpty()) {
+            logger.error("Null or empty string passed to RandomDivorceMethod.fromString: {}", text);
+            return NONE;
+        }
+
+        // String value (uppercase with underscores)
+        try {
+            return RandomDivorceMethod.valueOf(text.toUpperCase().replace(" ", "_"));
+        } catch (Exception ignored) {
+        }
+
+        // Display name matching
+        for (RandomDivorceMethod method : RandomDivorceMethod.values()) {
+            if (method.toString().equalsIgnoreCase(text)) {
+                return method;
+            }
+        }
+
+        // Name comparison
+        for (RandomDivorceMethod method : RandomDivorceMethod.values()) {
+            if (method.name().equalsIgnoreCase(text)) {
+                return method;
+            }
+        }
+
+        // Ordinal value
+        try {
+            return RandomDivorceMethod.values()[MathUtility.parseInt(text.trim())];
+        } catch (Exception ignored) {
+        }
+
+        // Log error and return default
+        logger.error("Unknown RandomDivorceMethod: {} - returning {}.", text, NONE);
+        return NONE;
     }
 
     @Override

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomDivorceMethodTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/RandomDivorceMethodTest.java
@@ -27,14 +27,6 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import mekhq.MekHQ;
-import mekhq.campaign.CampaignOptions;
-import mekhq.campaign.personnel.divorce.DisabledRandomDivorce;
-import mekhq.campaign.personnel.divorce.RandomDivorce;
-import org.junit.jupiter.api.Test;
-
-import java.util.ResourceBundle;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -42,12 +34,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ResourceBundle;
+
+import mekhq.MekHQ;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.personnel.divorce.DisabledRandomDivorce;
+import mekhq.campaign.personnel.divorce.RandomDivorce;
+import org.junit.jupiter.api.Test;
+
 public class RandomDivorceMethodTest {
     //region Variable Declarations
     private static final RandomDivorceMethod[] methods = RandomDivorceMethod.values();
 
     private final transient ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
-            MekHQ.getMHQOptions().getLocale());
+          MekHQ.getMHQOptions().getLocale());
     //endregion Variable Declarations
 
     //region Getters
@@ -101,9 +101,31 @@ public class RandomDivorceMethodTest {
 
     @Test
     public void testToStringOverride() {
-        assertEquals(resources.getString("RandomDivorceMethod.NONE.text"),
-                RandomDivorceMethod.NONE.toString());
+        assertEquals(resources.getString("RandomDivorceMethod.NONE.text"), RandomDivorceMethod.NONE.toString());
         assertEquals(resources.getString("RandomDivorceMethod.DICE_ROLL.text"),
-                RandomDivorceMethod.DICE_ROLL.toString());
+              RandomDivorceMethod.DICE_ROLL.toString());
+    }
+
+    @Test
+    public void testFromStringValidEnums() {
+        assertEquals(RandomDivorceMethod.NONE, RandomDivorceMethod.fromString("NONE"));
+        assertEquals(RandomDivorceMethod.DICE_ROLL, RandomDivorceMethod.fromString("DICE_ROLL"));
+        assertEquals(RandomDivorceMethod.DICE_ROLL,
+              RandomDivorceMethod.fromString("dice roll")); // Case and space insensitive
+    }
+
+    @Test
+    public void testFromStringInvalidEnums() {
+        assertEquals(RandomDivorceMethod.NONE, RandomDivorceMethod.fromString(null));
+        assertEquals(RandomDivorceMethod.NONE, RandomDivorceMethod.fromString(""));
+        assertEquals(RandomDivorceMethod.NONE, RandomDivorceMethod.fromString("InvalidMethod"));
+    }
+
+    @Test
+    public void testFromStringOrdinalNumbers() {
+        assertEquals(RandomDivorceMethod.NONE, RandomDivorceMethod.fromString("0")); // Ordinal mapping
+        assertEquals(RandomDivorceMethod.DICE_ROLL, RandomDivorceMethod.fromString("1"));
+        assertEquals(RandomDivorceMethod.NONE,
+              RandomDivorceMethod.fromString("2")); // Non-existent ordinal returns default
     }
 }


### PR DESCRIPTION
- Implemented a `fromString` method in `RandomDivorceMethod` for parsing string input into the corresponding enum value.
  - Supports matching by enum constant, case-insensitive alias, or ordinal value.
  - Defaults to `NONE` for unrecognized input.
  - Logs a warning when an unknown method is encountered.
- Updated `CampaignOptions` to use `fromString` for safer parsing of `RandomDivorceMethod`.

### Dev Notes
Fixes a log error when loading old campaigns with `RandomDivorceMethod ` set to a value that no longer exists.