### PR TITLE
Factions fixes

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -40,6 +40,7 @@ import java.time.LocalDate;
 import java.util.*;
 import java.util.Map.Entry;
 
+import megamek.client.ratgenerator.FactionRecord;
 import megamek.common.annotations.Nullable;
 import megamek.common.universe.Faction2;
 import megamek.common.universe.FactionTag;
@@ -135,11 +136,10 @@ public class Faction {
         for (Entry<Integer, String> entry : faction2.getCapitalChanges().entrySet()) {
             planetChanges.put(LocalDate.ofYearDay(entry.getKey(), 1), entry.getValue());
         }
-        if (!faction2.getYearsActive().isEmpty()) {
-            Integer startYear = faction2.getYearsActive().get(0).start;
-            start = startYear == null ? 0 : startYear;
-            Integer endYear = faction2.getYearsActive().get(0).end;
-            start = endYear == null ? 0 : endYear;
+        List<FactionRecord.DateRange> active = faction2.getYearsActive();
+        if (!active.isEmpty()) {
+            start = Objects.requireNonNullElse(active.get(0).start, 0);
+            end = Objects.requireNonNullElse(active.get(active.size() - 1).end, 9999);
         }
         HonorRating preInvasion = faction2.getPreInvasionHonorRating();
         preInvasionHonorRating = (preInvasion != null) ? preInvasion : HonorRating.STRICT;

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -501,18 +501,12 @@ public class GeneralTab {
     public void loadValuesFromCampaignOptions(@Nullable LocalDate presetDate, @Nullable Faction presetFaction) {
         txtName.setText(campaign.getName());
 
-        date = campaign.getLocalDate();
-        if (presetDate != null) {
-            date = presetDate;
-        }
+        setDate((presetDate != null) ? presetDate : campaign.getLocalDate());
 
-        comboFaction.setSelectedItem(campaign.getFaction());
+        comboFaction.setSelectedItem(new FactionDisplay(campaign.getFaction(), date));
         if (presetFaction != null) {
             comboFaction.setSelectedItem(new FactionDisplay(presetFaction, date));
         }
-
-        // Button labels are not updated when we repaint, so we have to specifically call it here
-        btnDate.setText(MekHQ.getMHQOptions().getDisplayFormattedDate(date));
 
         camouflage = campaign.getCamouflage();
         unitIcon = campaign.getUnitIcon();

--- a/MekHQ/testresources/data/universe/factions/CBS_test.yml
+++ b/MekHQ/testresources/data/universe/factions/CBS_test.yml
@@ -1,0 +1,28 @@
+# This is a test faction, do not update lore data
+key: CBS
+name: Test Faction
+capital: York (Clan)
+yearsActive:
+  - start: 2807
+    end: 3082
+tags:
+  - PLAYABLE
+  - MINOR
+  - CLAN
+  - BATCHALL
+color:
+  red: 255
+  green: 99
+  blue: 71
+logo: Clan/Clan Blood Spirit.png
+background: Clan/Clan Blood Spirit.png
+camos: Clans/Blood Spirit
+nameGenerator: Clan
+ratingLevels:
+  - Provisional Garrison
+  - Solahma
+  - Second Line
+  - Front Line
+  - Keshik
+fallBackFactions:
+  - CLAN.HW

--- a/MekHQ/testresources/data/universe/factions/CLAN_TAG.yml
+++ b/MekHQ/testresources/data/universe/factions/CLAN_TAG.yml
@@ -1,0 +1,6 @@
+# This is a test faction, do not update lore data
+key: CLAN_TAG
+name: irrelevant
+capital: irrelevant
+tags:
+  - CLAN

--- a/MekHQ/testresources/data/universe/factions/CS_test.yml
+++ b/MekHQ/testresources/data/universe/factions/CS_test.yml
@@ -1,0 +1,30 @@
+# This is a test faction, do not update lore data
+key: CS
+name: ComStar
+capital: Terra
+capitalChanges: 
+  3059: Tukayyid
+yearsActive:
+  - start: 2788
+    end: 3081
+tags:
+  - PLAYABLE
+  - MAJOR
+  - IS
+  - INACTIVE
+  - CONTROLLING
+  - GENEROUS
+color:
+  red: 255
+  green: 250
+  blue: 240
+logo: Inner Sphere/ComStar.png
+background: Inner Sphere/ComStar.png
+camos: ComStar
+ratingLevels:
+  - B
+  - A
+fallBackFactions:
+  - IS
+formationBaseSize: 6
+formationGrouping: 6

--- a/MekHQ/testresources/data/universe/factions/IS_TAG.yml
+++ b/MekHQ/testresources/data/universe/factions/IS_TAG.yml
@@ -1,0 +1,6 @@
+# This is a test faction, do not update lore data
+key: IS_TAG
+name: irrelevant
+capital: irrelevant
+tags:
+  - IS

--- a/MekHQ/testresources/data/universe/factions/LA_test.yml
+++ b/MekHQ/testresources/data/universe/factions/LA_test.yml
@@ -1,0 +1,43 @@
+# This is a test faction, do not update lore data
+key: LA
+name: Lyran Commonwealth
+nameChanges:
+  3058: Lyran Alliance
+  3085: Lyran Commonwealth
+capital: Tharkad
+yearsActive:
+  - start: 2341
+tags:
+  - PLAYABLE
+  - LENIENT
+  - MAJOR
+  - IS
+  - GENEROUS
+color:
+  red: 0
+  green: 114
+  blue: 188
+logo: Inner Sphere/Lyran Commonwealth.png
+background: Inner Sphere/Lyran Commonwealth.png
+camos: Lyran Commonwealth
+nameGenerator: LA
+eraMods:
+  - 0
+  - 0
+  - 0
+  - 1
+  - 1
+  - 2
+  - 2
+  - 0
+  - 0
+  - 1
+  - 0
+ratingLevels:
+  - F
+  - D
+  - C
+  - B
+  - A
+fallBackFactions:
+  - IS

--- a/MekHQ/testresources/data/universe/factions/MH_test.yml
+++ b/MekHQ/testresources/data/universe/factions/MH_test.yml
@@ -1,0 +1,39 @@
+# This is a test faction, do not update lore data
+key: MH
+name: Marian Hegemony
+capital: Alphard (MH)
+yearsActive:
+  - start: 2920
+tags:
+  - PLAYABLE
+  - PERIPHERY
+  - STINGY
+  - CONTROLLING
+color:
+  red: 246
+  green: 140
+  blue: 71
+logo: Periphery/Marian Hegemony.png
+background: Periphery/Marian Hegemony.png
+camos: Marian Hegemony
+eraMods:
+  - 0
+  - 0
+  - 0
+  - 0
+  - 0
+  - 3
+  - 3
+  - 2
+  - 1
+  - 2
+  - 2
+ratingLevels:
+  - F
+  - D
+  - C
+  - B
+  - A
+fallBackFactions:
+  - Periphery.ME
+formationBaseSize: 5

--- a/MekHQ/unittests/mekhq/campaign/force/CombatTeamTest.java
+++ b/MekHQ/unittests/mekhq/campaign/force/CombatTeamTest.java
@@ -35,22 +35,24 @@ package mekhq.campaign.force;
 import static mekhq.campaign.force.FormationLevel.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Set;
-
-import megamek.common.universe.Faction2;
-import megamek.common.universe.FactionTag;
+import megamek.common.universe.Factions2;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class CombatTeamTest {
-    private static Factions factions;
+    private static Factions2 testFactions2;
 
     @BeforeAll
     public static void setup() {
+        testFactions2 = new Factions2("testresources/data/universe/factions");
         Factions.setInstance(Factions.loadDefault());
-        factions = Factions.getInstance();
+    }
+
+    @SuppressWarnings("all") // get() without test; if it fails, test data is not loading; the test should fail
+    private Faction getFaction(String code) {
+        return new Faction(testFactions2.getFaction(code).get());
     }
 
     // Inner Sphere
@@ -58,7 +60,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_InnerSphere_LanceDepth() {
         // Setup
-        Faction faction = factions.getFaction("LA");
+        Faction faction = getFaction("LA");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, LANCE.getDepth());
@@ -70,7 +72,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_InnerSphere_CompanyDepth() {
         // Setup
-        Faction faction = factions.getFaction("LA");
+        Faction faction = getFaction("LA");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, COMPANY.getDepth());
@@ -82,7 +84,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_InnerSphere_BattalionDepth() {
         // Setup
-        Faction faction = factions.getFaction("LA");
+        Faction faction = getFaction("LA");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, BATTALION.getDepth());
@@ -94,7 +96,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_InnerSphere_RegimentDepth() {
         // Setup
-        Faction faction = factions.getFaction("LA");
+        Faction faction = getFaction("LA");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, REGIMENT.getDepth());
@@ -106,7 +108,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_InnerSphere_BrigadeDepth() {
         // Setup
-        Faction faction = factions.getFaction("LA");
+        Faction faction = getFaction("LA");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, BRIGADE.getDepth());
@@ -118,7 +120,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_InnerSphere_DivisionDepth() {
         // Setup
-        Faction faction = factions.getFaction("LA");
+        Faction faction = getFaction("LA");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, DIVISION.getDepth());
@@ -130,7 +132,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_InnerSphere_CorpsDepth() {
         // Setup
-        Faction faction = factions.getFaction("LA");
+        Faction faction = getFaction("LA");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, CORPS.getDepth());
@@ -142,7 +144,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_InnerSphere_ArmyDepth() {
         // Setup
-        Faction faction = factions.getFaction("LA");
+        Faction faction = getFaction("LA");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, ARMY.getDepth());
@@ -154,7 +156,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_InnerSphere_ArmyGroupDepth() {
         // Setup
-        Faction faction = factions.getFaction("LA");
+        Faction faction = getFaction("LA");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, ARMY_GROUP.getDepth());
@@ -168,7 +170,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_ClanFaction_LanceDepth() {
         // Setup
-        Faction faction = factions.getFaction("CJF");
+        Faction faction = getFaction("CBS");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, STAR_OR_NOVA.getDepth());
@@ -180,7 +182,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_ClanFaction_CompanyDepth() {
         // Setup
-        Faction faction = factions.getFaction("CJF");
+        Faction faction = getFaction("CBS");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, BINARY_OR_TRINARY.getDepth());
@@ -192,7 +194,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_ClanFaction_BattalionDepth() {
         // Setup
-        Faction faction = factions.getFaction("CJF");
+        Faction faction = getFaction("CBS");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, CLUSTER.getDepth());
@@ -204,7 +206,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_ClanFaction_RegimentDepth() {
         // Setup
-        Faction faction = factions.getFaction("CJF");
+        Faction faction = getFaction("CBS");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, GALAXY.getDepth());
@@ -216,7 +218,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_ClanFaction_BrigadeDepth() {
         // Setup
-        Faction faction = factions.getFaction("CJF");
+        Faction faction = getFaction("CBS");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, TOUMAN.getDepth());
@@ -230,7 +232,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_MarianHegemonyFaction_LanceDepth() {
         // Setup
-        Faction faction = factions.getFaction("MH");
+        Faction faction = getFaction("MH");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, LANCE.getDepth());
@@ -242,7 +244,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_MarianHegemonyFaction_CompanyDepth() {
         // Setup
-        Faction faction = factions.getFaction("MH");
+        Faction faction = getFaction("MH");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, COMPANY.getDepth());
@@ -254,7 +256,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_MarianHegemonyFaction_BattalionDepth() {
         // Setup
-        Faction faction = factions.getFaction("MH");
+        Faction faction = getFaction("MH");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, BATTALION.getDepth());
@@ -266,7 +268,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_MarianHegemonyFaction_RegimentDepth() {
         // Setup
-        Faction faction = factions.getFaction("MH");
+        Faction faction = getFaction("MH");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, REGIMENT.getDepth());
@@ -278,7 +280,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_MarianHegemonyFaction_BrigadeDepth() {
         // Setup
-        Faction faction = factions.getFaction("MH");
+        Faction faction = getFaction("MH");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, BRIGADE.getDepth());
@@ -290,7 +292,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_MarianHegemonyFaction_DivisionDepth() {
         // Setup
-        Faction faction = factions.getFaction("MH");
+        Faction faction = getFaction("MH");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, DIVISION.getDepth());
@@ -302,7 +304,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_MarianHegemonyFaction_CorpsDepth() {
         // Setup
-        Faction faction = factions.getFaction("MH");
+        Faction faction = getFaction("MH");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, CORPS.getDepth());
@@ -314,7 +316,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_MarianHegemonyFaction_ArmyDepth() {
         // Setup
-        Faction faction = factions.getFaction("MH");
+        Faction faction = getFaction("MH");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, ARMY.getDepth());
@@ -326,7 +328,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_MarianHegemonyFaction_ArmyGroupDepth() {
         // Setup
-        Faction faction = factions.getFaction("MH");
+        Faction faction = getFaction("MH");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, ARMY_GROUP.getDepth());
@@ -340,7 +342,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_ComStarFaction_LanceDepth() {
         // Setup
-        Faction faction = factions.getFaction("CS");
+        Faction faction = getFaction("CS");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, LEVEL_II_OR_CHOIR.getDepth());
@@ -352,7 +354,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_ComStarFaction_CompanyDepth() {
         // Setup
-        Faction faction = factions.getFaction("CS");
+        Faction faction = getFaction("CS");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, LEVEL_III.getDepth());
@@ -364,7 +366,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_ComStarFaction_BattalionDepth() {
         // Setup
-        Faction faction = factions.getFaction("CS");
+        Faction faction = getFaction("CS");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, LEVEL_IV.getDepth());
@@ -376,7 +378,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_ComStarFaction_RegimentDepth() {
         // Setup
-        Faction faction = factions.getFaction("CS");
+        Faction faction = getFaction("CS");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, LEVEL_V.getDepth());
@@ -388,7 +390,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_ComStarFaction_BrigadeDepth() {
         // Setup
-        Faction faction = factions.getFaction("CS");
+        Faction faction = getFaction("CS");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, LEVEL_VI.getDepth());
@@ -402,9 +404,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackInnerSphere_LanceDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.IS));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("IS_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, LANCE.getDepth());
@@ -416,9 +416,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackInnerSphere_CompanyDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.IS));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("IS_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, COMPANY.getDepth());
@@ -430,9 +428,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackInnerSphere_BattalionDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.IS));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("IS_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, BATTALION.getDepth());
@@ -444,9 +440,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackInnerSphere_RegimentDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.IS));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("IS_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, REGIMENT.getDepth());
@@ -458,9 +452,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackInnerSphere_BrigadeDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.IS));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("IS_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, BRIGADE.getDepth());
@@ -472,9 +464,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackInnerSphere_DivisionDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.IS));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("IS_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, DIVISION.getDepth());
@@ -486,9 +476,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackInnerSphere_CorpsDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.IS));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("IS_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, CORPS.getDepth());
@@ -500,9 +488,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackInnerSphere_ArmyDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.IS));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("IS_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, ARMY.getDepth());
@@ -514,9 +500,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackInnerSphere_ArmyGroupDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.IS));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("IS_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, ARMY_GROUP.getDepth());
@@ -530,9 +514,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackClanFaction_LanceDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.CLAN));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("CLAN_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, STAR_OR_NOVA.getDepth());
@@ -544,9 +526,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackClanFaction_CompanyDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.CLAN));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("CLAN_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, BINARY_OR_TRINARY.getDepth());
@@ -558,9 +538,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackClanFaction_BattalionDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.CLAN));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("CLAN_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, CLUSTER.getDepth());
@@ -572,9 +550,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackClanFaction_RegimentDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.CLAN));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("CLAN_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, GALAXY.getDepth());
@@ -586,9 +562,7 @@ public class CombatTeamTest {
     @Test
     public void testGetStandardForceSize_FallbackClanFaction_BrigadeDepth() {
         // Setup
-        Faction2 faction2 = new Faction2();
-        faction2.setTags(Set.of(FactionTag.CLAN));
-        Faction faction = new Faction(faction2);
+        var faction = getFaction("CLAN_TAG");
 
         // Act
         int result = CombatTeam.getStandardForceSize(faction, TOUMAN.getDepth());


### PR DESCRIPTION
**Requires the related MM PR.**
Fixes #7237 

- fixes a silly error with retrieving start and end dates from factions2
- fixes an error in the campaign options general tab where the factions list was not consistently updated when the date was set (when starting a new campaign, the faction list was shown for 3051 while the date was shown as 3151)
- changes the combatteam test to load test factions instead of using real factions/constructing fake factions. This removes the need for setting tags and I removed the setTags() method from Faction2 (which makes it again immutable as it should remain if possible). An alternative would have been to mock the test factions, I guess, but loading test factions is closer to reality and simpler to manage.
- adds a bunch of test factions in testresources. I made the file names distinct from the real factions so they're not accidentally updated with new data

