### PR TITLE
Fix: Added Clan Labels and Descriptions to Profession Descriptions and Labels

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -230,6 +230,14 @@ public enum PersonnelRole {
     }
 
     /**
+     * @deprecated use {@link #getTooltip(boolean)} instead
+     */
+    @Deprecated(since = "0.50.06", forRemoval = true)
+    public String getDescription() {
+        return getDescription(false);
+    }
+
+    /**
      * Retrieves the plain text description for this personnel role from the resource bundle.
      *
      * @return the description string associated with the personnel role.
@@ -237,8 +245,17 @@ public enum PersonnelRole {
      * @author Illiani
      * @since 0.50.06
      */
-    public String getDescription() {
-        return getTextAt(RESOURCE_BUNDLE, name() + ".description");
+    public String getDescription(final boolean isClan) {
+        final boolean useClan = isClan && hasClanName;
+        return getTextAt(RESOURCE_BUNDLE, name() + ".description" + (useClan ? ".clan" : ""));
+    }
+
+    /**
+     * @deprecated use {@link #getTooltip(boolean)} instead
+     */
+    @Deprecated(since = "0.50.06", forRemoval = true)
+    public String getTooltip() {
+        return getTooltip(false);
     }
 
     /**
@@ -254,8 +271,8 @@ public enum PersonnelRole {
      * @author Illiani
      * @since 0.50.06
      */
-    public String getTooltip() {
-        StringBuilder tooltip = new StringBuilder(getDescription()).append("<br>");
+    public String getTooltip(final boolean isClan) {
+        StringBuilder tooltip = new StringBuilder(getDescription(isClan)).append("<br>");
 
         List<String> skills = new ArrayList<>();
         if (this == VEHICLE_CREW) {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -769,7 +769,7 @@ public class CampaignGUI extends JPanel {
                 miHire.setMnemonic(role.getMnemonic());
                 miHire.setAccelerator(KeyStroke.getKeyStroke(role.getMnemonic(), InputEvent.ALT_DOWN_MASK));
             }
-            miHire.setToolTipText(role.getDescription());
+            miHire.setToolTipText(role.getDescription(getCampaign().isClanCampaign()));
             miHire.setActionCommand(role.name());
             miHire.addActionListener(this::hirePerson);
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -2053,8 +2053,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
 
             if (allCanPerform) {
-                cbMenuItem = new JCheckBoxMenuItem(role.toString());
-                cbMenuItem.setToolTipText(wordWrap(role.getTooltip(), 50));
+                cbMenuItem = new JCheckBoxMenuItem(role.getLabel(getCampaign().isClanCampaign()));
+                cbMenuItem.setToolTipText(wordWrap(role.getTooltip(getCampaign().isClanCampaign()), 50));
                 cbMenuItem.setActionCommand(makeCommand(CMD_PRIMARY_ROLE, role.name()));
                 cbMenuItem.addActionListener(this);
                 if (oneSelected && role == person.getPrimaryRole()) {
@@ -2097,8 +2097,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
 
             if (allCanPerform) {
-                cbMenuItem = new JCheckBoxMenuItem(role.toString());
-                cbMenuItem.setToolTipText(wordWrap(role.getTooltip()));
+                cbMenuItem = new JCheckBoxMenuItem(role.getLabel(getCampaign().isClanCampaign()));
+                cbMenuItem.setToolTipText(wordWrap(role.getTooltip(getCampaign().isClanCampaign())));
                 cbMenuItem.setActionCommand(makeCommand(CMD_SECONDARY_ROLE, role.name()));
                 cbMenuItem.addActionListener(this);
                 if (oneSelected && role == person.getSecondaryRole()) {

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelRoleTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelRoleTest.java
@@ -739,13 +739,25 @@ class PersonnelRoleTest {
 
     @ParameterizedTest
     @EnumSource(value = PersonnelRole.class, names = "NONE", mode = EnumSource.Mode.EXCLUDE)
-    void testGetDescription(PersonnelRole role) {
+    void testGetDescription_notClan(PersonnelRole role) {
         // Setup
 
         // Act
-        String description = role.getDescription();
+        String description = role.getDescription(false);
 
         // Assert
         assertTrue(isResourceKeyValid(description), "Role does not have a description: " + role.name());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = PersonnelRole.class, names = "NONE", mode = EnumSource.Mode.EXCLUDE)
+    void testGetDescription_Clan(PersonnelRole role) {
+        // Setup
+
+        // Act
+        String description = role.getDescription(true);
+
+        // Assert
+        assertTrue(isResourceKeyValid(description), "Role does not have a Clan description: " + role.name());
     }
 }


### PR DESCRIPTION
Profession labels were always using IS terms. Now they don't. For example the BA trooper profession will show as Elemental.