### PR TITLE
Fix: Fixed Age Modifiers Applying Incorrectly for Ages 31-40; Added Unit Tests for Age Modifiers

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/Aging.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Aging.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.personnel.skills;
 
@@ -56,7 +61,7 @@ public class Aging {
      * This is because modifying the experience a character has spent on {@code x} skill would get complicated quickly,
      * so we use this workaround.</p>
      */
-    private static final int AGING_SKILL_MODIFIER_DIVIDER = 100;
+    public static final int AGING_SKILL_MODIFIER_DIVIDER = 100;
 
     /**
      * Updates the aging modifiers for all skills of a given {@link Person} based on their current age and attributes.

--- a/MekHQ/src/mekhq/campaign/personnel/skills/enums/AgingMilestone.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/enums/AgingMilestone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.personnel.skills.enums;
 
@@ -35,7 +40,7 @@ import megamek.logging.MMLogger;
 public enum AgingMilestone {
     NONE(0, 25, 0, 0, 0, 0, 0, 0, 0, 0, false, false),
     TWENTY_FIVE(25, 31, 50, 50, 0, 50, 50, 50, 50, 0, false, false),
-    THIRTY_ONE(31, 14, 50, 50, 0, 50, 50, 50, 0, 1, false, false),
+    THIRTY_ONE(31, 41, 50, 50, 0, 50, 50, 50, 0, 1, false, false),
     FORTY_ONE(41, 51, 0, 0, -50, 0, 0, 0, 0, 1, false, false),
     FIFTY_ONE(51, 61, 0, -100, 0, -100, 0, 0, -50, 2, false, false),
     SIXTY_ONE(61, 71, -100, -100, -100, 0, 50, 0, -50, 2, true, false),
@@ -65,7 +70,6 @@ public enum AgingMilestone {
     private final int reputation;
     private final boolean slowLearner;
     private final boolean glassJaw;
-
     // Cumulative values
     private int cumulativeStrength;
     private int cumulativeBody;
@@ -121,6 +125,32 @@ public enum AgingMilestone {
         this.glassJaw = glassJaw;
     }
 
+    /**
+     * Retrieves the value of the specified skill attribute for this object.
+     *
+     * <p><b>Usage:</b> this exists to assit testing and should not be directly called. Use
+     * {@link #getAttributeModifier(SkillAttribute)} instead.</p>
+     *
+     * @param attribute the {@link SkillAttribute} to retrieve; must not be {@code null}
+     *
+     * @return the integer value of the specified attribute, or {@code NO_SKILL_ATTRIBUTE} if
+     *       {@code SkillAttribute.NONE} is provided
+     *
+     * @author Illiani
+     * @since 0.50.06
+     */
+    public int getAttribute(SkillAttribute attribute) {
+        return switch (attribute) {
+            case NONE -> NO_SKILL_ATTRIBUTE;
+            case STRENGTH -> strength;
+            case BODY -> body;
+            case DEXTERITY -> dexterity;
+            case REFLEXES -> reflexes;
+            case INTELLIGENCE -> intelligence;
+            case WILLPOWER -> willpower;
+            case CHARISMA -> charisma;
+        };
+    }
 
     // Getters
     public int getMilestone() {

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/enums/AgingMilestoneTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/enums/AgingMilestoneTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.skills.enums;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.Aging;
+import mekhq.campaign.universe.Factions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class AgingMilestoneTest {
+    private static LocalDate today = LocalDate.of(3150, 1, 1);
+    private static Campaign mockCampaign;
+
+    @BeforeAll
+    static void beforeAll() {
+        mockCampaign = mock(Campaign.class);
+        when(mockCampaign.getFaction()).thenReturn(Factions.getInstance().getDefaultFaction());
+    }
+
+    record milestoneRecord(int age, AgingMilestone expected) {
+    }
+
+    static Stream<milestoneRecord> milestoneProvider() {
+        return Stream.of(new milestoneRecord(24, AgingMilestone.NONE),
+              new milestoneRecord(25, AgingMilestone.TWENTY_FIVE),
+              new milestoneRecord(30, AgingMilestone.TWENTY_FIVE),
+              new milestoneRecord(31, AgingMilestone.THIRTY_ONE),
+              new milestoneRecord(40, AgingMilestone.THIRTY_ONE),
+              new milestoneRecord(41, AgingMilestone.FORTY_ONE),
+              new milestoneRecord(50, AgingMilestone.FORTY_ONE),
+              new milestoneRecord(51, AgingMilestone.FIFTY_ONE),
+              new milestoneRecord(60, AgingMilestone.FIFTY_ONE),
+              new milestoneRecord(61, AgingMilestone.SIXTY_ONE),
+              new milestoneRecord(70, AgingMilestone.SIXTY_ONE),
+              new milestoneRecord(71, AgingMilestone.SEVENTY_ONE),
+              new milestoneRecord(80, AgingMilestone.SEVENTY_ONE),
+              new milestoneRecord(81, AgingMilestone.EIGHTY_ONE),
+              new milestoneRecord(90, AgingMilestone.EIGHTY_ONE),
+              new milestoneRecord(91, AgingMilestone.NINETY_ONE),
+              new milestoneRecord(100, AgingMilestone.NINETY_ONE),
+              new milestoneRecord(101, AgingMilestone.ONE_HUNDRED_ONE),
+              new milestoneRecord(101, AgingMilestone.ONE_HUNDRED_ONE));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "milestoneProvider")
+    void testGetMilestone(milestoneRecord testCase) {
+        // Setup
+        Person person = new Person(mockCampaign);
+        person.setDateOfBirth(today.minusYears(testCase.age));
+        int age = person.getAge(today);
+
+        // Act
+        AgingMilestone actual = Aging.getMilestone(age);
+
+        // Assert
+        assertEquals(testCase.expected, actual, "Invalid milestone for age: " + age);
+    }
+
+    @Test
+    void testGetAgeModifier_strength() {
+        SkillAttribute attribute = SkillAttribute.STRENGTH;
+
+        for (int i = 0; i < 110; i++) {
+            // Setup
+            Person person = new Person(mockCampaign);
+            person.setDateOfBirth(today.minusYears(i));
+            int age = person.getAge(today);
+
+            AgingMilestone milestone = Aging.getMilestone(age);
+
+            // Act
+            int actual = Aging.getAgeModifier(milestone, attribute, SkillAttribute.NONE);
+
+            int expected = 0;
+            for (AgingMilestone validMilestone : AgingMilestone.values()) {
+                if (validMilestone.getMilestone() <= age) {
+                    expected += validMilestone.getAttribute(attribute);
+                }
+            }
+
+            expected = (int) Math.round((double) expected / Aging.AGING_SKILL_MODIFIER_DIVIDER);
+
+            // Assert
+            assertEquals(expected,
+                  actual,
+                  "Invalid age modifier for milestone: " + milestone.name() + " for " + attribute);
+        }
+    }
+
+    static Stream<Arguments> ageAndAttributeProvider() {
+        // Test all ages 0-109 for each desired attribute
+        return Stream.of(SkillAttribute.STRENGTH,
+                    SkillAttribute.BODY,
+                    SkillAttribute.DEXTERITY,
+                    SkillAttribute.REFLEXES,
+                    SkillAttribute.INTELLIGENCE,
+                    SkillAttribute.WILLPOWER,
+                    SkillAttribute.CHARISMA)
+                     .flatMap(attribute -> Stream.iterate(0, i -> i + 1)
+                                                 .limit(110)
+                                                 .map(age -> Arguments.of(age, attribute)));
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "ageAndAttributeProvider")
+    void testGetAgeModifier_allAttributes(int age, SkillAttribute attribute) {
+        Person person = new Person(mockCampaign);
+        person.setDateOfBirth(today.minusYears(age));
+        int personAge = person.getAge(today);
+
+        AgingMilestone milestone = Aging.getMilestone(personAge);
+
+        int actual = Aging.getAgeModifier(milestone, attribute, SkillAttribute.NONE);
+
+        int expected = 0;
+        for (AgingMilestone validMilestone : AgingMilestone.values()) {
+            if (validMilestone.getMilestone() <= personAge) {
+                expected += validMilestone.getAttribute(attribute);
+            }
+        }
+        expected = (int) Math.round((double) expected / Aging.AGING_SKILL_MODIFIER_DIVIDER);
+
+        assertEquals(expected,
+              actual,
+              "Invalid age modifier for milestone: " +
+                    milestone.name() +
+                    " for attribute: " +
+                    attribute.name() +
+                    " and age: " +
+                    age);
+    }
+}


### PR DESCRIPTION
The age modifiers for the 31-40 bracket were incorrectly only applying to some magical person that manages to be both >= 31+ and < 14. Instead of >= 31 and < 41.

Also, we previously didn't have any unit tests for this mechanic. Why I didn't test this I'll never know, but now I have. As I should have done when this was first developed. -_-