### PR TITLE
Fix: Prevented Forces from Being Locked in a Permanently Deployed State Following Mission Completion or Removal

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -28,6 +28,7 @@
 package mekhq.gui;
 
 import static megamek.client.ratgenerator.ForceDescriptor.RATING_5;
+import static mekhq.campaign.force.Force.NO_ASSIGNED_SCENARIO;
 import static mekhq.campaign.mission.enums.MissionStatus.PARTIAL;
 import static mekhq.campaign.mission.enums.MissionStatus.SUCCESS;
 import static mekhq.campaign.mission.enums.ScenarioStatus.REFUSED_ENGAGEMENT;
@@ -502,7 +503,21 @@ public final class BriefingTab extends CampaignGuiTab {
                   Objects.equals(String.valueOf(cmd.getStatus()), "Success"));
         }
 
-        // Get rid of any remaining scenarios
+        // Undeploy forces
+        for (Force force : getCampaign().getAllForces()) {
+            int scenarioAssignment = force.getScenarioId();
+            if (scenarioAssignment != NO_ASSIGNED_SCENARIO) {
+                Scenario scenario = getCampaign().getScenario(force.getScenarioId());
+
+                // This shouldn't be necessary, but now is as good a time as any to check for null scenarios
+                if (scenario == null || scenario.getMissionId() == mission.getId()) {
+                    force.setScenarioId(NO_ASSIGNED_SCENARIO, getCampaign());
+                    continue;
+                }
+            }
+        }
+
+        // Resolve any outstanding scenarios
         for (Scenario scenario : mission.getCurrentScenarios()) {
             scenario.setStatus(REFUSED_ENGAGEMENT);
         }
@@ -591,6 +606,16 @@ public final class BriefingTab extends CampaignGuiTab {
                         JOptionPane.YES_NO_OPTION)) {
             return;
         }
+
+        // Undeploy forces
+        for (Scenario scenario : mission.getScenarios()) {
+            for (Force force : getCampaign().getAllForces()) {
+                if (force.getScenarioId() == scenario.getId()) {
+                    force.setScenarioId(NO_ASSIGNED_SCENARIO, getCampaign());
+                }
+            }
+        }
+
         getCampaign().removeMission(mission);
         final List<Mission> missions = getCampaign().getSortedMissions();
         comboMission.setSelectedItem(missions.isEmpty() ? null : missions.get(0));


### PR DESCRIPTION
If a mission (Mission, Contract, or AtBContract) is deleted or completed while there are outstanding scenarios _and_ those scenarios had forces assigned to them; those forces would become permanently deployed.

Deleting the force would release the units.

Marking this as critical, as it's a real pain if it happens and isn't something we want in our Milestone candidate. However, this bug has likely been around for a few years, demonstrating that the chance of it occurring is relatively low.