### PR TITLE
Fix: #7151 Fixed Typos in Convoy Escort Scenarios

### DIFF
--- a/MekHQ/data/scenariotemplates/Close Air Support.xml
+++ b/MekHQ/data/scenariotemplates/Close Air Support.xml
@@ -4,7 +4,7 @@
     <shortBriefing>Provide air support, minimize losses.</shortBriefing>
     <detailedBriefing><![CDATA[Your mission is to provide air support to allied ground forces currently under heavy attack. The enemy is pressing hard, and without intervention, our forces will be overwhelmed. You are to engage hostile units with precision strikes, break enemy formations, and relieve pressure on friendly positions. Coordination with ground command will be critical to ensuring maximum impact.
 
-Your primary objective is to preserve at least 50% of allied forces. Their survival is paramount to maintaining battlefield cohesion. Simultaneously, you must destroy or route at least 50% of the enemy forces. This engagement is about turning the tide, forcing them to break, and ensuring our ground forces can hold firm.
+Your primary objective is to preserve at least 50% of allied forces. Their survival is paramount to maintaining battlefield cohesion. Simultaneously, you must destroy or rout at least 50% of the enemy forces. This engagement is about turning the tide, forcing them to break, and ensuring our ground forces can hold firm.
 
 The winner of this battle will control the field when the engagement is over. You must ensure that victory belongs to us. Strike hard, strike true, and do not let the enemy dictate the pace of battle. Your firepower will decide the outcome.]]></detailedBriefing>
     <battlefieldControl>VICTOR</battlefieldControl>

--- a/MekHQ/data/scenariotemplates/Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Convoy Escort.xml
@@ -5,7 +5,7 @@
     <shortBriefing>Escort supply convoy or defeat attackers.</shortBriefing>
     <detailedBriefing><![CDATA[An allied convoy carrying critical supplies is moving through hostile territory, and enemy forces are preparing to intercept. Your mission is to ensure that the convoy reaches its destination. At least 50% of the convoy must reach the far edge of the engagement area intact. These supplies are vital to sustaining our operations, and failure is not an option.
 
-Should the enemy resistance prove too strong for a full escort, you have an alternative means to secure victory. If at least 50% of the convoy survives while you destroy or route 50% of the enemy forces, the mission will be considered a success. Breaking the enemy’s will to fight will give the convoy a clear path forward.
+Should the enemy resistance prove too strong for a full escort, you have an alternative means to secure victory. If at least 50% of the convoy survives while you destroy or rout 50% of the enemy forces, the mission will be considered a success. Breaking the enemy’s will to fight will give the convoy a clear path forward.
 
 We will control the field at the conclusion of the battle. This means you have full authority to dictate the engagement on your terms. Use the terrain, control the tempo, and eliminate threats efficiently. Hold the line, protect the convoy, and ensure that these supplies reach their destination.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -5,7 +5,7 @@
     <shortBriefing>Escort critical convoy or defeat attackers.</shortBriefing>
     <detailedBriefing><![CDATA[An allied convoy carrying critical supplies is moving through hostile territory, and a large, heavily armed enemy force is preparing to intercept. Your mission is to ensure that at least 50% of the convoy reaches the far edge of the engagement area intact. These supplies are essential to sustaining our war effort, and failure is not an option.
 
-The enemy will come in force, but their attack is not unstoppable. If a full escort proves untenable, you have an alternative path to victory. Should at least 50% of the convoy survive while you destroy or route 50% of the attacking enemy force, the mission will be considered a success. Breaking their offensive will allow our convoy to continue forward without further resistance.
+The enemy will come in force, but their attack is not unstoppable. If a full escort proves untenable, you have an alternative path to victory. Should at least 50% of the convoy survive while you destroy or rout 50% of the attacking enemy force, the mission will be considered a success. Breaking their offensive will allow our convoy to continue forward without further resistance.
 
 We will control the field at the end of the battle, giving you full authority to dictate the engagement on our terms. Use the terrain, stagger your defenses, and counter their assault with precision. Hold the line, protect the convoy, and ensure these supplies reach their destination. Victory here will secure our war effort in this sector.]]></detailedBriefing>
     <battlefieldControl>PLAYER</battlefieldControl>


### PR DESCRIPTION
Close #7151

`destroy or route` -> `destroy or rout`