### PR TITLE
Fix: #7185 Fixed Mothballed Units Teleporting to Already Deployed Forces

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
+++ b/MekHQ/src/mekhq/campaign/unit/MothballInfo.java
@@ -33,9 +33,9 @@ import java.util.List;
 import java.util.UUID;
 
 import megamek.Version;
-import megamek.common.force.Force;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
@@ -63,7 +63,7 @@ public class MothballInfo {
      * Parameterless constructor, used for deserialization.
      */
     private MothballInfo() {
-        forceId = Force.NO_FORCE;
+        forceId = Force.FORCE_NONE;
     }
 
     /**
@@ -168,8 +168,11 @@ public class MothballInfo {
             unit.setNavigator(navigator);
         }
 
-        if (campaign.getForce(forceId) != null) {
-            campaign.addUnitToForce(unit, forceId);
+        Force force = campaign.getForce(forceId);
+        if (force != null) {
+            if (!force.isDeployed()) {
+                campaign.addUnitToForce(unit, forceId);
+            }
         }
 
         unit.resetEngineer();


### PR DESCRIPTION
Close #7185

Now, when activating a unit, if the unit is a part of a force that is currently marked as 'deployed' the unit is not returned to that force.

### Tests
- Tested that units would not be restored to their original force if that force is currently deployed to the AO (both deployed to a scenario and not).
- Tested that units _would_ be restored to their original force if that force is _not_ currently deployed to the AO.