### PR TITLE
Update Campaign.java to use Constant for Astech Team Size

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7872,7 +7872,7 @@ public class Campaign implements ITechManager {
     }
 
     public int getAstechNeed() {
-        return (Math.toIntExact(getActivePersonnel(true).stream().filter(Person::isTech).count()) * 6) -
+        return (Math.toIntExact(getActivePersonnel(true).stream().filter(Person::isTech).count()) * MHQConstants.ASTECH_TEAM_SIZE) -
                      getNumberAstechs();
     }
 


### PR DESCRIPTION
I was working on my own fork and spotted a place in Campaign.java that had a hard coded value and didn't use the provide contast this changes from that value to use the constant, no other changes. I've tested locally and it works no issues.