### PR TITLE
Improvement: Improved Robustness of Automatic Unmothballing in Contract Automation

### DIFF
--- a/MekHQ/resources/mekhq/resources/ContractAutomation.properties
+++ b/MekHQ/resources/mekhq/resources/ContractAutomation.properties
@@ -36,3 +36,4 @@ transitDescription.supplemental=Our target system is <b>%s</b>. This journey wil
 mothballingFailed.text=%s was not eligible to be automatically mothballed. Units cannot be\
   \ destroyed, refitting, undergoing repairs, mid-mothball, or already mothballed.
 activationFailed.text=%s could not be automatically un-mothballed.
+activationFailed.uuid=Unit ID %s does not exist, so could not be automatically un-mothballed.

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -171,7 +171,6 @@ import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.RandomDependents;
 import mekhq.campaign.personnel.SpecialAbility;
-import mekhq.campaign.personnel.medical.MedicalController;
 import mekhq.campaign.personnel.autoAwards.AutoAwardsController;
 import mekhq.campaign.personnel.death.RandomDeath;
 import mekhq.campaign.personnel.divorce.AbstractDivorce;
@@ -196,6 +195,7 @@ import mekhq.campaign.personnel.lifeEvents.NewYearsDayAnnouncement;
 import mekhq.campaign.personnel.lifeEvents.WinterHolidayAnnouncement;
 import mekhq.campaign.personnel.marriage.AbstractMarriage;
 import mekhq.campaign.personnel.marriage.DisabledRandomMarriage;
+import mekhq.campaign.personnel.medical.MedicalController;
 import mekhq.campaign.personnel.procreation.AbstractProcreation;
 import mekhq.campaign.personnel.procreation.DisabledRandomProcreation;
 import mekhq.campaign.personnel.ranks.RankSystem;
@@ -386,7 +386,7 @@ public class Campaign implements ITechManager {
     private StoryArc storyArc;
     private final FameAndInfamyController fameAndInfamy;
     private BehaviorSettings autoResolveBehaviorSettings;
-    private List<Unit> automatedMothballUnits;
+    private List<UUID> automatedMothballUnits;
     private int temporaryPrisonerCapacity;
     private boolean processProcurement;
 
@@ -5676,7 +5676,7 @@ public class Campaign implements ITechManager {
         }
 
         // remove from automatic mothballing
-        automatedMothballUnits.remove(unit);
+        automatedMothballUnits.remove(unit.getId());
 
         // finally, remove the unit
         getHangar().removeUnit(unit.getId());
@@ -6287,10 +6287,10 @@ public class Campaign implements ITechManager {
      * reducing their active maintenance costs and operational demands over time.
      * </p>
      *
-     * @return A {@link List} of {@link Unit} objects that are set for automated mothballing. Returns an empty list if
+     * @return A {@link List} of {@link UUID} objects that are set for automated mothballing. Returns an empty list if
      *       no units are configured.
      */
-    public List<Unit> getAutomatedMothballUnits() {
+    public List<UUID> getAutomatedMothballUnits() {
         return automatedMothballUnits;
     }
 
@@ -6301,9 +6301,9 @@ public class Campaign implements ITechManager {
      * Replaces the current list of units that have undergone automated mothballing.
      * </p>
      *
-     * @param automatedMothballUnits A {@link List} of {@link Unit} objects to configure for automated mothballing.
+     * @param automatedMothballUnits A {@link List} of {@link UUID} objects to configure for automated mothballing.
      */
-    public void setAutomatedMothballUnits(List<Unit> automatedMothballUnits) {
+    public void setAutomatedMothballUnits(List<UUID> automatedMothballUnits) {
         this.automatedMothballUnits = automatedMothballUnits;
     }
 
@@ -6527,13 +6527,13 @@ public class Campaign implements ITechManager {
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "personnelWhoAdvancedInXP");
 
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "automatedMothballUnits");
-        for (Unit unit : automatedMothballUnits) {
-            if (unit == null) {
+        for (UUID unitId : automatedMothballUnits) {
+            if (unitId == null) {
                 // <50.03 compatibility handler
                 continue;
             }
 
-            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mothballedUnit", unit.getId());
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mothballedUnit", unitId);
         }
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "automatedMothballUnits");
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "temporaryPrisonerCapacity", temporaryPrisonerCapacity);

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -95,7 +95,6 @@ import mekhq.campaign.market.contractMarket.AtbMonthlyContractMarket;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.Scenario;
-import mekhq.campaign.personnel.medical.advancedMedical.InjuryTypes;
 import mekhq.campaign.parts.EnginePart;
 import mekhq.campaign.parts.MekActuator;
 import mekhq.campaign.parts.MekLocation;
@@ -116,6 +115,7 @@ import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.education.EducationController;
 import mekhq.campaign.personnel.enums.FamilialRelationshipType;
+import mekhq.campaign.personnel.medical.advancedMedical.InjuryTypes;
 import mekhq.campaign.personnel.ranks.RankSystem;
 import mekhq.campaign.personnel.ranks.RankValidator;
 import mekhq.campaign.personnel.skills.RandomSkillPreferences;
@@ -352,7 +352,7 @@ public class CampaignXmlParser {
                 } else if (xn.equalsIgnoreCase("personnelWhoAdvancedInXP")) {
                     campaign.setPersonnelWhoAdvancedInXP(processPersonnelWhoAdvancedInXP(wn, campaign));
                 } else if (xn.equalsIgnoreCase("automatedMothballUnits")) {
-                    campaign.setAutomatedMothballUnits(processAutomatedMothballNodes(wn, campaign));
+                    campaign.setAutomatedMothballUnits(processAutomatedMothballNodes(wn));
                 } else if (xn.equalsIgnoreCase("shipSearchStart")) {
                     campaign.setShipSearchStart(MHQXMLUtility.parseDate(wn.getTextContent().trim()));
                 } else if (xn.equalsIgnoreCase("shipSearchType")) {
@@ -1095,10 +1095,10 @@ public class CampaignXmlParser {
         return personWhoAdvancedInXP;
     }
 
-    private static List<Unit> processAutomatedMothballNodes(Node workingNode, Campaign campaign) {
+    private static List<UUID> processAutomatedMothballNodes(Node workingNode) {
         logger.info("Loading Automated Mothball Nodes from XML...");
 
-        List<Unit> mothballedUnits = new ArrayList<>();
+        List<UUID> mothballedUnits = new ArrayList<>();
 
         NodeList workingList = workingNode.getChildNodes();
         for (int x = 0; x < workingList.getLength(); x++) {
@@ -1110,17 +1110,16 @@ public class CampaignXmlParser {
             }
 
             if (!childNode.getNodeName().equalsIgnoreCase("mothballedUnit")) {
-                logger.error("Unknown node type not loaded in Automated Mothball nodes: " + childNode.getNodeName());
+                logger.error("Unknown node type not loaded in Automated Mothball nodes: {}", childNode.getNodeName());
                 continue;
             }
 
-            Unit unit = campaign.getUnit(UUID.fromString(childNode.getTextContent()));
-
-            if (unit == null) {
-                logger.error("Unknown UUID: " + childNode.getTextContent());
+            try {
+                UUID unitId = UUID.fromString(childNode.getTextContent());
+                mothballedUnits.add(unitId);
+            } catch (IllegalArgumentException iae) {
+                logger.error("Invalid UUID: {}", childNode.getTextContent());
             }
-
-            mothballedUnits.add(unit);
         }
 
         logger.info("Load Automated Mothball Nodes Complete!");

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.market.contractMarket;
 

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/ContractAutomation.java
@@ -27,6 +27,12 @@
  */
 package mekhq.campaign.market.contractMarket;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.ResourceBundle;
+import java.util.UUID;
+
 import megamek.common.Entity;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
@@ -40,8 +46,6 @@ import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.actions.ActivateUnitAction;
 import mekhq.campaign.unit.actions.MothballUnitAction;
 import mekhq.gui.dialog.ContractAutomationDialog;
-
-import java.util.*;
 
 /**
  * The ContractAutomation class provides a suite of methods
@@ -110,21 +114,22 @@ public class ContractAutomation {
 
     /**
      * This method identifies all non-mothballed units within a campaign that are currently
-     * assigned to a {@code Force}. Those units are then GM Mothballed.
+     * assigned to a {@link Force}. Those units are then GM Mothballed.
      *
      * @param campaign The current campaign.
      * @return A list of all newly mothballed units.
      */
-    private static List<Unit> performAutomatedMothballing(Campaign campaign) {
-        List<Unit> mothballTargets = new ArrayList<>();
+    private static List<UUID> performAutomatedMothballing(Campaign campaign) {
+        List<UUID> mothballTargets = new ArrayList<>();
         MothballUnitAction mothballUnitAction = new MothballUnitAction(null, true);
 
         for (Force force : campaign.getAllForces()) {
-            for (UUID unitId : force.getUnits()) {
+            List<UUID> iterationSafeUnitIds = new ArrayList<>(force.getUnits());
+            for (UUID unitId : iterationSafeUnitIds) {
                 Unit unit = campaign.getUnit(unitId);
 
                 if (unit == null) {
-                    logger.error(String.format("Failed to get unit for unit ID %s", unitId));
+                    logger.error("Failed to get unit for unit ID {}", unitId);
                     continue;
                 }
 
@@ -135,24 +140,20 @@ public class ContractAutomation {
                         continue;
                     }
                 } catch (Exception e) {
-                    logger.error(String.format("Failed to get entity for %s", unit.getName()));
+                    logger.error("Failed to get entity for {}", unit.getName());
                     continue;
                 }
 
                 if (unit.isAvailable(false) && !unit.isUnderRepair()) {
-                    mothballTargets.add(unit);
+                    mothballTargets.add(unitId);
+
+                    mothballUnitAction.execute(campaign, unit);
+                    MekHQ.triggerEvent(new UnitChangedEvent(unit));
                 } else {
                     campaign.addReport(String.format(resources.getString("mothballingFailed.text"),
                         unit.getName()));
                 }
             }
-        }
-
-        // This needs to be a separate list as the act of mothballing the unit removes it from the
-        // list of units attached to the relevant force, resulting in a ConcurrentModificationException
-        for (Unit unit : mothballTargets) {
-            mothballUnitAction.execute(campaign, unit);
-            MekHQ.triggerEvent(new UnitChangedEvent(unit));
         }
 
         return mothballTargets;
@@ -167,13 +168,14 @@ public class ContractAutomation {
      * @param campaign The current campaign.
      */
     public static void performAutomatedActivation(Campaign campaign) {
-        List<Unit> units = campaign.getAutomatedMothballUnits();
-
         ActivateUnitAction activateUnitAction = new ActivateUnitAction(null, true);
 
-        for (Unit unit : units) {
+        List<UUID> unitIds = campaign.getAutomatedMothballUnits();
+        for (UUID unitId : unitIds) {
+            Unit unit = campaign.getUnit(unitId);
+
             if (unit == null) {
-                // <50.03 compatibility handler
+                campaign.addReport(String.format(resources.getString("activationFailed.uuid"), unitId.toString()));
                 continue;
             }
 
@@ -182,8 +184,7 @@ public class ContractAutomation {
                 MekHQ.triggerEvent(new UnitChangedEvent(unit));
 
                 if (unit.isMothballed()) {
-                    campaign.addReport(String.format(resources.getString("activationFailed.text"),
-                        unit.getName()));
+                    campaign.addReport(String.format(resources.getString("activationFailed.text"), unit.getName()));
                 }
             }
         }


### PR DESCRIPTION
### Dev Notes
During a recent user stream it was noted that units failed to unmothball upon arriving at the contract. I investigated, and the most likely cause was us storing units instead of unit IDs. If, for some reason, a unit changed they would no longer match what was stored. While this shouldn't happen I went ahead and switched to storing unit IDs - which are both unique and will never change.