### PR TITLE
PR: Moved SPA Info in Preparation for Future Changes

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsAbilityInfo.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsAbilityInfo.java
@@ -24,13 +24,8 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
- *
- * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
- * Microsoft's "Game Content Usage Rules"
- * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
- * affiliated with Microsoft.
  */
-package mekhq.utilities.spaUtilities.enums;
+package mekhq.gui.campaignOptions;
 
 import mekhq.campaign.personnel.SpecialAbility;
 
@@ -38,7 +33,7 @@ import mekhq.campaign.personnel.SpecialAbility;
  * The {@code AbilityInfo} class represents information about a specific ability, encapsulating its name, the associated
  * {@link SpecialAbility}, its active status, and its category.
  */
-public class AbilityInfo {
+public class CampaignOptionsAbilityInfo {
     private String name;
     private SpecialAbility ability;
     private boolean isEnabled;
@@ -64,7 +59,8 @@ public class AbilityInfo {
      * @param isEnabled {@code true} if the ability is enabled, otherwise {@code false}
      * @param category  the category of the ability, represented as an {@link AbilityCategory}
      */
-    public AbilityInfo(String name, SpecialAbility ability, boolean isEnabled, AbilityCategory category) {
+    public CampaignOptionsAbilityInfo(String name, SpecialAbility ability, boolean isEnabled,
+          AbilityCategory category) {
         this.name = name;
         this.ability = ability;
         this.isEnabled = isEnabled;

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsAbilityInfo.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsAbilityInfo.java
@@ -24,10 +24,16 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.campaignOptions;
 
 import mekhq.campaign.personnel.SpecialAbility;
+import mekhq.utilities.spaUtilities.enums.AbilityCategory;
 
 /**
  * The {@code AbilityInfo} class represents information about a specific ability, encapsulating its name, the associated
@@ -38,18 +44,6 @@ public class CampaignOptionsAbilityInfo {
     private SpecialAbility ability;
     private boolean isEnabled;
     private AbilityCategory category;
-
-    /**
-     * Enum {@code AbilityCategory} represents the categories abilities can belong to. Categories available:
-     * <ul>
-     *     <li>{@code COMBAT_ABILITIES}: Abilities related to combat actions</li>
-     *     <li>{@code MANEUVERING_ABILITIES}: Abilities related to movement and maneuvering</li>
-     *     <li>{@code UTILITY_ABILITIES}: Abilities providing utility or non-combat benefits</li>
-     * </ul>
-     */
-    public enum AbilityCategory {
-        COMBAT_ABILITY, MANEUVERING_ABILITY, UTILITY_ABILITY, CHARACTER_FLAW, CHARACTER_CREATION_ONLY
-    }
 
     /**
      * Constructs an {@code AbilityInfo} object with all fields initialized.

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.campaignOptions;
 
@@ -33,14 +38,14 @@ import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_GUNNERY;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_PILOTING;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.ROLEPLAY_GENERAL;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.SUPPORT;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_CREATION_ONLY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_FLAW;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.COMBAT_ABILITY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.MANEUVERING_ABILITY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.UTILITY_ABILITY;
 import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.ABRIDGED;
 import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP_ABRIDGED;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createSubTabs;
+import static mekhq.utilities.spaUtilities.enums.AbilityCategory.CHARACTER_CREATION_ONLY;
+import static mekhq.utilities.spaUtilities.enums.AbilityCategory.CHARACTER_FLAW;
+import static mekhq.utilities.spaUtilities.enums.AbilityCategory.COMBAT_ABILITY;
+import static mekhq.utilities.spaUtilities.enums.AbilityCategory.MANEUVERING_ABILITY;
+import static mekhq.utilities.spaUtilities.enums.AbilityCategory.UTILITY_ABILITY;
 
 import java.time.LocalDate;
 import java.util.Map;

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.campaignOptions;
 
@@ -33,14 +38,14 @@ import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_GUNNERY;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_PILOTING;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.ROLEPLAY_GENERAL;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.SUPPORT;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_CREATION_ONLY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_FLAW;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.COMBAT_ABILITY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.MANEUVERING_ABILITY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.UTILITY_ABILITY;
 import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.ABRIDGED;
 import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP_ABRIDGED;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createSubTabs;
+import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.CHARACTER_CREATION_ONLY;
+import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.CHARACTER_FLAW;
+import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.COMBAT_ABILITY;
+import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.MANEUVERING_ABILITY;
+import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.UTILITY_ABILITY;
 
 import java.time.LocalDate;
 import java.util.Map;

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -24,11 +24,6 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
- *
- * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
- * Microsoft's "Game Content Usage Rules"
- * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
- * affiliated with Microsoft.
  */
 package mekhq.gui.campaignOptions;
 
@@ -38,14 +33,14 @@ import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_GUNNERY;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_PILOTING;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.ROLEPLAY_GENERAL;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.SUPPORT;
+import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_CREATION_ONLY;
+import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_FLAW;
+import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.COMBAT_ABILITY;
+import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.MANEUVERING_ABILITY;
+import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.UTILITY_ABILITY;
 import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.ABRIDGED;
 import static mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode.STARTUP_ABRIDGED;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createSubTabs;
-import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.CHARACTER_CREATION_ONLY;
-import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.CHARACTER_FLAW;
-import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.COMBAT_ABILITY;
-import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.MANEUVERING_ABILITY;
-import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.UTILITY_ABILITY;
 
 import java.time.LocalDate;
 import java.util.Map;

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesTab.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.campaignOptions.contents;
 
@@ -33,13 +38,13 @@ import static mekhq.campaign.personnel.skills.SkillType.S_GUN_PROTO;
 import static mekhq.campaign.personnel.skills.SkillType.getExperienceLevelName;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_GUNNERY;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_PILOTING;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_CREATION_ONLY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_FLAW;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.COMBAT_ABILITY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.MANEUVERING_ABILITY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.UTILITY_ABILITY;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createParentPanel;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
+import static mekhq.utilities.spaUtilities.enums.AbilityCategory.CHARACTER_CREATION_ONLY;
+import static mekhq.utilities.spaUtilities.enums.AbilityCategory.CHARACTER_FLAW;
+import static mekhq.utilities.spaUtilities.enums.AbilityCategory.COMBAT_ABILITY;
+import static mekhq.utilities.spaUtilities.enums.AbilityCategory.MANEUVERING_ABILITY;
+import static mekhq.utilities.spaUtilities.enums.AbilityCategory.UTILITY_ABILITY;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -69,12 +74,12 @@ import mekhq.campaign.personnel.SkillPerquisite;
 import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo;
-import mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory;
 import mekhq.gui.campaignOptions.components.CampaignOptionsButton;
 import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
 import mekhq.gui.campaignOptions.components.CampaignOptionsHeaderPanel;
 import mekhq.gui.campaignOptions.components.CampaignOptionsStandardPanel;
 import mekhq.gui.dialog.EditSpecialAbilityDialog;
+import mekhq.utilities.spaUtilities.enums.AbilityCategory;
 
 /**
  * The {@code AbilitiesTab} class represents a GUI tab for configuring and managing special abilities in a campaign.

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesTab.java
@@ -24,11 +24,6 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
- *
- * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
- * Microsoft's "Game Content Usage Rules"
- * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
- * affiliated with Microsoft.
  */
 package mekhq.gui.campaignOptions.contents;
 
@@ -38,13 +33,13 @@ import static mekhq.campaign.personnel.skills.SkillType.S_GUN_PROTO;
 import static mekhq.campaign.personnel.skills.SkillType.getExperienceLevelName;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_GUNNERY;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_PILOTING;
+import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_CREATION_ONLY;
+import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_FLAW;
+import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.COMBAT_ABILITY;
+import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.MANEUVERING_ABILITY;
+import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.UTILITY_ABILITY;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createParentPanel;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
-import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.CHARACTER_CREATION_ONLY;
-import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.CHARACTER_FLAW;
-import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.COMBAT_ABILITY;
-import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.MANEUVERING_ABILITY;
-import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.UTILITY_ABILITY;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -73,13 +68,13 @@ import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.SkillPerquisite;
 import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.skills.SkillType;
+import mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo;
+import mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory;
 import mekhq.gui.campaignOptions.components.CampaignOptionsButton;
 import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
 import mekhq.gui.campaignOptions.components.CampaignOptionsHeaderPanel;
 import mekhq.gui.campaignOptions.components.CampaignOptionsStandardPanel;
 import mekhq.gui.dialog.EditSpecialAbilityDialog;
-import mekhq.utilities.spaUtilities.enums.AbilityInfo;
-import mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory;
 
 /**
  * The {@code AbilitiesTab} class represents a GUI tab for configuring and managing special abilities in a campaign.
@@ -93,7 +88,7 @@ public class AbilitiesTab {
     private static final ResourceBundle resources = ResourceBundle.getBundle(RESOURCE_PACKAGE);
 
     private ArrayList<String> level3Abilities;
-    private Map<String, AbilityInfo> allAbilityInfo;
+    private Map<String, CampaignOptionsAbilityInfo> allAbilityInfo;
     private JPanel combatTab;
     private JPanel maneuveringTab;
     private JPanel utilityTab;
@@ -218,7 +213,8 @@ public class AbilitiesTab {
             }
 
             // Mark the ability as active
-            allAbilityInfo.put(abilityName, new AbilityInfo(abilityName, clonedAbility, isEnabled, category));
+            allAbilityInfo.put(abilityName,
+                  new CampaignOptionsAbilityInfo(abilityName, clonedAbility, isEnabled, category));
         }
     }
 
@@ -306,7 +302,7 @@ public class AbilitiesTab {
         // Contents
         JButton btnEnableAll = new CampaignOptionsButton("AddAll");
         btnEnableAll.addActionListener(e -> {
-            for (AbilityInfo abilityInfo : allAbilityInfo.values()) {
+            for (CampaignOptionsAbilityInfo abilityInfo : allAbilityInfo.values()) {
                 abilityInfo.setEnabled(true);
             }
 
@@ -315,7 +311,7 @@ public class AbilitiesTab {
 
         JButton btnRemoveAll = new CampaignOptionsButton("RemoveAll");
         btnRemoveAll.addActionListener(e -> {
-            for (AbilityInfo abilityInfo : allAbilityInfo.values()) {
+            for (CampaignOptionsAbilityInfo abilityInfo : allAbilityInfo.values()) {
                 abilityInfo.setEnabled(false);
             }
 
@@ -345,7 +341,7 @@ public class AbilitiesTab {
         Collections.sort(sortedAbilityNames);
 
         for (String abilityName : sortedAbilityNames) {
-            AbilityInfo abilityInfo = allAbilityInfo.get(abilityName);
+            CampaignOptionsAbilityInfo abilityInfo = allAbilityInfo.get(abilityName);
 
             if (abilityInfo.getCategory() == abilityCategory) {
                 JPanel abilityPanel = createSPAPanel(abilityInfo);
@@ -394,7 +390,7 @@ public class AbilitiesTab {
      *
      * @return A {@code JPanel} containing the UI elements related to the ability.
      */
-    private JPanel createSPAPanel(AbilityInfo abilityInfo) {
+    private JPanel createSPAPanel(CampaignOptionsAbilityInfo abilityInfo) {
         SpecialAbility ability = abilityInfo.getAbility();
 
         // Initialization
@@ -481,7 +477,7 @@ public class AbilitiesTab {
     private boolean editSPA(SpecialAbility ability) {
         Map<String, SpecialAbility> temporaryMap = new HashMap<>();
 
-        for (Entry<String, AbilityInfo> info : allAbilityInfo.entrySet()) {
+        for (Entry<String, CampaignOptionsAbilityInfo> info : allAbilityInfo.entrySet()) {
             temporaryMap.put(info.getKey(), info.getValue().getAbility());
         }
 
@@ -554,7 +550,7 @@ public class AbilitiesTab {
     public void applyCampaignOptionsToCampaign(@Nullable CampaignPreset preset) {
         Map<String, SpecialAbility> enabledAbilities = new HashMap<>();
 
-        for (AbilityInfo abilityInfo : allAbilityInfo.values()) {
+        for (CampaignOptionsAbilityInfo abilityInfo : allAbilityInfo.values()) {
             if (abilityInfo.isEnabled()) {
                 enabledAbilities.put(abilityInfo.getAbility().getName(), abilityInfo.getAbility());
             }

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesTab.java
@@ -24,23 +24,27 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.campaignOptions.contents;
 
 import static mekhq.campaign.personnel.skills.SkillType.EXP_ELITE;
-import static mekhq.campaign.personnel.skills.SkillType.EXP_NONE;
 import static mekhq.campaign.personnel.skills.SkillType.S_GUN_BA;
 import static mekhq.campaign.personnel.skills.SkillType.S_GUN_PROTO;
 import static mekhq.campaign.personnel.skills.SkillType.getExperienceLevelName;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_GUNNERY;
 import static mekhq.campaign.personnel.skills.enums.SkillSubType.COMBAT_PILOTING;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_CREATION_ONLY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.CHARACTER_FLAW;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.COMBAT_ABILITY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.MANEUVERING_ABILITY;
-import static mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory.UTILITY_ABILITY;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createParentPanel;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
+import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.CHARACTER_CREATION_ONLY;
+import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.CHARACTER_FLAW;
+import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.COMBAT_ABILITY;
+import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.MANEUVERING_ABILITY;
+import static mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory.UTILITY_ABILITY;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -53,7 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ResourceBundle;
-import java.util.regex.Pattern;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -65,22 +68,18 @@ import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
-import megamek.logging.MMLogger;
 import mekhq.CampaignPreset;
-import mekhq.MekHQ;
-import mekhq.Utilities;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.SkillPerquisite;
 import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.skills.SkillType;
-import mekhq.campaign.personnel.skills.enums.SkillSubType;
-import mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo;
-import mekhq.gui.campaignOptions.CampaignOptionsAbilityInfo.AbilityCategory;
 import mekhq.gui.campaignOptions.components.CampaignOptionsButton;
 import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
 import mekhq.gui.campaignOptions.components.CampaignOptionsHeaderPanel;
 import mekhq.gui.campaignOptions.components.CampaignOptionsStandardPanel;
 import mekhq.gui.dialog.EditSpecialAbilityDialog;
+import mekhq.utilities.spaUtilities.enums.AbilityInfo;
+import mekhq.utilities.spaUtilities.enums.AbilityInfo.AbilityCategory;
 
 /**
  * The {@code AbilitiesTab} class represents a GUI tab for configuring and managing special abilities in a campaign.
@@ -94,7 +93,7 @@ public class AbilitiesTab {
     private static final ResourceBundle resources = ResourceBundle.getBundle(RESOURCE_PACKAGE);
 
     private ArrayList<String> level3Abilities;
-    private Map<String, CampaignOptionsAbilityInfo> allAbilityInfo;
+    private Map<String, AbilityInfo> allAbilityInfo;
     private JPanel combatTab;
     private JPanel maneuveringTab;
     private JPanel utilityTab;
@@ -219,8 +218,7 @@ public class AbilitiesTab {
             }
 
             // Mark the ability as active
-            allAbilityInfo.put(abilityName,
-                  new CampaignOptionsAbilityInfo(abilityName, clonedAbility, isEnabled, category));
+            allAbilityInfo.put(abilityName, new AbilityInfo(abilityName, clonedAbility, isEnabled, category));
         }
     }
 
@@ -308,7 +306,7 @@ public class AbilitiesTab {
         // Contents
         JButton btnEnableAll = new CampaignOptionsButton("AddAll");
         btnEnableAll.addActionListener(e -> {
-            for (CampaignOptionsAbilityInfo abilityInfo : allAbilityInfo.values()) {
+            for (AbilityInfo abilityInfo : allAbilityInfo.values()) {
                 abilityInfo.setEnabled(true);
             }
 
@@ -317,7 +315,7 @@ public class AbilitiesTab {
 
         JButton btnRemoveAll = new CampaignOptionsButton("RemoveAll");
         btnRemoveAll.addActionListener(e -> {
-            for (CampaignOptionsAbilityInfo abilityInfo : allAbilityInfo.values()) {
+            for (AbilityInfo abilityInfo : allAbilityInfo.values()) {
                 abilityInfo.setEnabled(false);
             }
 
@@ -347,7 +345,7 @@ public class AbilitiesTab {
         Collections.sort(sortedAbilityNames);
 
         for (String abilityName : sortedAbilityNames) {
-            CampaignOptionsAbilityInfo abilityInfo = allAbilityInfo.get(abilityName);
+            AbilityInfo abilityInfo = allAbilityInfo.get(abilityName);
 
             if (abilityInfo.getCategory() == abilityCategory) {
                 JPanel abilityPanel = createSPAPanel(abilityInfo);
@@ -396,7 +394,7 @@ public class AbilitiesTab {
      *
      * @return A {@code JPanel} containing the UI elements related to the ability.
      */
-    private JPanel createSPAPanel(CampaignOptionsAbilityInfo abilityInfo) {
+    private JPanel createSPAPanel(AbilityInfo abilityInfo) {
         SpecialAbility ability = abilityInfo.getAbility();
 
         // Initialization
@@ -483,7 +481,7 @@ public class AbilitiesTab {
     private boolean editSPA(SpecialAbility ability) {
         Map<String, SpecialAbility> temporaryMap = new HashMap<>();
 
-        for (Entry<String, CampaignOptionsAbilityInfo> info : allAbilityInfo.entrySet()) {
+        for (Entry<String, AbilityInfo> info : allAbilityInfo.entrySet()) {
             temporaryMap.put(info.getKey(), info.getValue().getAbility());
         }
 
@@ -556,7 +554,7 @@ public class AbilitiesTab {
     public void applyCampaignOptionsToCampaign(@Nullable CampaignPreset preset) {
         Map<String, SpecialAbility> enabledAbilities = new HashMap<>();
 
-        for (CampaignOptionsAbilityInfo abilityInfo : allAbilityInfo.values()) {
+        for (AbilityInfo abilityInfo : allAbilityInfo.values()) {
             if (abilityInfo.isEnabled()) {
                 enabledAbilities.put(abilityInfo.getAbility().getName(), abilityInfo.getAbility());
             }

--- a/MekHQ/src/mekhq/utilities/spaUtilities/enums/AbilityCategory.java
+++ b/MekHQ/src/mekhq/utilities/spaUtilities/enums/AbilityCategory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.utilities.spaUtilities.enums;
+
+/**
+ * Enum {@code AbilityCategory} represents the categories abilities can belong to. Categories available:
+ * <ul>
+ *     <li>{@code COMBAT_ABILITIES}: Abilities related to combat actions</li>
+ *     <li>{@code MANEUVERING_ABILITIES}: Abilities related to movement and maneuvering</li>
+ *     <li>{@code UTILITY_ABILITIES}: Abilities providing utility or non-combat benefits</li>
+ *     <li>{@code CHARACTER_FLAW}: Abilities that inflict penalties in exchange for XP</li>
+ *     <li>{@code CHARACTER_CREATION_ONLY}: Abilities that can only be selected when the character is created</li>
+ * </ul>
+ *
+ * @author Illiani
+ * @since 0.50.06
+ */
+public enum AbilityCategory {
+    COMBAT_ABILITY, MANEUVERING_ABILITY, UTILITY_ABILITY, CHARACTER_FLAW, CHARACTER_CREATION_ONLY
+}

--- a/MekHQ/src/mekhq/utilities/spaUtilities/enums/AbilityInfo.java
+++ b/MekHQ/src/mekhq/utilities/spaUtilities/enums/AbilityInfo.java
@@ -24,8 +24,13 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
-package mekhq.gui.campaignOptions;
+package mekhq.utilities.spaUtilities.enums;
 
 import mekhq.campaign.personnel.SpecialAbility;
 
@@ -33,7 +38,7 @@ import mekhq.campaign.personnel.SpecialAbility;
  * The {@code AbilityInfo} class represents information about a specific ability, encapsulating its name, the associated
  * {@link SpecialAbility}, its active status, and its category.
  */
-public class CampaignOptionsAbilityInfo {
+public class AbilityInfo {
     private String name;
     private SpecialAbility ability;
     private boolean isEnabled;
@@ -59,8 +64,7 @@ public class CampaignOptionsAbilityInfo {
      * @param isEnabled {@code true} if the ability is enabled, otherwise {@code false}
      * @param category  the category of the ability, represented as an {@link AbilityCategory}
      */
-    public CampaignOptionsAbilityInfo(String name, SpecialAbility ability, boolean isEnabled,
-                                      AbilityCategory category) {
+    public AbilityInfo(String name, SpecialAbility ability, boolean isEnabled, AbilityCategory category) {
         this.name = name;
         this.ability = ability;
         this.isEnabled = isEnabled;


### PR DESCRIPTION
### Dev Notes
I'm about to move some logic out of `AbilitiesTab.java` connected to the categorization of SPAs. This will allow that logic to be used anywhere, not just campaign options. However, to do that I needed to move the enum values out of `CampaignOptionsAbilityInfo.java`. I was advised to make a PR that just did the move and renaming, and then to follow up with the logic changes.