### PR TITLE
Fix #4780: Added Minimum Height to Tech List in Mass Mothball

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/MassMothballDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MassMothballDialog.java
@@ -205,8 +205,8 @@ public class MassMothballDialog extends JDialog implements ActionListener, ListS
 
         JScrollPane techListPane = new JScrollPaneWithSpeed();
         techListPane.setViewportView(techList);
-        techListPane.setMaximumSize(new Dimension(200, 100));
-        techListPane.setPreferredSize(new Dimension(200, 50));
+        techListPane.setMaximumSize(new Dimension(200, 400));
+        techListPane.setMinimumSize(new Dimension(200, 150));
 
         contentPanel.add(techListPane, gbc);
         techListsByUnitType.put(unitType, techList);


### PR DESCRIPTION
- Increased maximum height from 100px to 400px.
- Set a new minimum height of 150px (previously not defined).

Fix #4780