### PR TITLE
Fix: Stopped Certain Personal Log Entries being Deleted on Load

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -91,7 +91,6 @@ import mekhq.campaign.log.LogEntryFactory;
 import mekhq.campaign.log.LogEntryType;
 import mekhq.campaign.log.PersonalLogger;
 import mekhq.campaign.log.ServiceLogger;
-import mekhq.campaign.personnel.medical.advancedMedical.InjuryUtil;
 import mekhq.campaign.parts.Part;
 import mekhq.campaign.parts.Refit;
 import mekhq.campaign.personnel.enums.BloodGroup;
@@ -106,6 +105,7 @@ import mekhq.campaign.personnel.enums.ROMDesignation;
 import mekhq.campaign.personnel.enums.education.EducationLevel;
 import mekhq.campaign.personnel.enums.education.EducationStage;
 import mekhq.campaign.personnel.familyTree.Genealogy;
+import mekhq.campaign.personnel.medical.advancedMedical.InjuryUtil;
 import mekhq.campaign.personnel.ranks.Rank;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.personnel.ranks.RankValidator;
@@ -2957,12 +2957,18 @@ public class Person {
                                       "Removed from",
                                       "Added to");
 
+                                boolean shiftedLogType = false;
                                 for (String targetString : assignmentTargetStrings) {
                                     if (logEntryDescription.startsWith(targetString)) {
                                         logEntry.setType(ASSIGNMENT);
                                         person.addAssignmentLogEntry(logEntry);
+                                        shiftedLogType = true;
                                         break;
                                     }
+                                }
+
+                                if (!shiftedLogType) {
+                                    person.addPersonalLogEntry(logEntry);
                                 }
                             } else {
                                 // < 50.05 compatibility handler


### PR DESCRIPTION
Fix #6800

### Dev Notes
As part of the splitting up of the personal log we included code that would filter previous log entries into the new log types.

Unfortunately, a missed clause meant that some log entries were being filtered out but not added to another log.

This happened because during testing I used 'real data,' that is actual player saves, rather than 'constructed data,' a save I made up specifically to test. Due to the age of the campaigns I was testing, it wasn't immediately clear these log entries had been lost due to the number of log entries I was checking.