### PR TITLE
Fix: #6997 Fixed Perform Immediate Maintenance Not Immediately Performing Maintenance Defeating the Purpose of Having a 'Perform Immediate Maintenance' Option

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/UnitTableMouseAdapter.java
@@ -623,7 +623,11 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                 int maintenanceTime = unit.getMaintenanceTime();
 
                 if ((time - maintenanceTime) >= 0) {
-                    campaign.doMaintenance(unit);
+                    // This will increase the number of days until maintenance and then perform the maintenance. We
+                    // do it this way to ensure that everything is processed cleanly.
+                    while (unit.getDaysSinceMaintenance() != 0) {
+                        campaign.doMaintenance(unit);
+                    }
                 } else {
                     campaign.addReport(String.format(resources.getString("maintenanceAdHoc.unable"),
                           tech.getHyperlinkedFullTitle(),
@@ -947,6 +951,9 @@ public class UnitTableMouseAdapter extends JPopupMenuAdapter {
                 menuItem.setActionCommand(COMMAND_PERFORM_AD_HOC_MAINTENANCE);
                 menuItem.addActionListener(this);
                 menuItem.setEnabled(gui.getCampaign().getCampaignOptions().isCheckMaintenance());
+                if (oneSelected && menuItem.isEnabled()) {
+                    menuItem.setEnabled(unit.getDaysSinceMaintenance() != 0);
+                }
 
                 popup.add(menuItem);
             }


### PR DESCRIPTION
Fix #6997

It turns out the 'performMaintenance' option doesn't actually perform maintenance, it increases the amount of time until maintenance is due. However, as this changes the amount of time until next maintenance is due I mistakenly thought it was working. It was not. Now it is.