### PR TITLE
Fix: Dependents Now Correctly Contribute to Administration Requirements when Calculating Unit Reputation

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
@@ -114,7 +114,7 @@ public class AverageExperienceRating {
         int personnelCount = 0;
         double totalExperience = 0.0;
 
-        for (Person person : campaign.getActivePersonnel(true)) {
+        for (Person person : campaign.getActivePersonnel(false)) {
             Unit unit = person.getUnit();
 
             // if the person does not belong to a unit, then skip this person

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/SupportRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/SupportRating.java
@@ -108,10 +108,12 @@ public class SupportRating {
         // Get the total sums of personnel and administrators
         int totalPersonnelCount = getTotalPersonnelCount(campaign, technicianRequirements);
 
-        int administratorCount = (int) campaign.getActivePersonnel(true)
-                                             .stream()
-                                             .filter(Person::isAdministrator)
-                                             .count();
+        int administratorCount = 0;
+        for (Person person : campaign.getActivePersonnel(false)) {
+            if (person.isAdministrator() || person.isDependent()) {
+                administratorCount++;
+            }
+        }
 
         // Calculate personnel count based on campaign faction
         double divisor = campaign.getFaction().isPirate() || campaign.getFaction().isMercenary() ? 10 : 20;
@@ -287,7 +289,7 @@ public class SupportRating {
         techCounts.put("techAeroCount", 0);
         techCounts.put("techBattleArmorCount", 0);
 
-        for (Person person : campaign.getActivePersonnel(true)) {
+        for (Person person : campaign.getActivePersonnel(false)) {
             updateCount(person::isTechMek, "techMekCount", techCounts);
             updateCount(person::isTechMechanic, "techMechanicCount", techCounts);
             updateCount(person::isTechAero, "techAeroCount", techCounts);


### PR DESCRIPTION
Thanks to @Saklad5 for pointing this out.

CamOps considers all non-techs, non-combatants to be 'admin personnel' for the purposes of Unit Reputation. MekHQ, unlike CamOps, has distinct admin roles.

When writing the CamOps Reputation my eyes slipped over the importance of the wording in the below section:

![image](https://github.com/user-attachments/assets/9542f391-3f12-421a-8195-790642c1d241)

The paragraph clearly shows that Dependents (which would cover things like 'lawyers' and 'bean counters') should count towards the unit reputation. At least in their current iteration. In 50.07 we will probably need to adjust this to exclude 'unemployed' dependents, but otherwise this will be a significant boost towards making dependents feel like they have a use.

While I was at it I closed a couple of bugs where we were counting prisoners for some roles.