### PR TITLE
Fix: #6967 Crew can be assigned to dual cockpits

### DIFF
--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -263,6 +263,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     if (singlePerson &&
                               (unit.usesSoloPilot() ||
                                      (entity instanceof VTOL) ||
+                                     (entity instanceof Mek) ||
                                      entity.isSuperHeavy() ||
                                      entity.isTripodMek() ||
                                      entity.isQuadMek())) {
@@ -358,7 +359,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                         valid = areAllVehicleGunners;
                     } else if ((entity instanceof SmallCraft) || (entity instanceof Jumpship)) {
                         valid = areAllVesselGunners;
-                    } else if (entity.isTripodMek() || entity.isSuperHeavy() || entity.isQuadMek()) {
+                    } else if ((entity instanceof Mek) && !unit.usesSoloPilot()) {
                         valid = areAllBattleMekPilots;
                     } else {
                         valid = false;

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
@@ -130,9 +130,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         final boolean usesSoloPilot = units[0].usesSoloPilot();
         final boolean isVTOL = entity instanceof VTOL;
         final boolean isMek = entity instanceof Mek;
-        final boolean isTripod = entity instanceof TripodMek;
-        final boolean isQuadMek = entity instanceof QuadMek;
-        final boolean isSuperHeavyMek = isMek && entity.isSuperHeavy();
+        final boolean isMekWithGunner = (!usesSoloPilot && isMek);
         final boolean isProtoMek = entity instanceof ProtoMek;
         final boolean isConventionalAircraft = entity instanceof ConvFighter;
         final boolean isSmallCraftOrJumpShip = (entity instanceof SmallCraft) || (entity instanceof Jumpship);
@@ -238,7 +236,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         // Pilot Menu
         if (canTakeMoreDrivers) {
             // Pilot Menu
-            if (usesSoloPilot || isVTOL || isSmallCraftOrJumpShip || isSuperHeavyMek || isTripod || isQuadMek) {
+            if (isMek || usesSoloPilot || isVTOL || isSmallCraftOrJumpShip) {
                 if (isMek) {
                     filteredPersonnel = personnel.stream()
                                               .filter(person -> person.getPrimaryRole().isMekWarriorGrouping() ||
@@ -444,13 +442,14 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         }
 
         // Gunners Menu
-        if (canTakeMoreGunners && (isTank || isSmallCraftOrJumpShip || isSuperHeavyMek || isTripod || isQuadMek)) {
+
+        if (canTakeMoreGunners && (isTank || isSmallCraftOrJumpShip || isMekWithGunner)) {
             filteredPersonnel = personnel.stream()
                                       .filter(person -> (isSmallCraftOrJumpShip &&
                                                                person.hasRole(PersonnelRole.VESSEL_GUNNER)) ||
                                                               (isTank &&
                                                                      person.hasRole(PersonnelRole.VEHICLE_GUNNER)) ||
-                                                              ((isSuperHeavyMek || isTripod || isQuadMek) &&
+                                                              ((isMekWithGunner) &&
                                                                      person.getPrimaryRole().isMekWarriorGrouping() ||
                                                                      person.getSecondaryRole().isMekWarriorGrouping()))
                                       .collect(Collectors.toList());
@@ -476,7 +475,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                         skillLevel = person.getSkillLevel(campaign, !person.getPrimaryRole().isVesselGunner());
                     } else if (isTank) {
                         skillLevel = person.getSkillLevel(campaign, !person.getPrimaryRole().isVehicleGunner());
-                    } else if (isSuperHeavyMek || isTripod || isQuadMek) {
+                    } else if (isMekWithGunner) {
                         skillLevel = person.getSkillLevel(campaign, !person.getPrimaryRole().isMekWarriorGrouping());
                     }
 


### PR DESCRIPTION
Fixes #6967 

It was by sheer luck that their one Mek worked - it was a Quad Mek, so that's why the dual-cockpit worked. Anyway, this logic seems to work great. Tested with normal cockpits, dual cockpits, and cockpit command consoles. All work as expected now. 