### PR TITLE
Fix: #7072 Corrected Tooltip Panel Size in Finance Tab

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/FinancesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/FinancesTab.java
@@ -236,7 +236,7 @@ public class FinancesTab {
     public JPanel createFinancesGeneralOptionsTab() {
         // Header
         financesGeneralOptions = new CampaignOptionsHeaderPanel("FinancesGeneralTab",
-              getImageDirectory() + "logo_star_league.png", 6);
+              getImageDirectory() + "logo_star_league.png", 10);
 
         // Contents
         pnlGeneralOptions = createGeneralOptionsPanel();


### PR DESCRIPTION
Close #7072

There isn't a lot to say about this, I just needed to increase the number of placeholder lines to stop the panel from jumping about.