### PR TITLE
Improvement: #7262 Allowed All Tech, Medical, and select Civilian Professions to be Assigned to Support Vehicles as Vehicle Crew Without Needing to Be Assigned to the Vehicle Crew Profession

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4770,7 +4770,7 @@ public class Campaign implements ITechManager {
                              // if a legendary, primary tech and destroy by margin is NOT on
                              &&
                              ((tech.getExperienceLevel(this, false) == SkillType.EXP_LEGENDARY) ||
-                                    tech.getPrimaryRole().isVehicleCrew())) // For vessel crews
+                                    tech.getPrimaryRole().isVesselCrew())) // For vessel crews
                             && (roll < target.getValue())) {
                 tech.changeCurrentEdge(-1);
                 roll = tech.isRightTechTypeFor(partWork) ? d6(2) : Utilities.roll3d6();

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4148,6 +4148,10 @@ public class Person {
         return String.format("<a href='PERSON:%s'>%s</a>", getId(), getFullTitle());
     }
 
+    public String getFullTitleAndProfessions() {
+        return getFullTitle() + " (" + getPrimaryRoleDesc() + " / " + getSecondaryRoleDesc() + ')';
+    }
+
     /**
      * @return the primaryDesignator
      */

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -1029,6 +1029,29 @@ public enum PersonnelRole {
     }
 
     /**
+     * Returns {@code true} if this profession is suitable for vehicle crew positions.
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public boolean isVehicleCrewExtended() {
+        return this == VEHICLE_CREW ||
+                     this == MEK_TECH ||
+                     this == AERO_TEK ||
+                     this == MECHANIC ||
+                     this == BA_TECH ||
+                     this == ASTECH ||
+                     this == DOCTOR ||
+                     this == MEDIC ||
+                     this == COMMS_OPERATOR ||
+                     this == TECH_COMMUNICATIONS ||
+                     this == SENSOR_TECHNICIAN ||
+                     this == CHEF;
+    }
+
+
+
+    /**
      * @return {@code true} if the personnel has the Aerospace Pilot role, {@code false} otherwise.
      */
     public boolean isAerospacePilot() {
@@ -1222,7 +1245,7 @@ public enum PersonnelRole {
      *       Crew role, {@code false} otherwise.
      */
     public boolean isGroundVehicleCrew() {
-        return isGroundVehicleDriver() || isVehicleGunner() || isVehicleCrew();
+        return isGroundVehicleDriver() || isVehicleGunner() || isVehicleCrewExtended();
     }
 
     /**
@@ -1230,7 +1253,7 @@ public enum PersonnelRole {
      *       Crew role, {@code false} otherwise.
      */
     public boolean isNavalVehicleCrew() {
-        return isNavalVehicleDriver() || isVehicleGunner() || isVehicleCrew();
+        return isNavalVehicleDriver() || isVehicleGunner() || isVehicleCrewExtended();
     }
 
     /**
@@ -1238,7 +1261,7 @@ public enum PersonnelRole {
      *       {@code false} otherwise.
      */
     public boolean isVTOLCrew() {
-        return isVTOLPilot() || isVehicleGunner() || isVehicleCrew();
+        return isVTOLPilot() || isVehicleGunner() || isVehicleCrewExtended();
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -32,6 +32,7 @@
  */
 package mekhq.gui.menus;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -172,18 +173,10 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
             final boolean areAllVesselCrew = Stream.of(people)
                                                    .allMatch(person -> person.hasRole(PersonnelRole.VESSEL_CREW));
             final boolean areAllVehicleCrew = Stream.of(people)
-                                                    .allMatch(person -> person.hasRole(PersonnelRole.MEK_TECH) ||
-                                                                              person.hasRole(PersonnelRole.AERO_TEK) ||
-                                                                              person.hasRole(PersonnelRole.MECHANIC) ||
-                                                                              person.hasRole(PersonnelRole.BA_TECH) ||
-                                                                              person.hasRole(PersonnelRole.ASTECH) ||
-                                                                              person.hasRole(PersonnelRole.DOCTOR) ||
-                                                                              person.hasRole(PersonnelRole.MEDIC) ||
-                                                                              person.hasRole(PersonnelRole.COMMS_OPERATOR) ||
-                                                                              person.hasRole(PersonnelRole.TECH_COMMUNICATIONS) ||
-                                                                              person.hasRole(PersonnelRole.SENSOR_TECHNICIAN) ||
-                                                                              person.hasRole(PersonnelRole.CHEF) ||
-                                                                              person.hasRole(PersonnelRole.VEHICLE_CREW));
+                                                    .allMatch(person -> person.getPrimaryRole()
+                                                                              .isVehicleCrewExtended() ||
+                                                                              person.getSecondaryRole()
+                                                                                    .isVehicleCrewExtended());
             final boolean areAllSoldiers = Stream.of(people).allMatch(person -> person.hasRole(PersonnelRole.SOLDIER));
             final boolean areAllBattleArmourPilots = Stream.of(people)
                                                            .allMatch(person -> person.hasRole(PersonnelRole.BATTLE_ARMOUR));
@@ -315,9 +308,8 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                     unit.addPilotOrSoldier(people[0], useTransfers);
                                 }
 
-                                if (people[0].getRecruitment() == null) {
-                                    people[0].setRecruitment(campaign.getLocalDate());
-                                }
+                                Person person = people[0];
+                                ensureRecruitmentDate(campaign.getLocalDate(), person);
                             });
                             pilotEntityWeightMenu.add(miPilot);
                         }
@@ -341,9 +333,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                         useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                     }
                                     unit.addDriver(person, useTransfers);
-                                    if (person.getRecruitment() == null) {
-                                        person.setRecruitment(campaign.getLocalDate());
-                                    }
+                                    ensureRecruitmentDate(campaign.getLocalDate(), person);
                                 }
                             }
                         });
@@ -367,9 +357,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                     useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                 }
                                 unit.addDriver(people[0], useTransfers);
-                                if (people[0].getRecruitment() == null) {
-                                    people[0].setRecruitment(campaign.getLocalDate());
-                                }
+
+                                Person person = people[0];
+                                ensureRecruitmentDate(campaign.getLocalDate(), person);
                             });
                             driverEntityWeightMenu.add(miDriver);
                         }
@@ -406,9 +396,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                         useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                     }
                                     unit.addGunner(person, useTransfers);
-                                    if (person.getRecruitment() == null) {
-                                        person.setRecruitment(campaign.getLocalDate());
-                                    }
+                                    ensureRecruitmentDate(campaign.getLocalDate(), person);
                                 }
                             }
                         });
@@ -447,9 +435,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                         useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                     }
                                     unit.addVesselCrew(person, useTransfers);
-                                    if (person.getRecruitment() == null) {
-                                        person.setRecruitment(campaign.getLocalDate());
-                                    }
+                                    ensureRecruitmentDate(campaign.getLocalDate(), person);
                                 }
                             }
                         });
@@ -479,9 +465,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                     useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                 }
                                 unit.setTechOfficer(people[0], useTransfers);
-                                if (people[0].getRecruitment() == null) {
-                                    people[0].setRecruitment(campaign.getLocalDate());
-                                }
+
+                                Person person = people[0];
+                                ensureRecruitmentDate(campaign.getLocalDate(), person);
                             });
                             consoleCommanderEntityWeightMenu.add(miConsoleCommander);
                         }
@@ -498,9 +484,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                 useTransfers = campaign.getCampaignOptions().isUseTransfers();
                             }
                             unit.setTechOfficer(people[0], useTransfers);
-                            if (people[0].getRecruitment() == null) {
-                                people[0].setRecruitment(campaign.getLocalDate());
-                            }
+
+                            Person person = people[0];
+                            ensureRecruitmentDate(campaign.getLocalDate(), person);
                         });
                         techOfficerEntityWeightMenu.add(miTechOfficer);
                     }
@@ -527,9 +513,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                         useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                     }
                                     unit.addPilotOrSoldier(person, useTransfers);
-                                    if (person.getRecruitment() == null) {
-                                        person.setRecruitment(campaign.getLocalDate());
-                                    }
+                                    ensureRecruitmentDate(campaign.getLocalDate(), person);
                                 }
                             }
                         });
@@ -551,9 +535,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                             useTransfers = campaign.getCampaignOptions().isUseTransfers();
                         }
                         unit.setNavigator(people[0], useTransfers);
-                        if (people[0].getRecruitment() == null) {
-                            people[0].setRecruitment(campaign.getLocalDate());
-                        }
+
+                        Person person = people[0];
+                        ensureRecruitmentDate(campaign.getLocalDate(), person);
                     });
                     navigatorEntityWeightMenu.add(miNavigator);
                 }
@@ -610,6 +594,24 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                 }
             });
             add(miUnassignPerson);
+        }
+    }
+
+    /**
+     * Ensures that the given person's recruitment date is set.
+     *
+     * <p>If the {@code Person} does not already have a recruitment date assigned, this method assigns the provided
+     * date as their recruitment date.</p>
+     *
+     * @param today  the {@link LocalDate} to set as the recruitment date if not already set
+     * @param person the {@link Person} whose recruitment date is to be checked and possibly updated
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private static void ensureRecruitmentDate(LocalDate today, Person person) {
+        if (person.getRecruitment() == null) {
+            person.setRecruitment(today);
         }
     }
     //endregion Initialization

--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -172,7 +172,18 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
             final boolean areAllVesselCrew = Stream.of(people)
                                                    .allMatch(person -> person.hasRole(PersonnelRole.VESSEL_CREW));
             final boolean areAllVehicleCrew = Stream.of(people)
-                                                    .allMatch(person -> person.hasRole(PersonnelRole.VEHICLE_CREW));
+                                                    .allMatch(person -> person.hasRole(PersonnelRole.MEK_TECH) ||
+                                                                              person.hasRole(PersonnelRole.AERO_TEK) ||
+                                                                              person.hasRole(PersonnelRole.MECHANIC) ||
+                                                                              person.hasRole(PersonnelRole.BA_TECH) ||
+                                                                              person.hasRole(PersonnelRole.ASTECH) ||
+                                                                              person.hasRole(PersonnelRole.DOCTOR) ||
+                                                                              person.hasRole(PersonnelRole.MEDIC) ||
+                                                                              person.hasRole(PersonnelRole.COMMS_OPERATOR) ||
+                                                                              person.hasRole(PersonnelRole.TECH_COMMUNICATIONS) ||
+                                                                              person.hasRole(PersonnelRole.SENSOR_TECHNICIAN) ||
+                                                                              person.hasRole(PersonnelRole.CHEF) ||
+                                                                              person.hasRole(PersonnelRole.VEHICLE_CREW));
             final boolean areAllSoldiers = Stream.of(people).allMatch(person -> person.hasRole(PersonnelRole.SOLDIER));
             final boolean areAllBattleArmourPilots = Stream.of(people)
                                                            .allMatch(person -> person.hasRole(PersonnelRole.BATTLE_ARMOUR));
@@ -303,6 +314,10 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                 } else {
                                     unit.addPilotOrSoldier(people[0], useTransfers);
                                 }
+
+                                if (people[0].getRecruitment() == null) {
+                                    people[0].setRecruitment(campaign.getLocalDate());
+                                }
                             });
                             pilotEntityWeightMenu.add(miPilot);
                         }
@@ -326,6 +341,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                         useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                     }
                                     unit.addDriver(person, useTransfers);
+                                    if (person.getRecruitment() == null) {
+                                        person.setRecruitment(campaign.getLocalDate());
+                                    }
                                 }
                             }
                         });
@@ -349,6 +367,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                     useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                 }
                                 unit.addDriver(people[0], useTransfers);
+                                if (people[0].getRecruitment() == null) {
+                                    people[0].setRecruitment(campaign.getLocalDate());
+                                }
                             });
                             driverEntityWeightMenu.add(miDriver);
                         }
@@ -385,6 +406,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                         useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                     }
                                     unit.addGunner(person, useTransfers);
+                                    if (person.getRecruitment() == null) {
+                                        person.setRecruitment(campaign.getLocalDate());
+                                    }
                                 }
                             }
                         });
@@ -423,6 +447,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                         useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                     }
                                     unit.addVesselCrew(person, useTransfers);
+                                    if (person.getRecruitment() == null) {
+                                        person.setRecruitment(campaign.getLocalDate());
+                                    }
                                 }
                             }
                         });
@@ -452,6 +479,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                     useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                 }
                                 unit.setTechOfficer(people[0], useTransfers);
+                                if (people[0].getRecruitment() == null) {
+                                    people[0].setRecruitment(campaign.getLocalDate());
+                                }
                             });
                             consoleCommanderEntityWeightMenu.add(miConsoleCommander);
                         }
@@ -468,6 +498,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                 useTransfers = campaign.getCampaignOptions().isUseTransfers();
                             }
                             unit.setTechOfficer(people[0], useTransfers);
+                            if (people[0].getRecruitment() == null) {
+                                people[0].setRecruitment(campaign.getLocalDate());
+                            }
                         });
                         techOfficerEntityWeightMenu.add(miTechOfficer);
                     }
@@ -494,6 +527,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                         useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                     }
                                     unit.addPilotOrSoldier(person, useTransfers);
+                                    if (person.getRecruitment() == null) {
+                                        person.setRecruitment(campaign.getLocalDate());
+                                    }
                                 }
                             }
                         });
@@ -515,6 +551,9 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                             useTransfers = campaign.getCampaignOptions().isUseTransfers();
                         }
                         unit.setNavigator(people[0], useTransfers);
+                        if (people[0].getRecruitment() == null) {
+                            people[0].setRecruitment(campaign.getLocalDate());
+                        }
                     });
                     navigatorEntityWeightMenu.add(miNavigator);
                 }

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
@@ -342,7 +342,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                         }
 
                         if (subMenu != null) {
-                            final JMenuItem miPilot = new JMenuItem(person.getFullTitle());
+                            final JMenuItem miPilot = new JMenuItem(person.getFullTitleAndProfessions());
                             miPilot.setName("miPilot");
                             miPilot.addActionListener(evt -> {
                                 final Unit oldUnit = person.getUnit();
@@ -350,6 +350,10 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                                 if (oldUnit != null) {
                                     oldUnit.remove(person, !campaign.getCampaignOptions().isUseTransfers());
                                     useTransfers = campaign.getCampaignOptions().isUseTransfers();
+                                }
+
+                                if (person.getRecruitment() == null) {
+                                    person.setRecruitment(campaign.getLocalDate());
                                 }
 
                                 if (isVTOL || isSmallCraftOrJumpShip) {
@@ -428,7 +432,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                         }
 
                         if (subMenu != null) {
-                            final JMenuItem miDriver = new JMenuItem(person.getFullTitle());
+                            final JMenuItem miDriver = new JMenuItem(person.getFullTitleAndProfessions());
                             miDriver.setName("miDriver");
                             miDriver.addActionListener(evt -> {
                                 final Unit oldUnit = person.getUnit();
@@ -437,6 +441,11 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                                     oldUnit.remove(person, !campaign.getCampaignOptions().isUseTransfers());
                                     useTransfers = campaign.getCampaignOptions().isUseTransfers();
                                 }
+
+                                if (person.getRecruitment() == null) {
+                                    person.setRecruitment(campaign.getLocalDate());
+                                }
+
                                 units[0].addDriver(person, useTransfers);
                             });
                             subMenu.add(miDriver);
@@ -520,7 +529,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                     }
 
                     if (subMenu != null) {
-                        final JMenuItem miGunner = new JMenuItem(person.getFullTitle());
+                        final JMenuItem miGunner = new JMenuItem(person.getFullTitleAndProfessions());
                         miGunner.setName("miGunner");
                         miGunner.addActionListener(evt -> {
                             final Unit oldUnit = person.getUnit();
@@ -529,6 +538,11 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                                 oldUnit.remove(person, !campaign.getCampaignOptions().isUseTransfers());
                                 useTransfers = campaign.getCampaignOptions().isUseTransfers();
                             }
+
+                            if (person.getRecruitment() == null) {
+                                person.setRecruitment(campaign.getLocalDate());
+                            }
+
                             units[0].addGunner(person, useTransfers);
                         });
                         subMenu.add(miGunner);
@@ -548,9 +562,31 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         // Crewmember Menu
         if (units[0].canTakeMoreVesselCrew() && (isAero || units[0].getEntity().isSupportVehicle())) {
             filteredPersonnel = personnel.stream()
-                                      .filter(person -> person.hasRole(isAero ?
-                                                                             PersonnelRole.VESSEL_CREW :
-                                                                             PersonnelRole.VEHICLE_CREW))
+                                      .filter(person -> isAero
+                                                              ? person.hasRole(PersonnelRole.VESSEL_CREW)
+                                                              : (person.hasRole(PersonnelRole.MEK_TECH)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.AERO_TEK)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.MECHANIC)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.BA_TECH)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.ASTECH)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.DOCTOR)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.MEDIC)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.COMMS_OPERATOR)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.TECH_COMMUNICATIONS)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.SENSOR_TECHNICIAN)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.CHEF)
+                                                                       ||
+                                                                       person.hasRole(PersonnelRole.VEHICLE_CREW)))
                                       .collect(Collectors.toList());
             if (!filteredPersonnel.isEmpty()) {
                 // Create the SkillLevel Submenus
@@ -566,39 +602,22 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
 
                 // Add the person to the proper menu
                 for (final Person person : filteredPersonnel) {
-                    final JScrollableMenu subMenu;
-                    switch (person.getSkillLevel(campaign,
+                    final JScrollableMenu subMenu = switch (person.getSkillLevel(campaign,
                           isAero ?
                                 !person.getPrimaryRole().isVesselCrew() :
-                                !person.getPrimaryRole().isVehicleCrew())) {
-                        case LEGENDARY:
-                            subMenu = legendaryMenu;
-                            break;
-                        case HEROIC:
-                            subMenu = heroicMenu;
-                            break;
-                        case ELITE:
-                            subMenu = eliteMenu;
-                            break;
-                        case VETERAN:
-                            subMenu = veteranMenu;
-                            break;
-                        case REGULAR:
-                            subMenu = regularMenu;
-                            break;
-                        case GREEN:
-                            subMenu = greenMenu;
-                            break;
-                        case ULTRA_GREEN:
-                            subMenu = ultraGreenMenu;
-                            break;
-                        default:
-                            subMenu = null;
-                            break;
-                    }
+                                !person.getPrimaryRole().isVehicleCrewExtended())) {
+                        case LEGENDARY -> legendaryMenu;
+                        case HEROIC -> heroicMenu;
+                        case ELITE -> eliteMenu;
+                        case VETERAN -> veteranMenu;
+                        case REGULAR -> regularMenu;
+                        case GREEN -> greenMenu;
+                        case ULTRA_GREEN -> ultraGreenMenu;
+                        default -> null;
+                    };
 
                     if (subMenu != null) {
-                        final JMenuItem miCrewmember = new JMenuItem(person.getFullTitle());
+                        final JMenuItem miCrewmember = new JMenuItem(person.getFullTitleAndProfessions());
                         miCrewmember.setName("miCrewmember");
                         miCrewmember.addActionListener(evt -> {
                             final Unit oldUnit = person.getUnit();
@@ -607,6 +626,11 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                                 oldUnit.remove(person, !campaign.getCampaignOptions().isUseTransfers());
                                 useTransfers = campaign.getCampaignOptions().isUseTransfers();
                             }
+
+                            if (person.getRecruitment() == null) {
+                                person.setRecruitment(campaign.getLocalDate());
+                            }
+
                             units[0].addVesselCrew(person, useTransfers);
                         });
                         subMenu.add(miCrewmember);
@@ -638,7 +662,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                 // or a gunner, but not necessarily both
                 if (isTank) {
                     if (person.canDrive(units[0].getEntity()) || person.canGun(units[0].getEntity())) {
-                        final JMenuItem miConsoleCommander = new JMenuItem(person.getFullTitle());
+                        final JMenuItem miConsoleCommander = new JMenuItem(person.getFullTitleAndProfessions());
                         miConsoleCommander.setName("miConsoleCommander");
                         miConsoleCommander.addActionListener(evt -> {
                             final Unit oldUnit = person.getUnit();
@@ -647,12 +671,17 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                                 oldUnit.remove(person, !campaign.getCampaignOptions().isUseTransfers());
                                 useTransfers = campaign.getCampaignOptions().isUseTransfers();
                             }
+
+                            if (person.getRecruitment() == null) {
+                                person.setRecruitment(campaign.getLocalDate());
+                            }
+
                             units[0].setTechOfficer(person, useTransfers);
                         });
                         consoleCommanderMenu.add(miConsoleCommander);
                     }
                 } else if (person.canDrive(units[0].getEntity()) && person.canGun(units[0].getEntity())) {
-                    final JMenuItem miTechOfficer = new JMenuItem(person.getFullTitle());
+                    final JMenuItem miTechOfficer = new JMenuItem(person.getFullTitleAndProfessions());
                     miTechOfficer.setName("miTechOfficer");
                     miTechOfficer.addActionListener(evt -> {
                         final Unit oldUnit = person.getUnit();
@@ -661,6 +690,11 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                             oldUnit.remove(person, !campaign.getCampaignOptions().isUseTransfers());
                             useTransfers = campaign.getCampaignOptions().isUseTransfers();
                         }
+
+                        if (person.getRecruitment() == null) {
+                            person.setRecruitment(campaign.getLocalDate());
+                        }
+
                         units[0].setTechOfficer(person, useTransfers);
                     });
                     techOfficerMenu.add(miTechOfficer);
@@ -722,7 +756,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                     }
 
                     if (subMenu != null) {
-                        final JMenuItem miSoldier = new JMenuItem(person.getFullTitle());
+                        final JMenuItem miSoldier = new JMenuItem(person.getFullTitleAndProfessions());
                         miSoldier.setName("miSoldier");
                         miSoldier.addActionListener(evt -> {
                             final Unit oldUnit = person.getUnit();
@@ -731,6 +765,11 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                                 oldUnit.remove(person, !campaign.getCampaignOptions().isUseTransfers());
                                 useTransfers = campaign.getCampaignOptions().isUseTransfers();
                             }
+
+                            if (person.getRecruitment() == null) {
+                                person.setRecruitment(campaign.getLocalDate());
+                            }
+
                             units[0].addPilotOrSoldier(person, useTransfers);
                         });
                         subMenu.add(miSoldier);
@@ -796,7 +835,7 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                     }
 
                     if (subMenu != null) {
-                        final JMenuItem miNavigator = new JMenuItem(person.getFullTitle());
+                        final JMenuItem miNavigator = new JMenuItem(person.getFullTitleAndProfessions());
                         miNavigator.setName("miNavigator");
                         miNavigator.addActionListener(evt -> {
                             final Unit oldUnit = person.getUnit();
@@ -805,6 +844,11 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
                                 oldUnit.remove(person, !campaign.getCampaignOptions().isUseTransfers());
                                 useTransfers = campaign.getCampaignOptions().isUseTransfers();
                             }
+
+                            if (person.getRecruitment() == null) {
+                                person.setRecruitment(campaign.getLocalDate());
+                            }
+
                             units[0].setNavigator(person, useTransfers);
                         });
                         subMenu.add(miNavigator);

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelRoleTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelRoleTest.java
@@ -447,61 +447,106 @@ class PersonnelRoleTest {
         }
     }
 
-    @Test
-    void testIsGroundVehicleCrew() {
-        for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.GROUND_VEHICLE_DRIVER) ||
-                      (personnelRole == PersonnelRole.VEHICLE_GUNNER) ||
-                      (personnelRole == PersonnelRole.VEHICLE_CREW)) {
-                assertTrue(personnelRole.isGroundVehicleCrew());
-            } else {
-                assertFalse(personnelRole.isGroundVehicleCrew());
-            }
-        }
+    @ParameterizedTest
+    @EnumSource(PersonnelRole.class)
+    void testIsGroundVehicleCrew(PersonnelRole personnelRole) {
+        boolean expected = switch (personnelRole) {
+            case GROUND_VEHICLE_DRIVER,
+                 VEHICLE_GUNNER,
+                 MEK_TECH,
+                 AERO_TEK,
+                 MECHANIC,
+                 BA_TECH,
+                 ASTECH,
+                 DOCTOR,
+                 MEDIC,
+                 COMMS_OPERATOR,
+                 TECH_COMMUNICATIONS,
+                 SENSOR_TECHNICIAN,
+                 CHEF,
+                 VEHICLE_CREW -> true;
+            default -> false;
+        };
+
+        assertEquals(expected, personnelRole.isGroundVehicleCrew(),
+              () -> "Failed for role: " + personnelRole);
     }
 
-    @Test
-    void testIsNavalVehicleCrew() {
-        for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.NAVAL_VEHICLE_DRIVER) ||
-                      (personnelRole == PersonnelRole.VEHICLE_GUNNER) ||
-                      (personnelRole == PersonnelRole.VEHICLE_CREW)) {
-                assertTrue(personnelRole.isNavalVehicleCrew());
-            } else {
-                assertFalse(personnelRole.isNavalVehicleCrew());
-            }
-        }
+    @ParameterizedTest
+    @EnumSource(PersonnelRole.class)
+    void testIsNavalVehicleCrew(PersonnelRole personnelRole) {
+        boolean expected = switch (personnelRole) {
+            case NAVAL_VEHICLE_DRIVER,
+                 VEHICLE_GUNNER,
+                 MEK_TECH,
+                 AERO_TEK,
+                 MECHANIC,
+                 BA_TECH,
+                 ASTECH,
+                 DOCTOR,
+                 MEDIC,
+                 COMMS_OPERATOR,
+                 TECH_COMMUNICATIONS,
+                 SENSOR_TECHNICIAN,
+                 CHEF,
+                 VEHICLE_CREW -> true;
+            default -> false;
+        };
+
+        assertEquals(expected, personnelRole.isNavalVehicleCrew(),
+              () -> "Failed for role: " + personnelRole);
     }
 
-    @Test
-    void testIsVTOLCrew() {
-        for (final PersonnelRole personnelRole : roles) {
-            if ((personnelRole == PersonnelRole.VTOL_PILOT) ||
-                      (personnelRole == PersonnelRole.VEHICLE_GUNNER) ||
-                      (personnelRole == PersonnelRole.VEHICLE_CREW)) {
-                assertTrue(personnelRole.isVTOLCrew());
-            } else {
-                assertFalse(personnelRole.isVTOLCrew());
-            }
-        }
+    @ParameterizedTest
+    @EnumSource(PersonnelRole.class)
+    void testIsVTOLCrew(PersonnelRole personnelRole) {
+        boolean expected = switch (personnelRole) {
+            case VTOL_PILOT,
+                 VEHICLE_GUNNER,
+                 MEK_TECH,
+                 AERO_TEK,
+                 MECHANIC,
+                 BA_TECH,
+                 ASTECH,
+                 DOCTOR,
+                 MEDIC,
+                 COMMS_OPERATOR,
+                 TECH_COMMUNICATIONS,
+                 SENSOR_TECHNICIAN,
+                 CHEF,
+                 VEHICLE_CREW -> true;
+            default -> false;
+        };
+
+        assertEquals(expected, personnelRole.isVTOLCrew(),
+              () -> "Failed for role: " + personnelRole);
     }
 
-    @Test
-    void testIsVehicleCrewMember() {
-        for (final PersonnelRole personnelRole : roles) {
-            switch (personnelRole) {
-                case GROUND_VEHICLE_DRIVER:
-                case NAVAL_VEHICLE_DRIVER:
-                case VTOL_PILOT:
-                case VEHICLE_GUNNER:
-                case VEHICLE_CREW:
-                    assertTrue(personnelRole.isVehicleCrewMember());
-                    break;
-                default:
-                    assertFalse(personnelRole.isVehicleCrewMember());
-                    break;
-            }
-        }
+    @ParameterizedTest
+    @EnumSource(PersonnelRole.class)
+    void testIsVehicleCrewMember(PersonnelRole personnelRole) {
+        boolean expected = switch (personnelRole) {
+            case GROUND_VEHICLE_DRIVER,
+                 NAVAL_VEHICLE_DRIVER,
+                 VTOL_PILOT,
+                 VEHICLE_GUNNER,
+                 MEK_TECH,
+                 AERO_TEK,
+                 MECHANIC,
+                 BA_TECH,
+                 ASTECH,
+                 DOCTOR,
+                 MEDIC,
+                 COMMS_OPERATOR,
+                 TECH_COMMUNICATIONS,
+                 SENSOR_TECHNICIAN,
+                 CHEF,
+                 VEHICLE_CREW -> true;
+            default -> false;
+        };
+
+        assertEquals(expected, personnelRole.isVehicleCrewMember(),
+              () -> "Failed for role: " + personnelRole);
     }
 
     @Test


### PR DESCRIPTION
Fix #7262

MekTechs, AeroTechs, Mechanics, BA Techs, Astechs, Doctors, Medics, Comms Operators, Tech/Communications, Tech/Senor, and Chefs can now all be assigned to Support Vehicles as Vehicle Crew. This removes the need to change these personnel into Vehicle Crew just so they can be assigned to vehicles.

# Note
It is impossible to test this PR due to https://github.com/MegaMek/megamek/issues/7315 so it's likely to have issues that can be addressed once that issue report has been closed.