### PR TITLE
Fixed Aging Effects Applying Even When Disabled

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -1465,14 +1465,11 @@ public class BiographyTab {
         RandomGenderGenerator.setPercentFemale(sldGender.getValue());
         options.setNonBinaryDiceSize((int) spnNonBinaryDiceSize.getValue());
         options.setFamilyDisplayLevel(comboFamilyDisplayLevel.getSelectedItem());
-        if (options.isUseAgeEffects() != chkUseAgeEffects.isSelected()) {
-            for (Person person : campaign.getPersonnel()) {
-
-                if (chkUseAgeEffects.isSelected()) {
-                    updateAllSkillAgeModifiers(generalTab.getDate(), person);
-                } else {
-                    clearAllAgeModifiers(person);
-                }
+        for (Person person : campaign.getPersonnel()) {
+            if (chkUseAgeEffects.isSelected()) {
+                updateAllSkillAgeModifiers(generalTab.getDate(), person);
+            } else {
+                clearAllAgeModifiers(person);
             }
         }
         options.setUseAgeEffects(chkUseAgeEffects.isSelected());

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1586,9 +1586,12 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
                 int level = (Integer) skillLevels.get(type).getModel().getValue();
                 int bonus = (Integer) skillBonus.get(type).getModel().getValue();
                 SkillType skillType = SkillType.getType(type);
-                int ageModifier = getAgeModifier(milestone,
-                      skillType.getFirstAttribute(),
-                      skillType.getSecondAttribute());
+                int ageModifier = 0;
+                if (campaign.getCampaignOptions().isUseAgeEffects()) {
+                    ageModifier = getAgeModifier(milestone,
+                          skillType.getFirstAttribute(),
+                          skillType.getSecondAttribute());
+                }
                 person.addSkill(type, level, bonus, ageModifier);
             } else {
                 person.removeSkill(type);
@@ -1738,9 +1741,12 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
 
         int level = (Integer) skillLevels.get(type).getModel().getValue();
         int bonus = (Integer) skillBonus.get(type).getModel().getValue();
-        int ageModifier = getAgeModifier(getMilestone(person.getAge(campaign.getLocalDate())),
-              skillType.getFirstAttribute(),
-              skillType.getSecondAttribute());
+        int ageModifier = 0;
+        if (campaign.getCampaignOptions().isUseAgeEffects()) {
+            ageModifier = getAgeModifier(getMilestone(person.getAge(campaign.getLocalDate())),
+                  skillType.getFirstAttribute(),
+                  skillType.getSecondAttribute());
+        }
 
         if (skillType.isCountUp()) {
             int target = min(getCountUpMaxValue(), skillType.getTarget() + level + bonus + ageModifier);


### PR DESCRIPTION
- Refactored logic to always process age effect updates for all personnel when closing campaign options.
- Ensured age modifiers for skills are only applied when the "Use Age Effects" campaign option is enabled.