### PR TITLE
Fix: #7166 Fixed Displayed Applicant in New Personnel Market Lagging Behind Selection When Using Directional Keys

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
@@ -175,13 +175,6 @@ public class PersonnelMarketDialog {
         pnlLeft.add(pnlHeader, BorderLayout.NORTH);
 
         tablePanel = initializeTablePanel();
-        tablePanel.addListSelectionListener(e -> {
-            List<Person> applicants = tablePanel.getSelectedApplicants();
-            selectedPerson = applicants.isEmpty() ? null : applicants.get(0);
-            if (personViewPanel != null) {
-                personViewPanel.setPerson(selectedPerson);
-            }
-        });
         pnlLeft.add(tablePanel, BorderLayout.CENTER);
 
         JPanel pnlTips = initializeTipPanel();
@@ -379,6 +372,16 @@ public class PersonnelMarketDialog {
         PersonnelTablePanel tablePanel = new PersonnelTablePanel(campaign, currentApplicants);
 
         JTable personnelTable = tablePanel.getTable();
+        personnelTable.getSelectionModel().addListSelectionListener(e -> {
+            if (!e.getValueIsAdjusting()) {
+                SwingUtilities.invokeLater(() -> {
+                    List<Person> selected = tablePanel.getSelectedApplicants();
+                    Person selectedPerson = selected.isEmpty() ? null : selected.get(0);
+                    personViewPanel.setPerson(selectedPerson);
+                });
+            }
+        });
+
         if (personnelTable.getRowSorter() instanceof TableRowSorter<?> sorter) {
             roleComboBox.addActionListener(ev -> {
                 PersonnelFilter selectedFilter = roleComboBox.getSelectedItem();


### PR DESCRIPTION
Close #7166

This was a real brainteaser. Basically we were updating Person View at the moment when the directional key was pressed, which happened to occur _before_ the internal list of selected personnel was updated. This caused the selection to 'lag' one step behind the actual selected character. However, that selection was correct internally. Meaning that this was only a visual bug. It was weird, but it's fixed now.