### PR TITLE
Fix: #6948 Fixed Artillery Skill Only Being Factored into a Character's Experience Level when Use Artillery Skill is Disabled

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3781,7 +3781,7 @@ public class Person {
 
         return switch (role) {
             case VEHICLE_GUNNER -> {
-                if (isUseArtillery) {
+                if (!isUseArtillery) {
                     yield calculateExperienceLevelForProfession(associatedSkillNames, isAlternativeQualityAveraging);
                 } else {
                     if ((hasSkill(SkillType.S_GUN_VEE)) && (hasSkill(SkillType.S_ARTILLERY))) {


### PR DESCRIPTION
Fix #6948

This was caused by an inverted conditional, one of the classic blunders.