### PR TITLE
Improvement: Added The MG, MRB, MRBC, and MBA Factions for Use in Faction Standing

### DIFF
--- a/MekHQ/data/universe/factions/MBA.yml
+++ b/MekHQ/data/universe/factions/MBA.yml
@@ -1,0 +1,16 @@
+key: MRB
+name: Mercenary Bonding Authority
+capital: Twycross
+yearsActive:
+  - start: 3133
+tags:
+  - CLAN
+  - MERC
+  - SPECIAL
+  - CORPORATION
+color:
+  red: 169
+  green: 169
+  blue: 169
+fallBackFactions:
+  - CDS

--- a/MekHQ/data/universe/factions/MBA.yml
+++ b/MekHQ/data/universe/factions/MBA.yml
@@ -1,4 +1,4 @@
-key: MRB
+key: MBA
 name: Mercenary Bonding Authority
 capital: Twycross
 yearsActive:

--- a/MekHQ/data/universe/factions/MG.yml
+++ b/MekHQ/data/universe/factions/MG.yml
@@ -1,0 +1,13 @@
+key: MG
+name: Mercenary
+capital: Solaris
+yearsActive:
+  - start: 3000
+  - end: 2789
+tags:
+  - IS
+  - MERC
+  - SPECIAL
+  - CORPORATION
+fallBackFactions:
+  - MERC

--- a/MekHQ/data/universe/factions/MG.yml
+++ b/MekHQ/data/universe/factions/MG.yml
@@ -1,5 +1,5 @@
 key: MG
-name: Mercenary
+name: Mercenary Guild
 capital: Solaris
 yearsActive:
   - start: 3000

--- a/MekHQ/data/universe/factions/MRB.yml
+++ b/MekHQ/data/universe/factions/MRB.yml
@@ -1,0 +1,17 @@
+key: MRB
+name: Mercenary Review Board
+capital: Galatea
+yearsActive:
+  - start: 2789
+  - end: 3052
+tags:
+  - IS
+  - MERC
+  - SPECIAL
+  - CORPORATION
+color:
+  red: 169
+  green: 169
+  blue: 169
+fallBackFactions:
+  - CS

--- a/MekHQ/data/universe/factions/MRBC.yml
+++ b/MekHQ/data/universe/factions/MRBC.yml
@@ -1,4 +1,4 @@
-key: MRB
+key: MRBC
 name: Mercenary Review and Bonding Commission
 capital: Outreach
 capitalChanges:

--- a/MekHQ/data/universe/factions/MRBC.yml
+++ b/MekHQ/data/universe/factions/MRBC.yml
@@ -1,0 +1,19 @@
+key: MRB
+name: Mercenary Review and Bonding Commission
+capital: Outreach
+capitalChanges:
+  3067: Galatea
+yearsActive:
+  - start: 3052
+  - end: 3133
+tags:
+  - IS
+  - MERC
+  - SPECIAL
+  - CORPORATION
+color:
+  red: 169
+  green: 169
+  blue: 169
+fallBackFactions:
+  - MERC


### PR DESCRIPTION
This PR adds four new factions: the Mercenary Guild, the Mercenary Review Board, the Mercenary Review & Bonding Commission, and the Mercenary Bonding Authority.

These factions are not playable, but are designed to be used in MekHQ's Faction Standing system