### PR TITLE
fix: multiple small and simple fixes, reenable planet search, fix npe…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
       - name: Test All
         working-directory: mekhq
         run: ./gradlew testAll  --stacktrace --scan
+        env:
+          mm.profile: dev
 
       - name: Upload Test Logs on Failure
         uses: actions/upload-artifact@v4
@@ -121,6 +123,7 @@ jobs:
         with:
           name: cd-failure-logs
           path: ./mekhq/MekHQ/build/reports/
+          overwrite: true
 
       - name: Build with Gradle
         working-directory: mekhq

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -9501,22 +9501,6 @@ public class Campaign implements ITechManager {
         atbEventProcessor.shutdown();
     }
 
-    @Deprecated(forRemoval = true, since = "0.50.05")
-    public boolean checkOverDueLoans() {
-        Money overdueAmount = getFinances().checkOverdueLoanPayments(this);
-        if (overdueAmount.isPositive()) {
-            // FIXME : Localize
-            JOptionPane.showMessageDialog(null,
-                  "You have overdue loan payments totaling " +
-                        overdueAmount.toAmountAndSymbolString() +
-                        "\nYou must deal with these payments before advancing the day.\nHere are some options:\n  - Sell off equipment to generate funds.\n  - Pay off the collateral on the loan.\n  - Default on the loan.\n  - Just cheat and remove the loan via GM mode.",
-                  "Overdue Loan Payments",
-                  JOptionPane.WARNING_MESSAGE);
-            return true;
-        }
-        return false;
-    }
-
     /**
      * Checks if an employee turnover prompt should be displayed based on campaign options, current date, and other
      * conditions (like transit status and campaign start date).

--- a/MekHQ/src/mekhq/campaign/market/PartsStore.java
+++ b/MekHQ/src/mekhq/campaign/market/PartsStore.java
@@ -68,9 +68,11 @@ public class PartsStore {
     private Map<String, Part> nameAndDetailMap;
 
     public PartsStore(Campaign c) {
+        logger.debug("Creating PartsStore for campaign");
         parts = new ArrayList<>(EXPECTED_SIZE);
         nameAndDetailMap = new HashMap<>(EXPECTED_SIZE);
         stock(c);
+        logger.debug("Finished creating PartsStore for campaign");
     }
 
     public ArrayList<Part> getInventory() {

--- a/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/CombatRole.java
@@ -135,7 +135,7 @@ public enum CombatRole {
         } catch (Exception ignored) {
         }
 
-        MMLogger.create(CombatRole.class).error("Unable to parse " + text + " into an CombatRole. Returning RESERVE.");
+        MMLogger.create(CombatRole.class).warn("Unable to parse {} into an CombatRole. Returning RESERVE.", text);
         return RESERVE;
     }
     // endregion File I/O

--- a/MekHQ/src/mekhq/campaign/parts/VeeStabilizer.java
+++ b/MekHQ/src/mekhq/campaign/parts/VeeStabilizer.java
@@ -59,7 +59,7 @@ public class VeeStabilizer extends Part {
     public VeeStabilizer(int tonnage, int loc, Campaign c) {
         super(tonnage, c);
         this.loc = loc;
-        this.name = "Vehicle Stabiliser";
+        this.name = "Vehicle Stabilizer";
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -154,6 +154,7 @@ public class Person {
     public static final String UNLUCKY_LABEL = "UNLUCKY";
     public static final int MINIMUM_UNLUCKY = 0;
     public static final int MAXIMUM_UNLUCKY = 5;
+    private static final String DELIMITER = "::";
 
 
     private PersonAwardController awardController;
@@ -708,7 +709,7 @@ public class Person {
 
     /**
      * Return a full last name which may be a bloodname or a surname with or without a post-nominal. A bloodname will
-     * overrule a surname but we do not disallow surnames for clan personnel, if the player wants to input them
+     * overrule a surname, but we do not disallow surnames for clan personnel, if the player wants to input them
      *
      * @return a String of the person's last name
      */
@@ -2603,20 +2604,20 @@ public class Person {
             if (countOptions(PersonnelOptions.LVL3_ADVANTAGES) > 0) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent,
                       "advantages",
-                      getOptionList("::", PersonnelOptions.LVL3_ADVANTAGES));
+                      getOptionList(DELIMITER, PersonnelOptions.LVL3_ADVANTAGES));
             }
 
             if (countOptions(PersonnelOptions.EDGE_ADVANTAGES) > 0) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent,
                       "edge",
-                      getOptionList("::", PersonnelOptions.EDGE_ADVANTAGES));
+                      getOptionList(DELIMITER, PersonnelOptions.EDGE_ADVANTAGES));
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "edgeAvailable", getCurrentEdge());
             }
 
             if (countOptions(PersonnelOptions.MD_ADVANTAGES) > 0) {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent,
                       "implants",
-                      getOptionList("::", PersonnelOptions.MD_ADVANTAGES));
+                      getOptionList(DELIMITER, PersonnelOptions.MD_ADVANTAGES));
             }
 
             if (!techUnits.isEmpty()) {
@@ -3312,7 +3313,7 @@ public class Person {
             person.setFullName(); // this sets the name based on the loaded values
 
             if ((advantages != null) && !advantages.isBlank()) {
-                StringTokenizer st = new StringTokenizer(advantages, "::");
+                StringTokenizer st = new StringTokenizer(advantages, DELIMITER);
                 while (st.hasMoreTokens()) {
                     String adv = st.nextToken();
                     String advName = Crew.parseAdvantageName(adv);
@@ -3337,7 +3338,7 @@ public class Person {
             }
 
             if ((implants != null) && !implants.isBlank()) {
-                StringTokenizer st = new StringTokenizer(implants, "::");
+                StringTokenizer st = new StringTokenizer(implants, DELIMITER);
                 while (st.hasMoreTokens()) {
                     String adv = st.nextToken();
                     String advName = Crew.parseAdvantageName(adv);
@@ -3525,7 +3526,7 @@ public class Person {
      * @param edgeOptionList the list of edge triggers to remove
      */
     private static void updateOptions(String edgeTriggers, Person retVal, List<String> edgeOptionList) {
-        StringTokenizer st = new StringTokenizer(edgeTriggers, "::");
+        StringTokenizer st = new StringTokenizer(edgeTriggers, DELIMITER);
 
         while (st.hasMoreTokens()) {
             String trigger = st.nextToken();
@@ -3583,7 +3584,7 @@ public class Person {
      *
      * @param campaign     the campaign the person is a part of
      * @param money        the value of a single share
-     * @param sharesForAll whether or not all personnel have shares
+     * @param sharesForAll whether all personnel have shares
      */
     public void payPersonShares(final Campaign campaign, final Money money, final boolean sharesForAll) {
         final int shares = getNumShares(campaign, sharesForAll);
@@ -3860,7 +3861,7 @@ public class Person {
                 }
             }
             case VEHICLE_CREW -> {
-                // Vehicle crew are a special case as they just need one of any of the following skills to qualify,
+                // Vehicle crew are a special case as they just need any one of the following skills to qualify,
                 // rather than needing all relevant skills
                 List<String> relevantSkills = List.of(SkillType.S_TECH_MEK,
                       SkillType.S_TECH_AERO,
@@ -4233,7 +4234,7 @@ public class Person {
     }
 
     /**
-     * @return the the number of skills learned by the character.
+     * @return the number of skills learned by the character.
      */
     public int getSkillNumber() {
         return skills.size();
@@ -4470,7 +4471,7 @@ public class Person {
     }
 
     /**
-     * @return an html-coded list that says what abilities are enabled for this pilot
+     * @return a html-coded list that says what abilities are enabled for this pilot
      */
     public @Nullable String getAbilityListAsString(final String type) {
         final StringBuilder abilityString = new StringBuilder();
@@ -4588,7 +4589,7 @@ public class Person {
     }
 
     /**
-     * @return an html-coded tooltip that says what edge will be used
+     * @return a html-coded tooltip that says what edge will be used
      */
     public String getEdgeTooltip() {
         final StringBuilder stringBuilder = new StringBuilder();
@@ -4609,7 +4610,7 @@ public class Person {
      * Determines whether the user possesses the necessary skills to operate the given entity.
      *
      * <p>The required skills are based on the type of the provided entity. The method checks for specific piloting or
-     * gunnery skills relevant to the entity type, such as Mechs, VTOLs, tanks, aerospace units, battle armor, and
+     * gunnery skills relevant to the entity type, such as Meks, VTOLs, tanks, aerospace units, battle armor, and
      * others.</p>
      *
      * <p>If the appropriate skill(s) for the entity type are present, the method returns {@code true}; otherwise, it
@@ -4650,7 +4651,7 @@ public class Person {
      * Determines whether the user possesses the necessary skills to operate weapons for the given entity.
      *
      * <p>The required gunnery skill is dependent on the type of entity provided. This method checks for the relevant
-     * gunnery or weapon skill associated with the entity type, such as Mechs, tanks, aerospace units, battle armor,
+     * gunnery or weapon skill associated with the entity type, such as Mek, tanks, aerospace units, battle armor,
      * infantry, and others.</p>
      *
      * <p>Returns {@code true} if the necessary skill(s) to use the entity's weapons are present; {@code false}
@@ -5590,7 +5591,7 @@ public class Person {
      * without making any changes.</p>
      *
      * <p>The new score is computed as the sum of the current score and the delta, and it is passed
-     * to {@link Attributes#setAttributeScore(Phenotype, PersonnelOptions, SkillAttribute, int)} to ensure is compiles
+     * to {@link Attributes#setAttributeScore(Phenotype, PersonnelOptions, SkillAttribute, int)} to ensure it compiles
      * with the character's minimum and maximum attribute score values.</p>
      *
      * @param attribute The {@link SkillAttribute} whose score is to be modified. Must not be <code>null</code>.
@@ -5980,7 +5981,7 @@ public class Person {
             final UUID id = unit.getId();
             unit = campaign.getUnit(id);
             if (unit == null) {
-                logger.error(String.format("Person %s ('%s') references missing unit %s", getId(), getFullName(), id));
+                logger.error("Person {} ('{}') references missing unit {}", getId(), getFullName(), id);
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/SkillPrerequisite.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SkillPrerequisite.java
@@ -36,6 +36,7 @@ package mekhq.campaign.personnel;
 import java.io.PrintWriter;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.Map;
 
 import megamek.common.UnitType;
 import megamek.logging.MMLogger;
@@ -69,19 +70,17 @@ import org.w3c.dom.NodeList;
  *
  * @author Jay Lawson
  */
-public class SkillPerquisite {
-    private static final MMLogger logger = MMLogger.create(SkillPerquisite.class);
-    private Hashtable<String, Integer> skillSet;
+public class SkillPrerequisite {
+    private static final MMLogger logger = MMLogger.create(SkillPrerequisite.class);
+    private final Hashtable<String, Integer> skillSet = new Hashtable<>();
 
-    public SkillPerquisite() {
-        skillSet = new Hashtable<>();
+    public SkillPrerequisite() {
     }
 
     @Override
-    @SuppressWarnings("unchecked") // FIXME: Broken Java with it's Object clones
-    public SkillPerquisite clone() {
-        SkillPerquisite clone = new SkillPerquisite();
-        clone.skillSet = (Hashtable<String, Integer>) this.skillSet.clone();
+    public SkillPrerequisite clone() {
+        SkillPrerequisite clone = new SkillPrerequisite();
+        clone.skillSet.putAll(Map.copyOf(this.skillSet));
         return clone;
     }
 
@@ -125,42 +124,34 @@ public class SkillPerquisite {
      *
      * @param unitType the type of unit that is being checked
      *
-     * @return
+     * @return true if unit type qualifies as the expected type
      */
     public boolean qualifies(int unitType) {
-        switch (unitType) {
-            case UnitType.AERO:
-            case UnitType.AEROSPACEFIGHTER:
-                return skillSet.containsKey(SkillType.S_PILOT_AERO) || skillSet.containsKey(SkillType.S_GUN_AERO);
-            case UnitType.BATTLE_ARMOR:
-                return skillSet.containsKey(SkillType.S_GUN_BA) || skillSet.containsKey(SkillType.S_ANTI_MEK);
-            case UnitType.CONV_FIGHTER:
-                return skillSet.containsKey(SkillType.S_GUN_JET) || skillSet.containsKey(SkillType.S_PILOT_JET);
-            case UnitType.DROPSHIP:
-            case UnitType.JUMPSHIP:
-            case UnitType.WARSHIP:
-            case UnitType.SPACE_STATION:
-            case UnitType.SMALL_CRAFT:
-                return skillSet.containsKey(SkillType.S_PILOT_SPACE) ||
-                             skillSet.containsKey(SkillType.S_GUN_SPACE) ||
-                             skillSet.containsKey(SkillType.S_TECH_VESSEL) ||
-                             skillSet.containsKey(SkillType.S_NAVIGATION);
-            case UnitType.GUN_EMPLACEMENT:
-            case UnitType.TANK:
-                return skillSet.containsKey(SkillType.S_PILOT_GVEE) || skillSet.containsKey(SkillType.S_GUN_VEE);
-            case UnitType.INFANTRY:
-                return skillSet.containsKey(SkillType.S_SMALL_ARMS) || skillSet.containsKey(SkillType.S_ANTI_MEK);
-            case UnitType.NAVAL:
-                return skillSet.containsKey(SkillType.S_PILOT_NVEE) || skillSet.containsKey(SkillType.S_GUN_VEE);
-            case UnitType.PROTOMEK:
-                return skillSet.containsKey(SkillType.S_GUN_PROTO);
-            case UnitType.VTOL:
-                return skillSet.containsKey(SkillType.S_PILOT_VTOL) || skillSet.containsKey(SkillType.S_GUN_VEE);
-            case UnitType.MEK:
-                return skillSet.containsKey(SkillType.S_PILOT_MEK) || skillSet.containsKey(SkillType.S_GUN_MEK);
-            default:
-                return false;
-        }
+        return switch (unitType) {
+            case UnitType.AERO, UnitType.AEROSPACEFIGHTER ->
+                  skillSet.containsKey(SkillType.S_PILOT_AERO) || skillSet.containsKey(SkillType.S_GUN_AERO);
+            case UnitType.BATTLE_ARMOR ->
+                  skillSet.containsKey(SkillType.S_GUN_BA) || skillSet.containsKey(SkillType.S_ANTI_MEK);
+            case UnitType.CONV_FIGHTER ->
+                  skillSet.containsKey(SkillType.S_GUN_JET) || skillSet.containsKey(SkillType.S_PILOT_JET);
+            case UnitType.DROPSHIP, UnitType.JUMPSHIP, UnitType.WARSHIP, UnitType.SPACE_STATION, UnitType.SMALL_CRAFT ->
+                  skillSet.containsKey(SkillType.S_PILOT_SPACE) ||
+                        skillSet.containsKey(SkillType.S_GUN_SPACE) ||
+                        skillSet.containsKey(SkillType.S_TECH_VESSEL) ||
+                        skillSet.containsKey(SkillType.S_NAVIGATION);
+            case UnitType.GUN_EMPLACEMENT, UnitType.TANK ->
+                  skillSet.containsKey(SkillType.S_PILOT_GVEE) || skillSet.containsKey(SkillType.S_GUN_VEE);
+            case UnitType.INFANTRY ->
+                  skillSet.containsKey(SkillType.S_SMALL_ARMS) || skillSet.containsKey(SkillType.S_ANTI_MEK);
+            case UnitType.NAVAL ->
+                  skillSet.containsKey(SkillType.S_PILOT_NVEE) || skillSet.containsKey(SkillType.S_GUN_VEE);
+            case UnitType.PROTOMEK -> skillSet.containsKey(SkillType.S_GUN_PROTO);
+            case UnitType.VTOL ->
+                  skillSet.containsKey(SkillType.S_PILOT_VTOL) || skillSet.containsKey(SkillType.S_GUN_VEE);
+            case UnitType.MEK ->
+                  skillSet.containsKey(SkillType.S_PILOT_MEK) || skillSet.containsKey(SkillType.S_GUN_MEK);
+            default -> false;
+        };
     }
 
     public int getSkillLevel(String skillName) {
@@ -176,7 +167,7 @@ public class SkillPerquisite {
 
     @Override
     public String toString() {
-        String toReturn = "";
+        StringBuilder toReturn = new StringBuilder();
         Enumeration<String> enumKeys = skillSet.keys();
         while (enumKeys.hasMoreElements()) {
             String key = enumKeys.nextElement();
@@ -185,12 +176,14 @@ public class SkillPerquisite {
             if (lvl >= SkillType.EXP_GREEN) {
                 skillLvl = SkillType.getExperienceLevelName(lvl) + ' ';
             }
-            toReturn += skillLvl + SkillType.getType(key).getName();
+            if (SkillType.getType(key) != null) {
+                toReturn.append(skillLvl).append(SkillType.getType(key).getName());
+            }
             if (enumKeys.hasMoreElements()) {
-                toReturn += "<br>OR ";
+                toReturn.append("<br>OR ");
             }
         }
-        return '{' + toReturn + '}';
+        return '{' + toReturn.toString() + '}';
     }
 
     public void writeToXML(final PrintWriter pw, int indent) {
@@ -209,11 +202,11 @@ public class SkillPerquisite {
         MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "skillPrereq");
     }
 
-    public static SkillPerquisite generateInstanceFromXML(Node wn) {
-        SkillPerquisite retVal = null;
+    public static SkillPrerequisite generateInstanceFromXML(Node wn) {
+        SkillPrerequisite retVal = null;
 
         try {
-            retVal = new SkillPerquisite();
+            retVal = new SkillPrerequisite();
             NodeList nl = wn.getChildNodes();
 
             for (int x = 0; x < nl.getLength(); x++) {
@@ -247,18 +240,13 @@ public class SkillPerquisite {
         if (temp.length < 2) {
             return 0;
         } else {
-            switch (temp[1].substring(0, 1)) {
-                case "G":
-                    return 1;
-                case "R":
-                    return 2;
-                case "V":
-                    return 3;
-                case "E":
-                    return 4;
-                default:
-                    return 0;
-            }
+            return switch (temp[1].substring(0, 1)) {
+                case "G" -> 1;
+                case "R" -> 2;
+                case "V" -> 3;
+                case "E" -> 4;
+                default -> 0;
+            };
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/SpecialAbility.java
@@ -64,12 +64,7 @@ import megamek.logging.MMLogger;
 import mekhq.Utilities;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.personnel.enums.PersonnelRole;
-import mekhq.campaign.personnel.skills.Skills;
 import mekhq.utilities.MHQXMLUtility;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * This object will serve as a wrapper for a specific pilot special ability. In the actual person object we will use
@@ -100,7 +95,7 @@ public class SpecialAbility {
 
     // prerequisite skills and options
     private Vector<String> prereqAbilities;
-    private Vector<SkillPerquisite> prereqSkills;
+    private Vector<SkillPrerequisite> prereqSkills;
     private Map<String, String> prereqMisc;
 
     // these are abilities that will disqualify the person from getting the current
@@ -149,13 +144,13 @@ public class SpecialAbility {
         clone.invalidAbilities = (Vector<String>) this.invalidAbilities.clone();
         clone.removeAbilities = (Vector<String>) this.removeAbilities.clone();
         clone.choiceValues = (Vector<String>) this.choiceValues.clone();
-        clone.prereqSkills = (Vector<SkillPerquisite>) this.prereqSkills.clone();
+        clone.prereqSkills = (Vector<SkillPrerequisite>) this.prereqSkills.clone();
         clone.prereqMisc = new HashMap<>(this.prereqMisc);
         return clone;
     }
 
     public boolean isEligible(Person p) {
-        for (SkillPerquisite sp : prereqSkills) {
+        for (SkillPrerequisite sp : prereqSkills) {
             if (!sp.qualifies(p)) {
                 return false;
             }
@@ -180,7 +175,7 @@ public class SpecialAbility {
     }
 
     public boolean isEligible(boolean isClanPilot, Skills skills, PersonnelOptions options) {
-        for (SkillPerquisite sp : prereqSkills) {
+        for (SkillPrerequisite sp : prereqSkills) {
             if (!sp.qualifies(skills)) {
                 return false;
             }
@@ -236,11 +231,11 @@ public class SpecialAbility {
         this.weight = weight;
     }
 
-    public Vector<SkillPerquisite> getPrereqSkills() {
+    public Vector<SkillPrerequisite> getPrereqSkills() {
         return prereqSkills;
     }
 
-    public void setPrereqSkills(Vector<SkillPerquisite> prereq) {
+    public void setPrereqSkills(Vector<SkillPrerequisite> prereq) {
         prereqSkills = prereq;
     }
 
@@ -286,7 +281,7 @@ public class SpecialAbility {
               Utilities.combineString(invalidAbilities, "::"));
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "removeAbilities", Utilities.combineString(removeAbilities, "::"));
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "choiceValues", Utilities.combineString(choiceValues, "::"));
-        for (SkillPerquisite skillpre : prereqSkills) {
+        for (SkillPrerequisite skillpre : prereqSkills) {
             skillpre.writeToXML(pw, indent);
         }
 
@@ -322,7 +317,7 @@ public class SpecialAbility {
                 } else if (wn2.getNodeName().equalsIgnoreCase("choiceValues")) {
                     retVal.choiceValues = Utilities.splitString(wn2.getTextContent(), "::");
                 } else if (wn2.getNodeName().equalsIgnoreCase("skillPrereq")) {
-                    SkillPerquisite skill = SkillPerquisite.generateInstanceFromXML(wn2);
+                    SkillPrerequisite skill = SkillPrerequisite.generateInstanceFromXML(wn2);
                     if (!skill.isEmpty()) {
                         retVal.prereqSkills.add(skill);
                     }
@@ -379,7 +374,7 @@ public class SpecialAbility {
                 } else if (wn2.getNodeName().equalsIgnoreCase("choiceValues")) {
                     retVal.choiceValues = Utilities.splitString(wn2.getTextContent(), "::");
                 } else if (wn2.getNodeName().equalsIgnoreCase("skillPrereq")) {
-                    SkillPerquisite skill = SkillPerquisite.generateInstanceFromXML(wn2);
+                    SkillPrerequisite skill = SkillPrerequisite.generateInstanceFromXML(wn2);
                     if (!skill.isEmpty()) {
                         retVal.prereqSkills.add(skill);
                     }
@@ -606,7 +601,7 @@ public class SpecialAbility {
             toReturn += getDisplayName(prereq) + "<br>";
         }
 
-        for (SkillPerquisite skPr : prereqSkills) {
+        for (SkillPrerequisite skPr : prereqSkills) {
             toReturn += skPr + "<br>";
         }
 

--- a/MekHQ/src/mekhq/gui/MapTab.java
+++ b/MekHQ/src/mekhq/gui/MapTab.java
@@ -43,8 +43,11 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
 import java.util.Objects;
 import java.util.ResourceBundle;
+import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -119,13 +122,23 @@ public final class MapTab extends CampaignGuiTab implements ActionListener {
         panTopButtons.add(new JLabel(resourceMap.getString("lblFindPlanet.text")), gridBagConstraints);
 
         suggestPlanet = new JSuggestField(getFrame(), getCampaign().getSystemNames());
-        suggestPlanet.setFocusable(false);
         suggestPlanet.addActionListener(ev -> {
             PlanetarySystem p = getCampaign().getSystemByName(suggestPlanet.getText());
             if (null != p) {
                 panMap.setSelectedSystem(p);
                 panSystem.updatePlanetarySystem(p);
                 refreshPlanetView();
+            }
+        });
+        suggestPlanet.setBorder(BorderFactory.createLineBorder(suggestPlanet.getBackground(), 1));
+        suggestPlanet.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusGained(FocusEvent e) {
+                suggestPlanet.setBorder(BorderFactory.createLineBorder(suggestPlanet.getBackground(), 1));
+            }
+            @Override
+            public void focusLost(FocusEvent e) {
+                suggestPlanet.setBorder(BorderFactory.createLineBorder(suggestPlanet.getBackground(), 1));
             }
         });
         gridBagConstraints = new GridBagConstraints();

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -42,6 +42,7 @@ import mekhq.campaign.personnel.enums.PersonnelRoleSubType;
 import mekhq.campaign.personnel.skills.RandomSkillPreferences;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.universe.Faction;
+import mekhq.gui.CampaignGUI;
 import mekhq.gui.baseComponents.AbstractMHQTabbedPane;
 import mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode;
 import mekhq.gui.campaignOptions.contents.*;
@@ -109,6 +110,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     private MarketsTab marketsTab;
     private SystemsTab systemsTab;
     private RulesetsTab rulesetsTab;
+    private CampaignGUI campaignGui;
 
     /**
      * Constructs a {@code CampaignOptionsPane} for managing campaign settings. This initializes the tabbed pane and
@@ -123,7 +125,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         this.campaign = campaign;
         this.campaignOptions = campaign.getCampaignOptions();
         this.mode = mode;
-
+        if (campaign.getApp() != null) {
+            campaignGui = campaign.getApp().getCampaigngui();
+        }
         initialize();
     }
 
@@ -548,8 +552,9 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         }
 
         campaign.resetRandomDeath();
-
-        campaign.getApp().getCampaigngui().refreshMarketButtonLabels();
+        if (campaignGui != null) {
+            campaignGui.refreshMarketButtonLabels();
+        }
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/EditSkillPreRequisiteDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditSkillPreRequisiteDialog.java
@@ -51,17 +51,17 @@ import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
-import mekhq.campaign.personnel.SkillPerquisite;
+import mekhq.campaign.personnel.SkillPrerequisite;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
 
 /**
  * @author Taharqa
  */
-public class EditSkillPerquisiteDialog extends JDialog {
-    private static final MMLogger logger = MMLogger.create(EditSkillPerquisiteDialog.class);
+public class EditSkillPreRequisiteDialog extends JDialog {
+    private static final MMLogger logger = MMLogger.create(EditSkillPreRequisiteDialog.class);
 
-    private SkillPerquisite prereq;
+    private SkillPrerequisite prereq;
 
     private JButton btnClose;
     private JButton btnOK;
@@ -70,7 +70,7 @@ public class EditSkillPerquisiteDialog extends JDialog {
     private final Hashtable<String, JComboBox<SkillLevel>> skillLevels = new Hashtable<>();
     private final Hashtable<String, JCheckBox> skillChks = new Hashtable<>();
 
-    public EditSkillPerquisiteDialog(final JFrame frame, final SkillPerquisite pre) {
+    public EditSkillPreRequisiteDialog(final JFrame frame, final SkillPrerequisite pre) {
         super(frame, true);
         cancelled = false;
         prereq = pre;
@@ -138,7 +138,7 @@ public class EditSkillPerquisiteDialog extends JDialog {
      */
     private void setUserPreferences() {
         try {
-            PreferencesNode preferences = MekHQ.getMHQPreferences().forClass(EditSkillPerquisiteDialog.class);
+            PreferencesNode preferences = MekHQ.getMHQPreferences().forClass(EditSkillPreRequisiteDialog.class);
             this.setName("dialog");
             preferences.manage(new JWindowPreference(this));
         } catch (Exception ex) {
@@ -147,7 +147,7 @@ public class EditSkillPerquisiteDialog extends JDialog {
     }
 
     private void done() {
-        prereq = new SkillPerquisite();
+        prereq = new SkillPrerequisite();
         for (String type : SkillType.skillList) {
             if (skillChks.get(type).isSelected()) {
                 prereq.addPrereq(type, skillLevels.get(type).getSelectedIndex());
@@ -156,7 +156,7 @@ public class EditSkillPerquisiteDialog extends JDialog {
         this.setVisible(false);
     }
 
-    public SkillPerquisite getPrereq() {
+    public SkillPrerequisite getPrereq() {
         return prereq;
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/EditSpecialAbilityDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EditSpecialAbilityDialog.java
@@ -57,7 +57,7 @@ import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
-import mekhq.campaign.personnel.SkillPerquisite;
+import mekhq.campaign.personnel.SkillPrerequisite;
 import mekhq.campaign.personnel.SpecialAbility;
 
 /**
@@ -76,10 +76,10 @@ public class EditSpecialAbilityDialog extends JDialog {
     private JButton btnEditInvalid;
     private JButton btnEditRemove;
     private JButton btnClearPrerequisiteSkills;
-    private JButton btnAddSkillPerquisite;
+    private JButton btnAddSkillPrerequisite;
 
     private Vector<String> prerequisiteAbilities;
-    private Vector<SkillPerquisite> prerequisiteSkills;
+    private Vector<SkillPrerequisite> prerequisiteSkills;
     private Vector<String> invalidAbilities;
     private Vector<String> removeAbilities;
 
@@ -104,7 +104,7 @@ public class EditSpecialAbilityDialog extends JDialog {
         prerequisiteAbilities = (Vector<String>) ability.getPrereqAbilities().clone();
         invalidAbilities = (Vector<String>) ability.getInvalidAbilities().clone();
         removeAbilities = (Vector<String>) ability.getRemovedAbilities().clone();
-        prerequisiteSkills = (Vector<SkillPerquisite>) ability.getPrereqSkills().clone();
+        prerequisiteSkills = (Vector<SkillPrerequisite>) ability.getPrereqSkills().clone();
         cancelled = false;
         currentXP = ability.getCost();
         initComponents();
@@ -311,10 +311,10 @@ public class EditSpecialAbilityDialog extends JDialog {
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         panSkill.add(new JLabel("<html><b>Prerequisite Skill Sets</b></html>"), gridBagConstraints);
 
-        btnAddSkillPerquisite = new JButton("Add Skill Prerequisite");
-        btnAddSkillPerquisite.addActionListener(evt -> {
-            EditSkillPerquisiteDialog newSkillPrerequisiteDialog = new EditSkillPerquisiteDialog(null,
-                  new SkillPerquisite());
+        btnAddSkillPrerequisite = new JButton("Add Skill Prerequisite");
+        btnAddSkillPrerequisite.addActionListener(evt -> {
+            EditSkillPreRequisiteDialog newSkillPrerequisiteDialog = new EditSkillPreRequisiteDialog(null,
+                  new SkillPrerequisite());
             newSkillPrerequisiteDialog.setVisible(true);
             if (!newSkillPrerequisiteDialog.wasCancelled() && !newSkillPrerequisiteDialog.getPrereq().isEmpty()) {
                 prerequisiteSkills.add(newSkillPrerequisiteDialog.getPrereq());
@@ -328,7 +328,7 @@ public class EditSpecialAbilityDialog extends JDialog {
         gridBagConstraints.weighty = 0.0;
         gridBagConstraints.insets = new Insets(2, 2, 2, 2);
         gridBagConstraints.fill = GridBagConstraints.NONE;
-        panSkill.add(btnAddSkillPerquisite, gridBagConstraints);
+        panSkill.add(btnAddSkillPrerequisite, gridBagConstraints);
 
         btnClearPrerequisiteSkills = new JButton("Clear Skill Prerequisites");
         btnClearPrerequisiteSkills.addActionListener(evt -> {
@@ -357,7 +357,7 @@ public class EditSpecialAbilityDialog extends JDialog {
         JButton btnRemoveSkill;
         JButton btnEditSkill;
         for (int i = 0; i < prerequisiteSkills.size(); i++) {
-            SkillPerquisite skillPerquisite = prerequisiteSkills.get(i);
+            SkillPrerequisite skillPrerequisite = prerequisiteSkills.get(i);
             panSkPre = new JPanel(new GridBagLayout());
 
             GridBagConstraints c = new GridBagConstraints();
@@ -369,7 +369,7 @@ public class EditSpecialAbilityDialog extends JDialog {
             c.anchor = GridBagConstraints.NORTHWEST;
             c.insets = new Insets(2, 2, 2, 2);
             c.fill = GridBagConstraints.BOTH;
-            panSkPre.add(new JLabel("<html>" + skillPerquisite.toString() + "</html>"), c);
+            panSkPre.add(new JLabel("<html>" + skillPrerequisite.toString() + "</html>"), c);
 
             c.gridx = 1;
             c.gridy = 0;
@@ -501,12 +501,12 @@ public class EditSpecialAbilityDialog extends JDialog {
         getContentPane().repaint();
     }
 
-    private void removeSkillPerquisite(int i) {
+    private void removeSkillPreRequisite(int i) {
         prerequisiteSkills.remove(i);
     }
 
-    private void editSkillPerquisite(int i) {
-        EditSkillPerquisiteDialog newSkillPrerequisiteDialog = new EditSkillPerquisiteDialog(null,
+    private void editSkillPreRequisite(int i) {
+        EditSkillPreRequisiteDialog newSkillPrerequisiteDialog = new EditSkillPreRequisiteDialog(null,
               prerequisiteSkills.get(i));
         newSkillPrerequisiteDialog.setVisible(true);
         if (!newSkillPrerequisiteDialog.wasCancelled() && !newSkillPrerequisiteDialog.getPrereq().isEmpty()) {
@@ -527,7 +527,7 @@ public class EditSpecialAbilityDialog extends JDialog {
         @Override
         public void actionPerformed(ActionEvent evt) {
             int id = Integer.parseInt(evt.getActionCommand());
-            removeSkillPerquisite(id);
+            removeSkillPreRequisite(id);
             refreshGUI();
         }
     }
@@ -540,7 +540,7 @@ public class EditSpecialAbilityDialog extends JDialog {
         @Override
         public void actionPerformed(ActionEvent evt) {
             int id = Integer.parseInt(evt.getActionCommand());
-            editSkillPerquisite(id);
+            editSkillPreRequisite(id);
             refreshGUI();
         }
     }


### PR DESCRIPTION
# What it does?

- Removes one function marked for deletion
- Improves logger on campaign xml parser (not all entries, but most)
- Naming convention applied for some instances of "mek" incorrectly named in the code
- A few javadocs improvements
- SkillPerquisite renamed as SkillPrerequisite (probably need to be renamed to SkillPreRequisite)?
- Refactored SkillPrerequisite to use a more robust clone method.
- Missing "VeeStabiliser" in parts deserializer restored with special migration process that is "rename hardened".
- Fix NPE that is caused when setting up the config on a new campaign.
- Fix NPE on SPA Utilities.
- Restore funcitonality to Planet Search on map tab
- Remove the blue border when the planet search is focused.