### PR TITLE
Skip Turrets / Gun Emplacements when auto-configuring NPC ammo loadouts

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -819,8 +819,10 @@ public class AtBDynamicScenarioFactory {
                 Game cGame = campaign.getGame();
                 TeamLoadOutGenerator tlg = new TeamLoadOutGenerator(cGame);
                 if (campaign.getCampaignOptions().isAutoConfigMunitions()) {
-                    // Configure *all* generated units with appropriate munitions (for BV calcs)
-                    ArrayList<Entity> arrayGeneratedLance = new ArrayList<>(generatedLance);
+                    // Configure non-Turret generated units with appropriate munitions (for BV calcs)
+                    ArrayList<Entity> arrayGeneratedLance = new ArrayList<>(
+                          generatedLance.stream().filter(e -> !(e instanceof GunEmplacement)).toList()
+                    );
                     // bin fill ratio will be adjusted by the load out generator based on piracy and
                     // quality
                     ReconfigurationParameters rp = TeamLoadOutGenerator.generateParameters(cGame,

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -55,6 +55,7 @@ import megamek.codeUtilities.ObjectUtility;
 import megamek.common.Entity;
 import megamek.common.EntityListFile;
 import megamek.common.Game;
+import megamek.common.GunEmplacement;
 import megamek.common.annotations.Nullable;
 import megamek.common.containers.MunitionTree;
 import megamek.common.event.Subscribe;
@@ -1099,16 +1100,21 @@ public final class BriefingTab extends CampaignGuiTab {
 
         // Split up bot forces into teams for separate handling
         for (final BotForce botForce : scenario.getBotForces()) {
+            // Do not include Turrets
+            List<Entity> filteredEntityList =
+                  botForce.getFixedEntityList().stream().filter(
+                        e -> !(e instanceof GunEmplacement)
+                  ).toList();
             if (botForce.getName().contains(allyFaction)) {
                 // Stuff with our employer's name should be with us.
-                playerEntities.addAll(botForce.getFixedEntityList());
-                alliedEntities.addAll(botForce.getFixedEntityList());
+                playerEntities.addAll(filteredEntityList);
+                alliedEntities.addAll(filteredEntityList);
             } else {
                 int botTeam = botForce.getTeam();
                 if (!botTeamMappings.containsKey(botTeam)) {
                     botTeamMappings.put(botTeam, new ArrayList<>());
                 }
-                botTeamMappings.get(botTeam).addAll(botForce.getFixedEntityList());
+                botTeamMappings.get(botTeam).addAll(filteredEntityList);
             }
         }
 


### PR DESCRIPTION
This fix implements a long-standing request from the Turrets team to avoid reconfiguring the ammo of pre-configured turret / gun emplacement units.
This will prevent uneven play experiences and keep the turret BV stable.

Players are still free to reconfigure / auto-configure turret munitions within MegaMek if desired.

Testing:
- Ran all 3 projects' unit tests.
- Confirmed turrets are skipped when even when ammo auto-configuration is enabled.
- Confirmed other units get auto-configured as usual.