### PR TITLE
Fix #6412, #6422: Fixed Multiple Scenario Template Issues

### DIFF
--- a/MekHQ/data/scenariotemplates/Annihilation.xml
+++ b/MekHQ/data/scenariotemplates/Annihilation.xml
@@ -38,8 +38,6 @@ The victor controls the field, and we will be the ones standing when the dust se
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Annihilation.xml
+++ b/MekHQ/data/scenariotemplates/Annihilation.xml
@@ -2,9 +2,9 @@
 <ScenarioTemplate>
     <name>Annihilation</name>
     <shortBriefing>Obliterate the enemy force.</shortBriefing>
-    <detailedBriefing>Your orders are clear. This is not a surgical strike, nor a precision raid—this is extermination. The enemy force in this sector must be wiped out, with 95% confirmed casualties before we consider this battlefield secured. Their continued presence is unacceptable, and we cannot afford to let even a remnant regroup for future operations.
+    <detailedBriefing><![CDATA[Your orders are clear. This is not a surgical strike, nor a precision raid—this is extermination. The enemy force in this sector must be wiped out, with 95% confirmed casualties before we consider this battlefield secured. Their continued presence is unacceptable, and we cannot afford to let even a remnant regroup for future operations.
 
-The victor controls the field, and we will be the ones standing when the dust settles.</detailedBriefing>
+The victor controls the field, and we will be the ones standing when the dust settles.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Assassination.xml
+++ b/MekHQ/data/scenariotemplates/Assassination.xml
@@ -38,8 +38,6 @@ We expect a fierce but contained battle. Your forces will be operating behind en
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Assassination.xml
+++ b/MekHQ/data/scenariotemplates/Assassination.xml
@@ -2,9 +2,9 @@
 <ScenarioTemplate>
     <name>Assassination</name>
     <shortBriefing>Eliminate VIP, minimize own losses.</shortBriefing>
-    <detailedBriefing>This is a precision strike inside an active warzone. The enemy dominates the field, but we’re not here for a prolonged engagement—we’re here for a kill mission. Your primary objective is to assassinate a high-value target before they can escape. This individual is critical to the enemy’s war effort, and their elimination will shift the balance in our favor.
+    <detailedBriefing><![CDATA[This is a precision strike inside an active warzone. The enemy dominates the field, but we’re not here for a prolonged engagement—we’re here for a kill mission. Your primary objective is to assassinate a high-value target before they can escape. This individual is critical to the enemy’s war effort, and their elimination will shift the balance in our favor.
 
-We expect a fierce but contained battle. Your forces will be operating behind enemy lines, deep within hostile territory. Extraction is not a priority—the enemy will retain control of the battlefield when the dust settles. Your task is to neutralize the VIP, no other considerations are of value.</detailedBriefing>
+We expect a fierce but contained battle. Your forces will be operating behind enemy lines, deep within hostile territory. Extraction is not a priority—the enemy will retain control of the battlefield when the dust settles. Your task is to neutralize the VIP, no other considerations are of value.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Base Defense.xml
+++ b/MekHQ/data/scenariotemplates/Base Defense.xml
@@ -69,15 +69,6 @@ The victor will control the field when this is over. Ensure that it is us.</deta
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>1</deploymentZone>
-                    <deploymentZone>2</deploymentZone>
-                    <deploymentZone>3</deploymentZone>
-                    <deploymentZone>4</deploymentZone>
-                    <deploymentZone>5</deploymentZone>
-                    <deploymentZone>6</deploymentZone>
-                    <deploymentZone>7</deploymentZone>
-                    <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
                     <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
@@ -109,14 +100,6 @@ The victor will control the field when this is over. Ensure that it is us.</deta
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>1</deploymentZone>
-                    <deploymentZone>2</deploymentZone>
-                    <deploymentZone>3</deploymentZone>
-                    <deploymentZone>4</deploymentZone>
-                    <deploymentZone>5</deploymentZone>
-                    <deploymentZone>6</deploymentZone>
-                    <deploymentZone>7</deploymentZone>
-                    <deploymentZone>8</deploymentZone>
                     <deploymentZone>9</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>

--- a/MekHQ/data/scenariotemplates/Base Defense.xml
+++ b/MekHQ/data/scenariotemplates/Base Defense.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Base Defense</name>
     <shortBriefing>Defend allied facility, minimize damage.</shortBriefing>
-    <detailedBriefing>Your orders are clear: defend the base against the incoming enemy assault. At least 25% of the base infrastructure must remain intact by the end of the engagement.
+    <detailedBriefing><![CDATA[Your orders are clear: defend the base against the incoming enemy assault. At least 25% of the base infrastructure must remain intact by the end of the engagement.
 
 At the same time, this is not just about survival. You are to destroy at least 50% of enemy forces before the battle concludes.
 
-The victor will control the field when this is over. Ensure that it is us.</detailedBriefing>
+The victor will control the field when this is over. Ensure that it is us.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>true</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Breakthrough.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Breakthrough</name>
     <shortBriefing>Break through or destroy enemy.</shortBriefing>
-    <detailedBriefing>Your objective is to break through enemy lines and reach the far side of the engagement zone. At least 50% of your forces must reach the destination, and only fully operational units will count.
+    <detailedBriefing><![CDATA[Your objective is to break through enemy lines and reach the far side of the engagement zone. At least 50% of your forces must reach the destination, and only fully operational units will count.
 
 If the enemy resistance proves too strong, you have an alternative path to victory: destroy at least 50% of enemy forces to force them into disarray and open the way.
 
-Be advised: the enemy will control the field when this is over. Move fast, strike hard, and don’t look back.</detailedBriefing>
+Be advised: the enemy will control the field when this is over. Move fast, strike hard, and don’t look back.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Breakthrough.xml
@@ -34,7 +34,7 @@ Be advised: the enemy will control the field when this is over. Move fast, strik
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Breakthrough.xml
@@ -10,7 +10,7 @@ Be advised: the enemy will control the field when this is over. Move fast, strik
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/Chasing a Rumor.xml
+++ b/MekHQ/data/scenariotemplates/Chasing a Rumor.xml
@@ -39,8 +39,6 @@
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Chasing a Rumor.xml
+++ b/MekHQ/data/scenariotemplates/Chasing a Rumor.xml
@@ -3,9 +3,9 @@
     <name>Chasing a Rumor</name>
     <stratConScenarioType>SPECIAL_LOSTECH</stratConScenarioType>
     <shortBriefing>Fight to secure the hidden cache</shortBriefing>
-    <detailedBriefing>Intel suggests there is a hidden cache in this region. Unfortunately, enemy forces seem to have caught wind of this intel. The objective is to either destroy or force them to retreat. At least 50% of the enemy must be neutralized, while maintaining 50% of friendly forces.
+    <detailedBriefing><![CDATA[Intel suggests there is a hidden cache in this region. Unfortunately, enemy forces seem to have caught wind of this intel. The objective is to either destroy or force them to retreat. At least 50% of the enemy must be neutralized, while maintaining 50% of friendly forces.
 
-    If this scenario is lost, so too is the hidden cache.</detailedBriefing>
+If this scenario is lost, so too is the hidden cache.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Close Air Support.xml
+++ b/MekHQ/data/scenariotemplates/Close Air Support.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Close Air Support</name>
     <shortBriefing>Provide air support, minimize losses.</shortBriefing>
-    <detailedBriefing>Your mission is to provide air support to allied ground forces currently under heavy attack. The enemy is pressing hard, and without intervention, our forces will be overwhelmed. You are to engage hostile units with precision strikes, break enemy formations, and relieve pressure on friendly positions. Coordination with ground command will be critical to ensuring maximum impact.
+    <detailedBriefing><![CDATA[Your mission is to provide air support to allied ground forces currently under heavy attack. The enemy is pressing hard, and without intervention, our forces will be overwhelmed. You are to engage hostile units with precision strikes, break enemy formations, and relieve pressure on friendly positions. Coordination with ground command will be critical to ensuring maximum impact.
 
 Your primary objective is to preserve at least 50% of allied forces. Their survival is paramount to maintaining battlefield cohesion. Simultaneously, you must destroy or route at least 50% of the enemy forces. This engagement is about turning the tide, forcing them to break, and ensuring our ground forces can hold firm.
 
-The winner of this battle will control the field when the engagement is over. You must ensure that victory belongs to us. Strike hard, strike true, and do not let the enemy dictate the pace of battle. Your firepower will decide the outcome.</detailedBriefing>
+The winner of this battle will control the field when the engagement is over. You must ensure that victory belongs to us. Strike hard, strike true, and do not let the enemy dictate the pace of battle. Your firepower will decide the outcome.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Close Air Support.xml
+++ b/MekHQ/data/scenariotemplates/Close Air Support.xml
@@ -40,7 +40,6 @@ The winner of this battle will control the field when the engagement is over. Yo
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -52,7 +51,7 @@ The winner of this battle will control the field when the engagement is over. Yo
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>
@@ -69,19 +68,9 @@ The winner of this battle will control the field when the engagement is over. Yo
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones>
-                    <deploymentZone>1</deploymentZone>
-                    <deploymentZone>2</deploymentZone>
-                    <deploymentZone>3</deploymentZone>
-                    <deploymentZone>4</deploymentZone>
-                    <deploymentZone>5</deploymentZone>
-                    <deploymentZone>6</deploymentZone>
-                    <deploymentZone>7</deploymentZone>
-                    <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                </deploymentZones>
+                <deploymentZones />
                 <destinationZone>5</destinationZone>
-                <fixedUnitCount>0</fixedUnitCount>
+                <fixedUnitCount>5</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
@@ -91,7 +80,8 @@ The winner of this battle will control the field when the engagement is over. Yo
                 <minWeightClass>1</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>None</syncDeploymentType>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>
         </entry>

--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -64,7 +64,9 @@ We will control the field at the conclusion of the battle. This means you have f
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
@@ -77,8 +79,7 @@ We will control the field at the conclusion of the battle. This means you have f
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Convoy</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>RAIDER</forceRole>

--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -112,7 +112,7 @@ We will control the field at the conclusion of the battle. This means you have f
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>
                 <objectiveLinkedForces />
-                <retreatThreshold>50</retreatThreshold>
+                <retreatThreshold>0</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -3,11 +3,11 @@
     <name>Convoy Escort</name>
     <stratConScenarioType>CONVOY</stratConScenarioType>
     <shortBriefing>Escort supply convoy or defeat attackers.</shortBriefing>
-    <detailedBriefing>An allied convoy carrying critical supplies is moving through hostile territory, and enemy forces are preparing to intercept. Your mission is to ensure that the convoy reaches its destination. At least 50% of the convoy must reach the far edge of the engagement area intact. These supplies are vital to sustaining our operations, and failure is not an option.
+    <detailedBriefing><![CDATA[An allied convoy carrying critical supplies is moving through hostile territory, and enemy forces are preparing to intercept. Your mission is to ensure that the convoy reaches its destination. At least 50% of the convoy must reach the far edge of the engagement area intact. These supplies are vital to sustaining our operations, and failure is not an option.
 
 Should the enemy resistance prove too strong for a full escort, you have an alternative means to secure victory. If at least 50% of the convoy survives while you destroy or route 50% of the enemy forces, the mission will be considered a success. Breaking the enemy’s will to fight will give the convoy a clear path forward.
 
-We will control the field at the conclusion of the battle. This means you have full authority to dictate the engagement on your terms. Use the terrain, control the tempo, and eliminate threats efficiently. Hold the line, protect the convoy, and ensure that these supplies reach their destination.</detailedBriefing>
+We will control the field at the conclusion of the battle. This means you have full authority to dictate the engagement on your terms. Use the terrain, control the tempo, and eliminate threats efficiently. Hold the line, protect the convoy, and ensure that these supplies reach their destination.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
@@ -32,7 +32,9 @@ No distractions. No delays. No mercy. Execute the raid, cripple their supply lin
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
@@ -44,8 +46,7 @@ No distractions. No delays. No mercy. Execute the raid, cripple their supply lin
                 <minWeightClass>0</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeArc</syncDeploymentType>
-                <syncedForceName>Convoy</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>
         </entry>
@@ -91,10 +92,7 @@ No distractions. No delays. No mercy. Execute the raid, cripple their supply lin
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>2</deploymentZone>
-                    <deploymentZone>4</deploymentZone>
                     <deploymentZone>6</deploymentZone>
-                    <deploymentZone>8</deploymentZone>
                 </deploymentZones>
                 <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
@@ -94,7 +94,7 @@ No distractions. No delays. No mercy. Execute the raid, cripple their supply lin
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>6</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>0.5</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
@@ -103,7 +103,7 @@ No distractions. No delays. No mercy. Execute the raid, cripple their supply lin
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>
-                <retreatThreshold>50</retreatThreshold>
+                <retreatThreshold>0</retreatThreshold>
                 <subjectToRandomRemoval>false</subjectToRandomRemoval>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>

--- a/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
@@ -3,11 +3,11 @@
     <name>Convoy Interdiction</name>
     <stratConScenarioType>CONVOY</stratConScenarioType>
     <shortBriefing>Intercept and neutralize enemy convoy.</shortBriefing>
-    <detailedBriefing>An enemy convoy is on the move, and your orders are simple—hit them hard and stop at least 50% of their forces from reaching the far edge of the engagement zone. This is a direct strike, not a prolonged engagement. Destroy or cripple the convoy units with no regard for salvage or escort interference. Speed and overwhelming firepower are your greatest assets.
+    <detailedBriefing><![CDATA[An enemy convoy is on the move, and your orders are simple—hit them hard and stop at least 50% of their forces from reaching the far edge of the engagement zone. This is a direct strike, not a prolonged engagement. Destroy or cripple the convoy units with no regard for salvage or escort interference. Speed and overwhelming firepower are your greatest assets.
 
 There is no need to concern yourself with minimizing damage or securing the spoils. We do not have the luxury of holding the field, and enemy reinforcements will arrive quickly. Do not waste time engaging the escorts unless necessary—focus all efforts on neutralizing the convoy itself. Once the job is done, withdraw immediately.
 
-No distractions. No delays. No mercy. Execute the raid, cripple their supply line, and get out before the enemy can mount a counterattack.</detailedBriefing>
+No distractions. No delays. No mercy. Execute the raid, cripple their supply line, and get out before the enemy can mount a counterattack.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Convoy Raid.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Raid.xml
@@ -3,11 +3,11 @@
     <name>Convoy Raid</name>
     <stratConScenarioType>CONVOY</stratConScenarioType>
     <shortBriefing>Intercept and disrupt enemy convoy.</shortBriefing>
-    <detailedBriefing>An enemy supply convoy is on the move, and this is our chance to cripple their logistics. Your mission is to intercept and raid the convoy before it can escape the engagement zone. These supplies are vital to the enemy’s war effort, and every truck or transport we eliminate weakens their ability to fight. Speed and aggression will be key—hit them hard, hit them fast, and get out before their reinforcements arrive.
+    <detailedBriefing><![CDATA[An enemy supply convoy is on the move, and this is our chance to cripple their logistics. Your mission is to intercept and raid the convoy before it can escape the engagement zone. These supplies are vital to the enemy’s war effort, and every truck or transport we eliminate weakens their ability to fight. Speed and aggression will be key—hit them hard, hit them fast, and get out before their reinforcements arrive.
 
 Your primary objective is to prevent at least 50% of the convoy from reaching the far side of the engagement zone. Disrupt their formation, destroy their transports, and force them to abandon their mission. If their escort force proves too formidable, you have an alternative route to success—destroy at least 50% of the convoy’s escorts to force the remaining defenders to surrender. With their protection shattered, the convoy will have no choice but to stand down.
 
-The more convoy units that survive, the greater the spoils. Disabling transports instead of outright destruction may increase salvage potential, but that is a secondary concern to stopping the convoy itself. However, do not linger. The enemy will respond quickly, and we will not control the field once the battle ends. Execute the raid with precision, neutralize the targets, and withdraw before the enemy's full force arrives.</detailedBriefing>
+The more convoy units that survive, the greater the spoils. Disabling transports instead of outright destruction may increase salvage potential, but that is a secondary concern to stopping the convoy itself. However, do not linger. The enemy will respond quickly, and we will not control the field once the battle ends. Execute the raid with precision, neutralize the targets, and withdraw before the enemy's full force arrives.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Convoy Raid.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Raid.xml
@@ -32,7 +32,9 @@ The more convoy units that survive, the greater the spoils. Disabling transports
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
@@ -44,8 +46,7 @@ The more convoy units that survive, the greater the spoils. Disabling transports
                 <minWeightClass>0</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeArc</syncDeploymentType>
-                <syncedForceName>Convoy</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>
         </entry>
@@ -91,10 +92,7 @@ The more convoy units that survive, the greater the spoils. Disabling transports
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones>
-                    <deploymentZone>2</deploymentZone>
-                    <deploymentZone>4</deploymentZone>
                     <deploymentZone>6</deploymentZone>
-                    <deploymentZone>8</deploymentZone>
                 </deploymentZones>
                 <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Convoy Raid.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Raid.xml
@@ -94,7 +94,7 @@ The more convoy units that survive, the greater the spoils. Disabling transports
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>6</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>0.5</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Convoy Raid.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Raid.xml
@@ -103,7 +103,7 @@ The more convoy units that survive, the greater the spoils. Disabling transports
                 <generationOrder>5</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>
-                <retreatThreshold>50</retreatThreshold>
+                <retreatThreshold>0</retreatThreshold>
                 <subjectToRandomRemoval>false</subjectToRandomRemoval>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>

--- a/MekHQ/data/scenariotemplates/Covert Strike.xml
+++ b/MekHQ/data/scenariotemplates/Covert Strike.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Covert Strike</name>
     <shortBriefing>Eliminate VIP behind enemy lines.</shortBriefing>
-    <detailedBriefing>Your mission is simple but dangerous—eliminate a high-value target deep behind enemy lines. The VIP is heavily guarded by a formidable escort. The objective is singular and absolute: kill the VIP by any means necessary.
+    <detailedBriefing><![CDATA[Your mission is simple but dangerous—eliminate a high-value target deep behind enemy lines. The VIP is heavily guarded by a formidable escort. The objective is singular and absolute: kill the VIP by any means necessary.
 
 The enemy will not allow this to happen easily. Expect heavy resistance, tight security, and potential countermeasures to obscure or protect the target. Do not waste time engaging unnecessary forces—strike fast, neutralize the VIP, and disengage before the enemy can fully react.
 
-Be advised, the enemy will control the field at the end of the engagement. You will not be able to hold ground or claim battlefield salvage. This is an execution, not a siege. Kill the target and get out—nothing else matters.</detailedBriefing>
+Be advised, the enemy will control the field at the end of the engagement. You will not be able to hold ground or claim battlefield salvage. This is an execution, not a siege. Kill the target and get out—nothing else matters.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Covert Strike.xml
+++ b/MekHQ/data/scenariotemplates/Covert Strike.xml
@@ -40,8 +40,6 @@ Be advised, the enemy will control the field at the end of the engagement. You w
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -64,7 +64,9 @@ We will control the field at the end of the battle, giving you full authority to
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
+                <deploymentZones>
+                    <deploymentZone>10</deploymentZone>
+                </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
@@ -77,8 +79,7 @@ We will control the field at the end of the battle, giving you full authority to
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Convoy</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>RAIDER</forceRole>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -112,7 +112,7 @@ We will control the field at the end of the battle, giving you full authority to
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>1</minWeightClass>
                 <objectiveLinkedForces />
-                <retreatThreshold>50</retreatThreshold>
+                <retreatThreshold>0</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -3,11 +3,11 @@
     <name>Critical Convoy Escort</name>
     <stratConScenarioType>CONVOY</stratConScenarioType>
     <shortBriefing>Escort critical convoy or defeat attackers.</shortBriefing>
-    <detailedBriefing>An allied convoy carrying critical supplies is moving through hostile territory, and a large, heavily armed enemy force is preparing to intercept. Your mission is to ensure that at least 50% of the convoy reaches the far edge of the engagement area intact. These supplies are essential to sustaining our war effort, and failure is not an option.
+    <detailedBriefing><![CDATA[An allied convoy carrying critical supplies is moving through hostile territory, and a large, heavily armed enemy force is preparing to intercept. Your mission is to ensure that at least 50% of the convoy reaches the far edge of the engagement area intact. These supplies are essential to sustaining our war effort, and failure is not an option.
 
 The enemy will come in force, but their attack is not unstoppable. If a full escort proves untenable, you have an alternative path to victory. Should at least 50% of the convoy survive while you destroy or route 50% of the attacking enemy force, the mission will be considered a success. Breaking their offensive will allow our convoy to continue forward without further resistance.
 
-We will control the field at the end of the battle, giving you full authority to dictate the engagement on our terms. Use the terrain, stagger your defenses, and counter their assault with precision. Hold the line, protect the convoy, and ensure these supplies reach their destination. Victory here will secure our war effort in this sector.</detailedBriefing>
+We will control the field at the end of the battle, giving you full authority to dictate the engagement on our terms. Use the terrain, stagger your defenses, and counter their assault with precision. Hold the line, protect the convoy, and ensure these supplies reach their destination. Victory here will secure our war effort in this sector.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Decoy Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Engagement.xml
@@ -2,13 +2,13 @@
 <ScenarioTemplate>
     <name>Decoy Engagement</name>
     <shortBriefing>Engage enemy, act as decoy.</shortBriefing>
-    <detailedBriefing>Your mission is to serve as a decoy, drawing the attention of a large enemy force while our allies carry out critical objectives elsewhere in the sector. The enemy must believe you are the primary threat, forcing them to commit their forces fully to your position. Your task is to survive for the designated duration or, if possible, eliminate 75% of the enemy forces to break their will.
+    <detailedBriefing><![CDATA[Your mission is to serve as a decoy, drawing the attention of a large enemy force while our allies carry out critical objectives elsewhere in the sector. The enemy must believe you are the primary threat, forcing them to commit their forces fully to your position. Your task is to survive for the designated duration or, if possible, eliminate 75% of the enemy forces to break their will.
 
 This engagement is about endurance, misdirection, and tactical maneuvering. The enemy will press hard, believing you to be the key target, but you must endure. Use the terrain to your advantage, control the pace of the battle, and engage only when necessary. If you hold them long enough, our allies will complete their objectives uncontested.
 
 Should you succeed in routing 75% of the enemy force, they will lose cohesion, and we will control the battlefield at the end of the engagement. This will allow us full access to any salvageable assets left behind. Victory here will not only ensure the success of our allies but also give us a chance to recover valuable battlefield resources.
 
-Hold the line, weather the storm, and outlast them. If they break, the field is ours.</detailedBriefing>
+Hold the line, weather the storm, and outlast them. If they break, the field is ours.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Decoy Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Engagement.xml
@@ -42,8 +42,6 @@ Hold the line, weather the storm, and outlast them. If they break, the field is 
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Decoy Interception.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Interception.xml
@@ -42,8 +42,6 @@ Stand firm, draw them in, and ensure they never reach their goal. If they break,
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Decoy Interception.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Interception.xml
@@ -2,13 +2,13 @@
 <ScenarioTemplate>
     <name>Decoy Interception</name>
     <shortBriefing>Intercept enemy, act as decoy.</shortBriefing>
-    <detailedBriefing>Your mission is to intercept and engage enemy forces to draw them away from their primary objective. Our intelligence indicates that they are moving to secure a critical target, but by forcing an engagement, you will divert their attention and disrupt their plans. Your task is to hold them in combat for the specified duration or, if the opportunity presents itself, destroy 75% of their forces to rout them completely.
+    <detailedBriefing><![CDATA[Your mission is to intercept and engage enemy forces to draw them away from their primary objective. Our intelligence indicates that they are moving to secure a critical target, but by forcing an engagement, you will divert their attention and disrupt their plans. Your task is to hold them in combat for the specified duration or, if the opportunity presents itself, destroy 75% of their forces to rout them completely.
 
 This battle is about control and endurance. The longer you keep the enemy occupied, the more time our allies will have to complete their objectives elsewhere. Expect a determined enemy response, as they will attempt to break through and reestablish their mission. You must balance aggression with resilience—hold them long enough, or cripple them so severely that they can no longer continue the fight.
 
 Should you succeed in routing 75% of their forces, we will seize control of the battlefield at the end of the engagement. This will allow us to recover any remaining assets and deny the enemy any chance of regrouping. Whether by sheer endurance or decisive firepower, your success here will determine the outcome of operations across the sector.
 
-Stand firm, draw them in, and ensure they never reach their goal. If they break, the field is ours.</detailedBriefing>
+Stand firm, draw them in, and ensure they never reach their goal. If they break, the field is ours.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -2,12 +2,12 @@
 <ScenarioTemplate>
     <name>Deep Raid Defense</name>
     <shortBriefing>Defend grounded DropShip from raid.</shortBriefing>
-    <detailedBriefing>The enemy has launched a deep strike behind our lines, targeting one of our DropShips before it can take off. This is a calculated assault meant to cripple our logistics and deny us critical mobility. Your mission is to defend the DropShip until it can launch or eliminate at least 50% of the attacking force to force their retreat.
+    <detailedBriefing><![CDATA[The enemy has launched a deep strike behind our lines, targeting one of our DropShips before it can take off. This is a calculated assault meant to cripple our logistics and deny us critical mobility. Your mission is to defend the DropShip until it can launch or eliminate at least 50% of the attacking force to force their retreat.
 
 Expect long-range bombardment. The enemy is likely to deploy artillery strikes to weaken our defenses before engaging directly. You must counter their firepower while maintaining a strong perimeter around the DropShip. Close the distance where possible, neutralize their artillery assets, and prevent them from overwhelming our position before liftoff.
 
 We will control the battlefield at the end of the engagement, ensuring access to salvage and preventing any lingering enemy forces from regrouping. Hold the line, protect the DropShip, and make the enemy pay dearly for their incursion.
-    </detailedBriefing>
+    ]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid Defense.xml
@@ -4,9 +4,9 @@
     <shortBriefing>Defend grounded DropShip from raid.</shortBriefing>
     <detailedBriefing>The enemy has launched a deep strike behind our lines, targeting one of our DropShips before it can take off. This is a calculated assault meant to cripple our logistics and deny us critical mobility. Your mission is to defend the DropShip until it can launch or eliminate at least 50% of the attacking force to force their retreat.
 
-        Expect long-range bombardment. The enemy is likely to deploy artillery strikes to weaken our defenses before engaging directly. You must counter their firepower while maintaining a strong perimeter around the DropShip. Close the distance where possible, neutralize their artillery assets, and prevent them from overwhelming our position before liftoff.
+Expect long-range bombardment. The enemy is likely to deploy artillery strikes to weaken our defenses before engaging directly. You must counter their firepower while maintaining a strong perimeter around the DropShip. Close the distance where possible, neutralize their artillery assets, and prevent them from overwhelming our position before liftoff.
 
-        We will control the battlefield at the end of the engagement, ensuring access to salvage and preventing any lingering enemy forces from regrouping. Hold the line, protect the DropShip, and make the enemy pay dearly for their incursion.
+We will control the battlefield at the end of the engagement, ensuring access to salvage and preventing any lingering enemy forces from regrouping. Hold the line, protect the DropShip, and make the enemy pay dearly for their incursion.
     </detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
@@ -28,23 +28,13 @@
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>-3</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>true</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones>
-                    <deploymentZone>1</deploymentZone>
-                    <deploymentZone>2</deploymentZone>
-                    <deploymentZone>3</deploymentZone>
-                    <deploymentZone>4</deploymentZone>
-                    <deploymentZone>5</deploymentZone>
-                    <deploymentZone>6</deploymentZone>
-                    <deploymentZone>7</deploymentZone>
-                    <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                </deploymentZones>
+                <deploymentZones />
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
@@ -57,7 +47,8 @@
                 <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>None</syncDeploymentType>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>OpFor</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>
         </entry>
@@ -82,7 +73,6 @@
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Deep Raid.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid.xml
@@ -42,7 +42,6 @@ This engagement takes place in enemy territory, meaning we will not control the 
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -66,15 +65,13 @@ This engagement takes place in enemy territory, meaning we will not control the 
                 <actualDeploymentZone>-1</actualDeploymentZone>
                 <allowAeroBombs>false</allowAeroBombs>
                 <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>0</arrivalTurn>
+                <arrivalTurn>-3</arrivalTurn>
                 <canReinforceLinked>true</canReinforceLinked>
                 <contributesToBV>false</contributesToBV>
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones>
-                    <deploymentZone>10</deploymentZone>
-                </deploymentZones>
+                <deploymentZones />
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
@@ -87,7 +84,8 @@ This engagement takes place in enemy territory, meaning we will not control the 
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>None</syncDeploymentType>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>
         </entry>

--- a/MekHQ/data/scenariotemplates/Deep Raid.xml
+++ b/MekHQ/data/scenariotemplates/Deep Raid.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Deep Raid</name>
     <shortBriefing>Destroy or cripple DropShip.</shortBriefing>
-    <detailedBriefing>We have identified a vulnerable enemy DropShip deep behind enemy lines. This is a rare opportunity to eliminate a key enemy asset before it can escape. Your mission is to destroy the DropShip before it can lift off.
+    <detailedBriefing><![CDATA[We have identified a vulnerable enemy DropShip deep behind enemy lines. This is a rare opportunity to eliminate a key enemy asset before it can escape. Your mission is to destroy the DropShip before it can lift off.
 
 Expect rapid enemy response forces as the enemy scrambles to defend their asset. They will attempt to delay and stall you long enough for the DropShip to achieve liftoff. Speed is critical—push through their defenses, disable or destroy the DropShip, and exfiltrate before enemy reinforcements overwhelm your position.
 
-This engagement takes place in enemy territory, meaning we will not control the field at the end. There will be no opportunity for salvage or recovery, so focus solely on mission success. Strike fast, eliminate the target, and get out before the enemy locks down the area.</detailedBriefing>
+This engagement takes place in enemy territory, meaning we will not control the field at the end. There will be no opportunity for salvage or recovery, so focus solely on mission success. Strike fast, eliminate the target, and get out before the enemy locks down the area.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Diversion Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Diversion Engagement.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Diversion Engagement</name>
     <shortBriefing>Bypass or destroy diversionary force.</shortBriefing>
-    <detailedBriefing>The enemy has deployed a delaying force to stall our advance toward a critical objective. Their mission is to slow us down, bleed our forces, and buy time for their reinforcements to fortify their position. Your task is to push through their blockade and continue the advance.
+    <detailedBriefing><![CDATA[The enemy has deployed a delaying force to stall our advance toward a critical objective. Their mission is to slow us down, bleed our forces, and buy time for their reinforcements to fortify their position. Your task is to push through their blockade and continue the advance.
 
 Victory can be achieved in one of two ways. Ensure at least 50% of your forces reach the far edge of the engagement zone, bypassing the enemy’s attempt to hold you in place. Alternatively, if they commit too heavily to blocking your path, destroy at least 75% of their forces, breaking their ability to resist and forcing them to withdraw.
 
-Be advised: the enemy will control the field at the end of the engagement. There will be no time for salvage or securing the area. Speed and decisive action are key—either break through or break them entirely, but do not allow them to stall our momentum.</detailedBriefing>
+Be advised: the enemy will control the field at the end of the engagement. There will be no time for salvage or securing the area. Speed and decisive action are key—either break through or break them entirely, but do not allow them to stall our momentum.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/DropShip Raid.xml
+++ b/MekHQ/data/scenariotemplates/DropShip Raid.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>DropShip Raid</name>
     <shortBriefing>Destroy or cripple DropShip.</shortBriefing>
-    <detailedBriefing>An enemy DropShip has become stranded in contested territory, presenting us with an opportunity to eliminate a critical asset before they can recover or evacuate. Your mission is to destroy or cripple the DropShip while also eliminating at least 50% of its escort forces. We cannot allow the enemy to extract personnel, equipment, or intelligence—this DropShip must not leave the battlefield intact.
+    <detailedBriefing><![CDATA[An enemy DropShip has become stranded in contested territory, presenting us with an opportunity to eliminate a critical asset before they can recover or evacuate. Your mission is to destroy or cripple the DropShip while also eliminating at least 50% of its escort forces. We cannot allow the enemy to extract personnel, equipment, or intelligence—this DropShip must not leave the battlefield intact.
 
 Expect organized resistance. The enemy will fight to defend their stranded vessel, and their escort forces will attempt to buy time for emergency repairs or reinforcement. You must strike decisively, breaking their formation and overwhelming their defenses before they can rally.
 
-Victory in this engagement will determine control of the battlefield. If we succeed, we will hold the field at the end of the battle, giving us access to any remaining salvage and denying the enemy any chance of recovery. This is a rare chance to cripple enemy operations—strike hard, break them completely, and ensure they leave nothing behind but wreckage.</detailedBriefing>
+Victory in this engagement will determine control of the battlefield. If we succeed, we will hold the field at the end of the battle, giving us access to any remaining salvage and denying the enemy any chance of recovery. This is a rare chance to cripple enemy operations—strike hard, break them completely, and ensure they leave nothing behind but wreckage.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/DropShip Raid.xml
+++ b/MekHQ/data/scenariotemplates/DropShip Raid.xml
@@ -42,7 +42,6 @@ Victory in this engagement will determine control of the battlefield. If we succ
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
@@ -13,7 +13,7 @@ We will control the battlefield at the end of this engagement, ensuring that any
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>75</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
@@ -3,11 +3,11 @@
     <name>Emergency Convoy Defense</name>
     <stratConScenarioType>SPECIAL_RESUPPLY</stratConScenarioType>
     <shortBriefing>Escort DropShip, defeat enemy forces.</shortBriefing>
-    <detailedBriefing>Your aircraft convoy is being intercepted mid-flight by enemy forces executing a pincer maneuver. Their goal is to cut off all possible escape routes and eliminate or capture the supplies your convoy carries. If the convoy is lost, it will be a significant blow to your operational readiness. Your mission is to ensure the convoy reaches the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 50% of their forces.
+    <detailedBriefing><![CDATA[Your aircraft convoy is being intercepted mid-flight by enemy forces executing a pincer maneuver. Their goal is to cut off all possible escape routes and eliminate or capture the supplies your convoy carries. If the convoy is lost, it will be a significant blow to your operational readiness. Your mission is to ensure the convoy reaches the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 50% of their forces.
 
 The enemy has chosen a pincer formation to box you in, which means they are expecting to trap and overwhelm your forces. Break their formation before they can fully close the noose. Use superior positioning, speed, and tactical maneuvers to punch through their weakest link and deny them the ability to completely surround the convoy. If necessary, sacrifice the convoy to ensure the enemy force is broken—routing them is the priority, as failure to do so will allow them to wreak havoc on our logistics in future operations.
 
-We will control the battlefield at the end of this engagement, ensuring that any salvageable assets fall into our hands. This battle determines more than just one convoy’s fate—crush the enemy’s ability to operate in our skies and secure our logistics for the future.</detailedBriefing>
+We will control the battlefield at the end of this engagement, ensuring that any salvageable assets fall into our hands. This battle determines more than just one convoy’s fate—crush the enemy’s ability to operate in our skies and secure our logistics for the future.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
@@ -47,7 +47,7 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
-                <retreatThreshold>0</retreatThreshold>
+                <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
@@ -3,11 +3,11 @@
     <name>Emergency Convoy Defense</name>
     <stratConScenarioType>SPECIAL_RESUPPLY</stratConScenarioType>
     <shortBriefing>Prevent your resupply falling into the hands of the enemy.</shortBriefing>
-    <detailedBriefing>Your convoy has been trapped by an enemy force specialized in hunting down fast-moving targets. They are well-equipped for this type of engagement, and their goal is to intercept and capture your supplies. While securing the convoy is important, your primary objective is to eliminate at least 50% of the enemy force to ensure they cannot continue their raids. If they are not routed here, they will be free to attack other convoys, posing a long-term threat to our supply lines.
+    <detailedBriefing><![CDATA[Your convoy has been trapped by an enemy force specialized in hunting down fast-moving targets. They are well-equipped for this type of engagement, and their goal is to intercept and capture your supplies. While securing the convoy is important, your primary objective is to eliminate at least 50% of the enemy force to ensure they cannot continue their raids. If they are not routed here, they will be free to attack other convoys, posing a long-term threat to our supply lines.
 
 The enemy is built for speed and pursuit, meaning direct engagements may not always be favorable. Use ambush tactics, force them into unfavorable terrain, and disrupt their ability to maneuver. They rely on overwhelming pursuit capabilities—deny them the chance to use it effectively. If the convoy can be safely extracted, do so, but not at the expense of allowing the enemy to regroup for future strikes.
 
-We will control the battlefield at the conclusion of this engagement, ensuring that any remaining salvage remains in our possession. Turn the hunters into the hunted, cripple their forces, and make certain they never threaten our supply lines again.</detailedBriefing>
+We will control the battlefield at the conclusion of this engagement, ensuring that any remaining salvage remains in our possession. Turn the hunters into the hunted, cripple their forces, and make certain they never threaten our supply lines again.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
@@ -13,7 +13,7 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
@@ -13,7 +13,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
@@ -3,11 +3,11 @@
     <name>Emergency Convoy Defense</name>
     <stratConScenarioType>SPECIAL_RESUPPLY</stratConScenarioType>
     <shortBriefing>Prevent your resupply falling into the hands of the enemy.</shortBriefing>
-    <detailedBriefing>Your ground convoy is being cornered by aggressive enemy elements, intent on cutting off your supplies and crippling our logistics. The convoy is carrying essential resources for your operations, and its loss would be a severe blow. Your primary objective is to ensure the convoy reaches the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 50% of their forces.
+    <detailedBriefing><![CDATA[Your ground convoy is being cornered by aggressive enemy elements, intent on cutting off your supplies and crippling our logistics. The convoy is carrying essential resources for your operations, and its loss would be a severe blow. Your primary objective is to ensure the convoy reaches the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 50% of their forces.
 
 The enemy is executing a relentless pursuit, attempting to isolate and destroy the convoy before it can escape. If they are not routed here, they will continue striking at our logistics, inflicting immeasurable damage over time. Prioritize extracting the convoy, but if necessary, sacrificing the supplies is acceptable if it means crushing the enemy force beyond recovery.
 
-We will control the battlefield at the end of the engagement, ensuring that any remaining salvage or assets fall into our hands. This battle is about more than just one convoy—it is about securing the future of our supply lines. Break through, break them, and ensure they never threaten our logistics again.</detailedBriefing>
+We will control the battlefield at the end of the engagement, ensuring that any remaining salvage or assets fall into our hands. This battle is about more than just one convoy—it is about securing the future of our supply lines. Break through, break them, and ensure they never threaten our logistics again.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
@@ -47,7 +47,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
-                <retreatThreshold>0</retreatThreshold>
+                <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -3,11 +3,11 @@
     <name>Emergency Convoy Defense</name>
     <stratConScenarioType>SPECIAL_RESUPPLY</stratConScenarioType>
     <shortBriefing>Prevent your resupply falling into the hands of the enemy.</shortBriefing>
-    <detailedBriefing>An enemy force has breached our lines and is in pursuit of an allied convoy, carrying supplies critical to your operations. If these supplies are lost, so is a vital piece of our logistical network. Your mission is to ensure the successful extraction of the convoy by escorting it to the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 50% of their forces.
+    <detailedBriefing><![CDATA[An enemy force has breached our lines and is in pursuit of an allied convoy, carrying supplies critical to your operations. If these supplies are lost, so is a vital piece of our logistical network. Your mission is to ensure the successful extraction of the convoy by escorting it to the opposite edge of the engagement zone while simultaneously routing the enemy by destroying at least 50% of their forces.
 
 This enemy assault is a direct attempt to cripple our supply chain. If they are not stopped here, they will continue to strike at our convoys, causing immeasurable damage to our war effort. The convoy is a priority, but if ensuring the destruction of the enemy requires sacrificing the supplies, do not hesitate. Breaking their offensive strength is the ultimate objective.
 
-We will control the battlefield at the end of this engagement, allowing us to recover whatever remains and prevent further incursions. Ensure the convoy escapes if possible, but above all, crush the enemy’s ability to wage war in our territory. This ends here.</detailedBriefing>
+We will control the battlefield at the end of this engagement, allowing us to recover whatever remains and prevent further incursions. Ensure the convoy escapes if possible, but above all, crush the enemy’s ability to wage war in our territory. This ends here.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -13,7 +13,7 @@ We will control the battlefield at the end of this engagement, allowing us to re
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -113,7 +113,7 @@ We will control the battlefield at the end of this engagement, allowing us to re
                     <objectiveLinkedForce>OpFor</objectiveLinkedForce>
                 </objectiveLinkedForces>
                 <syncDeploymentType>SameEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncedForceName>Resupply Convoy</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>RAIDER</forceRole>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -47,7 +47,7 @@ We will control the battlefield at the end of this engagement, allowing us to re
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
-                <retreatThreshold>0</retreatThreshold>
+                <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
@@ -146,7 +146,7 @@ We will control the battlefield at the end of this engagement, allowing us to re
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
-                <retreatThreshold>0</retreatThreshold>
+                <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/data/scenariotemplates/Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Engagement.xml
@@ -40,8 +40,6 @@ Strike hard, eliminate the opposition, and take control. Victory is absolute, or
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Engagement.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Engagement</name>
     <shortBriefing>Engage and destroy enemy at the front.</shortBriefing>
-    <detailedBriefing>Your orders are simple—engage and destroy at least 50% of enemy forces. This is not a hit-and-run operation or a delaying action. You are to commit fully to the engagement and break their strength through superior firepower and tactical positioning.
+    <detailedBriefing><![CDATA[Your orders are simple—engage and destroy at least 50% of enemy forces. This is not a hit-and-run operation or a delaying action. You are to commit fully to the engagement and break their strength through superior firepower and tactical positioning.
 
 This battle will determine control of the battlefield. The victor will hold the field at the end of the engagement, securing any salvage and denying the enemy any chance of recovery. Every enemy unit destroyed weakens their ability to wage war—make sure they do not leave this battlefield intact.
 
-Strike hard, eliminate the opposition, and take control. Victory is absolute, or it is meaningless.</detailedBriefing>
+Strike hard, eliminate the opposition, and take control. Victory is absolute, or it is meaningless.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Frontier Assassination.xml
+++ b/MekHQ/data/scenariotemplates/Frontier Assassination.xml
@@ -40,8 +40,6 @@ The victor will control the battlefield at the end of the engagement, securing a
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Frontier Assassination.xml
+++ b/MekHQ/data/scenariotemplates/Frontier Assassination.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Frontier Assassination</name>
     <shortBriefing>Eliminate VIP, minimize own losses.</shortBriefing>
-    <detailedBriefing>An enemy VIP has been located in an isolated position, presenting a rare opportunity to eliminate a key target. Their removal will deal a significant blow to enemy operations, but they are not unprotected. Your mission is to kill the VIP and destroy at least 50% of their escort force.
+    <detailedBriefing><![CDATA[An enemy VIP has been located in an isolated position, presenting a rare opportunity to eliminate a key target. Their removal will deal a significant blow to enemy operations, but they are not unprotected. Your mission is to kill the VIP and destroy at least 50% of their escort force.
 
 The enemy may attempt an emergency extraction or stall for reinforcements. Do not let them escape. Strike hard, eliminate the target, and ensure their escort is crippled beyond recovery. If the enemy attempts to dig in, break their defensive perimeter and neutralize them with overwhelming force.
 
-The victor will control the battlefield at the end of the engagement, securing any salvage and eliminating remaining resistance. This is a chance to change the course of the conflict—do not let it slip away.</detailedBriefing>
+The victor will control the battlefield at the end of the engagement, securing any salvage and eliminating remaining resistance. This is a chance to change the course of the conflict—do not let it slip away.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Frontline Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Breakthrough.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Frontline Breakthrough</name>
     <shortBriefing>Break through enemy battlelines.</shortBriefing>
-    <detailedBriefing>You are tasked with penetrating the enemy’s main battle line and advancing beyond their position. The enemy has committed significant forces to this sector, making this a high-risk operation. Your primary objective is to reach the far edge of the engagement zone with at least 50% of your forces intact. If direct passage is impossible, an alternative path to victory is available—routing the enemy by destroying at least 50% of their forces.
+    <detailedBriefing><![CDATA[You are tasked with penetrating the enemy’s main battle line and advancing beyond their position. The enemy has committed significant forces to this sector, making this a high-risk operation. Your primary objective is to reach the far edge of the engagement zone with at least 50% of your forces intact. If direct passage is impossible, an alternative path to victory is available—routing the enemy by destroying at least 50% of their forces.
 
 Expect heavy resistance, as the enemy will not yield ground easily. Their forces are well-positioned to block your advance, and delaying tactics may be used to slow you down. Speed, decisive strikes, and tactical maneuvering will be key to achieving your objective. If you can break their formation or force them into disarray, the path forward will open.
 
-The enemy will control the battlefield once the engagement concludes, preventing any opportunity for salvage or recovery. This is a mission of mobility and force—break through, or break them. There is no room for hesitation.</detailedBriefing>
+The enemy will control the battlefield once the engagement concludes, preventing any opportunity for salvage or recovery. This is a mission of mobility and force—break through, or break them. There is no room for hesitation.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Frontline Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Breakthrough.xml
@@ -10,7 +10,7 @@ The enemy will control the battlefield once the engagement concludes, preventing
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/Frontline Disruption.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Disruption.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Frontline Disruption</name>
     <shortBriefing>Disrupt and delay frontline force.</shortBriefing>
-    <detailedBriefing>A large enemy force is advancing toward a critical objective, and it is your responsibility to stop them. Your mission is to disrupt their advance by preventing at least 50% of their forces from reaching the opposite edge of the engagement zone. If they succeed in breaking through in large numbers, the consequences for our campaign will be severe.
+    <detailedBriefing><![CDATA[A large enemy force is advancing toward a critical objective, and it is your responsibility to stop them. Your mission is to disrupt their advance by preventing at least 50% of their forces from reaching the opposite edge of the engagement zone. If they succeed in breaking through in large numbers, the consequences for our campaign will be severe.
 
 Expect a determined push, as the enemy will prioritize speed and aggression to force their way through. They may attempt to overwhelm your defenses with sheer numbers or concentrated strikes against weak points. You must hold firm, break their momentum, and deny them passage. Use the terrain, stagger your defenses, and eliminate high-value targets to throw their advance into disarray.
 
-We will control the battlefield at the conclusion of this engagement, ensuring that any remaining enemy assets are left for us to claim or destroy. This is our ground—stand fast, hold the line, and make certain they go no further.</detailedBriefing>
+We will control the battlefield at the conclusion of this engagement, ensuring that any remaining enemy assets are left for us to claim or destroy. This is our ground—stand fast, hold the line, and make certain they go no further.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Frontline Disruption.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Disruption.xml
@@ -33,9 +33,7 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones>
-                    <deploymentZone>6</deploymentZone>
-                </deploymentZones>
+                <deploymentZones />
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
@@ -48,7 +46,8 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>None</syncDeploymentType>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>OpFor</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>
         </entry>
@@ -64,7 +63,9 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
+                <deploymentZones>
+                    <deploymentZone>6</deploymentZone>
+                </deploymentZones>
                 <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
@@ -77,38 +78,7 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>SameEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
-                <useArtillery>false</useArtillery>
-            </value>
-        </entry>
-        <entry>
-            <key>Reinforcements</key>
-            <value>
-                <actualDeploymentZone>-1</actualDeploymentZone>
-                <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>-3</arrivalTurn>
-                <canReinforceLinked>false</canReinforceLinked>
-                <contributesToBV>false</contributesToBV>
-                <contributesToMapSize>true</contributesToMapSize>
-                <contributesToUnitCount>false</contributesToUnitCount>
-                <deployOffboard>false</deployOffboard>
-                <deploymentZones />
-                <destinationZone>5</destinationZone>
-                <fixedUnitCount>0</fixedUnitCount>
-                <forceAlignment>0</forceAlignment>
-                <forceMultiplier>1.0</forceMultiplier>
-                <forceName>Reinforcements</forceName>
-                <generationMethod>0</generationMethod>
-                <generationOrder>1</generationOrder>
-                <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
-                <objectiveLinkedForces />
-                <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>
         </entry>

--- a/MekHQ/data/scenariotemplates/Frontline Disruption.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Disruption.xml
@@ -12,7 +12,7 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>70</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/Frontline Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Engagement.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Frontline Engagement</name>
     <shortBriefing>Engage and destroy enemy at the front.</shortBriefing>
-    <detailedBriefing>The enemy is fully committed to battle along the frontline, engaging our forces in a direct confrontation. Your mission is to break their offensive by defeating at least 50% of their forces. This engagement is a decisive clash—victory here will shift the momentum of the war in our favor.
+    <detailedBriefing><![CDATA[The enemy is fully committed to battle along the frontline, engaging our forces in a direct confrontation. Your mission is to break their offensive by defeating at least 50% of their forces. This engagement is a decisive clash—victory here will shift the momentum of the war in our favor.
 
 Expect a determined enemy response. They will not withdraw easily and may attempt to reinforce their position as losses mount. Strike hard, exploit weaknesses, and maintain battlefield control. This is not a delaying action—this is a battle for dominance.
 
-The victor will control the battlefield at the end of the engagement, securing salvage and eliminating any remaining resistance. Ensure that when the dust settles, it is our forces standing over the wreckage. Crush them and claim the field.</detailedBriefing>
+The victor will control the battlefield at the end of the engagement, securing salvage and eliminating any remaining resistance. Ensure that when the dust settles, it is our forces standing over the wreckage. Crush them and claim the field.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Frontline Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Engagement.xml
@@ -40,8 +40,6 @@ The victor will control the battlefield at the end of the engagement, securing s
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Heavy Recon Evasion</name>
     <shortBriefing>Evade patrols while scanning enemy heavies.</shortBriefing>
-    <detailedBriefing>You are to advance toward an overwhelming enemy position and gather intelligence on their strength. This is a high-risk reconnaissance mission, and direct engagement is not an option. Stealth, speed, and deception will be your greatest assets.
+    <detailedBriefing><![CDATA[You are to advance toward an overwhelming enemy position and gather intelligence on their strength. This is a high-risk reconnaissance mission, and direct engagement is not an option. Stealth, speed, and deception will be your greatest assets.
 
 If you are compromised, expect a swift and overwhelming response. Avoid unnecessary confrontations and prioritize evasion over combat. At least one of your units must survive.
 
-The enemy will control the field at the end of the engagement, meaning there will be no reinforcements or recovery options. Get in, gather intel, and get out—undetected and alive.</detailedBriefing>
+The enemy will control the field at the end of the engagement, meaning there will be no reinforcements or recovery options. Get in, gather intel, and get out—undetected and alive.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -42,8 +42,6 @@ The enemy will control the field at the end of the engagement, meaning there wil
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Hostile Facility.xml
+++ b/MekHQ/data/scenariotemplates/Hostile Facility.xml
@@ -76,7 +76,6 @@ The victor will control the battlefield at the end of the engagement. If the fac
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Hostile Facility.xml
+++ b/MekHQ/data/scenariotemplates/Hostile Facility.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Facility Assault</name>
     <shortBriefing>Assault and weaken enemy-held facility.</shortBriefing>
-    <detailedBriefing>An enemy-controlled facility has been designated for destruction. This installation is too valuable to remain in enemy hands, and its defenders must be eliminated to ensure it is no longer operational. Your mission is to destroy at least 75% of the defending forces. This is not an occupation—this is eradication.
+    <detailedBriefing><![CDATA[An enemy-controlled facility has been designated for destruction. This installation is too valuable to remain in enemy hands, and its defenders must be eliminated to ensure it is no longer operational. Your mission is to destroy at least 75% of the defending forces. This is not an occupation—this is eradication.
 
 The priority is destruction, not capture. Do not concern yourself with securing the facility unless it becomes strategically viable after the defenders are wiped out. The enemy will fight to protect this installation, but their defenses will crumble under sustained pressure. Crush their forces, level their defenses, and ensure that when this battle is over, the facility is either in our hands or of no use to anyone.
 
-The victor will control the battlefield at the end of the engagement. If the facility remains salvageable after the assault, we will claim it. If not, the enemy will be left with nothing but ruins. Execute with overwhelming force and leave no doubt who owns this battlefield.</detailedBriefing>
+The victor will control the battlefield at the end of the engagement. If the facility remains salvageable after the assault, we will claim it. If not, the enemy will be left with nothing but ruins. Execute with overwhelming force and leave no doubt who owns this battlefield.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>true</isHostileFacility>
     <mapParameters>

--- a/MekHQ/data/scenariotemplates/Intercept Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Intercept Engagement.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Intercept Engagement</name>
     <shortBriefing>Break through or destroy intercepting force.</shortBriefing>
-    <detailedBriefing>One of your forces has been intercepted by a large enemy contingent, cutting off their path to safety. The enemy intends to encircle and destroy your units before they can regroup. Your mission is to break through their lines and reach safety or destroy at least 75% of their forces to render them combat ineffective.
+    <detailedBriefing><![CDATA[One of your forces has been intercepted by a large enemy contingent, cutting off their path to safety. The enemy intends to encircle and destroy your units before they can regroup. Your mission is to break through their lines and reach safety or destroy at least 75% of their forces to render them combat ineffective.
 
 The enemy holds the advantage in numbers and positioning, but they are not unbeatable. A direct breakthrough will require speed, coordination, and decisive strikes against their weakest points. If a clean escape is not possible, you must shift to a battle of attrition—eliminating 75% of their forces will ensure they can no longer threaten your retreat.
 
-The enemy will control the battlefield at the end of the engagement, meaning no recovery of fallen assets will be possible. Time is against you—break out before they close the trap, or break them so thoroughly that they can no longer fight.</detailedBriefing>
+The enemy will control the battlefield at the end of the engagement, meaning no recovery of fallen assets will be possible. Time is against you—break out before they close the trap, or break them so thoroughly that they can no longer fight.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Intercept the Escapees.xml
+++ b/MekHQ/data/scenariotemplates/Intercept the Escapees.xml
@@ -3,13 +3,13 @@
     <name>Intercept the Escapees</name>
     <stratConScenarioType>SPECIAL_JAIL_BREAK</stratConScenarioType>
     <shortBriefing>Prevent the escapees from linking up with enemy forces.</shortBriefing>
-    <detailedBriefing>Allied command has located a group of escaped prisoners, and enemy forces are moving to recover them. These individuals possess critical intelligence and cannot be allowed to fall back into enemy hands. Your mission is to eliminate the prisoners or destroy at least 50% of the enemy recovery team to ensure their operation fails.
+    <detailedBriefing><![CDATA[Allied command has located a group of escaped prisoners, and enemy forces are moving to recover them. These individuals possess critical intelligence and cannot be allowed to fall back into enemy hands. Your mission is to eliminate the prisoners or destroy at least 50% of the enemy recovery team to ensure their operation fails.
 
 The enemy will likely deploy fast-moving extraction units or specialized recovery teams to secure the prisoners before we can intervene. Expect them to use speed and misdirection, avoiding direct combat whenever possible. Intercept their efforts, neutralize the prisoners before they can be extracted, and cripple the recovery force to prevent future attempts.
 
 Failure to prevent the enemy from rescuing the prisoners will grant them valuable intelligence, jeopardizing operations in this sector (the loss of 1 CVP, StratCon only). That is not an option. The victor will control the battlefield at the end of the engagement, giving us the opportunity to secure the area and eliminate any remaining threats.
 
-Execute with precision. The enemy must leave empty-handed.</detailedBriefing>
+Execute with precision. The enemy must leave empty-handed.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Interception Defense.xml
+++ b/MekHQ/data/scenariotemplates/Interception Defense.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Interception Defense</name>
     <shortBriefing>Stop enemy from reaching the edge.</shortBriefing>
-    <detailedBriefing>Enemy forces are on the move, heading toward an unknown objective, and we cannot allow them to reach their destination. Their intent remains unclear, but their movement suggests a high-value mission. Your objective is to intercept and engage the enemy, destroying at least 50% of their forces before they can escape via the opposite edge of the engagement zone.
+    <detailedBriefing><![CDATA[Enemy forces are on the move, heading toward an unknown objective, and we cannot allow them to reach their destination. Their intent remains unclear, but their movement suggests a high-value mission. Your objective is to intercept and engage the enemy, destroying at least 50% of their forces before they can escape via the opposite edge of the engagement zone.
 
 Expect the enemy to favor speed and mobility, avoiding prolonged engagements as they push toward their objective. Deny them their escape route, break their formation, and ensure they do not reach their goal intact. They may attempt to punch through with concentrated force or use diversionary tactics to slip past your defenses—anticipate their maneuvers and shut them down.
 
-We will control the battlefield at the end of the engagement, securing any remaining assets and preventing any further movement from enemy reinforcements. This mission is about disruption and dominance—cripple their forces, seize the field, and ensure that whatever they were planning never comes to pass.</detailedBriefing>
+We will control the battlefield at the end of the engagement, securing any remaining assets and preventing any further movement from enemy reinforcements. This mission is about disruption and dominance—cripple their forces, seize the field, and ensure that whatever they were planning never comes to pass.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Interception Defense.xml
+++ b/MekHQ/data/scenariotemplates/Interception Defense.xml
@@ -83,36 +83,6 @@ We will control the battlefield at the end of the engagement, securing any remai
                 <useArtillery>false</useArtillery>
             </value>
         </entry>
-        <entry>
-            <key>Reinforcements</key>
-            <value>
-                <actualDeploymentZone>-1</actualDeploymentZone>
-                <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>-3</arrivalTurn>
-                <canReinforceLinked>true</canReinforceLinked>
-                <contributesToBV>false</contributesToBV>
-                <contributesToMapSize>true</contributesToMapSize>
-                <contributesToUnitCount>false</contributesToUnitCount>
-                <deployOffboard>false</deployOffboard>
-                <deploymentZones />
-                <destinationZone>5</destinationZone>
-                <fixedUnitCount>0</fixedUnitCount>
-                <forceAlignment>0</forceAlignment>
-                <forceMultiplier>1.0</forceMultiplier>
-                <forceName>Reinforcements</forceName>
-                <generationMethod>0</generationMethod>
-                <generationOrder>1</generationOrder>
-                <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
-                <objectiveLinkedForces />
-                <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>OpFor</syncedForceName>
-                <useArtillery>false</useArtillery>
-            </value>
-        </entry>
     </scenarioForces>
     <scenarioObjectives>
         <scenarioObjective>

--- a/MekHQ/data/scenariotemplates/Interception Defense.xml
+++ b/MekHQ/data/scenariotemplates/Interception Defense.xml
@@ -12,7 +12,7 @@ We will control the battlefield at the end of the engagement, securing any remai
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Irregular Force Assault</name>
     <shortBriefing>Engage infantry supported by frontline forces.</shortBriefing>
-    <detailedBriefing>Hostile infantry and local insurgents are being reinforced by frontline enemy units, creating a growing threat in this sector. If left unchecked, their combined strength will destabilize our operations and undermine our control of the region. Your mission is to engage and destroy at least 50% of the combined enemy force, neutralizing their ability to continue resistance.
+    <detailedBriefing><![CDATA[Hostile infantry and local insurgents are being reinforced by frontline enemy units, creating a growing threat in this sector. If left unchecked, their combined strength will destabilize our operations and undermine our control of the region. Your mission is to engage and destroy at least 50% of the combined enemy force, neutralizing their ability to continue resistance.
 
 Expect a mix of tactics—the insurgents will use terrain, ambushes, and guerrilla warfare, while the frontline units will provide structured firepower and coordination. Do not underestimate either force. Eliminate them with precision, break their ability to fight, and ensure this sector is pacified.
 
-The victor will control the battlefield at the end of the engagement, securing any remaining assets and preventing further insurgent activity. This is a mission of suppression and dominance—strike hard, eliminate resistance, and leave no doubt who commands this region.</detailedBriefing>
+The victor will control the battlefield at the end of the engagement, securing any remaining assets and preventing further insurgent activity. This is a mission of suppression and dominance—strike hard, eliminate resistance, and leave no doubt who commands this region.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Assault.xml
@@ -46,7 +46,6 @@ The victor will control the battlefield at the end of the engagement, securing a
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Irregular Force Suppression.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Suppression.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Irregular Force Suppression</name>
     <shortBriefing>Engage and defeat irregular-supported force.</shortBriefing>
-    <detailedBriefing>Local insurgent forces are receiving direct military support in this region, strengthening their ability to disrupt our operations. If they are not dealt with decisively, they will continue to erode our control and pose a long-term threat. Your mission is to engage and destroy at least 50% of the combined enemy force, cutting off their ability to operate effectively.
+    <detailedBriefing><![CDATA[Local insurgent forces are receiving direct military support in this region, strengthening their ability to disrupt our operations. If they are not dealt with decisively, they will continue to erode our control and pose a long-term threat. Your mission is to engage and destroy at least 50% of the combined enemy force, cutting off their ability to operate effectively.
 
 Expect a blend of unconventional tactics and structured military resistance. The insurgents will use ambushes, terrain familiarity, and hit-and-run attacks, while their military allies will bring firepower, coordination, and heavier assets into the fight. Dismantle their cohesion, eliminate key targets, and disrupt their ability to function as a fighting force.
 
-The victor will control the battlefield at the end of the engagement, securing any remaining assets and ensuring this region remains under our command. This mission is about eradication—strike hard, leave no room for recovery, and establish total dominance.</detailedBriefing>
+The victor will control the battlefield at the end of the engagement, securing any remaining assets and ensuring this region remains under our command. This mission is about eradication—strike hard, leave no room for recovery, and establish total dominance.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Irregular Force Suppression.xml
+++ b/MekHQ/data/scenariotemplates/Irregular Force Suppression.xml
@@ -46,7 +46,6 @@ The victor will control the battlefield at the end of the engagement, securing a
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -2,12 +2,11 @@
 <ScenarioTemplate>
     <name>Isolated DropShip Defense</name>
     <shortBriefing>Defend isolated DropShip from interception.</shortBriefing>
-    <detailedBriefing>An allied DropShip has been isolated behind enemy lines, and hostile forces are closing in fast. Your mission is to defend the DropShip until it can lift off or, if necessary, destroy at least 50% of the enemy forces to break their assault. If the DropShip fails to escape and the enemy remains intact, our strategic situation will be severely compromised.
+    <detailedBriefing><![CDATA[An allied DropShip has been isolated behind enemy lines, and hostile forces are closing in fast. Your mission is to defend the DropShip until it can lift off or, if necessary, destroy at least 50% of the enemy forces to break their assault. If the DropShip fails to escape and the enemy remains intact, our strategic situation will be severely compromised.
 
-        Expect a relentless assault from multiple directions, with enemy units prioritizing disabling the DropShip before it can launch. They may attempt to immobilize it, breach its hull, or delay its departure long enough for reinforcements to arrive. You must hold the line, intercept high-threat targets, and keep the DropShip secure until it achieves liftoff. If the situation demands it, eliminating half of the enemy force will force them to retreat, buying the DropShip a chance to escape.
+Expect a relentless assault from multiple directions, with enemy units prioritizing disabling the DropShip before it can launch. They may attempt to immobilize it, breach its hull, or delay its departure long enough for reinforcements to arrive. You must hold the line, intercept high-threat targets, and keep the DropShip secure until it achieves liftoff. If the situation demands it, eliminating half of the enemy force will force them to retreat, buying the DropShip a chance to escape.
 
-        The enemy will control the field at the end of the engagement, meaning no salvage or recovery will be possible. This is a battle of survival—ensure the DropShip gets out or cripple the enemy so thoroughly that they can no longer threaten it.
-    </detailedBriefing>
+The enemy will control the field at the end of the engagement, meaning no salvage or recovery will be possible. This is a battle of survival—ensure the DropShip gets out or cripple the enemy so thoroughly that they can no longer threaten it.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
+++ b/MekHQ/data/scenariotemplates/Isolated DropShip Defense.xml
@@ -43,7 +43,6 @@
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -73,17 +72,7 @@
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones>
-                    <deploymentZone>1</deploymentZone>
-                    <deploymentZone>2</deploymentZone>
-                    <deploymentZone>3</deploymentZone>
-                    <deploymentZone>4</deploymentZone>
-                    <deploymentZone>5</deploymentZone>
-                    <deploymentZone>6</deploymentZone>
-                    <deploymentZone>7</deploymentZone>
-                    <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                </deploymentZones>
+                <deploymentZones />
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
@@ -96,7 +85,8 @@
                 <objectiveLinkedForces/>
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>None</syncDeploymentType>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>ARTILLERY</forceRole>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
@@ -40,8 +40,6 @@ The victor will control the battlefield at the end of the engagement, securing d
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -53,7 +51,7 @@ The victor will control the battlefield at the end of the engagement, securing d
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere Air Intercept.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Low-Atmosphere Air Intercept</name>
     <shortBriefing>Intercept and destroy hostile air forces.</shortBriefing>
-    <detailedBriefing>A hostile aircraft force is inbound, and we have an opportunity to intercept and cripple their strength before they can achieve their objective. Your mission is to engage and destroy at least 50% of the enemy force, ensuring their airpower is severely diminished.
+    <detailedBriefing><![CDATA[A hostile aircraft force is inbound, and we have an opportunity to intercept and cripple their strength before they can achieve their objective. Your mission is to engage and destroy at least 50% of the enemy force, ensuring their airpower is severely diminished.
 
 Expect high-speed engagements, aggressive maneuvers, and coordinated enemy tactics. Control the airspace, dictate the terms of engagement, and eliminate their ability to regroup. Do not allow them to disengage intact—press the attack and ensure their losses are irreversible.
 
-The victor will control the battlefield at the end of the engagement, securing dominance over the skies and denying the enemy future operational capabilities in this region. Strike fast, strike hard, and establish air superiority.</detailedBriefing>
+The victor will control the battlefield at the end of the engagement, securing dominance over the skies and denying the enemy future operational capabilities in this region. Strike fast, strike hard, and establish air superiority.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Assault.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Assault.xml
@@ -31,12 +31,7 @@ We will control the field at the end of the engagement, ensuring that any wrecka
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones>
-                    <deploymentZone>2</deploymentZone>
-                    <deploymentZone>4</deploymentZone>
-                    <deploymentZone>6</deploymentZone>
-                    <deploymentZone>8</deploymentZone>
-                </deploymentZones>
+                <deploymentZones />
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
@@ -49,7 +44,8 @@ We will control the field at the end of the engagement, ensuring that any wrecka
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>5</startingAltitude>
-                <syncDeploymentType>None</syncDeploymentType>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>DropShip</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>
         </entry>
@@ -65,8 +61,10 @@ We will control the field at the end of the engagement, ensuring that any wrecka
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
-                <destinationZone>6</destinationZone>
+                <deploymentZones>
+                    <deploymentZone>6</deploymentZone>
+                </deploymentZones>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Assault.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Assault.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Low-Atmosphere DropShip Assault</name>
     <shortBriefing>Destroy DropShip before it escape.</shortBriefing>
-    <detailedBriefing>A hostile DropShip is attempting to escape in low atmosphere, and we cannot allow it to break free. Whether it carries enemy personnel, critical cargo, or valuable intelligence, its destruction is paramount. Your mission is to intercept and destroy the DropShip before it can escape.
+    <detailedBriefing><![CDATA[A hostile DropShip is attempting to escape in low atmosphere, and we cannot allow it to break free. Whether it carries enemy personnel, critical cargo, or valuable intelligence, its destruction is paramount. Your mission is to intercept and destroy the DropShip before it can escape.
 
 Expect the enemy to deploy defensive escorts and countermeasures to protect their vessel. They may attempt evasive maneuvers or a high-speed burn to reach the upper atmosphere. You must strike decisively and disable or destroy the DropShip before it leaves your engagement range.
 
-We will control the field at the end of the engagement, ensuring that any wreckage or surviving assets remain in our hands. This is a one-shot opportunity—do not let them escape.</detailedBriefing>
+We will control the field at the end of the engagement, ensuring that any wreckage or surviving assets remain in our hands. This is a one-shot opportunity—do not let them escape.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Low-Atmosphere DropShip Escort</name>
     <shortBriefing>Escort DropShip, defeat enemy forces.</shortBriefing>
-    <detailedBriefing>An allied DropShip is under threat, with enemy air assets moving to intercept before it can reach safety. This vessel is critical to our operations, and its loss is not an option. Your mission is to protect the DropShip and destroy at least 50% of the attacking enemy forces.
+    <detailedBriefing><![CDATA[An allied DropShip is under threat, with enemy air assets moving to intercept before it can reach safety. This vessel is critical to our operations, and its loss is not an option. Your mission is to protect the DropShip and destroy at least 50% of the attacking enemy forces.
 
 Expect aggressive aerial engagements, fast-moving strike craft, and possible long-range missile attacks. Use superior positioning, coordinated fire, and defensive tactics to neutralize threats before they can bring down our DropShip. Every enemy unit destroyed increases the DropShip’s chance of survival—hit them hard and make them pay for their assault.
 
-The victor will control the battlefield at the end of the engagement, ensuring we hold the airspace and any remaining salvage. Defend the DropShip, eliminate the threat, and dominate the skies.</detailedBriefing>
+The victor will control the battlefield at the end of the engagement, ensuring we hold the airspace and any remaining salvage. Defend the DropShip, eliminate the threat, and dominate the skies.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
@@ -12,7 +12,7 @@ The victor will control the battlefield at the end of the engagement, ensuring w
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>17</baseHeight>
         <baseWidth>50</baseWidth>
         <heightScalingIncrement>5</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
@@ -36,7 +36,7 @@ The victor will control the battlefield at the end of the engagement, ensuring w
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
@@ -40,8 +40,6 @@ There will be no time to secure the battlefield at the end of the engagement, me
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -53,7 +51,7 @@ There will be no time to secure the battlefield at the end of the engagement, me
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>0</minWeightClass>
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere Reinforcements Intercepted.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Low-Atmosphere Reinforcements Intercepted</name>
     <shortBriefing>Destroy hostile air forces.</shortBriefing>
-    <detailedBriefing>Your reinforcements have been intercepted by enemy forces, cutting them off before they can complete their original mission. This is an intentional move to stall our operations and weaken our ability to project force. Your mission is to break free from the engagement by destroying at least 50% of the enemy force. Until that threshold is met, you will remain pinned down and unable to proceed.
+    <detailedBriefing><![CDATA[Your reinforcements have been intercepted by enemy forces, cutting them off before they can complete their original mission. This is an intentional move to stall our operations and weaken our ability to project force. Your mission is to break free from the engagement by destroying at least 50% of the enemy force. Until that threshold is met, you will remain pinned down and unable to proceed.
 
 The enemy will press hard to keep you contained, using aggressive maneuvers and potentially overwhelming numbers to delay your advance. Do not get bogged down in a prolonged engagement—focus fire, break their cohesion, and force them into retreat. Once their losses become unsustainable, the path forward will be clear.
 
-There will be no time to secure the battlefield at the end of the engagement, meaning any salvage will be lost. Speed is essential—eliminate the enemy and move out before reinforcements arrive.</detailedBriefing>
+There will be no time to secure the battlefield at the end of the engagement, meaning any salvage will be lost. Speed is essential—eliminate the enemy and move out before reinforcements arrive.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Minor Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Minor Engagement.xml
@@ -40,8 +40,6 @@ The victor will control the battlefield at the end of the engagement, securing t
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Minor Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Minor Engagement.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Minor Engagement</name>
     <shortBriefing>Engage and destroy enemy forces.</shortBriefing>
-    <detailedBriefing>The enemy has positioned forces in this area, but they are not yet fully committed to battle. Your objective is to inflict enough damage to force them to withdraw. Destroy at least 25% of their forces to break their resolve and make it clear that holding this position is not worth the cost.
+    <detailedBriefing><![CDATA[The enemy has positioned forces in this area, but they are not yet fully committed to battle. Your objective is to inflict enough damage to force them to withdraw. Destroy at least 25% of their forces to break their resolve and make it clear that holding this position is not worth the cost.
 
 This is a show of strength—hit them hard, make them bleed, and leave no doubt that further resistance is futile. They may attempt a counteroffensive, but once their losses mount, they will have no choice but to retreat.
 
-The victor will control the battlefield at the end of the engagement, securing the area and denying the enemy any future foothold here. Send a message—this ground belongs to us.</detailedBriefing>
+The victor will control the battlefield at the end of the engagement, securing the area and denying the enemy any future foothold here. Send a message—this ground belongs to us.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Picket Line Breakthrough</name>
     <shortBriefing>Break through enemy picket line.</shortBriefing>
-    <detailedBriefing>The enemy has established a picket line to screen their front, but a successful breakthrough will force them to redeploy reserves and grant us a strong strategic position. Your mission is to breach their defenses and reach the opposite edge of the engagement zone with at least 50% of your forces intact.
+    <detailedBriefing><![CDATA[The enemy has established a picket line to screen their front, but a successful breakthrough will force them to redeploy reserves and grant us a strong strategic position. Your mission is to breach their defenses and reach the opposite edge of the engagement zone with at least 50% of your forces intact.
 
 Expect light screening forces supported by rapid response elements. The enemy will attempt to stall your advance while preparing a counterattack. Speed, decisive strikes, and maintaining momentum will be key to breaking through before they can reinforce.
 
-As you will be pushing into enemy territory, we will be unable to secure the battlefield following the engagement. Any salvage or wreckage left behind will be lost, so prioritize survival and mission success over prolonged engagements. Punch through, force them to react, and establish dominance beyond their lines.</detailedBriefing>
+As you will be pushing into enemy territory, we will be unable to secure the battlefield following the engagement. Any salvage or wreckage left behind will be lost, so prioritize survival and mission success over prolonged engagements. Punch through, force them to react, and establish dominance beyond their lines.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
@@ -10,7 +10,7 @@ As you will be pushing into enemy territory, we will be unable to secure the bat
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>50</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/Pivotal Battle.xml
+++ b/MekHQ/data/scenariotemplates/Pivotal Battle.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Pivotal Engagement</name>
     <shortBriefing>Decisive battle—defeat enemy forces.</shortBriefing>
-    <detailedBriefing>A massive enemy force has taken to the field, and if they are allowed to gain momentum, they will become an unstoppable threat. Your mission is to blunt their advance by destroying at least 25% of their forces, forcing them to slow their assault and reconsider their position.
+    <detailedBriefing><![CDATA[A massive enemy force has taken to the field, and if they are allowed to gain momentum, they will become an unstoppable threat. Your mission is to blunt their advance by destroying at least 25% of their forces, forcing them to slow their assault and reconsider their position.
 
 The enemy is relying on overwhelming numbers, expecting to steamroll our defenses. Target high-value units, disrupt their formations, and make them bleed for every inch of ground. If they hesitate or falter, their offensive will collapse before it can reach full strength.
 
-The victor will control the battlefield at the end of the engagement, ensuring we hold the ground and any remaining salvage. Stand firm, inflict maximum damage, and break their momentum before it’s too late.</detailedBriefing>
+The victor will control the battlefield at the end of the engagement, ensuring we hold the ground and any remaining salvage. Stand firm, inflict maximum damage, and break their momentum before it’s too late.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Pivotal Battle.xml
+++ b/MekHQ/data/scenariotemplates/Pivotal Battle.xml
@@ -40,8 +40,6 @@ The victor will control the battlefield at the end of the engagement, ensuring w
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Recon Evasion.xml
@@ -42,8 +42,6 @@ The enemy will control the field at the end of the engagement, meaning there wil
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Recon Evasion.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Recon Evasion</name>
     <shortBriefing>Evade patrols until scan is complete.</shortBriefing>
-    <detailedBriefing>We have a rare opportunity to gather critical intelligence on enemy operations by monitoring their movements. Your mission is to remain in position for the required duration, observing and collecting data on enemy activity while avoiding direct engagement. The information you gather will be far more valuable than any destruction you could inflict.
+    <detailedBriefing><![CDATA[We have a rare opportunity to gather critical intelligence on enemy operations by monitoring their movements. Your mission is to remain in position for the required duration, observing and collecting data on enemy activity while avoiding direct engagement. The information you gather will be far more valuable than any destruction you could inflict.
 
 The enemy is unaware of our presence, but if discovered, they will respond with overwhelming force. Stealth and discretion are paramount—engage only if absolutely necessary, and prioritize survival over combat. Avoid unnecessary detection, maintain a low profile, and ensure you remain operational for the duration of the mission.
 
-The enemy will control the field at the end of the engagement, meaning there will be no opportunity for salvage or reinforcement. This is about intelligence, not confrontation—stay hidden, gather what we need, and withdraw before they know you were ever there. At least one of your units must survive.</detailedBriefing>
+The enemy will control the field at the end of the engagement, meaning there will be no opportunity for salvage or reinforcement. This is about intelligence, not confrontation—stay hidden, gather what we need, and withdraw before they know you were ever there. At least one of your units must survive.]]></detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <battlefieldControl>ENEMY</battlefieldControl>

--- a/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Reconnaissance Interdiction</name>
     <shortBriefing>Prevent hostile reconnaissance.</shortBriefing>
-    <detailedBriefing>Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
+    <detailedBriefing><![CDATA[Enemy reconnaissance units have been deployed to gather intelligence on our movements, threatening the security of our operations. Your mission is to eliminate them before they can complete their reconnaissance. If they succeed, our positions will be compromised, giving the enemy a critical advantage.
 
 Expect these forces to prioritize speed, evasion, and long-range observation tactics. They will attempt to avoid direct engagement and may have stealth capabilities or electronic warfare support to mask their presence. You must act quickly, intercept their units, and wipe them out before they can relay any useful data.
 
-We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.</detailedBriefing>
+We will control the battlefield at the end of the engagement, ensuring that any remaining enemy assets or reconnaissance equipment are in our hands. Hunt them down, erase all traces of their mission, and ensure our movements remain hidden.]]></detailedBriefing>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>
     <battlefieldControl>PLAYER</battlefieldControl>

--- a/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Reconnaissance Interdiction.xml
@@ -42,8 +42,6 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Reinforcements Intercepted</name>
     <shortBriefing>Destroy hostile forces.</shortBriefing>
-    <detailedBriefing>Your reinforcements have been intercepted and pinned down, preventing them from completing their original mission. The enemy is attempting to isolate and eliminate them before they can rejoin the fight. Your objective is to break them free by destroying at least 50% of the enemy forces, forcing a retreat and allowing your units to escape.
+    <detailedBriefing><![CDATA[Your reinforcements have been intercepted and pinned down, preventing them from completing their original mission. The enemy is attempting to isolate and eliminate them before they can rejoin the fight. Your objective is to break them free by destroying at least 50% of the enemy forces, forcing a retreat and allowing your units to escape.
 
 Expect the enemy to hold strong defensive positions, using suppression tactics to keep your forces contained. Focus on eliminating key threats, breaking their formation, and forcing their forces into disarray. Speed and precision will be critical—you must deal enough damage to secure an escape route before more reinforcements arrive.
 
-There is no time to secure the battlefield at the end of the engagement, meaning any salvage will be lost. This is a fight for survival and mobility, not territory. Break their grip, get our forces out, and resume the mission.</detailedBriefing>
+There is no time to secure the battlefield at the end of the engagement, meaning any salvage will be lost. This is a fight for survival and mobility, not territory. Break their grip, get our forces out, and resume the mission.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Reinforcements Intercepted.xml
@@ -40,8 +40,6 @@ There is no time to secure the battlefield at the end of the engagement, meaning
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/Space Aerospace Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space Aerospace Intercept.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Space Aerospace Intercept</name>
     <shortBriefing>Intercept and destroy incoming aerospace units.</shortBriefing>
-    <detailedBriefing>Enemy AeroSpace assets have entered our airspace, threatening our operations and territorial control. Your mission is to intercept and destroy at least 50% of the enemy’s AeroSpace forces, ensuring they are unable to regroup or continue their mission.
+    <detailedBriefing><![CDATA[Enemy AeroSpace assets have entered our airspace, threatening our operations and territorial control. Your mission is to intercept and destroy at least 50% of the enemy’s AeroSpace forces, ensuring they are unable to regroup or continue their mission.
 
 Expect high-speed engagements with agile enemy fighters and possible bomber or support craft in formation. Control the skies, dictate the terms of engagement, and press the attack until the enemy is forced to retreat or is completely neutralized. Do not allow them to escape unscathed—this is an opportunity to cripple their airpower.
 
-The victor will control the battlefield at the end of the engagement, securing dominance over the airspace and ensuring enemy forces are unable to reestablish a foothold. Strike hard, eliminate the threat, and claim the skies as our own.</detailedBriefing>
+The victor will control the battlefield at the end of the engagement, securing dominance over the airspace and ensuring enemy forces are unable to reestablish a foothold. Strike hard, eliminate the threat, and claim the skies as our own.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Space Aerospace Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space Aerospace Intercept.xml
@@ -42,8 +42,6 @@ The victor will control the battlefield at the end of the engagement, securing d
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -56,7 +54,7 @@ The victor will control the battlefield at the end of the engagement, securing d
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>

--- a/MekHQ/data/scenariotemplates/Space Blockade Run.xml
+++ b/MekHQ/data/scenariotemplates/Space Blockade Run.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Space Blockade Run</name>
     <shortBriefing>Break enemy blockade, escort DropShip.</shortBriefing>
-    <detailedBriefing>An allied DropShip must bypass an enemy space blockade, and you are its only chance at breaking through. Your mission is to escort the DropShip safely to the far edge of the engagement area, ensuring it can escape enemy interdiction. If a direct escort proves too difficult, an alternative objective is available—destroy at least 50% of the enemy forces to weaken their blockade and force them to disengage.
+    <detailedBriefing><![CDATA[An allied DropShip must bypass an enemy space blockade, and you are its only chance at breaking through. Your mission is to escort the DropShip safely to the far edge of the engagement area, ensuring it can escape enemy interdiction. If a direct escort proves too difficult, an alternative objective is available—destroy at least 50% of the enemy forces to weaken their blockade and force them to disengage.
 
 The enemy will attempt to intercept, disable, or destroy the DropShip before it can escape. Expect interdiction fighters and AeroSpace superiority craft. Protect the DropShip at all costs—keep the enemy occupied, disrupt their formations, and eliminate high-threat targets before they can close in.
 
-The enemy will control the battlefield at the end of the engagement, meaning there will be no chance for salvage or recovery. Your priority is to see the DropShip through or cripple enough enemy forces to force a retreat. Ensure the mission succeeds—our strategic mobility depends on it.</detailedBriefing>
+The enemy will control the battlefield at the end of the engagement, meaning there will be no chance for salvage or recovery. Your priority is to see the DropShip through or cripple enough enemy forces to force a retreat. Ensure the mission succeeds—our strategic mobility depends on it.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Space Blockade Run.xml
+++ b/MekHQ/data/scenariotemplates/Space Blockade Run.xml
@@ -47,7 +47,7 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>
@@ -76,7 +76,7 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <minWeightClass>1</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
@@ -115,7 +115,7 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <minWeightClass>1</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>OppositeEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>

--- a/MekHQ/data/scenariotemplates/Space Blockade Run.xml
+++ b/MekHQ/data/scenariotemplates/Space Blockade Run.xml
@@ -77,7 +77,7 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>5</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncDeploymentType>SameEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>

--- a/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
@@ -33,12 +33,7 @@ We will control the battlefield at the end of the engagement, guaranteeing any w
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>true</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones>
-                    <deploymentZone>2</deploymentZone>
-                    <deploymentZone>4</deploymentZone>
-                    <deploymentZone>6</deploymentZone>
-                    <deploymentZone>8</deploymentZone>
-                </deploymentZones>
+                <deploymentZones />
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
@@ -50,8 +45,9 @@ We will control the battlefield at the end of the engagement, guaranteeing any w
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>None</syncDeploymentType>
+                <startingAltitude>5</startingAltitude>
+                <syncDeploymentType>OppositeEdge</syncDeploymentType>
+                <syncedForceName>DropShip</syncedForceName>
                 <useArtillery>false</useArtillery>
             </value>
         </entry>
@@ -68,7 +64,7 @@ We will control the battlefield at the end of the engagement, guaranteeing any w
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones />
-                <destinationZone>5</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -79,9 +75,9 @@ We will control the battlefield at the end of the engagement, guaranteeing any w
                 <minWeightClass>1</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <startingAltitude>5</startingAltitude>
+                <syncDeploymentType>SameEdge</syncDeploymentType>
+                <syncedForceName>DropShip</syncedForceName>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>ESCORT</forceRole>
@@ -100,7 +96,9 @@ We will control the battlefield at the end of the engagement, guaranteeing any w
                 <contributesToMapSize>true</contributesToMapSize>
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
-                <deploymentZones />
+                <deploymentZones>
+                    <deploymentZone>6</deploymentZone>
+                </deploymentZones>
                 <destinationZone>6</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
@@ -112,10 +110,9 @@ We will control the battlefield at the end of the engagement, guaranteeing any w
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <subjectToRandomRemoval>false</subjectToRandomRemoval>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
+                <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
                 <roleChoices>
                     <forceRole>MEK_CARRIER</forceRole>

--- a/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
@@ -99,7 +99,7 @@ We will control the battlefield at the end of the engagement, guaranteeing any w
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>6</destinationZone>
+                <destinationZone>2</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Space DropShip Intercept</name>
     <shortBriefing>Prevent DropShip escape.</shortBriefing>
-    <detailedBriefing>A hostile DropShip is attempting to evade our AeroSpace forces in space, seeking to escape or reposition for a future operation. Your mission is to intercept and destroy the DropShip before it can escape our engagement zone.
+    <detailedBriefing><![CDATA[A hostile DropShip is attempting to evade our AeroSpace forces in space, seeking to escape or reposition for a future operation. Your mission is to intercept and destroy the DropShip before it can escape our engagement zone.
 
 Expect the target to engage in evasive maneuvers, using vector thrusting, and potential escort craft to delay or deflect your attack. You must act swiftly and decisively—disable their engines, breach their hull, and ensure they do not survive this encounter.
 
-We will control the battlefield at the end of the engagement, guaranteeing any wreckage or surviving assets remain in our hands. Eliminate the DropShip, secure the battlespace, and leave nothing for the enemy to salvage.</detailedBriefing>
+We will control the battlefield at the end of the engagement, guaranteeing any wreckage or surviving assets remain in our hands. Eliminate the DropShip, secure the battlespace, and leave nothing for the enemy to salvage.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Space Reinforcements Intercepted</name>
     <shortBriefing>Destroy hostile air forces.</shortBriefing>
-    <detailedBriefing>Your reinforcements have been intercepted in space, cut off before they could reach their destination. There is nowhere to hide—this is a direct engagement where survival depends on decisive action. Your mission is to destroy at least 50% of the enemy forces to break free and allow your forces to resume their original mission.
+    <detailedBriefing><![CDATA[Your reinforcements have been intercepted in space, cut off before they could reach their destination. There is nowhere to hide—this is a direct engagement where survival depends on decisive action. Your mission is to destroy at least 50% of the enemy forces to break free and allow your forces to resume their original mission.
 
 The enemy will press the attack, seeking to pin your reinforcements down and eliminate them before they can regroup. Expect high-speed dogfights, coordinated fire from multiple vectors, and no room for retreat. Strike hard, cripple their numbers, and shatter their formation before they can overwhelm you.
 
-There will be no time to secure the battlefield after the engagement, meaning any salvage or wreckage will be lost. This is about survival and operational integrity—break free, push forward, and ensure your reinforcements reach their objective.</detailedBriefing>
+There will be no time to secure the battlefield after the engagement, meaning any salvage or wreckage will be lost. This is about survival and operational integrity—break free, push forward, and ensure your reinforcements reach their objective.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
+++ b/MekHQ/data/scenariotemplates/Space Reinforcements Intercepted.xml
@@ -42,8 +42,6 @@ There will be no time to secure the battlefield after the engagement, meaning an
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
@@ -56,7 +54,7 @@ There will be no time to secure the battlefield after the engagement, meaning an
                 <minWeightClass>0</minWeightClass>
                 <objectiveLinkedForces />
                 <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
+                <startingAltitude>5</startingAltitude>
                 <syncDeploymentType>None</syncDeploymentType>
                 <useArtillery>false</useArtillery>
             </value>

--- a/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
+++ b/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
@@ -82,36 +82,6 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <useArtillery>false</useArtillery>
             </value>
         </entry>
-        <entry>
-            <key>Reinforcements</key>
-            <value>
-                <actualDeploymentZone>-1</actualDeploymentZone>
-                <allowAeroBombs>false</allowAeroBombs>
-                <allowedUnitType>-2</allowedUnitType>
-                <arrivalTurn>-3</arrivalTurn>
-                <canReinforceLinked>true</canReinforceLinked>
-                <contributesToBV>false</contributesToBV>
-                <contributesToMapSize>true</contributesToMapSize>
-                <contributesToUnitCount>false</contributesToUnitCount>
-                <deployOffboard>false</deployOffboard>
-                <deploymentZones />
-                <destinationZone>5</destinationZone>
-                <fixedUnitCount>0</fixedUnitCount>
-                <forceAlignment>0</forceAlignment>
-                <forceMultiplier>1.0</forceMultiplier>
-                <forceName>Reinforcements</forceName>
-                <generationMethod>0</generationMethod>
-                <generationOrder>1</generationOrder>
-                <maxWeightClass>4</maxWeightClass>
-                <minWeightClass>1</minWeightClass>
-                <objectiveLinkedForces />
-                <retreatThreshold>50</retreatThreshold>
-                <startingAltitude>0</startingAltitude>
-                <syncDeploymentType>OppositeEdge</syncDeploymentType>
-                <syncedForceName>Player</syncedForceName>
-                <useArtillery>false</useArtillery>
-            </value>
-        </entry>
     </scenarioForces>
     <scenarioObjectives>
         <scenarioObjective>

--- a/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
+++ b/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>Tactical Withdrawal</name>
     <shortBriefing>Escape superior enemy force.</shortBriefing>
-    <detailedBriefing>A superior enemy force is in pursuit, intent on overwhelming and eliminating your units before they can escape. Your mission is to break free and reach the opposite edge of the engagement zone with at least 50% of your forces intact. Survival and mobility are your priorities—this is not a battle of attrition.
+    <detailedBriefing><![CDATA[A superior enemy force is in pursuit, intent on overwhelming and eliminating your units before they can escape. Your mission is to break free and reach the opposite edge of the engagement zone with at least 50% of your forces intact. Survival and mobility are your priorities—this is not a battle of attrition.
 
 Expect the enemy to use speed, encirclement tactics, and suppression fire to slow your advance. They have the numbers, but you have the initiative—use terrain, evasive maneuvers, and covering fire to outmaneuver them. If they manage to pin you down, your escape will become far more difficult. Keep moving and do not allow them to dictate the fight.
 
-The enemy will control the battlefield at the end of the engagement, meaning there will be no chance to recover fallen assets. This is a fight for survival—get clear, regroup, and live to fight another day.</detailedBriefing>
+The enemy will control the battlefield at the end of the engagement, meaning there will be no chance to recover fallen assets. This is a fight for survival—get clear, regroup, and live to fight another day.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <isHostileFacility>false</isHostileFacility>
     <isAlliedFacility>false</isAlliedFacility>

--- a/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
+++ b/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
@@ -12,7 +12,7 @@ The enemy will control the battlefield at the end of the engagement, meaning the
     <isAlliedFacility>false</isAlliedFacility>
     <mapParameters>
         <allowedTerrainTypes />
-        <allowRotation>true</allowRotation>
+        <allowRotation>false</allowRotation>
         <baseHeight>70</baseHeight>
         <baseWidth>17</baseWidth>
         <heightScalingIncrement>0</heightScalingIncrement>

--- a/MekHQ/data/scenariotemplates/VIP Ambush.xml
+++ b/MekHQ/data/scenariotemplates/VIP Ambush.xml
@@ -40,8 +40,6 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/VIP Ambush.xml
+++ b/MekHQ/data/scenariotemplates/VIP Ambush.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>VIP Ambush</name>
     <shortBriefing>Ambush and eliminate VIP, evade reinforcements.</shortBriefing>
-    <detailedBriefing>An enemy VIP has been left exposed, presenting a rare opportunity to eliminate a high-value target. Your mission is to execute the VIP before their reinforcements arrive. This individual’s removal will cripple enemy operations, disrupt their chain of command, and eliminate a key asset from the battlefield.
+    <detailedBriefing><![CDATA[An enemy VIP has been left exposed, presenting a rare opportunity to eliminate a high-value target. Your mission is to execute the VIP before their reinforcements arrive. This individual’s removal will cripple enemy operations, disrupt their chain of command, and eliminate a key asset from the battlefield.
 
 Expect the enemy to stall for time, deploying fast-moving elements or defensive tactics to delay your strike. Speed and precision are critical—do not allow them the time to reinforce or extract the target. If you hesitate, they will escape or be reinforced, and this opportunity will be lost.
 
-The enemy will control the battlefield at the end of the engagement, meaning there will be no chance for recovery or salvage. This is a surgical strike—neutralize the target and withdraw before the enemy locks down the area.</detailedBriefing>
+The enemy will control the battlefield at the end of the engagement, meaning there will be no chance for recovery or salvage. This is a surgical strike—neutralize the target and withdraw before the enemy locks down the area.]]></detailedBriefing>
     <battlefieldControl>ENEMY</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/VIP Defense.xml
+++ b/MekHQ/data/scenariotemplates/VIP Defense.xml
@@ -40,8 +40,6 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                     <deploymentZone>6</deploymentZone>
                     <deploymentZone>7</deploymentZone>
                     <deploymentZone>8</deploymentZone>
-                    <deploymentZone>9</deploymentZone>
-                    <deploymentZone>10</deploymentZone>
                 </deploymentZones>
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>

--- a/MekHQ/data/scenariotemplates/VIP Defense.xml
+++ b/MekHQ/data/scenariotemplates/VIP Defense.xml
@@ -2,11 +2,11 @@
 <ScenarioTemplate>
     <name>VIP Defense</name>
     <shortBriefing>Protect VIP and defeat enemy.</shortBriefing>
-    <detailedBriefing>An important allied VIP is under direct threat, with enemy forces moving to eliminate them. Your mission is to ensure the VIP’s survival and destroy at least 50% of the attacking force to break their assassination attempt.
+    <detailedBriefing><![CDATA[An important allied VIP is under direct threat, with enemy forces moving to eliminate them. Your mission is to ensure the VIP’s survival and destroy at least 50% of the attacking force to break their assassination attempt.
 
 Expect the enemy to employ fast-moving strike teams, precision fire support, and possibly infiltration tactics to bypass defenses and reach the VIP. You must identify and eliminate key threats quickly while maintaining a defensive perimeter around the target. Every second counts—if the enemy is allowed to press their attack unchecked, the VIP will not survive.
 
-We will control the battlefield at the end of the engagement, ensuring that any surviving enemy forces are neutralized and that all salvageable assets remain in our hands. Hold the line, eliminate the attackers, and ensure our VIP lives to fight another day.</detailedBriefing>
+We will control the battlefield at the end of the engagement, ensuring that any surviving enemy forces are neutralized and that all salvageable assets remain in our hands. Hold the line, eliminate the attackers, and ensure our VIP lives to fight another day.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>
     <mapParameters>
         <allowedTerrainTypes />

--- a/MekHQ/data/scenariotemplates/VIP Defense.xml
+++ b/MekHQ/data/scenariotemplates/VIP Defense.xml
@@ -79,7 +79,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <generationOrder>1</generationOrder>
                 <maxWeightClass>4</maxWeightClass>
                 <minWeightClass>3</minWeightClass>
-                <retreatThreshold>0</retreatThreshold>
+                <retreatThreshold>50</retreatThreshold>
                 <startingAltitude>0</startingAltitude>
                 <syncDeploymentType>SameEdge</syncDeploymentType>
                 <syncedForceName>Player</syncedForceName>


### PR DESCRIPTION
Fix #6412
Fix #6422

- Added CDATA tags to briefing descriptions.
- Adjusted retreat thresholds in scenario templates so that convoys will automatically begin in 'retreat'.
- Fixed `destinationZone` values in multiple scenario templates.
- Disabled `allowRotation` setting across all scenario templates. The chances of rotating the map breaking the destination edge settings was very high and it was easier to disable this functionality than rewrite destination edges to use dynamic edges.
- Simplified deployment zone configurations across multiple scenario templates to better control the flow of scenarios.
- Fixed `syncDeploymentType` and `syncedForceName` in a number of scenario templates.