### PR TITLE
Fix #6758: Fixed Ransom Events Not Ransoming Prisoners

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerRansomEventDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/randomEvents/prisonerDialogs/PrisonerRansomEventDialog.java
@@ -67,10 +67,7 @@ public class PrisonerRansomEventDialog extends ImmersiveDialogCore {
               null,
               false,
               null,
-              null,
-              false);
-
-        setAlwaysOnTop(true);
+              null, true);
     }
 
     /**


### PR DESCRIPTION
- Adjusted dialog to modal to ensure the dialog is resolved before we check for user response.

Fix #6758