### PR TITLE
Fix: #7156 Fixed Golden Hello in New Personnel Market Not Remembering Last Setting

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
@@ -228,7 +228,7 @@ public class PersonnelMarketDialog {
         // Golden Hello Checkbox
         leftGbc.gridy = leftRow++;
         leftGbc.insets = new Insets(0, 0, 8, 0);
-        JCheckBox goldenHelloCheckbox = new JCheckBox(getTextAt(RESOURCE_BUNDLE,
+        goldenHelloCheckbox.setText(getTextAt(RESOURCE_BUNDLE,
               "checkbox.personnelMarket.goldenHello"));
         goldenHelloCheckbox.setSelected(market.isOfferingGoldenHello());
         goldenHelloCheckbox.setEnabled(market.getAssociatedPersonnelMarketStyle() == MEKHQ);


### PR DESCRIPTION
Close #7156

The golden hello functionality was working, however when the personnel market was opened it was being reset to 'off'. Now it properly remembers its last state between open-close instances.