### PR TITLE
Fix #6718: Ensured Only Active Techs are Reassigned When Activating Units from a Mothballed State

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -128,7 +128,7 @@ public class MothballInfo {
      */
     public void restorePreMothballInfo(Unit unit, Campaign campaign) {
         Person tech = campaign.getPerson(techId);
-        if (tech != null) {
+        if (tech != null && tech.getStatus().isActive()) {
             unit.setTech(tech);
         }
 


### PR DESCRIPTION
Fix #6718

- Prevented inactive techs from being reassigned to units when activating a unit from a mothballed state.