### PR TITLE
Slightly Adjusted Tooltip Initial Delay Setting

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -226,7 +226,7 @@ public class MekHQ implements GameListener {
      */
     private static void setTooltipSettings() {
         ToolTipManager tooltipManager = ToolTipManager.sharedInstance();
-        tooltipManager.setInitialDelay(0);
+        tooltipManager.setInitialDelay(100);
         tooltipManager.setDismissDelay(Integer.MAX_VALUE);
         tooltipManager.setReshowDelay(0);
     }


### PR DESCRIPTION
- Changed the tooltip initial delay in `MekHQ.java` from `0` to `100` milliseconds for improved play feel.