### PR TITLE
Fix #6778: Prisoners Are Now Correctly Released When Enemy Routs

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -652,11 +652,11 @@ public class AtBContract extends Contract {
                 routEnd = today.plusMonths(max(1, d6() - 3)).minusDays(1);
 
                 PrisonerMissionEndEvent prisoners = new PrisonerMissionEndEvent(campaign, this);
-                if (campaign.getFriendlyPrisoners().isEmpty()) {
+                if (!campaign.getFriendlyPrisoners().isEmpty()) {
                     prisoners.handlePrisoners(true, true);
                 }
 
-                if (campaign.getCurrentPrisoners().isEmpty()) {
+                if (!campaign.getCurrentPrisoners().isEmpty()) {
                     prisoners.handlePrisoners(true, false);
                 }
 


### PR DESCRIPTION
Fix #6778

### Dev Notes
When the enemy routs all held prisoners are meant to be ransomed or released. However, we were only triggering those events if there were _no_ prisoners, not when there _were_ prisoners.