### PR TITLE
Fix: #7007 Fixed Cancel Deployment Producing Scenario with 0 BV Budget

### DIFF
--- a/MekHQ/src/mekhq/gui/StratconPanel.java
+++ b/MekHQ/src/mekhq/gui/StratconPanel.java
@@ -1098,8 +1098,12 @@ public class StratconPanel extends JPanel implements ActionListener {
                     scenarioWizard.toFront();
                     scenarioWizard.setVisible(true);
                 }
-                if (selectedScenario != null && !isCommitForces()) {
+                if (selectedScenario != null && scenarioWizard.isWasCanceled()) {
+                    logger.info("Scenario wizard was cancelled. Resetting scenario to default state.");
                     selectedScenario.resetScenario(campaign);
+
+                    // We currently retain the wizard in memory, so need to make sure we reset the canceled state
+                    scenarioWizard.setWasCanceled(false);
                 }
 
                 setCommitForces(false);

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.stratcon;
 
@@ -108,6 +113,8 @@ public class StratconScenarioWizard extends JDialog {
 
     private JComboBox<String> cboTransportType = new JComboBox<>();
 
+    private boolean wasCanceled;
+
     private JPanel contentPanel;
     private JButton btnCommit;
     private JButton btnCancel;
@@ -154,6 +161,14 @@ public class StratconScenarioWizard extends JDialog {
         availableLeadershipUnits.clearSelection();
 
         setUI(isPrimaryForce);
+    }
+
+    public boolean isWasCanceled() {
+        return wasCanceled;
+    }
+
+    public void setWasCanceled(boolean wasCancelled) {
+        this.wasCanceled = wasCancelled;
     }
 
     /**
@@ -697,7 +712,10 @@ public class StratconScenarioWizard extends JDialog {
 
         btnCancel = new JButton(MHQInternationalization.getTextAt(resourcePath, "leadershipCancel.text"));
         btnCancel.setActionCommand("CANCEL_CLICK");
-        btnCancel.addActionListener(evt -> closeWizard());
+        btnCancel.addActionListener(evt -> {
+            wasCanceled = true;
+            closeWizard();
+        });
         btnCancel.setEnabled(true);
 
         // Configure layout constraints for the buttons


### PR DESCRIPTION
Fix #7007

When a player deploys to a hidden scenario we generate the scenario, including the BV budget of forces assigned to that scenario. However, if the player cancels deployment - at that moment - the budget was getting set to 0 because we were not correctly resetting the scenario. This was due to the conditional that checked for the deployment being canceled was not functioning fully. However, as the force didn't get deployed it gave the impression that it _was_ fully functional.

We fixed this by added a new variable to the deployment wizard that explicitly states whether the deployment was canceled. If that event comes to pass the scenario is reset fully. However, the originally generated force is not, preventing the 0 BV bug.

### Design Notes
The cancel deployment bug is a hacky solution to a UX problem and one we should really rethink. However, such a task isn't on my schedule so would need to be picked up by another developer. Basically the problem we have to solve is that players sometimes want to backtrack out of deployment. However, if the player force is 'ambushed' (i.e. the scenario is populated at point of deployment) the player should - at that point - be barred from canceling the deployment as their force has been ambushed.