### PR TITLE
Fix: Fixed Exception During Campaign Preset Saving Caused by Two Wrongly Setup Skills

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -836,8 +836,8 @@ public class SkillType {
         lookupHash.put(S_INTEREST_HISTORY, createInterestHistory());
         lookupHash.put(S_INTEREST_LITERATURE, createInterestLiterature());
         lookupHash.put(S_INTEREST_HOLO_GAMES, createInterestHoloGames());
-        lookupHash.put(S_INTEREST_FASHION, createInterestSports());
-        lookupHash.put(S_INTEREST_MUSIC, createInterestSports());
+        lookupHash.put(S_INTEREST_FASHION, createInterestFashion());
+        lookupHash.put(S_INTEREST_MUSIC, createInterestMusic());
         lookupHash.put(S_INTEREST_MILITARY, createInterestMilitary());
         lookupHash.put(S_INTEREST_ANTIQUES, createInterestAntiques());
         lookupHash.put(S_INTEREST_THEOLOGY, createInterestTheology());


### PR DESCRIPTION
Two skills were calling the wrong setup method resulting in campaign options failing to save.

This is another notch in the stick of 'skills need to be enums'