### PR TITLE
Issue #6753: Check if `Game` is null when replacing a Unit's Entity & Transfer C3 During Refit if Possible

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -41,6 +41,7 @@ import megamek.common.annotations.Nullable;
 import megamek.common.equipment.MiscMounted;
 import megamek.common.loaders.BLKFile;
 import megamek.common.loaders.EntityLoadingException;
+import megamek.common.util.C3Util;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestEntity;
@@ -1691,7 +1692,7 @@ public class Refit extends Part implements IAcquisitionWork {
             part.updateConditionFromPart();
         }
 
-        oldUnit.getEntity().setC3UUIDAsString(oldEntity.getC3UUIDAsString());
+        C3Util.copyC3Networks(oldEntity, oldUnit.getEntity());
         oldUnit.getEntity().setExternalIdAsString(oldUnit.getId().toString());
         getCampaign().clearGameData(oldUnit.getEntity());
         getCampaign().reloadGameEntities();

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -469,7 +469,9 @@ public class Unit implements ITechnology {
             en.setDuplicateMarker(this.entity.getDuplicateMarker());
             en.generateShortName();
             en.generateDisplayName();
-            C3Util.copyC3Networks(this.entity, en);
+            if (en.getGame() != null) {
+                C3Util.copyC3Networks(this.entity, en);
+            }
         }
         this.entity = en;
     }


### PR DESCRIPTION
An `Entity` needs to be in a game to copy its C3. If it's not a `Game`, let's not copy its C3 network. Fortunately, when refitting, we can still restore the C3 info later once the new entity is added to the game. Neat!