### PR TITLE
Fix: #7285 Fixed Babies Ripping Holes in the Space Time Continuum and Being Simultaneously Born Both in the Past and Future

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2327,7 +2327,7 @@ public class Campaign implements ITechManager {
             }
 
             if ((person.isPregnant()) && (currentDate.isAfter(person.getDueDate()))) {
-                currentChildren.addAll(getProcreation().birthHistoric(this, localDate, person, babysFather));
+                currentChildren.addAll(getProcreation().birthHistoric(this, currentDate, person, babysFather));
                 babysFather = null;
             }
 
@@ -2335,7 +2335,7 @@ public class Campaign implements ITechManager {
                       (currentSpouse.isPregnant()) &&
                       (currentDate.isAfter(currentSpouse.getDueDate()))) {
                 currentChildren.addAll(getProcreation().birthHistoric(this,
-                      localDate,
+                      currentDate,
                       currentSpouse,
                       spousesBabysFather));
                 spousesBabysFather = null;


### PR DESCRIPTION
Fix #7285 

This PR fixes an issue where we were birthing babies on the correct date, but logging their birth date as the current date. This resulted in Babies of Past and Future, something I'm fair certain would constitute a breach of the Temporal Prime Directive.

This was only a visual bug.