### PR TITLE
Fix: #7077 Removed Duplicate 'Haunted' Personality Quirk

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -2785,7 +2785,7 @@ public class Person {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "socialDescriptionIndex", socialDescriptionIndex);
 
             if (personalityQuirk != PersonalityQuirk.NONE) {
-                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "personalityQuirk", personalityQuirk.ordinal());
+                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "personalityQuirk", personalityQuirk.name());
             }
 
             MHQXMLUtility.writeSimpleXMLTag(pw, indent,
@@ -3277,6 +3277,11 @@ public class Person {
                     person.socialDescriptionIndex = MathUtility.parseInt(wn2.getTextContent());
                 } else if (nodeName.equalsIgnoreCase("personalityQuirk")) {
                     person.personalityQuirk = PersonalityQuirk.fromString(wn2.getTextContent());
+
+                    // < 50.07 compatibility handler
+                    if (person.personalityQuirk == PersonalityQuirk.BROKEN) {
+                        person.personalityQuirk = PersonalityQuirk.HAUNTED;
+                    }
                 } else if (nodeName.equalsIgnoreCase("personalityQuirkDescriptionIndex")) {
                     person.personalityQuirkDescriptionIndex = MathUtility.parseInt(wn2.getTextContent());
                 } else if ((nodeName.equalsIgnoreCase("reasoning"))) {

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/PersonalityQuirk.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/PersonalityQuirk.java
@@ -303,6 +303,7 @@ public enum PersonalityQuirk {
     FREEZES,
     TRAUMATIZED,
     HAUNTED,
+    @Deprecated(since = "0.50.07", forRemoval = true)
     BROKEN,
     REGRETS,
     DARK_SECRET,


### PR DESCRIPTION
It looks like I originally planned to have another quirk called 'Broken' however never realized it. Chances are I went on a dinner break and forgot to write the entry. As I have no recollection of what the intention was here I opted to remove the duplicate quirk (including a compatibility handler).

While I was at it, I also changed the format quirks are saved in from ordinal to name for more robust saving.