### PR TITLE
Fixed Skill Panel Layout Calculation in Campaign Options IIC

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsTab.java
@@ -275,15 +275,16 @@ public class SkillsTab {
         layout.gridx = 0;
         layout.gridy++;
         int tableCounter = 0;
-        for (int i = 0; i < 4; i++) {
+        int rows = (int) Math.ceil(skillPanels.size() / 5.0);
+        for (int i = 0; i < rows; i++) {
             layout.gridy++;
             layout.gridx = 0;
             for (int j = 0; j < 5; j++) {
-                if (tableCounter < skillPanels.size()) {
-                    panel.add(skillPanels.get(tableCounter), layout);
-                    layout.gridx++;
+                int index = i * 5 + j;
+                if (index < skillPanels.size()) {
+                    panel.add(skillPanels.get(index), layout);
                 }
-                tableCounter++;
+                layout.gridx++;
             }
         }
 


### PR DESCRIPTION
- Replaced hardcoded rows with a dynamic calculation based on skill panel size.

### Dev Notes
This fixes a bug where each skills tab could only display a maximum of 20 skills.