### PR TITLE
Improvement: Added Helper Method to Make Testing Real Campaign Objects Easy

### DIFF
--- a/MekHQ/src/mekhq/campaign/utilities/TestableCampaign.java
+++ b/MekHQ/src/mekhq/campaign/utilities/TestableCampaign.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.utilities;
+
+import megamek.common.EquipmentType;
+import megamek.logging.MMLogger;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.campaign.personnel.ranks.Ranks;
+import mekhq.campaign.personnel.skills.SkillType;
+import mekhq.campaign.universe.Systems;
+
+import java.io.IOException;
+
+/**
+ * The {@code TestableCampaign} class provides a static utility method for preparing the minimal required subsystems to
+ * create and test a {@link Campaign} object.
+ *
+ * @author Illiani
+ * @since 0.50.07
+ */
+public class TestableCampaign {
+    private final static MMLogger LOGGER = MMLogger.create(TestableCampaign.class);
+
+    /**
+     * Initializes the minimal set of subsystems required to create a {@link Campaign} object for use in unit testing.
+     *
+     * <p>This includes loading system data, initializing equipment types, and setting up rank systems. If {@code
+     * shouldInitializeSkillTypes} is {@code true}, skill types are also initialized, which is necessary for random
+     * personnel generation when using the {@link Campaign#newPerson(PersonnelRole)} family of methods.</p>
+     *
+     * <p>If personnel objects are being created via {@link Person#Person(Campaign)}, skill type initialization may
+     * not be required, and this parameter can be set to {@code false}.</p>
+     *
+     * <p><b>Usage:</b> this method should be used judiciously and only once per battery of tests. Generally
+     * speaking, creating {@link Campaign} objects is expensive and not suitable for every test battery. Instead,
+     * consider breaking the dependency on {@link Campaign} in the method you're trying to test. This can be done by
+     * only passing in the values essential to the method (or class's) function, rather than the entire {@link Campaign}
+     * object. If this cannot be done, then create a single {@link Campaign} object for the whole test class (via this
+     * method) and then modify that single object to meet your needs. This will help ensure test time doesn't balloon
+     * unnecessarily.</p>
+     *
+     * @param shouldInitializeSkillTypes {@code true} to initialize additional resources required for personnel
+     *                                   generation; {@code false} otherwise. This can generally be left {@code false}
+     *                                   unless using the {@link Campaign#newPerson(PersonnelRole)} methods.
+     *
+     * @return a new {@link Campaign} instance with the required subsystems initialized for testing
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public static Campaign initializeCampaignForTesting(boolean shouldInitializeSkillTypes) {
+        try {
+            Systems.setInstance(Systems.loadDefault());
+        } catch (IOException e) {
+            LOGGER.error("Failed to load default systems", e);
+        }
+
+        EquipmentType.initializeTypes();
+
+        Ranks.initializeRankSystems();
+
+        if (shouldInitializeSkillTypes) {
+            SkillType.initializeTypes();
+        }
+
+        return new Campaign();
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/CapturePrisonersTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/CapturePrisonersTest.java
@@ -24,28 +24,23 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
- *
- * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
- * Microsoft's "Game Content Usage Rules"
- * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
- * affiliated with Microsoft.
  */
 package mekhq.campaign.randomEvents.prisoners;
 
 import megamek.common.ITechnology;
-import megamek.common.ITechnology.AvailabilityValue;
 import megamek.common.MapSettings;
+import megamek.common.ITechnology.AvailabilityValue;
+import megamek.common.ITechnology.TechRating;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.randomEvents.prisoners.enums.PrisonerStatus;
 import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.Factions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import mekhq.campaign.universe.Faction.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.util.Set;
 
 import static java.lang.Math.round;
 import static megamek.common.MiscType.createBeagleActiveProbe;
@@ -54,9 +49,13 @@ import static mekhq.campaign.randomEvents.prisoners.CapturePrisoners.*;
 import static mekhq.campaign.randomEvents.prisoners.enums.PrisonerStatus.BECOMING_BONDSMAN;
 import static mekhq.campaign.randomEvents.prisoners.enums.PrisonerStatus.PRISONER;
 import static mekhq.campaign.rating.IUnitRating.DRAGOON_C;
-import static mekhq.campaign.utilities.TestableCampaign.initializeCampaignForTesting;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * The {@link CapturePrisonersTest} class is a test suite for validating the functionality of the
@@ -69,49 +68,21 @@ import static org.mockito.Mockito.spy;
  * prisoner defection are also tested for various factions and conditions.</p>
  */
 class CapturePrisonersTest {
-    static Campaign campaign;
-    static Faction campaignFaction;
-    static Scenario scenario;
-
-    static final LocalDate TODAY = LocalDate.of(3151, 1, 1);
-    static Faction innerSphereFaction;
-    static Faction mercenaryFaction;
-    static Faction clanFaction;
-
-    @BeforeAll
-    static void beforeAll() {
-        campaign = initializeCampaignForTesting(true);
-        campaign.setLocalDate(TODAY);
-
-        try {
-            Factions.setInstance(Factions.loadDefault());
-        } catch (Exception e) {
-            fail("Failed to create default faction set: " + e.getMessage());
-        }
-
-        Factions factions = Factions.getInstance();
-        innerSphereFaction = factions.getFaction("LA");
-        mercenaryFaction = factions.getFaction("MERC");
-        clanFaction = factions.getFaction("CJF");
-    }
-
-    @BeforeEach
-    void beforeEach() {
-        scenario = new Scenario();
-
-        campaign.setFaction(innerSphereFaction);
-        campaignFaction = innerSphereFaction;
-    }
-
     @Test
     void testCapturePrisoners_Ground() {
         // Setup
-        AvailabilityValue activeProbeAvailability = getPartAvailability(TODAY, true);
-        AvailabilityValue improvedSensorsAvailability = getPartAvailability(TODAY, false);
+        Campaign mockCampaign = mock(Campaign.class);
+        Faction mockFaction = mock(Faction.class);
+        Scenario scenario = new Scenario();
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        AvailabilityValue activeProbeAvailability = getPartAvailability(today, true);
+        AvailabilityValue improvedSensorsAvailability = getPartAvailability(today, false);
 
         // Act
         int quality = -1;
-        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, quality);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, quality);
 
         // Assert
         int expectedTargetNumber = BASE_TARGET_NUMBER
@@ -129,12 +100,17 @@ class CapturePrisonersTest {
     @Test
     void testCapturePrisoners_Ground_ActiveProbe() {
         // Setup
-        AvailabilityValue activeProbeAvailability = getPartAvailability(TODAY, true);
-        AvailabilityValue improvedSensorsAvailability = getPartAvailability(TODAY, false);
+        Campaign mockCampaign = mock(Campaign.class);
+        Faction mockFaction = mock(Faction.class);
+        Scenario scenario = new Scenario();
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        AvailabilityValue activeProbeAvailability = getPartAvailability(today, true);
+        AvailabilityValue improvedSensorsAvailability = getPartAvailability(today, false);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario,
-              activeProbeAvailability.getIndex());
+        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, activeProbeAvailability.getIndex());
 
         // Assert
         int expectedTargetNumber = BASE_TARGET_NUMBER
@@ -151,12 +127,17 @@ class CapturePrisonersTest {
     @Test
     void testCapturePrisoners_Ground_ImprovedSensors() {
         // Setup
-        AvailabilityValue activeProbeAvailability = getPartAvailability(TODAY, true);
-        AvailabilityValue improvedSensorsAvailability = getPartAvailability(TODAY, false);
+        Campaign mockCampaign = mock(Campaign.class);
+        Faction mockFaction = mock(Faction.class);
+        Scenario scenario = new Scenario();
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        AvailabilityValue activeProbeAvailability = getPartAvailability(today, true);
+        AvailabilityValue improvedSensorsAvailability = getPartAvailability(today, false);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario,
-              improvedSensorsAvailability.getIndex());
+        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, improvedSensorsAvailability.getIndex());
 
         // Assert
         int expectedTargetNumber = BASE_TARGET_NUMBER
@@ -173,10 +154,17 @@ class CapturePrisonersTest {
     @Test
     void testCapturePrisoners_Space() {
         // Setup
+        Campaign mockCampaign = mock(Campaign.class);
+        Faction mockFaction = mock(Faction.class);
+
+        Scenario scenario = new Scenario();
         scenario.setBoardType(MapSettings.MEDIUM_SPACE);
 
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C);
 
         // Assert
         int expectedTargetNumber = BASE_TARGET_NUMBER
@@ -190,8 +178,17 @@ class CapturePrisonersTest {
 
     @Test
     void testAttemptCaptureOfNPC_PickedUp() {
+        // Setup
+        Campaign mockCampaign = mock(Campaign.class);
+        Faction mockFaction = mock(Faction.class);
+
+        Scenario scenario = new Scenario();
+
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C);
 
         // Assert
         assertTrue(capturePrisoners.attemptCaptureOfNPC(true));
@@ -200,7 +197,15 @@ class CapturePrisonersTest {
     @Test
     void testAttemptCaptureOfNPC_NotPickedUp_Captured() {
         // Setup
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
+        Campaign mockCampaign = mock(Campaign.class);
+        Faction mockFaction = mock(Faction.class);
+
+        Scenario scenario = new Scenario();
+
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
                 return this.getSarTargetNumber().getValue(); // Whatever value goes here will be the value rolled
@@ -217,7 +222,15 @@ class CapturePrisonersTest {
     @Test
     void testAttemptCaptureOfNPC_NotPickedUp_Escaped() {
         // Setup
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
+        Campaign mockCampaign = mock(Campaign.class);
+        Faction mockFaction = mock(Faction.class);
+
+        Scenario scenario = new Scenario();
+
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
                 return this.getSarTargetNumber().getValue() - 1; // Whatever value goes here will be the value rolled
@@ -234,9 +247,19 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_CampaignOperations_InnerSphereFaction() {
         // Setup
-        Person prisoner = new Person(campaign);
+        Campaign mockCampaign = mock(Campaign.class);
 
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        Faction mockFaction = mock(Faction.class);
+        when(mockCampaign.getFaction()).thenReturn(mockFaction);
+
+        Scenario scenario = new Scenario();
+
+        Person prisoner = new Person(mockCampaign);
+
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
                 return 5; // Whatever value goes here will be the value rolled
@@ -245,7 +268,7 @@ class CapturePrisonersTest {
 
         // Act
         CapturePrisoners capturePrisoners = spy(realCapturePrisoners);
-        capturePrisoners.processPrisoner(prisoner, campaignFaction, false, true);
+        capturePrisoners.processPrisoner(prisoner, mockFaction, false, true);
 
         // Assert
         PrisonerStatus expectedStatus = PRISONER;
@@ -257,15 +280,23 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_CampaignOperations_ClanFaction_TakenAsPrisoner() {
         // Setup
-        campaign.setFaction(clanFaction);
-        campaignFaction = clanFaction;
+        Campaign mockCampaign = mock(Campaign.class);
 
-        Person prisoner = new Person(campaign);
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
 
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
+        Faction campaignFaction = new Faction();
+        campaignFaction.setTags(Set.of(Tag.CLAN));
+        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
+
+        Scenario scenario = new Scenario();
+
+        Person prisoner = new Person(mockCampaign);
+
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
-                return prisoner.getOriginFaction().getHonorRating(campaign).getBondsmanTargetNumber() - 1;
+                return prisoner.getOriginFaction().getHonorRating(mockCampaign).getBondsmanTargetNumber() - 1;
             }
         };
 
@@ -283,16 +314,26 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_CampaignOperations_ClanFaction_TakenAsBondsman() {
         // Setup
-        campaign.setFaction(clanFaction);
-        campaignFaction = clanFaction;
+        Campaign mockCampaign = mock(Campaign.class);
 
-        Person prisoner = new Person(campaign);
-        prisoner.setOriginFaction(clanFaction);
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
 
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
+        Faction campaignFaction = new Faction();
+        campaignFaction.setTags(Set.of(Tag.CLAN));
+        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
+
+        Scenario scenario = new Scenario();
+
+        Person prisoner = new Person(mockCampaign);
+        Faction prisonerFaction = new Faction();
+        campaignFaction.setTags(Set.of(Tag.CLAN));
+        prisoner.setOriginFaction(prisonerFaction);
+
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
-                return prisoner.getOriginFaction().getHonorRating(campaign).getBondsmanTargetNumber() + 1;
+                return prisoner.getOriginFaction().getHonorRating(mockCampaign).getBondsmanTargetNumber() + 1;
             }
         };
 
@@ -310,9 +351,19 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_MekHQ_InnerSphereFaction() {
         // Setup
-        Person prisoner = new Person(campaign);
+        Campaign mockCampaign = mock(Campaign.class);
 
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        Faction mockFaction = mock(Faction.class);
+        when(mockCampaign.getFaction()).thenReturn(mockFaction);
+
+        Scenario scenario = new Scenario();
+
+        Person prisoner = new Person(mockCampaign);
+
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
                 return 5; // Whatever value goes here will be the value rolled
@@ -321,7 +372,7 @@ class CapturePrisonersTest {
 
         // Act
         CapturePrisoners capturePrisoners = spy(realCapturePrisoners);
-        capturePrisoners.processPrisoner(prisoner, campaignFaction, true, true);
+        capturePrisoners.processPrisoner(prisoner, mockFaction, true, true);
 
         // Assert
         PrisonerStatus expectedStatus = PRISONER;
@@ -333,15 +384,23 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_MekHQ_ClanFaction_TakenAsPrisoner() {
         // Setup
-        campaign.setFaction(clanFaction);
-        campaignFaction = clanFaction;
+        Campaign mockCampaign = mock(Campaign.class);
 
-        Person prisoner = new Person(campaign);
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
 
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
+        Faction campaignFaction = new Faction();
+        campaignFaction.setTags(Set.of(Tag.CLAN));
+        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
+
+        Scenario scenario = new Scenario();
+
+        Person prisoner = new Person(mockCampaign);
+
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
-                return prisoner.getOriginFaction().getHonorRating(campaign).getBondsmanTargetNumber() - 1;
+                return prisoner.getOriginFaction().getHonorRating(mockCampaign).getBondsmanTargetNumber() - 1;
             }
         };
 
@@ -359,16 +418,25 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_MekHQ_ClanFaction_TakenAsBondsman() {
         // Setup
-        campaign.setFaction(clanFaction);
-        campaignFaction = clanFaction;
+        Campaign mockCampaign = mock(Campaign.class);
 
-        Person prisoner = new Person(campaign);
-        prisoner.setOriginFaction(innerSphereFaction);
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
 
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
+        Faction campaignFaction = new Faction();
+        campaignFaction.setTags(Set.of(Tag.CLAN));
+        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
+
+        Scenario scenario = new Scenario();
+
+        Person prisoner = new Person(mockCampaign);
+        Faction prisonerFaction = new Faction();
+        prisoner.setOriginFaction(prisonerFaction);
+
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
-                return prisoner.getOriginFaction().getHonorRating(campaign).getBondsmanTargetNumber() + 1;
+                return prisoner.getOriginFaction().getHonorRating(mockCampaign).getBondsmanTargetNumber() + 1;
             }
         };
 
@@ -386,10 +454,20 @@ class CapturePrisonersTest {
     @Test
     void testDetermineDefectionChance() {
         // Setup
-        Person prisoner = new Person(campaign);
+        Campaign mockCampaign = mock(Campaign.class);
+
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        Faction campaignFaction = new Faction();
+        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
+
+        Scenario scenario = new Scenario();
+
+        Person prisoner = new Person(mockCampaign);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C);
         capturePrisoners.determineDefectionChance(prisoner, true);
         int defectionChance = capturePrisoners.determineDefectionChance(prisoner, true);
 
@@ -403,11 +481,23 @@ class CapturePrisonersTest {
     @Test
     void testDetermineDefection_Chance_MercenaryPrisoner() {
         // Setup
-        Person prisoner = new Person(campaign);
-        prisoner.setOriginFaction(mercenaryFaction);
+        Campaign mockCampaign = mock(Campaign.class);
+
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        Faction campaignFaction = new Faction();
+        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
+
+        Scenario scenario = new Scenario();
+
+        Person prisoner = new Person(mockCampaign);
+        Faction prisonerFaction = new Faction();
+        prisonerFaction.setTags(Set.of(Tag.MERC));
+        prisoner.setOriginFaction(prisonerFaction);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C);
         capturePrisoners.determineDefectionChance(prisoner, true);
         int defectionChance = capturePrisoners.determineDefectionChance(prisoner, true);
 
@@ -421,14 +511,22 @@ class CapturePrisonersTest {
     @Test
     void testDetermineDefection_Chance_ClanPrisoner_NotDezgraFaction() {
         // Setup
-        campaign.setFaction(clanFaction);
-        campaignFaction = clanFaction;
+        Campaign mockCampaign = mock(Campaign.class);
 
-        Person prisoner = new Person(campaign);
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        Faction campaignFaction = new Faction();
+        campaignFaction.setTags(Set.of(Tag.CLAN));
+        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
+
+        Scenario scenario = new Scenario();
+
+        Person prisoner = new Person(mockCampaign);
         prisoner.setClanPersonnel(true);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C);
         capturePrisoners.determineDefectionChance(prisoner, true);
         int defectionChance = capturePrisoners.determineDefectionChance(prisoner, true);
 
@@ -442,14 +540,22 @@ class CapturePrisonersTest {
     @Test
     void testDetermineDefection_Chance_ClanPrisoner_DezgraFaction() {
         // Setup
-        campaign.setFaction(mercenaryFaction);
+        Campaign mockCampaign = mock(Campaign.class);
 
-        Person prisoner = new Person(campaign);
-        prisoner.setOriginFaction(clanFaction);
+        LocalDate today = LocalDate.of(3151, 1, 1);
+        when(mockCampaign.getLocalDate()).thenReturn(today);
+
+        Faction campaignFaction = new Faction();
+        campaignFaction.setTags(Set.of(Tag.MERC));
+        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
+
+        Scenario scenario = new Scenario();
+
+        Person prisoner = new Person(mockCampaign);
         prisoner.setClanPersonnel(true);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C);
         int defectionChance = capturePrisoners.determineDefectionChance(prisoner, true);
 
         // Assert

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/CapturePrisonersTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/CapturePrisonersTest.java
@@ -24,23 +24,28 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.randomEvents.prisoners;
 
 import megamek.common.ITechnology;
-import megamek.common.MapSettings;
 import megamek.common.ITechnology.AvailabilityValue;
-import megamek.common.ITechnology.TechRating;
+import megamek.common.MapSettings;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.randomEvents.prisoners.enums.PrisonerStatus;
 import mekhq.campaign.universe.Faction;
-import mekhq.campaign.universe.Faction.Tag;
+import mekhq.campaign.universe.Factions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
-import java.util.Set;
 
 import static java.lang.Math.round;
 import static megamek.common.MiscType.createBeagleActiveProbe;
@@ -49,13 +54,9 @@ import static mekhq.campaign.randomEvents.prisoners.CapturePrisoners.*;
 import static mekhq.campaign.randomEvents.prisoners.enums.PrisonerStatus.BECOMING_BONDSMAN;
 import static mekhq.campaign.randomEvents.prisoners.enums.PrisonerStatus.PRISONER;
 import static mekhq.campaign.rating.IUnitRating.DRAGOON_C;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
+import static mekhq.campaign.utilities.TestableCampaign.initializeCampaignForTesting;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 /**
  * The {@link CapturePrisonersTest} class is a test suite for validating the functionality of the
@@ -68,21 +69,49 @@ import static org.mockito.Mockito.when;
  * prisoner defection are also tested for various factions and conditions.</p>
  */
 class CapturePrisonersTest {
+    static Campaign campaign;
+    static Faction campaignFaction;
+    static Scenario scenario;
+
+    static final LocalDate TODAY = LocalDate.of(3151, 1, 1);
+    static Faction innerSphereFaction;
+    static Faction mercenaryFaction;
+    static Faction clanFaction;
+
+    @BeforeAll
+    static void beforeAll() {
+        campaign = initializeCampaignForTesting(true);
+        campaign.setLocalDate(TODAY);
+
+        try {
+            Factions.setInstance(Factions.loadDefault());
+        } catch (Exception e) {
+            fail("Failed to create default faction set: " + e.getMessage());
+        }
+
+        Factions factions = Factions.getInstance();
+        innerSphereFaction = factions.getFaction("LA");
+        mercenaryFaction = factions.getFaction("MERC");
+        clanFaction = factions.getFaction("CJF");
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        scenario = new Scenario();
+
+        campaign.setFaction(innerSphereFaction);
+        campaignFaction = innerSphereFaction;
+    }
+
     @Test
     void testCapturePrisoners_Ground() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction mockFaction = mock(Faction.class);
-        Scenario scenario = new Scenario();
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        AvailabilityValue activeProbeAvailability = getPartAvailability(today, true);
-        AvailabilityValue improvedSensorsAvailability = getPartAvailability(today, false);
+        AvailabilityValue activeProbeAvailability = getPartAvailability(TODAY, true);
+        AvailabilityValue improvedSensorsAvailability = getPartAvailability(TODAY, false);
 
         // Act
         int quality = -1;
-        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, quality);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, quality);
 
         // Assert
         int expectedTargetNumber = BASE_TARGET_NUMBER
@@ -100,17 +129,12 @@ class CapturePrisonersTest {
     @Test
     void testCapturePrisoners_Ground_ActiveProbe() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction mockFaction = mock(Faction.class);
-        Scenario scenario = new Scenario();
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        AvailabilityValue activeProbeAvailability = getPartAvailability(today, true);
-        AvailabilityValue improvedSensorsAvailability = getPartAvailability(today, false);
+        AvailabilityValue activeProbeAvailability = getPartAvailability(TODAY, true);
+        AvailabilityValue improvedSensorsAvailability = getPartAvailability(TODAY, false);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, activeProbeAvailability.getIndex());
+        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario,
+              activeProbeAvailability.getIndex());
 
         // Assert
         int expectedTargetNumber = BASE_TARGET_NUMBER
@@ -127,17 +151,12 @@ class CapturePrisonersTest {
     @Test
     void testCapturePrisoners_Ground_ImprovedSensors() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction mockFaction = mock(Faction.class);
-        Scenario scenario = new Scenario();
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        AvailabilityValue activeProbeAvailability = getPartAvailability(today, true);
-        AvailabilityValue improvedSensorsAvailability = getPartAvailability(today, false);
+        AvailabilityValue activeProbeAvailability = getPartAvailability(TODAY, true);
+        AvailabilityValue improvedSensorsAvailability = getPartAvailability(TODAY, false);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, improvedSensorsAvailability.getIndex());
+        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario,
+              improvedSensorsAvailability.getIndex());
 
         // Assert
         int expectedTargetNumber = BASE_TARGET_NUMBER
@@ -154,17 +173,10 @@ class CapturePrisonersTest {
     @Test
     void testCapturePrisoners_Space() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction mockFaction = mock(Faction.class);
-
-        Scenario scenario = new Scenario();
         scenario.setBoardType(MapSettings.MEDIUM_SPACE);
 
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
 
         // Assert
         int expectedTargetNumber = BASE_TARGET_NUMBER
@@ -178,17 +190,8 @@ class CapturePrisonersTest {
 
     @Test
     void testAttemptCaptureOfNPC_PickedUp() {
-        // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction mockFaction = mock(Faction.class);
-
-        Scenario scenario = new Scenario();
-
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
 
         // Assert
         assertTrue(capturePrisoners.attemptCaptureOfNPC(true));
@@ -197,15 +200,7 @@ class CapturePrisonersTest {
     @Test
     void testAttemptCaptureOfNPC_NotPickedUp_Captured() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction mockFaction = mock(Faction.class);
-
-        Scenario scenario = new Scenario();
-
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C) {
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
                 return this.getSarTargetNumber().getValue(); // Whatever value goes here will be the value rolled
@@ -222,15 +217,7 @@ class CapturePrisonersTest {
     @Test
     void testAttemptCaptureOfNPC_NotPickedUp_Escaped() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-        Faction mockFaction = mock(Faction.class);
-
-        Scenario scenario = new Scenario();
-
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C) {
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
                 return this.getSarTargetNumber().getValue() - 1; // Whatever value goes here will be the value rolled
@@ -247,19 +234,9 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_CampaignOperations_InnerSphereFaction() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
+        Person prisoner = new Person(campaign);
 
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        Faction mockFaction = mock(Faction.class);
-        when(mockCampaign.getFaction()).thenReturn(mockFaction);
-
-        Scenario scenario = new Scenario();
-
-        Person prisoner = new Person(mockCampaign);
-
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C) {
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
                 return 5; // Whatever value goes here will be the value rolled
@@ -268,7 +245,7 @@ class CapturePrisonersTest {
 
         // Act
         CapturePrisoners capturePrisoners = spy(realCapturePrisoners);
-        capturePrisoners.processPrisoner(prisoner, mockFaction, false, true);
+        capturePrisoners.processPrisoner(prisoner, campaignFaction, false, true);
 
         // Assert
         PrisonerStatus expectedStatus = PRISONER;
@@ -280,23 +257,15 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_CampaignOperations_ClanFaction_TakenAsPrisoner() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
+        campaign.setFaction(clanFaction);
+        campaignFaction = clanFaction;
 
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
+        Person prisoner = new Person(campaign);
 
-        Faction campaignFaction = new Faction();
-        campaignFaction.setTags(Set.of(Tag.CLAN));
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-
-        Scenario scenario = new Scenario();
-
-        Person prisoner = new Person(mockCampaign);
-
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C) {
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
-                return prisoner.getOriginFaction().getHonorRating(mockCampaign).getBondsmanTargetNumber() - 1;
+                return prisoner.getOriginFaction().getHonorRating(campaign).getBondsmanTargetNumber() - 1;
             }
         };
 
@@ -314,26 +283,16 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_CampaignOperations_ClanFaction_TakenAsBondsman() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
+        campaign.setFaction(clanFaction);
+        campaignFaction = clanFaction;
 
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
+        Person prisoner = new Person(campaign);
+        prisoner.setOriginFaction(clanFaction);
 
-        Faction campaignFaction = new Faction();
-        campaignFaction.setTags(Set.of(Tag.CLAN));
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-
-        Scenario scenario = new Scenario();
-
-        Person prisoner = new Person(mockCampaign);
-        Faction prisonerFaction = new Faction();
-        campaignFaction.setTags(Set.of(Tag.CLAN));
-        prisoner.setOriginFaction(prisonerFaction);
-
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C) {
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
-                return prisoner.getOriginFaction().getHonorRating(mockCampaign).getBondsmanTargetNumber() + 1;
+                return prisoner.getOriginFaction().getHonorRating(campaign).getBondsmanTargetNumber() + 1;
             }
         };
 
@@ -351,19 +310,9 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_MekHQ_InnerSphereFaction() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
+        Person prisoner = new Person(campaign);
 
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        Faction mockFaction = mock(Faction.class);
-        when(mockCampaign.getFaction()).thenReturn(mockFaction);
-
-        Scenario scenario = new Scenario();
-
-        Person prisoner = new Person(mockCampaign);
-
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, mockFaction, scenario, DRAGOON_C) {
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
                 return 5; // Whatever value goes here will be the value rolled
@@ -372,7 +321,7 @@ class CapturePrisonersTest {
 
         // Act
         CapturePrisoners capturePrisoners = spy(realCapturePrisoners);
-        capturePrisoners.processPrisoner(prisoner, mockFaction, true, true);
+        capturePrisoners.processPrisoner(prisoner, campaignFaction, true, true);
 
         // Assert
         PrisonerStatus expectedStatus = PRISONER;
@@ -384,23 +333,15 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_MekHQ_ClanFaction_TakenAsPrisoner() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
+        campaign.setFaction(clanFaction);
+        campaignFaction = clanFaction;
 
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
+        Person prisoner = new Person(campaign);
 
-        Faction campaignFaction = new Faction();
-        campaignFaction.setTags(Set.of(Tag.CLAN));
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-
-        Scenario scenario = new Scenario();
-
-        Person prisoner = new Person(mockCampaign);
-
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C) {
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
-                return prisoner.getOriginFaction().getHonorRating(mockCampaign).getBondsmanTargetNumber() - 1;
+                return prisoner.getOriginFaction().getHonorRating(campaign).getBondsmanTargetNumber() - 1;
             }
         };
 
@@ -418,25 +359,16 @@ class CapturePrisonersTest {
     @Test
     void testProcessPrisoner_MekHQ_ClanFaction_TakenAsBondsman() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
+        campaign.setFaction(clanFaction);
+        campaignFaction = clanFaction;
 
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
+        Person prisoner = new Person(campaign);
+        prisoner.setOriginFaction(innerSphereFaction);
 
-        Faction campaignFaction = new Faction();
-        campaignFaction.setTags(Set.of(Tag.CLAN));
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-
-        Scenario scenario = new Scenario();
-
-        Person prisoner = new Person(mockCampaign);
-        Faction prisonerFaction = new Faction();
-        prisoner.setOriginFaction(prisonerFaction);
-
-        CapturePrisoners realCapturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C) {
+        CapturePrisoners realCapturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C) {
             @Override
             protected int d6(int dice) {
-                return prisoner.getOriginFaction().getHonorRating(mockCampaign).getBondsmanTargetNumber() + 1;
+                return prisoner.getOriginFaction().getHonorRating(campaign).getBondsmanTargetNumber() + 1;
             }
         };
 
@@ -454,20 +386,10 @@ class CapturePrisonersTest {
     @Test
     void testDetermineDefectionChance() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        Faction campaignFaction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-
-        Scenario scenario = new Scenario();
-
-        Person prisoner = new Person(mockCampaign);
+        Person prisoner = new Person(campaign);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
         capturePrisoners.determineDefectionChance(prisoner, true);
         int defectionChance = capturePrisoners.determineDefectionChance(prisoner, true);
 
@@ -481,23 +403,11 @@ class CapturePrisonersTest {
     @Test
     void testDetermineDefection_Chance_MercenaryPrisoner() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
-
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        Faction campaignFaction = new Faction();
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-
-        Scenario scenario = new Scenario();
-
-        Person prisoner = new Person(mockCampaign);
-        Faction prisonerFaction = new Faction();
-        prisonerFaction.setTags(Set.of(Tag.MERC));
-        prisoner.setOriginFaction(prisonerFaction);
+        Person prisoner = new Person(campaign);
+        prisoner.setOriginFaction(mercenaryFaction);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
         capturePrisoners.determineDefectionChance(prisoner, true);
         int defectionChance = capturePrisoners.determineDefectionChance(prisoner, true);
 
@@ -511,22 +421,14 @@ class CapturePrisonersTest {
     @Test
     void testDetermineDefection_Chance_ClanPrisoner_NotDezgraFaction() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
+        campaign.setFaction(clanFaction);
+        campaignFaction = clanFaction;
 
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        Faction campaignFaction = new Faction();
-        campaignFaction.setTags(Set.of(Tag.CLAN));
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-
-        Scenario scenario = new Scenario();
-
-        Person prisoner = new Person(mockCampaign);
+        Person prisoner = new Person(campaign);
         prisoner.setClanPersonnel(true);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
         capturePrisoners.determineDefectionChance(prisoner, true);
         int defectionChance = capturePrisoners.determineDefectionChance(prisoner, true);
 
@@ -540,22 +442,14 @@ class CapturePrisonersTest {
     @Test
     void testDetermineDefection_Chance_ClanPrisoner_DezgraFaction() {
         // Setup
-        Campaign mockCampaign = mock(Campaign.class);
+        campaign.setFaction(mercenaryFaction);
 
-        LocalDate today = LocalDate.of(3151, 1, 1);
-        when(mockCampaign.getLocalDate()).thenReturn(today);
-
-        Faction campaignFaction = new Faction();
-        campaignFaction.setTags(Set.of(Tag.MERC));
-        when(mockCampaign.getFaction()).thenReturn(campaignFaction);
-
-        Scenario scenario = new Scenario();
-
-        Person prisoner = new Person(mockCampaign);
+        Person prisoner = new Person(campaign);
+        prisoner.setOriginFaction(clanFaction);
         prisoner.setClanPersonnel(true);
 
         // Act
-        CapturePrisoners capturePrisoners = new CapturePrisoners(mockCampaign, campaignFaction, scenario, DRAGOON_C);
+        CapturePrisoners capturePrisoners = new CapturePrisoners(campaign, campaignFaction, scenario, DRAGOON_C);
         int defectionChance = capturePrisoners.determineDefectionChance(prisoner, true);
 
         // Assert

--- a/MekHQ/unittests/mekhq/campaign/utilities/TestableCampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/utilities/TestableCampaignTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.utilities;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.enums.PersonnelRole;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static mekhq.campaign.utilities.TestableCampaign.initializeCampaignForTesting;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * A test class for testing the functionality and initialization of {@link Campaign} objects.
+ *
+ * <p>The test methods ensure that the critical functions of {@link Campaign} operate as expected, including
+ * initialization and personnel generation. This class uses the
+ * {@link TestableCampaign#initializeCampaignForTesting(boolean)} utility to set up the environment before tests are
+ * executed.</p>
+ *
+ * @author Illiani
+ * @since 0.50.07
+ */
+class TestableCampaignTest {
+    static Campaign campaign;
+
+    /**
+     * Sets up resources required for all test methods within this test class by initializing a {@link Campaign}
+     * object.
+     *
+     * <p>This method also validates that the {@link TestableCampaign#initializeCampaignForTesting(boolean)} utility
+     * function successfully initializes and returns a non-null {@link Campaign} instance. If the function returns null
+     * or throws an exception, the test will fail.</p>
+     *
+     * <p>This test is the first warning sign that we've changed something in {@link Campaign} initialization that
+     * will result in test failure. Generally, if we're seeing this test fail, it means a new step needs to be added to
+     * {@link TestableCampaign#initializeCampaignForTesting(boolean)}.</p>
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    @BeforeAll
+    static void beforeAll() {
+        try {
+            campaign = initializeCampaignForTesting(true);
+        } catch (Exception e) {
+            fail("Failed to create new campaign: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Tests that a new person can be generated for a campaign without throwing any exceptions.
+     *
+     * <p>This method verifies the functionality of the {@link Campaign#newPerson(PersonnelRole)} method to ensure
+     * that a new person can be successfully created. If the method encounters an exception or fails during execution,
+     * the test will fail and provide the exception message.</p>
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    @Test
+    void test_canGeneratePerson() {
+        try {
+            campaign.newPerson(PersonnelRole.MEKWARRIOR);
+        } catch (Exception e) {
+            fail("Failed to create new person: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
# Introduction
We've long had an issue of over dependency on the `Campaign` class. This makes it difficult to test with real objects, as the path to setting up a testable Campaign object is not necessarily clear.

This has historically resulted in two consequences: we stop testing as soon as we hit something that requires campaign. Or, we mock campaign and then discover (very quickly) just how entwined many of our core systems are _to_ campaign and how mocking isn't always sufficient to cover all needs.

That last point is the bigger problem, as it results in us being in an awkward situation where to test certain actions we have to mock half of the functionality implemented in campaign and several of the subsystems linked to it. Speaking from experience, this gets messy fast. The more effort something takes, the less likely it's going to be done, resulting in the first point: a lack of tests for campaign-related functionality.

# Solution
While on my vacation I've been putting a lot of thought into this problem and how to solve it. Today, I decided to put some of my theories into practice and see whether I could simplify the campaign testing process. This was predominantly a mental exercise and I hadn't expected practical results. However, I'm happy to say that the exercise proved fruitful.

This experimentation has resulted in the creation of the `initializeCampaignForTesting` utility method. This static method does all of the setup required to test with real campaign objects. It also optionally includes an extra step for when we want to specifically use `campaign.newPerson()` (as that requires Skill Types to be initialized). I opted to create a special handler there, as that's one of our more under tested areas specifically due to the difficulty of testing with campaign.

# Usage
To use this method just slap a method call in a `BeforeAll` at the top of your test. You can then call the generated campaign in any test without issue. If you are performing specialized tasks you may need to initialize some components separately (such as initializing default currencies if you're handling currency stuff). I opted not to initialize _everything_ in an attempt to try and keep this method as small as possible. That means only the bare minimum is initialized.

<img width="570" alt="image" src="https://github.com/user-attachments/assets/9ee77c57-20a9-4a6e-a771-99c7ca4d61eb" />

# Some Considerations
Campaign objects are large and therefore expensive to create. Test authors should avoid using real campaign objects wherever possible. Instead, a better approach is to break the class or method's dependency on campaign. This can be done by passing in only the specific information necessary. Or, using getters to handle interaction with campaign _inside_ campaign, rather than in remote classes.

Given the encompassing nature of Campaign, breaking dependency isn't always possible. In those cases we should try to mock Campaign, instead. For most simple tasks this is easily done. In cases where mocking Campaign isn't practical or cannot provide reliable results, that's when we should be using this new utility method. It is a method of _last_ resort, not first.

Overuse of real campaign objects in testing _will_ result in test times skyrocketing.

# Future Work
We really need to break Campaign into multiple smaller classes. Even ignoring the benefits to testing this would create, we pass campaign around like a bag of candy. This is demonstrably expensive and has led to the situation we find ourselves in. With this in mind I propose a three-pronged approach:

- Reduce dependency on campaign wherever possible: as we're modifying classes and methods, see if improvements can be made to remove dependency on campaign.
- Move campaign's logic out of campaign itself, so that `Campaign.java` is a purely data class. I am imagining `CampaignData.java` and `CampaignLogic.java`. Ideally, the latter being largely static methods allowing us to call the functionality without needing to move the whole class about. Especially as `CampaignLogic.java` will likely inherit `Campaign.java`'s chunkiness.
- As we're moving logic out of Campaign be on the lookout for places where further separation can be made. For example, we likely don't need to have most (all?) of Parts in Use living in CampaignLogic.