### PR TITLE
Fixed Incorrect Constants and Pronoun Placement in BirthAnnouncement

### DIFF
--- a/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
@@ -134,7 +134,7 @@ babyBorn.message.27.ic={2}''s delivery was rough - a baby {10}, {15}kg.\
   <p>It''s a relief. I was really worried we''d lose them both.</p>
 babyBorn.message.28.ic=In a world that seems constantly on fire, today we witnessed a moment of peace.\
   <p>{2} gave birth to a baby {10}, weighing {15}kg.</p>\
-  <p>When {3} held {13} for the first time, they had tears in {9} eyes. It''s not often we get to see something so\
+  <p>When {3} held {13} for the first time, {7} had tears in {9} eyes. It''s not often we get to see something so\
   \ pure.</p>\
   <p>Both {5} and baby are doing well.</p>
 babyBorn.message.29.ic={2} delivered a baby {10} at {1}-local, weighing {15}kg.\

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/BirthAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/BirthAnnouncement.java
@@ -63,7 +63,7 @@ public class BirthAnnouncement {
     private final Person parent;
 
     private final static double AVERAGE_BABY_WEIGHT_IN_KG = 3.5;
-    private final static int SUPPRESS_DIALOG_RESPONSE_INDEX = 3;
+    private final static int SUPPRESS_DIALOG_RESPONSE_INDEX = 2;
 
 
     /**
@@ -92,7 +92,7 @@ public class BirthAnnouncement {
 
         if (dialog.getDialogChoice() == SUPPRESS_DIALOG_RESPONSE_INDEX) {
             CampaignOptions campaignOptions = campaign.getCampaignOptions();
-            campaignOptions.setShowLifeEventDialogBirths(false);
+            campaignOptions.setShowLifeEventDialogBirths(true);
         }
     }
 


### PR DESCRIPTION
- Updated `SUPPRESS_DIALOG_RESPONSE_INDEX` constant value from `3` to `2` to align with the expected dialog behavior.
- Corrected `CampaignOptions` logic to properly set `ShowLifeEventDialogBirths` to `true` when the suppression option is selected.
- Adjusted pronoun placeholders in `BirthAnnouncement.properties` to use the correct variable for improved message clarity.