### PR TITLE
Fix: Added Missing Exceptional Attribute Charisma SPA

### DIFF
--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -823,6 +823,16 @@ This SPA increases that maximum by 1, but does not increase the Attribute itself
         <skillPrereq/>
     </ability>
     <ability>
+        <lookupName>exceptional_attribute_charisma</lookupName>
+        <displayName>Exceptional Attribute - Chrisma (ATOW)</displayName>
+        <desc><![CDATA[Characters can only increase their Attributes up to a maximum determined by their Phenotype.
+
+This SPA increases that maximum by 1, but does not increase the Attribute itself.]]></desc>
+        <xpCost>200</xpCost>
+        <weight>1</weight>
+        <skillPrereq/>
+    </ability>
+    <ability>
         <lookupName>eagle_eyes</lookupName>
         <xpCost>100</xpCost>
         <weight>2</weight>


### PR DESCRIPTION
Fix #6817

### Dev Notes
For some reason exceptional attribute charisma was set up in code, but not included in the spa file. Most likely this was a copy-paste error.