### PR TITLE
Improved SkillLevel Parsing from Older Campaigns

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -6395,7 +6395,7 @@ public class CampaignOptions {
 
                     // region AtB Tab
                 } else if (nodeName.equalsIgnoreCase("skillLevel")) {
-                    retVal.setSkillLevel(SkillLevel.valueOf(wn2.getTextContent().trim()));
+                    retVal.setSkillLevel(SkillLevel.parseFromString(wn2.getTextContent().trim()));
                     // region ACAR Tab
                 } else if (nodeName.equalsIgnoreCase("autoResolveMethod")) {
                     retVal.setAutoResolveMethod(AutoResolveMethod.valueOf(wn2.getTextContent().trim()));


### PR DESCRIPTION
- Refactored `CampaignOptions` to use `SkillLevel.parseFromString()` instead of `SkillLevel.valueOf()` for `skillLevel` parsing.