### PR TITLE
Fix: Stopped Mercenary Auctions Gifting a Hundred Support Points (No Really)

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/MercenaryAuction.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/MercenaryAuction.java
@@ -126,7 +126,8 @@ public class MercenaryAuction {
               maximumBid,
               AUCTION_TIER_SUCCESS_PERCENT,
               max(requiredCombatTeams, 1));
-        int finalBid = (mercenaryAuctionDialog.getSpinnerValue() / minimumBid) * AUCTION_TIER_SUCCESS_PERCENT;
+        int finalBidPercentChance = (mercenaryAuctionDialog.getSpinnerValue() / minimumBid) *
+                                          AUCTION_TIER_SUCCESS_PERCENT;
 
         // If the player confirmed the auction, then check whether they were successful,
         // deliver the unit, and deduct funds.
@@ -136,8 +137,8 @@ public class MercenaryAuction {
 
         // The use of <= is important here as it ensures that even if the user bids 50 %, they can
         // still win.
-        if (randomInt(100) <= finalBid) {
-            campaignState.changeSupportPoints(finalBid);
+        if (randomInt(100) <= finalBidPercentChance) {
+            campaignState.changeSupportPoints(-mercenaryAuctionDialog.getSpinnerValue());
 
             // The delivery time is so that the unit addition is picked up by the 'mothball'
             // campaign option. It also makes sense the unit wouldn't magically materialize in your

--- a/MekHQ/src/mekhq/campaign/randomEvents/MercenaryAuction.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/MercenaryAuction.java
@@ -126,7 +126,7 @@ public class MercenaryAuction {
               maximumBid,
               AUCTION_TIER_SUCCESS_PERCENT,
               max(requiredCombatTeams, 1));
-        int finalBidPercentChance = (mercenaryAuctionDialog.getSpinnerValue() / minimumBid) *
+        int bidSuccessChance = (mercenaryAuctionDialog.getSpinnerValue() / minimumBid) *
                                           AUCTION_TIER_SUCCESS_PERCENT;
 
         // If the player confirmed the auction, then check whether they were successful,
@@ -137,7 +137,7 @@ public class MercenaryAuction {
 
         // The use of <= is important here as it ensures that even if the user bids 50 %, they can
         // still win.
-        if (randomInt(100) <= finalBidPercentChance) {
+        if (randomInt(100) <= bidSuccessChance) {
             campaignState.changeSupportPoints(-mercenaryAuctionDialog.getSpinnerValue());
 
             // The delivery time is so that the unit addition is picked up by the 'mothball'


### PR DESCRIPTION
### Dev Notes
We were incorrectly adding the total bid success chance to the players available Support Points instead of deducting the support points spent.