### PR TITLE
Personnel report rework for addition of secondary roles

### DIFF
--- a/MekHQ/resources/mekhq/resources/PersonnelReport.properties
+++ b/MekHQ/resources/mekhq/resources/PersonnelReport.properties
@@ -1,0 +1,6 @@
+# suppress inspection "UnusedProperty" for the whole file
+## reports
+secondary.support= \ \
+  \{0}
+secondary.combat= \ \
+  \{0}

--- a/MekHQ/resources/mekhq/resources/PersonnelReport.properties
+++ b/MekHQ/resources/mekhq/resources/PersonnelReport.properties
@@ -1,6 +1,43 @@
 # suppress inspection "UnusedProperty" for the whole file
 ## reports
-secondary.support= \ \
-  \{0}
-secondary.combat= \ \
-  \{0}
+secondary.support.header.text=Secondary RoleSupport Personnel
+secondary.support.text=Total Secondary Role Support Personnel
+
+secondary.combat.header.text=Secondary Role Combat Personnel
+secondary.combat.text=Total Secondary Role Combat Personnel
+
+combat.personnel.header.text=Combat Personnel
+combat.personnel.text=Total Combat Personnel
+combat.injured.text=Injured Combat Personnel
+combat.MIA.text=MIA Combat Personnel
+combat.KIA.text=KIA Combat Personnel
+combat.retired.text=Retired Combat Personnel
+combat.dead.text=Dead Combat Personnel
+combat.student.text=Student Combat Personnel
+combat.salary.text=Monthly Salary For Combat Personnel
+
+support.personnel.header.text=Support Personnel
+support.personnel.text=Total Support Personnel
+support.injured.text=Injured Support Personnel
+support.MIA.text=MIA Support Personnel
+support.KIA.text=KIA Support Personnel
+support.retired.text=Retired Support Personnel
+support.dead.text=Dead Support Personnel
+support.student.text=Student Support Personnel
+support.salary.text=Monthly Salary For Support Personnel
+
+support.dependant.text=You have {0} adult civilian of which {1} are students
+support.dependants.text=You have {0} adult civilian of which {1} are students
+support.child.text=You have {0} child of which {1} are students
+support.children.text=You have {0} children of which {1} are students
+dependant.salary.text=Monthly Salary For Civilians
+
+prisoner.text=You have {0} prisoner
+prisoners.text=You have {0} prisoners
+
+bondsman.text=You have {0} bondsman
+bondsmen.text=You have {0} bondsmen
+
+secondary.combat={0}
+secondary.support={0}
+

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -34,6 +34,7 @@
 package mekhq.campaign.report;
 
 import java.time.LocalDate;
+import java.util.EnumMap;
 
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
@@ -244,15 +245,15 @@ public class PersonnelReport extends AbstractReport {
     }
 
     public String getSecondarySupportPersonnelDetails() {
-        final PersonnelRole[] personnelRoles = PersonnelRole.values();
-        int[] countPersonByType = new int[personnelRoles.length];
+        EnumMap<PersonnelRole, Integer> countPersonByType = new EnumMap<>(PersonnelRole.class);
         int countSecondary = 0;
         for (Person person : getCampaign().getPersonnel()) {
             // Add them to the total count
             final boolean secondarySupport = person.getSecondaryRole().isSupport(true);
 
             if (secondarySupport && person.getPrisonerStatus().isFree() && person.getStatus().isActive()) {
-                countPersonByType[person.getSecondaryRole().ordinal()]++;
+                countPersonByType.put(person.getSecondaryRole(),
+                      (countPersonByType.getOrDefault(person.getSecondaryRole(), 0) + 1));
                 countSecondary++;
                 }
             }
@@ -261,27 +262,28 @@ public class PersonnelReport extends AbstractReport {
 
         sb.append(String.format("%-30s%4s\n", "Total Secondary Role Support Personnel", countSecondary));
 
-        for (PersonnelRole role : personnelRoles) {
-            if (role.isSupport(true)) {
+        countPersonByType.forEach((role, value) ->
+            {if (role.isSupport(true) && value >= 0){
                 sb.append(String.format("    %-30s    %4s\n",
-                      role.getLabel(getCampaign().getFaction().isClan()),
-                      countPersonByType[role.ordinal()]));
+                     role.getLabel(getCampaign().getFaction().isClan()),
+                      value));
             }
-        }
+        });
 
         return sb.toString();
     }
 
     public String getSecondaryCombatPersonnelDetails() {
-        final PersonnelRole[] personnelRoles = PersonnelRole.values();
-        int[] countPersonByType = new int[personnelRoles.length];
+        EnumMap<PersonnelRole, Integer> countPersonByType = new EnumMap<>(PersonnelRole.class);
+
         int countSecondary = 0;
         for (Person person : getCampaign().getPersonnel()) {
             // Add them to the total count
             final boolean secondaryCombat = person.getSecondaryRole().isCombat();
 
             if (secondaryCombat && person.getPrisonerStatus().isFree() && person.getStatus().isActive()) {
-                countPersonByType[person.getSecondaryRole().ordinal()]++;
+                countPersonByType.put(person.getSecondaryRole(),
+                      (countPersonByType.getOrDefault(person.getSecondaryRole(), 0) + 1));
                 countSecondary++;
             }
         }
@@ -290,13 +292,13 @@ public class PersonnelReport extends AbstractReport {
 
         sb.append(String.format("%-30s %4s\n", "Total Secondary Role Combat Personnel", countSecondary));
 
-        for (PersonnelRole role : personnelRoles) {
-            if (role.isCombat()) {
-                sb.append(String.format("    %-30s    %4s\n",
-                      role.getLabel(getCampaign().getFaction().isClan()),
-                      countPersonByType[role.ordinal()]));
-            }
+        countPersonByType.forEach((role, value) ->
+        {if (role.isCombat() && value >= 0){
+            sb.append(String.format("    %-30s    %4s\n",
+                  role.getLabel(getCampaign().getFaction().isClan()),
+                  value));
         }
+        });
 
         return sb.toString();
     }

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -36,10 +36,14 @@ package mekhq.campaign.report;
 import java.time.LocalDate;
 import java.util.EnumMap;
 
+import megamek.common.internationalization.I18n;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
+
+import static mekhq.utilities.MHQInternationalization.getFormattedText;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
  * @author Jay Lawson
@@ -270,7 +274,7 @@ public class PersonnelReport extends AbstractReport {
             }
         });
 
-        return sb.toString();
+        return getFormattedTextAt("mekhq.resources.PersonnelReport", "secondary.support", sb.toString());
     }
 
     public String getSecondaryCombatPersonnelDetails() {
@@ -300,6 +304,6 @@ public class PersonnelReport extends AbstractReport {
         }
         });
 
-        return sb.toString();
+        return getFormattedTextAt("mekhq.resources.PersonnelReport", "secondary.combat", sb.toString());
     }
 }

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -108,6 +108,8 @@ public class PersonnelReport extends AbstractReport {
             }
         }
 
+        sb.append(getSecondaryCombatPersonnelDetails());
+
         sb.append('\n')
               .append(String.format("%-30s        %4s\n", "Injured Combat Personnel", countInjured))
               .append(String.format("%-30s        %4s\n", "MIA Combat Personnel", countMIA))
@@ -171,7 +173,6 @@ public class PersonnelReport extends AbstractReport {
             } else if (primarySupport && person.getStatus().isStudent()) {
                 countStudents++;
             }
-
             if (person.getPrimaryRole().isDependent() &&
                       !person.getStatus().isDepartedUnit() &&
                       person.getPrisonerStatus().isFree()) {
@@ -217,6 +218,8 @@ public class PersonnelReport extends AbstractReport {
         sb.append(String.format("    %-30s    %4s\n", "Temp Medics", getCampaign().getMedicPool()));
         sb.append(String.format("    %-30s    %4s\n", "Temp Astechs", getCampaign().getAstechPool()));
 
+        sb.append(getSecondarySupportPersonnelDetails());
+
         sb.append('\n')
               .append(String.format("%-30s        %4s\n", "Injured Support Personnel", countInjured))
               .append(String.format("%-30s        %4s\n", "MIA Support Personnel", countMIA))
@@ -236,6 +239,64 @@ public class PersonnelReport extends AbstractReport {
               .append(civilianSalaries.toAmountAndSymbolString())
               .append(String.format("\nYou have " + prisoners + " prisoner%s", prisoners == 1 ? "" : "s"))
               .append(String.format("\nYou have " + bondsmen + " %s", (bondsmen == 1) ? "bondsman" : "bondsmen"));
+
+        return sb.toString();
+    }
+
+    public String getSecondarySupportPersonnelDetails() {
+        final PersonnelRole[] personnelRoles = PersonnelRole.values();
+        int[] countPersonByType = new int[personnelRoles.length];
+        int countSecondary = 0;
+        for (Person person : getCampaign().getPersonnel()) {
+            // Add them to the total count
+            final boolean secondarySupport = person.getSecondaryRole().isSupport(true);
+
+            if (secondarySupport && person.getPrisonerStatus().isFree() && person.getStatus().isActive()) {
+                countPersonByType[person.getSecondaryRole().ordinal()]++;
+                countSecondary++;
+                }
+            }
+
+        StringBuilder sb = new StringBuilder("\nSecondary Role Support Personnel\n\n");
+
+        sb.append(String.format("%-30s%4s\n", "Total Secondary Role Support Personnel", countSecondary));
+
+        for (PersonnelRole role : personnelRoles) {
+            if (role.isSupport(true)) {
+                sb.append(String.format("    %-30s    %4s\n",
+                      role.getLabel(getCampaign().getFaction().isClan()),
+                      countPersonByType[role.ordinal()]));
+            }
+        }
+
+        return sb.toString();
+    }
+
+    public String getSecondaryCombatPersonnelDetails() {
+        final PersonnelRole[] personnelRoles = PersonnelRole.values();
+        int[] countPersonByType = new int[personnelRoles.length];
+        int countSecondary = 0;
+        for (Person person : getCampaign().getPersonnel()) {
+            // Add them to the total count
+            final boolean secondaryCombat = person.getSecondaryRole().isCombat();
+
+            if (secondaryCombat && person.getPrisonerStatus().isFree() && person.getStatus().isActive()) {
+                countPersonByType[person.getSecondaryRole().ordinal()]++;
+                countSecondary++;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder("\nSecondary Role Combat Personnel\n\n");
+
+        sb.append(String.format("%-30s %4s\n", "Total Secondary Role Combat Personnel", countSecondary));
+
+        for (PersonnelRole role : personnelRoles) {
+            if (role.isCombat()) {
+                sb.append(String.format("    %-30s    %4s\n",
+                      role.getLabel(getCampaign().getFaction().isClan()),
+                      countPersonByType[role.ordinal()]));
+            }
+        }
 
         return sb.toString();
     }

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -35,14 +35,14 @@ package mekhq.campaign.report;
 
 import java.time.LocalDate;
 import java.util.EnumMap;
+import java.util.ResourceBundle;
 
-import megamek.common.internationalization.I18n;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 
-import static mekhq.utilities.MHQInternationalization.getFormattedText;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 /**
@@ -54,6 +54,9 @@ public class PersonnelReport extends AbstractReport {
         super(campaign);
     }
     //endregion Constructors
+
+    private final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.PersonnelReport",
+          MekHQ.getMHQOptions().getLocale());
 
     public String getCombatPersonnelDetails() {
         final PersonnelRole[] personnelRoles = PersonnelRole.values();
@@ -101,9 +104,9 @@ public class PersonnelReport extends AbstractReport {
 
         }
 
-        StringBuilder sb = new StringBuilder("Combat Personnel\n\n");
+        StringBuilder sb = new StringBuilder(resources.getString("combat.personnel.header.text")+"\n\n");
 
-        sb.append(String.format("%-30s        %4s\n", "Total Combat Personnel", countTotal));
+        sb.append(String.format("%-30s        %4s\n", resources.getString("combat.personnel.text"), countTotal));
 
         for (PersonnelRole role : personnelRoles) {
             if (role.isCombat()) {
@@ -116,16 +119,16 @@ public class PersonnelReport extends AbstractReport {
         sb.append(getSecondaryCombatPersonnelDetails());
 
         sb.append('\n')
-              .append(String.format("%-30s        %4s\n", "Injured Combat Personnel", countInjured))
-              .append(String.format("%-30s        %4s\n", "MIA Combat Personnel", countMIA))
-              .append(String.format("%-30s        %4s\n", "KIA Combat Personnel", countKIA))
-              .append(String.format("%-30s        %4s\n", "Retired Combat Personnel", countRetired))
-              .append(String.format("%-30s        %4s\n", "Dead Combat Personnel", countDead))
-              .append(String.format("%-30s        %4s\n", "Student Combat Personnel", countStudents))
-              .append("\nMonthly Salary For Combat Personnel: ")
+              .append(String.format("%-30s        %4s\n", resources.getString("combat.injured.text"), countInjured))
+              .append(String.format("%-30s        %4s\n", resources.getString("combat.MIA.text"), countMIA))
+              .append(String.format("%-30s        %4s\n", resources.getString("combat.KIA.text"), countKIA))
+              .append(String.format("%-30s        %4s\n", resources.getString("combat.retired.text"), countRetired))
+              .append(String.format("%-30s        %4s\n", resources.getString("combat.dead.text"), countDead))
+              .append(String.format("%-30s        %4s\n", resources.getString("combat.student.text"), countStudents))
+              .append("\n").append(resources.getString("combat.salary.text")).append(": ")
               .append(salary.toAmountAndSymbolString());
 
-        return sb.toString();
+        return getFormattedTextAt("mekhq.resources.PersonnelReport", "secondary.combat", sb.toString());
     }
 
     public String getSupportPersonnelDetails() {
@@ -207,9 +210,9 @@ public class PersonnelReport extends AbstractReport {
                                    .getRoleBaseSalaries()[PersonnelRole.MEDIC.ordinal()].getAmount().doubleValue() *
                                    getCampaign().getMedicPool());
 
-        StringBuilder sb = new StringBuilder("Support Personnel\n\n");
+        StringBuilder sb = new StringBuilder(resources.getString("support.personnel.header.text")+"\n\n");
 
-        sb.append(String.format("%-30s        %4s\n", "Total Support Personnel", countTotal));
+        sb.append(String.format("%-30s        %4s\n", resources.getString("support.personnel.text"), countTotal));
 
         for (PersonnelRole role : personnelRoles) {
             if (role.isSupport(true)) {
@@ -226,26 +229,31 @@ public class PersonnelReport extends AbstractReport {
         sb.append(getSecondarySupportPersonnelDetails());
 
         sb.append('\n')
-              .append(String.format("%-30s        %4s\n", "Injured Support Personnel", countInjured))
-              .append(String.format("%-30s        %4s\n", "MIA Support Personnel", countMIA))
-              .append(String.format("%-30s        %4s\n", "KIA Support Personnel", countKIA))
-              .append(String.format("%-30s        %4s\n", "Retired Support Personnel", countRetired))
-              .append(String.format("%-30s        %4s\n", "Dead Support Personnel", countDead))
-              .append(String.format("%-30s        %4s\n", "Student Support Personnel", countStudents))
-              .append("\nMonthly Salary For Support Personnel: ")
+              .append(String.format("%-30s        %4s\n", resources.getString("support.injured.text"), countInjured))
+              .append(String.format("%-30s        %4s\n", resources.getString("support.MIA.text"), countMIA))
+              .append(String.format("%-30s        %4s\n", resources.getString("support.KIA.text"), countKIA))
+              .append(String.format("%-30s        %4s\n", resources.getString("support.retired.text"), countRetired))
+              .append(String.format("%-30s        %4s\n", resources.getString("support.dead.text"), countDead))
+              .append(String.format("%-30s        %4s\n", resources.getString("support.student.text"), countStudents))
+              .append("\n").append(resources.getString("support.salary.text")).append(": ")
               .append(salary.toAmountAndSymbolString())
-              .append(String.format("\nYou have " + dependents + " adult %s ",
-                    (dependents == 1) ? "civilian" : "civilians") + "of which " + dependentStudents + " are students")
-              .append(String.format("\nYou have " + children + " %s ", (children == 1) ? "child" : "children") +
-                            "of which " +
-                            childrenStudents +
-                            " are students")
-              .append("\nMonthly Salary For Civilians: ")
+              .append((dependents == 1) ? "\n"+ getFormattedTextAt("mekhq.resources.PersonnelReport", "support.dependant.text"
+                          , dependents, dependentStudents): "\n"+ getFormattedTextAt("mekhq.resources"
+                          + ".PersonnelReport", "support.dependants.text", dependents, dependentStudents))
+              .append((children == 1) ? "\n"+ getFormattedTextAt("mekhq.resources.PersonnelReport", "support.child.text"
+                    , children, childrenStudents): "\n"+ getFormattedTextAt("mekhq.resources"
+                    + ".PersonnelReport", "support.children.text", children, childrenStudents))
+              .append("\n").append(resources.getString("dependant.salary.text")).append(": ")
               .append(civilianSalaries.toAmountAndSymbolString())
-              .append(String.format("\nYou have " + prisoners + " prisoner%s", prisoners == 1 ? "" : "s"))
-              .append(String.format("\nYou have " + bondsmen + " %s", (bondsmen == 1) ? "bondsman" : "bondsmen"));
+              .append("\n").append(resources.getString("support.salary.text")).append(": ")
+              .append("\n").append((prisoners == 1) ? getFormattedTextAt("mekhq.resources"
+                    + ".PersonnelReport", "prisoner.text", prisoners):getFormattedTextAt("mekhq.resources"
+                    + ".PersonnelReport", "prisoners.text", prisoners)).append(": ")
+              .append("\n").append((bondsmen == 1) ? getFormattedTextAt("mekhq.resources"
+                    + ".PersonnelReport", "bondsman.text", bondsmen):getFormattedTextAt("mekhq.resources"
+                    + ".PersonnelReport", "bondsmen.text", bondsmen)).append(": ");
 
-        return sb.toString();
+        return getFormattedTextAt("mekhq.resources.PersonnelReport", "secondary.support", sb.toString());
     }
 
     public String getSecondarySupportPersonnelDetails() {
@@ -262,9 +270,9 @@ public class PersonnelReport extends AbstractReport {
                 }
             }
 
-        StringBuilder sb = new StringBuilder("\nSecondary Role Support Personnel\n\n");
+        StringBuilder sb = new StringBuilder("\n" + resources.getString("secondary.support.header.text")+"\n\n");
 
-        sb.append(String.format("%-30s%4s\n", "Total Secondary Role Support Personnel", countSecondary));
+        sb.append(String.format("%-30s %4s\n", resources.getString("secondary.support.text"), countSecondary));
 
         countPersonByType.forEach((role, value) ->
             {if (role.isSupport(true) && value >= 0){
@@ -292,9 +300,9 @@ public class PersonnelReport extends AbstractReport {
             }
         }
 
-        StringBuilder sb = new StringBuilder("\nSecondary Role Combat Personnel\n\n");
+        StringBuilder sb = new StringBuilder("\n" + resources.getString("secondary.combat.header.text")+"\n\n");
 
-        sb.append(String.format("%-30s %4s\n", "Total Secondary Role Combat Personnel", countSecondary));
+        sb.append(String.format("%-30s %4s\n", resources.getString("secondary.combat.text"), countSecondary));
 
         countPersonByType.forEach((role, value) ->
         {if (role.isCombat() && value >= 0){

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -272,7 +272,7 @@ public class PersonnelReport extends AbstractReport {
 
         StringBuilder sb = new StringBuilder("\n" + resources.getString("secondary.support.header.text")+"\n\n");
 
-        sb.append(String.format("%-30s %4s\n", resources.getString("secondary.support.text"), countSecondary));
+        sb.append(String.format("%-30s%4s\n", resources.getString("secondary.support.text"), countSecondary));
 
         countPersonByType.forEach((role, value) ->
             {if (role.isSupport(true) && value >= 0){


### PR DESCRIPTION
Replaces [PR#7158](https://github.com/MegaMek/mekhq/pull/7158) with a better attempt at i18n support. Answers RFE https://github.com/MegaMek/mekhq/issues/7045

current report
![current personnel report](https://github.com/user-attachments/assets/2d268a81-4f11-499f-b597-449d05e03651)

new report no secondary personnel
![updated new report part 1](https://github.com/user-attachments/assets/66985168-3583-409f-9108-ba445332c1cb)
with some secondary personnel
![updated new report part 2](https://github.com/user-attachments/assets/c35b66f5-fa73-4698-b0cc-838582e5b9b0)
