### PR TITLE
Feature: New Campaigns Now Start on Their Faction's Capital Planet

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -107,10 +107,10 @@ import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.generator.RandomUnitGenerator;
-import megamek.client.ratgenerator.AvailabilityRating;
 import megamek.client.ui.swing.util.PlayerColour;
 import megamek.codeUtilities.ObjectUtility;
 import megamek.common.*;
+import megamek.common.ITechnology.AvailabilityValue;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.equipment.BombMounted;
@@ -125,8 +125,6 @@ import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.BuildingBlock;
-import megamek.common.ITechnology.AvailabilityValue;
-import megamek.common.ITechnology.TechRating;
 import megamek.logging.MMLogger;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
@@ -264,8 +262,6 @@ import mekhq.service.IAutosaveService;
 import mekhq.service.mrms.MRMSService;
 import mekhq.utilities.MHQXMLUtility;
 import mekhq.utilities.ReportingUtilities;
-import mekhq.campaign.universe.PlanetarySystem.PlanetarySophistication;
-import mekhq.campaign.universe.PlanetarySystem.PlanetaryRating;
 
 /**
  * The main campaign class, keeps track of teams and units
@@ -9935,5 +9931,61 @@ public class Campaign implements ITechManager {
             }
         }
         return units;
+    }
+
+
+    /**
+     * Determines the appropriate starting planet for a new campaign.
+     *
+     * <p>This method first attempts to obtain the starting planet from the campaign's primary method. If no valid
+     * system is found, or if the result is "Terra" (which is the default value used when no system is set), it selects
+     * a fallback faction's starting planet using the following logic:</p>
+     *
+     * <ul>
+     *     <li>If the faction is "PIR", a random pirate faction (other than "PIR" itself) with an available starting
+     *     planet is chosen, if available.</li>
+     *     <li>If the faction is a clan, the generic "CLAN" faction is used as the fallback.</li>
+     *     <li>Otherwise, the default faction (Mercenary) is used as the fallback.</li>
+     * </ul>
+     *
+     * <p>The returned result is always the system's primary planet.</p>
+     *
+     * @param campaign the campaign context for which to determine the starting planet
+     *
+     * @return the {@link Planet} object representing the new campaign's starting planet
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public Planet getNewCampaignStartingPlanet() {
+        Factions factions = Factions.getInstance();
+
+        PlanetarySystem startingSystem = faction.getStartingPlanet(this, currentDay);
+
+        if (startingSystem == null) {
+            Faction fallbackFaction = factions.getDefaultFaction();
+            startingSystem = fallbackFaction.getStartingPlanet(this, currentDay);
+        } else if (startingSystem.getId().equalsIgnoreCase("Terra")) {
+            Faction fallbackFaction = factions.getDefaultFaction();
+
+            if (faction.getShortName().equalsIgnoreCase("PIR")) {
+                List<Faction> pirateFactions = new ArrayList<>();
+                for (Faction faction : factions.getActiveFactions(currentDay)) {
+                    if (faction.isPirate() && !faction.getShortName().equalsIgnoreCase("PIR")) {
+                        pirateFactions.add(faction);
+                    }
+                }
+
+                if (!pirateFactions.isEmpty()) {
+                    fallbackFaction = ObjectUtility.getRandomItem(pirateFactions);
+                }
+            } else if (faction.isClan()) {
+                fallbackFaction = factions.getFaction("CLAN");
+            }
+
+            startingSystem = fallbackFaction.getStartingPlanet(this, currentDay);
+        }
+
+        return startingSystem.getPrimaryPlanet();
     }
 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -9950,8 +9950,6 @@ public class Campaign implements ITechManager {
      *
      * <p>The returned result is always the system's primary planet.</p>
      *
-     * @param campaign the campaign context for which to determine the starting planet
-     *
      * @return the {@link Planet} object representing the new campaign's starting planet
      *
      * @author Illiani

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -53,7 +53,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
-import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JProgressBar;
 import javax.swing.SwingWorker;
@@ -88,6 +87,7 @@ import mekhq.campaign.storyarc.StoryArc;
 import mekhq.campaign.storyarc.StoryArcStub;
 import mekhq.campaign.unit.Unit;
 import mekhq.campaign.universe.Factions;
+import mekhq.campaign.universe.Planet;
 import mekhq.campaign.universe.RATManager;
 import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.eras.Eras;
@@ -357,7 +357,6 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 // This needs to be before we trigger the customize preset dialog
                 campaign.setLocalDate(DEFAULT_START_DATE);
                 campaign.getGameOptions().getOption(OptionsConstants.ALLOWED_YEAR).setValue(campaign.getGameYear());
-                campaign.setStartingSystem((preset == null) ? null : preset.getPlanet());
 
                 CampaignOptionsDialogMode mode = isSelect ? STARTUP_ABRIDGED : STARTUP;
                 CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(getFrame(), campaign, preset, mode);
@@ -368,6 +367,14 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 } else {
                     setVisible(true); // restore loader visibility
                 }
+
+                // Starting planet
+                Planet startingPlanet = (preset == null) ? null : preset.getPlanet();
+                // If the player hasn't set a starting planet in the preset, use the default for their chosen faction
+                if (startingPlanet == null) {
+                    startingPlanet = campaign.getNewCampaignStartingPlanet();
+                }
+                campaign.setStartingSystem(startingPlanet);
 
                 // initialize reputation
                 ReputationController reputationController = new ReputationController();


### PR DESCRIPTION
When starting a new campaign the campaign will start on the capital planet for their faction. If no capital is set in factions.xml the mercenary capital will be used.

For Clan factions, without a capital planet, we use Strana Mechty.

For the Pirate faction we pick the capital planet of a random pirate faction (usually Tortuga Dominions). If there are no pirate factions they use the mercenary capital, instead.