### PR TITLE
Updated .gitignore To Refine Campaign File Tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,9 @@
 /MekHQ/bin/
 /MekHQ/build/
 /MekHQ/campaigns/
-!/MekHQ/campaigns/Fist and Falcon/
-!/MekHQ/campaigns/Sword and Dragon/
-!/MekHQ/campaigns/Wolf and Blake/
+/MekHQ/campaigns/
+!/MekHQ/campaigns/The Learning Ropes.cpnx.gz
+!/MekHQ/campaigns/archive/
 /MekHQ/classes/
 /MekHQ/data/images/awards/
 !/MekHQ/data/images/awards/standard/


### PR DESCRIPTION
- Adjusted `/MekHQ/campaigns/` rules to ignore all campaigns except specific files and directories.
- Added exception for `/MekHQ/campaigns/The Learning Ropes.cpnx.gz`.
- Included `/MekHQ/campaigns/archive/` in tracking by overriding ignore.
- Removed specific entries for older campaigns (e.g., Fist and Falcon, Sword and Dragon, Wolf and Blake) as these are now included in `archive`