### PR TITLE
Refactored Centralized Skill Check Class to Use `TargetRoll`; Fixed Multiple Bugs

### DIFF
--- a/MekHQ/resources/mekhq/resources/SkillCheckUtility.properties
+++ b/MekHQ/resources/mekhq/resources/SkillCheckUtility.properties
@@ -5,3 +5,8 @@ skillCheck.results.failure=Failed
 skillCheck.rerolled={0} used a point of <b>Edge</b> when making this check.
 skillCheck.nullSkillName=ERROR: Skill name is null. Please report this bug to the MegaMek team.
 skillCheck.nullPerson=ERROR: Person is null. Please report this bug to the MegaMek team.
+# Target Roll Modifiers
+skillCheck.untrained.twoLinkedAttributes=Untrained Target Number (Two Linked Attributes)
+skillCheck.untrained.oneLinkedAttribute=Untrained Target Number (One Linked Attribute)
+skillCheck.untrained.skill=Untrained Skill Modifier
+skillCheck.miscModifier=Misc Modifier

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
@@ -193,13 +193,13 @@ public class Attributes {
      */
     public int getAttribute(SkillAttribute attribute) {
         return switch (attribute) {
-            case STRENGTH -> strength;
-            case BODY -> body;
-            case REFLEXES -> reflexes;
-            case DEXTERITY -> dexterity;
-            case INTELLIGENCE -> intelligence;
-            case WILLPOWER -> willpower;
-            case CHARISMA -> charisma;
+            case STRENGTH -> clamp(strength, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+            case BODY -> clamp(body, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+            case REFLEXES -> clamp(reflexes, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+            case DEXTERITY -> clamp(dexterity, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+            case INTELLIGENCE -> clamp(intelligence, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+            case WILLPOWER -> clamp(willpower, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+            case CHARISMA -> clamp(charisma, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
             default -> 0;
         };
     }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
@@ -477,21 +477,44 @@ public class SkillCheckUtility {
     }
 
     /**
-     * Calculates the total attribute modifier for a given skill type based on the character's attributes.
+     * Calculates the total attribute modifier for a given skill type based on the character's attributes
+     * and applies the modifiers to the target roll.
      *
-     * <p>The modifier is determined by summing up the individual attribute modifiers for the skill's linked
-     * attributes.</p>
+     * <p>This method retrieves the attributes linked to the specified {@link SkillType} and calculates
+     * the total contribution of their modifiers to the target roll. Each attribute's score is converted
+     * into an individual modifier using {@link #getIndividualAttributeModifier(int)}, and the modifier is
+     * then added to both:</p>
      *
-     * @param targetNumber
-     * @param characterAttributes the {@link Attributes} of the person performing the skill check
-     * @param skillType           the {@link SkillType} being checked
+     * <ul>
+     *   <li>The total attribute modifier (returned by the method), and</li>
+     *   <li>The {@link TargetRoll}, where the attribute modifier is applied as a negative value.</li>
+     * </ul>
      *
-     * @return the total attribute modifier for the skill check
+     * <p></p>Attributes that are set to {@link SkillAttribute#NONE} are ignored during this process.</p>
+     *
+     * <p>The calculated attribute modifiers are applied directly to the {@link TargetRoll} using
+     * {@link TargetRoll#addModifier(int, String)}, where the negative modifier is associated with the
+     * attribute's label.</p>
+     *
+     * @param targetNumber         the {@link TargetRoll} representing the current target number,
+     *                             which will be adjusted based on the character's attribute modifiers
+     * @param characterAttributes  the {@link Attributes} object representing the character's
+     *                             raw attribute scores that determine the skill check modifiers
+     * @param skillType            the {@link SkillType} being assessed, whose linked attributes
+     *                             contribute to the total modifier calculation
+     *
+     * @return the total attribute modifier calculated for the given skill type, which is the sum
+     *         of the individual modifiers for each linked attribute. If any of the parameters are {@code null}
+     *         returns 0.
      *
      * @author Illiani
      * @since 0.50.05
      */
     public static int getTotalAttributeModifier(TargetRoll targetNumber, final Attributes characterAttributes, final SkillType skillType) {
+        if (targetNumber == null || characterAttributes == null || skillType == null) {
+            return 0;
+        }
+
         List<SkillAttribute> linkedAttributes = List.of(skillType.getFirstAttribute(), skillType.getSecondAttribute());
 
         int totalModifier = 0;

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
@@ -490,7 +490,7 @@ public class SkillCheckUtility {
      *   <li>The {@link TargetRoll}, where the attribute modifier is applied as a negative value.</li>
      * </ul>
      *
-     * <p></p>Attributes that are set to {@link SkillAttribute#NONE} are ignored during this process.</p>
+     * <p>Attributes that are set to {@link SkillAttribute#NONE} are ignored during this process.</p>
      *
      * <p>The calculated attribute modifiers are applied directly to the {@link TargetRoll} using
      * {@link TargetRoll#addModifier(int, String)}, where the negative modifier is associated with the

--- a/MekHQ/src/mekhq/gui/dialog/SkillCheckDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SkillCheckDialog.java
@@ -106,6 +106,7 @@ public class SkillCheckDialog {
         String results = performSkillCheck(dialog.getComboBoxChoiceIndex(), dialog.getSpinnerValue(), choiceIndex);
 
         // Results Dialog
+        campaign.addReport(results.replaceAll("<p>", "<br><br>").replaceAll("</p>", ""));
         showResultsDialog(results);
     }
 
@@ -303,7 +304,7 @@ public class SkillCheckDialog {
 
         for (String skillName : SkillType.getSkillList()) {
             SkillType skillType = SkillType.getType(skillName);
-            int targetNumber = determineTargetNumber(character, skillType, 0);
+            int targetNumber = determineTargetNumber(character, skillType, 0).getValue();
             boolean isCountsUp = SkillType.getType(skillName).isCountUp();
 
             // Build the label with the target number

--- a/MekHQ/src/mekhq/gui/dialog/SkillCheckDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/SkillCheckDialog.java
@@ -150,7 +150,7 @@ public class SkillCheckDialog {
     private String performSkillCheck(int selectedSkill, int selectedModifier, int choiceIndex) {
         String skillName = skillNames.get(selectedSkill);
         boolean useEdge = choiceIndex == DIALOG_USE_EDGE_INDEX;
-        SkillCheckUtility utility = new SkillCheckUtility(character, skillName, selectedModifier, useEdge);
+        SkillCheckUtility utility = new SkillCheckUtility(character, skillName, null, selectedModifier, useEdge, true);
         isSuccess = utility.isSuccess();
 
         return utility.getResultsText();

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
@@ -30,10 +30,13 @@ package mekhq.campaign.personnel.skills;
 import static mekhq.campaign.personnel.skills.Attributes.DEFAULT_ATTRIBUTE_SCORE;
 import static mekhq.campaign.personnel.skills.Attributes.MAXIMUM_ATTRIBUTE_SCORE;
 import static mekhq.campaign.personnel.skills.Attributes.MINIMUM_ATTRIBUTE_SCORE;
+import static mekhq.campaign.personnel.skills.SkillCheckUtility.UNTRAINED_SKILL_MODIFIER;
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE;
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES;
+import static mekhq.campaign.personnel.skills.SkillCheckUtility.determineTargetNumber;
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.getIndividualAttributeModifier;
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.getTotalAttributeModifier;
+import static mekhq.campaign.personnel.skills.SkillCheckUtility.getTotalAttributeScoreForSkill;
 import static mekhq.campaign.personnel.skills.SkillCheckUtility.performQuickSkillCheck;
 import static mekhq.campaign.personnel.skills.SkillType.S_GUN_MEK;
 import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.DISASTROUS;
@@ -47,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import megamek.common.TargetRoll;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
@@ -87,7 +91,7 @@ class SkillCheckUtilityTest {
         assertEquals(expectedResultsText, checkUtility.getResultsText());
 
         int expectedTargetNumber = Integer.MAX_VALUE;
-        assertEquals(expectedTargetNumber, checkUtility.getTargetNumber());
+        assertEquals(expectedTargetNumber, checkUtility.getTargetNumber().getValue());
 
         int expectedRoll = Integer.MIN_VALUE;
         assertEquals(expectedRoll, checkUtility.getRoll());
@@ -105,7 +109,7 @@ class SkillCheckUtilityTest {
         assertEquals(expectedResultsText, checkUtility.getResultsText());
 
         int expectedTargetNumber = Integer.MAX_VALUE;
-        assertEquals(expectedTargetNumber, checkUtility.getTargetNumber());
+        assertEquals(expectedTargetNumber, checkUtility.getTargetNumber().getValue());
 
         int expectedRoll = Integer.MIN_VALUE;
         assertEquals(expectedRoll, checkUtility.getRoll());
@@ -132,8 +136,10 @@ class SkillCheckUtilityTest {
               DEFAULT_ATTRIBUTE_SCORE,
               DEFAULT_ATTRIBUTE_SCORE);
 
+        TargetRoll targetNumber = new TargetRoll();
+
         // Act
-        int totalModifier = SkillCheckUtility.getTotalAttributeModifier(attributes, testSkillType);
+        int totalModifier = SkillCheckUtility.getTotalAttributeModifier(targetNumber, attributes, testSkillType);
 
         // Assert
         assertEquals(1, totalModifier);
@@ -154,8 +160,10 @@ class SkillCheckUtilityTest {
               DEFAULT_ATTRIBUTE_SCORE,
               DEFAULT_ATTRIBUTE_SCORE);
 
+        TargetRoll targetNumber = new TargetRoll();
+
         // Act
-        int totalModifier = SkillCheckUtility.getTotalAttributeModifier(attributes, testSkillType);
+        int totalModifier = SkillCheckUtility.getTotalAttributeModifier(targetNumber, attributes, testSkillType);
 
         // Assert
         assertEquals(2, totalModifier);
@@ -176,8 +184,10 @@ class SkillCheckUtilityTest {
               DEFAULT_ATTRIBUTE_SCORE,
               DEFAULT_ATTRIBUTE_SCORE);
 
+        TargetRoll targetNumber = new TargetRoll();
+
         // Act
-        int totalModifier = SkillCheckUtility.getTotalAttributeModifier(attributes, testSkillType);
+        int totalModifier = SkillCheckUtility.getTotalAttributeModifier(targetNumber, attributes, testSkillType);
 
         // Assert
         assertEquals(0, totalModifier);
@@ -219,11 +229,13 @@ class SkillCheckUtilityTest {
               DEFAULT_ATTRIBUTE_SCORE,
               DEFAULT_ATTRIBUTE_SCORE);
 
+        TargetRoll targetNumber = new TargetRoll();
+
         // Act
-        int totalScore = SkillCheckUtility.getTotalAttributeScoreForSkill(attributes, testSkillType);
+        int totalScore = SkillCheckUtility.getTotalAttributeScoreForSkill(targetNumber, attributes, testSkillType);
 
         // Assert
-        assertEquals(7, totalScore);
+        assertEquals(7, totalScore, targetNumber.toString());
     }
 
     @Test
@@ -241,11 +253,13 @@ class SkillCheckUtilityTest {
               DEFAULT_ATTRIBUTE_SCORE,
               DEFAULT_ATTRIBUTE_SCORE);
 
+        TargetRoll targetNumber = new TargetRoll();
+
         // Act
-        int totalScore = SkillCheckUtility.getTotalAttributeScoreForSkill(attributes, testSkillType);
+        SkillCheckUtility.getTotalAttributeScoreForSkill(targetNumber, attributes, testSkillType);
 
         // Assert
-        assertEquals(14, totalScore);
+        assertEquals(-14, targetNumber.getValue(), targetNumber.toString());
     }
 
     @Test
@@ -263,8 +277,10 @@ class SkillCheckUtilityTest {
               DEFAULT_ATTRIBUTE_SCORE,
               DEFAULT_ATTRIBUTE_SCORE);
 
+        TargetRoll targetNumber = new TargetRoll();
+
         // Act
-        int totalScore = SkillCheckUtility.getTotalAttributeScoreForSkill(attributes, testSkillType);
+        int totalScore = SkillCheckUtility.getTotalAttributeScoreForSkill(targetNumber, attributes, testSkillType);
 
         // Assert
         assertEquals(0, totalScore);
@@ -285,11 +301,13 @@ class SkillCheckUtilityTest {
               DEFAULT_ATTRIBUTE_SCORE,
               DEFAULT_ATTRIBUTE_SCORE);
 
+        TargetRoll targetNumber = new TargetRoll();
+
         // Act
-        int totalScore = SkillCheckUtility.getTotalAttributeScoreForSkill(attributes, testSkillType);
+        SkillCheckUtility.getTotalAttributeScoreForSkill(targetNumber, attributes, testSkillType);
 
         // Assert
-        assertEquals(7, totalScore);
+        assertEquals(-7, targetNumber.getValue(), targetNumber.toString());
     }
 
     @Test
@@ -305,12 +323,13 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(person, testSkillType, 0);
+            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, 0);
 
             // Assert
-            int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE -
-                                             person.getAttributeScore(REFLEXES);
-            assertEquals(expectedTargetNumber, targetNumber);
+            int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE
+                                             + UNTRAINED_SKILL_MODIFIER
+                                             - person.getAttributeScore(REFLEXES);
+            assertEquals(expectedTargetNumber, targetNumber.getValue(), targetNumber.toString());
         }
     }
 
@@ -326,13 +345,14 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(person, testSkillType, 0);
+            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, 0);
 
             // Assert
-            int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES -
-                                             person.getAttributeScore(REFLEXES) -
-                                             person.getAttributeScore(DEXTERITY);
-            assertEquals(expectedTargetNumber, targetNumber);
+            int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES
+                                             - person.getAttributeScore(REFLEXES)
+                                             - person.getAttributeScore(DEXTERITY)
+                                             + UNTRAINED_SKILL_MODIFIER;
+            assertEquals(expectedTargetNumber, targetNumber.getValue(), targetNumber.toString());
         }
     }
 
@@ -364,13 +384,13 @@ class SkillCheckUtilityTest {
                 mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
                 // Act
-                int targetNumber = SkillCheckUtility.determineTargetNumber(mockPerson, testSkillType, 0);
+                TargetRoll targetNumber = determineTargetNumber(mockPerson, testSkillType, 0);
 
                 // Assert
                 int skillTargetNumber = skill.getFinalSkillValue(new PersonnelOptions(), 0);
-                int attributeAdjustment = getTotalAttributeModifier(characterAttributes, testSkillType);
+                int attributeAdjustment = getTotalAttributeModifier(new TargetRoll(), characterAttributes, testSkillType);
                 assertEquals(skillTargetNumber - attributeAdjustment,
-                      targetNumber,
+                      targetNumber.getValue(),
                       "Attribute Score: " + attributeScore);
             }
         }
@@ -403,12 +423,14 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(mockPerson, testSkillType, 0);
+            TargetRoll targetNumber = determineTargetNumber(mockPerson, testSkillType, 0);
 
             // Assert
             int skillTargetNumber = skill.getFinalSkillValue(new PersonnelOptions(), 0);
-            int attributeAdjustment = getTotalAttributeModifier(characterAttributes, testSkillType);
-            assertEquals(skillTargetNumber - attributeAdjustment, targetNumber, "Attribute Score: " + 300);
+            int attributeAdjustment = getTotalAttributeModifier(new TargetRoll(), characterAttributes, testSkillType);
+            int expectedValue = skillTargetNumber - attributeAdjustment;
+
+            assertEquals(expectedValue, targetNumber.getValue(), targetNumber.toString());
         }
     }
 
@@ -439,14 +461,14 @@ class SkillCheckUtilityTest {
                 mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
                 // Act
-                int targetNumber = SkillCheckUtility.determineTargetNumber(mockPerson, testSkillType, 0);
+                TargetRoll targetNumber = determineTargetNumber(mockPerson, testSkillType, 0);
 
                 // Assert
                 int skillTargetNumber = skill.getFinalSkillValue(new PersonnelOptions(), 0);
-                int attributeAdjustment = getTotalAttributeModifier(characterAttributes, testSkillType);
+                int attributeAdjustment = getTotalAttributeModifier(new TargetRoll(), characterAttributes, testSkillType);
                 assertEquals(skillTargetNumber - attributeAdjustment,
-                      targetNumber,
-                      "Attribute Score: " + attributeScore);
+                      targetNumber.getValue(),
+                      targetNumber + " [Attribute Score: " + attributeScore + ']');
             }
         }
     }
@@ -468,13 +490,14 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(person, testSkillType, 0);
+            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, 0);
 
             // Assert
-            int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES -
-                                             SkillCheckUtility.getTotalAttributeScoreForSkill(invalidAttributes,
-                                                   testSkillType);
-            assertEquals(expectedTargetNumber, targetNumber);
+            int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES
+                                             + UNTRAINED_SKILL_MODIFIER
+                                             - SkillCheckUtility.getTotalAttributeScoreForSkill(new TargetRoll(),
+                  invalidAttributes, testSkillType);
+            assertEquals(expectedTargetNumber, targetNumber.getValue(), targetNumber.toString());
         }
     }
 
@@ -494,10 +517,11 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(edgeCaseSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(person, edgeCaseSkillType, 0);
+            TargetRoll targetNumber = determineTargetNumber(person, edgeCaseSkillType, 0);
 
             // Assert
-            assertEquals(UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE, targetNumber);
+            int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_ONE_LINKED_ATTRIBUTE + UNTRAINED_SKILL_MODIFIER;
+            assertEquals(expectedTargetNumber, targetNumber.getValue(), targetNumber.toString());
         }
     }
 
@@ -507,10 +531,7 @@ class SkillCheckUtilityTest {
         Campaign mockCampaign = mock(Campaign.class);
         Person person = new Person(mockCampaign);
 
-        Attributes attributes = new Attributes(DEFAULT_ATTRIBUTE_SCORE, DEFAULT_ATTRIBUTE_SCORE, 3,
-              // A valid negative modifier attribute
-              2,
-              // A valid negative modifier attribute
+        Attributes attributes = new Attributes(DEFAULT_ATTRIBUTE_SCORE, DEFAULT_ATTRIBUTE_SCORE, 1, 1,
               DEFAULT_ATTRIBUTE_SCORE, DEFAULT_ATTRIBUTE_SCORE, DEFAULT_ATTRIBUTE_SCORE);
 
         person.setATOWAttributes(attributes);
@@ -523,13 +544,14 @@ class SkillCheckUtilityTest {
             mockSkillType.when(() -> SkillType.getType("MISSING_NAME")).thenReturn(testSkillType);
 
             // Act
-            int targetNumber = SkillCheckUtility.determineTargetNumber(person, testSkillType, 0);
+            TargetRoll targetNumber = determineTargetNumber(person, testSkillType, 0);
 
             // Assert
-            int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES -
-                                             SkillCheckUtility.getTotalAttributeScoreForSkill(attributes,
+            int expectedTargetNumber = UNTRAINED_TARGET_NUMBER_TWO_LINKED_ATTRIBUTES
+                                             + UNTRAINED_SKILL_MODIFIER
+                                             - getTotalAttributeScoreForSkill(new TargetRoll(), attributes,
                                                    testSkillType);
-            assertEquals(expectedTargetNumber, targetNumber);
+            assertEquals(expectedTargetNumber, targetNumber.getValue(), targetNumber.toString());
         }
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillCheckUtilityTest.java
@@ -81,7 +81,7 @@ import org.mockito.Mockito;
 class SkillCheckUtilityTest {
     @Test
     void testIsPersonNull_EdgeDisallowed() {
-        SkillCheckUtility checkUtility = new SkillCheckUtility(null, S_GUN_MEK, 0, false);
+        SkillCheckUtility checkUtility = new SkillCheckUtility(null, S_GUN_MEK, null, 0, false, false);
 
         int expectedMarginOfSuccess = getMarginValue(DISASTROUS);
         assertEquals(expectedMarginOfSuccess, checkUtility.getMarginOfSuccess());
@@ -99,7 +99,7 @@ class SkillCheckUtilityTest {
 
     @Test
     void testIsPersonNull_EdgeAllowed() {
-        SkillCheckUtility checkUtility = new SkillCheckUtility(null, S_GUN_MEK, 0, true);
+        SkillCheckUtility checkUtility = new SkillCheckUtility(null, S_GUN_MEK, null, 0, true, false);
 
         int expectedMarginOfSuccess = getMarginValue(DISASTROUS);
         assertEquals(expectedMarginOfSuccess, checkUtility.getMarginOfSuccess());
@@ -117,7 +117,7 @@ class SkillCheckUtilityTest {
 
     @Test
     void testIsPersonNull_PerformQuickSkillCheck() {
-        boolean results = performQuickSkillCheck(null, S_GUN_MEK, 0);
+        boolean results = performQuickSkillCheck(null, S_GUN_MEK, null, 0);
         assertFalse(results);
     }
 


### PR DESCRIPTION
### Dev Notes
Without going into the nitty gritty there were a few places where we were calculating target number incorrectly. This PR addresses this, while also moving the class to use `TargetRoll` which I should have done in the first place as it allows for much better modifier tracking.