### PR TITLE
Improvement: Princess No Longer Gets Crazy Buffed Tactics

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -2889,11 +2889,6 @@ public class AtBDynamicScenarioFactory {
             };
         }
 
-        // Are they a formation leader? If so, increase their 'tactics' by 2
-        if (randomInt(getStandardForceSize(faction)) == 0) {
-            skillLevel = Math.min(skillLevel + 2, 10);
-        }
-
         if (randomSkillPreferences.randomizeSkill()) {
             int randomnessRoll = d6();
 


### PR DESCRIPTION
As part of the 50.05 change to Tactics we started giving Princess Tactics. If a unit was nominated as the OpFor leader they received a +2 modifier. However, this creates a really poor play experience as observed in a recent player stream. This PR walks back that bonus.