### PR TITLE
Improvement: Added Aggregate Faction Tag

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -36,21 +36,19 @@ package mekhq.campaign.universe;
 import static megamek.common.Compute.randomInt;
 
 import java.awt.Color;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import megamek.client.ratgenerator.FactionRecord;
 import megamek.common.annotations.Nullable;
 import megamek.common.universe.Faction2;
 import megamek.common.universe.FactionTag;
+import megamek.common.universe.HonorRating;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
-import megamek.common.universe.HonorRating;
-
-import java.nio.file.Path;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
@@ -508,5 +506,19 @@ public class Faction {
      */
     public boolean performsBatchalls() {
         return faction2.performsBatchalls();
+    }
+
+    /**
+     * @return {@code true} if the faction is an aggregate of independent 'factions', rather than a singular
+     *       organization.
+     *
+     *       <p>For example, "PIR" (pirates) is used to abstractly represent all pirates, not individual pirate
+     *       groups.</p>
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public boolean isAggregate() {
+        return faction2.isAggregate();
     }
 }

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
@@ -316,7 +316,7 @@ public class FactionStandings {
 
             String otherFactionCode = otherFaction.getShortName();
 
-            if (isUntrackedFaction(otherFactionCode)) {
+            if (otherFaction.isAggregate()) {
                 continue;
             }
 
@@ -382,6 +382,7 @@ public class FactionStandings {
      *
      * @return {@code true} if the faction is untracked; {@code false} otherwise
      */
+    @Deprecated(since = "0.50.07", forRemoval = true)
     public static boolean isUntrackedFaction(final String factionCode) {
         final List<String> untrackedFactionTags = Arrays.asList("MERC",
               "PIR",
@@ -574,7 +575,7 @@ public class FactionStandings {
 
             String otherFactionCode = otherFaction.getShortName();
 
-            if (isUntrackedFaction(otherFactionCode)) {
+            if (otherFaction.isAggregate()) {
                 continue;
             }
 
@@ -747,9 +748,7 @@ public class FactionStandings {
             deltaDirection = getTextAt(RESOURCE_BUNDLE, "factionStandings.change.decreased");
         }
 
-        String factionName = relevantFaction == null ?
-                                   getTextAt(RESOURCE_BUNDLE, "factionStandings.change.report.unknownFaction") :
-                                   relevantFaction.getFullName(gameYear);
+        String factionName = relevantFaction.getFullName(gameYear);
         if (!factionName.contains(getTextAt(RESOURCE_BUNDLE, "factionStandings.change.report.clan.check"))) {
             factionName = getTextAt(RESOURCE_BUNDLE, "factionStandings.change.report.clan.prefix") + ' ' + factionName;
         }
@@ -813,7 +812,7 @@ public class FactionStandings {
                 continue;
             }
 
-            if (isNotValidForTracking(faction, gameYear, factionCode)) {
+            if (isNotValidForTracking(faction, gameYear)) {
                 continue;
             }
 
@@ -885,7 +884,7 @@ public class FactionStandings {
 
             String otherFactionCode = otherFaction.getShortName();
 
-            if (isUntrackedFaction(otherFactionCode)) {
+            if (otherFaction.isAggregate()) {
                 continue;
             }
 
@@ -985,7 +984,7 @@ public class FactionStandings {
         for (Faction otherFaction : allFactions) {
             String otherFactionCode = otherFaction.getShortName();
 
-            if (isNotValidForTracking(otherFaction, gameYear, otherFactionCode)) {
+            if (isNotValidForTracking(otherFaction, gameYear)) {
                 continue;
             }
 
@@ -1014,18 +1013,17 @@ public class FactionStandings {
      *
      * @param otherFaction the {@link Faction} to evaluate
      * @param gameYear the year for which validity should be checked
-     * @param otherFactionCode the short code identifying the other faction
      * @return {@code true} if the faction is either invalid in the specified year or is untracked; {@code false} otherwise
      *
      * @author Illiani
      * @since 0.50.07
      */
-    private boolean isNotValidForTracking(Faction otherFaction, int gameYear, String otherFactionCode) {
+    private boolean isNotValidForTracking(Faction otherFaction, int gameYear) {
         if (!otherFaction.validIn(gameYear)) {
             return true;
         }
 
-        return isUntrackedFaction(otherFactionCode);
+        return otherFaction.isAggregate();
     }
 
     /**
@@ -1092,7 +1090,7 @@ public class FactionStandings {
             Faction originFaction = victim.getOriginFaction();
             String factionCode = originFaction.getShortName();
 
-            if (isUntrackedFaction(factionCode)) {
+            if (originFaction.isAggregate()) {
                 continue;
             }
 

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/gmToolsDialog/FactionSelectionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/gmToolsDialog/FactionSelectionDialog.java
@@ -182,7 +182,7 @@ public class FactionSelectionDialog extends JDialog {
             }
         }
 
-        activeFactions.removeIf(faction -> FactionStandings.isUntrackedFaction(faction.getShortName()));
+        activeFactions.removeIf(Faction::isAggregate);
         activeFactions.sort(Comparator.comparing(faction -> faction.getFullName(today.getYear())));
 
         allFactions.addAll(activeFactions);

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/manualMissionDialogs/SimulateMissionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/manualMissionDialogs/SimulateMissionDialog.java
@@ -255,7 +255,7 @@ public class SimulateMissionDialog extends JDialog {
         Factions factions = Factions.getInstance();
         List<Faction> activeFactions = new ArrayList<>(factions.getActiveFactions(today));
 
-        activeFactions.removeIf(faction -> FactionStandings.isUntrackedFaction(faction.getShortName()));
+        activeFactions.removeIf(Faction::isAggregate);
         activeFactions.sort(Comparator.comparing(faction -> faction.getFullName(today.getYear())));
 
         // This is a placeholder to ensure that the indexes of the combos and the list remain in sync


### PR DESCRIPTION
# Requires https://github.com/MegaMek/megamek/pull/7265

This PR adds a new faction tag `AGGREGATE` that is used to flag that a faction is not a singular entity but an aggregate of different independent factions.

The example I used in the code was the pirate faction. This represents not a singular monolithic pirate organization, but an _aggregate_ of numerous pirate bands.

This was introduced to simplify Faction Standing so that we can easily exclude aggregate factions from Faction Standing tracking.