### PR TITLE
Improvement: Updated Campaign Options Iconography for 50.06

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -54,7 +54,7 @@ lblReputation.tooltip=Which reputation method should your campaign be graded aga
   <br><b>Recommended:</b> Campaign Operations
 lblManualUnitRatingModifier.text=Manual Modifier
 lblManualUnitRatingModifier.tooltip=This allows you to manually adjust your reputation rating.
-lblResetCriminalRecord.text=Reset Criminal Record \u26A0 \uD83C\uDF1F
+lblResetCriminalRecord.text=Reset Criminal Record \u26A0 \u2728
 lblResetCriminalRecord.tooltip=Reset date of last crime and all penalties to Reputation from crime.\
   <br>\
   <br><b>Warning:</b> The Reputation report won't update to reflect this change until the next Monday.
@@ -123,7 +123,7 @@ maintenanceTab.border="One 'Mek lance can beat one mob, large or small, any time
   <br>Lecture at the New Avalon Institute of Science, 3017</i>
 # createRepairTab
 lblRepairTab.text=Repair Options
-lblTechsUseAdministration.text=Techs Use Administration \u270E \uD83C\uDF1F
+lblTechsUseAdministration.text=Techs Use Administration \u270E \u2728
 lblTechsUseAdministration.tooltip=Daily available tech minutes is increased and decreased based on the Tech's\
   \ <i>Administration</i> skill. Each skill level (Green, Regular, etc.) in <i>Administration</i> increases available\
   \ minutes by around 5%.
@@ -214,7 +214,7 @@ lblAcquisitionTab.text=Acquisition & Delivery Options
 lblAcquisitionPanel.text=Acquisitions
 lblChoiceAcquireSkill.text=Acquisitions Skill
 lblChoiceAcquireSkill.tooltip=What skill should be used when performing acquisition checks?
-lblProcurementPersonnelPick.text=Acquisitions Personnel \uD83C\uDF1F
+lblProcurementPersonnelPick.text=Acquisitions Personnel \u2728
 lblProcurementPersonnelPick.tooltip=Who should be able to make procurement checks?
 lblAcquireClanPenalty.text=Penalty for Clan Equipment
 lblAcquireClanPenalty.tooltip=The penalty for acquisition checks when attempting to acquire Clan\
@@ -443,11 +443,11 @@ lblDisplayScenarioLog.text=Expand Scenario Log by Default \u2728
 lblDisplayScenarioLog.tooltip=Determines whether the scenario log will be expanded by default
 lblDisplayKillRecord.text=Expand Kill Log by Default \u2728
 lblDisplayKillRecord.tooltip=Determines whether the kill log will be expanded by default
-lblDisplayMedicalRecord.text=Expand Medical Log by Default \uD83C\uDF1F
+lblDisplayMedicalRecord.text=Expand Medical Log by Default \u2728
 lblDisplayMedicalRecord.tooltip=Determines whether the medical log will be expanded by default
-lblDisplayAssignmentRecord.text=Expand Assignment Log by Default \uD83C\uDF1F
+lblDisplayAssignmentRecord.text=Expand Assignment Log by Default \u2728
 lblDisplayAssignmentRecord.tooltip=Determines whether the assignment log will be expanded by default
-lblDisplayPerformanceRecord.text=Expand Performance Report by Default \uD83C\uDF1F
+lblDisplayPerformanceRecord.text=Expand Performance Report by Default \u2728
 lblDisplayPerformanceRecord.tooltip=Determines whether the Skill, XP and SPA gain log will be expanded by default
 # createPersonnelInformationTab
 lblPersonnelInformation.text=Personnel Information Options \u270E
@@ -561,7 +561,7 @@ lblPrisonersPanel.text=Prisoners
 lblPrisonerCaptureStyle.text=Capture Style \u2728
 lblPrisonerCaptureStyle.tooltip=This is the ruleset to use when determining if a person has been\
   \ captured by the force following a scenario.
-lblResetTemporaryPrisonerCapacity.text=Reset Prisoner Capacity Reductions \uD83C\uDF1F
+lblResetTemporaryPrisonerCapacity.text=Reset Prisoner Capacity Reductions \u2728
 lblResetTemporaryPrisonerCapacity.tooltip=This option removes any penalties to Prisoner Capacity that might have been\
   \ added by Prisoner Events.
 # createDependentsPanel
@@ -593,7 +593,7 @@ lblUseTougherHealing.tooltip=The healing check will be penalized for every addit
 lblMaximumPatients.text=Base Beds per Doctor \u2728
 lblMaximumPatients.tooltip=This is the base number of patients that can be treated per doctor. This can be modified by\
   \ Administration.
-lblDoctorsUseAdministration.text=Doctors Need Administration \u270E \uD83C\uDF1F
+lblDoctorsUseAdministration.text=Doctors Need Administration \u270E \u2728
 lblDoctorsUseAdministration.tooltip=If enabled, the <i>Administration</i> skill of each Doctor influences how many hospital\
   \ beds they generate. Each skill level in <i>Administration</i> (Green, Regular, etc.) increases the number of beds by\
   \ around 20%.
@@ -697,7 +697,7 @@ lblFamilyDisplayLevel.tooltip=This setting is the relation to the selected chara
   \ display up to, including the previous levels.\
   <br>\
   <br><b>Warning:</b> Higher levels require more processing when loading a character.
-lblUseAgeEffects.text=Character Age Affects Skills \u26A0 \u270E \uD83C\uDF1F
+lblUseAgeEffects.text=Character Age Affects Skills \u26A0 \u270E \u2728
 lblUseAgeEffects.tooltip=Based on ATOW, As a character ages, their skills improve and decrease (mostly decrease).
 # createAnniversariesPanel
 lblAnniversariesPanel.text=Anniversaries \u2728
@@ -714,7 +714,7 @@ lblAnnounceChildBirthdays.tooltip=If enabled, 18th birthdays will always be anno
   <br>\
   <br><b>Warning:</b> Enabling this option will override any other settings.
 # createLifeEventsPanel
-lblLifeEventsPanel.text=Life Events \uD83C\uDF1F
+lblLifeEventsPanel.text=Life Events \u2728
 lblShowLifeEventDialogBirths.text=Personnel Giving Birth
 lblShowLifeEventDialogBirths.tooltip=Whenever a child is born, an in character dialog will appear announcing the event.
 lblShowLifeEventDialogComingOfAge.text=Children Coming of Age
@@ -1459,7 +1459,7 @@ lblContractSearchRadius.tooltip=Limits the location of contract offers to system
 lblVariableContractLength.text=Vary Contract Lengths
 lblVariableContractLength.tooltip=The length of the contract has a duration variance instead of\
   \ just using the constant base length for the mission type.
-lblUseDynamicDifficulty.text=Dynamically Adjust Contract Difficulty \uD83C\uDF1F
+lblUseDynamicDifficulty.text=Dynamically Adjust Contract Difficulty \u2728
 lblUseDynamicDifficulty.tooltip=The difficulty of random contracts is adjusted based on the average skill level of combat\
   \ personnel in your campaign. The higher skilled you are, the more challenging - and potentially rewarding - contracts\
   \ will be.
@@ -1813,19 +1813,19 @@ lblExtraRandomness.tooltip=If checked, an additional 1d6 will be rolled per skil
   <br>\
   <br><b>Warning:</b> Due to the way experience levels are calculated, enabling this option will\
   \ more frequently have characters created with slightly lower than normal experience levels.
-lblComingOfAgeAbilities.text=Award Coming of Age SPAs \u2714 \uD83C\uDF1F
+lblComingOfAgeAbilities.text=Award Coming of Age SPAs \u2714 \u2728
 lblComingOfAgeAbilities.tooltip=If checked, all characters will be awarded a single SPA when they turn 16.\
   <br>\
   <br><b>Recommendation:</b> This was balanced around the pool of SPAs being rather large, due to the addition of ATOW\
   \ SPAs. If you are working with a smaller SPA pool, perhaps due to disabling those SPAs, you might want to leave\
   \ this off.
 lblATOWAttributesPanel.text=A Time of War Traits
-lblUseAttributes.text=Use Attributes \u26A0 \uD83C\uDF1F
+lblUseAttributes.text=Use Attributes \u26A0 \u2728
 lblUseAttributes.tooltip=If checked, characters will be generated with <i>A Time of War</i> Attribute scores.\
   <br>\
   <br><b>Warning:</b> If enabled (or disabled) mid-campaign, you need to navigate to the personnel tab, and (while in\
   \ GM Mode) you should use the right-click menu to reset attribute scores for all personnel.
-lblRandomizeAttributes.text=Extra Random Attributes \uD83C\uDF1F
+lblRandomizeAttributes.text=Extra Random Attributes \u2728
 lblRandomizeAttributes.tooltip=If checked, an extra d6 is rolled for each of the character's ATOW Attributes.\
   <br>\
   <br>On a roll of a 6 the Attribute is increased by 1, and a second d6 is rolled. If that is also a 6, the Attribute is\
@@ -1833,7 +1833,7 @@ lblRandomizeAttributes.tooltip=If checked, an extra d6 is rolled for each of the
   <br>\
   <br>On a roll of a 6 the Attribute is decreased by 1, and a second d6 is rolled. If that is also a 1, the Attribute is\
   \ decreased by 1 again; and so on, until 1s stop being rolled.
-lblRandomizeTraits.text=Randomize Traits \uD83C\uDF1F
+lblRandomizeTraits.text=Randomize Traits \u2728
 lblRandomizeTraits.tooltip=If checked, a newly created character's Connections, Wealth, Reputation, and Unlucky scores\
   \ are randomized.\
   <br>\
@@ -1932,7 +1932,7 @@ lblCommandSkillsElite.tooltip=Modifier made to the 2d6 roll used to determine wh
   <br><b>6-9:</b> Regular\
   <br><b>10-11:</b> Veteran\
   <br><b>12+:</b> Elite
-lblRoleplaySkillsModifier.text=Roleplay Skills \u26A0 \uD83C\uDF1F
+lblRoleplaySkillsModifier.text=Roleplay Skills \u26A0 \u2728
 lblRoleplaySkillsModifier.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
   \ with points in one (or more) of the roleplay skills.\
   <br>\
@@ -1966,7 +1966,7 @@ lblSecondarySkillChance.tooltip=The percentage chance a conventional infantry ch
 lblSecondarySkillBonus.text=Modifier
 lblSecondarySkillBonus.tooltip=The skill level modifier applied to the skill (if present).
 ## Recruitment Bonuses Tab
-lblRecruitmentBonusesTab.text=Recruitment Modifiers \uD83C\uDF1F
+lblRecruitmentBonusesTab.text=Recruitment Modifiers \u2728
 lblRecruitmentBonusesTabBody.text=When a character is generated, a 2d6 is rolled to determine their experience level (Green,\
   \ Regular, etc.). These options allow you to apply a modifier to those rolls, specific to each profession.
 lblRecruitmentBonusesCombatPanel.text=Combat Roles


### PR DESCRIPTION
This PR just switches any instances of the 'Added since the last Development release' added during the 50.05 dev cycle with  the 'Added since the last <b>Milestone</b> release' icon.