### PR TITLE
Improvement: Added GM Option to Remove All Roleplay Skills From A Character

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -310,6 +310,7 @@ regenerateLoyalty.text=Regenerate Loyalty
 regeneratePersonality.text=Regenerate Personality
 addRandomSPA.text=Add Random SPA
 generateRoleplaySkills.text=Generate Random Roleplay Skills
+removeRoleplaySkills.text=Remove All Roleplay Skills
 generateRoleplayAttributes.text=Reset Roleplay Attributes
 generateRoleplayTraits.text=Reset Roleplay Traits
 addMinimumComplement.text=Add minimum complement

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -238,6 +238,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private static final String CMD_PERSONALITY = "PERSONALITY";
     private static final String CMD_ADD_RANDOM_ABILITY = "ADD_RANDOM_ABILITY";
     private static final String CMD_GENERATE_ROLEPLAY_SKILLS = "GENERATE_ROLEPLAY_SKILLS";
+    private static final String CMD_REMOVE_ROLEPLAY_SKILLS = "REMOVE_ROLEPLAY_SKILLS";
     private static final String CMD_GENERATE_ROLEPLAY_ATTRIBUTES = "GENERATE_ROLEPLAY_ATTRIBUTES";
     private static final String CMD_GENERATE_ROLEPLAY_TRAITS = "GENERATE_ROLEPLAY_TRAITS";
 
@@ -1504,6 +1505,22 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 for (Person person : people) {
                     skillGenerator.generateRoleplaySkills(person);
                     MekHQ.triggerEvent(new PersonChangedEvent(person));
+                }
+                break;
+            }
+            case CMD_REMOVE_ROLEPLAY_SKILLS: {
+                RandomSkillPreferences skillPreferences = getCampaign().getRandomSkillPreferences();
+                AbstractSkillGenerator skillGenerator = new DefaultSkillGenerator(skillPreferences);
+                for (Person person : people) {
+                    // We make an iteration safe list so we can easily remove skills during the loop
+                    List<Skill> allSkills = new ArrayList<>(person.getSkills().getSkills());
+                    for (Skill skill : allSkills) {
+                        SkillType skillType = skill.getType();
+
+                        if (skillType.isRoleplaySkill()) {
+                            person.removeSkill(skillType.getName());
+                        }
+                    }
                 }
                 break;
             }
@@ -4013,6 +4030,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
             menuItem = new JMenuItem(resources.getString("generateRoleplaySkills.text"));
             menuItem.setActionCommand(CMD_GENERATE_ROLEPLAY_SKILLS);
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
+
+            menuItem = new JMenuItem(resources.getString("removeRoleplaySkills.text"));
+            menuItem.setActionCommand(CMD_REMOVE_ROLEPLAY_SKILLS);
             menuItem.addActionListener(this);
             menu.add(menuItem);
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1509,8 +1509,6 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 break;
             }
             case CMD_REMOVE_ROLEPLAY_SKILLS: {
-                RandomSkillPreferences skillPreferences = getCampaign().getRandomSkillPreferences();
-                AbstractSkillGenerator skillGenerator = new DefaultSkillGenerator(skillPreferences);
                 for (Person person : people) {
                     // We make an iteration safe list so we can easily remove skills during the loop
                     List<Skill> allSkills = new ArrayList<>(person.getSkills().getSkills());


### PR DESCRIPTION
Not everyone is a fan of roleplay skills, but roleplay skill generation is enabled by default in most stock presets. This adds a GM option to the personnel right-click menu that allows players to remove all currently generated roleplay skills from a character. It supports selecting multiple characters at once.