### PR TITLE
Fix #6678, #6679, #6681, #6686: Added 7 New Unofficial SPAs for Admin Characters

### DIFF
--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -462,6 +462,26 @@
 
     <!-- Misc SPA -->
     <ability>
+        <lookupName>admin_coordinator</lookupName>
+        <displayName>Coordinator (Unofficial)</displayName>
+        <desc><![CDATA[This character is exceptionally skilled at liaising with allied forces, ensuring reinforcements arrive where they're needed.
+
+If this character is the senior Admin/Command character, the reinforcement target number is reduced by 1.]]></desc>
+        <xpCost>100</xpCost>
+        <weight>1</weight>
+        <skillPrereq/>
+    </ability>
+    <ability>
+        <lookupName>admin_logistician</lookupName>
+        <displayName>Logistician (Unofficial)</displayName>
+        <desc><![CDATA[This character is an expert at managing interstellar supply lines.
+
+Parts procured by this character have their delivery time reduced by 10%]]></desc>
+        <xpCost>50</xpCost>
+        <weight>1</weight>
+        <skillPrereq/>
+    </ability>
+    <ability>
         <lookupName>admin_mediator</lookupName>
         <displayName>Mediator (Unofficial)</displayName>
         <desc><![CDATA[Whether with a smoothing word or a calming presence, this character knows how to solve disputes.

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -462,6 +462,14 @@
 
     <!-- Misc SPA -->
     <ability>
+        <lookupName>admin_scrounge</lookupName>
+        <displayName>Scrounge (Unofficial)</displayName>
+        <desc><![CDATA[The character can make one additional procurement attempt per day.]]></desc>
+        <xpCost>200</xpCost>
+        <weight>1</weight>
+        <skillPrereq/>
+    </ability>
+    <ability>
         <lookupName>atow_alternate_id</lookupName>
         <displayName>Alternate ID (ATOW)</displayName>
         <desc><![CDATA[A low Reputation trait infers a penalty to Negotiation, Streetwise and Protocols skill checks. This SPA reduces that penalty by 2.

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -462,6 +462,42 @@
 
     <!-- Misc SPA -->
     <ability>
+        <lookupName>admin_interstellar_negotiator</lookupName>
+        <displayName>Interstellar Negotiator (Unofficial)</displayName>
+        <desc><![CDATA[No matter who's in charge, this character always has a way of bringing down the price.
+
+If this character is the senior-most Admin/Transport character, the cost of interstellar travel is reduced by 15%]]></desc>
+        <xpCost>100</xpCost>
+        <weight>1</weight>
+        <skillPrereq>
+            <skill>Administration::Veteran</skill>
+        </skillPrereq>
+    </ability>
+    <ability>
+        <lookupName>admin_networker</lookupName>
+        <displayName>Networker (Unofficial)</displayName>
+        <desc><![CDATA[This character knows people in high places.
+
+If this character is the senior-most Admin/Command character, the number of contracts offered each month is increased by 1 (may still be 0).]]></desc>
+        <xpCost>200</xpCost>
+        <weight>1</weight>
+        <skillPrereq>
+            <skill>Administration::Elite</skill>
+        </skillPrereq>
+    </ability>
+    <ability>
+        <lookupName>admin_tetris_master</lookupName>
+        <displayName>Tetris Master (Unofficial)</displayName>
+        <desc><![CDATA[This character has mastered the subtle art of stacking cargo boxes.
+
+The campaign's cargo capacity is increased by 5% per character with this SPA.]]></desc>
+        <xpCost>100</xpCost>
+        <weight>1</weight>
+        <skillPrereq>
+            <skill>Administration::Regular</skill>
+        </skillPrereq>
+    </ability>
+    <ability>
         <lookupName>admin_coordinator</lookupName>
         <displayName>Coordinator (Unofficial)</displayName>
         <desc><![CDATA[This character is exceptionally skilled at liaising with allied forces, ensuring reinforcements arrive where they're needed.
@@ -469,7 +505,9 @@
 If this character is the senior Admin/Command character, the reinforcement target number is reduced by 1.]]></desc>
         <xpCost>100</xpCost>
         <weight>1</weight>
-        <skillPrereq/>
+        <skillPrereq>
+            <skill>Administration::Veteran</skill>
+        </skillPrereq>
     </ability>
     <ability>
         <lookupName>admin_logistician</lookupName>
@@ -479,7 +517,9 @@ If this character is the senior Admin/Command character, the reinforcement targe
 Parts procured by this character have their delivery time reduced by 10%]]></desc>
         <xpCost>50</xpCost>
         <weight>1</weight>
-        <skillPrereq/>
+        <skillPrereq>
+            <skill>Administration::Veteran</skill>
+        </skillPrereq>
     </ability>
     <ability>
         <lookupName>admin_mediator</lookupName>
@@ -489,7 +529,9 @@ Parts procured by this character have their delivery time reduced by 10%]]></des
 This character's Administration skill is increased by 1 when calculating the campaign's Admin Capacity.]]></desc>
         <xpCost>50</xpCost>
         <weight>1</weight>
-        <skillPrereq/>
+        <skillPrereq>
+            <skill>Administration::Regular</skill>
+        </skillPrereq>
     </ability>
     <ability>
         <lookupName>admin_scrounge</lookupName>
@@ -499,7 +541,9 @@ This character's Administration skill is increased by 1 when calculating the cam
 They can make one additional procurement attempt per day.]]></desc>
         <xpCost>200</xpCost>
         <weight>1</weight>
-        <skillPrereq/>
+        <skillPrereq>
+            <skill>Administration::Elite</skill>
+        </skillPrereq>
     </ability>
     <ability>
         <lookupName>atow_alternate_id</lookupName>

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -462,9 +462,21 @@
 
     <!-- Misc SPA -->
     <ability>
+        <lookupName>admin_mediator</lookupName>
+        <displayName>Mediator (Unofficial)</displayName>
+        <desc><![CDATA[Whether with a smoothing word or a calming presence, this character knows how to solve disputes.
+
+This character's Administration skill is increased by 1 when calculating the campaign's Admin Capacity.]]></desc>
+        <xpCost>50</xpCost>
+        <weight>1</weight>
+        <skillPrereq/>
+    </ability>
+    <ability>
         <lookupName>admin_scrounge</lookupName>
         <displayName>Scrounge (Unofficial)</displayName>
-        <desc><![CDATA[The character can make one additional procurement attempt per day.]]></desc>
+        <desc><![CDATA[The character is adept at finding resources in places nobody else would think to look.
+
+They can make one additional procurement attempt per day.]]></desc>
         <xpCost>200</xpCost>
         <weight>1</weight>
         <skillPrereq/>

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -52,6 +52,7 @@ import static mekhq.campaign.mission.resupplyAndCaches.Resupply.isProhibitedUnit
 import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.processAbandonedConvoy;
 import static mekhq.campaign.parts.enums.PartQuality.QUALITY_A;
 import static mekhq.campaign.personnel.DiscretionarySpending.performDiscretionarySpending;
+import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_INTERSTELLAR_NEGOTIATOR;
 import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_LOGISTICIAN;
 import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_SCROUNGE;
 import static mekhq.campaign.personnel.backgrounds.BackgroundsController.randomMercenaryCompanyNameGenerator;
@@ -7157,6 +7158,14 @@ public class Campaign implements ITechManager {
             }
 
             totalCost = totalCost.plus(ownDropshipCost).plus(ownJumpshipCost);
+        }
+
+        Person negotiator = getSeniorAdminPerson(AdministratorSpecialization.TRANSPORT);
+        if (negotiator != null) {
+            PersonnelOptions options = negotiator.getOptions();
+            if (options.booleanOption(ADMIN_INTERSTELLAR_NEGOTIATOR) && totalCost.isPositive()) {
+                totalCost = totalCost.multipliedBy(0.15);
+            }
         }
 
         return totalCost;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3230,7 +3230,7 @@ public class Campaign implements ITechManager {
                 int effectiveMaxAcquisitions = defaultMaxAcquisitions;
 
                 PersonnelOptions options = person.getOptions();
-                if (options.getOption(ADMIN_SCROUNGE).booleanValue()) {
+                if (options.booleanOption(ADMIN_SCROUNGE)) {
                     effectiveMaxAcquisitions++;
                 }
 
@@ -3252,7 +3252,7 @@ public class Campaign implements ITechManager {
                 int effectiveMaxAcquisitions = defaultMaxAcquisitions;
 
                 PersonnelOptions options = person.getOptions();
-                if (options.getOption(ADMIN_SCROUNGE).booleanValue()) {
+                if (options.booleanOption(ADMIN_SCROUNGE)) {
                     effectiveMaxAcquisitions++;
                 }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -52,6 +52,7 @@ import static mekhq.campaign.mission.resupplyAndCaches.Resupply.isProhibitedUnit
 import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.processAbandonedConvoy;
 import static mekhq.campaign.parts.enums.PartQuality.QUALITY_A;
 import static mekhq.campaign.personnel.DiscretionarySpending.performDiscretionarySpending;
+import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_SCROUNGE;
 import static mekhq.campaign.personnel.backgrounds.BackgroundsController.randomMercenaryCompanyNameGenerator;
 import static mekhq.campaign.personnel.education.EducationController.getAcademy;
 import static mekhq.campaign.personnel.education.TrainingCombatTeams.processTrainingCombatTeams;
@@ -171,7 +172,6 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.RandomDependents;
 import mekhq.campaign.personnel.SpecialAbility;
-import mekhq.campaign.personnel.medical.MedicalController;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.death.RandomDeath;
 import mekhq.campaign.personnel.divorce.AbstractDivorce;
@@ -196,6 +196,7 @@ import mekhq.campaign.personnel.lifeEvents.NewYearsDayAnnouncement;
 import mekhq.campaign.personnel.lifeEvents.WinterHolidayAnnouncement;
 import mekhq.campaign.personnel.marriage.AbstractMarriage;
 import mekhq.campaign.personnel.marriage.DisabledRandomMarriage;
+import mekhq.campaign.personnel.medical.MedicalController;
 import mekhq.campaign.personnel.procreation.AbstractProcreation;
 import mekhq.campaign.personnel.procreation.DisabledRandomProcreation;
 import mekhq.campaign.personnel.ranks.RankSystem;
@@ -3218,7 +3219,7 @@ public class Campaign implements ITechManager {
     public @Nullable Person getLogisticsPerson() {
         final String skill = campaignOptions.getAcquisitionSkill();
         final ProcurementPersonnelPick acquisitionCategory = campaignOptions.getAcquisitionPersonnelCategory();
-        final int maxAcquisitions = campaignOptions.getMaxAcquisitions();
+        final int defaultMaxAcquisitions = campaignOptions.getMaxAcquisitions();
 
         int bestSkill = -1;
         Person procurementCharacter = null;
@@ -3226,11 +3227,18 @@ public class Campaign implements ITechManager {
             return null;
         } else if (skill.equals(S_TECH)) {
             for (Person person : getActivePersonnel(false)) {
+                int effectiveMaxAcquisitions = defaultMaxAcquisitions;
+
+                PersonnelOptions options = person.getOptions();
+                if (options.getOption(ADMIN_SCROUNGE).booleanValue()) {
+                    effectiveMaxAcquisitions++;
+                }
+
                 if (isIneligibleToPerformProcurement(person, acquisitionCategory)) {
                     continue;
                 }
 
-                if (maxAcquisitions > 0 && (person.getAcquisitions() >= maxAcquisitions)) {
+                if (defaultMaxAcquisitions > 0 && (person.getAcquisitions() >= effectiveMaxAcquisitions)) {
                     continue;
                 }
 
@@ -3241,11 +3249,18 @@ public class Campaign implements ITechManager {
             }
         } else {
             for (Person person : getActivePersonnel(false)) {
+                int effectiveMaxAcquisitions = defaultMaxAcquisitions;
+
+                PersonnelOptions options = person.getOptions();
+                if (options.getOption(ADMIN_SCROUNGE).booleanValue()) {
+                    effectiveMaxAcquisitions++;
+                }
+
                 if (isIneligibleToPerformProcurement(person, acquisitionCategory)) {
                     continue;
                 }
 
-                if (maxAcquisitions > 0 && (person.getAcquisitions() >= maxAcquisitions)) {
+                if (defaultMaxAcquisitions > 0 && (person.getAcquisitions() >= effectiveMaxAcquisitions)) {
                     continue;
                 }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -52,6 +52,7 @@ import static mekhq.campaign.mission.resupplyAndCaches.Resupply.isProhibitedUnit
 import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.processAbandonedConvoy;
 import static mekhq.campaign.parts.enums.PartQuality.QUALITY_A;
 import static mekhq.campaign.personnel.DiscretionarySpending.performDiscretionarySpending;
+import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_LOGISTICIAN;
 import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_SCROUNGE;
 import static mekhq.campaign.personnel.backgrounds.BackgroundsController.randomMercenaryCompanyNameGenerator;
 import static mekhq.campaign.personnel.education.EducationController.getAcademy;
@@ -3577,6 +3578,11 @@ public class Campaign implements ITechManager {
                         PartAcquisitionResult result = findContactForAcquisition(shoppingItem, person, system);
                         if (result == PartAcquisitionResult.Success) {
                             int transitTime = calculatePartTransitTime(system);
+
+                            PersonnelOptions options = person.getOptions();
+                            double logisticianModifier = options.booleanOption(ADMIN_LOGISTICIAN) ? 0.9 : 1.0;
+                            transitTime = (int) Math.round(transitTime * logisticianModifier);
+
                             int totalQuantity = 0;
                             while (shoppingItem.getQuantity() > 0 &&
                                          canAcquireParts(person) &&

--- a/MekHQ/src/mekhq/campaign/CampaignSummary.java
+++ b/MekHQ/src/mekhq/campaign/CampaignSummary.java
@@ -33,6 +33,7 @@
 package mekhq.campaign;
 
 import static mekhq.campaign.force.Force.FORCE_ORIGIN;
+import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_TETRIS_MASTER;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.areFieldKitchensWithinCapacity;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.checkFieldKitchenCapacity;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.checkFieldKitchenUsage;
@@ -56,6 +57,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.enums.MissionStatus;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.unit.CargoStatistics;
 import mekhq.campaign.unit.HangarStatistics;
@@ -191,6 +193,17 @@ public class CampaignSummary {
         // cargo capacity
         CargoStatistics cargoStats = campaign.getCargoStatistics();
         cargoCapacity = cargoStats.getTotalCombinedCargoCapacity();
+
+        double tetrisMasterMultiplier = 1.0;
+        for (Person person : campaign.getActivePersonnel(false)) {
+            PersonnelOptions options = person.getOptions();
+            if (options.booleanOption(ADMIN_TETRIS_MASTER)) {
+                tetrisMasterMultiplier += 0.05;
+            }
+        }
+
+        cargoCapacity = cargoCapacity * tetrisMasterMultiplier;
+
         cargoTons = cargoStats.getCargoTonnage(false);
         double mothballedTonnage = cargoStats.getCargoTonnage(false, true);
         cargoTons = (cargoTons + mothballedTonnage);

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -38,6 +38,7 @@ import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.LOGISTICS;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.TRANSPORT;
 import static mekhq.campaign.mission.AtBContract.getEffectiveNumUnits;
+import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_NETWORKER;
 import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
 
 import java.time.format.DateTimeFormatter;
@@ -57,8 +58,7 @@ import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.enums.AtBContractType;
 import mekhq.campaign.mission.enums.ContractCommandRights;
 import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.skills.SkillType;
-import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.rating.CamOpsReputation.ReputationController;
 import mekhq.campaign.rating.IUnitRating;
@@ -123,7 +123,16 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                 return;
             }
 
-            int numContracts = d6() - 4 + unitRatingMod;
+            Person negotiator = campaign.getSeniorAdminPerson(COMMAND);
+            int negotiatorModifier = 0;
+            if (negotiator != null) {
+                PersonnelOptions options = negotiator.getOptions();
+                if (options.booleanOption(ADMIN_NETWORKER)) {
+                    negotiatorModifier++;
+                }
+            }
+
+            int numContracts = d6() - 4 + unitRatingMod + negotiatorModifier;
 
             if (newCampaign) {
                 // For a similar reason as previously stated, we want the user to be able to jump into the action off

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
@@ -29,6 +29,8 @@ package mekhq.campaign.market.contractMarket;
 
 import static megamek.common.Compute.d6;
 import static megamek.common.enums.SkillLevel.REGULAR;
+import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
+import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_NETWORKER;
 import static mekhq.campaign.randomEvents.GrayMonday.isGrayMonday;
 
 import java.time.format.DateTimeFormatter;
@@ -49,6 +51,7 @@ import mekhq.campaign.mission.Contract;
 import mekhq.campaign.mission.enums.AtBContractType;
 import mekhq.campaign.mission.enums.ContractCommandRights;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.rating.CamOpsReputation.ReputationController;
 import mekhq.campaign.rating.IUnitRating;
@@ -108,8 +111,18 @@ public class CamOpsContractMarket extends AbstractContractMarket {
         int ratingMod = campaign.getReputation().getReputationModifier();
         HiringHallModifiers hiringHallModifiers = getHiringHallModifiers(campaign);
         int negotiationSkill = findNegotiationSkill(campaign);
+
+        Person negotiator = campaign.getSeniorAdminPerson(COMMAND);
+        int negotiatorModifier = 0;
+        if (negotiator != null) {
+            PersonnelOptions options = negotiator.getOptions();
+            if (options.booleanOption(ADMIN_NETWORKER)) {
+                negotiatorModifier++;
+            }
+        }
+
         int numOffers = getNumberOfOffers(rollNegotiation(negotiationSkill, ratingMod + hiringHallModifiers.offersMod) -
-                                                BASE_NEGOTIATION_TARGET);
+                BASE_NEGOTIATION_TARGET) + negotiatorModifier;
 
         if (isGrayMonday) {
             for (int i = 0; i < numOffers; i++) {

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -106,6 +106,8 @@ public class PersonnelOptions extends PilotOptions {
 
     public static final String ADMIN_SCROUNGE = "admin_scrounge";
     public static final String ADMIN_MEDIATOR = "admin_mediator";
+    public static final String ADMIN_LOGISTICIAN = "admin_logistician";
+    public static final String ADMIN_COORDINATOR = "admin_coordinator";
 
     @Override
     public void initialize() {
@@ -192,6 +194,8 @@ public class PersonnelOptions extends PilotOptions {
 
         addOption(l3a, ADMIN_SCROUNGE, false);
         addOption(l3a, ADMIN_MEDIATOR, false);
+        addOption(l3a, ADMIN_LOGISTICIAN, false);
+        addOption(l3a, ADMIN_COORDINATOR, false);
 
         addOption(edge, EDGE_MEDICAL, true);
         addOption(edge, EDGE_REPAIR_BREAK_PART, true);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -87,6 +87,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String FLAW_GREMLINS = "flaw_gremlins";
     public static final String ATOW_TECH_EMPATHY = "atow_tech_empathy";
     public static final String FLAW_TRANSIT_DISORIENTATION_SYNDROME = "flaw_transit_disorientation_syndrome";
+
     public static final String MUTATION_FREAKISH_STRENGTH = "mutation_freakish_strength";
     public static final String MUTATION_EXCEPTIONAL_IMMUNE_SYSTEM = "mutation_exceptional_immune_system";
     public static final String MUTATION_EXOTIC_APPEARANCE = "mutation_exotic_appearance";
@@ -102,6 +103,8 @@ public class PersonnelOptions extends PilotOptions {
     public static final String EXCEPTIONAL_ATTRIBUTE_INTELLIGENCE = "exceptional_attribute_intelligence";
     public static final String EXCEPTIONAL_ATTRIBUTE_WILLPOWER = "exceptional_attribute_willpower";
     public static final String EXCEPTIONAL_ATTRIBUTE_CHARISMA = "exceptional_attribute_charisma";
+
+    public static final String ADMIN_SCROUNGE = "admin_scrounge";
 
     @Override
     public void initialize() {
@@ -185,6 +188,8 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, EXCEPTIONAL_ATTRIBUTE_INTELLIGENCE, false);
         addOption(l3a, EXCEPTIONAL_ATTRIBUTE_WILLPOWER, false);
         addOption(l3a, EXCEPTIONAL_ATTRIBUTE_CHARISMA, false);
+
+        addOption(l3a, ADMIN_SCROUNGE, false);
 
         addOption(edge, EDGE_MEDICAL, true);
         addOption(edge, EDGE_REPAIR_BREAK_PART, true);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -108,6 +108,9 @@ public class PersonnelOptions extends PilotOptions {
     public static final String ADMIN_MEDIATOR = "admin_mediator";
     public static final String ADMIN_LOGISTICIAN = "admin_logistician";
     public static final String ADMIN_COORDINATOR = "admin_coordinator";
+    public static final String ADMIN_TETRIS_MASTER = "admin_tetris_master";
+    public static final String ADMIN_NETWORKER = "admin_networker";
+    public static final String ADMIN_INTERSTELLAR_NEGOTIATOR = "admin_interstellar_negotiator";
 
     @Override
     public void initialize() {
@@ -196,6 +199,9 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, ADMIN_MEDIATOR, false);
         addOption(l3a, ADMIN_LOGISTICIAN, false);
         addOption(l3a, ADMIN_COORDINATOR, false);
+        addOption(l3a, ADMIN_TETRIS_MASTER, false);
+        addOption(l3a, ADMIN_NETWORKER, false);
+        addOption(l3a, ADMIN_INTERSTELLAR_NEGOTIATOR, false);
 
         addOption(edge, EDGE_MEDICAL, true);
         addOption(edge, EDGE_REPAIR_BREAK_PART, true);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -105,6 +105,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String EXCEPTIONAL_ATTRIBUTE_CHARISMA = "exceptional_attribute_charisma";
 
     public static final String ADMIN_SCROUNGE = "admin_scrounge";
+    public static final String ADMIN_MEDIATOR = "admin_mediator";
 
     @Override
     public void initialize() {
@@ -190,6 +191,7 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, EXCEPTIONAL_ATTRIBUTE_CHARISMA, false);
 
         addOption(l3a, ADMIN_SCROUNGE, false);
+        addOption(l3a, ADMIN_MEDIATOR, false);
 
         addOption(edge, EDGE_MEDICAL, true);
         addOption(edge, EDGE_REPAIR_BREAK_PART, true);

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -48,6 +48,7 @@ import static mekhq.campaign.mission.ScenarioMapParameters.MapLocation.AllGround
 import static mekhq.campaign.mission.ScenarioMapParameters.MapLocation.LowAtmosphere;
 import static mekhq.campaign.mission.ScenarioMapParameters.MapLocation.Space;
 import static mekhq.campaign.mission.ScenarioMapParameters.MapLocation.SpecificGroundTerrain;
+import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_COORDINATOR;
 import static mekhq.campaign.personnel.skills.SkillType.S_ADMIN;
 import static mekhq.campaign.personnel.skills.SkillType.S_TACTICS;
 import static mekhq.campaign.personnel.skills.SkillType.getSkillHash;
@@ -105,6 +106,7 @@ import mekhq.campaign.mission.enums.ScenarioType;
 import mekhq.campaign.mission.resupplyAndCaches.StarLeagueCache;
 import mekhq.campaign.mission.resupplyAndCaches.StarLeagueCache.CacheType;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.turnoverAndRetention.Fatigue;
@@ -1904,6 +1906,15 @@ public class StratconRulesManager {
         if (commandRights.isLiaison()) {
             int liaisonModifier = -1;
             reinforcementTargetNumber.addModifier(liaisonModifier, "Liaison Command Rights");
+        }
+
+        // Liaison SPA
+        if (commandLiaison != null) {
+            PersonnelOptions options = commandLiaison.getOptions();
+            if (options.booleanOption(ADMIN_COORDINATOR)) {
+                int liaisonModifier = -1;
+                reinforcementTargetNumber.addModifier(liaisonModifier, "Coordinator SPA");
+            }
         }
 
         // Return final value


### PR DESCRIPTION
Fix #6678
Fix #6679
Fix #6681
Fix #6686

### Interstellar Negotiator
**Cost**: 100 xp
**Requirements**: Veteran Administration

No matter who's in charge, this character always has a way of bringing down the price.

If this character is the senior-most Admin/Transport character, the cost of interstellar travel is reduced by 15%

### Networker
**Cost**: 200 xp
**Requirements**: Elite Administration

This character knows people in high places.

If this character is the senior-most Admin/Command character, the number of contracts offered each month is increased by 1.

### Tetris Master
**Cost**: 100 xp
**Requirements**: Regular Administration

This character has mastered the subtle art of stacking boxes.

The campaign's cargo capacity is increased by 5% per character with this SPA.

### Coordinator
**Cost**: 100 xp
**Requirements**: Veteran Administration

This character is exceptionally skilled at liaising with allied forces, ensuring reinforcements arrive where they're needed.

If this character is the senior Admin/Command character, the reinforcement target number is reduced by 1.

### Logistician
**Cost**: 50 xp
**Requirements**: Veteran Administration

This character is an expert at managing interstellar supply lines.

Parts procured by this character have their delivery time reduced by 10%.

### Mediator
**Cost**: 50 xp
**Requirements**: Regular Administration

Whether with a smoothing word or a calming presence, this character knows how to solve disputes.

This character's Administration skill is increased by 1 when calculating the campaign's Admin Capacity.

### Scrounge
**Cost**: 200 xp
**Requirements**: Elite Administration

The character is adept at finding resources in places nobody else would think to look.

They can make one additional procurement attempt per day.