### PR TITLE
Improvement: #6878 Added the Ability to Hide Personalities on Individual Characters

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -269,6 +269,9 @@ miMarriageable.text=Marriageable
 miMarriageable.toolTipText=If this is selected, then the person will be included as a potential spouse for marriages (married personnel will not be included even if this flag is selected, nor will characters under 18 years old)
 miTryingToConceive.text=Trying to Conceive
 miTryingToConceive.toolTipText=If this is selected, the person has a chance to have children created through random procreation (this flag is ignored for personnel under 18 years old).
+miHidePersonality.text=Hide Personality
+miHidePersonality.toolTipText=If this is selected, the character's personality description will be hidden. This is useful\
+  \ if you want to write your own description.
 ### Randomization Menu
 randomizationMenu.text=Randomization
 miRandomName.single.text=Randomize Name

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -329,6 +329,7 @@ public class Person {
     // this is a flag used in random procreation to determine whether to attempt to
     // procreate
     private boolean tryingToConceive;
+    private boolean hidePersonality;
     // endregion Flags
 
     // Generic extra data, for use with plugins and mods
@@ -2365,6 +2366,14 @@ public class Person {
     public void setTryingToConceive(final boolean tryingToConceive) {
         this.tryingToConceive = tryingToConceive;
     }
+
+    public boolean isHidePersonality() {
+        return hidePersonality;
+    }
+
+    public void setHidePersonality(final boolean hidePersonality) {
+        this.hidePersonality = hidePersonality;
+    }
     // endregion Flags
 
     public ExtraData getExtraData() {
@@ -2787,6 +2796,8 @@ public class Person {
             if (!isTryingToConceive()) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "tryingToConceive", false);
             }
+
+            MHQXMLUtility.writeSimpleXMLTag(pw, indent, "hidePersonality", hidePersonality);
             // endregion Flags
 
             if (!extraData.isEmpty()) {
@@ -3276,6 +3287,8 @@ public class Person {
                     person.setMarriageable(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("tryingToConceive")) {
                     person.setTryingToConceive(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (nodeName.equalsIgnoreCase("hidePersonality")) {
+                    person.setHidePersonality(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("extraData")) {
                     person.extraData = ExtraData.createFromXml(wn2);
                 }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -3853,6 +3853,22 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu.add(cbMenuItem);
         }
 
+        if (getCampaignOptions().isUseRandomPersonalities()) {
+            cbMenuItem = new JCheckBoxMenuItem(resources.getString("miHidePersonality.text"));
+            cbMenuItem.setToolTipText(MultiLineTooltip.splitToolTip(resources.getString("miHidePersonality.toolTipText"),
+                  100));
+            cbMenuItem.setName("miHidePersonality");
+            cbMenuItem.setSelected(person.isHidePersonality());
+            cbMenuItem.addActionListener(evt -> {
+                final boolean hidePersonality = !person.isHidePersonality();
+                Stream.of(selected).forEach(selectedPerson -> {
+                    selectedPerson.setHidePersonality(hidePersonality);
+                    MekHQ.triggerEvent(new PersonChangedEvent(selectedPerson));
+                });
+            });
+            menu.add(cbMenuItem);
+        }
+
         JMenuHelpers.addMenuIfNonEmpty(popup, menu);
         // endregion Flags Menu
 

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -289,7 +289,9 @@ public class PersonViewPanel extends JScrollablePanel {
             gridY++;
         }
 
-        if ((!person.getPersonalityDescription().isBlank()) && (campaignOptions.isUseRandomPersonalities()) &&
+        if ((!person.getPersonalityDescription().isBlank()) &&
+                  (campaignOptions.isUseRandomPersonalities()) &&
+                  (!person.isHidePersonality()) &&
                   (!person.isChild(campaign.getLocalDate()))) { // we don't display for children, as most of the
             // descriptions won't fit
             JTextPane txtDesc = new JTextPane();


### PR DESCRIPTION
Fix #6878

The player just needs to select the character (or characters) they want to hide the personality of, hit 'hide personality' and that characters personality will be hidden. This allows the player to write their own descriptions, using the biography panel in Edit Person, without needing to disable the entire random personality system.