### PR TITLE
Improvement: #7196 Improved Civilian Generation to Include Better Control Over Random Profession Selection

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -555,11 +555,8 @@ lblDependentProfessionDieSize.text=Dependent Profession Chance: \u26A0 <span sty
 lblDependentProfessionDieSize.tooltip=This is the number of sides on the die rolled to determine whether a\
   \ a civilian should generate with the Dependent profession.\
   <br>\
-  <br>A civilian will generation with the Dependent profession on a roll of 1. Set to 0 to disable civilians \
-  having a fixed chance to generate with the Dependent profession.\
-  <br>\
-  <br><b>Warning:</b> Setting this to 0 will not completely disable the Dependent profession, it only removes the \
-  fixed chance of Civilians generating with that profession.
+  <br>A civilian will generation with the Dependent profession on a roll of 1. Set to 0 to prevent Civilians from \
+  spawning with the catch-all 'Professional' profession.
 lblCivilianProfessionDieSize.text=Civilian Profession Chance: \u26A0 <span style="color:#C344C3;">\u2605</span> 1 in
 lblCivilianProfessionDieSize.tooltip=This is the number of sides on the die rolled to determine whether a\
   \ a civilian should generate with a random non-Dependent profession.\

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -551,6 +551,24 @@ lblUseRandomDependentAddition.tooltip=This enables the monthly addition of rando
 lblUseRandomDependentRemoval.text=Random Removal
 lblUseRandomDependentRemoval.tooltip=This enables the monthly removal of random civilians from the\
   \ campaign.
+lblDependentProfessionDieSize.text=Dependent Profession Chance: \u26A0 <span style="color:#C344C3;">\u2605</span> 1 in
+lblDependentProfessionDieSize.tooltip=This is the number of sides on the die rolled to determine whether a\
+  \ a civilian should generate with the Dependent profession.\
+  <br>\
+  <br>A civilian will generation with the Dependent profession on a roll of 1. Set to 0 to disable civilians \
+  having a fixed chance to generate with the Dependent profession.\
+  <br>\
+  <br><b>Warning:</b> Setting this to 0 will not completely disable the Dependent profession, it only removes the \
+  fixed chance of Civilians generating with that profession.
+lblCivilianProfessionDieSize.text=Civilian Profession Chance: \u26A0 <span style="color:#C344C3;">\u2605</span> 1 in
+lblCivilianProfessionDieSize.tooltip=This is the number of sides on the die rolled to determine whether a\
+  \ a civilian should generate with a random non-Dependent profession.\
+  <br>\
+  <br>A civilian will generate with a non-Dependent profession on a roll of 1. Set to 0 to disable random \
+  non-Dependent profession assignment.\
+  <br>\
+  <br><b>Warning:</b> This check is made <i>after</i> the check to see whether a character is generated as a \
+  Dependent. That means the actual chance of a character generating as a Dependent will be lower than displayed.
 # createMedicalTab
 lblMedicalTab.text=Medical Options
 lblUseAdvancedMedical.text=Use Advanced Medical \u270E \u2318

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1923,10 +1923,8 @@ public class Campaign implements ITechManager {
         PersonnelRole civilianProfession = PersonnelRole.MISCELLANEOUS_JOB;
 
         int dependentProfessionDieSize = campaignOptions.getDependentProfessionDieSize();
-        if (dependentProfessionDieSize > 0) { // A value of 0 denotes that this system has been disabled
-            if (randomInt(dependentProfessionDieSize) == 0) {
-                civilianProfession = PersonnelRole.DEPENDENT;
-            }
+        if (dependentProfessionDieSize == 0 || randomInt(dependentProfessionDieSize) == 0) {
+            civilianProfession = PersonnelRole.DEPENDENT;
         }
 
         int civilianProfessionDieSize = campaignOptions.getCivilianProfessionDieSize();

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -52,7 +52,6 @@ import java.util.stream.Collectors;
 
 import megamek.Version;
 import megamek.codeUtilities.MathUtility;
-import megamek.common.EquipmentType;
 import megamek.common.TechConstants;
 import megamek.common.enums.SkillLevel;
 import megamek.common.options.GameOptions;
@@ -75,14 +74,13 @@ import mekhq.campaign.personnel.enums.*;
 import mekhq.campaign.personnel.skills.Skills;
 import mekhq.campaign.randomEvents.prisoners.enums.PrisonerCaptureStyle;
 import mekhq.campaign.rating.UnitRatingMethod;
+import mekhq.campaign.universe.PlanetarySystem.PlanetaryRating;
+import mekhq.campaign.universe.PlanetarySystem.PlanetarySophistication;
 import mekhq.gui.campaignOptions.enums.ProcurementPersonnelPick;
 import mekhq.service.mrms.MRMSOption;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import mekhq.campaign.universe.PlanetarySystem.PlanetarySophistication;
-import mekhq.campaign.universe.Planet;
-import mekhq.campaign.universe.PlanetarySystem.PlanetaryRating;
 
 /**
  * @author natit
@@ -278,6 +276,8 @@ public class CampaignOptions {
     // Dependent
     private boolean useRandomDependentAddition;
     private boolean useRandomDependentRemoval;
+    private int dependentProfessionDieSize;
+    private int civilianProfessionDieSize;
 
     // Personnel Removal
     private boolean usePersonnelRemoval;
@@ -833,6 +833,8 @@ public class CampaignOptions {
         // Dependent
         setUseRandomDependentAddition(false);
         setUseRandomDependentRemoval(false);
+        setDependentProfessionDieSize(4);
+        setCivilianProfessionDieSize(2);
 
         // Personnel Removal
         setUsePersonnelRemoval(false);
@@ -2388,6 +2390,22 @@ public class CampaignOptions {
 
     public void setUseRandomDependentRemoval(final boolean useRandomDependentRemoval) {
         this.useRandomDependentRemoval = useRandomDependentRemoval;
+    }
+
+    public int getDependentProfessionDieSize() {
+        return dependentProfessionDieSize;
+    }
+
+    public void setDependentProfessionDieSize(final int dependentProfessionDieSize) {
+        this.dependentProfessionDieSize = dependentProfessionDieSize;
+    }
+
+    public int getCivilianProfessionDieSize() {
+        return civilianProfessionDieSize;
+    }
+
+    public void setCivilianProfessionDieSize(final int civilianProfessionDieSize) {
+        this.civilianProfessionDieSize = civilianProfessionDieSize;
     }
     // endregion Dependent
 
@@ -5052,6 +5070,8 @@ public class CampaignOptions {
         // region Dependent
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useRandomDependentAddition", isUseRandomDependentAddition());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useRandomDependentRemoval", isUseRandomDependentRemoval());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "dependentProfessionDieSize", getDependentProfessionDieSize());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "civilianProfessionDieSize", getCivilianProfessionDieSize());
         // endregion Dependent
 
         // region Personnel Removal
@@ -5899,6 +5919,10 @@ public class CampaignOptions {
                     campaignOptions.setUseRandomDependentAddition(Boolean.parseBoolean(nodeContents));
                 } else if (nodeName.equalsIgnoreCase("useRandomDependentRemoval")) {
                     campaignOptions.setUseRandomDependentRemoval(Boolean.parseBoolean(nodeContents));
+                } else if (nodeName.equalsIgnoreCase("dependentProfessionDieSize")) {
+                    campaignOptions.setDependentProfessionDieSize(MathUtility.parseInt(nodeContents, 4));
+                } else if (nodeName.equalsIgnoreCase("civilianProfessionDieSize")) {
+                    campaignOptions.setCivilianProfessionDieSize(MathUtility.parseInt(nodeContents, 2));
                     // endregion Dependent
 
                     // region Personnel Removal

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsUtilities.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsUtilities.java
@@ -245,6 +245,25 @@ public class CampaignOptionsUtilities {
         return customWrapSize == null ? 100 : customWrapSize;
     }
 
+    /**
+     * Creates a {@link MouseAdapter} that updates the text of a {@link JLabel} within the specified panel to display a
+     * tip string when the mouse enters a related component.
+     *
+     * <p>
+     * When the mouse enters a component with the specified name, this adapter retrieves a localized tip string
+     * associated with that component. If the tip contains fewer than five HTML line break tags ({@code <br>}), extra
+     * line breaks are appended to ensure a minimum number of lines. The formatted tip is then set as the text of a
+     * {@link JLabel} within the provided panel, specifically targeting labels whose name matches the required pattern.
+     * </p>
+     *
+     * @param associatedHeaderPanel   the {@link JPanel} containing the label to update
+     * @param sourceComponentBaseName the name of the component whose tip string will be shown in the label
+     *
+     * @return a {@link MouseAdapter} instance that updates the label with formatted tip text on mouse enter
+     *
+     * @author Illiani
+     * @since 0.50.06
+     */
     public static MouseAdapter createTipPanelUpdater(CampaignOptionsHeaderPanel associatedHeaderPanel,
           @Nullable String sourceComponentBaseName) {
         return createTipPanelUpdater(associatedHeaderPanel, sourceComponentBaseName, null);
@@ -263,6 +282,8 @@ public class CampaignOptionsUtilities {
      *
      * @param associatedHeaderPanel         the {@link JPanel} containing the label to update
      * @param sourceComponentBaseName the name of the component whose tip string will be shown in the label
+     * @param replacementText the specific text to use, or {@code null} if the text should be dynamically fetched
+     *                        from the source component.
      *
      * @return a {@link MouseAdapter} instance that updates the label with formatted tip text on mouse enter
      *

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
@@ -199,6 +199,10 @@ public class PersonnelTab {
     private JPanel dependentsPanel;
     private JCheckBox chkUseRandomDependentAddition;
     private JCheckBox chkUseRandomDependentRemoval;
+    private JLabel lblDependentProfessionDieSize;
+    private JSpinner spnDependentProfessionDieSize;
+    private JLabel lblCivilianProfessionDieSize;
+    private JSpinner spnCivilianProfessionDieSize;
     //end Prisoners and Dependents Tab
     //end Salaries Tab
 
@@ -239,6 +243,10 @@ public class PersonnelTab {
         dependentsPanel = new JPanel();
         chkUseRandomDependentAddition = new JCheckBox();
         chkUseRandomDependentRemoval = new JCheckBox();
+        lblDependentProfessionDieSize = new JLabel();
+        spnDependentProfessionDieSize = new JSpinner();
+        lblCivilianProfessionDieSize = new JLabel();
+        spnCivilianProfessionDieSize = new JSpinner();
     }
 
     /**
@@ -1050,7 +1058,7 @@ public class PersonnelTab {
         // Header
         prisonersAndDependentsHeader = new CampaignOptionsHeaderPanel("PrisonersAndDependentsTab",
               getImageDirectory() + "logo_illyrian_palatinate.png",
-              2);
+              9);
 
         // Contents
         prisonerPanel = createPrisonersPanel();
@@ -1133,9 +1141,26 @@ public class PersonnelTab {
         chkUseRandomDependentAddition = new CampaignOptionsCheckBox("UseRandomDependentAddition");
         chkUseRandomDependentAddition.addMouseListener(createTipPanelUpdater(prisonersAndDependentsHeader,
               "UseRandomDependentAddition"));
+
         chkUseRandomDependentRemoval = new CampaignOptionsCheckBox("UseRandomDependentRemoval");
         chkUseRandomDependentRemoval.addMouseListener(createTipPanelUpdater(prisonersAndDependentsHeader,
               "UseRandomDependentRemoval"));
+
+        lblDependentProfessionDieSize = new CampaignOptionsLabel("DependentProfessionDieSize");
+        lblDependentProfessionDieSize.addMouseListener(createTipPanelUpdater(prisonersAndDependentsHeader,
+              "DependentProfessionDieSize"));
+        spnDependentProfessionDieSize = new CampaignOptionsSpinner("DependentProfessionDieSize",
+              4, 0, 100, 1);
+        spnDependentProfessionDieSize.addMouseListener(createTipPanelUpdater(prisonersAndDependentsHeader,
+              "DependentProfessionDieSize"));
+
+        lblCivilianProfessionDieSize = new CampaignOptionsLabel("CivilianProfessionDieSize");
+        lblCivilianProfessionDieSize.addMouseListener(createTipPanelUpdater(prisonersAndDependentsHeader,
+              "CivilianProfessionDieSize"));
+        spnCivilianProfessionDieSize = new CampaignOptionsSpinner("CivilianProfessionDieSize",
+              2, 0, 100, 1);
+        spnCivilianProfessionDieSize.addMouseListener(createTipPanelUpdater(prisonersAndDependentsHeader,
+              "CivilianProfessionDieSize"));
 
         // Layout the Panel
         final JPanel panel = new CampaignOptionsStandardPanel("DependentsPanel", true, "DependentsPanel");
@@ -1148,6 +1173,17 @@ public class PersonnelTab {
 
         layout.gridy++;
         panel.add(chkUseRandomDependentRemoval, layout);
+
+        layout.gridy++;
+        panel.add(lblDependentProfessionDieSize, layout);
+        layout.gridx++;
+        panel.add(spnDependentProfessionDieSize, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(lblCivilianProfessionDieSize, layout);
+        layout.gridx++;
+        panel.add(spnCivilianProfessionDieSize, layout);
 
         return panel;
     }
@@ -1308,6 +1344,8 @@ public class PersonnelTab {
         comboPrisonerCaptureStyle.setSelectedItem(options.getPrisonerCaptureStyle());
         chkUseRandomDependentAddition.setSelected(options.isUseRandomDependentAddition());
         chkUseRandomDependentRemoval.setSelected(options.isUseRandomDependentRemoval());
+        spnDependentProfessionDieSize.setValue(options.getDependentProfessionDieSize());
+        spnCivilianProfessionDieSize.setValue(options.getCivilianProfessionDieSize());
     }
 
     /**
@@ -1400,5 +1438,7 @@ public class PersonnelTab {
         }
         options.setUseRandomDependentAddition(chkUseRandomDependentAddition.isSelected());
         options.setUseRandomDependentRemoval(chkUseRandomDependentRemoval.isSelected());
+        options.setDependentProfessionDieSize((int) spnDependentProfessionDieSize.getValue());
+        options.setCivilianProfessionDieSize((int) spnCivilianProfessionDieSize.getValue());
     }
 }


### PR DESCRIPTION
Close #7196

This adds two new campaign options. The first is a set chance that a random Civilian will generate with the 'Dependent' profession (as opposed to the catch-all 'Professional' profession). The second is the chance that the Civilian will generate with a random civilian profession.