### PR TITLE
Fix: #7127 No Longer Unassign Primary Role if Secondary is Admin, Unassign Secondary Instead

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -3363,20 +3363,20 @@ public class Person {
 
             // This resolves a bug squashed in 2025 (50.03) but lurked in our codebase
             // potentially as far back as 2014. The next two handlers should never be removed.
-            if (!person.canPerformRole(campaign.getLocalDate(), person.getPrimaryRole(), true)) {
-                person.setPrimaryRole(campaign, PersonnelRole.NONE);
-
-                campaign.addReport(String.format(resources.getString("ineligibleForPrimaryRole"),
-                      spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor()),
-                      CLOSING_SPAN_TAG,
-                      person.getHyperlinkedFullTitle()));
-            }
-
             if (!person.canPerformRole(campaign.getLocalDate(), person.getSecondaryRole(), false)) {
                 person.setSecondaryRole(PersonnelRole.NONE);
 
                 campaign.addReport(String.format(resources.getString("ineligibleForSecondaryRole"),
                       spanOpeningWithCustomColor(ReportingUtilities.getWarningColor()),
+                      CLOSING_SPAN_TAG,
+                      person.getHyperlinkedFullTitle()));
+            }
+
+            if (!person.canPerformRole(campaign.getLocalDate(), person.getPrimaryRole(), true)) {
+                person.setPrimaryRole(campaign, PersonnelRole.NONE);
+
+                campaign.addReport(String.format(resources.getString("ineligibleForPrimaryRole"),
+                      spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor()),
                       CLOSING_SPAN_TAG,
                       person.getHyperlinkedFullTitle()));
             }


### PR DESCRIPTION
Close #7127

All this does is swap the checks around so that we check whether the character's secondary profession is valid first, _then_ the primary profession. This ensures that if the character has conflicting professions we remove their secondary profession and not their first. As that lead to weird situations where characters ended up with no primary profession but a secondary profession. Something which should not normally be possible.