### PR TITLE
Fix: Fixed Skill Modifiers Not Being Factored into Profession Experience Level

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3924,7 +3924,7 @@ public class Person {
                 return SkillType.EXP_NONE;
             }
 
-            int individualSkillLevel = skill.getLevel();
+            int individualSkillLevel = skill.getTotalSkillLevel();
             totalSkillLevel += individualSkillLevel;
 
             if (isAlternativeQualityAveraging) {


### PR DESCRIPTION
Experience level calculations for professions (green, regular, etc) were not correctly factoring in modifiers to that skill. This would have been something fixed by the 50.07 change to attribute scores, but might as well be corrected now as it's more obvious following my update to experience level calculations.