### PR TITLE
Fixed NPE in `updateCommander` (Sentry)

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -182,7 +182,7 @@ public class CombatTeam {
         this.role = role;
     }
 
-    public UUID getCommanderId() {
+    public @Nullable UUID getCommanderId() {
         return commanderId;
     }
 
@@ -388,7 +388,7 @@ public class CombatTeam {
     }
 
     /* Code to find unit commander from ForceViewPanel */
-    public static UUID findCommander(int forceId, Campaign campaign) {
+    public static @Nullable UUID findCommander(int forceId, Campaign campaign) {
         return campaign.getForce(forceId).getForceCommanderID();
     }
 

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -673,6 +673,7 @@ public class Force {
         }
 
         if (highestRankedPerson == null) {
+            logger.info("Force {} has no eligible commanders", getName());
             forceCommanderID = null;
         } else {
             forceCommanderID = highestRankedPerson.getId();

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -570,7 +570,7 @@ public class Force {
         this.id = i;
     }
 
-    public UUID getForceCommanderID() {
+    public @Nullable UUID getForceCommanderID() {
         return forceCommanderID;
     }
 
@@ -583,7 +583,7 @@ public class Force {
      * @see #setOverrideForceCommanderID(UUID)
      * @see #updateCommander(Campaign)
      */
-    private void setForceCommanderID(UUID commanderID) {
+    private void setForceCommanderID(@Nullable UUID commanderID) {
         forceCommanderID = commanderID;
     }
 
@@ -672,7 +672,12 @@ public class Force {
             }
         }
 
-        forceCommanderID = highestRankedPerson.getId();
+        if (highestRankedPerson == null) {
+            forceCommanderID = null;
+        } else {
+            forceCommanderID = highestRankedPerson.getId();
+        }
+
         updateCombatTeamCommanderIfCombatTeam(campaign);
 
         if (getParentForce() != null) {


### PR DESCRIPTION
- Updated several methods and variables to explicitly acknowledge that commander-related UUIDs can be null.

Fix [Sentry Report](https://sentry.tapenvy.us/organizations/tapenvyus/issues/4375/?alert_rule_id=13&alert_type=issue&notification_uuid=d9e5f9cb-b1dd-438e-a7b4-b4fd34dc8b54&project=10&referrer=discord)