### PR TITLE
Fix #6717: Fixed Skill Compatibility Version Check

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -994,7 +994,7 @@ public class SkillType {
             }
 
             // Skill settings from prior to this are incompatible and cannot be used, so we use the default values instead.
-            boolean preDatesSkillChanges = version.isLowerThan(new Version("0.50.05"));
+            boolean preDatesSkillChanges = version.isLowerThan(new Version("0.50.06"));
             if (preDatesSkillChanges) {
                 compatibilityHandler(skillType);
             }
@@ -1051,7 +1051,7 @@ public class SkillType {
             }
 
             // Skill settings from prior to this are incompatible and cannot be used, so we use the default values instead.
-            boolean preDatesSkillChanges = version.isLowerThan(new Version("0.50.05"));
+            boolean preDatesSkillChanges = version.isLowerThan(new Version("0.50.06"));
             if (preDatesSkillChanges) {
                 compatibilityHandler(skillType);
             }


### PR DESCRIPTION
- Raised the compatibility version check from `0.50.05` to `0.50.06` in `SkillType.java`.

Fix #6717

### Dev Notes
This fixes an issue caused by the recent version changes. The check was previously checking for saves prior to 50.05 - which would have caught any save not saved in 50.05 (specifically including Nightlies). However, with the version changes nightlies return as being from 50.05, causing the compatibility fixes to not fire. This essentially prevented any save from a nightly prior to the skill changes from being updated to the current version.

Thankfully, the only stuff covered by the compatibility handler was internal data. Had this affected user-facing stuff, it would have been unfixable. As resetting the skill in this manner will be occurring every time a save is loaded prior to 50.06, meaning any user-made changes would have been lost.