### PR TITLE
Fixed: Corrected Formatting of Bondsref Messaging

### DIFF
--- a/MekHQ/resources/mekhq/resources/PrisonerEvents.properties
+++ b/MekHQ/resources/mekhq/resources/PrisonerEvents.properties
@@ -1,7 +1,7 @@
 # suppress inspection "UnusedMessageFormatParameter" for whole file
 # suppress inspection "UnusedProperty" for whole file
 # CapturePrisoners.java
-bondsref.report={0} has performed {0}<b>Bondsref</b>{1} instead of accepting capture by our forces.\
+bondsref.report={0} has performed {1}<b>Bondsref</b>{2} instead of accepting capture by our forces.\
   \ Their body has been transported to the morgue.
 # EVENT GENERAL
 result.ooc=Closing or canceling this conversation will automatically pick the first option.\


### PR DESCRIPTION
Stops this nonsense:

![image](https://github.com/user-attachments/assets/e95e7267-123f-4b29-b51c-24d1a13b4323)
