### PR TITLE
Fix: Stopped Applicants in the New Personnel Market from Forgetting their Profession

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6664,6 +6664,7 @@ public class Campaign implements ITechManager {
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "info");
 
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "id", id.toString());
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "calendar", getLocalDate());
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "name", name);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "faction", getFaction().getShortName());
         if (retainerEmployerCode != null) {
@@ -6707,7 +6708,6 @@ public class Campaign implements ITechManager {
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastForceId", lastForceId);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastMissionId", lastMissionId);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "lastScenarioId", lastScenarioId);
-        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "calendar", getLocalDate());
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "initiativeBonus", initiativeBonus);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "initiativeMaxBonus", initiativeMaxBonus);
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "nameGen");


### PR DESCRIPTION
Applicants in the new personnel market were being marked as ineligible for their professions as MekHQ thought they were children. This was due to the date being stored much deeper in the save xml than it probably should have been. As a result date was initializing _after_ the personnel market.

While I could have moved the personnel market I opted to move the placement of the campaign date as otherwise I can easily imagine how this might caught out future developers.