### PR TITLE
Fix: Fixed Role Filter Not Filtering When New Personnel Market Dialog is Opened Despite the Previous Filter Being Remembered Correctly

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
@@ -380,31 +380,41 @@ public class PersonnelMarketDialog {
 
         JTable personnelTable = tablePanel.getTable();
         if (personnelTable.getRowSorter() instanceof TableRowSorter<?> sorter) {
-            roleComboBox.addActionListener(ev -> {
-                PersonnelFilter selectedFilter = roleComboBox.getSelectedItem();
-                if (selectedFilter == null) {
-                    selectedFilter = ALL;
-                } else {
-                    market.setLastSelectedFilter(roleComboBox.getSelectedIndex());
-                }
-                PersonnelFilter finalSelectedFilter = selectedFilter;
-                sorter.setRowFilter(new RowFilter<TableModel, Integer>() {
-                    @Override
-                    public boolean include(Entry<? extends TableModel, ? extends Integer> entry) {
-                        int modelRow = entry.getIdentifier();
-                        TableModel model = entry.getModel();
-                        if (model instanceof PersonTableModel) {
-                            Person person = ((PersonTableModel) model).getPerson(modelRow);
-                            return finalSelectedFilter.getFilteredInformation(person, campaign.getLocalDate());
-                        }
-                        return true;
-                    }
-                });
-            });
+            filterRoles(sorter);
+            roleComboBox.addActionListener(ev -> filterRoles(sorter));
         }
         return tablePanel;
     }
 
+    /**
+     * Applies filtering logic to the given table row sorter based on the selected role filter.
+     *
+     * @param sorter the {@link TableRowSorter} to which the filtering logic is applied
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private void filterRoles(TableRowSorter<?> sorter) {
+        PersonnelFilter selectedFilter = roleComboBox.getSelectedItem();
+        if (selectedFilter == null) {
+            selectedFilter = ALL;
+        } else {
+            market.setLastSelectedFilter(roleComboBox.getSelectedIndex());
+        }
+        PersonnelFilter finalSelectedFilter = selectedFilter;
+        sorter.setRowFilter(new RowFilter<TableModel, Integer>() {
+            @Override
+            public boolean include(Entry<? extends TableModel, ? extends Integer> entry) {
+                int modelRow = entry.getIdentifier();
+                TableModel model = entry.getModel();
+                if (model instanceof PersonTableModel) {
+                    Person person = ((PersonTableModel) model).getPerson(modelRow);
+                    return finalSelectedFilter.getFilteredInformation(person, campaign.getLocalDate());
+                }
+                return true;
+            }
+        });
+    }
 
     /**
      * Initializes and returns the detail view pane for the selected person.


### PR DESCRIPTION
This was caused by  missed call, so that the table would only be filtered when the role filter was updated and not when the dialog was opened.