### PR TITLE
Added secondary role sections to personnel report

### DIFF
--- a/MekHQ/resources/mekhq/resources/PersonnelReport.properties
+++ b/MekHQ/resources/mekhq/resources/PersonnelReport.properties
@@ -1,0 +1,6 @@
+# suppress inspection "UnusedProperty" for the whole file
+## reports
+secondary.support= \ \
+  \{0}
+secondary.combat= \ \
+  \{0}

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -34,6 +34,7 @@
 package mekhq.campaign.report;
 
 import java.time.LocalDate;
+import java.util.EnumMap;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -244,15 +245,15 @@ public class PersonnelReport extends AbstractReport {
     }
 
     public String getSecondarySupportPersonnelDetails() {
-        final PersonnelRole[] personnelRoles = PersonnelRole.values();
-        int[] countPersonByType = new int[personnelRoles.length];
+        EnumMap<PersonnelRole, Integer> countPersonByType = new EnumMap<>(PersonnelRole.class);
         int countSecondary = 0;
         for (Person person : getCampaign().getPersonnel()) {
             // Add them to the total count
             final boolean secondarySupport = person.getSecondaryRole().isSupport(true);
 
             if (secondarySupport && person.getPrisonerStatus().isFree() && person.getStatus().isActive()) {
-                countPersonByType[person.getSecondaryRole().ordinal()]++;
+                countPersonByType.put(person.getSecondaryRole(),
+                      (countPersonByType.getOrDefault(person.getSecondaryRole(), 0) + 1));
                 countSecondary++;
                 }
             }
@@ -261,27 +262,28 @@ public class PersonnelReport extends AbstractReport {
 
         sb.append(String.format("%-30s%4s\n", "Total Secondary Role Support Personnel", countSecondary));
 
-        for (PersonnelRole role : personnelRoles) {
-            if (role.isSupport(true)) {
+        countPersonByType.forEach((role, value) ->
+            {if (role.isSupport(true) && value >= 0){
                 sb.append(String.format("    %-30s    %4s\n",
-                      role.getLabel(getCampaign().getFaction().isClan()),
-                      countPersonByType[role.ordinal()]));
+                     role.getLabel(getCampaign().getFaction().isClan()),
+                      value));
             }
-        }
+        });
 
         return sb.toString();
     }
 
     public String getSecondaryCombatPersonnelDetails() {
-        final PersonnelRole[] personnelRoles = PersonnelRole.values();
-        int[] countPersonByType = new int[personnelRoles.length];
+        EnumMap<PersonnelRole, Integer> countPersonByType = new EnumMap<>(PersonnelRole.class);
+
         int countSecondary = 0;
         for (Person person : getCampaign().getPersonnel()) {
             // Add them to the total count
             final boolean secondaryCombat = person.getSecondaryRole().isCombat();
 
             if (secondaryCombat && person.getPrisonerStatus().isFree() && person.getStatus().isActive()) {
-                countPersonByType[person.getSecondaryRole().ordinal()]++;
+                countPersonByType.put(person.getSecondaryRole(),
+                      (countPersonByType.getOrDefault(person.getSecondaryRole(), 0) + 1));
                 countSecondary++;
             }
         }
@@ -290,13 +292,13 @@ public class PersonnelReport extends AbstractReport {
 
         sb.append(String.format("%-30s %4s\n", "Total Secondary Role Combat Personnel", countSecondary));
 
-        for (PersonnelRole role : personnelRoles) {
-            if (role.isCombat()) {
-                sb.append(String.format("    %-30s    %4s\n",
-                      role.getLabel(getCampaign().getFaction().isClan()),
-                      countPersonByType[role.ordinal()]));
-            }
+        countPersonByType.forEach((role, value) ->
+        {if (role.isCombat() && value >= 0){
+            sb.append(String.format("    %-30s    %4s\n",
+                  role.getLabel(getCampaign().getFaction().isClan()),
+                  value));
         }
+        });
 
         return sb.toString();
     }

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -36,10 +36,14 @@ package mekhq.campaign.report;
 import java.time.LocalDate;
 import java.util.EnumMap;
 
+import megamek.common.internationalization.I18n;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
+
+import static mekhq.utilities.MHQInternationalization.getFormattedText;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * @author Jay Lawson
@@ -270,7 +274,7 @@ public class PersonnelReport extends AbstractReport {
             }
         });
 
-        return sb.toString();
+        return getFormattedTextAt("mekhq.resources.PersonnelReport", "secondary.support", sb.toString());
     }
 
     public String getSecondaryCombatPersonnelDetails() {
@@ -300,6 +304,6 @@ public class PersonnelReport extends AbstractReport {
         }
         });
 
-        return sb.toString();
+        return getFormattedTextAt("mekhq.resources.PersonnelReport", "secondary.combat", sb.toString());
     }
 }

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -108,6 +108,8 @@ public class PersonnelReport extends AbstractReport {
             }
         }
 
+        sb.append(getSecondaryCombatPersonnelDetails());
+
         sb.append('\n')
               .append(String.format("%-30s        %4s\n", "Injured Combat Personnel", countInjured))
               .append(String.format("%-30s        %4s\n", "MIA Combat Personnel", countMIA))
@@ -171,7 +173,6 @@ public class PersonnelReport extends AbstractReport {
             } else if (primarySupport && person.getStatus().isStudent()) {
                 countStudents++;
             }
-
             if (person.getPrimaryRole().isDependent() &&
                       !person.getStatus().isDepartedUnit() &&
                       person.getPrisonerStatus().isFree()) {
@@ -217,6 +218,8 @@ public class PersonnelReport extends AbstractReport {
         sb.append(String.format("    %-30s    %4s\n", "Temp Medics", getCampaign().getMedicPool()));
         sb.append(String.format("    %-30s    %4s\n", "Temp Astechs", getCampaign().getAstechPool()));
 
+        sb.append(getSecondarySupportPersonnelDetails());
+
         sb.append('\n')
               .append(String.format("%-30s        %4s\n", "Injured Support Personnel", countInjured))
               .append(String.format("%-30s        %4s\n", "MIA Support Personnel", countMIA))
@@ -236,6 +239,64 @@ public class PersonnelReport extends AbstractReport {
               .append(civilianSalaries.toAmountAndSymbolString())
               .append(String.format("\nYou have " + prisoners + " prisoner%s", prisoners == 1 ? "" : "s"))
               .append(String.format("\nYou have " + bondsmen + " %s", (bondsmen == 1) ? "bondsman" : "bondsmen"));
+
+        return sb.toString();
+    }
+
+    public String getSecondarySupportPersonnelDetails() {
+        final PersonnelRole[] personnelRoles = PersonnelRole.values();
+        int[] countPersonByType = new int[personnelRoles.length];
+        int countSecondary = 0;
+        for (Person person : getCampaign().getPersonnel()) {
+            // Add them to the total count
+            final boolean secondarySupport = person.getSecondaryRole().isSupport(true);
+
+            if (secondarySupport && person.getPrisonerStatus().isFree() && person.getStatus().isActive()) {
+                countPersonByType[person.getSecondaryRole().ordinal()]++;
+                countSecondary++;
+                }
+            }
+
+        StringBuilder sb = new StringBuilder("\nSecondary Role Support Personnel\n\n");
+
+        sb.append(String.format("%-30s%4s\n", "Total Secondary Role Support Personnel", countSecondary));
+
+        for (PersonnelRole role : personnelRoles) {
+            if (role.isSupport(true)) {
+                sb.append(String.format("    %-30s    %4s\n",
+                      role.getLabel(getCampaign().getFaction().isClan()),
+                      countPersonByType[role.ordinal()]));
+            }
+        }
+
+        return sb.toString();
+    }
+
+    public String getSecondaryCombatPersonnelDetails() {
+        final PersonnelRole[] personnelRoles = PersonnelRole.values();
+        int[] countPersonByType = new int[personnelRoles.length];
+        int countSecondary = 0;
+        for (Person person : getCampaign().getPersonnel()) {
+            // Add them to the total count
+            final boolean secondaryCombat = person.getSecondaryRole().isCombat();
+
+            if (secondaryCombat && person.getPrisonerStatus().isFree() && person.getStatus().isActive()) {
+                countPersonByType[person.getSecondaryRole().ordinal()]++;
+                countSecondary++;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder("\nSecondary Role Combat Personnel\n\n");
+
+        sb.append(String.format("%-30s %4s\n", "Total Secondary Role Combat Personnel", countSecondary));
+
+        for (PersonnelRole role : personnelRoles) {
+            if (role.isCombat()) {
+                sb.append(String.format("    %-30s    %4s\n",
+                      role.getLabel(getCampaign().getFaction().isClan()),
+                      countPersonByType[role.ordinal()]));
+            }
+        }
 
         return sb.toString();
     }


### PR DESCRIPTION
This is what I came up with to answer my own RFE #[7045](https://github.com/MegaMek/mekhq/issues/7045)

added a count of personnel performing secondary roles split by combat and support along with a breakdown of a count of each type of role.

Located just below the primary role counts and above the extra if an the bottom of each section.

![current personnel report](https://github.com/user-attachments/assets/47985328-b1e7-46fd-8bed-2a712b4355e9)
![new personnel report](https://github.com/user-attachments/assets/6094c192-d532-4fe6-a8e2-d50a20f46013)


Not that elegant just added the total for each secondary role under the current ones, have not added to the salary or other parts of the report at the moment,
 