### PR TITLE
Fixed: Fixed Exception During Avionics Evaluation

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Avionics.java
+++ b/MekHQ/src/mekhq/campaign/parts/Avionics.java
@@ -198,7 +198,13 @@ public class Avionics extends Part {
     @Override
     public Money getStickerPrice() {
         // Tech Manual p283 - cost is only valid for Conventional Fighters
-        if (unit != null && unit.getEntity() instanceof ConvFighter) {
+        if (unit == null) {
+            return Money.zero();
+        }
+
+        Entity entity = unit.getEntity();
+
+        if (entity != null && entity.isConventionalFighter()) {
             return Money.of(4000 * this.unitTonnage * 0.1);
         } else {
             return Money.zero();

--- a/MekHQ/src/mekhq/campaign/parts/Avionics.java
+++ b/MekHQ/src/mekhq/campaign/parts/Avionics.java
@@ -25,6 +25,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.parts;
 

--- a/MekHQ/src/mekhq/campaign/parts/Avionics.java
+++ b/MekHQ/src/mekhq/campaign/parts/Avionics.java
@@ -198,7 +198,7 @@ public class Avionics extends Part {
     @Override
     public Money getStickerPrice() {
         // Tech Manual p283 - cost is only valid for Conventional Fighters
-        if (unit.getEntity() instanceof ConvFighter) {
+        if (unit != null && unit.getEntity() instanceof ConvFighter) {
             return Money.of(4000 * this.unitTonnage * 0.1);
         } else {
             return Money.zero();


### PR DESCRIPTION
Recent changes to `Avionics#getStickerPrice` prevent existing campaign saves from being loaded if that campaign has a unit that uses Avionics. Or, if the campaign has an Avionics part in their warehouse.

This is because `unit` is `null` both during loading and while a part is loose in the warehouse.

Added null protection to the method which resolves the issue.