### PR TITLE
Improvement: Added Rank System Code to Faction Data

### DIFF
--- a/MekHQ/data/universe/factions/ABN.yml
+++ b/MekHQ/data/universe/factions/ABN.yml
@@ -6,6 +6,7 @@ tags:
   - ABANDONED
   - INACTIVE
   - CHAOS
+  - AGGREGATE
 color:
   red: 0
   green: 0

--- a/MekHQ/data/universe/factions/ARC.yml
+++ b/MekHQ/data/universe/factions/ARC.yml
@@ -28,3 +28,4 @@ eraMods:
   - 0
   - 3
   - 3
+rankSystem: ACM

--- a/MekHQ/data/universe/factions/BAN.yml
+++ b/MekHQ/data/universe/factions/BAN.yml
@@ -4,6 +4,7 @@ yearsActive:
   - start: 2830
 tags:
   - CLAN
+  - AGGREGATE
 ratingLevels:
   - Solahma
 fallBackFactions:

--- a/MekHQ/data/universe/factions/CC.yml
+++ b/MekHQ/data/universe/factions/CC.yml
@@ -37,3 +37,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: CCAF

--- a/MekHQ/data/universe/factions/CDS.yml
+++ b/MekHQ/data/universe/factions/CDS.yml
@@ -21,7 +21,7 @@ logo: Clan/Clan Diamond Shark.png
 background: Clan/Clan Diamond Shark.png
 camos: Clans/Diamond Shark
 camosChanges:
-  3100: Clan/Sea Fox (Dark Age)
+  3100: Clans/Sea Fox (Dark Age)
 nameGenerator: Clan
 ratingLevels:
   - Provisional Garrison

--- a/MekHQ/data/universe/factions/CLAN.yml
+++ b/MekHQ/data/universe/factions/CLAN.yml
@@ -7,6 +7,7 @@ tags:
   - SPECIAL
   - CLAN
   - BATCHALL
+  - AGGREGATE
 color:
   red: 139
   green: 69

--- a/MekHQ/data/universe/factions/CM.yml
+++ b/MekHQ/data/universe/factions/CM.yml
@@ -8,6 +8,7 @@ tags:
   - IS
   - SMALL
   - CHAOS
+  - AGGREGATE
 color:
   red: 169
   green: 169

--- a/MekHQ/data/universe/factions/CS.yml
+++ b/MekHQ/data/universe/factions/CS.yml
@@ -27,3 +27,4 @@ fallBackFactions:
   - IS
 formationBaseSize: 6
 formationGrouping: 6
+rankSystem: CG

--- a/MekHQ/data/universe/factions/DC.yml
+++ b/MekHQ/data/universe/factions/DC.yml
@@ -39,3 +39,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: DCMS

--- a/MekHQ/data/universe/factions/DIS.yml
+++ b/MekHQ/data/universe/factions/DIS.yml
@@ -4,6 +4,7 @@ capital: Terra
 tags:
   - SPECIAL
   - CHAOS
+  - AGGREGATE
 color:
   red: 192
   green: 192

--- a/MekHQ/data/universe/factions/FC.yml
+++ b/MekHQ/data/universe/factions/FC.yml
@@ -39,3 +39,4 @@ ratingLevels:
 fallBackFactions:
   - LA
   - FS
+rankSystem: AFFC

--- a/MekHQ/data/universe/factions/FRR.yml
+++ b/MekHQ/data/universe/factions/FRR.yml
@@ -39,3 +39,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: KA

--- a/MekHQ/data/universe/factions/FS.yml
+++ b/MekHQ/data/universe/factions/FS.yml
@@ -36,3 +36,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: AFFS

--- a/MekHQ/data/universe/factions/FWL.yml
+++ b/MekHQ/data/universe/factions/FWL.yml
@@ -37,3 +37,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: FWLM

--- a/MekHQ/data/universe/factions/IND.yml
+++ b/MekHQ/data/universe/factions/IND.yml
@@ -5,6 +5,7 @@ tags:
   - IS
   - SMALL
   - CHAOS
+  - AGGREGATE
 color:
   red: 191
   green: 179

--- a/MekHQ/data/universe/factions/IS.yml
+++ b/MekHQ/data/universe/factions/IS.yml
@@ -1,5 +1,8 @@
 key: IS
 name: Inner Sphere - General
+tags:
+  - IS
+  - AGGREGATE
 ratingLevels:
   - F
   - D

--- a/MekHQ/data/universe/factions/LA.yml
+++ b/MekHQ/data/universe/factions/LA.yml
@@ -40,3 +40,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: LCAF

--- a/MekHQ/data/universe/factions/MERC.yml
+++ b/MekHQ/data/universe/factions/MERC.yml
@@ -8,6 +8,7 @@ capitalChanges:
 tags:
   - MERC
   - PLAYABLE
+  - AGGREGATE
 color:
   red: 169
   green: 169

--- a/MekHQ/data/universe/factions/MH.yml
+++ b/MekHQ/data/universe/factions/MH.yml
@@ -36,3 +36,4 @@ ratingLevels:
 fallBackFactions:
   - Periphery.ME
 formationBaseSize: 5
+rankSystem: MHAF

--- a/MekHQ/data/universe/factions/MOC.yml
+++ b/MekHQ/data/universe/factions/MOC.yml
@@ -35,3 +35,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - Periphery.CM
+rankSystem: MAF

--- a/MekHQ/data/universe/factions/NONE.yml
+++ b/MekHQ/data/universe/factions/NONE.yml
@@ -7,6 +7,7 @@ tags:
   - ABANDONED
   - INACTIVE
   - CHAOS
+  - AGGREGATE
 color:
   red: 0
   green: 0

--- a/MekHQ/data/universe/factions/OA.yml
+++ b/MekHQ/data/universe/factions/OA.yml
@@ -37,3 +37,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - Periphery.OS
+rankSystem: AMC

--- a/MekHQ/data/universe/factions/PIR.yml
+++ b/MekHQ/data/universe/factions/PIR.yml
@@ -4,6 +4,7 @@ capital: Terra
 tags:
   - PLAYABLE
   - PIRATE
+  - AGGREGATE
 color:
   red: 128
   green: 40

--- a/MekHQ/data/universe/factions/Periphery.yml
+++ b/MekHQ/data/universe/factions/Periphery.yml
@@ -2,6 +2,7 @@ key: Periphery
 name: Periphery
 tags:
   - PERIPHERY
+  - AGGREGATE
 ratingLevels:
   - F
   - D

--- a/MekHQ/data/universe/factions/REB.yml
+++ b/MekHQ/data/universe/factions/REB.yml
@@ -3,6 +3,7 @@ name: Rebels
 capital: Terra
 tags:
   - REBEL
+  - AGGREGATE
 color:
   red: 192
   green: 192

--- a/MekHQ/data/universe/factions/RON.yml
+++ b/MekHQ/data/universe/factions/RON.yml
@@ -4,6 +4,7 @@ capital: Predlitz
 tags:
   - MINOR
   - IS
+  - AGGREGATE
 color:
   red: 237
   green: 28

--- a/MekHQ/data/universe/factions/TC.yml
+++ b/MekHQ/data/universe/factions/TC.yml
@@ -35,3 +35,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - Periphery.HR
+rankSystem: TDF

--- a/MekHQ/data/universe/factions/UND.yml
+++ b/MekHQ/data/universe/factions/UND.yml
@@ -6,6 +6,7 @@ tags:
   - ABANDONED
   - INACTIVE
   - CHAOS
+  - AGGREGATE
 color:
   red: 0
   green: 0

--- a/MekHQ/data/universe/factions/WOB.yml
+++ b/MekHQ/data/universe/factions/WOB.yml
@@ -24,3 +24,4 @@ fallBackFactions:
   - IS
 formationBaseSize: 6
 formationGrouping: 6
+rankSystem: WOBM

--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -49,6 +49,8 @@ import megamek.common.universe.FactionTag;
 import megamek.common.universe.HonorRating;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.ranks.RankSystem;
+import mekhq.campaign.personnel.ranks.Ranks;
 
 /**
  * @author Jay Lawson (jaylawson39 at yahoo.com)
@@ -495,6 +497,45 @@ public class Faction {
      */
     public int getFormationGrouping() {
         return faction2.getFormationGrouping();
+    }
+
+    /**
+     * Retrieves the rank system identifier for this faction.
+     *
+     * <p>The method checks the `rankSystem` field; if it is set and not {@code -1}, its value is returned
+     * directly.</p>
+     *
+     * <p>If the rank system is unspecified but there are fallback factions, the method iterates through each
+     * fallback faction, returning the first available rank system found among them.</p>
+     *
+     * <p>If no fallback faction provides a rank system, the method returns a default value based on whether the
+     * faction is a clan or not.</p>
+     *
+     * @return the rank system identifier for this faction, or a default value ({@code CLAN} for Clan factions,
+     *       {@code SLDF} for non-Clan factions) if not specified.
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public String getRankSystemCode() {
+        return faction2.getRankSystem();
+    }
+
+    /**
+     * Returns the {@link RankSystem} object associated with this faction.
+     *
+     * <p>This uses the rank system code obtained from {@link #getRankSystemCode()} and looks up the corresponding
+     * {@link RankSystem} instance using {@code Ranks.getRankSystemFromCode}. If a {@link RankSystem} cannot be found
+     * for the return value of {@link #getRankSystemCode()}, the rank system associated with
+     * {@link Ranks#DEFAULT_SYSTEM_CODE} will be returned.</p>
+     *
+     * @return the {@code RankSystem} for this faction, or {@code null} if not found
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public RankSystem getRankSystem() {
+        return Ranks.getRankSystemFromCode(getRankSystemCode());
     }
 
     /**


### PR DESCRIPTION
# Requires https://github.com/MegaMek/megamek/pull/7266

This PR adds Rank System codes to those factions with associated rank systems in MekHQ. This allows us to easily fetch the appropriate rank system in the event we, for example, want to generate NPC personnel with appropriate ranks for their faction.

While updating mhq's faction data for this change I also went ahead and copied-over the AGGREGATE tag changes that were made yesterday (I forgot to duplicate the change in mhq's code repository).