### PR TITLE
Fix: Fixed Recruitment Report Not Showing Rank

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2218,7 +2218,7 @@ public class Campaign implements ITechManager {
                                                                 "personnelRecruitmentPrisoner.text")) :
                                "";
             addReport(String.format(resources.getString("personnelRecruitmentAddedToRoster.text"),
-                  person.getHyperlinkedName(),
+                  person.getHyperlinkedFullTitle(),
                   formerSurname,
                   add));
         }


### PR DESCRIPTION
This fixes the message reported when a character joins the campaign to show the character's rank as well as their name