### PR TITLE
Fixed an NPE During Contract Resolution (Sentry)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,9 @@
 /MekHQ/bin/
 /MekHQ/build/
 /MekHQ/campaigns/*
-!/MekHQ/campaigns/The Learning Ropes.cpnx.gz
+!/MekHQ/campaigns/archive
 !/MekHQ/campaigns/archive/**
+!/MekHQ/campaigns/The Learning Ropes.cpnx.gz
 /MekHQ/classes/
 /MekHQ/data/images/awards/
 !/MekHQ/data/images/awards/standard/

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -83,6 +83,7 @@ import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.randomEvents.prisoners.PrisonerMissionEndEvent;
+import mekhq.campaign.stratcon.StratconCampaignState;
 import mekhq.campaign.stratcon.StratconScenario;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Faction;
@@ -559,9 +560,14 @@ public final class BriefingTab extends CampaignGuiTab {
             case FAILED, BREACH -> getCampaign().getCampaignOptions().getMissionXpFail();
             case SUCCESS, PARTIAL -> {
                 if ((getCampaign().getCampaignOptions().isUseStratCon()) &&
-                          (mission instanceof AtBContract) &&
-                          (((AtBContract) mission).getStratconCampaignState().getVictoryPoints() >= 3)) {
-                    yield getCampaign().getCampaignOptions().getMissionXpOutstandingSuccess();
+                          (mission instanceof AtBContract)) {
+                    StratconCampaignState stratConCampaignState = ((AtBContract) mission).getStratconCampaignState();
+
+                    if (stratConCampaignState == null || stratConCampaignState.getVictoryPoints() < 3) {
+                        yield getCampaign().getCampaignOptions().getMissionXpSuccess();
+                    } else {
+                        yield getCampaign().getCampaignOptions().getMissionXpOutstandingSuccess();
+                    }
                 } else {
                     yield getCampaign().getCampaignOptions().getMissionXpSuccess();
                 }


### PR DESCRIPTION
- Fixed an NPE caused by having StratCon enabled, but where the current `Mission` is not a StratCon-enabled `AtBContract`.

Fix: [Sentry Report](https://sentry.tapenvy.us/organizations/tapenvyus/issues/4359/?alert_rule_id=13&alert_type=issue&notification_uuid=264e9440-951e-4e95-8812-ea438e97309a&project=10&referrer=discord)