### PR TITLE
Fixed Gender Generation

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1133,12 +1133,11 @@ lblRandomMarriageAgeRange.tooltip=This plus/minus age forms the possible range o
   \ in the forming of a random marriage.
 # createPercentageRandomMarriagePanel
 lblPercentageRandomMarriagePanel.text=Marriage Dice
-lblRandomMarriageOppositeSexDiceSize.text=Opposite Sex Marriage Chance \u2728: 1 in
+lblRandomMarriageOppositeSexDiceSize.text=Marriage Chance \u2728: 1 in
 lblRandomMarriageOppositeSexDiceSize.tooltip=This determines the number of sides on the die rolled\
   \ to determine whether a character gets married. Marriage occurs on a roll of 1.
 lblRandomSameSexMarriageDiceSize.text=Same-Sex Marriage Chance \u26A0 \u2728: 1 in
-lblRandomSameSexMarriageDiceSize.tooltip=This determines the number of sides on the die rolled to\
-  \ determine whether a marriage is same-sex. Same-sex marriage occurs on a roll of 1.\
+lblRandomSameSexMarriageDiceSize.tooltip=This is the likelihood a random marriage will be same-sex.\
   <br>\
   <br>Set this value to 0 to disable same-sex marriages.\
   <br>\

--- a/MekHQ/src/mekhq/campaign/personnel/generator/AbstractPersonnelGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/AbstractPersonnelGenerator.java
@@ -46,6 +46,7 @@ import mekhq.campaign.personnel.skills.SkillType;
  * Represents a class which can generate new {@link Person} objects for a {@link Campaign}.
  */
 public abstract class AbstractPersonnelGenerator {
+
     private RandomNameGenerator randomNameGenerator = RandomNameGenerator.getInstance();
 
     private RandomSkillPreferences rSkillPrefs = new RandomSkillPreferences();
@@ -140,10 +141,14 @@ public abstract class AbstractPersonnelGenerator {
     protected void generateNameAndGender(Campaign campaign, Person person, Gender gender) {
         int nonBinaryDiceSize = campaign.getCampaignOptions().getNonBinaryDiceSize();
 
-        if ((gender == Gender.RANDOMIZE) && (nonBinaryDiceSize > 0) && (Compute.randomInt(nonBinaryDiceSize) == 0)) {
-            person.setGender(RandomGenderGenerator.generateOther());
+        if (gender != Gender.RANDOMIZE) {
+            person.setGender(gender);
         } else {
-            person.setGender(RandomGenderGenerator.generate());
+            if (nonBinaryDiceSize > 0 && Compute.randomInt(nonBinaryDiceSize) == 0) {
+                person.setGender(RandomGenderGenerator.generateOther());
+            } else {
+                person.setGender(RandomGenderGenerator.generate());
+            }
         }
 
         String factionCode = campaign.getCampaignOptions().isUseOriginFactionForNames() ?

--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
@@ -53,6 +53,7 @@ import mekhq.campaign.universe.selectors.planetSelectors.AbstractPlanetSelector;
  */
 public class DefaultPersonnelGenerator extends AbstractPersonnelGenerator {
 
+
     private final AbstractFactionSelector factionSelector;
     private final AbstractPlanetSelector planetSelector;
 

--- a/MekHQ/unittests/mekhq/campaign/personnel/marriage/AbstractMarriageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/marriage/AbstractMarriageTest.java
@@ -27,6 +27,18 @@
  */
 package mekhq.campaign.personnel.marriage;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import megamek.common.enums.Gender;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
@@ -42,14 +54,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(value = MockitoExtension.class)
 public class AbstractMarriageTest {
@@ -503,7 +507,7 @@ public class AbstractMarriageTest {
         final List<Person> mockPersonnel = new ArrayList<>();
         mockPersonnel.add(mockMale);
         mockPersonnel.add(mockFemale);
-        when(mockCampaign.getActivePersonnel()).thenReturn(mockPersonnel);
+        when(mockCampaign.getActivePersonnel(false)).thenReturn(mockPersonnel);
 
         final Person mockPerson = mock(Person.class);
         when(mockPerson.getGender()).thenReturn(Gender.FEMALE);


### PR DESCRIPTION
The logic used to generate a character's gender was faulty, resulting in characters being generated with incorrect genders.

This was highlighted by a user who wanted to disable same-sex marriage, but found same-sex marriages were still occurring.

While I was addressing this I also did some like refactoring of marriage gender generation and clarified the language used for the marriage chance campaign options. As those were a source of frequent confusion.