### PR TITLE
Fix #6668: Fixed Creative Accounting for Ammunition in Resupplies

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/GenerateResupplyContents.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/GenerateResupplyContents.java
@@ -45,6 +45,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.lang.Math.min;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_AMMO_TONNAGE;
+import static mekhq.campaign.mission.resupplyAndCaches.Resupply.RESUPPLY_ARMOR_TONNAGE;
 import static mekhq.campaign.unit.Unit.getRandomUnitQuality;
 
 /**
@@ -155,20 +157,21 @@ public class GenerateResupplyContents {
             }
 
             if (partFetched) {
-                switch (dropType) {
-                    case DROP_TYPE_PARTS -> partsPool.remove(potentialPart);
-                    case DROP_TYPE_ARMOR -> armorPool.remove(potentialPart);
-                    case DROP_TYPE_AMMO -> ammoBinPool.remove(potentialPart);
-                }
-
-                // Ammo and Armor are delivered in batches of 5t,
-                // so we need to make sure we're treating them as 5t no matter their actual weight.
-                double partWeight = 5;
-
-                if (dropType == DropType.DROP_TYPE_PARTS) {
-                    partWeight = potentialPart.getTonnage();
-                    partWeight = partWeight == 0 ? RESUPPLY_MINIMUM_PART_WEIGHT : partWeight;
-                }
+                double partWeight = switch (dropType) {
+                    case DROP_TYPE_PARTS -> {
+                        partsPool.remove(potentialPart);
+                        double tonnage = potentialPart.getTonnage();
+                        yield tonnage == 0 ? RESUPPLY_MINIMUM_PART_WEIGHT : tonnage;
+                    }
+                    case DROP_TYPE_ARMOR -> {
+                        armorPool.remove(potentialPart);
+                        yield RESUPPLY_ARMOR_TONNAGE;
+                    }
+                    case DROP_TYPE_AMMO -> {
+                        ammoBinPool.remove(potentialPart);
+                        yield RESUPPLY_AMMO_TONNAGE;
+                    }
+                };
 
                 currentLoad += partWeight;
                 droppedItems.add(potentialPart);


### PR DESCRIPTION
- Stopped the employer depot crew from counting every ton of ammunition as five tons. Where did the other 4 tons go? Well, where else do you think the Smugglers get their wares?

Fix #6668

### Dev Notes
The Resupply module went through a _lot_ of revisions during development, as we sought to 'get it right'. During an early build ammunition was delivered in batches of five tons. So every time you go LRMs, for example, you would get five tons of LRMs.

However, we received feedback that this didn't feel great, so instead we moved ammunition to be delivered in patches of 1 ton.

Unfortunately, I missed a single instance where the old 5 tons was being used. Meaning ammunition was being treated as if it weighed 5x as much as was actually delivered.