### PR TITLE
Improvement: Added Random Callsigns to Units Generated Randomly for Scenarios

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.mission;
 
@@ -55,6 +60,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import megamek.client.bot.princess.CardinalEdge;
+import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.generator.RandomUnitGenerator;
@@ -2716,19 +2722,19 @@ public class AtBDynamicScenarioFactory {
      */
     public static @Nullable Entity createEntityWithCrew(Faction faction, SkillLevel skill, Campaign campaign,
           MekSummary unitData) {
-        Entity en;
+        Entity entity;
         try {
-            en = new MekFileParser(unitData.getSourceFile(), unitData.getEntryName()).getEntity();
+            entity = new MekFileParser(unitData.getSourceFile(), unitData.getEntryName()).getEntity();
         } catch (Exception ex) {
             logger.error("Unable to load entity: {}: {}", unitData.getSourceFile(), unitData.getEntryName(), ex);
             return null;
         }
 
-        en.setOwner(campaign.getPlayer());
-        en.setGame(campaign.getGame());
+        entity.setOwner(campaign.getPlayer());
+        entity.setGame(campaign.getGame());
 
-        RandomNameGenerator rng = RandomNameGenerator.getInstance();
-        rng.setChosenFaction(faction.getNameGenerator());
+        RandomNameGenerator nameGenerator = RandomNameGenerator.getInstance();
+        nameGenerator.setChosenFaction(faction.getNameGenerator());
 
         Gender gender;
         int nonBinaryDiceSize = campaign.getCampaignOptions().getNonBinaryDiceSize();
@@ -2739,7 +2745,9 @@ public class AtBDynamicScenarioFactory {
             gender = RandomGenderGenerator.generate();
         }
 
-        String[] crewNameArray = rng.generateGivenNameSurnameSplit(gender, faction.isClan(), faction.getShortName());
+        String[] crewNameArray = nameGenerator.generateGivenNameSurnameSplit(gender,
+              faction.isClan(),
+              faction.getShortName());
         String crewName = crewNameArray[0];
         crewName += !StringUtility.isNullOrBlank(crewNameArray[1]) ? ' ' + crewNameArray[1] : "";
 
@@ -2762,11 +2770,11 @@ public class AtBDynamicScenarioFactory {
         skill = SkillLevel.parseFromInteger(skillValue);
 
         skillGenerator.setLevel(skill);
-        int[] skills = skillGenerator.generateRandomSkills(en);
+        int[] skills = skillGenerator.generateRandomSkills(entity);
 
         if (faction.isClan() && (d6(2) > (6 - skill.ordinal() + skills[0] + skills[1]))) {
             Phenotype phenotype = Phenotype.NONE;
-            switch (en.getUnitType()) {
+            switch (entity.getUnitType()) {
                 case MEK:
                     phenotype = Phenotype.MEKWARRIOR;
                     break;
@@ -2809,23 +2817,28 @@ public class AtBDynamicScenarioFactory {
 
         extraData.put(0, innerMap);
 
-        en.setCrew(new Crew(en.getCrew().getCrewType(),
-              crewName,
-              Compute.getFullCrewSize(en),
+        // Create the crew object
+        Crew entityCrew = new Crew(entity.getCrew().getCrewType(),
+              crewName, Compute.getFullCrewSize(entity),
               skills[0],
               skills[1],
               gender,
-              faction.isClan(),
-              extraData));
+              faction.isClan(), extraData);
+
+        // Assign a callsign to the unit commander
+        entityCrew.setNickname(RandomCallsignGenerator.getInstance().generate(), 0);
+
+        // Assign the crew to the unit
+        entity.setCrew(entityCrew);
 
         CampaignOptions campaignOptions = campaign.getCampaignOptions();
         if (campaignOptions.isUseTactics() || campaignOptions.isUseInitiativeBonus()) {
-            en.getCrew().setCommandBonus(getTacticsModifier(skill, campaign.getRandomSkillPreferences(), faction));
+            entity.getCrew().setCommandBonus(getTacticsModifier(skill, campaign.getRandomSkillPreferences(), faction));
         }
 
-        en.setExternalIdAsString(UUID.randomUUID().toString());
+        entity.setExternalIdAsString(UUID.randomUUID().toString());
 
-        return en;
+        return entity;
     }
 
     /**


### PR DESCRIPTION
I spotted one of our frequent Streamers assigning enemy units random callsigns and their players seemed to be having a lot of fun with the sometimes odd names they'd end up with.

I thought this was a great idea.

With this PR randomly (not fixed) enemy units will be assigned callsigns from the random callsign list. This only affects units generated via `AtBDynamicScenarioFactory`.