### PR TITLE
Fix: Fixed Required Combat Teams Returning Lower Than Intended Values

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -469,9 +469,7 @@ public class AtBContract extends Contract {
             caclulatedForceSize = 1;
         }
 
-        int baseRequiredLances = effectiveNumUnits / caclulatedForceSize;
-
-        return max(baseRequiredLances, 1);
+        return max(caclulatedForceSize, 1);
     }
 
     /**


### PR DESCRIPTION
Removes unnecessary line in calculations. While me and Psi were futzing about trying to make this approach work I managed to leave in a line from a draft that made it into the final merge.