### PR TITLE
Fix: #7074 Corrected Typo in Briefing Room Tutorial Panel

### DIFF
--- a/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
@@ -43,7 +43,7 @@ txtStratConTutorial.text=<h2>Scenarios</h2>\
   <li>-1 CVP for each Turning Point loss.</li>\
   <li><b>Crisis</b> scenarios: -1 CVP for a loss or draw. No CVP is awarded for a win.</li></ul>\
   <h2>Combat Roles</h2>\
-  Upon arrival in a target system, assign your forces to combat roles (bottom left corner). Each role serves a specific\
+  Upon arrival in a target system, assign your forces to combat roles (bottom right corner). Each role serves a specific\
   \ purpose:\
   <ul><li><b>Frontline:</b> Enables scenario support with minefields or infantry (if available).</li>\
   <li><b>Maneuver</b> & <b>Auxiliary:</b> Increase the chance of successful reinforcement.</li>\


### PR DESCRIPTION
Close #7074

`bottom left corner` -> `bottom right corner`