### PR TITLE
Fix to prevent NPE when trimming in-memory Event Log for date range

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6414,13 +6414,13 @@ public class Campaign implements ITechManager {
     }
 
     private void addInMemoryLogHistory(LogEntry le) {
-        if (!inMemoryLogHistory.isEmpty()) {
-            while (ChronoUnit.DAYS.between(inMemoryLogHistory.get(0).getDate(), le.getDate()) >
-                         MHQConstants.MAX_HISTORICAL_LOG_DAYS) {
-                // we've hit the max size for the in-memory based on the UI display limit prune
-                // the oldest entry
-                inMemoryLogHistory.remove(0);
-            }
+        Iterator<LogEntry> iterator = inMemoryLogHistory.iterator();
+        while (iterator.hasNext() &&
+              ChronoUnit.DAYS.between(iterator.next().getDate(), le.getDate()) >
+                     MHQConstants.MAX_HISTORICAL_LOG_DAYS) {
+            // we've hit the max size for the in-memory based on the UI display limit prune
+            // the oldest entry
+            iterator.remove();
         }
         inMemoryLogHistory.add(le);
     }


### PR DESCRIPTION
Fixes an NPE when:
1. the MekHQ option "Temporarily Retain Daily Log History" is enabled, and
2. all in-memory events are some time in the past, and
3. a new event (such as a contract) is added to the event log, such that
4. The span between all old events' dates and the new event's projected date is > 120 days.

This causes the in-memory log cache to be trimmed, which we _were_ doing in an unsafe fashion.
This patch replaces the unsafe method with a safe `while iterator.hasNext() / iterator.remove()` loop.

FOR DISCUSSION:
1. Why is the in-memory log populated from a campaign file's saved events?  It should probably be left empty.
2. Why does the in-memory log cache even exist?

Testing:
- Confirmed original save now works correctly when adding contracts
- Ran all 3 projects' unit tests

Close #7149