### PR TITLE
Fix: Fixed Formatting of General Tab in Campaign Options

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -59,19 +59,19 @@ lblIcon.tooltip=Pick an insignia for your campaign. Or leave blank to use an ima
   \ campaign faction.
 # createFurtherReadingPanel
 lblFurtherReadingPanel.text=Suggested Reading
-lblFurtherReading.text=<html><h2>BATTLEMECH MANUAL (BMM)</h2>\
+lblFurtherReading.text=<html><h2 style="text-align:center;">BATTLEMECH MANUAL (BMM)</h2>\
   The BattleMech Manual, built from the ground up with the latest rules, is specifically designed for BattleTech players\
   \ seeking an all-'Mek combat experience. It serves as the ideal starting point for new players learning the battle rules.\
-  <h2>TOTAL WARFARE (TW)</h2>\
+  <h2 style="text-align:center;">TOTAL WARFARE (TW)</h2>\
   Total Warfare is the definitive rulebook for experienced BattleTech players, serving as a comprehensive reference\
   \ guide rather than an introductory teaching tool. For construction rules related to the various units featured in\
   \ Total Warfare, refer to the TechManual.\
-  <h2>CAMPAIGN OPERATIONS (CamOps)</h2>\
+  <h2 style="text-align:center;">CAMPAIGN OPERATIONS (CamOps)</h2>\
   Campaign Operations offers rules for creating and managing forces, whether it is a struggling mercenary battalion or\
   \ a well-equipped House regiment. The book's final sections introduce diverse options for campaign play, enabling\
   \ players to run thrilling campaigns of virtually any type with their newly created forces. Campaign Operations\
   \ serves as the foundational rulebook for modern MekHQ.\
-  <h2>A TIME OF WAR (ATOW)</h2>\
+  <h2 style="text-align:center;">A TIME OF WAR (ATOW)</h2>\
   BattleTech: A Time of War is one of two official role-playing games set in the universe of Battletech. It lets players\
   \ step into any role - from elite MechWarrior to cunning spy - using a detailed, point-based system. Starting in 2024,\
   \ we adopted ATOW as primary reference point for character progression in MekHQ. In 2025 we started incorporating more\

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -228,6 +228,8 @@ public class GeneralTab {
 
         layout.gridy = 0;
         layout.gridwidth = 5;
+        layout.weightx = 1.0;
+        layout.fill = GridBagConstraints.HORIZONTAL;
         panel.add(headerPanel, layout);
 
         layout.gridwidth = 1;
@@ -293,6 +295,7 @@ public class GeneralTab {
 
         final JLabel lblHeader = new JLabel(getTextAt(getCampaignOptionsResourceBundle(), "lblGeneral.text"),
               SwingConstants.CENTER);
+        lblHeader.setMinimumSize(UIUtil.scaleForGUI(600, 0));
         setFontScaling(lblHeader, true, 2);
         lblHeader.setName("lblGeneral");
 


### PR DESCRIPTION
The General Tab became a tad squashed following recent formatting changes, so I went in and enforced a minimum width. This should resolve the issue. I also fixed some of the labels being squashed.

### Before
<img width="450" alt="image" src="https://github.com/user-attachments/assets/2f00cfc2-3eca-40cb-8da0-80bb58886fd6" />

### After
<img width="641" alt="image" src="https://github.com/user-attachments/assets/ed186fd7-01fd-4441-8805-7683615b3d99" />

