### PR TITLE
Fix: Fix Skill Fetching in Find Best in Role Comparison

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3192,7 +3192,7 @@ public class Campaign implements ITechManager {
                     bestInRole = person;
                     highest = currentSkillLevel;
                 } else if (secondary != null && currentSkillLevel == highest) {
-                    Skill secondarySkill = person.getSkill(primary);
+                    Skill secondarySkill = person.getSkill(secondary);
 
                     if (secondarySkill == null) {
                         continue;


### PR DESCRIPTION
This was accidentally missed out of the attribute score rollout PR.