### PR TITLE
Fix: Fixed Unclear Wording in Procurement when Out of Acquisition Attempts

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7474,7 +7474,7 @@ public class Campaign implements ITechManager {
 
         if (null == person) {
             return new TargetRoll(TargetRoll.IMPOSSIBLE,
-                  "Your procurement personnel have used up all their " + "acquisition attempts for this period");
+                  "Your procurement personnel have used up all their acquisition attempts for this period");
         }
         final Skill skill = person.getSkillForWorkingOn(getCampaignOptions().getAcquisitionSkill());
         if (null != getShoppingList().getShoppingItem(acquisition.getNewEquipment()) && checkDaysToWait) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7473,7 +7473,8 @@ public class Campaign implements ITechManager {
         }
 
         if (null == person) {
-            return new TargetRoll(TargetRoll.IMPOSSIBLE, "No one on your force is capable of acquiring parts");
+            return new TargetRoll(TargetRoll.IMPOSSIBLE,
+                  "Your procurement personnel have used up all their " + "acquisition attempts for this period");
         }
         final Skill skill = person.getSkillForWorkingOn(getCampaignOptions().getAcquisitionSkill());
         if (null != getShoppingList().getShoppingItem(acquisition.getNewEquipment()) && checkDaysToWait) {


### PR DESCRIPTION
The procurement error display for when a campaign has no procurement personnel is reused when the campaign's procurement personnel have run out of acquisitions for the period. Specifically, it stated that nobody in the campaign was capable of acquiring parts. Which is factually correct, however gives the impression that there are no acquisitions personnel, as opposed to them just being out of acquisition attempts.

I reworded this message to specifically state that the personnel are out of acquisitions. The message is still reused if there are no acquisitions personnel in the campaign, but even then it's factually correct and far less likely to cause confusion than the original message.

In the land of wishes and fairies we'd rework this entire system, but that's out of scope for this PR.