### PR TITLE
Fixed Target Number Display in Skill Check Utility

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
@@ -283,7 +283,7 @@ public class SkillCheckUtility {
               genderedReferenced,
               skillName,
               roll,
-              targetNumber);
+              targetNumber.getValue());
 
         String edgeUseText = !usedEdge ? "" : getFormattedTextAt(RESOURCE_BUNDLE, "skillCheck.rerolled", firstName);
 


### PR DESCRIPTION
- Corrected the handling of `targetNumber` by calling `.getValue()` rather than displaying the raw `TargetRoll` string.