### PR TITLE
Fixed Defection Logic for Prisoners

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/CapturePrisoners.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/CapturePrisoners.java
@@ -236,7 +236,7 @@ public class CapturePrisoners {
         }
 
         // Attempt defection
-        if (prisoner.getPrisonerStatus().isPrisoner() && !campaignFaction.isClan()) {
+        if (!campaignFaction.isClan()) {
             int defectionChance = determineDefectionChance(prisoner, true);
 
             if (randomInt(defectionChance) == 0) {

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/CapturePrisoners.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/CapturePrisoners.java
@@ -236,19 +236,21 @@ public class CapturePrisoners {
         }
 
         // Attempt defection
-        int defectionChance = determineDefectionChance(prisoner, true);
+        if (prisoner.getPrisonerStatus().isPrisoner() && !campaignFaction.isClan()) {
+            int defectionChance = determineDefectionChance(prisoner, true);
 
-        if (randomInt(defectionChance) == 0) {
-            if (prisoner.isClanPersonnel()) {
-                prisoner.setPrisonerStatus(campaign, BECOMING_BONDSMAN, true);
+            if (randomInt(defectionChance) == 0) {
+                if (prisoner.isClanPersonnel()) {
+                    prisoner.setPrisonerStatus(campaign, BECOMING_BONDSMAN, true);
 
-                LocalDate today = campaign.getLocalDate();
-                prisoner.setBecomingBondsmanEndDate(today.plusWeeks(d6(1)));
-            } else {
-                prisoner.setPrisonerStatus(campaign, PRISONER_DEFECTOR, false);
+                    LocalDate today = campaign.getLocalDate();
+                    prisoner.setBecomingBondsmanEndDate(today.plusWeeks(d6(1)));
+                } else {
+                    prisoner.setPrisonerStatus(campaign, PRISONER_DEFECTOR, false);
+                }
+
+                new DefectionOffer(campaign, prisoner, prisoner.isClanPersonnel());
             }
-
-            new DefectionOffer(campaign, prisoner, prisoner.isClanPersonnel());
         }
 
         handlePostCapture(prisoner, prisoner.getPrisonerStatus());


### PR DESCRIPTION
- Added a check to ensure defection logic is only applied to prisoners with valid prisoner status.

### Dev Notes
Clan campaigns do not use 'defections' they take Bondsmen, instead.