### PR TITLE
Fix what units are passed to detach trailer/tractor so it only shows when needed

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1239,8 +1239,8 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
 
                 JMenuHelpers.addMenuIfNonEmpty(popup,
                       new AssignForceToTowTransportMenu(gui.getCampaign(), new HashSet<>(unitsInForces)));
-                detachFromTractorTransportMenuClass(units, popup);
-                detachTrailerTransportMenuClass(units, popup);
+                detachFromTractorTransportMenuClass(unitsInForces, popup);
+                detachTrailerTransportMenuClass(unitsInForces, popup);
             }
         } else if (unitsSelected) {
             Unit unit = units.get(0);


### PR DESCRIPTION
Unassign Towed Units from Tractor / Unassign Force from Tractor was always showing instead of only showing when needed. This fixes that. It was using the incorrect "units", it should be using "unitsInForces".