### PR TITLE
Improvement: Added Missing Unique Faction Standing Labels for the Four Mercenary Organizations

### DIFF
--- a/MekHQ/resources/mekhq/resources/FactionStandings.properties
+++ b/MekHQ/resources/mekhq/resources/FactionStandings.properties
@@ -82,6 +82,7 @@ campaignOptionsChanged.description.disabled=You have just disabled <b>Faction St
   <p>{0}<b>Warning</b>:{1} This is a <b>permanent</b> change that <b>cannot be undone</b>.</p>
 # STANDING LEVELS
 ## Standing Effects
+factionStandingLevel.pirateOrMercenary=This faction does not confer bonuses or penalties.
 factionStandingLevel.negotiation=Contract Negotiations ({0})
 factionStandingLevel.resupply=Resupply Sizes ({0}%)
 factionStandingLevel.commandCircuit=COMMAND CIRCUIT ACCESS GRANTED
@@ -159,6 +160,15 @@ factionStandingLevel.STANDING_LEVEL_0.WOB.description=Declared beyond salvation.
 factionStandingLevel.STANDING_LEVEL_0.clan.label=An Enemy of the Clan
 factionStandingLevel.STANDING_LEVEL_0.clan.description=Branded as a threat to the Clan way of life. Destruction is the\
   \ only sentence.
+### Mercenary Organizations
+factionStandingLevel.STANDING_LEVEL_0.MG.label=Blacklisted
+factionStandingLevel.STANDING_LEVEL_0.MG.description=No reputable employer will touch you.
+factionStandingLevel.STANDING_LEVEL_0.MRB.label=Expunged
+factionStandingLevel.STANDING_LEVEL_0.MRB.description=You are barred from legitimate contracts.
+factionStandingLevel.STANDING_LEVEL_0.MRBC.label=Blacklisted
+factionStandingLevel.STANDING_LEVEL_0.MRBC.description=No one will touch you. You're on your own now.
+factionStandingLevel.STANDING_LEVEL_0.MBA.label=Contract Null
+factionStandingLevel.STANDING_LEVEL_0.MBA.description=Your bonds are void. Your unit is blacklisted.
 ## STANDING_LEVEL_1
 ### Inner Sphere
 factionStandingLevel.STANDING_LEVEL_1.innerSphere.label=Reviled
@@ -222,6 +232,16 @@ factionStandingLevel.STANDING_LEVEL_1.WOB.description=You profane Blake with you
 ### Clan
 factionStandingLevel.STANDING_LEVEL_1.clan.label=Dezgra
 factionStandingLevel.STANDING_LEVEL_1.clan.description=True scum unworthy of social or battle honors.
+### Mercenary Organizations
+factionStandingLevel.STANDING_LEVEL_1.MG.label=Sanctioned
+factionStandingLevel.STANDING_LEVEL_1.MG.description=Guild officials watch your every move for further violations.
+factionStandingLevel.STANDING_LEVEL_1.MRB.label=Under Investigation
+factionStandingLevel.STANDING_LEVEL_1.MRB.description=Official reprimands are on file. Most employers avoid association.
+factionStandingLevel.STANDING_LEVEL_1.MRBC.label=Barely Bondable
+factionStandingLevel.STANDING_LEVEL_1.MRBC.description=Your word's worth nothing. Clients require triple insurance - \
+  if they bother hiring you at all.
+factionStandingLevel.STANDING_LEVEL_1.MBA.label=Debtor-Grade
+factionStandingLevel.STANDING_LEVEL_1.MBA.description=Your performance carries loss and liability. Monitoring is active.
 ## STANDING_LEVEL_2
 ### Inner Sphere
 factionStandingLevel.STANDING_LEVEL_2.innerSphere.label=Notorious
@@ -285,6 +305,17 @@ factionStandingLevel.STANDING_LEVEL_2.WOB.description=You spurn the Word. The Or
 factionStandingLevel.STANDING_LEVEL_2.clan.label=Disgraced
 factionStandingLevel.STANDING_LEVEL_2.clan.description=You are remembered only for your insults. No warrior will honor\
   \ your name.
+### Mercenary Organizations
+factionStandingLevel.STANDING_LEVEL_2.MG.label=Unreliable
+factionStandingLevel.STANDING_LEVEL_2.MG.description=Employers are warned to proceed with caution.
+factionStandingLevel.STANDING_LEVEL_2.MRB.label=Flagged for Risk
+factionStandingLevel.STANDING_LEVEL_2.MRB.description=Your record contains red flags. You operate on probation.
+factionStandingLevel.STANDING_LEVEL_2.MRBC.label=F
+factionStandingLevel.STANDING_LEVEL_2.MRBC.description=The MRBC keeps your file, but sponsors won't vouch for you. \
+  Tread carefully.
+factionStandingLevel.STANDING_LEVEL_2.MBA.label=Marginal Partner
+factionStandingLevel.STANDING_LEVEL_2.MBA.description=You deliver inconsistent outcomes and disrupt market \
+  expectations. All contracts require oversight.
 ## STANDING_LEVEL_3
 ### Inner Sphere
 factionStandingLevel.STANDING_LEVEL_3.innerSphere.label=Distrusted
@@ -347,6 +378,18 @@ factionStandingLevel.STANDING_LEVEL_3.WOB.description=Beware, the Eye of Blake n
 factionStandingLevel.STANDING_LEVEL_3.clan.label=Unworthy
 factionStandingLevel.STANDING_LEVEL_3.clan.description=Viewed as lacking the steel of a true warrior. Barely tolerated,\
   \ easily discarded.
+### Mercenary Organizations
+factionStandingLevel.STANDING_LEVEL_3.MG.label=Questionable
+factionStandingLevel.STANDING_LEVEL_3.MG.description=Your reputation raises eyebrows. Expect short leashes and \
+  limited trust.
+factionStandingLevel.STANDING_LEVEL_3.MRB.label=Conditional Status
+factionStandingLevel.STANDING_LEVEL_3.MRB.description=You are recognized by the MRB but lack a consistent track \
+  record. Access to sensitive contracts is restricted pending further evaluation.
+factionStandingLevel.STANDING_LEVEL_3.MRBC.label=D
+factionStandingLevel.STANDING_LEVEL_3.MRBC.description=You're on the books, but barely. You're not trusted with \
+  anything important.
+factionStandingLevel.STANDING_LEVEL_3.MBA.label=Provisional Clearance
+factionStandingLevel.STANDING_LEVEL_3.MBA.description=Cleared for low-value engagements.
 ## STANDING_LEVEL_4 (neutral)
 ### Inner Sphere
 factionStandingLevel.STANDING_LEVEL_4.innerSphere.label=Unknown
@@ -408,6 +451,18 @@ factionStandingLevel.STANDING_LEVEL_4.WOB.description=You walk in darkness, neit
 factionStandingLevel.STANDING_LEVEL_4.clan.label=Unproven
 factionStandingLevel.STANDING_LEVEL_4.clan.description=No blood, no honor, no record. You are nothing until tested in\
   \ combat.
+### Mercenary Organizations
+factionStandingLevel.STANDING_LEVEL_4.MG.label=Unproven
+factionStandingLevel.STANDING_LEVEL_4.MG.description=A blank slate in the eyes of the Guild.
+factionStandingLevel.STANDING_LEVEL_4.MRB.label=Registered
+factionStandingLevel.STANDING_LEVEL_4.MRB.description=Your unit is officially recorded with no major infractions. You\
+  \ are eligible for standard contracts without restriction.
+factionStandingLevel.STANDING_LEVEL_4.MRBC.label=C
+factionStandingLevel.STANDING_LEVEL_4.MRBC.description=No major black marks, no medals either. You'll get a contract \
+  - just don't expect the good ones yet.
+factionStandingLevel.STANDING_LEVEL_4.MBA.label=Contract Eligible
+factionStandingLevel.STANDING_LEVEL_4.MBA.description=You meet minimum standards. Your unit holds neutral economic \
+  value. Contract allocation is algorithmic - no favor, no prejudice.
 ## STANDING_LEVEL_5
 ### Inner Sphere
 factionStandingLevel.STANDING_LEVEL_5.innerSphere.label=An Acknowledged Asset
@@ -471,6 +526,18 @@ factionStandingLevel.STANDING_LEVEL_5.WOB.description=You serve the Word with co
 factionStandingLevel.STANDING_LEVEL_5.clan.label=Proven
 factionStandingLevel.STANDING_LEVEL_5.clan.description=You have shown you can fight. The Clan grants you cautious\
   \ recognition.
+### Mercenary Organizations
+factionStandingLevel.STANDING_LEVEL_5.MG.label=Active
+factionStandingLevel.STANDING_LEVEL_5.MG.description=You are a known unit in good standing.
+factionStandingLevel.STANDING_LEVEL_5.MRB.label=Certified Reliable
+factionStandingLevel.STANDING_LEVEL_5.MRB.description=Your service record shows contract fulfillment with minimal \
+  issues. The MRB considers you a dependable option.
+factionStandingLevel.STANDING_LEVEL_5.MRBC.label=B
+factionStandingLevel.STANDING_LEVEL_5.MRBC.description=You get the job done, and you don't make waves. Contract \
+  liaisons start remembering your name - and not with a curse.
+factionStandingLevel.STANDING_LEVEL_5.MBA.label=Trusted Commodity
+factionStandingLevel.STANDING_LEVEL_5.MBA.description=You are a dependable variable. Mid-tier employers compete for \
+  your loyalty.
 ## STANDING_LEVEL_6
 ### Inner Sphere
 factionStandingLevel.STANDING_LEVEL_6.innerSphere.label=A Trusted Operator
@@ -533,6 +600,18 @@ factionStandingLevel.STANDING_LEVEL_6.WOB.description=You act with purpose and o
 factionStandingLevel.STANDING_LEVEL_6.clan.label=Respected
 factionStandingLevel.STANDING_LEVEL_6.clan.description=You have earned respect. Warriors accept you as a worthy combat\
   \ partner.
+### Mercenary Organizations
+factionStandingLevel.STANDING_LEVEL_6.MG.label=Trusted
+factionStandingLevel.STANDING_LEVEL_6.MG.description=Your unit delivers consistent results. The Guild recommends \
+  your services.
+factionStandingLevel.STANDING_LEVEL_6.MRB.label=Cleared for Priority Assignments
+factionStandingLevel.STANDING_LEVEL_6.MRB.description=You are approved for high-value contracts. MRB liaisons track \
+  your unit's performance as a benchmark for compliance.
+factionStandingLevel.STANDING_LEVEL_6.MRBC.label=A
+factionStandingLevel.STANDING_LEVEL_6.MRBC.description=Clients with real targets and real pay are taking an interest.
+factionStandingLevel.STANDING_LEVEL_6.MBA.label=Strategic Asset
+factionStandingLevel.STANDING_LEVEL_6.MBA.description=You generate consistent returns. Your bonds are sought and your \
+  profile is regularly praised.
 ## STANDING_LEVEL_7
 ### Inner Sphere
 factionStandingLevel.STANDING_LEVEL_7.innerSphere.label=A Favored Ally
@@ -595,6 +674,19 @@ factionStandingLevel.STANDING_LEVEL_7.WOB.description=Your faith in the Word is 
 factionStandingLevel.STANDING_LEVEL_7.clan.label=Honored
 factionStandingLevel.STANDING_LEVEL_7.clan.description=Warriors gain status by facing you in combat. Your skills are\
   \ recognized by all in the Clan.
+### Mercenary Organizations
+factionStandingLevel.STANDING_LEVEL_7.MG.label=Distinguished
+factionStandingLevel.STANDING_LEVEL_7.MG.description=You are a model of professional conduct. The Guild highlights \
+  you as a benchmark for mercenary reliability.
+factionStandingLevel.STANDING_LEVEL_7.MRB.label=Fully Endorsed
+factionStandingLevel.STANDING_LEVEL_7.MRB.description=ComStar arbitration services cite your unit as a model of \
+  contract execution and ethical conduct. Priority postings are routinely offered.
+factionStandingLevel.STANDING_LEVEL_7.MRBC.label=A*
+factionStandingLevel.STANDING_LEVEL_7.MRBC.description=You've seen the meat grinder and walked out the other side. \
+  The MRBC backs you, and green units want to learn from you.
+factionStandingLevel.STANDING_LEVEL_7.MBA.label=Venerated Contractor
+factionStandingLevel.STANDING_LEVEL_7.MBA.description=You are spoken of in quarterly briefs. Your efficiency serves \
+  Clan Sea Fox and is an extension of their honor.
 ## STANDING_LEVEL_8
 ### Inner Sphere
 factionStandingLevel.STANDING_LEVEL_8.innerSphere.label=A Champion of the Realm
@@ -658,6 +750,19 @@ factionStandingLevel.STANDING_LEVEL_8.WOB.description=Your words carry divine au
 factionStandingLevel.STANDING_LEVEL_8.clan.label=A Vision of Kerensky
 factionStandingLevel.STANDING_LEVEL_8.clan.description=The Clans speak of you as embodying the ideals of the founder.\
   \ Your tactics are studied by all.
+### Mercenary Organizations
+factionStandingLevel.STANDING_LEVEL_8.MG.label=Gold Star Command
+factionStandingLevel.STANDING_LEVEL_8.MG.description=Your name is synonymous with success and integrity. The Guild \
+  offers you its most sensitive, high-stakes contracts.
+factionStandingLevel.STANDING_LEVEL_8.MRB.label=Exemplary Status
+factionStandingLevel.STANDING_LEVEL_8.MRB.description=Your reputation precedes you. The MRB archives your record as a\
+  \ case study in professional excellence. Employers compete for your service.
+factionStandingLevel.STANDING_LEVEL_8.MRBC.label=Living Legend
+factionStandingLevel.STANDING_LEVEL_8.MRBC.description=You're the standard. The Wolf's Dragoons themselves speak your \
+  name with respect.
+factionStandingLevel.STANDING_LEVEL_8.MBA.label=Exemplar of Profit and Purpose
+factionStandingLevel.STANDING_LEVEL_8.MBA.description=You embody the ideal synthesis of combat efficacy and economic \
+  utility.
 # STANDING CHANGES
 factionStandings.change.report=Your <b>Standing</b> with {0} has {1}<b>{2}</b>{3} by {4} <b>Regard</b>. {5}
 factionStandings.change.report.milestone.new=You are now {0}<b>{1}</b>{2}.

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandingLevel.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandingLevel.java
@@ -44,7 +44,6 @@ import megamek.codeUtilities.MathUtility;
 import megamek.logging.MMLogger;
 import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.universe.Faction;
-import mekhq.gui.dialog.factionStanding.FactionStandingReport;
 
 /**
  * Represents a standing level within the Faction Standing reputation system.
@@ -410,39 +409,64 @@ public enum FactionStandingLevel {
     }
 
     /**
-     * Use {@link #getEffectsDescription(boolean, CampaignOptions)} instead
+     * Use {@link #getEffectsDescription(boolean, boolean, CampaignOptions)} instead
      */
     @Deprecated(since = "0.50.07", forRemoval = true)
     public String getEffectsDescription() {
-        return getEffectsDescription(false, new CampaignOptions());
+        return getEffectsDescription(false, false, new CampaignOptions());
     }
 
     /**
-     * Generates a textual description of all effects based on the current faction standing modifiers.
-     *
-     * <p>This method inspects various modifiers (such as negotiation, resupply, command circuit access, outlaw status,
-     * batchall permission, recruitment popularity, barracks cost, unit market rarity, contract pay, and support point
-     * modifiers) and compiles their effects into a comma-separated string. Only effects that deviate from their default
-     * values are included in the output.</p>
-     *
-     * @return a comma-separated {@link String} listing all active faction standing effects; returns
-     * an empty string if there are no effects.
+     * Use {@link #getEffectsDescription(boolean, boolean, CampaignOptions)} instead
      */
+    @Deprecated(since = "0.50.07", forRemoval = true)
     public String getEffectsDescription(boolean isClan, CampaignOptions campaignOptions) {
-        MMLogger logger = MMLogger.create(FactionStandingReport.class);
-        logger.info(this);
+        return getEffectsDescription(isClan, false, campaignOptions);
+    }
+
+    /**
+     * Generates a textual summary of all currently active effects resulting from faction standing modifiers.
+     *
+     * <p>This method evaluates a range of standing-related modifiers and permissions - including negotiation,
+     * resupply, command circuit access, outlaw status, batchall rights, recruitment popularity and rolls, barracks
+     * costs, unit market rarity, contract pay, and support point modifiers.</p>
+     *
+     * <p></p>Only effects that differ from their default or neutral values, and that are allowed by the current
+     * campaign options, are included in the output.</p>
+     *
+     * <p></p>Each effect is represented as a localized formatted string, and all applicable effects are concatenated
+     * into a comma-separated result.</p>
+     *
+     * <p>The result provides a concise overview for the user or UI, listing only those standing effects that are
+     * relevant for the given context (e.g., depending on whether the organization is a Clan or on available campaign
+     * options).</p>
+     *
+     * @param isClan           {@code true} if the organization being described is a Clan; enables consideration of
+     *                                     Clan-specific modifiers.
+     * @param isPirateOrMercenaryOrganization           {@code true} if the organization being described is a pirate
+     *                                                              or mercenary organization
+     * @param campaignOptions  the current {@link CampaignOptions} that determine which standing effects are in use.
+     * @return a comma-separated {@link String} listing all non-default, active faction standing effects;
+     *         returns an empty string if there are no applicable effects.
+     */
+    public String getEffectsDescription(boolean isClan, boolean isPirateOrMercenaryOrganization,
+          CampaignOptions campaignOptions) {
+        if (isPirateOrMercenaryOrganization) {
+            return getTextAt(RESOURCE_BUNDLE, "factionStandingLevel.pirateOrMercenary");
+        }
+
         List<String> effects = new ArrayList<>();
 
         if (hasCommandCircuitAccess && campaignOptions.isUseFactionStandingCommandCircuitSafe()) {
-            effects.add(getFormattedTextAt(RESOURCE_BUNDLE, "factionStandingLevel.commandCircuit"));
+            effects.add(getTextAt(RESOURCE_BUNDLE, "factionStandingLevel.commandCircuit"));
         }
 
         if (isOutlawed && campaignOptions.isUseFactionStandingOutlawedSafe()) {
-            effects.add(getFormattedTextAt(RESOURCE_BUNDLE, "factionStandingLevel.outlawed"));
+            effects.add(getTextAt(RESOURCE_BUNDLE, "factionStandingLevel.outlawed"));
         }
 
         if (isClan && !isBatchallAllowed && campaignOptions.isUseFactionStandingBatchallRestrictionsSafe()) {
-            effects.add(getFormattedTextAt(RESOURCE_BUNDLE, "factionStandingLevel.batchall"));
+            effects.add(getTextAt(RESOURCE_BUNDLE, "factionStandingLevel.batchall"));
         }
 
         if (negotiationModifier != 0 && campaignOptions.isUseFactionStandingNegotiationSafe()) {

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/FactionStandingReport.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/FactionStandingReport.java
@@ -64,6 +64,7 @@ import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.util.UIUtil;
 import megamek.logging.MMLogger;
+import megamek.utilities.FastJScrollPane;
 import megamek.utilities.ImageUtilities;
 import mekhq.MekHQ;
 import mekhq.campaign.CampaignOptions;
@@ -81,7 +82,6 @@ import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 import mekhq.gui.dialog.factionStanding.gmToolsDialog.GMTools;
 import mekhq.gui.dialog.factionStanding.manualMissionDialogs.SimulateMissionDialog;
 import mekhq.gui.dialog.glossary.NewDocumentationEntryDialog;
-import mekhq.gui.utilities.JScrollPaneWithSpeed;
 import mekhq.gui.utilities.WrapLayout;
 
 /**
@@ -322,7 +322,7 @@ public class FactionStandingReport extends JDialog {
             JPanel factionPanel = createFactionPanel(faction);
             groupPanel.add(factionPanel);
         }
-        JScrollPane groupScrollPane = new JScrollPaneWithSpeed(groupPanel,
+        JScrollPane groupScrollPane = new FastJScrollPane(groupPanel,
               JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
               JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
         groupScrollPane.setName("factionReportGroupScrollPane" + factions);
@@ -469,14 +469,18 @@ public class FactionStandingReport extends JDialog {
               climateRegard);
 
         // Parent panel
+        boolean isMercenaryOrganization = faction.isMercenaryOrganization();
+        boolean isClan = !isMercenaryOrganization && faction.isClan();
+        boolean isPirateOrMercenaryOrganization = isMercenaryOrganization || factionCode.equals("PIR");
+
         JPanel pnlFactionStanding = new JPanel();
         pnlFactionStanding.setName("pnlFactionStanding" + factionCode);
         pnlFactionStanding.setLayout(new BoxLayout(pnlFactionStanding, BoxLayout.Y_AXIS));
         pnlFactionStanding.setBorder(createStandingColoredRoundedTitledBorder(factionStanding.getStandingLevel()));
         pnlFactionStanding.setPreferredSize(new Dimension(FACTION_PANEL_WIDTH, FACTION_PANEL_HEIGHT));
         pnlFactionStanding.setMaximumSize(new Dimension(FACTION_PANEL_WIDTH, FACTION_PANEL_HEIGHT));
-        pnlFactionStanding.addMouseListener(createEffectsPanelUpdater(getEffectsDescription(faction.isClan(),
-              climateRegard)));
+        pnlFactionStanding.addMouseListener(createEffectsPanelUpdater(getEffectsDescription(isClan,
+              isPirateOrMercenaryOrganization, climateRegard)));
 
         // Faction Logo
         ImageIcon icon = Factions.getFactionLogo(gameYear, factionCode);
@@ -531,12 +535,8 @@ public class FactionStandingReport extends JDialog {
         Border compound = BorderFactory.createCompoundBorder(rounded, padding);
 
         int stars = factionStandingLevel + 1;
-        StringBuilder title = new StringBuilder();
-        for (int i = 0; i < stars; i++) {
-            title.append("\u2605 ");
-        }
 
-        return BorderFactory.createTitledBorder(compound, title.toString());
+        return BorderFactory.createTitledBorder(compound, "\u2605 ".repeat(Math.max(0, stars)));
     }
 
     private static Border getRoundedBorder(int factionStandingLevel) {
@@ -647,6 +647,7 @@ public class FactionStandingReport extends JDialog {
      * Calculates the standing effects description string for a given faction regard value.
      *
      * @param isClan {@code true} if the faction is a Clan faction, otherwise {@code false}
+     * @param isPirateOrMercenaryOrganization {@code true} if the faction is a pirate or mercenary organization
      * @param factionRegard the regard value of the faction
      *
      * @return the standing effects description for the corresponding {@link FactionStandingLevel}
@@ -654,9 +655,10 @@ public class FactionStandingReport extends JDialog {
      * @author Illiani
      * @since 0.50.07
      */
-    private String getEffectsDescription(boolean isClan, double factionRegard) {
+    private String getEffectsDescription(boolean isClan, boolean isPirateOrMercenaryOrganization,
+          double factionRegard) {
         FactionStandingLevel factionStanding = FactionStandingUtilities.calculateFactionStandingLevel(factionRegard);
-        return factionStanding.getEffectsDescription(isClan, campaignOptions);
+        return factionStanding.getEffectsDescription(isClan, isPirateOrMercenaryOrganization, campaignOptions);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/utilities/JScrollPaneWithSpeed.java
+++ b/MekHQ/src/mekhq/gui/utilities/JScrollPaneWithSpeed.java
@@ -24,24 +24,29 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.utilities;
 
 import java.awt.Component;
-import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
 import megamek.client.ui.clientGUI.GUIPreferences;
+import megamek.utilities.FastJScrollPane;
 
 /**
- * Use the version housed in MegaMek, instead
+ * Use {@link FastJScrollPane} instead
  */
 @Deprecated(since = "0.50.07")
 public class JScrollPaneWithSpeed extends JScrollPane {
     static final int BASE_INCREMENT = 16;
 
     /**
-     * @see JPanel#JPanel()
+     * Use {@link FastJScrollPane#FastJScrollPane()} instead
      */
     public JScrollPaneWithSpeed() {
         super(null);
@@ -49,7 +54,7 @@ public class JScrollPaneWithSpeed extends JScrollPane {
     }
 
     /**
-     * @see JPanel#JPanel()
+     * Use {@link FastJScrollPane#FastJScrollPane()} instead
      */
     public JScrollPaneWithSpeed(Component view) {
         super(view);
@@ -57,7 +62,7 @@ public class JScrollPaneWithSpeed extends JScrollPane {
     }
 
     /**
-     * @see JPanel#JPanel()
+     * Use {@link FastJScrollPane#FastJScrollPane()} instead
      */
     public JScrollPaneWithSpeed(Component view, int vsbPolicy, int hsbPolicy) {
         super(view, vsbPolicy, hsbPolicy);


### PR DESCRIPTION
- Added unique faction standing milestone labels and descriptions for the Mercenary's Guild, Mercenary Review Board, Mercenary Review and Bonding Commission, and the Mercenary Bonding Authority
- Added special handler for mercenary organization and the pirate faction, so that these will not show standing-based modifiers in the standings report.
- Labeled `JScrollPaneWithSpeed` (MekHQ version) to point towards `FastJScrollPane`. It was previously deprecated but no pointer was included.
- 