### PR TITLE
Added Seed Force to Log During Scenario Generation

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -3308,7 +3308,11 @@ public class AtBDynamicScenarioFactory {
         for (int forceID : scenario.getForceIDs()) {
             ScenarioForceTemplate forceTemplate = scenario.getPlayerForceTemplates().get(forceID);
             if (forceTemplate != null && forceTemplate.getContributesToBV()) {
-                bvBudget += campaign.getForce(forceID).getTotalBV(campaign, forceStandardBattleValue);
+                Force force = campaign.getForce(forceID);
+                if (force != null) {
+                    bvBudget += campaign.getForce(forceID).getTotalBV(campaign, forceStandardBattleValue);
+                    logger.info("Forced BV contribution for {}: {}", force.getName(), bvBudget);
+                }
             }
         }
 


### PR DESCRIPTION
- Resolved potential `NullPointerException` by adding a null check for `Force` objects during BV calculation within `AtBDynamicScenarioFactory`.
- Added detailed logging to capture BV contributions for individual forces.

![image](https://github.com/user-attachments/assets/d3ee4945-2cbf-4eaa-9393-0b8fcf4eacc6)
