### PR TITLE
Fix: #7026 Fixed 'XP' Appearing Twice in Academy Tooltips

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -800,7 +800,7 @@ public class Academy implements Comparable<Academy> {
                     tooltip.append(skill).append("<br>");
                     continue;
                 } else if (skill.equalsIgnoreCase("xp")) {
-                    tooltip.append(skill).append("XP (");
+                    tooltip.append(skill).append(" (");
                 } else {
                     skillParsed = skillParser(skill);
                     tooltip.append(skillParsed).append(" (");


### PR DESCRIPTION
Fix #7026

We were accidentally including an explicit 'XP' append as well as an implicit. Now we're just using the implicit.
