### PR TITLE
Fix #3870: Allowed Extra Maintenance Time for Self-Crewed Units (Such as DropShips); Allowed Maintenance Time Changes for Mothballed Units

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -73,7 +73,6 @@ import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
-import mekhq.campaign.personnel.skills.RandomSkillPreferences;
 import mekhq.campaign.event.RepairStatusChangedEvent;
 import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.finances.Money;
@@ -84,6 +83,7 @@ import mekhq.campaign.parts.Refit;
 import mekhq.campaign.parts.enums.PartQuality;
 import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.RandomSkillPreferences;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.actions.ActivateUnitAction;
 import mekhq.campaign.unit.actions.CancelMothballUnitAction;
@@ -907,9 +907,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
             // if we're using maintenance and have selected something that requires
             // maintenance and
             // isn't mothballed or being mothballed
-            if (gui.getCampaign().getCampaignOptions().isCheckMaintenance() &&
-                      (maintenanceTime > 0) &&
-                      Stream.of(units).anyMatch(u -> !u.isMothballing() && !u.isMothballed())) {
+            if (gui.getCampaign().getCampaignOptions().isCheckMaintenance()) {
                 menuItem = new JMenu(resources.getString("maintenanceExtraTime.text"));
 
                 for (int x = 1; x <= 4; x++) {
@@ -917,7 +915,7 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
 
                     // if we've got just one unit selected,
                     // have the courtesy to show the multiplier if relevant
-                    if (oneSelected && (unit.getMaintenanceMultiplier() == x) && !unit.isSelfCrewed()) {
+                    if (oneSelected && (unit.getMaintenanceMultiplier() == x)) {
                         maintenanceMultiplierItem.setSelected(true);
                     }
 


### PR DESCRIPTION
- Removed conditional that was (potentially unintentionally) blocking extra-maintenance time picking for Large Vessels.
- Allowed extra maintenance time to be set on Mothballed Units

Fix #3870