### PR TITLE
Fix for Capital Ship Armor Repair Time

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -410,16 +410,31 @@ public class Armor extends Part implements IAcquisitionWork {
     }
 
     public int getBaseTimeFor(Entity entity) {
-        if (null != entity) {
-            if (entity instanceof Tank) {
-                return 3;
-            }
-            // December 2017 errata, only large craft should return 15m/point.
-            else if (entity.hasETypeFlag(Entity.ETYPE_DROPSHIP) || entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
-                return 15;
-            }
+        if (null == entity) {
+            return 5;
         }
-        return 5;
+        // FIXME: this mess is because switch cannot switch on longs as of Java 17.
+        // Options include: Waiting for Java to support that, or changing the entire
+        // way the 'ETYPE' works on Entity to implement bitset or some similar.
+        // For repair types, see StratOps, Master Repair Table, p183
+        String typeKey;
+        if (entity instanceof Tank) {
+            typeKey = "TANK";
+        } else if (entity.hasETypeFlag(Entity.ETYPE_WARSHIP)) {
+            typeKey = "CAPITAL";
+        } else if (entity.hasETypeFlag(Entity.ETYPE_AERO)) {
+            typeKey = "AEROSPACE";
+        } else {
+            typeKey = "DEFAULT";
+        }
+
+        return (switch (typeKey) {
+            case "TANK" -> 3;
+            case "CAPITAL" -> 120;
+            case "AEROSPACE" -> 15;
+            default -> 5;
+        });
+
     }
 
     @Override
@@ -574,18 +589,21 @@ public class Armor extends Part implements IAcquisitionWork {
 
     /**
      * Searches the warehouse for a compatible parts and returns how many points of armor are found.
+     *
      * @return returns points of armor are found
      */
     public int getAmountAvailable() {
         return campaign.getWarehouse()
-                     .streamSpareParts().filter(this::isSameArmorPart)
+                     .streamSpareParts()
+                     .filter(this::isSameArmorPart)
                      .mapToInt(part -> ((Armor) part).getAmount())
                      .sum();
     }
 
     /**
-     * Searches the warehouse for a compatible parts changes the amount available. This will continue to remove parts
-     * if more than one part needs to be removed to cover the amount.
+     * Searches the warehouse for a compatible parts changes the amount available. This will continue to remove parts if
+     * more than one part needs to be removed to cover the amount.
+     *
      * @param amount points of armor to add or remove
      */
     public void changeAmountAvailable(int amount) {
@@ -715,7 +733,9 @@ public class Armor extends Part implements IAcquisitionWork {
 
     /**
      * Finds a spare part, if applicable, and changes its amount, creating a new part if needed.
+     *
      * @param amount value to change the part's amount by. Can be positive to add or negative to remove.
+     *
      * @return leftover amount; should be 0 except when removing if the part removed didn't have enough
      */
     protected int changeAmountAvailableSingle(int amount) {
@@ -741,14 +761,12 @@ public class Armor extends Part implements IAcquisitionWork {
 
     /**
      * Not sure how true this title is, it was used in {@link Armor#getAmountAvailable}
+     *
      * @param part is this part the same
-     * @return true if the two parts are the same, at least as far as {@link Armor#getAmountAvailable} is
-     * concerned
+     *
+     * @return true if the two parts are the same, at least as far as {@link Armor#getAmountAvailable} is concerned
      */
     private boolean isSameArmorPart(Part part) {
-        return (part instanceof Armor armor) &&
-                     armor.isPresent() &&
-                     !armor.isReservedForRefit() &&
-                     isSameType(armor);
+        return (part instanceof Armor armor) && armor.isPresent() && !armor.isReservedForRefit() && isSameType(armor);
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -32,6 +32,7 @@ import java.io.PrintWriter;
 import java.text.DecimalFormat;
 import java.util.Objects;
 
+import megamek.common.Aero;
 import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.IArmorState;
@@ -39,6 +40,7 @@ import megamek.common.ITechnology;
 import megamek.common.Tank;
 import megamek.common.TargetRoll;
 import megamek.common.TechAdvancement;
+import megamek.common.Warship;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.ArmorType;
 import megamek.logging.MMLogger;
@@ -410,19 +412,19 @@ public class Armor extends Part implements IAcquisitionWork {
     }
 
     public int getBaseTimeFor(Entity entity) {
-        if (null == entity) {
+        if (entity == null) {
             return 5;
         }
         // FIXME: this mess is because switch cannot switch on longs as of Java 17.
         // Options include: Waiting for Java to support that, or changing the entire
         // way the 'ETYPE' works on Entity to implement bitset or some similar.
-        // For repair types, see StratOps, Master Repair Table, p183
+        // For repair types, see CamOps, Master Repair Table, p207
         String typeKey;
         if (entity instanceof Tank) {
             typeKey = "TANK";
-        } else if (entity.hasETypeFlag(Entity.ETYPE_WARSHIP)) {
+        } else if (entity instanceof Warship) {
             typeKey = "CAPITAL";
-        } else if (entity.hasETypeFlag(Entity.ETYPE_AERO)) {
+        } else if (entity instanceof Aero) {
             typeKey = "AEROSPACE";
         } else {
             typeKey = "DEFAULT";


### PR DESCRIPTION
Fixes issue #175. Updates armor part with correct times for capital scale ships per Master Repair Table in StratOps p183.