### PR TITLE
Fix: #7222Stopped New Personnel Market from Thinking Nearly Every Profession was Extinct

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
@@ -84,7 +84,7 @@ public class NewPersonnelMarket {
     private static int LOW_POPULATION_RECRUITMENT_DIVIDER = 1;
     private static int UNIT_REPUTATION_RECRUITMENT_CUTOFF = Integer.MIN_VALUE;
     @SuppressWarnings(value = "FieldCanBeLocal")
-    private static int PROFESSION_EXTINCTION_IGNORE_VALUE = -1;
+    private static final int PROFESSION_EXTINCTION_IGNORE_VALUE = -1;
 
     final private Campaign campaign;
     private PersonnelMarketStyle associatedPersonnelMarketStyle = PERSONNEL_MARKET_DISABLED;
@@ -868,6 +868,11 @@ public class NewPersonnelMarket {
 
         int introductionYear = entry.introductionYear();
         int extinctionYear = entry.extinctionYear();
+
+        if (extinctionYear == PROFESSION_EXTINCTION_IGNORE_VALUE) {
+            extinctionYear = Integer.MAX_VALUE;
+        }
+
         while (gameYear < introductionYear || (gameYear >= extinctionYear)) {
             PersonnelRole fallbackProfession = entry.fallbackProfession();
             entry = unorderedMarketEntries.get(fallbackProfession);


### PR DESCRIPTION
Close #7222

The new personnel market includes some code that checks whether a profession is valid for the current game year. A profession might not be valid if it's for a unit that hasn't been invented yet, or one that has gone extinct. For units that never go extinct the extinction year `-1` is used. However, we missed a single check to convert this into a usable value, this meant that all professions would substitute fallback roles. Which, in most cases, was soldier and (sometimes) vehicle crew.

To demonstrate this issue I've included examples below. In both cases the market was generated by spending a month on Galatea in 3151 with a Heroic-rated campaign. Golden Hello disabled.

### Bug Intact
<img width="469" alt="image" src="https://github.com/user-attachments/assets/bd0478c4-136b-4b1e-972e-8cc9fd9ffb2c" />

<img width="468" alt="image" src="https://github.com/user-attachments/assets/9bdbe1ea-66b0-4c7e-b0e0-4aab010d3fcc" />

### Bug Fixed
<img width="471" alt="image" src="https://github.com/user-attachments/assets/cfa33774-5eea-4737-9cc2-de65911529ea" />

<img width="456" alt="image" src="https://github.com/user-attachments/assets/6cf95284-fb44-4283-9e39-f78cbabe4312" />
