### PR TITLE
Updated Rank System XML Version to 0.50.06

### DIFF
--- a/MekHQ/userdata/data/universe/ranks.xml
+++ b/MekHQ/userdata/data/universe/ranks.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rankSystems version="0.50.05">
+<rankSystems version="0.50.06">
 </rankSystems>


### PR DESCRIPTION
- Updated the XML version in `ranks.xml` from `0.50.05` to `0.50.06`.
- This stops IDEA whining at us every PR.