### PR TITLE
Fix: #6996 Fixed Sorting of Next Maintenance Column in Hangar

### DIFF
--- a/MekHQ/src/mekhq/gui/HangarTab.java
+++ b/MekHQ/src/mekhq/gui/HangarTab.java
@@ -190,6 +190,7 @@ public final class HangarTab extends CampaignGuiTab {
         unitSorter.setComparator(UnitTableModel.COL_PILOT, new PersonTitleStringSorter(getCampaign()));
         unitSorter.setComparator(UnitTableModel.COL_TECH_CRW, new PersonTitleStringSorter(getCampaign()));
         unitSorter.setComparator(UnitTableModel.COL_MAINTAIN, new FormattedNumberSorter());
+        unitSorter.setComparator(UnitTableModel.COL_MAINTAIN_CYCLE, new NaturalOrderComparator());
         unitTable.setRowSorter(unitSorter);
         List<SortKey> sortKeys = new ArrayList<>();
         sortKeys.add(new SortKey(UnitTableModel.COL_TYPE, SortOrder.DESCENDING));

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -292,12 +292,12 @@ public class UnitTableModel extends DataTableModel {
             case COL_MAINTAIN -> unit.getMaintenanceCost().toAmountAndSymbolString();
             case COL_MAINTAIN_CYCLE -> {
                 if (!campaign.getCampaignOptions().isCheckMaintenance()) {
-                    yield '-';
+                    yield "-"; // Do not convert this into a character, it will break sorting
                 }
 
                 boolean needsMaintenance = unit.requiresMaintenance();
                 if (!needsMaintenance) {
-                    yield '-';
+                    yield "-"; // Do not convert this into a character, it will break sorting
                 }
 
                 double daysSinceLastMaintenance = unit.getDaysSinceMaintenance();


### PR DESCRIPTION
Fix #6996

The use of individual characters for mothballed units was breaking sorting. Now it isn't. I also added in natural language sorting so that it would sort more cleanly.