### PR TITLE
Fix: #7180 Fixed Tooltips for Personnel Generation in Campaign Options

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -731,14 +731,14 @@ lblRandomizeOrigin.text=Randomize Origin
 lblRandomizeOrigin.tooltip=This option determines whether new characters should randomize their\
   \ origins based on campaign faction and planet.
 lblRandomizeDependentsOrigin.text=Randomize Civilian Origins
-lblRandomizeDependentsOrigin.tooltip=This generates a random origin faction and planet for\
-  \ personnel based on the selected settings.
-lblRandomizeAroundSpecifiedPlanet.text=Randomize Around Specific Planet
-lblRandomizeAroundSpecifiedPlanet.tooltip=Civilians have their origins randomized so that they do\
+lblRandomizeDependentsOrigin.tooltip=Civilians have their origins randomized so that they do\
   \ not come from the current planet and the campaign's faction but instead have origins randomized\
   \ in the same way as standard personnel.
-lblSpecifiedSystemFactionSpecific.text=Faction Specific \u26A0
-lblSpecifiedSystemFactionSpecific.tooltip=Limit the system options based on faction.\
+lblRandomizeAroundSpecifiedPlanet.text=Randomize Around Specific Planet
+lblRandomizeAroundSpecifiedPlanet.tooltip=This causes new personnel to always generate around a specific planet \
+  (chosen below).
+lblSpecifiedSystemFactionSpecific.text=Limit System Options by Campaign Faction \u26A0
+lblSpecifiedSystemFactionSpecific.tooltip=Temporarily limit the system options based on faction.\
   <br>\
   <br><b>Warning:</b> Must be toggled off-and-on again if you change faction after enabling this option.
 lblSpecifiedSystem.text=System


### PR DESCRIPTION
Close #7180

Some of the background options had misplaced tooltips, showing the tooltips for other options. Furthermore, the 'Faction Specific' label wasn't clear in that it only filtered the system picker rather than being a campaign option in its own right.

I updated the tooltips and the label to make this clearer.