### PR TITLE
Improvement: Added Chance for Mercenary Campaigns to Begin in Another Playable Faction's Territory

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -9971,8 +9971,7 @@ public class Campaign implements ITechManager {
             if (faction.getShortName().equalsIgnoreCase("PIR")) {
                 List<Faction> pirateFactions = new ArrayList<>();
                 for (Faction activeFaction : factions.getActiveFactions(currentDay)) {
-                    if (activeFaction.isPlayable() &&
-                              activeFaction.isPirate() &&
+                    if (activeFaction.isPirate() &&
                               !activeFaction.getShortName().equalsIgnoreCase("PIR")) {
                         pirateFactions.add(activeFaction);
                     }


### PR DESCRIPTION
- 75% of the time mercenary campaigns will begin on their faction's capital (Galatea, etc)
- 25% of the time a random playable faction (non-Clan) will be selected and the campaign will begin on their capital, instead