### PR TITLE
Fix: Added Missing Campaign Options Iconography to New Weapons Restock Percentage Option; Changed Color of Iconography to Stand Out

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -36,9 +36,12 @@ lblGeneralBody.text=<center><p>"War has been described as an art, as a science, 
   \ competing in a wide-open market, the mercenary leader does not have this advantage, and it\
   \ behooves him to run his firm wisely, efficiently, and economically."\
   <br><i>From "The Soldier's Balance Sheet" by Colonel David "Bear" Tarquin</i></p></center>\
-  <p><table align="center"><tr><td>\u270E Custom system unique to <i>MekHQ</i>.</td><td>\u2318 Documentation included in <i>MekHQ/docs</i>.</td></tr>\
-  <tr><td>\u26A0 Tooltip contains important information.</td><td>\u2714 Tooltip contains a recommendation.</td></tr>\
-  <tr><td>\u2605 Added since the last <b>Development</b> release.</td><td>\u2606 Added since the last <b>Milestone</b>\
+  <p><table align="center"><tr><td>\u270E Custom system unique to <i>MekHQ</i>.</td>\
+  <td>\u2318 Documentation included in <i>MekHQ/docs</i>.</td></tr>\
+  <tr><td>\u26A0 Tooltip contains important information.</td>\
+  <td>\u2714 Tooltip contains a recommendation.</td></tr>\
+  <tr><td><span style="color:#00008b;">\u2605</span> Added since the last <b>Development</b> release.</td>\
+  <td><span style="color:#00008b;">\u2606</span> Added since the last <b>Milestone</b>\
   \ release.</td></tr></table></p>
 lblName.text=Unit Name
 lblName.tooltip=The most important decision you will ever make.
@@ -54,11 +57,11 @@ lblReputation.tooltip=Which reputation method should your campaign be graded aga
   <br><b>Recommended:</b> Campaign Operations
 lblManualUnitRatingModifier.text=Manual Modifier
 lblManualUnitRatingModifier.tooltip=This allows you to manually adjust your reputation rating.
-lblResetCriminalRecord.text=Reset Criminal Record \u26A0 \u2606
+lblResetCriminalRecord.text=Reset Criminal Record \u26A0 <span style="color:#00008b;">\u2606</span>
 lblResetCriminalRecord.tooltip=Reset date of last crime and all penalties to Reputation from crime.\
   <br>\
   <br><b>Warning:</b> The Reputation report won't update to reflect this change until the next Monday.
-lblClampReputationPayMultiplier.text=Clamp Reputation Pay Multiplier \u26A0 \u2714 \u2606
+lblClampReputationPayMultiplier.text=Clamp Reputation Pay Multiplier \u26A0 \u2714 <span style="color:#00008b;">\u2606</span>
 lblClampReputationPayMultiplier.tooltip=When using CamOps Reputation your unit's reputation score\
   \ affects contract pay. This option clamps the reputation-based multiplier between 50 and 200%.\
   <br>\
@@ -67,7 +70,7 @@ lblClampReputationPayMultiplier.tooltip=When using CamOps Reputation your unit's
   \ particularly a problem for generational campaigns expected to last decades or longer.\
   <br>\
   <br><b>Recommended</b>: Leave enabled.
-lblReduceReputationPerformanceModifier.text=Reduce Mission Performance Score \u26A0 \u2714 \u2606
+lblReduceReputationPerformanceModifier.text=Reduce Mission Performance Score \u26A0 \u2714 <span style="color:#00008b;">\u2606</span>
 lblReduceReputationPerformanceModifier.tooltip=When using CamOps Reputation your unit's past\
   \ contract performance affects contract pay. This option reduces the impact of successes,\
   \ failures, and breaches by 80%.\
@@ -77,7 +80,7 @@ lblReduceReputationPerformanceModifier.tooltip=When using CamOps Reputation your
   \ Reputation. This has knock-on effects whenever Reputation is used to influence a system.\
   <br>\
   <br><b>Recommended</b>: This option helps slow growth to more sane levels. Leave enabled.
-lblReputationPerformanceModifierCutOff.text=Ignore Old Missions \u26A0 \u2714 \u2606
+lblReputationPerformanceModifierCutOff.text=Ignore Old Missions \u26A0 \u2714 <span style="color:#00008b;">\u2606</span>
 lblReputationPerformanceModifierCutOff.tooltip=When using CamOps Reputation all past contracts\
   \ affect future contract pay. This option tells MekHQ to ignore any contracts that were completed\
   \ over a decade ago. Only Legacy AtB and StratCon contracts are affected.\
@@ -123,7 +126,7 @@ maintenanceTab.border="One 'Mek lance can beat one mob, large or small, any time
   <br>Lecture at the New Avalon Institute of Science, 3017</i>
 # createRepairTab
 lblRepairTab.text=Repair Options
-lblTechsUseAdministration.text=Techs Use Administration \u270E \u2606
+lblTechsUseAdministration.text=Techs Use Administration \u270E <span style="color:#00008b;">\u2606</span>
 lblTechsUseAdministration.tooltip=Daily available tech minutes is increased and decreased based on the Tech's\
   \ <i>Administration</i> skill. Each skill level (Green, Regular, etc.) in <i>Administration</i> increases available\
   \ minutes by around 5%.
@@ -154,7 +157,7 @@ lblMaintenanceTab.text=Maintenance Options
 lblCheckMaintenance.text=Enable Unit Maintenance
 lblCheckMaintenance.tooltip=If checked, each unit will make a parts-specific maintenance check at\
   \ the end of each maintenance cycle
-lblMaintenanceDays.text=Base Maintenance Cycle \u2606
+lblMaintenanceDays.text=Base Maintenance Cycle <span style="color:#00008b;">\u2606</span>
 lblMaintenanceDays.tooltip=This setting determines how frequently maintenance checks are made while\
   \ on non-Garrison contracts. Peacetime frequency is x4 this value.
 lblMaintenanceBonus.text=Maintenance Modifier
@@ -178,10 +181,10 @@ lblReverseQualityNames.tooltip=If checked, equipment and unit quality names will
   <br>\
   <br><b>Warning:</b> This option is not reflected in the 'Operations/Finances/Price Multipliers'\
   \ tab.
-lblUseRandomUnitQualities.text=Random New Unit Quality \u270E \u2606
+lblUseRandomUnitQualities.text=Random New Unit Quality \u270E <span style="color:#00008b;">\u2606</span>
 lblUseRandomUnitQualities.tooltip=Determines whether the quality of new units is randomized based\
   \ on market or salvage status. Otherwise, quality will always default to D.
-lblUsePlanetaryModifiers.text=Use Planetary Modifiers \u2606
+lblUsePlanetaryModifiers.text=Use Planetary Modifiers <span style="color:#00008b;">\u2606</span>
 lblUsePlanetaryModifiers.tooltip=Determines whether certain planetary conditions will impact\
   \ maintenance checks based on repair location.
 lblUseUnofficialMaintenance.text=Only Damage Worst Rated Equipment \u270E \u26A0
@@ -214,7 +217,7 @@ lblAcquisitionTab.text=Acquisition & Delivery Options
 lblAcquisitionPanel.text=Acquisitions
 lblChoiceAcquireSkill.text=Acquisitions Skill
 lblChoiceAcquireSkill.tooltip=What skill should be used when performing acquisition checks?
-lblProcurementPersonnelPick.text=Acquisitions Personnel \u2606
+lblProcurementPersonnelPick.text=Acquisitions Personnel <span style="color:#00008b;">\u2606</span>
 lblProcurementPersonnelPick.tooltip=Who should be able to make procurement checks?
 lblAcquireClanPenalty.text=Penalty for Clan Equipment
 lblAcquireClanPenalty.tooltip=The penalty for acquisition checks when attempting to acquire Clan\
@@ -227,7 +230,7 @@ lblAcquireWaitingPeriod.tooltip=How many days should pass between acquisition at
 lblMaxAcquisitions.text=Max Acquisition Rolls per Period
 lblMaxAcquisitions.tooltip=How many times can a character make an acquisition check per period?
 # createAutoLogisticsPanel
-lblAutoLogisticsPanel.text=AutoLogistics \u2606
+lblAutoLogisticsPanel.text=AutoLogistics <span style="color:#00008b;">\u2606</span>
 lblAutoLogisticsMekHead.text='Mek Head Restock Percent
 lblAutoLogisticsMekHead.tooltip=autoLogistics counts the number of each 'Mek head type in use and\
   \ then automatically orders replacement spares equal to the percentage set in this option.
@@ -257,7 +260,7 @@ lblAutoLogisticsJumpJets.tooltip=autoLogistics counts the number of jump jets in
 lblAutoLogisticsEngines.text=Engine Restock Percent
 lblAutoLogisticsEngines.tooltip=autoLogistics counts the number of engines in use and then\
   \ automatically orders replacement spares equal to the percentage set in this option.
-lblAutoLogisticsWeapons.text=Weapon Restock Percent
+lblAutoLogisticsWeapons.text=Weapon Restock Percent <span style="color:#00008b;">\u2605</span>
 lblAutoLogisticsWeapons.tooltip=autoLogistics counts the number of weapons in use and then\
   \ automatically orders replacement spares equal to the percentage set in this option.
 lblAutoLogisticsOther.text=Other Restock Percent
@@ -265,7 +268,7 @@ lblAutoLogisticsOther.tooltip=autoLogistics counts each part in use, that is not
   \ the other options, and automatically orders replacement spares equal to the percentage set in\
   \ this options.
 # createDeliveryPanel
-lblDeliveryPanel.text=Deliveries \u2606
+lblDeliveryPanel.text=Deliveries <span style="color:#00008b;">\u2606</span>
 lblTransitTimeUnits.text=Delivery Scale
 lblTransitTimeUnits.tooltip=Should deliveries be scaled using days, weeks, or months? Campaign\
   \ Operations uses months.
@@ -410,7 +413,7 @@ lblUseAlternativeQualityAveraging.text=Use Higher-Precision Skill Averaging \u27
 lblUseAlternativeQualityAveraging.tooltip=Where two skills determine experience level, attempt to\
   \ average by number (e.g., 8/4), rather than product (e.g., Regular/Green), for greater precision.
 # createPersonnelCleanUpPanel
-lblPersonnelCleanUpPanel.text=Personnel Cleanup \u270E \u2606
+lblPersonnelCleanUpPanel.text=Personnel Cleanup \u270E <span style="color:#00008b;">\u2606</span>
 lblUsePersonnelRemoval.text=Enable Personnel Cleanup
 lblUsePersonnelRemoval.tooltip=If enabled, personnel data will be deleted on the last day of each\
   \ month for any personnel who been left from the unit for over a month.
@@ -440,17 +443,17 @@ lblPersonnelLogEdgeGain.text=Log Edge Gains
 lblPersonnelLogEdgeGain.tooltip=Add log entries to the personnel log when gaining or changing Edge.\
   \ It doesn't include changes made in the customize person dialog nor any made before hiring a\
   \ person.
-lblDisplayPersonnelLog.text=Expand Personal Log by Default \u2606
+lblDisplayPersonnelLog.text=Expand Personal Log by Default <span style="color:#00008b;">\u2606</span>
 lblDisplayPersonnelLog.tooltip=Determines whether the personnel log will be expanded by default
-lblDisplayScenarioLog.text=Expand Scenario Log by Default \u2606
+lblDisplayScenarioLog.text=Expand Scenario Log by Default <span style="color:#00008b;">\u2606</span>
 lblDisplayScenarioLog.tooltip=Determines whether the scenario log will be expanded by default
-lblDisplayKillRecord.text=Expand Kill Log by Default \u2606
+lblDisplayKillRecord.text=Expand Kill Log by Default <span style="color:#00008b;">\u2606</span>
 lblDisplayKillRecord.tooltip=Determines whether the kill log will be expanded by default
-lblDisplayMedicalRecord.text=Expand Medical Log by Default \u2606
+lblDisplayMedicalRecord.text=Expand Medical Log by Default <span style="color:#00008b;">\u2606</span>
 lblDisplayMedicalRecord.tooltip=Determines whether the medical log will be expanded by default
-lblDisplayAssignmentRecord.text=Expand Assignment Log by Default \u2606
+lblDisplayAssignmentRecord.text=Expand Assignment Log by Default <span style="color:#00008b;">\u2606</span>
 lblDisplayAssignmentRecord.tooltip=Determines whether the assignment log will be expanded by default
-lblDisplayPerformanceRecord.text=Expand Performance Report by Default \u2606
+lblDisplayPerformanceRecord.text=Expand Performance Report by Default <span style="color:#00008b;">\u2606</span>
 lblDisplayPerformanceRecord.tooltip=Determines whether the Skill, XP and SPA gain log will be expanded by default
 # createPersonnelInformationTab
 lblPersonnelInformation.text=Personnel Information Options \u270E
@@ -478,7 +481,7 @@ lblTrackTotalXPEarnings.tooltip=This tracks the total amount of experience earne
 lblShowOriginFaction.text=Display Origin Faction
 lblShowOriginFaction.tooltip=Display the origin faction of a person in the personnel table.
 # createAdministratorsTab
-lblAdministratorsPanel.text=Administrators \u270E \u2606
+lblAdministratorsPanel.text=Administrators \u270E <span style="color:#00008b;">\u2606</span>
 lblAdminsHaveNegotiation.text=Admins Have Negotiation
 lblAdminsHaveNegotiation.tooltip=Generate all admin personnel with ranks in the Negotiation skill.
 lblAdminExperienceLevelIncludeNegotiation.text=Negotiation Factored into Experience Level
@@ -490,7 +493,7 @@ lblAdminExperienceLevelIncludeScrounge.text=Scrounge Factored into Experience Le
 lblAdminExperienceLevelIncludeScrounge.tooltip=All admin personnel will factor the Scrounge skill\
   \ into their experience level calculations (green, regular, etc.).
 # createAwardsTab
-lblAwardsTab.text=Awards Options \u270E \u2318 \u2606
+lblAwardsTab.text=Awards Options \u270E \u2318 <span style="color:#00008b;">\u2606</span>
 lblAwardBonusStyle.text=Bonuses
 lblAwardBonusStyle.tooltip=Toggle XP and/or Edge bonuses from awards.
 lblAwardTierSize.text=Tier Size
@@ -561,10 +564,10 @@ lblEnableMiscAwards.tooltip=These awards aren't covered by the other categories.
 lblPrisonersAndDependentsTab.text=Prisoners & Civilians Options \u270E \u2318
 # createPrisonersPanel
 lblPrisonersPanel.text=Prisoners
-lblPrisonerCaptureStyle.text=Capture Style \u2606
+lblPrisonerCaptureStyle.text=Capture Style <span style="color:#00008b;">\u2606</span>
 lblPrisonerCaptureStyle.tooltip=This is the ruleset to use when determining if a person has been\
   \ captured by the force following a scenario.
-lblResetTemporaryPrisonerCapacity.text=Reset Prisoner Capacity Reductions \u2606
+lblResetTemporaryPrisonerCapacity.text=Reset Prisoner Capacity Reductions <span style="color:#00008b;">\u2606</span>
 lblResetTemporaryPrisonerCapacity.tooltip=This option removes any penalties to Prisoner Capacity that might have been\
   \ added by Prisoner Events.
 # createDependentsPanel
@@ -593,16 +596,16 @@ lblUseRandomHitsForVehicles.tooltip=The number of hits that crews and infantry r
   \ randomly selected between the minimum value and five, during scenario resolution.
 lblUseTougherHealing.text=Use Tougher Healing \u270E
 lblUseTougherHealing.tooltip=The healing check will be penalized for every additional hit above 2.
-lblMaximumPatients.text=Base Beds per Doctor \u2606
+lblMaximumPatients.text=Base Beds per Doctor <span style="color:#00008b;">\u2606</span>
 lblMaximumPatients.tooltip=This is the base number of patients that can be treated per doctor. This can be modified by\
   \ Administration.
-lblDoctorsUseAdministration.text=Doctors Need Administration \u270E \u2606
+lblDoctorsUseAdministration.text=Doctors Need Administration \u270E <span style="color:#00008b;">\u2606</span>
 lblDoctorsUseAdministration.tooltip=If enabled, the <i>Administration</i> skill of each Doctor influences how many hospital\
   \ beds they generate. Each skill level in <i>Administration</i> (Green, Regular, etc.) increases the number of beds by\
   \ around 20%.
 # createSalariesTab
 lblSalariesTab.text=Salary Options
-lblDisableSecondaryRoleSalary.text=Disable Secondary Role Salaries \u270E \u2606
+lblDisableSecondaryRoleSalary.text=Disable Secondary Role Salaries \u270E <span style="color:#00008b;">\u2606</span>
 lblDisableSecondaryRoleSalary.tooltip=Determines whether personnel will have their salaries\
   \ increased by their secondary role (if any).
 # createSalaryMultipliersPanel
@@ -700,10 +703,10 @@ lblFamilyDisplayLevel.tooltip=This setting is the relation to the selected chara
   \ display up to, including the previous levels.\
   <br>\
   <br><b>Warning:</b> Higher levels require more processing when loading a character.
-lblUseAgeEffects.text=Character Age Affects Skills \u26A0 \u270E \u2606
+lblUseAgeEffects.text=Character Age Affects Skills \u26A0 \u270E <span style="color:#00008b;">\u2606</span>
 lblUseAgeEffects.tooltip=Based on ATOW, As a character ages, their skills improve and decrease (mostly decrease).
 # createAnniversariesPanel
-lblAnniversariesPanel.text=Anniversaries \u2606
+lblAnniversariesPanel.text=Anniversaries <span style="color:#00008b;">\u2606</span>
 lblAnnounceBirthdays.text=Announce Birthdays
 lblAnnounceBirthdays.tooltip=A daily report notification will occur whenever a character celebrates\
   \ their birthday.
@@ -717,7 +720,7 @@ lblAnnounceChildBirthdays.tooltip=If enabled, 18th birthdays will always be anno
   <br>\
   <br><b>Warning:</b> Enabling this option will override any other settings.
 # createLifeEventsPanel
-lblLifeEventsPanel.text=Life Events \u2606
+lblLifeEventsPanel.text=Life Events <span style="color:#00008b;">\u2606</span>
 lblShowLifeEventDialogBirths.text=Personnel Giving Birth
 lblShowLifeEventDialogBirths.tooltip=Whenever a child is born, an in character dialog will appear announcing the event.
 lblShowLifeEventDialogComingOfAge.text=Children Coming of Age
@@ -729,7 +732,7 @@ lblShowLifeEventDialogCelebrations.tooltip=On certain dates an in character dial
 # createBackgroundsTab
 lblBackgroundsTab.text=Background Options \u270E
 # createRandomBackgroundsPanel
-lblRandomBackgroundsPanel.text=Random Backgrounds \u2606
+lblRandomBackgroundsPanel.text=Random Backgrounds <span style="color:#00008b;">\u2606</span>
 lblUseRandomPersonalities.text=Assign Random Personalities \u2318
 lblUseRandomPersonalities.tooltip=Personnel are generated with random personality traits, quirks\
   \ and reasoning.\
@@ -795,7 +798,7 @@ lblExtraRandomOrigin.tooltip=Random origin is randomized to the planetary level 
 lblDeathTab.text=Death Options \u270E
 lblUseRandomDeathSuicideCause.text=Enable Cause of Death: Suicide
 lblUseRandomDeathSuicideCause.tooltip=This includes suicide as a potential cause for a random death.
-lblRandomDeathMultiplier.text=Random Death Multiplier \u2318 \u26A0 \u2606
+lblRandomDeathMultiplier.text=Random Death Multiplier \u2318 \u26A0 <span style="color:#00008b;">\u2606</span>
 lblRandomDeathMultiplier.tooltip=This multiplier is applied directly to a character's chance to\
   \ randomly die. The higher this value, the more likely characters will die from random causes.\
   <br>\
@@ -804,7 +807,7 @@ lblRandomDeathMultiplier.tooltip=This multiplier is applied directly to a charac
 # createDeathAgeGroupsPanel
 lblDeathAgeGroupsPanel.text=Death by Age Group
 # createEducationTab
-lblEducationTab.text=Education Options \u270E \u2318 \u2606
+lblEducationTab.text=Education Options \u270E \u2318 <span style="color:#00008b;">\u2606</span>
 lblUseEducationModule.text=Enable Education Module
 lblUseEducationModule.tooltip=Enables the Education Module.
 lblCurriculumXpRate.text=Base XP Rate
@@ -875,7 +878,7 @@ lblFactionNames.tooltip=All names will be generated based on the selected factio
 lblAssignPortraitOnRoleChange.text=Reassign Portrait on Role Change
 lblAssignPortraitOnRoleChange.tooltip=With this enabled, a person without a portrait will\
   \ automatically gain a random portrait when their primary role is changed switched.
-lblAllowDuplicatePortraits.text=Allow Duplicate Portraits \u2606
+lblAllowDuplicatePortraits.text=Allow Duplicate Portraits <span style="color:#00008b;">\u2606</span>
 lblAllowDuplicatePortraits.tooltip=With this enabled, random portraits are no longer unique\
   \ and several different people can have the same portrait.
 # createRandomPortraitPanel
@@ -939,7 +942,7 @@ fatigueTab.border="I say to Hell with Information! Ammunition is Ammunition!"\
   <br><i>Unknown Mercenary\
   <br>Clan Invasion</i>
 # createTurnoverTab
-lblTurnoverTab.text=Turnover Options \u270E \u2318 \u2606
+lblTurnoverTab.text=Turnover Options \u270E \u2318 <span style="color:#00008b;">\u2606</span>
 lblTurnoverTabBody.text=Turnover is a reasonably complex system. It is highly recommended that you\
   \ read through the documentation: <i>MekHQ/docs/Personnel Modules/Turnover and Retention.pdf</i>
 lblUseRandomRetirement.text=Enable Random Turnover
@@ -1055,7 +1058,7 @@ lblManagementSkillPenalty.text=Unskilled Penalty
 lblManagementSkillPenalty.tooltip=The unskilled modifier to turnover target numbers. Each rank in\
   \ Leadership reduces this number by 1.
 # createFatigueTab
-lblFatigueTab.text=Fatigue Options \u2606
+lblFatigueTab.text=Fatigue Options <span style="color:#00008b;">\u2606</span>
 lblFatigueTabBody.text=The rules for Fatigue can be found in Campaign Operations. With our\
   \ implementation covered in the Turnover and Retention documentation.
 lblUseFatigue.text=Enable Fatigue
@@ -1107,7 +1110,7 @@ lblUsePrisonerMarriages.text=Enable Prisoner Marriages
 lblUsePrisonerMarriages.tooltip=Allow prisoners to marry other prisoners, and manually marrying a\
   \ prisoner to a free member of the force. Bondsmen are treated as free personnel when it comes to\
   \ this option, and are thus not affected by it.
-lblNoInterestInMarriageDiceSize.text=No Interest in Marriage Chance \u2606: 1 in
+lblNoInterestInMarriageDiceSize.text=No Interest in Marriage Chance <span style="color:#00008b;">\u2606</span>: 1 in
 lblNoInterestInMarriageDiceSize.tooltip=This is the number of sides on the die rolled to determine\
   \ whether a character has no interest in marriage. This die is rolled when a character is\
   \ created, with no interest in marriage being determined on a roll of 1. This can be overridden\
@@ -1122,7 +1125,7 @@ lblLogMarriageNameChanges.tooltip=This enables the addition of a personnel log e
   \ name is changed during marriage.
 # createRandomMarriagePanel
 lblRandomMarriages.text=Random Marriages
-lblRandomMarriageMethod.text=Random Marriage Method \u2606
+lblRandomMarriageMethod.text=Random Marriage Method <span style="color:#00008b;">\u2606</span>
 lblRandomMarriageMethod.tooltip=This is the method used to determine if an eligible person randomly\
   \ marries.
 lblUseRandomClanPersonnelMarriages.text=Enable Random Clan Marriages
@@ -1136,16 +1139,16 @@ lblRandomMarriageAgeRange.tooltip=This plus/minus age forms the possible range o
   \ in the forming of a random marriage.
 # createPercentageRandomMarriagePanel
 lblPercentageRandomMarriagePanel.text=Marriage Dice
-lblRandomMarriageOppositeSexDiceSize.text=Marriage Chance \u2606: 1 in
+lblRandomMarriageOppositeSexDiceSize.text=Marriage Chance <span style="color:#00008b;">\u2606</span>: 1 in
 lblRandomMarriageOppositeSexDiceSize.tooltip=This determines the number of sides on the die rolled\
   \ to determine whether a character gets married. Marriage occurs on a roll of 1.
-lblRandomSameSexMarriageDiceSize.text=Same-Sex Marriage Chance \u26A0 \u2606: 1 in
+lblRandomSameSexMarriageDiceSize.text=Same-Sex Marriage Chance \u26A0 <span style="color:#00008b;">\u2606</span>: 1 in
 lblRandomSameSexMarriageDiceSize.tooltip=This is the likelihood a random marriage will be same-sex.\
   <br>\
   <br>Set this value to 0 to disable same-sex marriages.\
   <br>\
   <br>The default value is based on real world data.
-lblRandomNewDependentMarriage.text=Inter-Unit Marriage Chance \u2606: 1 in
+lblRandomNewDependentMarriage.text=Inter-Unit Marriage Chance <span style="color:#00008b;">\u2606</span>: 1 in
 lblRandomNewDependentMarriage.tooltip=This determines the number of sides on the die rolled to\
   \ determine whether a marriage is to another character in the campaign unit. Inter-unit marriage\
   \ occurs on a roll of 1.\
@@ -1164,7 +1167,7 @@ lblUsePrisonerDivorce.tooltip=Allow divorce when one or both of the couple are c
   \ by it.
 # createRandomDivorcePanel
 lblRandomDivorcePanel.text=Random Divorce
-lblRandomDivorceMethod.text=Random Divorce Method \u2606
+lblRandomDivorceMethod.text=Random Divorce Method <span style="color:#00008b;">\u2606</span>
 lblRandomDivorceMethod.tooltip=This is the method used to determine if an eligible person randomly\
   \ divorces.
 lblUseRandomOppositeSexDivorce.text=Use Random Opposite Sex Divorce
@@ -1180,7 +1183,7 @@ lblUseRandomPrisonerDivorce.text=Use Random Prisoner Divorce
 lblUseRandomPrisonerDivorce.tooltip=Allow random divorce when one or both of the couple are\
   \ currently prisoners. Bondsmen are treated as free personnel when it comes to this option, and\
   \ are thus not affected by it.
-lblRandomDivorceDiceSize.text=Random Divorce Chance: \u2606 1 in
+lblRandomDivorceDiceSize.text=Random Divorce Chance: <span style="color:#00008b;">\u2606</span> 1 in
 lblRandomDivorceDiceSize.tooltip=This is the number of sides featured on the weekly dice rolled to\
   \ see whether a marriage ends in divorce. Divorce occurs on a roll of 1.\
   <br>\
@@ -1222,14 +1225,14 @@ lblDetermineFatherAtBirth.tooltip=The father of a child will be determined based
 lblDisplayTrueDueDate.text=Display True Due Date
 lblDisplayTrueDueDate.tooltip=This displays the actual date the baby will be delivered on the\
   \ mother's personnel sheet instead of an estimated due date.
-lblNoInterestInChildrenDiceSize.text=No Interest in Children Chance \u2606: 1 in
+lblNoInterestInChildrenDiceSize.text=No Interest in Children Chance <span style="color:#00008b;">\u2606</span>: 1 in
 lblNoInterestInChildrenDiceSize.tooltip=This is the number of sides on the die rolled to determine\
   \ whether a character has no interest in children. This die is rolled when creating the\
   \ character, with no interest occurring on a roll of 1. The results of this roll can be changed\
   \ by right-clicking on the character and changing the 'Interested in Children' flag.\
   <br>\
   <br>Changing this value to 1 will mean all characters are interested in children.
-lblUseMaternityLeave.text=Enable Automatic Maternity Leave \u2606
+lblUseMaternityLeave.text=Enable Automatic Maternity Leave <span style="color:#00008b;">\u2606</span>
 lblUseMaternityLeave.tooltip=If enabled, pregnant personnel will be placed on maternity leave 20\
   \ weeks before they give birth and will not return to active duty until after they have given\
   \ birth.
@@ -1237,7 +1240,7 @@ lblLogProcreation.text=Log Procreation
 lblLogProcreation.tooltip=This enables logging the date of conception and birth in a person's logs.
 # createRandomProcreationPanel
 lblRandomProcreationPanel.text=Random Procreation
-lblRandomProcreationMethod.text=Random Procreation Method \u2606
+lblRandomProcreationMethod.text=Random Procreation Method <span style="color:#00008b;">\u2606</span>
 lblRandomProcreationMethod.tooltip=This is the method used to determine if an eligible person\
   \ randomly procreates.
 lblUseRelationshiplessRandomProcreation.text=Enable Random Relationshipless Procreation
@@ -1248,11 +1251,11 @@ lblUseRandomClanPersonnelProcreation.tooltip=Allow clan-origin personnel to rand
 lblUseRandomPrisonerProcreation.text=Enable Random Prisoner Procreation
 lblUseRandomPrisonerProcreation.tooltip=Allow prisoners to randomly procreate. Bondsmen are treated\
   \ as free personnel when it comes to this option, and are thus not affected by it.
-lblRandomProcreationRelationshipDiceSize.text=Normal Procreation Chance \u2606: 1 in
+lblRandomProcreationRelationshipDiceSize.text=Normal Procreation Chance <span style="color:#00008b;">\u2606</span>: 1 in
 lblRandomProcreationRelationshipDiceSize.tooltip=This is the number of sides on the dice rolled\
   \ weekly to determine whether a woman in a relationship will fall pregnant. A roll of 1 results\
   \ in a pregnancy.
-lblRandomProcreationRelationshiplessDiceSize.text=Relationshipless Procreation Chance \u2606: 1 in
+lblRandomProcreationRelationshiplessDiceSize.text=Relationshipless Procreation Chance <span style="color:#00008b;">\u2606</span>: 1 in
 lblRandomProcreationRelationshiplessDiceSize.tooltip=This is the number of sides on the dice rolled\
   \ weekly to determine whether a woman not in a relationship will fall pregnant. A roll of 1\
   \ results in a pregnancy.
@@ -1311,9 +1314,9 @@ lblFinancialYearDuration.tooltip=This changes the Financial Term, which is when 
 lblNewFinancialYearFinancesToCSVExportBox.text=Export Finances as CSV Table on Term End
 lblNewFinancialYearFinancesToCSVExportBox.tooltip=This writes the finance table to a CSV file on\
   \ the first day of a new financial term, right before the table is carried over to the next period.
-lblSimulateGrayMonday.text=Simulate Gray Monday \u2606
+lblSimulateGrayMonday.text=Simulate Gray Monday <span style="color:#00008b;">\u2606</span>
 lblSimulateGrayMonday.tooltip=Simulate the economic and social upheaval of Gray Monday.
-lblAllowMonthlyReinvestment.text=Allow Monthly Reinvestment of Wealth \u2606
+lblAllowMonthlyReinvestment.text=Allow Monthly Reinvestment of Wealth <span style="color:#00008b;">\u2606</span>
 lblAllowMonthlyReinvestment.tooltip=Each month the campaign commander will use their Wealth trait to\
   \ reinvest money back into the campaign.\
   <br>\
@@ -1325,7 +1328,7 @@ lblSellUnitsBox.tooltip=Units can be sold.
 lblSellPartsBox.text=Enable the Sale of Parts
 lblSellPartsBox.tooltip=Parts can be sold.
 # createTaxesPanel
-lblTaxesPanel.text=Taxes \u270E \u2606
+lblTaxesPanel.text=Taxes \u270E <span style="color:#00008b;">\u2606</span>
 lblUseTaxesBox.text=Enable Taxes
 lblUseTaxesBox.tooltip=If enabled, taxes will be paid at the end of each financial term.\
   <br>\
@@ -1418,7 +1421,7 @@ lblPersonnelMarketDylansWeight.tooltip=This is the weight between 0 and 1 used b
 lblPersonnelMarketReportRefresh.text=Post Report on Market Refresh
 lblPersonnelMarketReportRefresh.tooltip=Adds a report to the daily log when the personnel market\
   \ refreshes.
-lblUsePersonnelHireHiringHallOnly.text=Hiring Halls & Capitals Only \u270E \u2606
+lblUsePersonnelHireHiringHallOnly.text=Hiring Halls & Capitals Only \u270E <span style="color:#00008b;">\u2606</span>
 lblUsePersonnelHireHiringHallOnly.tooltip=Enabling this option disables the personnel market\
   \ outside of hiring halls or capital planets.
 # createPersonnelMarketRemovalOptionsPanel
@@ -1443,7 +1446,7 @@ lblUnitMarketRarityModifier.tooltip=This setting increases or decreases the roll
 lblInstantUnitMarketDelivery.text=Enable Instant Deliveries
 lblInstantUnitMarketDelivery.tooltip=Units bought from the unit market appear in the hangar\
   \ immediately rather than having to wait for delivery.
-lblMothballUnitMarketDeliveries.text=Deliver Units Mothballed \u2606
+lblMothballUnitMarketDeliveries.text=Deliver Units Mothballed <span style="color:#00008b;">\u2606</span>
 lblMothballUnitMarketDeliveries.tooltip=Units bought from the unit market will arrive in a\
   \ mothballed state.
 lblUnitMarketReportRefresh.text=Post Report on Market Refresh
@@ -1462,7 +1465,7 @@ lblContractSearchRadius.tooltip=Limits the location of contract offers to system
 lblVariableContractLength.text=Vary Contract Lengths
 lblVariableContractLength.tooltip=The length of the contract has a duration variance instead of\
   \ just using the constant base length for the mission type.
-lblUseDynamicDifficulty.text=Dynamically Adjust Contract Difficulty \u2606
+lblUseDynamicDifficulty.text=Dynamically Adjust Contract Difficulty <span style="color:#00008b;">\u2606</span>
 lblUseDynamicDifficulty.tooltip=The difficulty of random contracts is adjusted based on the average skill level of combat\
   \ personnel in your campaign. The higher skilled you are, the more challenging - and potentially rewarding - contracts\
   \ will be.
@@ -1547,7 +1550,7 @@ lblPlayerControlsAttachedUnits.tooltip=All attached units are placed under your 
 lblSPAUpgradeIntensity.text=SPA Chance
 lblSPAUpgradeIntensity.tooltip=How likely it is that regular+ OpFor pilots will receive SPAs. -1\
   \ indicates never, 3 indicates always.
-lblAutoConfigMunitions.text=OpFor Equips Special Munitions \u270E \u2318 \u2606
+lblAutoConfigMunitions.text=OpFor Equips Special Munitions \u270E \u2318 <span style="color:#00008b;">\u2606</span>
 lblAutoConfigMunitions.tooltip=Use semi-intelligent configuration of allied and enemy munitions,\
   \ tailored to each scenario.
 lblScenarioModMax.text=Maximum Count
@@ -1631,7 +1634,7 @@ lblUseAtB.tooltip=AtB was MekHQ's first attempt at a Digital GM. It creates rand
   <br>\
   <br><b>Warning:</b> If StratCon is enabled, all Legacy options are ignored.
 # createAutoResolvePanel
-lblAutoResolvePanel.text=AutoResolve \u270E \u2318 \u2606
+lblAutoResolvePanel.text=AutoResolve \u270E \u2318 <span style="color:#00008b;">\u2606</span>
 lblAutoResolveMethod.text=AutoResolve Method \u26A0
 lblAutoResolveMethod.tooltip=<b>Princess</b> \u2014 Princess plays the scenario on your behalf.\
   <br><b>ACAR: Abstract Combat Auto Resolution</b> \u2014 A complex simulation that completes the entire\
@@ -1769,7 +1772,7 @@ lblVocationalXP.text=Vocational XP per \u26A0
 lblVocationalXP.tooltip=How much experience should be awarded per vocational experience check? This\
   \ value is doubled while on any contract not classified as 'Garrison Type' (any contract that\
   \ ends in 'Duty,' other than 'Relief Duty').
-lblVocationalXPFrequency.text=Months \u2606
+lblVocationalXPFrequency.text=Months <span style="color:#00008b;">\u2606</span>
 lblVocationalXPFrequency.tooltip=How many months occur between vocational experience checks?\
   \ Characters will make a vocational experience check every time this many months has passed.
 lblVocationalXPTargetNumber.text=Vocational XP Target Number
@@ -1781,7 +1784,7 @@ lblMissionXpFail.tooltip=How much experience is awarded for a failed contract? T
 lblMissionXpSuccess.text=Success
 lblMissionXpSuccess.tooltip=How much experience is awarded for a successful contract? This is\
   \ granted to all active personnel.
-lblMissionXpOutstandingSuccess.text=Outstanding Success (StratCon Only) \u2606
+lblMissionXpOutstandingSuccess.text=Outstanding Success (StratCon Only) <span style="color:#00008b;">\u2606</span>
 lblMissionXpOutstandingSuccess.tooltip=Experience points awarded when successfully concluding a\
   \ mission with 3+ campaign victory points.
 # createAdministratorsPanel
@@ -1816,24 +1819,24 @@ lblExtraRandomness.tooltip=If checked, an additional 1d6 will be rolled per skil
   <br>\
   <br><b>Warning:</b> Due to the way experience levels are calculated, enabling this option will\
   \ more frequently have characters created with slightly lower than normal experience levels.
-lblComingOfAgeAbilities.text=Award Coming of Age SPAs \u2714 \u2606
+lblComingOfAgeAbilities.text=Award Coming of Age SPAs \u2714 <span style="color:#00008b;">\u2606</span>
 lblComingOfAgeAbilities.tooltip=If checked, all characters will be awarded a single SPA when they turn 16.\
   <br>\
   <br><b>Recommendation:</b> This was balanced around the pool of SPAs being rather large, due to the addition of ATOW\
   \ SPAs. If you are working with a smaller SPA pool, perhaps due to disabling those SPAs, you might want to leave\
   \ this off.
 lblATOWAttributesPanel.text=A Time of War Traits
-lblUseAttributes.text=Use Attributes \u26A0 \u2606
+lblUseAttributes.text=Use Attributes \u26A0 <span style="color:#00008b;">\u2606</span>
 lblUseAttributes.tooltip=If checked, characters will be generated with <i>A Time of War</i> Attribute scores.\
   <br>\
   <br><b>Warning:</b> If enabled (or disabled) mid-campaign, you need to navigate to the personnel tab, and (while in\
   \ GM Mode) you should use the right-click menu to reset attribute scores for all personnel.
-lblRandomizeAttributes.text=Random Attributes \u2605
+lblRandomizeAttributes.text=Random Attributes <span style="color:#00008b;">\u2605</span>
 lblRandomizeAttributes.tooltip=If checked, a d6 is rolled for each of the character's ATOW Attributes.\
   <br>\
   <br>On a roll of a 6 the Attribute is increased by 1. On a roll of a 6 the Attribute is decreased\
   \ by 1.
-lblRandomizeTraits.text=Randomize Traits \u2606
+lblRandomizeTraits.text=Randomize Traits <span style="color:#00008b;">\u2606</span>
 lblRandomizeTraits.tooltip=If checked, a newly created character's Connections, Wealth, Reputation, and Unlucky scores\
   \ are randomized.\
   <br>\
@@ -1932,7 +1935,7 @@ lblCommandSkillsElite.tooltip=Modifier made to the 2d6 roll used to determine wh
   <br><b>6-9:</b> Regular\
   <br><b>10-11:</b> Veteran\
   <br><b>12+:</b> Elite
-lblRoleplaySkillsModifier.text=Roleplay Skills \u26A0 \u2606
+lblRoleplaySkillsModifier.text=Roleplay Skills \u26A0 <span style="color:#00008b;">\u2606</span>
 lblRoleplaySkillsModifier.tooltip=Modifier made to the 2d6 roll used to determine whether a character is created\
   \ with points in one (or more) of the roleplay skills.\
   <br>\
@@ -1968,7 +1971,7 @@ lblSecondarySkillChance.tooltip=The percentage chance a conventional infantry ch
 lblSecondarySkillBonus.text=Modifier
 lblSecondarySkillBonus.tooltip=The skill level modifier applied to the skill (if present).
 ## Recruitment Bonuses Tab
-lblRecruitmentBonusesTab.text=Recruitment Modifiers \u2606
+lblRecruitmentBonusesTab.text=Recruitment Modifiers <span style="color:#00008b;">\u2606</span>
 lblRecruitmentBonusesTabBody.text=When a character is generated, a 2d6 is rolled to determine their experience level (Green,\
   \ Regular, etc.). These options allow you to apply a modifier to those rolls, specific to each profession.
 lblRecruitmentBonusesCombatPanel.text=Combat Roles


### PR DESCRIPTION
<img width="924" alt="image" src="https://github.com/user-attachments/assets/56e3bb89-6fd4-410b-95ed-5bc7cfbb9b57" />
