### PR TITLE
Improvement: Depreciated BatchallFactions.java

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -79,8 +79,9 @@ import megamek.common.enums.SkillLevel;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.icons.Camouflage;
 import megamek.common.planetaryconditions.Atmosphere;
-import megamek.common.universe.FactionTag;
 import megamek.common.planetaryconditions.Wind;
+import megamek.common.universe.FactionTag;
+import megamek.common.universe.HonorRating;
 import megamek.logging.MMLogger;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
@@ -120,8 +121,6 @@ import mekhq.campaign.universe.PlanetarySystem;
 import mekhq.campaign.universe.Systems;
 import mekhq.campaign.universe.UnitGeneratorParameters;
 import mekhq.campaign.universe.enums.EraFlag;
-import megamek.common.universe.HonorRating;
-import mekhq.campaign.universe.factionStanding.BatchallFactions;
 
 /**
  * This class handles the creation and substantive manipulation of AtBDynamicScenarios
@@ -1089,7 +1088,7 @@ public class AtBDynamicScenarioFactory {
         if (generatedForce.getTeam() != 1 &&
                   forceTemplate.getGenerationMethod() != ForceGenerationMethod.None.ordinal() &&
                   campaign.getCampaignOptions().isUseGenericBattleValue() &&
-                  BatchallFactions.usesBatchalls(factionCode) &&
+                  faction.performsBatchalls() &&
                   contract.isBatchallAccepted()) {
             // Simulate bidding away of forces
             List<Entity> bidAwayForces = new ArrayList<>();
@@ -1097,7 +1096,7 @@ public class AtBDynamicScenarioFactory {
 
             if (generatedForce.getTeam() != 1 &&
                       campaign.getCampaignOptions().isUseGenericBattleValue() &&
-                      BatchallFactions.usesBatchalls(factionCode) &&
+                      faction.performsBatchalls() &&
                       contract.isBatchallAccepted()) {
                 // Player force values
                 int playerBattleValue = calculateEffectiveBV(scenario, campaign, true);
@@ -1240,7 +1239,7 @@ public class AtBDynamicScenarioFactory {
             // Report the bidding results (if any) to the player
             if (generatedForce.getTeam() != 1 &&
                       campaign.getCampaignOptions().isUseGenericBattleValue() &&
-                      BatchallFactions.usesBatchalls(factionCode) &&
+                      faction.performsBatchalls() &&
                       contract.isBatchallAccepted()) {
                 reportResultsOfBidding(campaign, bidAwayForces, generatedForce, supplementedForces, faction);
             }

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/BatchallFactions.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/BatchallFactions.java
@@ -33,21 +33,15 @@
 package mekhq.campaign.universe.factionStanding;
 
 import java.util.List;
-import java.util.ResourceBundle;
 
 import megamek.codeUtilities.MathUtility;
 import megamek.common.Compute;
-import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 
 /**
- * Provides utility methods for working with clan factions within the Fame and Infamy module:
- * determining whether they engage in batchalling, retrieving greetings and version strings for
- * factions based on various conditions, such as the faction code, infamy level, and current year.
- * <p>
- * The class is stateless and all methods are static, so it doesn't need to be instantiated.
- * Therefore, all of its methods can be called directly on the class.
+ * Unused outside deprecated classes and methods
  */
+@Deprecated(since = "0.50.07", forRemoval = true)
 public class BatchallFactions {
 
     public static final List<String> BATCHALL_FACTIONS = List.of("CBS", "CB", "CCC", "CCO",


### PR DESCRIPTION
This PR deprecates the no-longer needed `BatchallFactions.java` class. That functionality has been superseded by @SJuliez new faction and the Faction Standing code