### PR TITLE
Fixed Exception When Adopting Child with Existing Parents (Sentry)

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -119,6 +119,7 @@ import mekhq.campaign.personnel.enums.ROMDesignation;
 import mekhq.campaign.personnel.enums.SplittingSurnameStyle;
 import mekhq.campaign.personnel.enums.education.EducationLevel;
 import mekhq.campaign.personnel.enums.education.EducationStage;
+import mekhq.campaign.personnel.familyTree.Genealogy;
 import mekhq.campaign.personnel.generator.AbstractSkillGenerator;
 import mekhq.campaign.personnel.generator.DefaultSkillGenerator;
 import mekhq.campaign.personnel.generator.SingleSpecialAbilityGenerator;
@@ -869,26 +870,48 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_ADOPTION: {
-                Person orphan = gui.getCampaign().getPerson(UUID.fromString(data[1]));
+                Person orphan = getCampaign().getPerson(UUID.fromString(data[1]));
+                if (orphan == null) {
+                    logger.error("Could not find orphaned person with UUID {}. No changes will be made.", data[1]);
+                    return;
+                }
+
+                Genealogy orphanGenealogy = orphan.getGenealogy();
+                if (orphanGenealogy == null) {
+                    logger.error("Could not find orphaned person's genealogy. No changes will be made.");
+                    return;
+                }
 
                 // clear the old parents
-                List<Person> originalParents = orphan.getGenealogy().getParents();
+                List<Person> originalParents = orphanGenealogy.getParents();
                 for (Person parent : originalParents) {
-                    orphan.getGenealogy().removeFamilyMember(FamilialRelationshipType.PARENT, parent);
+                    orphanGenealogy.removeFamilyMember(FamilialRelationshipType.PARENT, parent);
                 }
 
                 // add the new
                 for (Person person : people) {
-                    person.getGenealogy().addFamilyMember(FamilialRelationshipType.CHILD, orphan);
-                    orphan.getGenealogy().addFamilyMember(FamilialRelationshipType.PARENT, person);
+                    Genealogy personGenealogy = person.getGenealogy();
+                    if (personGenealogy == null) {
+                        logger.error("Could not find {}'s genealogy. No changes will be made.", person.getFullTitle());
+                        continue;
+                    }
+
+                    personGenealogy.addFamilyMember(FamilialRelationshipType.CHILD, orphan);
+                    orphanGenealogy.addFamilyMember(FamilialRelationshipType.PARENT, person);
 
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
 
-                    if (person.getGenealogy().hasSpouse()) {
-                        Person spouse = person.getGenealogy().getSpouse();
+                    if (personGenealogy.hasSpouse()) {
+                        Person spouse = personGenealogy.getSpouse();
+                        Genealogy spouseGenealogy = spouse.getGenealogy();
+                        if (spouseGenealogy == null) {
+                            logger.error("Could not find {}'s (spouse) genealogy. No changes will be made.",
+                                  spouse.getFullTitle());
+                            continue;
+                        }
 
                         spouse.getGenealogy().addFamilyMember(FamilialRelationshipType.CHILD, orphan);
-                        orphan.getGenealogy().addFamilyMember(FamilialRelationshipType.PARENT, spouse);
+                        orphanGenealogy.addFamilyMember(FamilialRelationshipType.PARENT, spouse);
 
                         MekHQ.triggerEvent(new PersonChangedEvent(spouse));
                     }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -869,10 +869,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_ADOPTION: {
-                Person orphan = getCampaign().getPerson(UUID.fromString(data[1]));
+                Person orphan = gui.getCampaign().getPerson(UUID.fromString(data[1]));
 
                 // clear the old parents
-                for (Person parent : orphan.getGenealogy().getParents()) {
+                List<Person> originalParents = orphan.getGenealogy().getParents();
+                for (Person parent : originalParents) {
                     orphan.getGenealogy().removeFamilyMember(FamilialRelationshipType.PARENT, parent);
                 }
 


### PR DESCRIPTION
- Resolved an issue where adopting a child with existing parents triggered a `ConcurrentModificationException` by creating a new list and iterating through that instead of the raw genealogy object.

Fix [Sentry Report](https://sentry.tapenvy.us/organizations/tapenvyus/issues/4577/events/529935dd7a414abf802548522e7b1bb3/)