### PR TITLE
Fix: Fixed Typo in Recruiter Notes for Aggression Variant 1 Personality Trait

### DIFF
--- a/MekHQ/resources/mekhq/resources/Aggression.properties
+++ b/MekHQ/resources/mekhq/resources/Aggression.properties
@@ -258,7 +258,7 @@ CONFIDENT.ronin=I''ve seen how you run things - solid, but you need someone who 
   \ walks into a fight knowing the outcome - and delivers - you''ve found them.</p>\
   <p>I don''t doubt. I don''t stumble. And I don''t lose. Give the order, and I''ll deliver the win.</p>
 CONFIDENT.interviewerNote.0=Calm assurance. Inspires teammates, unnerves enemies. Confidence backed by presence.
-CONFIDENT.interviewerNote.1=reats doubt like weakness. Believes they''re the best - and fights like it.
+CONFIDENT.interviewerNote.1=Treats doubt like weakness. Believes they''re the best - and fights like it.
 CONFIDENT.interviewerNote.2=Enters every situation like it''s already won. Walks the line between skill and arrogance.
 CONFIDENT.interviewerNote.3=Never hesitates. Expects the world to adjust to their decisions.
 CONFIDENT.interviewerNote.4=Doesn''t posture - just leads. Speaks, and others follow without question.


### PR DESCRIPTION
`reats` -> `Treats`