### PR TITLE
Fix: Significantly Improved TO&E Reading Speed by Removing C3 Calculations

### DIFF
--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -189,6 +189,7 @@ public class ForceViewPanel extends JScrollablePanel {
         for (UUID uid : force.getAllUnits(false)) {
             Unit unit = campaign.getUnit(uid);
             if (null != unit) {
+                // Never factor in C3 in this check. It will cause the TO&E to lock up for large campaigns.
                 bv += unit.getEntity().calculateBattleValue(true, !unit.hasPilot());
                 cost = cost.plus(unit.getEntity().getCost(true));
                 ton += unit.getEntity().getWeight();
@@ -559,6 +560,8 @@ public class ForceViewPanel extends JScrollablePanel {
 
     public String getForceSummary(Unit unit) {
         String toReturn = "<html><font size='4'><b>" + unit.getName() + "</b></font><br/>";
+
+        // Never factor in C3 in this check. It will cause the TO&E to lock up for large campaigns.
         toReturn += "<font><b>BV:</b> " +
                           unit.getEntity().calculateBattleValue(true, null == unit.getEntity().getCrew()) +
                           "<br/>";

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -182,16 +182,15 @@ public class ForceViewPanel extends JScrollablePanel {
         }
 
         for (UUID uid : force.getAllUnits(false)) {
-            bv = force.getTotalBV(campaign, true);
-
-            Unit u = campaign.getUnit(uid);
-            if (null != u) {
-                cost = cost.plus(u.getEntity().getCost(true));
-                ton += u.getEntity().getWeight();
-                String utype = UnitType.getTypeDisplayableName(u.getEntity().getUnitType());
+            Unit unit = campaign.getUnit(uid);
+            if (null != unit) {
+                bv += unit.getEntity().calculateBattleValue(true, !unit.hasPilot());
+                cost = cost.plus(unit.getEntity().getCost(true));
+                ton += unit.getEntity().getWeight();
+                String unitTypeName = UnitType.getTypeDisplayableName(unit.getEntity().getUnitType());
                 if (null == type) {
-                    type = utype;
-                } else if (!utype.equals(type)) {
+                    type = unitTypeName;
+                } else if (!unitTypeName.equals(type)) {
                     type = resourceMap.getString("mixed");
                 }
             }
@@ -555,7 +554,9 @@ public class ForceViewPanel extends JScrollablePanel {
 
     public String getForceSummary(Unit unit) {
         String toReturn = "<html><font size='4'><b>" + unit.getName() + "</b></font><br/>";
-        toReturn += "<font><b>BV:</b> " + unit.getEntity().calculateBattleValue() + "<br/>";
+        toReturn += "<font><b>BV:</b> " +
+                          unit.getEntity().calculateBattleValue(true, null == unit.getEntity().getCrew()) +
+                          "<br/>";
         toReturn += unit.getStatus();
         Entity entity = unit.getEntity();
         if (entity.hasNavalC3()) {

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.view;
 


### PR DESCRIPTION
Fix #6794

We previously received feedback from a user that C3 was not being factored into BV calculations in the TO&E tab. We then went in and fixed this, however that caused the every C3 equipped unit needing to read the ammo loadout of every unit in the TO&E any time the TO&E was interacted with. This resulted in a lock-up for large campaigns.