### PR TITLE
Improvement: Added Improved Ability to Fetch Commander from Campaign; Added Ability to Fetch Second in Command

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3600,71 +3600,78 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Determines the commander of the unit.
+     * Retrieves the current campaign commander.
      *
-     * <p>If a flagged commander exists, that person is returned. Otherwise, the highest-ranking member among the
-     * unit's active personnel is selected as commander. In case of a rank tie, a skill-based tiebreaker is used to
-     * determine precedence.</p>
+     * <p>If a commander is specifically flagged, that person will be returned. Otherwise, the highest-ranking member
+     * among the unit's active personnel is selected.</p>
      *
-     * @return the {@link Person} serving as commander, or {@code null} if no eligible personnel are found.
+     * @return the {@link Person} who is the commander, or {@code null} if there are no suitable candidates.
      *
      * @author Illiani
      * @since 0.50.07
      */
     public @Nullable Person getCommander() {
-        Person commander = getFlaggedCommander();
-
-        if (commander != null) {
-            return commander;
-        }
-
-        for (Person person : getActivePersonnel(false)) {
-            if (commander == null) {
-                commander = person;
-                continue;
-            }
-
-            if (person.outRanksUsingSkillTiebreaker(this, commander)) {
-                commander = person;
-            }
-        }
-
-        return commander;
+        return findTopCommanders()[0];
     }
 
     /**
      * Retrieves the second-in-command among the unit's active personnel.
      *
      * <p>The second-in-command is determined as the highest-ranking active personnel member who is not the flagged
-     * commander. If more than one candidate has the same rank, a skill-based tiebreaker is used to determine which
-     * person outranks the others.</p>
+     * commander (if one exists). If multiple candidates have the same rank, a skill-based tiebreaker is used.</p>
      *
      * @return the {@link Person} who is considered the second-in-command, or {@code null} if there are no suitable
-     *       candidates.
+     * candidates.
      *
      * @author Illiani
      * @since 0.50.07
      */
     public @Nullable Person getSecondInCommand() {
-        Person commander = getCommander();
+        return findTopCommanders()[1];
+    }
 
+    /**
+     * Finds the current top two candidates for command among active personnel.
+     *
+     * <p>In a single pass, this method determines the commander and the second-in-command using a flagged commander
+     * if one is specified, otherwise relying on rank and skill tiebreakers.</p>
+     *
+     * @return an array where index 0 is the commander (may be the flagged commander), and index 1 is the
+     *       second-in-command; either or both may be {@code null} if no suitable personnel are available.
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private Person[] findTopCommanders() {
+        Person flaggedCommander = getFlaggedCommander();
+        Person commander = flaggedCommander;
         Person secondInCommand = null;
+
         for (Person person : getActivePersonnel(false)) {
-            if (person.equals(commander)) {
-                continue;
-            }
-
-            if (secondInCommand == null) {
-                secondInCommand = person;
-                continue;
-            }
-
-            if (person.outRanksUsingSkillTiebreaker(this, secondInCommand)) {
-                secondInCommand = person;
+            // If we have a flagged commander, skip them
+            if (flaggedCommander != null) {
+                if (person.equals(flaggedCommander)) {
+                    continue;
+                }
+                // Second in command is best among non-flagged
+                if (secondInCommand == null || person.outRanksUsingSkillTiebreaker(this, secondInCommand)) {
+                    secondInCommand = person;
+                }
+            } else {
+                if (commander == null) {
+                    commander = person;
+                } else if (person.outRanksUsingSkillTiebreaker(this, commander)) {
+                    secondInCommand = commander;
+                    commander = person;
+                } else if (secondInCommand == null || person.outRanksUsingSkillTiebreaker(this, secondInCommand)) {
+                    if (!person.equals(commander)) {
+                        secondInCommand = person;
+                    }
+                }
             }
         }
 
-        return secondInCommand;
+        return new Person[] { commander, secondInCommand};
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -773,7 +773,7 @@ public class Resupply {
         negotiatorSkill = NONE.ordinal();
 
         if (contract.getContractType().isGuerrillaWarfare()) {
-            negotiator = campaign.getFlaggedCommander();
+            negotiator = campaign.getCommander();
         } else {
             negotiator = null;
 

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/ComingOfAgeAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/ComingOfAgeAnnouncement.java
@@ -180,7 +180,7 @@ public class ComingOfAgeAnnouncement {
      */
     private @Nullable Person getSpeaker() {
         Genealogy genealogy = birthdayHaver.getGenealogy();
-        Person commander = campaign.getFlaggedCommander();
+        Person commander = campaign.getCommander();
 
         if (genealogy == null) {
             logger.debug("No genealogy found for {}. Using fallback speaker.", birthdayHaver.getFullName());

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/CommandersDayAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/CommandersDayAnnouncement.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.personnel.lifeEvents;
 
@@ -107,7 +112,7 @@ public class CommandersDayAnnouncement {
      */
     private String getInCharacterMessage() {
         // Commander Data
-        Person commander = campaign.getFlaggedCommander();
+        Person commander = campaign.getCommander();
         String commanderAddress = campaign.getCommanderAddress(false);
 
         String commanderSurname = commander.getSurname();

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/FreedomDayAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/FreedomDayAnnouncement.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.personnel.lifeEvents;
 
@@ -80,7 +85,7 @@ public class FreedomDayAnnouncement {
      */
     public FreedomDayAnnouncement(Campaign campaign) {
         this.campaign = campaign;
-        Person commander = campaign.getFlaggedCommander();
+        Person commander = campaign.getCommander();
 
         String inCharacterMessage = getInCharacterMessage();
         String outOfCharacterMessage = getFormattedTextAt(RESOURCE_BUNDLE, "freedomDay.message.ooc");

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/NewYearsDayAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/NewYearsDayAnnouncement.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.personnel.lifeEvents;
 
@@ -115,7 +120,7 @@ public class NewYearsDayAnnouncement {
     private @Nullable Person getSpeaker() {
         List<Person> activePersonnel = campaign.getActivePersonnel(false);
 
-        Person commander = campaign.getFlaggedCommander();
+        Person commander = campaign.getCommander();
         if (commander != null) {
             activePersonnel.remove(commander);
         }

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -223,11 +223,11 @@ public class RetirementDefectionTracker {
                 int modifier = campaign.getCampaignOptions().getManagementSkillPenalty();
 
                 if (campaign.getCampaignOptions().isUseCommanderLeadershipOnly()) {
-                    Person flaggedCommander = campaign.getFlaggedCommander();
-                    if (flaggedCommander != null && flaggedCommander.hasSkill((SkillType.S_LEADER))) {
-                        modifier -= flaggedCommander.getSkill(SkillType.S_LEADER)
-                                          .getFinalSkillValue(flaggedCommander.getOptions(),
-                                                flaggedCommander.getATOWAttributes());
+                    Person commander = campaign.getCommander();
+                    if (commander != null && commander.hasSkill((SkillType.S_LEADER))) {
+                        modifier -= commander.getSkill(SkillType.S_LEADER)
+                                          .getFinalSkillValue(commander.getOptions(),
+                                                commander.getATOWAttributes());
                     }
                 } else {
                     modifier -= getManagementSkillModifier(person);

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/ReputationController.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/ReputationController.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.rating.CamOpsReputation;
 
@@ -143,7 +148,7 @@ public class ReputationController {
         atbModifier = averageSkillLevel.ordinal();
 
         // step two: calculate command rating
-        commanderMap = calculateCommanderRating(campaign, campaign.getFlaggedCommander());
+        commanderMap = calculateCommanderRating(campaign, campaign.getCommander());
         commanderRating = commanderMap.get("total");
 
         // step three: calculate combat record rating
@@ -253,7 +258,7 @@ public class ReputationController {
               commanderRating));
 
         description.append("<table>");
-        Person commander = campaign.getFlaggedCommander();
+        Person commander = campaign.getCommander();
 
         String commanderName = resources.getString("commanderNone.text");
         if (commander != null) {

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -186,7 +186,7 @@ public class GeneralTab {
         // Generate new random campaign name
         btnNameGenerator = new CampaignOptionsButton("NameGenerator");
         btnNameGenerator.addActionListener(e -> txtName.setText(BackgroundsController.randomMercenaryCompanyNameGenerator(
-              campaign.getFlaggedCommander())));
+              campaign.getCommander())));
 
         // Campaign faction
         lblFaction = new CampaignOptionsLabel("Faction");

--- a/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/GMToolsDialog.java
@@ -1111,7 +1111,7 @@ public class GMToolsDialog extends AbstractMHQDialogBasic {
               "btnGenerateCompanyName.toolTipText",
               evt -> {
                   lastGeneratedCompanyName = randomMercenaryCompanyNameGenerator(gui.getCampaign()
-                                                                                       .getFlaggedCommander());
+                                                                                       .getCommander());
                   txtCompanyNamesGenerated.setText(lastGeneratedCompanyName);
               });
     }

--- a/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
@@ -539,7 +539,7 @@ public class PersonnelMarketDialog extends JDialog {
         if (campaignFaction.isClan()) {
             setTitle(getTextAt(RESOURCE_BUNDLE, "title.personnelMarket.clan"));
         } else if (campaignFaction.isComStarOrWoB()) {
-            Person commander = campaign.getFlaggedCommander();
+            Person commander = campaign.getCommander();
             String address = commander != null ? commander.getTitleAndSurname() : campaign.getCommanderAddress(false);
             setTitle(getFormattedTextAt(RESOURCE_BUNDLE,
                   "title.personnelMarket.comStarOrWoB",

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -96,7 +96,7 @@ public class NagController {
         }
 
         // No Commander
-        if (NoCommanderNagDialog.checkNag(campaign.getFlaggedCommander())) {
+        if (NoCommanderNagDialog.checkNag(campaign.getCommander())) {
             NoCommanderNagDialog noCommanderNagDialog = new NoCommanderNagDialog(campaign);
             if (noCommanderNagDialog.shouldCancelAdvanceDay()) {
                 return true;

--- a/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ForceViewPanel.java
@@ -179,11 +179,11 @@ public class ForceViewPanel extends JScrollablePanel {
         String type = null;
 
         Person commanderPerson = campaign.getPerson(force.getForceCommanderID());
-        String commander = commanderPerson != null ? commanderPerson.getFullTitle() : "";
 
         if (force.getId() == 0) {
-            commander = campaign.getFlaggedCommander() != null ? campaign.getFlaggedCommander().getFullTitle() : "";
+            commanderPerson = campaign.getCommander();
         }
+        String commanderName = commanderPerson != null ? commanderPerson.getFullTitle() : "";
 
         for (UUID uid : force.getAllUnits(false)) {
             Unit unit = campaign.getUnit(uid);
@@ -239,7 +239,7 @@ public class ForceViewPanel extends JScrollablePanel {
             nexty++;
         }
 
-        if (!commander.isBlank()) {
+        if (!commanderName.isBlank()) {
             lblCommander1.setName("lblCommander1");
             lblCommander1.setText(resourceMap.getString("lblCommander1.text"));
             gridBagConstraints = new GridBagConstraints();
@@ -250,7 +250,7 @@ public class ForceViewPanel extends JScrollablePanel {
             pnlStats.add(lblCommander1, gridBagConstraints);
 
             lblCommander2.setName("lblCommander2");
-            lblCommander2.setText(commander);
+            lblCommander2.setText(commanderName);
             lblCommander1.setLabelFor(lblCommander2);
             gridBagConstraints = new GridBagConstraints();
             gridBagConstraints.gridx = 1;

--- a/MekHQ/unittests/mekhq/campaign/rating/CamOpsReputation/ReputationControllerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/CamOpsReputation/ReputationControllerTest.java
@@ -24,8 +24,24 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.rating.CamOpsReputation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import megamek.common.enums.SkillLevel;
 import mekhq.campaign.Campaign;
@@ -33,13 +49,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
-
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
 
 class ReputationControllerTest {
     private ReputationController reputation;
@@ -57,7 +66,7 @@ class ReputationControllerTest {
     void setUp() {
         reputation = new ReputationController();
         campaign = mock(Campaign.class);
-        when(campaign.getFlaggedCommander()).thenReturn(null);
+        when(campaign.getCommander()).thenReturn(null);
         when(campaign.getFinances()).thenReturn(null);
         when(campaign.getDateOfLastCrime()).thenReturn(null);
         averageExperienceRating = mockStatic(AverageExperienceRating.class);


### PR DESCRIPTION
This effectively replaces the older `getFlaggedCommander()` getter, that just fetched the flagged commander or returned `null` with a version that more robust version. I added this because of the increased reliance on the flagged commander in modern mhq. However, we know that not all players bother with the commander flag. This PR allows us to more reliably fetch a commander figure in those campaigns. For campaigns that do use the commander flag nothing will have changed.

I also added a 'second second in command' method, mainly for use in the in-dev Faction Standing system but I also figured it'd be useful elsewhere.