### PR TITLE
Improvement: Added Hint Panel to TO&E Tab; Updated Glossary With New TO&E-Related Entries

### DIFF
--- a/MekHQ/resources/mekhq/resources/ForceType.properties
+++ b/MekHQ/resources/mekhq/resources/ForceType.properties
@@ -1,4 +1,4 @@
-STANDARD.label=Standard
+STANDARD.label=Combat
 SUPPORT.label=Support
 SUPPORT.symbol=\ \u2205
 CONVOY.label=Convoy

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1463,3 +1463,10 @@ AutoResolveMethod.ABSTRACT_COMBAT.text=Abstract Combat Auto Resolution (ACAR)
 AutoResolveMethod.ABSTRACT_COMBAT.toolTipText=ACAR, a fast simulation using a subset of the abstract combat system rules
 AutoResolveMethod.promptForAutoResolveMethod.text=Select the method to use for auto resolving the scenario.
 AutoResolveMethod.promptForAutoResolveMethod.title=Auto Resolve Method
+TOE.keyText=<b><a href='GLOSSARY:TOE'>About the TO&E</a>\
+  &nbsp;&nbsp;&nbsp;&nbsp;<b>Bold</b>&nbsp;&nbsp;<a href='GLOSSARY:COMBAT_TEAMS'>Combat Team</a>\
+  &nbsp;&nbsp;&nbsp;&nbsp;<u>Underlined</u>&nbsp;&nbsp;Combat Team Status Overridden\
+  &nbsp;&nbsp;&nbsp;&nbsp;<s>c</s>&nbsp;&nbsp;<a href='GLOSSARY:FORCE_TYPE_COMBAT'>Factored into Contract Pay</a>\
+  &nbsp;&nbsp;&nbsp;&nbsp;&#926;&nbsp;&nbsp;<a href='GLOSSARY:FORCE_TYPE_CONVOY'>Convoy Force</a>\
+  &nbsp;&nbsp;&nbsp;&nbsp;&#10023;&nbsp;&nbsp;<a href='GLOSSARY:FORCE_TYPE_SECURITY'>Security Force</a>\
+  &nbsp;&nbsp;&nbsp;&nbsp;&#8709;&nbsp;&nbsp;<a href='GLOSSARY:FORCE_TYPE_SUPPORT'>Support Force</a>

--- a/MekHQ/resources/mekhq/resources/Glossary.properties
+++ b/MekHQ/resources/mekhq/resources/Glossary.properties
@@ -1,4 +1,4 @@
-# suppress inspection "UnusedProperty" for whole file
+# suppress inspection "UnusedProperty" for the whole file
 # Please try and keep all entries in alphabetical order for ease of reference
 ### A
 ADMIN_STRAIN.title=Administrative Strain
@@ -37,29 +37,24 @@ COMBAT_TEAMS.definition=Combat Teams are cohesive groups of forces designed to f
   \ Lances and their support units.\
   <p>A key feature of Combat Teams is player control: you decide exactly which forces should be assigned to scenarios.\
   \ By default, any force without child forces and containing at least one unit is automatically considered a Combat\
-  \ Team. However, you can adjust this defaults, by right-clicking on a force and selecting 'Never Consider a Combat\
-  \ Team', or 'Always Consider a Combat Team'. To remove any overrides, simply use the same right-click menu and select\
-  \ "Remove Combat Team Override".</p>\
+  \ Team. However, you can adjust this default by right-clicking on a force and selecting ''Never Consider a Combat\
+  \ Team,'' or ''Always Consider a Combat Team.'' To remove any overrides, simply use the same right-click menu and select\
+  \ "Remove Combat Team Override."</p>\
+  <p>In your <a href='GLOSSARY:TOE'>TO&E</a> a Combat Team is indicated by the name of the force being <b>bold</b>. If\
+  \ you override the default Combat Team selection, the force will be underlined. This allows you to easily see which\
+  \ forces you adjusted in the event you need to update your TO&E.</p>\
   <p><b>EXAMPLE</b></p>\
   <p>If you have a Company of three Lances, MekHQ would normally treat each Lance as an individual Combat Team. But if\
   \ you want the entire Company to deploy as one Combat Team, you can override the default setting by right-clicking on\
-  \ the company-level force and selecting 'Always Consider a Combat Team'.</p>\
+  \ the company-level force and selecting ''Always Consider a Combat Team.'' This is particularly useful for large campaigns\
+  \ where deploying in Lance-level formations results in implaussibly large numbers of scenarios each week.</p>\
   <p><b>FORCE TYPE</b></p>\
-  <p>There are four kinds of force classification. Each is set up for a specific duty. A force's type can be changed by\
-  \ right-clicking on the force and selecting the type of your choice.</p>\
-  <p><b>Standard:</b> this is the default force type. A standard force is one meant for general combat.</p>\
-  <p><b>Support:</b> a Support Force is any force not typically deployed in combat scenarios. This classification is\
-  \ ideal for units like support vehicles, civilians, or other forces that belong in the TO&E but aren't meant to fight.\
-  \ If <a href='GLOSSARY:STRATCON'>StratCon</a> is enabled, Support Forces are rarely deployed to scenarios, making them\
-  \ a useful classification for logistical or non-combat units.</p>\
-  <p><b>Convoy:</b> these forces perform logistical support generally behind the front lines. Running supplies and making\
-  \ sure front line forces are kept stocked up. If <a href='GLOSSARY:STRATCON'>StratCon</a> is enabled, while on contract,\
-  \ you can use Convoy Forces during monthly <a href='GLOSSARY:RESUPPLY'>Resupplies</a>.</p>\
-  <p><b>Security:</b> forces assigned to Security duties are primarily responsible for managing prisoners of war. If the\
-  \ <i>Campaign Operations</i> or <i>MekHQ</i> capture styles are enabled in campaign options, units assigned to Security\
-  \ Forces will contribute to the campaign's <a href='GLOSSARY:PRISONER_CAPACITY'>Prisoner Capacity</a>.\
+  <p>There are four kinds of force classification: <a href='GLOSSARY:FORCE_TYPE_COMBAT'>Combat</a>,\
+  \ <a href='GLOSSARY:FORCE_TYPE_CONVOY'>Convoy</a>, <a href='GLOSSARY:FORCE_TYPE_SECURITY'>Security</a>, and\
+  \ <a href='GLOSSARY:FORCE_TYPE_SUPPORT'>Support</a>. Each is set up for a specific duty. A force''s type can be changed\
+  \ by right-clicking on the force and selecting the type of your choice.</p>\
   <p>For more details on Combat Teams, refer to the documentation in:\
-  <br><i>MekHQ/docs/StratCon/Combat Teams, Roles, Training & Reinforcements.pdf</i></p>\
+  <br><i>MekHQ/docs/StratCon/Combat Teams, Roles, Training & Reinforcements.pdf</i></p>
 CONTRACT_VICTORY_POINTS.title=Contract Victory Points
 CONTRACT_VICTORY_POINTS.definition=Contract Victory Points (CVP) represent an abstract measure of\
   \ your contract''s overall strategic success. Most contracts require a positive CVP to be\
@@ -101,6 +96,31 @@ FATIGUE.definition=Fatigue represents how exhausted a character is from their ex
   <p>The core rules for Reputation can be found in Campaign Operations, with additional rules\
   \ available in:\
   <br><i>MekHQ/docs/Personnel Modules/Turnover & Retention Module (feat. Fatigue).pdf</i></p>
+FORCE_TYPE_COMBAT.title=Combat Forces
+FORCE_TYPE_COMBAT.definition=This is the default force type.\
+  <p>A combat force is one meant for general combat and is the only type of <a href='GLOSSARY:COMBAT_TEAMS'>Combat Team</a>\
+  \ that is considered when determining contract pay.</p>\
+  <p>If you have a <a href='GLOSSARY:DIGITAL_GM'>Digital GM</a> enabled, forces marked as Combat Forces can be drawn\
+  \ into scenarios. Make sure you reassign any forces you don''t want fighting.</p>
+FORCE_TYPE_CONVOY.title=Convoy Forces
+FORCE_TYPE_CONVOY.definition=These forces perform logistical support generally behind the front lines. Running supplies\
+  \ and making sure front line forces are kept stocked up.\
+  <p>If <a href='GLOSSARY:STRATCON'>StratCon</a> is enabled, while on contract, you can use Convoy Forces during monthly\
+  \ <a href='GLOSSARY:RESUPPLY'>Resupplies</a>. However, be careful when building your resupply convoys. You should avoid\
+  \ having a force totaling more than 200t as this increases the chance the enemy will intercept your convoy.</p>
+FORCE_TYPE_SECURITY.title=Security Forces
+FORCE_TYPE_SECURITY.definition=Forces assigned to Security duties are primarily responsible for managing prisoners of\
+  \ war. If the <i>Campaign Operations</i> or <i>MekHQ</i> capture styles are enabled in campaign options, units assigned\
+  \ to Security Forces will contribute to the campaign''s <a href='GLOSSARY:PRISONER_CAPACITY'>Prisoner Capacity</a>.
+FORCE_TYPE_SUPPORT.title=Support Forces
+FORCE_TYPE_SUPPORT.definition=A Support Force is any force not typically deployed in combat scenarios. This classification\
+  \ is ideal for units like support vehicles, civilians, or other forces that belong in the <a href='GLOSSARY:TOE'>TO&E</a>\
+  \ but aren''t meant to fight.\
+  <p>If <a href='GLOSSARY:STRATCON'>StratCon</a> is enabled, Support Forces are rarely deployed to scenarios, making them\
+  \ a useful classification for logistical or non-combat units.</p>\
+  <p>You should consider placing any DropShips and JumpShips into Support Forces unless you have enough Aerospace assets\
+  \ to protect them. This represents you keeping these valuable vessels away from the fighting rather than risking them\
+  \ close to hostile territory.</p>
 ### G
 ### H
 ### I
@@ -129,6 +149,32 @@ MANAGEMENT_SKILL.definition=Management Skill represents the individual leadershi
   \ target number by 3.</p>\
   <p>For more details on Management Skill and its effects, refer to the documentation in:\
   <br><i>MekHQ/docs/Personnel Modules/Turnover & Retention Module (feat. Fatigue).pdf</i></p>
+MORALE.title=Morale
+MORALE.definition=MekHQ Morale system is only in use while a <a href='GLOSSARY:DIGITAL_GM'>Digital GM</a> is enabled.\
+  <p>This system reflects not only the mental state of opposing forces but also their ability to resist effectively.\
+  \ Morale levels range from "routed" (very low) to "overwhelming" (very high), with several steps in between.\
+  <p><b>MORALE CHECKS</b></p>\
+  <p>At the start of each month 2d6 is rolled to see if the enemy''s morale changes. On a 4 or less, their morale\
+  \ improves one step towards "routed." On a 10+ their morale drops one step towards "overwhelming."</p>\
+  <p>There are several factors that modify this roll:</p>\
+  <p>- <b>Reliability:</b> The higher rated the enemy force, the harder they are to rout. Rebels, forces from minor\
+  \ factions, mercenaries, and pirates are all easier to rout. While Clan factions are harder to rout.</p>\
+  <p>- <b>Performance:</b> If you achieved more victories than defeats, during the prior month, the enemy is more likely\
+  \ to fail their morale check. Conversely, if you have had more defeats than victories, the enemy is more likely to\
+  \ pass their morale check. When comparing victories to defeats, any decisive defeat or victory counts twice. While\
+  \ pyrrhic victories and draws are not counted at all. Refusing an engagement (by skipping a scenario) normally counts\
+  \ as a decisive defeat. However, this can be reduced to just a normal defeat by deploying a force to the scenario but\
+  \ not fighting the scenario. As the enemy must plan around your forces, even if they don''t engage, they are less able\
+  \ to achieve their own goals. This concept is known as ''fleet in being.''\
+  <p><b>ROUTING THE ENEMY</b></p>\
+  <p>When an enemy is routed, their forces are severely damaged and unable to offer effective resistance. Routed enemies\
+  \ will not generate new scenarios. For any contract other than Garrison Duty, Cadre Duty, Security Duty, or Riot Duty,\
+  \ all remaining objectives are considered completed, and the contract''s conclusion date is moved to the next day.</p>\
+  <p>For those contracts listed above (so-called ''garrison type contracts'') the contract does not end early, but the\
+  \ enemy forces are in full retreat. After the first month of peace, there is a 25% chance a new opposition will arrive;\
+  \ otherwise the peace continues.\
+  <p>For more details on Loyalty and its effects, refer to the documentation in:\
+  <br><i>MekHQ/docs/StratCon/MekHQ Morale.pdf</i></p>
 ### N
 ### O
 ### P
@@ -152,19 +198,20 @@ RESUPPLY.definition=Monthly Resupplies are the primary way to receive supplies w
   <p>In Guerilla Warfare contracts, Resupplies come from local smugglers instead of your employer. These supplies are\
   \ more expensive and less reliable. Smuggler deals carry the risk of scams, and offers may not appear every month.</p>\
   <p><b>CONTENTS</b></p>\
-  <p>The contents of a Resupply are based on the combat units in your TO&E, with an emphasis based on damaged or missing\
-  \ equipment. This is then compared against the items you have in your warehouse, with the focus on items you're running\
-  \ low on. While Resupplies will not always contain exactly what you need when you need it, they will always provide\
-  \ items you can use.</p>\
+  <p>The contents of a Resupply are based on the combat units in your <a href='GLOSSARY:TOE'>TO&E</a> with an emphasis\
+  \ based on damaged or missing equipment. This is then compared against the items you have in your warehouse, with the\
+  \ focus on items you''re running low on. While Resupplies will not always contain exactly what you need when you need\
+  \ it, they will always provide items you can use.</p>\
   <p><b>PLAYER CONVOYS</b></p>\
   <p>Player Convoys offer a high-risk, high-reward option for securing larger Resupplies. Designating a force as a\
   \ <a href='GLOSSARY:COMBAT_TEAMS'>Convoy</a> increases the size of your Resupply by 400%, but at the cost of exposure\
-  \ to interception. If the Convoy is intercepted, you'll need to fight off enemy forces to protect your supplies. Losing\
+  \ to interception. If the Convoy is intercepted, you''ll need to fight off enemy forces to protect your supplies. Losing\
   \ a Convoy can result in the permanent loss of all assigned units and personnel.</p>\
-  <p>NPC Convoys are a safer but smaller alternative. If an NPC Convoy is intercepted, you'll lose the supplies but not\
+  <p>NPC Convoys are a safer but smaller alternative. If an NPC Convoy is intercepted, you''ll lose the supplies but not\
   \ any personnel or units.</p>\
-  <p>Convoy size influences interception risk. Larger convoys are more detectable and easier to target. If a convoy is\
-  \ intercepted, you can send support to defend it.</p>\
+  <p>Convoy size influences interception risk. Larger convoys are more detectable and easier to target. For the best\
+  \ results, aim for around 200t. The enemy having high <a href='GLOSSARY:MORALE'>Morale</a> also increases the chance a convoy is intercepted. If\
+  \ a convoy is intercepted, you can send a <a href='GLOSSARY:COMBAT_TEAMS'>Combat Team</a> to defend it.</p>\
   <p>For more details on Resupplies, refer to the documentation in:\
   <br><i>MekHQ/docs/StratCon/Resupply & Convoys.pdf</i></p>
 ### S
@@ -192,7 +239,15 @@ STRATCON_FACILITIES.definition=In <a href='GLOSSARY:STRATCON'>StratCon</a>, the\
   \ crucial to locate and neutralize (or capture) it. Poor modifiers from enemy facilities can mean\
   \ the difference between a tough fight and a complete massacre.</p>
 ### T
-TURNING_POINT.title=Turning Point Scenarios
+TOE.title=The TO&E
+TOE.definition=Your Table of Organization and Equipment (TO&E) is a living representation of the military staffing and\
+  \ equipment that comprise your unit. There, you arrange your forces into <a href='GLOSSARY:COMBAT_TEAMS'>Combat\
+  \ Teams</a> and can get an overview of your available forces.\
+  <p>It is important to note that units stored outside the TO&E are not normally considered for things like contract\
+  \ pay, or Field Kitchen availability. For all intents and purposes, MekHQ will ignore units stored loose in your\
+  \ hangar. So it can be useful to keep even non-combat units in the TO&E. Those, however, should be stored in\
+  \ <a href='GLOSSARY:FORCE_TYPE_SUPPORT'>Support Forces</a> lest they be drawn into combat.
+
 TURNING_POINT.definition=Turning Points are scenarios of significant strategic importance. The\
   \ exact reason a scenario is designated as a Turning Point is left to your interpretation. It\
   \ could be a battle over a critical location, an engagement with a high-ranking enemy officer, or\
@@ -225,7 +280,7 @@ TURNOVER.definition=Turnover is the system that determines when and why personne
   <p><b>SPECIAL CASES</b></p>\
   <p>Family ties can influence turnover - spouses and children may leave together. Loyalty is a key factor in retention\
   \ and can shift based on campaign events. Campaign <a href='GLOSSARY:REPUTATION'>Reputation</a> and mission success\
-  \ affect morale and turnover rates.</p>\
+  \ affect <a href='GLOSSARY:MORALE'>Morale</a> and turnover rates.</p>\
   <p>For more details on Turnover, refer to the documentation in:\
   <br><i>MekHQ/docs/Personnel Modules/Turnover & Retention Module (feat. Fatigue).pdf</i></p>
 ### U

--- a/MekHQ/src/mekhq/gui/ForceRenderer.java
+++ b/MekHQ/src/mekhq/gui/ForceRenderer.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui;
 
@@ -176,12 +181,13 @@ public class ForceRenderer extends DefaultTreeCellRenderer {
             ForceType forceType = force.getForceType();
             String typeKey = forceType.getSymbol();
 
-            String formattedForceName = String.format("<html>%s%s%s%s%s%s</html>",
-                force.isCombatTeam() ? "<b>" : "",
-                force.getOverrideCombatTeam() != COMBAT_TEAM_OVERRIDE_NONE ? "<u>" : "",
-                force.getName(),
-                force.isCombatTeam() ? "</b>" : "",
-                force.getOverrideCombatTeam() != COMBAT_TEAM_OVERRIDE_NONE ? "</u>" : "",
+            String formattedForceName = String.format("<html>%s%s%s%s%s%s%s</html>",
+                  force.isCombatTeam() ? "<b>" : "",
+                  force.getOverrideCombatTeam() != COMBAT_TEAM_OVERRIDE_NONE ? "<u>" : "",
+                  force.getName(),
+                  force.isCombatTeam() ? "</b>" : "",
+                  force.getOverrideCombatTeam() != COMBAT_TEAM_OVERRIDE_NONE ? "</u>" : "",
+                  force.isCombatTeam() ? " <s>c</s>" : "",
                 typeKey);
 
             setText(formattedForceName);

--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -24,16 +24,40 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedText;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.tree.TreeSelectionModel;
+
 import megamek.common.event.Subscribe;
 import mekhq.MekHQ;
-import mekhq.campaign.event.*;
+import mekhq.campaign.event.DeploymentChangedEvent;
+import mekhq.campaign.event.NetworkChangedEvent;
+import mekhq.campaign.event.OrganizationChangedEvent;
+import mekhq.campaign.event.PersonChangedEvent;
+import mekhq.campaign.event.PersonRemovedEvent;
+import mekhq.campaign.event.ScenarioResolvedEvent;
+import mekhq.campaign.event.UnitChangedEvent;
+import mekhq.campaign.event.UnitRemovedEvent;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.adapter.TOEMouseAdapter;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
 import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.handler.TOETransferHandler;
 import mekhq.gui.model.CrewListModel;
@@ -42,10 +66,6 @@ import mekhq.gui.utilities.JScrollPaneWithSpeed;
 import mekhq.gui.view.ForceViewPanel;
 import mekhq.gui.view.PersonViewPanel;
 import mekhq.gui.view.UnitViewPanel;
-
-import javax.swing.*;
-import javax.swing.tree.TreeSelectionModel;
-import java.awt.*;
 
 /**
  * Display organization tree (TO&amp;E) and force/unit summary
@@ -76,7 +96,7 @@ public final class TOETab extends CampaignGuiTab {
     public void initTab() {
         setLayout(new GridBagLayout());
 
-        orgModel = new OrgTreeModel(getCampaign());
+        OrgTreeModel orgModel = new OrgTreeModel(getCampaign());
         orgTree = new JTree(orgModel);
         orgTree.getAccessibleContext().setAccessibleName("Table of Organization and Equipment (TOE)");
         TOEMouseAdapter.connect(getCampaignGui(), orgTree);
@@ -88,14 +108,31 @@ public final class TOETab extends CampaignGuiTab {
         orgTree.setDropMode(DropMode.ON);
         orgTree.setTransferHandler(new TOETransferHandler(getCampaignGui()));
 
+        JEditorPane keyPane = new JEditorPane();
+        keyPane.setContentType("text/html");
+        keyPane.setText(getFormattedText("TOE.keyText"));
+        keyPane.setEditable(false);
+        keyPane.setBorder(null);
+        keyPane.setOpaque(false);
+        keyPane.addHyperlinkListener(evt -> {
+            if (evt.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                ImmersiveDialogCore.handleImmersiveHyperlinkClick(null, getCampaign(), evt.getDescription());
+            }
+        });
+        JPanel southPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        southPanel.add(keyPane);
+
+        JPanel leftPanel = new JPanel(new BorderLayout());
+        leftPanel.add(new JScrollPane(orgTree), BorderLayout.CENTER);
+        leftPanel.add(southPanel, BorderLayout.SOUTH);
+
         panForceView = new JPanel();
         panForceView.getAccessibleContext().setAccessibleName("Selected Force Viewer");
         panForceView.setMinimumSize(new Dimension(550, 600));
         panForceView.setPreferredSize(new Dimension(550, 600));
         panForceView.setLayout(new BorderLayout());
 
-        JScrollPane scrollOrg = new JScrollPaneWithSpeed(orgTree);
-        splitOrg = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, scrollOrg, panForceView);
+        splitOrg = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, leftPanel, panForceView);
         splitOrg.setOneTouchExpandable(true);
         splitOrg.setResizeWeight(1.0);
         splitOrg.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, evt -> refreshForceView());

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -1132,7 +1132,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
 
             menu = new JMenu("Change Force Type");
 
-            menuItem = new JMenuItem("Make Standard Force");
+            menuItem = new JMenuItem("Make Combat Force");
             menuItem.setActionCommand(COMMAND_CHANGE_FORCE_TYPE_STANDARD + forceIds);
             menuItem.addActionListener(this);
             menu.add(menuItem);

--- a/MekHQ/src/mekhq/gui/dialog/GlossaryDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GlossaryDialog.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.dialog;
 
@@ -47,6 +52,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.HyperlinkEvent.EventType;
 
 import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 
@@ -84,11 +90,15 @@ public class GlossaryDialog extends JDialog {
      * @param campaign The {@link Campaign} object containing resources and glossary entries.
      * @param key      The unique identifier for the glossary term to be displayed.
      */
-    public GlossaryDialog(JDialog parent, Campaign campaign, String key) {
+    public GlossaryDialog(@Nullable JDialog parent, Campaign campaign, String key) {
         this.parent = parent;
         this.campaign = campaign;
 
-        parent.setVisible(false);
+        // Originally the dialog was designed to be called from within a JDialog, however that isn't always the case
+        // anymore, so now we hide and reveal the parent dialog (later) only if it exists.
+        if (parent != null) {
+            parent.setVisible(false);
+        }
         buildDialog(key);
     }
 
@@ -174,6 +184,9 @@ public class GlossaryDialog extends JDialog {
      */
     private void onCloseAction() {
         dispose();
-        parent.setVisible(true);
+
+        if (parent != null) {
+            parent.setVisible(true);
+        }
     }
 }


### PR DESCRIPTION
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/c9369839-fa0b-4aa8-b712-7ddcb6595ae0" />

This adds a panel to the bottom of the TO&E tab that includes a key for the informatics we use in the TO&E as well as hyperlinked terms.

These links bring up the Glossary, allowing the user instance access to information about the TO&E itself, combat teams, force types, resupplies, a whole bunch of other stuff. If this proves successful I'm inclined to add something like this to the other tabs.

While I was at it I did a grammar sweep of the glossary, added a couple of extra entries, and renamed 'standard' forces to 'combat' as the standard term was causing confusion.

<img width="749" alt="image" src="https://github.com/user-attachments/assets/e9cb46ee-d541-4228-8adc-82010dc5c974" />

<img width="1597" alt="image" src="https://github.com/user-attachments/assets/dce812a2-c5a7-4cd3-ab8c-59f28188403c" />
