### PR TITLE
Fix: Reset Initial Delay of Tooltips to Pre-50.05 Values

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -231,7 +231,6 @@ public class MekHQ implements GameListener {
      */
     private static void setTooltipSettings() {
         ToolTipManager tooltipManager = ToolTipManager.sharedInstance();
-        tooltipManager.setInitialDelay(100);
         tooltipManager.setDismissDelay(Integer.MAX_VALUE);
         tooltipManager.setReshowDelay(0);
     }


### PR DESCRIPTION
Fix #6819

### Dev Notes
We had some player feedback that the initial delay in 50.05 was too short. The issue revolves around the conflicting tooltip needs for MekHQ and MegaMek. With whatever settings are assigned in MekHQ propagating into MegaMek. While later changing the settings in MegaMek propagate back onto MekHQ for the rest of the session.

Unfortunately, both MekHQ and MegaMek share a tooltip manager instance, so this issue is not easily resolved. MekHQ desperately needs tooltips to not dismiss. However, players have long lived with tooltips taking a while to display, so an intermediate solution is to revert back to <50.05 settings for tooltip display delay, while keeping the changes that stop tooltips from prematurely dismissing.