### PR TITLE
Remove Redundant Logging in SkillType Updates

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -1168,20 +1168,8 @@ public class SkillType {
         }
 
         skillType.subType = temporarySkillType.getSubType();
-        logger.info("SkillType {} has been updated to sub type {}",
-              skillType.getName(),
-              temporarySkillType.getSubType());
-
         skillType.firstAttribute = temporarySkillType.getFirstAttribute();
-        logger.info("SkillType {} has been updated to first attribute {}",
-              skillType.getName(),
-              temporarySkillType.getFirstAttribute());
-
         skillType.secondAttribute = temporarySkillType.getSecondAttribute();
-        logger.info("SkillType {} has been updated to second attribute {}",
-              skillType.getName(),
-              temporarySkillType.getSecondAttribute());
-
         skillType.countUp = temporarySkillType.isCountUp();
     }
 


### PR DESCRIPTION
- Stopped skill type compatibility handler spamming the log whenever a save is loaded.