### PR TITLE
Fix #6750: Corrected Destination Edges

### DIFF
--- a/MekHQ/data/scenariotemplates/Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Breakthrough.xml
@@ -34,7 +34,7 @@ Be advised: the enemy will control the field when this is over. Move fast, strik
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -102,7 +102,7 @@ We will control the field at the conclusion of the battle. This means you have f
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>1</forceAlignment>
                 <forceMultiplier>0.5</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Interdiction.xml
@@ -94,7 +94,7 @@ No distractions. No delays. No mercy. Execute the raid, cripple their supply lin
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>0.5</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Convoy Raid.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Raid.xml
@@ -94,7 +94,7 @@ The more convoy units that survive, the greater the spoils. Disabling transports
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>0.5</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -102,7 +102,7 @@ We will control the field at the end of the battle, giving you full authority to
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>1</forceAlignment>
                 <forceMultiplier>0.5</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Diversion Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Diversion Engagement.xml
@@ -34,7 +34,7 @@ Be advised: the enemy will control the field at the end of the engagement. There
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - Low-Atmosphere.xml
@@ -37,7 +37,7 @@ We will control the battlefield at the end of this engagement, ensuring that any
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -68,7 +68,7 @@ We will control the battlefield at the end of this engagement, ensuring that any
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player - VTOL.xml
@@ -37,7 +37,7 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense - Player.xml
@@ -37,7 +37,7 @@ We will control the battlefield at the end of the engagement, ensuring that any 
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
+++ b/MekHQ/data/scenariotemplates/Emergency Convoy Defense.xml
@@ -136,7 +136,7 @@ We will control the battlefield at the end of this engagement, allowing us to re
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Frontline Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Breakthrough.xml
@@ -34,7 +34,7 @@ The enemy will control the battlefield once the engagement concludes, preventing
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Frontline Disruption.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Disruption.xml
@@ -66,7 +66,7 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.5</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Intercept Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Intercept Engagement.xml
@@ -34,7 +34,7 @@ The enemy will control the battlefield at the end of the engagement, meaning no 
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Interception Defense.xml
+++ b/MekHQ/data/scenariotemplates/Interception Defense.xml
@@ -67,7 +67,7 @@ We will control the battlefield at the end of the engagement, securing any remai
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.5</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Assault.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Assault.xml
@@ -64,7 +64,7 @@ We will control the field at the end of the engagement, ensuring that any wrecka
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
@@ -36,7 +36,7 @@ The victor will control the battlefield at the end of the engagement, ensuring w
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -98,7 +98,7 @@ The victor will control the battlefield at the end of the engagement, ensuring w
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones />
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>1</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
@@ -34,7 +34,7 @@ As you will be pushing into enemy territory, we will be unable to secure the bat
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Space Blockade Run.xml
+++ b/MekHQ/data/scenariotemplates/Space Blockade Run.xml
@@ -36,7 +36,7 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -65,7 +65,7 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones />
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>1</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
+++ b/MekHQ/data/scenariotemplates/Space DropShip Intercept.xml
@@ -64,7 +64,7 @@ We will control the battlefield at the end of the engagement, guaranteeing any w
                 <contributesToUnitCount>false</contributesToUnitCount>
                 <deployOffboard>false</deployOffboard>
                 <deploymentZones />
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>
@@ -99,7 +99,7 @@ We will control the battlefield at the end of the engagement, guaranteeing any w
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>

--- a/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
+++ b/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
@@ -36,7 +36,7 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <deploymentZones>
                     <deploymentZone>6</deploymentZone>
                 </deploymentZones>
-                <destinationZone>2</destinationZone>
+                <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>0</forceAlignment>
                 <forceMultiplier>1.0</forceMultiplier>


### PR DESCRIPTION
- Corrected destination edge to use static for 'opposite' and not 'north' board edge.

Fix #6750