### PR TITLE
Fix #1914 : Refactored Contract Terms Negotiations to Be Closer to RAW

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -34,6 +34,9 @@ import static megamek.common.enums.SkillLevel.ELITE;
 import static megamek.common.enums.SkillLevel.GREEN;
 import static megamek.common.enums.SkillLevel.REGULAR;
 import static megamek.common.enums.SkillLevel.VETERAN;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.LOGISTICS;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.TRANSPORT;
 import static mekhq.campaign.mission.AtBContract.getEffectiveNumUnits;
 import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
 
@@ -627,24 +630,18 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
          * the highest admin skill, or higher negotiation if the admin
          * skills are equal.
          */
-        Person adminCommand = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_COMMAND,
-              SkillType.S_ADMIN,
-              SkillType.S_NEG);
-        Person adminTransport = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_TRANSPORT,
-              SkillType.S_ADMIN,
-              SkillType.S_NEG);
-        Person adminLogistics = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_LOGISTICS,
-              SkillType.S_ADMIN,
-              SkillType.S_NEG);
+        Person adminCommand = campaign.getSeniorAdminPerson(COMMAND);
+        Person adminTransport = campaign.getSeniorAdminPerson(TRANSPORT);
+        Person adminLogistics = campaign.getSeniorAdminPerson(LOGISTICS);
         int adminCommandExp = (adminCommand == null) ?
-                                    SkillType.EXP_ULTRA_GREEN :
-                                    adminCommand.getSkill(SkillType.S_ADMIN).getExperienceLevel();
+                                    SkillType.EXP_NONE :
+                                    adminCommand.getSkill(SkillType.S_NEG).getExperienceLevel();
         int adminTransportExp = (adminTransport == null) ?
-                                      SkillType.EXP_ULTRA_GREEN :
-                                      adminTransport.getSkill(SkillType.S_ADMIN).getExperienceLevel();
+                                      SkillType.EXP_NONE :
+                                      adminTransport.getSkill(SkillType.S_NEG).getExperienceLevel();
         int adminLogisticsExp = (adminLogistics == null) ?
-                                      SkillType.EXP_ULTRA_GREEN :
-                                      adminLogistics.getSkill(SkillType.S_ADMIN).getExperienceLevel();
+                                      SkillType.EXP_NONE :
+                                      adminLogistics.getSkill(SkillType.S_NEG).getExperienceLevel();
 
         /* Treat government units like merc units that have a retainer contract */
         if ((!campaign.getFaction().isMercenary() && !campaign.getFaction().isPirate()) ||

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -29,6 +29,9 @@
 package mekhq.gui.view;
 
 import static megamek.client.ui.WrapLayout.wordWrap;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.LOGISTICS;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.TRANSPORT;
 
 import java.awt.Cursor;
 import java.awt.GridBagConstraints;
@@ -80,6 +83,10 @@ public class ContractSummaryPanel extends JPanel {
     private JLabel txtStraightSupport;
     private JLabel txtBattleLossComp;
 
+    private Person commandNegotiator;
+    private Person transportNegotiator;
+    private Person logisticsNegotiator;
+
     private final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.ContractMarketDialog",
             MekHQ.getMHQOptions().getLocale());
     private ContractPaymentBreakdown contractPaymentBreakdown;
@@ -102,12 +109,12 @@ public class ContractSummaryPanel extends JPanel {
                 logRerolls = 1;
                 tranRerolls = 1;
             } else {
-                Person admin = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_COMMAND, SkillType.S_NEG, SkillType.S_ADMIN);
-                cmdRerolls = (admin == null || admin.getSkill(SkillType.S_NEG) == null) ? 0 : admin.getSkill(SkillType.S_NEG).getLevel();
-                admin = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_LOGISTICS, SkillType.S_NEG, SkillType.S_ADMIN);
-                logRerolls = (admin == null || admin.getSkill(SkillType.S_NEG) == null) ? 0 : admin.getSkill(SkillType.S_NEG).getLevel();
-                admin = campaign.findBestInRole(PersonnelRole.ADMINISTRATOR_TRANSPORT, SkillType.S_NEG, SkillType.S_ADMIN);
-                tranRerolls = (admin == null || admin.getSkill(SkillType.S_NEG) == null) ? 0 : admin.getSkill(SkillType.S_NEG).getLevel();
+                commandNegotiator = campaign.getSeniorAdminPerson(COMMAND);
+                cmdRerolls = (commandNegotiator == null || commandNegotiator.getSkill(SkillType.S_NEG) == null) ? 0 : 1;
+                logisticsNegotiator = campaign.getSeniorAdminPerson(LOGISTICS);
+                logRerolls = (logisticsNegotiator == null || logisticsNegotiator.getSkill(SkillType.S_NEG) == null) ? 0 : 1;
+                transportNegotiator = campaign.getSeniorAdminPerson(TRANSPORT);
+                tranRerolls = (transportNegotiator == null || transportNegotiator.getSkill(SkillType.S_NEG) == null) ? 0 : 1;
             }
         }
 
@@ -572,37 +579,45 @@ public class ContractSummaryPanel extends JPanel {
     }
 
     private void setCommandRerollButtonText(JButton rerollButton) {
-        int rerolls = (cmdRerolls - campaign.getContractMarket().getRerollsUsed(contract,
-                AbstractContractMarket.CLAUSE_COMMAND));
-        rerollButton.setText(generateRerollText(rerolls));
+        String addendum = "";
+        if (commandNegotiator != null) {
+            addendum = " (" + commandNegotiator.getFullTitle() + ')';
+        }
+        rerollButton.setText(generateRerollText(addendum));
     }
 
     private void setTransportRerollButtonText(JButton rerollButton) {
-        int rerolls = (tranRerolls - campaign.getContractMarket().getRerollsUsed(contract,
-                AbstractContractMarket.CLAUSE_TRANSPORT));
-        rerollButton.setText(generateRerollText(rerolls));
+        String addendum = "";
+        if (transportNegotiator != null) {
+            addendum = " (" + transportNegotiator.getFullTitle() + ')';
+        }
+
+        rerollButton.setText(generateRerollText(addendum));
     }
 
     private void setSalvageRerollButtonText(JButton rerollButton) {
-        int rerolls = (logRerolls - campaign.getContractMarket().getRerollsUsed(contract,
-            AbstractContractMarket.CLAUSE_SALVAGE));
-        rerollButton.setText(generateRerollText(rerolls));
+        String addendum = "";
+        if (logisticsNegotiator != null) {
+            addendum = " (" + logisticsNegotiator.getFullTitle() + ')';
+        }
+
+        rerollButton.setText(generateRerollText(addendum));
     }
 
     private void setSupportRerollButtonText(JButton rerollButton) {
-        int rerolls = (logRerolls - campaign.getContractMarket().getRerollsUsed(contract,
-                AbstractContractMarket.CLAUSE_SUPPORT));
-        rerollButton.setText(generateRerollText(rerolls));
+        setSalvageRerollButtonText(rerollButton);
     }
 
+    /**
+     * @deprecated use {@link #generateRerollText(String)} instead.}
+     */
+    @Deprecated(since = "0.50.05", forRemoval = true)
     private String generateRerollText(int rerolls) {
-        StringBuilder text = new StringBuilder(resourceMap.getString("lblRenegotiate.text"));
-        if (method != ContractMarketMethod.CAM_OPS) {
-            text.append(" (")
-                .append(rerolls)
-                .append(')');
-        }
-        return text.toString();
+        return generateRerollText("");
+    }
+
+    private String generateRerollText(String addendum) {
+        return resourceMap.getString("lblRenegotiate.text") + addendum;
     }
 
     public void refreshAmounts() {

--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -55,8 +55,6 @@ import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Contract;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.skills.SkillType;
-import mekhq.campaign.personnel.enums.PersonnelRole;
-import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.universe.Systems;
 import mekhq.gui.enums.MHQTabType;
 
@@ -613,7 +611,7 @@ public class ContractSummaryPanel extends JPanel {
      */
     @Deprecated(since = "0.50.05", forRemoval = true)
     private String generateRerollText(int rerolls) {
-        return generateRerollText("");
+        return generateRerollText("( " + rerolls + ')');
     }
 
     private String generateRerollText(String addendum) {


### PR DESCRIPTION
- More consistently use the Negotiation skill for negotiations.
- The most senior Admin characters in each roll (Command, Logistics, and Transport) are used, not necessarily the best per skills. This brings negotiation in line with other systems while also giving the player more control and predictability over who makes the rolls.
- Reduced the number of negotiation rerolls to 1 (rather than 1 per rank in Negotiation). This matches RAW.
- Labeled the renegotiation buttons with who is negotiating

Fix #1914 (by providing the player a way to directly influence who performs the negotiations)

### Dev Notes
These changes mark another step down in the power of the player and further slow progression by reducing the frequency of 'perfect' contracts. Now choosing to negotiate is a gamble, rather than players being able to negotiate their way into ideal conditions for most contracts offered.