### PR TITLE
Fixed Null Pointer Issue in Refit Handling

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -41,10 +41,10 @@ import static mekhq.campaign.log.LogEntryType.PERFORMANCE;
 import static mekhq.campaign.log.LogEntryType.SERVICE;
 import static mekhq.campaign.personnel.PersonnelOptions.*;
 import static mekhq.campaign.personnel.enums.BloodGroup.getRandomBloodGroup;
+import static mekhq.campaign.personnel.skills.Aging.getReputationAgeModifier;
 import static mekhq.campaign.personnel.skills.Attributes.DEFAULT_ATTRIBUTE_SCORE;
 import static mekhq.campaign.personnel.skills.Attributes.MAXIMUM_ATTRIBUTE_SCORE;
 import static mekhq.campaign.personnel.skills.Attributes.MINIMUM_ATTRIBUTE_SCORE;
-import static mekhq.campaign.personnel.skills.Aging.getReputationAgeModifier;
 import static mekhq.campaign.personnel.skills.SkillType.S_ADMIN;
 
 import java.io.PrintWriter;
@@ -86,6 +86,7 @@ import mekhq.campaign.log.PersonalLogger;
 import mekhq.campaign.log.ServiceLogger;
 import mekhq.campaign.mod.am.InjuryUtil;
 import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.Refit;
 import mekhq.campaign.personnel.enums.BloodGroup;
 import mekhq.campaign.personnel.enums.ManeiDominiClass;
 import mekhq.campaign.personnel.enums.ManeiDominiRank;
@@ -4720,7 +4721,8 @@ public class Person {
         // Tech assignments
         if (isTech()) {
             for (Unit unit : techUnits) {
-                boolean isActiveTech = Objects.equals(unit.getRefit().getTech(), this);
+                Refit refit = unit.getRefit();
+                boolean isActiveTech = refit != null && Objects.equals(refit.getTech(), this);
 
                 if (unit.isMothballing() && isActiveTech) {
                     return true;

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -6119,7 +6119,7 @@ public class Unit implements ITechnology {
         refit = r;
     }
 
-    public Refit getRefit() {
+    public @Nullable Refit getRefit() {
         return refit;
     }
 


### PR DESCRIPTION
- Resolved potential null pointer exception when accessing `Refit` in `Person`'s tech assignment logic by adding a null check.
- Updated `Unit#getRefit()` method to explicitly indicate the possibility of a nullable return with `@Nullable` annotation.

### Dev Notes
Maternity leave once again bites me in the butt.