### PR TITLE
Added Missing 'Has Documentation' Icon to Unit Market Options in Campaign Options IIC

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1422,7 +1422,7 @@ lblUsePersonnelHireHiringHallOnly.tooltip=Enabling this option disables the pers
 # createPersonnelMarketRemovalOptionsPanel
 lblPersonnelMarketRemovalOptionsPanel.text=Removal Target Numbers
 # createUnitMarketTab
-lblUnitMarketTab.text=Unit Market Options \u270E
+lblUnitMarketTab.text=Unit Market Options \u270E \u2318
 lblUnitMarketMethod.text=Market Method
 lblUnitMarketMethod.tooltip=This is the method of unit market used to generate new units for the\
   \ market.


### PR DESCRIPTION
- Updated the label `lblUnitMarketTab.text` in `CampaignOptionsDialog.properties` to include an additional Unicode character (`\u2318`).