### PR TITLE
Improvement: #7218 Add Advance Days Button to New Personnel Market Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/PersonnelMarket.properties
+++ b/MekHQ/resources/mekhq/resources/PersonnelMarket.properties
@@ -6,6 +6,7 @@ title.personnelMarket.mercenary=++ACCESSING MERCNET RECRUITMENT SERVICES++
 title.personnelMarket.normal=++ACCESSING PERSONNEL REQUISITIONS++
 button.personnelMarket.hire.normal=<html><b>Recruit</b></html>
 button.personnelMarket.hire.gm=Recruit (GM)
+button.personnelMarket.advanceDays=Advance Days
 checkbox.personnelMarket.goldenHello=Offer Golden Hello
 label.personnelMarket.filter=Role:
 label.personnelMarket.availability=<html><b>Personnel Availability</b></html>

--- a/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
@@ -68,6 +68,7 @@ import mekhq.campaign.market.personnelMarket.markets.NewPersonnelMarket;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.PlanetarySystem;
+import mekhq.gui.dialog.AdvanceDaysDialog;
 import mekhq.gui.enums.PersonnelFilter;
 import mekhq.gui.view.PersonViewPanel;
 
@@ -106,7 +107,7 @@ import mekhq.gui.view.PersonViewPanel;
  * @author Illiani
  * @since 0.50.06
  */
-public class PersonnelMarketDialog {
+public class PersonnelMarketDialog extends JDialog {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.PersonnelMarket";
 
     private static final int MAXIMUM_DAYS_IN_MONTH = 31;
@@ -153,14 +154,11 @@ public class PersonnelMarketDialog {
      * @since 0.50.06
      */
     public void initializeComponents() {
-        JDialog dialog = new JDialog(parent);
-        setDialogTitle(dialog);
-        dialog.addWindowListener(new WindowAdapter() {
+        setDialogTitle();
+        addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
-                market.setOfferingGoldenHello(goldenHelloCheckbox.isSelected());
-                market.setCurrentApplicants(currentApplicants);
-                dialog.dispose();
+                closeAction();
             }
         });
 
@@ -194,13 +192,28 @@ public class PersonnelMarketDialog {
 
         // This handles the initializing and display of the applicant panel
         JSplitPane splitPane = initializePersonView(selectedPerson, mainPanel);
-        dialog.getContentPane().add(splitPane, BorderLayout.CENTER);
+        getContentPane().add(splitPane, BorderLayout.CENTER);
 
         // Finalize the dialog
-        dialog.setModal(true);
-        dialog.pack();
-        dialog.setLocationRelativeTo(parent);
-        dialog.setVisible(true);
+        setModal(true);
+        pack();
+        setLocationRelativeTo(parent);
+        setVisible(true);
+    }
+
+    /**
+     * Applies the current UI settings to the {@link NewPersonnelMarket} object and closes the dialog.
+     *
+     * <p>This method updates the market's "golden hello" offering status and the list of current applicants based on
+     * the user selections, then disposes of the dialog.</p>
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private void closeAction() {
+        market.setOfferingGoldenHello(goldenHelloCheckbox.isSelected());
+        market.setCurrentApplicants(currentApplicants);
+        dispose();
     }
 
 
@@ -344,6 +357,21 @@ public class PersonnelMarketDialog {
         addGMButton.setEnabled(isGM);
         buttonPanel.add(addGMButton);
 
+        JButton advanceMultipleDays = new JButton(getTextAt(RESOURCE_BUNDLE, "button.personnelMarket.advanceDays"));
+        advanceMultipleDays.addActionListener(e -> {
+            closeAction(); // Close old instance
+
+            AdvanceDaysDialog advanceDaysDialog = new AdvanceDaysDialog(parent, campaign.getApp().getCampaigngui());
+            advanceDaysDialog.setVisible(true);
+            advanceDaysDialog.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosed(WindowEvent e) {
+                    new PersonnelMarketDialog(market); // Open a new instance (to ensure the market is refreshed)
+                }
+            });
+        });
+        buttonPanel.add(advanceMultipleDays);
+
         return buttonPanel;
     }
 
@@ -480,25 +508,23 @@ public class PersonnelMarketDialog {
     /**
      * Sets the dialog's title based on market and campaign context.
      *
-     * @param dialog the dialog window to set the title on
-     *
      * @author Illiani
      * @since 0.50.06
      */
-    private void setDialogTitle(JDialog dialog) {
+    private void setDialogTitle() {
         Faction campaignFaction = campaign.getFaction();
         if (campaignFaction.isClan()) {
-            dialog.setTitle(getTextAt(RESOURCE_BUNDLE, "title.personnelMarket.clan"));
+            setTitle(getTextAt(RESOURCE_BUNDLE, "title.personnelMarket.clan"));
         } else if (campaignFaction.isComStarOrWoB()) {
             Person commander = campaign.getFlaggedCommander();
             String address = commander != null ? commander.getTitleAndSurname() : campaign.getCommanderAddress(false);
-            dialog.setTitle(getFormattedTextAt(RESOURCE_BUNDLE,
+            setTitle(getFormattedTextAt(RESOURCE_BUNDLE,
                   "title.personnelMarket.comStarOrWoB",
                   address.toUpperCase()));
         } else if (campaignFaction.isMercenary()) {
-            dialog.setTitle(getTextAt(RESOURCE_BUNDLE, "title.personnelMarket.mercenary"));
+            setTitle(getTextAt(RESOURCE_BUNDLE, "title.personnelMarket.mercenary"));
         } else if (campaignFaction.isMercenary()) {
-            dialog.setTitle(getTextAt(RESOURCE_BUNDLE, "title.personnelMarket.normal"));
+            setTitle(getTextAt(RESOURCE_BUNDLE, "title.personnelMarket.normal"));
         }
     }
 


### PR DESCRIPTION
Close #7218

This adds a shortcut button to the new personnel market that opens the advance multiple days dialog. I opted for this approach for a couple of reasons.

- The new personnel market always updates on the 1st of the month, meaning advancing intermediary days is unnecessary.
- Adding an 'advance to new month' button would require a lot of work essentially replicating the functionality found in the advance multiple days dialog.
- Using the advance multiple days dialog means that any improvements made to that dialog will be replicated here. Furthermore, it gives the player the most control over how many days they advance.