### PR TITLE
Issue #6790: Prevent NPE from C3 when Refitting

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -171,7 +171,6 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.RandomDependents;
 import mekhq.campaign.personnel.SpecialAbility;
-import mekhq.campaign.personnel.medical.MedicalController;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.death.RandomDeath;
 import mekhq.campaign.personnel.divorce.AbstractDivorce;
@@ -196,6 +195,7 @@ import mekhq.campaign.personnel.lifeEvents.NewYearsDayAnnouncement;
 import mekhq.campaign.personnel.lifeEvents.WinterHolidayAnnouncement;
 import mekhq.campaign.personnel.marriage.AbstractMarriage;
 import mekhq.campaign.personnel.marriage.DisabledRandomMarriage;
+import mekhq.campaign.personnel.medical.MedicalController;
 import mekhq.campaign.personnel.procreation.AbstractProcreation;
 import mekhq.campaign.personnel.procreation.DisabledRandomProcreation;
 import mekhq.campaign.personnel.ranks.RankSystem;
@@ -8286,7 +8286,7 @@ public class Campaign implements ITechManager {
         getHangar().forEachUnit(u -> {
             Entity en = u.getEntity();
             if (null != en) {
-                game.addEntity(en);
+                game.addEntity(en, false);
             }
         });
     }

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1692,10 +1692,10 @@ public class Refit extends Part implements IAcquisitionWork {
             part.updateConditionFromPart();
         }
 
-        C3Util.copyC3Networks(oldEntity, oldUnit.getEntity());
         oldUnit.getEntity().setExternalIdAsString(oldUnit.getId().toString());
         getCampaign().clearGameData(oldUnit.getEntity());
         getCampaign().reloadGameEntities();
+        C3Util.copyC3Networks(oldEntity, oldUnit.getEntity());
 
         // reload any soldiers
         for (Person soldier : soldiers) {


### PR DESCRIPTION
Fixes #6790 
Fixes #6791 

Regarding the change to `Campaign::reloadGameEntities`: This prevents `addEntity` from generating a `GameEntityNewEvent` and setting the initial BV. This is unnecessary as these units were already added to the game and we're just reloading them. This includes when returning from scenarios, the other place `reloadGameEntities` is used. 

When calculating the BV of C3 it will clear C3 connections if they aren't valid, so this prevents networks from being broken as the entities are re-added to the game.