### PR TITLE
Fix: Fixed Missing 'New Option' Icon from New Personnel Market

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1498,7 +1498,7 @@ contractMarketTab.border="So there I was, between rock and a hard place, when su
 # createPersonnelMarketTab
 lblPersonnelMarketTab.text=Personnel Market Options
 # createPersonnelMarketGeneralOptionsPanel
-lblPersonnelMarketStyle.text=Market Style \u26A0 \u2714
+lblPersonnelMarketStyle.text=Market Style \u26A0 \u2714 <span style="color:#C344C3;">\u2605</span>
 lblPersonnelMarketStyle.tooltip=If enabled, each month personnel will apply to join your campaign.\
   <br>\
   <br><b>None</b> means the new personnel markets are disabled. If you want to continue using a deprecated market method,\


### PR DESCRIPTION
As per title. Ignore the commit comment.