### PR TITLE
Fix: Fixed Error When Attempting to Fetch Bloodname for Characters Without a Bloodname

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -29,35 +29,11 @@
 package mekhq;
 
 import static java.lang.Math.max;
+import static mekhq.MHQConstants.BATTLE_OF_TUKAYYID;
 import static mekhq.campaign.personnel.skills.SkillType.EXP_ELITE;
 import static mekhq.campaign.personnel.skills.SkillType.EXP_GREEN;
 import static mekhq.campaign.personnel.skills.SkillType.EXP_HEROIC;
 import static mekhq.campaign.personnel.skills.SkillType.EXP_LEGENDARY;
-import static mekhq.campaign.personnel.skills.SkillType.EXP_NONE;
-import static mekhq.campaign.personnel.skills.SkillType.EXP_REGULAR;
-import static mekhq.campaign.personnel.skills.SkillType.EXP_ULTRA_GREEN;
-import static mekhq.campaign.personnel.skills.SkillType.EXP_VETERAN;
-
-import java.awt.Graphics2D;
-import java.awt.Image;
-import java.awt.image.BufferedImage;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FilenameFilter;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.function.Consumer;
-import javax.swing.JTable;
-import javax.swing.table.TableModel;
-
-import static java.lang.Math.max;
-import static mekhq.MHQConstants.BATTLE_OF_TUKAYYID;
-import static mekhq.campaign.personnel.skills.SkillType.EXP_ELITE;
-import static mekhq.campaign.personnel.skills.SkillType.EXP_GREEN;
 import static mekhq.campaign.personnel.skills.SkillType.EXP_NONE;
 import static mekhq.campaign.personnel.skills.SkillType.EXP_REGULAR;
 import static mekhq.campaign.personnel.skills.SkillType.EXP_ULTRA_GREEN;
@@ -815,14 +791,14 @@ public class Utilities {
      * a pre-selected portrait, provided one is to their index Additionally, any extraData parameters should be migrated
      * here
      *
-     * @param p           the person to be renamed, if applicable
+     * @param person           the person to be renamed, if applicable
      * @param oldCrew     the crew object they were a part of
      * @param crewIndex   the index of the person in the crew
      * @param crewOptions whether or not to run the populateOptionsFromCrew for this person
      */
-    private static void migrateCrewData(Person p, Crew oldCrew, int crewIndex, boolean crewOptions) {
+    private static void migrateCrewData(Person person, Crew oldCrew, int crewIndex, boolean crewOptions) {
         if (crewOptions) {
-            populateOptionsFromCrew(p, oldCrew);
+            populateOptionsFromCrew(person, oldCrew);
         }
 
         // this is a bit of a hack, but instead of tracking it elsewhere we only set
@@ -839,26 +815,27 @@ public class Utilities {
 
                 if (!(name.equalsIgnoreCase(RandomNameGenerator.UNNAMED) ||
                             name.equalsIgnoreCase(RandomNameGenerator.UNNAMED_FULL_NAME))) {
-                    p.migrateName(name);
+                    person.migrateName(name);
                 }
             } else {
-                p.setGivenName(givenName);
-                p.setSurname(oldCrew.getExtraDataValue(crewIndex, Crew.MAP_SURNAME));
-                if (p.getSurname() == null) {
-                    p.setSurname("");
+                person.setGivenName(givenName);
+                person.setSurname(oldCrew.getExtraDataValue(crewIndex, Crew.MAP_SURNAME));
+                if (person.getSurname() == null) {
+                    person.setSurname("");
                 }
 
                 String phenotype = oldCrew.getExtraDataValue(crewIndex, Crew.MAP_PHENOTYPE);
                 if (phenotype != null) {
-                    p.setPhenotype(Phenotype.parseFromString(phenotype));
+                    person.setPhenotype(Phenotype.parseFromString(phenotype));
                 }
 
-                p.setBloodname(oldCrew.getExtraDataValue(crewIndex, Crew.MAP_BLOODNAME));
+                String bloodname = oldCrew.getExtraDataValue(crewIndex, Crew.MAP_BLOODNAME);
+                person.setBloodname(bloodname == null ? "" : bloodname);
             }
 
             // Only created crew can be assigned a portrait, so this is safe to put in here
             if (!oldCrew.getPortrait(crewIndex).isDefault()) {
-                p.setPortrait(oldCrew.getPortrait(crewIndex).clone());
+                person.setPortrait(oldCrew.getPortrait(crewIndex).clone());
             }
         }
     }

--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -826,7 +826,7 @@ public class Utilities {
 
                 String phenotype = oldCrew.getExtraDataValue(crewIndex, Crew.MAP_PHENOTYPE);
                 if (phenotype != null) {
-                    person.setPhenotype(Phenotype.parseFromString(phenotype));
+                    person.setPhenotype(Phenotype.fromString(phenotype));
                 }
 
                 String bloodname = oldCrew.getExtraDataValue(crewIndex, Crew.MAP_BLOODNAME);

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -38,6 +38,7 @@ import static java.lang.Math.floor;
 import static java.lang.Math.min;
 import static java.lang.Math.round;
 import static megamek.codeUtilities.MathUtility.clamp;
+import static megamek.codeUtilities.StringUtility.isNullOrBlank;
 import static megamek.common.Compute.randomInt;
 import static megamek.common.enums.SkillLevel.REGULAR;
 import static mekhq.campaign.log.LogEntryType.ASSIGNMENT;
@@ -66,7 +67,6 @@ import java.util.stream.Stream;
 import megamek.Version;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.codeUtilities.MathUtility;
-import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
@@ -91,7 +91,6 @@ import mekhq.campaign.log.LogEntryFactory;
 import mekhq.campaign.log.LogEntryType;
 import mekhq.campaign.log.PersonalLogger;
 import mekhq.campaign.log.ServiceLogger;
-import mekhq.campaign.personnel.medical.advancedMedical.InjuryUtil;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
 import mekhq.campaign.personnel.enums.BloodGroup;
@@ -106,6 +105,7 @@ import mekhq.campaign.personnel.enums.ROMDesignation;
 import mekhq.campaign.personnel.enums.education.EducationLevel;
 import mekhq.campaign.personnel.enums.education.EducationStage;
 import mekhq.campaign.personnel.familyTree.Genealogy;
+import mekhq.campaign.personnel.medical.advancedMedical.InjuryUtil;
 import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.personnel.ranks.RankValidator;
@@ -548,7 +548,7 @@ public class Person {
         this.phenotype = phenotype;
     }
 
-    public String getBloodname() {
+    public @Nullable String getBloodname() {
         return bloodname;
     }
 
@@ -714,10 +714,9 @@ public class Person {
      * @return a String of the person's last name
      */
     public String getLastName() {
-        String lastName = !StringUtility.isNullOrBlank(getBloodname()) ?
-                                getBloodname() :
-                                !StringUtility.isNullOrBlank(getSurname()) ? getSurname() : "";
-        if (!StringUtility.isNullOrBlank(getPostNominal())) {
+        String lastName = !isNullOrBlank(getBloodname()) ?
+                                getBloodname() : !isNullOrBlank(getSurname()) ? getSurname() : "";
+        if (!isNullOrBlank(getPostNominal())) {
             lastName += (lastName.isBlank() ? "" : " ") + getPostNominal();
         }
         return lastName;
@@ -866,7 +865,7 @@ public class Person {
                     givenName.append(' ').append(name[i]);
                 }
 
-                if (!(!StringUtility.isNullOrBlank(getBloodname()) && getBloodname().equals(name[i]))) {
+                if (!(!isNullOrBlank(getBloodname()) && getBloodname().equals(name[i]))) {
                     givenName.append(' ').append(name[i]);
                 }
             }
@@ -2312,12 +2311,12 @@ public class Person {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "id", id.toString());
 
             // region Name
-            if (!StringUtility.isNullOrBlank(getPreNominal())) {
+            if (!isNullOrBlank(getPreNominal())) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "preNominal", getPreNominal());
             }
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "givenName", getGivenName());
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "surname", getSurname());
-            if (!StringUtility.isNullOrBlank(getPostNominal())) {
+            if (!isNullOrBlank(getPostNominal())) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "postNominal", getPostNominal());
             }
 
@@ -2325,7 +2324,7 @@ public class Person {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "maidenName", getMaidenName());
             }
 
-            if (!StringUtility.isNullOrBlank(getCallsign())) {
+            if (!isNullOrBlank(getCallsign())) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "callsign", getCallsign());
             }
             // endregion Name
@@ -2363,11 +2362,11 @@ public class Person {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "phenotype", getPhenotype().name());
             }
 
-            if (!StringUtility.isNullOrBlank(bloodname)) {
+            if (!isNullOrBlank(bloodname)) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "bloodname", bloodname);
             }
 
-            if (!StringUtility.isNullOrBlank(biography)) {
+            if (!isNullOrBlank(biography)) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "biography", biography);
             }
 
@@ -2691,7 +2690,7 @@ public class Person {
 
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "reasoningDescriptionIndex", reasoningDescriptionIndex);
 
-            if (!StringUtility.isNullOrBlank(personalityDescription)) {
+            if (!isNullOrBlank(personalityDescription)) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "personalityDescription", personalityDescription);
             }
 
@@ -5224,7 +5223,10 @@ public class Person {
           int rankIndex) {
         return reputation +
                      (isUseAgingEffects ?
-                            getReputationAgeModifier(getAge(today), isClanCampaign, !bloodname.isBlank(), rankIndex) :
+                            getReputationAgeModifier(getAge(today),
+                                  isClanCampaign,
+                                  !isNullOrBlank(bloodname),
+                                  rankIndex) :
                             0);
     }
 


### PR DESCRIPTION
Fix [Sentry Report A](https://sentry.tapenvy.us/organizations/tapenvyus/issues/4610/events/8879ee6b92fa453586fa405c00629436/), [Sentry Report B](https://sentry.tapenvy.us/organizations/tapenvyus/issues/4610/events/8879ee6b92fa453586fa405c00629436/)

### Dev Notes
As part of CamOps Reputation we need to test whether a character has a Bloodname. By all accounts bloodname should initialize as a blank string, however Sentry reports show it can also be null. So we need to test for null state.