### PR TITLE
Improvement: Added Scenario Briefing Dialog to Briefing Room on Scenario Start

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -257,3 +257,6 @@ dialogInvalidFaction.ooc=Your chosen campaign faction is not valid for the curre
   <p>Before you can proceed, you must choose a new faction in Campaign Options.</p>
 dialogCheckDueScenarios.title=Scenarios Must Be Completed
 dialogCheckDueScenarios.text=You must complete scenarios with a date of today or earlier before advancing the day.
+dialogScenarioAcceptance.outOfCharacter=<b>Reactor online, sensors online, weapons online. All systems nominal.</b>
+dialogScenarioAcceptance.button.accept=Commence Drop
+dialogScenarioAcceptance.button.cancel=Return to the Launch Bay

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6481,7 +6481,7 @@ public class Campaign implements ITechManager {
 
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "missions");
         for (final Mission mission : getMissions()) {
-            mission.writeToXML(pw, indent);
+            mission.writeToXML(this, pw, indent);
         }
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "missions");
 
@@ -6551,7 +6551,7 @@ public class Campaign implements ITechManager {
         if (getCampaignOptions().isUseAtB()) {
             // TODO : AbstractContractMarket : Remove next two lines
             // CAW: implicit DEPENDS-ON to the <missions> node, do not move this above it
-            contractMarket.writeToXML(pw, indent);
+            contractMarket.writeToXML(this, pw, indent);
 
             if (!combatTeams.isEmpty()) {
                 MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "combatTeams");

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of MekHQ.
+ * This file is part of <MekHQ.
  *
- * MekHQ is free software: you can redistribute it and/or modify
+ * <MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * MekHQ is distributed in the hope that it will be useful,
+ * <MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.market.contractMarket;
 
@@ -841,12 +846,20 @@ public abstract class AbstractContractMarket {
         return mod;
     }
 
+    /**
+     * @deprecated use {@link #writeToXML(Campaign, PrintWriter, int)} instead
+     */
+    @Deprecated(since = "0.50.06", forRemoval = true)
     public void writeToXML(final PrintWriter pw, int indent) {
+        return;
+    }
+
+    public void writeToXML(Campaign campaign, final PrintWriter pw, int indent) {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "contractMarket");
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "method", method.toString());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "lastId", lastId);
         for (final Contract contract : contracts) {
-            contract.writeToXML(pw, indent);
+            contract.writeToXML(campaign, pw, indent);
         }
 
         for (final Integer key : clauseMods.keySet()) {

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of <MekHQ.
+ * This file is part of MekHQ.
  *
- * <MekHQ is free software: you can redistribute it and/or modify
+ * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * <MekHQ is distributed in the hope that it will be useful,
+ * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -25,7 +25,7 @@
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
  *
- * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
  * Microsoft's "Game Content Usage Rules"
  * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
  * affiliated with Microsoft.

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -99,6 +99,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextPane;
 import javax.swing.SwingConstants;
 
+import megamek.Version;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.ratgenerator.FactionRecord;
 import megamek.client.ratgenerator.RATGenerator;
@@ -127,6 +128,7 @@ import mekhq.campaign.mission.enums.ScenarioStatus;
 import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.backgrounds.BackgroundsController;
+import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.Phenotype;
 import mekhq.campaign.randomEvents.MercenaryAuction;
 import mekhq.campaign.randomEvents.RoninOffer;
@@ -159,6 +161,7 @@ public class AtBContract extends Contract {
     protected AtBContract parentContract;
     /* hired by another mercenary unit on contract to a third-party employer */ boolean mercSubcontract;
 
+    protected Person employerLiaison;
     protected String employerCode;
     protected String enemyCode;
     protected String enemyName;
@@ -230,6 +233,7 @@ public class AtBContract extends Contract {
 
     public AtBContract(String name) {
         super(name, "Independent");
+        employerLiaison = null;
         employerCode = "IND";
         enemyCode = "IND";
         enemyName = "Independent";
@@ -1177,8 +1181,8 @@ public class AtBContract extends Contract {
     }
 
     @Override
-    protected int writeToXMLBegin(final PrintWriter pw, int indent) {
-        indent = super.writeToXMLBegin(pw, indent);
+    protected int writeToXMLBegin(Campaign campaign, final PrintWriter pw, int indent) {
+        indent = super.writeToXMLBegin(campaign, pw, indent);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "employerCode", getEmployerCode());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "enemyCode", getEnemyCode());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "contractType", getContractType().name());
@@ -1247,98 +1251,108 @@ public class AtBContract extends Contract {
             stratconCampaignState.Serialize(pw);
         }
 
+        if (employerLiaison != null) {
+            employerLiaison.writeToXML(pw, indent, campaign);
+        }
+
         return indent;
     }
 
     @Override
-    public void loadFieldsFromXmlNode(Node wn) throws ParseException {
-        super.loadFieldsFromXmlNode(wn);
-        NodeList nl = wn.getChildNodes();
+    public void loadFieldsFromXmlNode(Campaign campaign, Version version, Node node) throws ParseException {
+        super.loadFieldsFromXmlNode(campaign, version, node);
+        NodeList childNodes = node.getChildNodes();
 
-        for (int x = 0; x < nl.getLength(); x++) {
-            Node wn2 = nl.item(x);
+        for (int x = 0; x < childNodes.getLength(); x++) {
+            Node item = childNodes.item(x);
 
             try {
-                if (wn2.getNodeName().equalsIgnoreCase("employerCode")) {
-                    employerCode = wn2.getTextContent();
-                } else if (wn2.getNodeName().equalsIgnoreCase("enemyCode")) {
-                    enemyCode = wn2.getTextContent();
-                } else if (wn2.getNodeName().equalsIgnoreCase("contractType")) {
-                    setContractType(AtBContractType.parseFromString(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("allySkill")) {
-                    setAllySkill(parseFromString(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("allyQuality")) {
-                    allyQuality = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("enemySkill")) {
-                    setEnemySkill(parseFromString(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("enemyQuality")) {
-                    enemyQuality = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("allyBotName")) {
-                    allyBotName = wn2.getTextContent();
-                } else if (wn2.getNodeName().equalsIgnoreCase("enemyBotName")) {
-                    enemyBotName = wn2.getTextContent();
-                } else if (wn2.getNodeName().equalsIgnoreCase("allyCamoCategory")) {
-                    getAllyCamouflage().setCategory(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("allyCamoFileName")) {
-                    getAllyCamouflage().setFilename(wn2.getTextContent().trim());
-                } else if (wn2.getTextContent().equalsIgnoreCase("allyColour")) {
-                    setAllyColour(PlayerColour.parseFromString(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("enemyCamoCategory")) {
-                    getEnemyCamouflage().setCategory(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("enemyCamoFileName")) {
-                    getEnemyCamouflage().setFilename(wn2.getTextContent().trim());
-                } else if (wn2.getTextContent().equalsIgnoreCase("enemyColour")) {
-                    setEnemyColour(PlayerColour.parseFromString(wn2.getTextContent().trim()));
+                if (item.getNodeName().equalsIgnoreCase("employerCode")) {
+                    employerCode = item.getTextContent();
+                } else if (item.getNodeName().equalsIgnoreCase("enemyCode")) {
+                    enemyCode = item.getTextContent();
+                } else if (item.getNodeName().equalsIgnoreCase("contractType")) {
+                    setContractType(AtBContractType.parseFromString(item.getTextContent().trim()));
+                } else if (item.getNodeName().equalsIgnoreCase("allySkill")) {
+                    setAllySkill(parseFromString(item.getTextContent().trim()));
+                } else if (item.getNodeName().equalsIgnoreCase("allyQuality")) {
+                    allyQuality = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("enemySkill")) {
+                    setEnemySkill(parseFromString(item.getTextContent().trim()));
+                } else if (item.getNodeName().equalsIgnoreCase("enemyQuality")) {
+                    enemyQuality = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("allyBotName")) {
+                    allyBotName = item.getTextContent();
+                } else if (item.getNodeName().equalsIgnoreCase("enemyBotName")) {
+                    enemyBotName = item.getTextContent();
+                } else if (item.getNodeName().equalsIgnoreCase("allyCamoCategory")) {
+                    getAllyCamouflage().setCategory(item.getTextContent().trim());
+                } else if (item.getNodeName().equalsIgnoreCase("allyCamoFileName")) {
+                    getAllyCamouflage().setFilename(item.getTextContent().trim());
+                } else if (item.getTextContent().equalsIgnoreCase("allyColour")) {
+                    setAllyColour(PlayerColour.parseFromString(item.getTextContent().trim()));
+                } else if (item.getNodeName().equalsIgnoreCase("enemyCamoCategory")) {
+                    getEnemyCamouflage().setCategory(item.getTextContent().trim());
+                } else if (item.getNodeName().equalsIgnoreCase("enemyCamoFileName")) {
+                    getEnemyCamouflage().setFilename(item.getTextContent().trim());
+                } else if (item.getTextContent().equalsIgnoreCase("enemyColour")) {
+                    setEnemyColour(PlayerColour.parseFromString(item.getTextContent().trim()));
                     // <50.03 compatibility handler
-                } else if (wn2.getNodeName().equalsIgnoreCase("requiredLances") ||
-                                 wn2.getNodeName().equalsIgnoreCase("requiredCombatTeams")) {
-                    requiredCombatTeams = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("moraleLevel")) {
-                    setMoraleLevel(AtBMoraleLevel.parseFromString(wn2.getTextContent().trim()));
-                } else if (wn2.getNodeName().equalsIgnoreCase("routEnd")) {
-                    routEnd = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("routedPayout")) {
-                    String cleanValue = wn2.getTextContent().trim().replaceAll("[^0-9.]", "");
+                } else if (item.getNodeName().equalsIgnoreCase("requiredLances") ||
+                                 item.getNodeName().equalsIgnoreCase("requiredCombatTeams")) {
+                    requiredCombatTeams = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("moraleLevel")) {
+                    setMoraleLevel(AtBMoraleLevel.parseFromString(item.getTextContent().trim()));
+                } else if (item.getNodeName().equalsIgnoreCase("routEnd")) {
+                    routEnd = MHQXMLUtility.parseDate(item.getTextContent().trim());
+                } else if (item.getNodeName().equalsIgnoreCase("routedPayout")) {
+                    String cleanValue = item.getTextContent().trim().replaceAll("[^0-9.]", "");
                     double value = Double.parseDouble(cleanValue);
                     routedPayout = Money.of(value);
-                } else if (wn2.getNodeName().equalsIgnoreCase("partsAvailabilityLevel")) {
-                    partsAvailabilityLevel = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("extensionLength")) {
-                    extensionLength = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("sharesPct")) {
-                    sharesPct = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("batchallAccepted")) {
-                    batchallAccepted = Boolean.parseBoolean(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("playerMinorBreaches")) {
-                    playerMinorBreaches = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("employerMinorBreaches")) {
-                    employerMinorBreaches = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("contractScoreArbitraryModifier")) {
-                    contractScoreArbitraryModifier = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("priorLogisticsFailure")) {
-                    priorLogisticsFailure = Boolean.parseBoolean(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("battleTypeMod")) {
-                    battleTypeMod = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("nextWeekBattleTypeMod")) {
-                    nextWeekBattleTypeMod = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("commandRoll")) {
-                    commandRoll = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("salvageRoll")) {
-                    salvageRoll = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("supportRoll")) {
-                    supportRoll = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("transportRoll")) {
-                    transportRoll = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase("specialEventScenarioDate")) {
-                    specialEventScenarioDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
-                } else if (wn2.getNodeName().equalsIgnoreCase("specialEventScenarioType")) {
-                    specialEventScenarioType = Integer.parseInt(wn2.getTextContent());
-                } else if (wn2.getNodeName().equalsIgnoreCase(StratconCampaignState.ROOT_XML_ELEMENT_NAME)) {
-                    stratconCampaignState = StratconCampaignState.Deserialize(wn2);
+                } else if (item.getNodeName().equalsIgnoreCase("partsAvailabilityLevel")) {
+                    partsAvailabilityLevel = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("extensionLength")) {
+                    extensionLength = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("sharesPct")) {
+                    sharesPct = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("batchallAccepted")) {
+                    batchallAccepted = Boolean.parseBoolean(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("playerMinorBreaches")) {
+                    playerMinorBreaches = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("employerMinorBreaches")) {
+                    employerMinorBreaches = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("contractScoreArbitraryModifier")) {
+                    contractScoreArbitraryModifier = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("priorLogisticsFailure")) {
+                    priorLogisticsFailure = Boolean.parseBoolean(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("battleTypeMod")) {
+                    battleTypeMod = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("nextWeekBattleTypeMod")) {
+                    nextWeekBattleTypeMod = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("commandRoll")) {
+                    commandRoll = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("salvageRoll")) {
+                    salvageRoll = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("supportRoll")) {
+                    supportRoll = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("transportRoll")) {
+                    transportRoll = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase("specialEventScenarioDate")) {
+                    specialEventScenarioDate = MHQXMLUtility.parseDate(item.getTextContent().trim());
+                } else if (item.getNodeName().equalsIgnoreCase("specialEventScenarioType")) {
+                    specialEventScenarioType = Integer.parseInt(item.getTextContent());
+                } else if (item.getNodeName().equalsIgnoreCase(StratconCampaignState.ROOT_XML_ELEMENT_NAME)) {
+                    stratconCampaignState = StratconCampaignState.Deserialize(item);
                     stratconCampaignState.setContract(this);
                     this.setStratconCampaignState(stratconCampaignState);
-                } else if (wn2.getNodeName().equalsIgnoreCase("parentContractId")) {
-                    parentContract = new AtBContractRef(Integer.parseInt(wn2.getTextContent()));
+                } else if (item.getNodeName().equalsIgnoreCase("parentContractId")) {
+                    parentContract = new AtBContractRef(Integer.parseInt(item.getTextContent()));
+                } else if (item.getNodeName().equalsIgnoreCase("person")) {
+                    employerLiaison = Person.generateInstanceFromXML(item, campaign, version);
+
+                    if (employerLiaison == null) {
+                        createEmployerLiaison(campaign);
+                    }
                 }
             } catch (Exception e) {
                 logger.error("", e);
@@ -1374,6 +1388,18 @@ public class AtBContract extends Contract {
 
     public Faction getEmployerFaction() {
         return Factions.getInstance().getFaction(getEmployerCode());
+    }
+
+    public Person getEmployerLiaison() {
+        return employerLiaison;
+    }
+
+    public void setEmployerLiaison(Person employerLiaison) {
+        this.employerLiaison = employerLiaison;
+    }
+
+    public void createEmployerLiaison(Campaign campaign) {
+        employerLiaison = campaign.newPerson(PersonnelRole.ADMINISTRATOR_COMMAND, getEmployerCode(), Gender.RANDOMIZE);
     }
 
     public String getEmployerCode() {

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -2,14 +2,14 @@
  * Copyright (c) 2011 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
  * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of <MekHQ.
+ * This file is part of MekHQ.
  *
- * <MekHQ is free software: you can redistribute it and/or modify
+ * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * <MekHQ is distributed in the hope that it will be useful,
+ * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -26,7 +26,7 @@
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
  *
- * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
  * Microsoft's "Game Content Usage Rules"
  * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
  * affiliated with Microsoft.

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -2,14 +2,14 @@
  * Copyright (c) 2011 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
  * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of MekHQ.
+ * This file is part of <MekHQ.
  *
- * MekHQ is free software: you can redistribute it and/or modify
+ * <MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * MekHQ is distributed in the hope that it will be useful,
+ * <MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -25,9 +25,20 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.mission;
 
+import java.io.PrintWriter;
+import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import megamek.Version;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
@@ -40,11 +51,6 @@ import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import java.io.PrintWriter;
-import java.text.ParseException;
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 
 /**
  * Contracts - we need to track static amounts here because changes in the
@@ -720,8 +726,8 @@ public class Contract extends Mission {
     }
 
     @Override
-    protected int writeToXMLBegin(final PrintWriter pw, int indent) {
-        indent = super.writeToXMLBegin(pw, indent);
+    protected int writeToXMLBegin(Campaign campaign, final PrintWriter pw, int indent) {
+        indent = super.writeToXMLBegin(campaign, pw, indent);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "nMonths", nMonths);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startDate", startDate);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "endDate", endDate);
@@ -751,7 +757,7 @@ public class Contract extends Mission {
     }
 
     @Override
-    public void loadFieldsFromXmlNode(Node wn) throws ParseException {
+    public void loadFieldsFromXmlNode(Campaign campaign, Version version, Node wn) throws ParseException {
         // Okay, now load mission-specific fields!
         NodeList nl = wn.getChildNodes();
 

--- a/MekHQ/src/mekhq/campaign/mission/Mission.java
+++ b/MekHQ/src/mekhq/campaign/mission/Mission.java
@@ -2,14 +2,14 @@
  * Copyright (c) 2011 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
  * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of <MekHQ.
+ * This file is part of MekHQ.
  *
- * <MekHQ is free software: you can redistribute it and/or modify
+ * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * <MekHQ is distributed in the hope that it will be useful,
+ * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -26,7 +26,7 @@
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
  *
- * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
  * Microsoft's "Game Content Usage Rules"
  * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
  * affiliated with Microsoft.

--- a/MekHQ/src/mekhq/campaign/mission/Mission.java
+++ b/MekHQ/src/mekhq/campaign/mission/Mission.java
@@ -2,14 +2,14 @@
  * Copyright (c) 2011 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
  * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of MekHQ.
+ * This file is part of <MekHQ.
  *
- * MekHQ is free software: you can redistribute it and/or modify
+ * <MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * MekHQ is distributed in the hope that it will be useful,
+ * <MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -25,6 +25,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.mission;
 
@@ -227,12 +232,29 @@ public class Mission {
     }
 
     // region File I/O
+
+    /**
+     * @deprecated use {@link #writeToXML(Campaign, PrintWriter, int) instead}
+     */
+    @Deprecated(since = "0.50.06", forRemoval = true)
     public void writeToXML(final PrintWriter pw, int indent) {
-        indent = writeToXMLBegin(pw, indent);
+        return;
+    }
+
+    public void writeToXML(Campaign campaign, final PrintWriter pw, int indent) {
+        indent = writeToXMLBegin(campaign, pw, indent);
         writeToXMLEnd(pw, indent);
     }
 
+    /**
+     * @deprecated use {@link #writeToXMLBegin(Campaign, PrintWriter, int)} instead;
+     */
+    @Deprecated(since = "0.50.06", forRemoval = true)
     protected int writeToXMLBegin(final PrintWriter pw, int indent) {
+        return indent;
+    }
+
+    protected int writeToXMLBegin(Campaign campaign, final PrintWriter pw, int indent) {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "mission", "id", id, "type", getClass());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "name", name);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "type", type);
@@ -256,13 +278,21 @@ public class Mission {
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "mission");
     }
 
+    /**
+     * @deprecated use {@link #loadFieldsFromXmlNode(Campaign, Version, Node)}  instead;
+     */
+    @Deprecated(since = "0.50.06", forRemoval = true)
     public void loadFieldsFromXmlNode(Node wn) throws ParseException {
+        return;
+    }
+
+    public void loadFieldsFromXmlNode(Campaign campaign, Version version, Node wn) throws ParseException {
         // do nothing
     }
 
-    public static Mission generateInstanceFromXML(Node wn, Campaign c, Version version) {
+    public static Mission generateInstanceFromXML(Node node, Campaign campaign, Version version) {
         Mission retVal = null;
-        NamedNodeMap attrs = wn.getAttributes();
+        NamedNodeMap attrs = node.getAttributes();
         Node classNameNode = attrs.getNamedItem("type");
         String className = classNameNode.getTextContent();
 
@@ -270,10 +300,10 @@ public class Mission {
             // Instantiate the correct child class, and call its parsing
             // function.
             retVal = (Mission) Class.forName(className).newInstance();
-            retVal.loadFieldsFromXmlNode(wn);
+            retVal.loadFieldsFromXmlNode(campaign, version, node);
 
             // Okay, now load mission-specific fields!
-            NodeList nl = wn.getChildNodes();
+            NodeList nl = node.getChildNodes();
 
             for (int x = 0; x < nl.getLength(); x++) {
                 Node wn2 = nl.item(x);
@@ -284,10 +314,10 @@ public class Mission {
                                  wn2.getNodeName().equalsIgnoreCase("systemId")) {
                     retVal.systemId = wn2.getTextContent();
                 } else if (wn2.getNodeName().equalsIgnoreCase("planetName")) {
-                    PlanetarySystem system = c.getSystemByName(wn2.getTextContent());
+                    PlanetarySystem system = campaign.getSystemByName(wn2.getTextContent());
 
                     if (system != null) {
-                        retVal.systemId = c.getSystemByName(wn2.getTextContent()).getId();
+                        retVal.systemId = campaign.getSystemByName(wn2.getTextContent()).getId();
                     } else {
                         retVal.legacyPlanetName = wn2.getTextContent();
                     }
@@ -315,7 +345,7 @@ public class Mission {
 
                             continue;
                         }
-                        Scenario s = Scenario.generateInstanceFromXML(wn3, c, version);
+                        Scenario s = Scenario.generateInstanceFromXML(wn3, campaign, version);
 
                         if (null != s) {
                             retVal.addScenario(s);

--- a/MekHQ/src/mekhq/campaign/storyarc/storypoint/MissionStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyarc/storypoint/MissionStoryPoint.java
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of <MekHQ.
+ * This file is part of MekHQ.
  *
- * <MekHQ is free software: you can redistribute it and/or modify
+ * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * <MekHQ is distributed in the hope that it will be useful,
+ * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -25,7 +25,7 @@
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
  *
- * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
  * Microsoft's "Game Content Usage Rules"
  * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
  * affiliated with Microsoft.

--- a/MekHQ/src/mekhq/campaign/storyarc/storypoint/MissionStoryPoint.java
+++ b/MekHQ/src/mekhq/campaign/storyarc/storypoint/MissionStoryPoint.java
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of MekHQ.
+ * This file is part of <MekHQ.
  *
- * MekHQ is free software: you can redistribute it and/or modify
+ * <MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * MekHQ is distributed in the hope that it will be useful,
+ * <MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.storyarc.storypoint;
 
@@ -33,9 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.Version;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
@@ -43,6 +45,8 @@ import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.enums.MissionStatus;
 import mekhq.campaign.storyarc.StoryPoint;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * A StoryPoint class to start a new mission. A MissionStoryPoint will not
@@ -170,7 +174,7 @@ public class MissionStoryPoint extends StoryPoint {
             if (mission.getId() > 0) {
                 MHQXMLUtility.writeSimpleXMLTag(pw1, indent, "missionId", mission.getId());
             } else {
-                mission.writeToXML(pw1, indent);
+                mission.writeToXML(getCampaign(), pw1, indent);
             }
         }
         writeToXmlEnd(pw1, --indent);

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -789,8 +789,6 @@ public final class BriefingTab extends CampaignGuiTab {
             speaker = contract.getEmployerLiaison();
         }
 
-        AtBContract contract = null;
-
         List<Person> forceCommanders = new ArrayList<>();
         for (Force force : getCampaign().getAllForces()) {
             Person commander = getCampaign().getPerson(force.getForceCommanderID());

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -63,6 +63,7 @@ import megamek.common.Game;
 import megamek.common.GunEmplacement;
 import megamek.common.annotations.Nullable;
 import megamek.common.containers.MunitionTree;
+import megamek.common.enums.Gender;
 import megamek.common.event.Subscribe;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.sorter.NaturalOrderComparator;
@@ -787,6 +788,9 @@ public final class BriefingTab extends CampaignGuiTab {
         Person speaker = null;
         if (mission instanceof AtBContract contract) {
             speaker = contract.getEmployerLiaison();
+        } else {
+            // If we're not working with an AtBContract we have to generate the liaison each time
+            speaker = getCampaign().newPerson(PersonnelRole.ADMINISTRATOR_COMMAND, "IND", Gender.RANDOMIZE);
         }
 
         List<Person> forceCommanders = new ArrayList<>();

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of <MekHQ.
+ * This file is part of MekHQ.
  *
- * <MekHQ is free software: you can redistribute it and/or modify
+ * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * <MekHQ is distributed in the hope that it will be useful,
+ * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -25,7 +25,7 @@
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
  *
- * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
  * Microsoft's "Game Content Usage Rules"
  * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
  * affiliated with Microsoft.

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -777,6 +777,13 @@ public final class BriefingTab extends CampaignGuiTab {
             return true;
         }
 
+        String description = scenario.getDescription().replaceAll("(\r\n|\n)", "<br>");
+
+        // If there isn't a description, we have nothing to display, so just act as if the player confirmed the dialog
+        if (description.isBlank()) {
+            return true;
+        }
+
         Mission mission = null;
         if (scenario.getMissionId() != -1) {
             mission = getCampaign().getMission(scenario.getMissionId());
@@ -790,7 +797,7 @@ public final class BriefingTab extends CampaignGuiTab {
             speaker = contract.getEmployerLiaison();
         } else {
             // If we're not working with an AtBContract we have to generate the liaison each time
-            speaker = getCampaign().newPerson(PersonnelRole.ADMINISTRATOR_COMMAND, "IND", Gender.RANDOMIZE);
+            speaker = getCampaign().newPerson(PersonnelRole.ADMINISTRATOR_COMMAND, "MERC", Gender.RANDOMIZE);
         }
 
         List<Person> forceCommanders = new ArrayList<>();
@@ -812,8 +819,6 @@ public final class BriefingTab extends CampaignGuiTab {
                 overallCommander = commander;
             }
         }
-
-        String description = scenario.getDescription().replaceAll("(\r\n|\n)", "<br>");
 
         List<String> buttons = List.of(resourceMap.getString("dialogScenarioAcceptance.button.accept"),
               resourceMap.getString("dialogScenarioAcceptance.button.cancel"));

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of <MekHQ.
+ * This file is part of MekHQ.
  *
- * <MekHQ is free software: you can redistribute it and/or modify
+ * MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * <MekHQ is distributed in the hope that it will be useful,
+ * MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -25,7 +25,7 @@
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
  *
- * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
  * Microsoft's "Game Content Usage Rules"
  * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
  * affiliated with Microsoft.

--- a/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
+++ b/MekHQ/src/mekhq/gui/baseComponents/immersiveDialogs/ImmersiveDialogCore.java
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
  *
- * This file is part of MekHQ.
+ * This file is part of <MekHQ.
  *
- * MekHQ is free software: you can redistribute it and/or modify
+ * <MekHQ is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * MekHQ is distributed in the hope that it will be useful,
+ * <MekHQ is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. <MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.baseComponents.immersiveDialogs;
 
@@ -53,6 +58,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkEvent.EventType;
 
@@ -66,6 +72,7 @@ import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.Factions;
 import mekhq.gui.CampaignGUI;
 import mekhq.gui.dialog.GlossaryDialog;
 
@@ -177,7 +184,7 @@ public class ImmersiveDialogCore extends JDialog {
      *
      * @return The padding value as an integer.
      */
-    protected int getPADDING() {
+    protected int getPadding() {
         return PADDING;
     }
 
@@ -496,7 +503,7 @@ public class ImmersiveDialogCore extends JDialog {
      */
     protected JPanel populateButtonPanel(List<ButtonLabelTooltipPair> buttons, boolean isVerticalLayout,
           @Nullable JPanel supplementalPanel) {
-        final int padding = getPADDING();
+        final int padding = getPadding();
 
         // Main container panel to hold the spinner and button panel
         JPanel containerPanel = new JPanel();
@@ -669,6 +676,8 @@ public class ImmersiveDialogCore extends JDialog {
         speakerBox.setLayout(new BoxLayout(speakerBox, BoxLayout.Y_AXIS));
         speakerBox.setAlignmentX(Component.CENTER_ALIGNMENT);
         speakerBox.setMaximumSize(new Dimension(IMAGE_WIDTH, scaleForGUI(MAX_VALUE)));
+        speakerBox.setBorder(new EmptyBorder(0, getPadding(), 0, getPadding()));
+
 
         // Get speaker details
         String speakerName = campaign.getName();
@@ -772,17 +781,23 @@ public class ImmersiveDialogCore extends JDialog {
             return campaign.getCampaignFactionIcon();
         }
 
-        Portrait portrait = speaker.getPortrait();
+        Image baseImage;
+        if (campaign.getPersonnel().contains(speaker)) {
+            Portrait portrait = speaker.getPortrait();
 
-        if (portrait == null || Objects.equals(portrait.getFilename(), DEFAULT_PORTRAIT_FILENAME)) {
-            return campaign.getCampaignFactionIcon();
+            if (portrait == null || Objects.equals(portrait.getFilename(), DEFAULT_PORTRAIT_FILENAME)) {
+                return campaign.getCampaignFactionIcon();
+            }
+
+            baseImage = portrait.getBaseImage();
+        } else {
+            baseImage = Factions.getFactionLogo(campaign.getGameYear(), speaker.getOriginFaction().getShortName())
+                              .getImage();
         }
 
         // The following sorcery is due to the compressed manner in which personnel portraits are stored.
         // We need to manipulate the original base image, otherwise it looks grainy and terrible.
         ImageObserver observer = (img, infoFlags, x, y, width, height) -> true;
-
-        Image baseImage = portrait.getBaseImage();
         int baseImageHeight = baseImage.getHeight(observer);
         int baseImageWidth = baseImage.getWidth(observer);
         int targetWidth = Math.max(1, IMAGE_WIDTH);

--- a/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ContractMarketDialog.java
@@ -517,14 +517,16 @@ public class ContractMarketDialog extends JDialog {
 
     private void acceptContract(ActionEvent evt) {
         if (selectedContract != null) {
-            if (selectedContract instanceof AtBContract) {
+            if (selectedContract instanceof AtBContract contract) {
                 if (!triggerConfirmationDialog()) {
                     return;
                 }
 
                 if (campaign.getCampaignOptions().isUseStratCon()) {
-                    new DialogContractStart(campaign, (AtBContract) selectedContract);
+                    new DialogContractStart(campaign, contract);
                 }
+
+                contract.createEmployerLiaison(campaign);
             }
 
             selectedContract.setName(contractView.getContractName());


### PR DESCRIPTION
When the player selects 'Start Game' in the Briefing Room instead of going straight to the connection dialog they are presented with the scenario briefing.

The briefing will be delivered by a representative of the contact employer. This representative will deliver all briefings for the duration of the contract, becoming a familiar name the player can latch onto.

The briefing will be delivered to the most senior member of the drop.

~~This feature is for Legacy AtB and StratCon enabled campaigns only due to a reliance on code that is exclusive to the Digital GMs.~~

The persistent employer representative feature is available for Legacy AtB and StratCon enabled campaigns only.

<img width="947" alt="image" src="https://github.com/user-attachments/assets/dfd3bd3e-e8b4-4d89-b0a8-9ced296cd9ef" />


