### PR TITLE
Fix: Stopped New Civilians Spawning While Not On Planet via Marriage; #6954 Fixed Inability to Disable New Civilians via Marriage

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1150,7 +1150,8 @@ lblRandomNewDependentMarriage.tooltip=This determines the number of sides on the
   \ determine whether a marriage is to another character in the campaign unit. Inter-unit marriage\
   \ occurs on a roll of 1.\
   <br>\
-  <br>Set this value to 0 to disable inter-unit marriages.
+  <br>Set this value to 0 to disable inter-unit marriages, or 1 to disable the creation of new\
+  \ civilians via marriage.
 # createDivorceTab
 lblDivorceTab.text=Divorce Options \u270E
 lblUseManualDivorce.text=Enable Manual Divorce

--- a/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
@@ -396,8 +396,12 @@ public abstract class AbstractMarriage {
             }
         }
 
-        if ((!isInterUnit) || (potentialSpouses.isEmpty())) {
+        if (!isInterUnit && campaign.getLocation().isOnPlanet()) {
             spouse = createExternalSpouse(campaign, today, person, spouseGender);
+        }
+
+        if (spouse == null) {
+            return;
         }
 
         marry(campaign, today, person, spouse, MergingSurnameStyle.WEIGHTED, isBackground);
@@ -418,7 +422,9 @@ public abstract class AbstractMarriage {
                                     (Compute.randomInt(campaign.getCampaignOptions().getNonBinaryDiceSize()) == 0);
 
         if (isNonBinary) {
-            gender = gender.isMale() ? Gender.OTHER_MALE : Gender.OTHER_FEMALE;
+            gender = gender.isMale() ?
+                           megamek.common.enums.Gender.OTHER_MALE :
+                           megamek.common.enums.Gender.OTHER_FEMALE;
         }
 
         Person externalSpouse = campaign.newDependent(gender);


### PR DESCRIPTION
Fix #6954

Now it is possible to disable your personnel from marrying extra-unit by setting intra-unit chance to 1. Also, civilians won't materialize out of the aether while in transit.