### PR TITLE
Fix #6771: Loosened Government Force Command Rights Re-Roll Restrictions

### DIFF
--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -559,10 +559,7 @@ public class ContractSummaryPanel extends JPanel {
 
     private boolean hasCommandRerolls() {
         // Only allow command clause rerolls for mercenaries and pirates; house units are always integrated
-        return allowRerolls
-                && (campaign.getFaction().isMercenary()
-                    || campaign.getFaction().isPirate())
-                && (campaign.getContractMarket().getRerollsUsed(contract,
+        return allowRerolls && (campaign.getContractMarket().getRerollsUsed(contract,
                     AbstractContractMarket.CLAUSE_COMMAND) < cmdRerolls);
     }
 


### PR DESCRIPTION
- Removed restrictions for government forces when determining command clause reroll eligibility.

Fix #6771