### PR TITLE
Refactor: Add safeties around failure points

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Availability.java
+++ b/MekHQ/src/mekhq/campaign/parts/Availability.java
@@ -36,6 +36,8 @@ import megamek.logging.MMLogger;
 import megamek.common.ITechnology.AvailabilityValue;
 import megamek.common.ITechnology.TechRating;
 
+import java.util.Arrays;
+
 /**
  * Helper functions for determining part availability and tech base
  * and the associated modifiers. A lot of this code is borrowed from
@@ -47,20 +49,19 @@ public class Availability {
     private static final MMLogger logger = MMLogger.create(Availability.class);
 
     public static int getAvailabilityModifier(AvailabilityValue availability) {
-        switch (availability) {
-            case A:
-                return -4;
-            case B:
-                return -3;
-            case C:
-                return -2;
-            case D:
-                return -1;
-            case E:
-                return 0;
-            case F:
-                return 2;
-            case X:
+        if (availability == null) {
+            // We don't know why we got a null availability, but it shouldn't raise.
+            return 999;
+        }
+        
+        return switch (availability) {
+            case A -> -4;
+            case B -> -3;
+            case C -> -2;
+            case D -> -1;
+            case E -> 0;
+            case F -> 2;
+            case X ->
                 // FIXME : Per IO, any IS equipment with a base SW availability of E-F that goes
                 // FIXME : extinct during the SW has it increased by 1 with F+1 meaning that
                 // there
@@ -69,11 +70,12 @@ public class Availability {
                 // FIXME : rules in StratOps, so for now I'm considering it equivalent to X,
                 // which
                 // FIXME : gives a +5.
-                return 5;
-            default:
+                  5;
+            default -> {
                 logger.error("Attempting to get availability modifier for unknown rating of " + availability);
-                return 999;
-        }
+                yield 999;
+            }
+        };
     }
 
     public static int getTechModifier(TechRating tech) {

--- a/MekHQ/src/mekhq/campaign/parts/MissingPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/MissingPart.java
@@ -34,6 +34,8 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.Arrays;
 
 import megamek.common.ITechnology;
 import megamek.common.TargetRoll;
@@ -314,6 +316,16 @@ public abstract class MissingPart extends Part implements IAcquisitionWork {
         }
         //availability mod
         AvailabilityValue avail = getAvailability();
+        if (avail == null) {
+            target.addModifier(
+                  TargetRoll.IMPOSSIBLE, 
+                  MessageFormat.format(
+                        "Attempting to get availability modifier for null availability: {0}", 
+                        getPartName()
+                  )
+            );
+            return target;
+        }
         int availabilityMod = Availability.getAvailabilityModifier(avail);
         target.addModifier(availabilityMod, "availability (" + avail.getName() + ')');
 


### PR DESCRIPTION
Add safety checks around some availability calls that led to the NPE in #7138.
Also allowed Idea to convert the switch/case block in `getAvailabilityModifier()` to new style.

It looks like the bug was actually fixed by updates in MegaMek code sometime in the last couple weeks but I have not found the exact commit.

Testing:
- Ran repro with OP's campaign save to check correctness
- Ran all 3 projects' unit tests.

Close #7138 