### PR TITLE
Fix: Fixed Crewmember Assignment Incorrectly Showing as Pilot Assignment

### DIFF
--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -426,7 +426,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                 }
                             }
                         });
-                        pilotEntityWeightMenu.add(miCrewmember);
+                        crewmemberEntityWeightMenu.add(miCrewmember);
                     }
                 }
 


### PR DESCRIPTION
This PR corrects a copy-paste error from all the way back in 2021 that incorrectly added crew members to the pilot menu, instead of the crew member menu.

This was only a visual error.