### PR TITLE
Fixed Command Skills Counting Down not Up

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -1181,6 +1181,8 @@ public class SkillType {
         logger.info("SkillType {} has been updated to second attribute {}",
               skillType.getName(),
               temporarySkillType.getSecondAttribute());
+
+        skillType.countUp = temporarySkillType.isCountUp();
     }
 
 


### PR DESCRIPTION
- It appears 50.05 picked up a brief bug where the three command skills (Strategy, Command, and Leadership) started counting down, not up. This corrects that.