### PR TITLE
Fix: #6998 Fixed Tactics Bonus to No Longer Use the Tactic Number as a Bonus

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -6777,8 +6777,8 @@ public class CampaignOptions {
      * @param gameOptions the {@link GameOptions} to update based on the current campaign options.
      */
     public void updateGameOptionsFromCampaignOptions(GameOptions gameOptions) {
-        gameOptions.getOption(RPG_COMMAND_INIT).setValue(useTactics);
         gameOptions.getOption(RPG_INDIVIDUAL_INITIATIVE).setValue(useInitiativeBonus);
+        gameOptions.getOption(RPG_COMMAND_INIT).setValue(useTactics || useInitiativeBonus);
         gameOptions.getOption(RPG_TOUGHNESS).setValue(useToughness);
         gameOptions.getOption(RPG_ARTILLERY_SKILL).setValue(useArtillery);
         gameOptions.getOption(RPG_PILOT_ADVANTAGES).setValue(useAbilities);

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4477,8 +4477,7 @@ public class Unit implements ITechnology {
             // Tactics command bonus. This should actually reflect the unit's commander
             if (null != commander && commander.hasSkill(SkillType.S_TACTICS)) {
                 entity.getCrew()
-                      .setCommandBonus(commander.getSkill(SkillType.S_TACTICS)
-                                             .getFinalSkillValue(commander.getOptions()));
+                      .setCommandBonus(commander.getSkill(SkillType.S_TACTICS).getTotalSkillLevel());
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4473,7 +4473,8 @@ public class Unit implements ITechnology {
 
         // Set Tactics-based Commander's Initiative Bonus, if applicable
         entity.getCrew().setCommandBonus(0);
-        if (getCampaign().getCampaignOptions().isUseTactics()) {
+        if (getCampaign().getCampaignOptions().isUseTactics() ||
+                  getCampaign().getCampaignOptions().isUseInitiativeBonus()) {
             // Tactics command bonus. This should actually reflect the unit's commander
             if (null != commander && commander.hasSkill(SkillType.S_TACTICS)) {
                 entity.getCrew()


### PR DESCRIPTION
Fix #6998
Related Issue https://github.com/MegaMek/megamek/issues/7054

The initiative bonus from Tactics, when that campaign option was enabled, was incorrectly using the skill target number as a modifier and _not_ the combined skill levels, bonus, and aging modifiers.

I also fixed a bug where Tactics was not being applied to the unit if Individual Initiative Tactics Modifiers was enabled.

Finally I fixed a third bug where Commander Initiative wasn't being enabled in MegaMek when the above mentioned option was enabled.

There is a forth related bug, but that's a wholly MegaMek issue and is being handled by Sleet. But basically if individual initiative was enabled we are still using the highest initiative from all units under a player's control _not_ just the modifiers from the specific unit making the roll.