### PR TITLE
Fix: Prevented Unscrupulous from Performing Extreme Expenditure on Prisoners to Rob Them of Their Wealth Trait

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1072,6 +1072,14 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_SPENDING_SPREE: {
                 for (Person person : people) {
+                    if (!person.getPrisonerStatus().isFreeOrBondsman()) {
+                        continue;
+                    }
+
+                    if (!person.getStatus().isActive()) {
+                        continue;
+                    }
+
                     if (person.getWealth() > MINIMUM_WEALTH) {
                         if (person.isHasPerformedExtremeExpenditure()) {
                             String report = getExpenditureExhaustedReportMessage(person.getHyperlinkedFullTitle());
@@ -3769,9 +3777,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             int spending = getExpenditure(willpower, wealth);
             String spendingString = Money.of(spending).toAmountString();
             menuItem = new JMenuItem(String.format(resources.getString("wealth.extreme.single"), spendingString));
-            menuItem.setEnabled(!person.isHasPerformedExtremeExpenditure());
+            menuItem.setEnabled(!person.isHasPerformedExtremeExpenditure() &&
+                                      person.getStatus().isActive() &&
+                                      person.getPrisonerStatus().isFreeOrBondsman());
         } else {
             menuItem = new JMenuItem(resources.getString("wealth.extreme.multiple"));
+            menuItem.setEnabled(StaticChecks.areAnyActive(selected) && StaticChecks.areAnyFreeOrBondsman(selected));
         }
         menuItem.setActionCommand(CMD_SPENDING_SPREE);
         menuItem.addActionListener(this);

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -24,15 +24,15 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.utilities;
 
-import megamek.common.UnitType;
-import mekhq.campaign.Campaign;
-import mekhq.campaign.force.Force;
-import mekhq.campaign.personnel.Person;
-import mekhq.campaign.personnel.enums.Profession;
-import mekhq.campaign.unit.Unit;
+import static mekhq.campaign.force.ForceType.STANDARD;
 
 import java.util.Arrays;
 import java.util.List;
@@ -41,7 +41,12 @@ import java.util.StringJoiner;
 import java.util.Vector;
 import java.util.stream.Stream;
 
-import static mekhq.campaign.force.ForceType.STANDARD;
+import megamek.common.UnitType;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.force.Force;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.Profession;
+import mekhq.campaign.unit.Unit;
 
 public class StaticChecks {
 
@@ -318,6 +323,10 @@ public class StaticChecks {
         return Arrays.stream(people).allMatch(p -> p.getStatus().isActive());
     }
 
+    public static boolean areAnyActive(Person... people) {
+        return Stream.of(people).anyMatch(p -> p.getStatus().isActive());
+    }
+
     public static boolean areAllStudents(Person... people) {
         return Arrays.stream(people).allMatch(p -> p.getStatus().isStudent());
     }
@@ -348,6 +357,10 @@ public class StaticChecks {
 
     public static boolean areAnyFree(Person... people) {
         return Stream.of(people).anyMatch(p -> p.getPrisonerStatus().isFree());
+    }
+
+    public static boolean areAnyFreeOrBondsman(Person... people) {
+        return Stream.of(people).anyMatch(p -> p.getPrisonerStatus().isFreeOrBondsman());
     }
 
     public static boolean areAllPrisoners(Person... people) {


### PR DESCRIPTION
Added checks to ensure characters are both Active and Free (or Bondsman) before Extreme Expenditure can be used on them.