### PR TITLE
Fix incorrect boardsSelectedVector breaks passing scenario maps from MekHQ to MegaMek

### DIFF
--- a/MekHQ/src/mekhq/utilities/ScenarioUtils.java
+++ b/MekHQ/src/mekhq/utilities/ScenarioUtils.java
@@ -130,12 +130,14 @@ public class ScenarioUtils {
             }
 
             // Reset size parameters after getting new instance
+            // Note that the side effect of "setMapSize" is to fill the boardsSelectedVector
+            // with null entries!
+            // We know we are only using a single map so replace the null 0th entry
             mapSettings.setBoardSize(mapSizeX, mapSizeY);
             mapSettings.setMapSize(1, 1);
-            mapSettings.getBoardsSelectedVector().add(MapSettings.BOARD_GENERATED);
+            mapSettings.getBoardsSelectedVector().set(0, MapSettings.BOARD_GENERATED);
         }
+
         return mapSettings;
-
-
     }
 }


### PR DESCRIPTION
Fixes the breaking bug where scenarios could not load into MegaMek from MekHQ with auto-generated maps.
Root cause was the way that `setMapSize()` resets the `selectedBoardsVector` to (X * Y) null entries, instead of leaving it cleared.

Testing:
- Ran OP's campaign scenario and confirmed map now loads.
- Ran all 3 projects' unit tests.

Close #7141 