### PR TITLE
Fix #6701: Added Colorblind Assistance to Refit Not Found Text

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -2612,7 +2612,7 @@ public class Refit extends Part implements IAcquisitionWork {
     @Override
     public String failToFind() {
         return ReportingUtilities.messageSurroundedBySpanWithColor(MekHQ.getMHQOptions().getFontColorNegativeHexColor(),
-              " refit kit not found.");
+              " <b>refit kit not found</b>.");
     }
 
     /**

--- a/MekHQ/src/mekhq/utilities/ReportingUtilities.java
+++ b/MekHQ/src/mekhq/utilities/ReportingUtilities.java
@@ -65,7 +65,7 @@ public class ReportingUtilities {
     /**
      * Takes the color and a message to create a full <span></span> message
      * for output to simplify the process. Uses
-     * {@link #spanOpeningWithCustomColor(String)} and {@link CLOSING_SPAN_TAG} in
+     * {@link #spanOpeningWithCustomColor(String)} and {@link #CLOSING_SPAN_TAG} in
      * the process of formation.
      *
      * @param colorToUse Color for the text within the span tag.


### PR DESCRIPTION
- Update the error message in `Refit.java` to include bold HTML tags for better visual emphasis when a refit kit is not found.
- Correct JavaDoc reference formatting for `CLOSING_SPAN_TAG` in `ReportingUtilities.java`.

Fix #6701