### PR TITLE
Fix #4014: Improve OmniPod handling and UI visibility in Repair Bay Acquisitions Dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AcquisitionsDialog.java
@@ -100,7 +100,7 @@ public class AcquisitionsDialog extends JDialog {
 
         JPanel pnlMain = new JPanel();
         pnlMain.setLayout(new GridBagLayout());
- 
+
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.fill    = GridBagConstraints.BOTH;
         gridBagConstraints.anchor  = GridBagConstraints.NORTHWEST;
@@ -362,7 +362,7 @@ public class AcquisitionsDialog extends JDialog {
                                        countModifier +
                                        " on order";
 
-                if (partCountInfo.getOmniPodCount() > 0) {
+                if (partCountInfo.getOmniPodCount() > 0 && part.isOmniPoddable()) {
                     inventoryInfo += ", " + partCountInfo.getOmniPodCount() + countModifier + " OmniPod";
                 }
 
@@ -549,7 +549,9 @@ public class AcquisitionsDialog extends JDialog {
             btnDepod = new JButton("Remove One From Pod");
             btnDepod.setToolTipText("Remove replacement from pod");
             btnDepod.setName("btnDepod");
-            btnDepod.setVisible(partCountInfo.getOmniPodCount() > 0);
+            btnDepod.setVisible(partCountInfo.getOmniPodCount() > 0 &&
+                                      part.getMissingPart() != null &&
+                                      part.isOmniPoddable());
             btnDepod.addActionListener(ev -> {
                 MissingPart podded = part.getMissingPart();
                 podded.setOmniPodded(true);


### PR DESCRIPTION
- Restrict OmniPod-related logic to only apply when parts are OmniPoddable.
- Ensure the "Remove One From Pod" button is only visible if:
    1. OmniPod count > 0,
    2. A missing part exists, and
    3. The part is OmniPoddable.

Fix #4014