### PR TITLE
Fix: (Sentry) Fixed Exception When Processing Education Tagalongs if Tagalong Has Exited the Campaign

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1344,7 +1344,10 @@ public class Person {
 
         for (UUID tagAlongId : eduTagAlongs) {
             Person tagAlong = campaign.getPerson(tagAlongId);
-            tagAlong.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ACTIVE);
+
+            if (tagAlong != null) {
+                tagAlong.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ACTIVE);
+            }
         }
         this.setEduTagAlongs(new ArrayList<>());
 


### PR DESCRIPTION
Fix [Sentry Report](https://sentry.tapenvy.us/organizations/tapenvyus/issues/4912/events/073f9cb31b5f4bd384d6fb3a83f739f9/)

If the player deleted one of a character's education tagalongs they'd be hit with an exception when we attempted to update the status of a tagalong when setting the character to a non-Student status.