### PR TITLE
Fix: #7025 Fixed Mass Repair Dialog Throwing Exception When Run From Warehouse

### DIFF
--- a/MekHQ/src/mekhq/service/mrms/MRMSService.java
+++ b/MekHQ/src/mekhq/service/mrms/MRMSService.java
@@ -1228,8 +1228,8 @@ public class MRMSService {
         @Override
         public int compare(Person tech1, Person tech2) {
             // Sort the valid techs by applicable skill. Let's start with the least experienced and work our way up
-            // until we find someone who can perform the work. If we have two techs with the same skill, put the one
-            // with the lesser XP in the front. If we have tech with the same XP, put the one with the more time ahead.
+            // until we find someone who can perform the work. If we have two techs with the same XP, put the one with
+            // the more time ahead.
             Skill skill1 = tech1.getSkillForWorkingOn(partWork);
             Skill skill2 = tech2.getSkillForWorkingOn(partWork);
 
@@ -1249,22 +1249,6 @@ public class MRMSService {
                 return experienceCompare;
             }
 
-            // At this point, the same experience level
-            int xp1 = tech1.getXP();
-            int xp2 = tech2.getXP();
-
-            // Only treat ELITE as a special case, otherwise compare XP
-            if (skill1.getLevel() == SkillType.EXP_ELITE && skill2.getLevel() == SkillType.EXP_ELITE) {
-                // Both ELITE, compare by minutes left
-                return Integer.compare(tech1.getMinutesLeft(), tech2.getMinutesLeft());
-            }
-
-            int xpCompare = Integer.compare(xp1, xp2);
-            if (xpCompare != 0) {
-                return xpCompare;
-            }
-
-            // Finally, compare by minutes left
             return Integer.compare(tech1.getMinutesLeft(), tech2.getMinutesLeft());
         }
     }

--- a/MekHQ/src/mekhq/service/mrms/MRMSService.java
+++ b/MekHQ/src/mekhq/service/mrms/MRMSService.java
@@ -1244,7 +1244,7 @@ public class MRMSService {
                 return -1;
             }
 
-            int experienceCompare = Integer.compare(skill1.getExperienceLevel(), skill2.getExperienceLevel());
+            int experienceCompare = Integer.compare(skill1.getTotalSkillLevel(), skill2.getTotalSkillLevel());
             if (experienceCompare != 0) {
                 return experienceCompare;
             }

--- a/MekHQ/src/mekhq/service/mrms/MRMSService.java
+++ b/MekHQ/src/mekhq/service/mrms/MRMSService.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.service.mrms;
 
@@ -1222,25 +1227,45 @@ public class MRMSService {
 
         @Override
         public int compare(Person tech1, Person tech2) {
-            // Sort the valid techs by applicable skill. Let's start with the least
-            // experienced and
-            // work our way up until we find someone who can perform the work. If we have
-            // two techs
-            // with the same skill, put the one with the lesser XP in the front. If we have
-            // tech
-            // with the same XP, put the one with the more time ahead.
+            // Sort the valid techs by applicable skill. Let's start with the least experienced and work our way up
+            // until we find someone who can perform the work. If we have two techs with the same skill, put the one
+            // with the lesser XP in the front. If we have tech with the same XP, put the one with the more time ahead.
             Skill skill1 = tech1.getSkillForWorkingOn(partWork);
             Skill skill2 = tech2.getSkillForWorkingOn(partWork);
 
-            if (skill1.getExperienceLevel() == skill2.getExperienceLevel()) {
-                if ((tech1.getXP() == tech2.getXP()) || (skill1.getLevel() == SkillType.EXP_ELITE)) {
-                    return tech1.getMinutesLeft() - tech2.getMinutesLeft();
-                } else {
-                    return (tech1.getXP() < tech2.getXP()) ? -1 : 1;
-                }
+            // Nulls at the end
+            if (skill1 == null && skill2 == null) {
+                return 0;
+            }
+            if (skill1 == null) {
+                return 1;
+            }
+            if (skill2 == null) {
+                return -1;
             }
 
-            return skill1.getExperienceLevel() < skill2.getExperienceLevel() ? -1 : 1;
+            int experienceCompare = Integer.compare(skill1.getExperienceLevel(), skill2.getExperienceLevel());
+            if (experienceCompare != 0) {
+                return experienceCompare;
+            }
+
+            // At this point, the same experience level
+            int xp1 = tech1.getXP();
+            int xp2 = tech2.getXP();
+
+            // Only treat ELITE as a special case, otherwise compare XP
+            if (skill1.getLevel() == SkillType.EXP_ELITE && skill2.getLevel() == SkillType.EXP_ELITE) {
+                // Both ELITE, compare by minutes left
+                return Integer.compare(tech1.getMinutesLeft(), tech2.getMinutesLeft());
+            }
+
+            int xpCompare = Integer.compare(xp1, xp2);
+            if (xpCompare != 0) {
+                return xpCompare;
+            }
+
+            // Finally, compare by minutes left
+            return Integer.compare(tech1.getMinutesLeft(), tech2.getMinutesLeft());
         }
     }
 

--- a/MekHQ/src/mekhq/service/mrms/MRMSService.java
+++ b/MekHQ/src/mekhq/service/mrms/MRMSService.java
@@ -1235,7 +1235,7 @@ public class MRMSService {
 
             // Nulls at the end
             if (skill1 == null && skill2 == null) {
-                return 0;
+                return Integer.compare(tech1.getMinutesLeft(), tech2.getMinutesLeft());
             }
             if (skill1 == null) {
                 return 1;


### PR DESCRIPTION
Fix #7025

We were running into comparison errors when comparing techs because we were using mixed comparison methods. Comparing both by experience level, and then if experience levels were equal by XP OR skill level (if Elite). Then finally available time.

This creates several issues:
- This assumes that a character with greater XP is more skilled than a character with less. However this fails to account for characters with dual professions.
- We were not checking whether a character was Elite, but if they had level 4 in the appropriate skill. However level 4 in a skill does not necessarily mean a character is Elite (depending on campaign options).
- The 'Elite' comparison also doesn't account for anything that might be influencing that skill (modifying the skill level, such as SPAs). 
- Finally the Elite comparison also doesn't consider how to handle a character that has higher than level 4 in the skill (at that point it reverts back to XP, rendering this special handler somewhat redundant).

To mitigate this issue I've changed up the comparison. We now only compare final skill levels followed by available minutes in the event that final skill levels are equal. I also added in better null handling, in the event we feed a null skill into the comparison (this can happen if the unit attached to the part doesn't have a tech skill).

The way the final skill level comparison works it is compares total skill level (factoring in all modifiers). This means that if we're comparing two techs we're sorting based on who has the highest skill. _Not_ who has the highest experience level (green, regular, etc). This better handles irregular experience levels. Such as if the player modified their campaign options so that MekTechs hit Elite at a different time to AeroTeks, for example.

### Suspected Cause
That MRMS is randomly breaking like this is concerning, but I suspect it's likely due to MRMS finally getting some attention after years of neglect. This is being compounded by two factors: with the mass adoption of ATOW skills level 4 is no longer 'Elite', it's 'Veteran'; there are now significantly more skill modifiers than when MRMS was developed.

### Tests
- Tested the warehouse repair multiple times
- Tested unit repair multiple times