### PR TITLE
Fix: #7012 Properly update capacities when changing Transporters via refit

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1656,6 +1656,20 @@ public class Campaign implements ITechManager {
 
     /**
      * This will update the transport in the transports list with current capacities. When a unit is added or removed
+     * from a transport, that information needs updated in the campaign transport map. This method will update the
+     * map for every {@code CampaignTransportType} for the given transport.
+     *
+     * @see Campaign#updateTransportInTransports(CampaignTransportType, Unit)
+     * @param transport             Unit
+     */
+    public void updateTransportInTransports(Unit transport) {
+        for (CampaignTransportType campaignTransportType : CampaignTransportType.values()) {
+            updateTransportInTransports (campaignTransportType, transport);
+        }
+    }
+
+    /**
+     * This will update the transport in the transports list with current capacities. When a unit is added or removed
      * from a transport, that information needs updated in the campaign transport map. This method takes the
      * CampaignTransportType and transport as inputs and updates the map with the current capacities of the transport.
      *

--- a/MekHQ/src/mekhq/campaign/parts/Refit.java
+++ b/MekHQ/src/mekhq/campaign/parts/Refit.java
@@ -1554,8 +1554,6 @@ public class Refit extends Part implements IAcquisitionWork {
         // don't forget to switch entities!
         // ----------------- from here on oldUnit refers to the new entity -------------------------
         oldUnit.setEntity(newEntity);
-        // Bay capacities might have changed - reset them
-        oldUnit.initializeAllTransportSpace();
 
         // set up new parts
         ArrayList<Part> newParts = new ArrayList<>();
@@ -1696,6 +1694,11 @@ public class Refit extends Part implements IAcquisitionWork {
         getCampaign().clearGameData(oldUnit.getEntity());
         getCampaign().reloadGameEntities();
         C3Util.copyC3Networks(oldEntity, oldUnit.getEntity());
+
+        // Bay capacities might have changed - reset them
+        oldUnit.clearAllTransportSpace();
+        oldUnit.initializeAllTransportSpace();
+        campaign.updateTransportInTransports(oldUnit);
 
         // reload any soldiers
         for (Person soldier : soldiers) {

--- a/MekHQ/src/mekhq/campaign/unit/AbstractTransportedUnitsSummary.java
+++ b/MekHQ/src/mekhq/campaign/unit/AbstractTransportedUnitsSummary.java
@@ -161,7 +161,7 @@ public abstract class AbstractTransportedUnitsSummary implements ITransportedUni
      * @return The current capacity of the transporter, or 0
      */
     @Override
-    public double getCurrentTransportCapacity(TransporterType transporterType) {
+    public double getCurrentTransportCapacity(@Nullable TransporterType transporterType) {
         return transportCapacity.getOrDefault(transporterType, 0.0);
     }
 
@@ -226,6 +226,14 @@ public abstract class AbstractTransportedUnitsSummary implements ITransportedUni
         }
 
         clearTransportedEntities();
+    }
+
+    /**
+     * Completely clears the capacity map. Helpful if the transportCapacity has a TransporterType for a Transporter
+     * the unit no longer has - such as after a refit.
+     */
+    public void clearTransportCapacityMap() {
+        transportCapacity = new HashMap<>();
     }
 
     protected Set<Entity> clearTransportedEntities() {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -384,6 +384,19 @@ public class Unit implements ITechnology {
         }
     }
 
+    public void clearAllTransportSpace() {
+        for (CampaignTransportType campaignTransportType : CampaignTransportType.values()) {
+            clearTransportSpace(campaignTransportType);
+        }
+    }
+
+    private void clearTransportSpace(CampaignTransportType campaignTransportType) {
+        AbstractTransportedUnitsSummary summary = getTransportedUnitsSummary(campaignTransportType);
+        if (summary != null) {
+            summary.clearTransportCapacityMap();
+        }
+    }
+
     private ShipTransportedUnitsSummary getShipTransportedUnitsSummary() {
         return (ShipTransportedUnitsSummary) getTransportedUnitsSummary(SHIP_TRANSPORT);
     }
@@ -445,7 +458,7 @@ public class Unit implements ITechnology {
      *
      * @return transported units summary of that type, or null
      */
-    public AbstractTransportedUnitsSummary getTransportedUnitsSummary(CampaignTransportType campaignTransportType) {
+    public @Nullable AbstractTransportedUnitsSummary getTransportedUnitsSummary(CampaignTransportType campaignTransportType) {
         for (AbstractTransportedUnitsSummary transportedUnitSummary : transportedUnitsSummaries) {
             if (transportedUnitSummary.getClass() == campaignTransportType.getTransportedUnitsSummaryType()) {
                 return transportedUnitSummary;

--- a/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
+++ b/MekHQ/src/mekhq/campaign/unit/actions/RestoreUnitAction.java
@@ -121,6 +121,7 @@ public class RestoreUnitAction implements IUnitAction {
         unit.removeParts();
 
         unit.initializeAllTransportSpace();
+        campaign.updateTransportInTransports(unit);
 
         unit.initializeParts(true);
         unit.runDiagnostic(false);

--- a/MekHQ/src/mekhq/gui/menus/AssignForceToShipTransportMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignForceToShipTransportMenu.java
@@ -31,10 +31,8 @@ package mekhq.gui.menus;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.campaign.utilities.CampaignTransportUtilities;
 import mekhq.utilities.MHQInternationalization;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.enums.CampaignTransportType;
-import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.unit.Unit;
 
 import javax.swing.*;
@@ -106,15 +104,7 @@ public class AssignForceToShipTransportMenu extends AssignForceToTransportMenu {
 
         }
         Set<Unit> oldTransports = transport.loadShipTransport(transporterType, units);
-        if (!oldTransports.isEmpty()) {
-            oldTransports.forEach(oldTransport -> campaign.updateTransportInTransports(campaignTransportType, oldTransport));
-            oldTransports.forEach(oldTransport -> MekHQ.triggerEvent(new UnitChangedEvent(transport)));
-        }
-        for (Unit unit : units) {
-            MekHQ.triggerEvent(new UnitChangedEvent(unit));
-        }
-        campaign.updateTransportInTransports(campaignTransportType, transport);
-        MekHQ.triggerEvent(new UnitChangedEvent(transport));
+        updateTransportsForTransportMenuAction(SHIP_TRANSPORT, transport, units, oldTransports);
     }
 
 }

--- a/MekHQ/src/mekhq/gui/menus/AssignForceToTacticalTransportMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignForceToTacticalTransportMenu.java
@@ -31,10 +31,8 @@ package mekhq.gui.menus;
 import mekhq.campaign.unit.enums.TransporterType;
 import mekhq.campaign.utilities.CampaignTransportUtilities;
 import mekhq.utilities.MHQInternationalization;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.enums.CampaignTransportType;
-import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.unit.Unit;
 
 import javax.swing.*;
@@ -106,14 +104,6 @@ public class AssignForceToTacticalTransportMenu extends AssignForceToTransportMe
 
         }
         Set<Unit> oldTransports = transport.loadTacticalTransport(transporterType, units);
-        if (!oldTransports.isEmpty()) {
-            oldTransports.forEach(oldTransport -> campaign.updateTransportInTransports(TACTICAL_TRANSPORT, oldTransport));
-            oldTransports.forEach(oldTransport -> MekHQ.triggerEvent(new UnitChangedEvent(transport)));
-        }
-        for (Unit unit : units) {
-            MekHQ.triggerEvent(new UnitChangedEvent(unit));
-        }
-        campaign.updateTransportInTransports(TACTICAL_TRANSPORT, transport);
-        MekHQ.triggerEvent(new UnitChangedEvent(transport));
+        updateTransportsForTransportMenuAction(TACTICAL_TRANSPORT, transport, units, oldTransports);
     }
 }

--- a/MekHQ/src/mekhq/gui/menus/AssignForceToTransportMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignForceToTransportMenu.java
@@ -28,8 +28,10 @@
 
 package mekhq.gui.menus;
 
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.enums.CampaignTransportType;
+import mekhq.campaign.event.UnitChangedEvent;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.unit.enums.TransporterType;
@@ -171,4 +173,25 @@ public abstract class AssignForceToTransportMenu extends JScrollableMenu {
      */
     protected abstract void transportMenuAction(ActionEvent evt, TransporterType transporterType, Unit transport, Set<Unit> units);
 
+    /**
+     * Shared updates used by {@link AssignForceToShipTransportMenu} and {@link AssignForceToTacticalTransportMenu}
+     * @param transport transport (Unit) that has loaded these units
+     * @param units units being assigned to the transport
+     * @param oldTransports transports (Unit) that had previously transported the units
+     */
+    protected void updateTransportsForTransportMenuAction(CampaignTransportType campaignTransportType, Unit transport,
+          Set<Unit> units, Set<Unit> oldTransports) {
+        if (!oldTransports.isEmpty()) {
+            oldTransports.forEach(oldTransport -> {
+                oldTransport.initializeAllTransportSpace();
+                campaign.updateTransportInTransports(campaignTransportType, oldTransport);
+            });
+            oldTransports.forEach(oldTransport -> MekHQ.triggerEvent(new UnitChangedEvent(transport)));
+        }
+        for (Unit unit : units) {
+            MekHQ.triggerEvent(new UnitChangedEvent(unit));
+        }
+        campaign.updateTransportInTransports(campaignTransportType, transport);
+        MekHQ.triggerEvent(new UnitChangedEvent(transport));
+    }
 }


### PR DESCRIPTION
Fixes #7012 

After a refit it was improperly updating the transport capacity. It was also not removing `TransporterType`s that the unit no longer had. I added some nullable tags as well.