### PR TITLE
Fix: Fixed Commander's Day Suppression

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4887,7 +4887,9 @@ public class Campaign implements ITechManager {
         // Process personnel
         int peopleWhoCelebrateCommandersDay = 0;
         int commanderDayTargetNumber = 5;
-        boolean isCommandersDay = isCommandersDay(currentDay) && getFlaggedCommander() != null;
+        boolean isCommandersDay = isCommandersDay(currentDay) &&
+                                        getFlaggedCommander() != null &&
+                                        campaignOptions.isShowLifeEventDialogCelebrations();
         for (Person person : personnel) {
             if (person.getStatus().isDepartedUnit()) {
                 continue;


### PR DESCRIPTION
We weren't checking whether celebration announcements were enabled when triggering Commander's Day.