### PR TITLE
Fix: Stopped Random Death Not Randomly Causing People to Die

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -749,6 +749,10 @@ public class Campaign implements ITechManager {
     // endregion Markets
 
     // region Personnel Modules
+    public void resetRandomDeath() {
+        this.randomDeath = new RandomDeath(this);
+    }
+
     public AbstractDivorce getDivorce() {
         return divorce;
     }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -670,6 +670,9 @@ public class CampaignXmlParser {
             }
         });
 
+        // Reset Random Death to match current campaign options
+        campaign.resetRandomDeath();
+
         logger.info("Load of campaign file complete!");
 
         return campaign;

--- a/MekHQ/src/mekhq/campaign/personnel/death/RandomDeath.java
+++ b/MekHQ/src/mekhq/campaign/personnel/death/RandomDeath.java
@@ -24,12 +24,31 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.personnel.death;
 
+import static mekhq.campaign.personnel.enums.TenYearAgeRange.determineAgeRange;
+import static mekhq.campaign.universe.enums.EraFlag.*;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
 import megamek.Version;
 import megamek.common.Compute;
-import megamek.common.EquipmentType;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.util.weightedMaps.WeightedDoubleMap;
@@ -53,17 +72,6 @@ import mekhq.utilities.ReportingUtilities;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.time.LocalDate;
-import java.util.*;
-
-import static mekhq.campaign.personnel.enums.TenYearAgeRange.determineAgeRange;
-import static mekhq.campaign.universe.enums.EraFlag.*;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
-import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 
 /**
  * Handles logic for simulating random deaths in a campaign.
@@ -91,7 +99,7 @@ public class RandomDeath {
     private final Map<AgeGroup, Boolean> enabledAgeGroups;
     private final boolean enableRandomDeathSuicideCause;
     private Map<Gender, Map<TenYearAgeRange, WeightedDoubleMap<PersonnelStatus>>> causes;
-    private final double randomDeathMultiplier;
+    private double randomDeathMultiplier;
 
     // Base Chances
     private final List<RandomDeathChance> deathChances = List.of(
@@ -363,7 +371,9 @@ public class RandomDeath {
             return false;
         }
 
-        return randomInt(DIE_SIZE) < actualDeathChance;
+        int roll = randomInt(DIE_SIZE);
+
+        return roll < actualDeathChance;
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -503,6 +503,8 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             options.updateGameOptionsFromCampaignOptions(campaign.getGameOptions());
             MekHQ.triggerEvent(new OptionsChangedEvent(campaign));
         }
+
+        campaign.resetRandomDeath();
     }
 
     /**


### PR DESCRIPTION
Random death is initialized when the campaign is initialized, however it relies on campaign options. The default death multiplier is 0.

All of this combined to make death chance 0. Which is somewhat less than intended.

Now we correctly reinitialize random death both when the campaign is loaded and when campaign options is exited.