### PR TITLE
Improvement: #7220 Loosened Applicant Experience Level Clamping in New Personnel Market

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import megamek.common.Compute;
 import megamek.common.enums.Gender;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -243,7 +244,7 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
         unorderedMarketEntries = sanitizeMarketEntries(unorderedMarketEntries);
         List<PersonnelMarketEntry> orderedMarketEntries = getMarketEntriesAsList(unorderedMarketEntries);
 
-        for (int roll = 0; roll < getRecruitmentRolls(); roll++) {
+        for (int recruitmentRoll = 0; recruitmentRoll < getRecruitmentRolls(); recruitmentRoll++) {
             Person applicant = generateSingleApplicant(unorderedMarketEntries, orderedMarketEntries);
             if (applicant == null) {
                 continue;
@@ -252,8 +253,22 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
             int applicantSkill = applicant.getSkillLevel(getCampaign(), false).getExperienceLevel();
 
             if (applicantSkill > averageSkillLevel) {
-                getLogger().debug("Applicant is too experienced for the campaign, skipping.");
-                continue;
+                boolean notInterested = false;
+
+                int difference = applicantSkill - averageSkillLevel;
+                for (int i = 0; i < difference; i++) {
+                    int interestRoll = Compute.randomInt(4); // TODO make this a campaign option
+
+                    if (interestRoll != 0) {
+                        notInterested = true;
+                        break;
+                    }
+                }
+
+                if (notInterested) {
+                    getLogger().debug("Applicant is too experienced for the campaign, skipping.");
+                    continue;
+                }
             }
 
             addApplicant(applicant);

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -257,7 +257,7 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
 
                 int difference = applicantSkill - averageSkillLevel;
                 for (int i = 0; i < difference; i++) {
-                    int interestRoll = Compute.randomInt(4); // TODO make this a campaign option
+                    int interestRoll = Compute.randomInt(5); // TODO make this a campaign option
 
                     if (interestRoll != 0) {
                         notInterested = true;

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -257,7 +257,7 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
 
                 int difference = applicantSkill - averageSkillLevel;
                 for (int i = 0; i < difference; i++) {
-                    int interestRoll = Compute.randomInt(5); // TODO make this a campaign option
+                    int interestRoll = Compute.randomInt(10); // TODO make this a campaign option
 
                     if (interestRoll != 0) {
                         notInterested = true;


### PR DESCRIPTION
Close #7220

The new recruitment market removes applicants that are greater than 1-2 steps below the average experience of the campaign force. This PR loosens that so that there is still a chance those personnel will still apply. The chance is as follows:

| Difference | Chance of Still Applying | Campaign Example                        |
|------------|--------------------------|--------------------------------|
| 1 Step     | 10%                      | Regular campaign, Veteran applicant |
| 2 Steps    | 1%                       | Regular campaign, Elite applicant |
| 3 Steps    | 0%                       | Regular campaign, Heroic+ applicant   |

The minimum is still Green. Meaning that Green and Ultra-Green recruits will always be available.

### Further Work
The plan is to make the 'show of interest' chance to be a campaign option (which would also allow for it to be disabled entirely), however I want to bring the new personnel market in line first, before adding campaign options. That way it can all be done at once to reduce conflicts.