### PR TITLE
Improvement: #7261 Expanded Age Notifications to Include Important Milestones

### DIFF
--- a/MekHQ/resources/mekhq/resources/AgingMilestone.properties
+++ b/MekHQ/resources/mekhq/resources/AgingMilestone.properties
@@ -1,0 +1,10 @@
+AgingMilestone.NONE.label=Young
+AgingMilestone.TWENTY_FIVE.label=Young Adult
+AgingMilestone.THIRTY_ONE.label=In Their Prime
+AgingMilestone.FORTY_ONE.label=Late Prime
+AgingMilestone.FIFTY_ONE.label=Middle-Aged
+AgingMilestone.SIXTY_ONE.label=Old
+AgingMilestone.SEVENTY_ONE.label=Very Old
+AgingMilestone.EIGHTY_ONE.label=Elderly
+AgingMilestone.NINETY_ONE.label=Extremely Old
+AgingMilestone.ONE_HUNDRED_ONE.label=Ancient

--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -31,6 +31,11 @@ LayeredForceIconLayer.LOGO.text=Logos
 LayeredForceIconLayer.LOGO.toolTipText=This tab contains canon faction logos that can be added to the center of a force icon.
 #### Anniversaries
 anniversaryBirthday.text=%s is <b>%s%s%s</b> today!
+anniversaryBirthday.third=They are now eligible to attend <b>Junior School</b>.
+anniversaryBirthday.tenth=They are now eligible to attend <b>High School</b>.
+anniversaryBirthday.sixteenth=They are now eligible for <b>Profession Assignment</b>.
+anniversaryBirthday.milestone=They are now considered <b>%s</b>.
+anniversaryBirthday.retirement=They are considering <b>Retirement</b>.
 anniversaryRecruitment.text=%s celebrates <b>%s%s%s</b> years with %s!
 #### Personnel Removal
 personnelRemoval.text=Old personnel records have been tidied away.

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -705,8 +705,8 @@ lblAnnounceRecruitmentAnniversaries.tooltip=A daily report notification will occ
   \ character celebrates a recruitment anniversary.
 lblAnnounceOfficersOnly.text=Officers Only
 lblAnnounceOfficersOnly.tooltip=Only report officer anniversaries.
-lblAnnounceChildBirthdays.text=Always Announce 18th Birthdays \u26A0
-lblAnnounceChildBirthdays.tooltip=If enabled, 18th birthdays will always be announced.\
+lblAnnounceChildBirthdays.text=Always Announce Child Birthdays \u26A0 <span style="color:#C344C3;">\u2605</span>
+lblAnnounceChildBirthdays.tooltip=If enabled, the birthdays of children will always be announced.\
   <br>\
   <br><b>Warning:</b> Enabling this option will override any other settings.
 # createLifeEventsPanel

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5429,7 +5429,7 @@ public class Campaign implements ITechManager {
                 String report = String.format(resources.getString("anniversaryBirthday.text"),
                       person.getHyperlinkedFullTitle(),
                       spanOpeningWithCustomColor(ReportingUtilities.getPositiveColor()),
-                      person.getAge(getLocalDate()),
+                      age,
                       CLOSING_SPAN_TAG);
 
                 // Aging Effects

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5424,6 +5424,10 @@ public class Campaign implements ITechManager {
         boolean isUseAgingEffects = campaignOptions.isUseAgeEffects();
         boolean isUseTurnover = campaignOptions.isUseRandomRetirement();
 
+        final int JUNIOR_SCHOOL_AGE = 3;
+        final int HIGH_SCHOOL_AGE = 10;
+        final int EMPLOYMENT_AGE = 16;
+
         if ((person.getRank().isOfficer()) || (!campaignOptions.isAnnounceOfficersOnly())) {
             if (isBirthday && campaignOptions.isAnnounceBirthdays()) {
                 String report = String.format(resources.getString("anniversaryBirthday.text"),
@@ -5445,11 +5449,11 @@ public class Campaign implements ITechManager {
 
                 // Special Ages
                 String addendum = "";
-                if (isUseEducation && age == 3) {
+                if (isUseEducation && age == JUNIOR_SCHOOL_AGE) {
                     addendum = resources.getString("anniversaryBirthday.third");
-                } else if (isUseEducation && age == 10) {
+                } else if (isUseEducation && age == HIGH_SCHOOL_AGE) {
                     addendum = resources.getString("anniversaryBirthday.tenth");
-                } else if (age == 16) { // This age is always relevant
+                } else if (age == EMPLOYMENT_AGE) { // This age is always relevant
                     addendum = resources.getString("anniversaryBirthday.sixteenth");
                 }
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Aging.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Aging.java
@@ -269,7 +269,7 @@ public class Aging {
     public static void applyAgingSPA(int characterAge, Person person) {
         PersonnelOptions options = person.getOptions();
         for (AgingMilestone milestone : AgingMilestone.values()) {
-            if (characterAge == milestone.getMilestone()) {
+            if (characterAge == milestone.getMinimumAge()) {
                 // Glass Jaw
                 if (milestone.isGlassJaw()) {
                     boolean hasGlassJaw = options.booleanOption(FLAW_GLASS_JAW);
@@ -312,12 +312,12 @@ public class Aging {
      */
     public static AgingMilestone getMilestone(int characterAge) {
         // Early exit, so we don't need to loop through all values for young characters
-        if (characterAge < TWENTY_FIVE.getMilestone()) {
+        if (characterAge < TWENTY_FIVE.getMinimumAge()) {
             return NONE;
         }
 
         for (AgingMilestone milestone : AgingMilestone.values()) {
-            if ((characterAge >= milestone.getMilestone()) && (characterAge < milestone.getMaximumAge())) {
+            if ((characterAge >= milestone.getMinimumAge()) && (characterAge < milestone.getMaximumAge())) {
                 return milestone;
             }
         }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/enums/AgingMilestone.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/enums/AgingMilestone.java
@@ -34,6 +34,7 @@ package mekhq.campaign.personnel.skills.enums;
 
 import static java.lang.Integer.MAX_VALUE;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.NO_SKILL_ATTRIBUTE;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.logging.MMLogger;
 
@@ -50,6 +51,7 @@ public enum AgingMilestone {
     ONE_HUNDRED_ONE(101, MAX_VALUE, -200, -200, -200, -150, -200, -100, -1500, 2, true, true);
 
     private static final MMLogger logger = MMLogger.create(AgingMilestone.class);
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.AgingMilestone";
 
     public static final int CLAN_REPUTATION_MULTIPLIER = 150;
     public static final int STAR_CAPTAIN_RANK_INDEX = 34;
@@ -157,6 +159,10 @@ public enum AgingMilestone {
         return milestone;
     }
 
+    public int getMinimumAge() {
+        return milestone;
+    }
+
     public int getMaximumAge() {
         return maximumAge;
     }
@@ -188,5 +194,9 @@ public enum AgingMilestone {
 
     public boolean isGlassJaw() {
         return glassJaw;
+    }
+
+    public String getLabel() {
+        return getTextAt(RESOURCE_BUNDLE, "AgingMilestone." + name() + ".label");
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/enums/AgingMilestone.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/enums/AgingMilestone.java
@@ -155,6 +155,11 @@ public enum AgingMilestone {
     }
 
     // Getters
+
+    /**
+     * Use {@link #getMinimumAge()} instead
+     */
+    @Deprecated(since = "0.50.07", forRemoval = true)
     public int getMilestone() {
         return milestone;
     }

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -79,7 +79,7 @@ import org.w3c.dom.NodeList;
 public class RetirementDefectionTracker {
     private static final MMLogger logger = MMLogger.create(RetirementDefectionTracker.class);
 
-    final static public int RETIREMENT_AGE = 50;
+    public static final int RETIREMENT_AGE = 50;
 
     /*
      * In case the dialog is closed after making the retirement rolls

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -79,6 +79,8 @@ import org.w3c.dom.NodeList;
 public class RetirementDefectionTracker {
     private static final MMLogger logger = MMLogger.create(RetirementDefectionTracker.class);
 
+    final static public int RETIREMENT_AGE = 50;
+
     /*
      * In case the dialog is closed after making the retirement rolls
      * and determining payouts, but before the retirees have been paid,
@@ -144,7 +146,7 @@ public class RetirementDefectionTracker {
             }
 
             if (person.isFounder()) {
-                if (person.getAge(campaign.getLocalDate()) < 50) {
+                if (person.getAge(campaign.getLocalDate()) < RETIREMENT_AGE) {
                     if (!campaign.getCampaignOptions().isUseRandomFounderTurnover()) {
                         continue;
                     }
@@ -179,7 +181,7 @@ public class RetirementDefectionTracker {
 
             // Desirability modifier
             if ((campaign.getCampaignOptions().isUseSkillModifiers()) &&
-                      (person.getAge(campaign.getLocalDate()) < 50)) {
+                      (person.getAge(campaign.getLocalDate()) < RETIREMENT_AGE)) {
                 targetNumber.addModifier(person.getExperienceLevel(campaign, false) - 2,
                       resources.getString("desirability.text"));
             }
@@ -1085,7 +1087,7 @@ public class RetirementDefectionTracker {
                   campaign.getCampaignOptions().getServiceContractDuration())) {
                 payoutAmount = Money.of(0);
                 // person is retiring
-            } else if (person.getAge(campaign.getLocalDate()) >= 50) {
+            } else if (person.getAge(campaign.getLocalDate()) >= RETIREMENT_AGE) {
                 payoutAmount = getPayoutOrBonusValue(campaign, person).multipliedBy(campaign.getCampaignOptions()
                                                                                           .getPayoutRetirementMultiplier());
                 // person was sacked

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/enums/AgingMilestoneTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/enums/AgingMilestoneTest.java
@@ -119,7 +119,7 @@ class AgingMilestoneTest {
 
             int expected = 0;
             for (AgingMilestone validMilestone : AgingMilestone.values()) {
-                if (validMilestone.getMilestone() <= age) {
+                if (validMilestone.getMinimumAge() <= age) {
                     expected += validMilestone.getAttribute(attribute);
                 }
             }
@@ -160,7 +160,7 @@ class AgingMilestoneTest {
 
         int expected = 0;
         for (AgingMilestone validMilestone : AgingMilestone.values()) {
-            if (validMilestone.getMilestone() <= personAge) {
+            if (validMilestone.getMinimumAge() <= personAge) {
                 expected += validMilestone.getAttribute(attribute);
             }
         }

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/enums/AgingMilestoneTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/enums/AgingMilestoneTest.java
@@ -32,7 +32,9 @@
  */
 package mekhq.campaign.personnel.skills.enums;
 
+import static mekhq.utilities.MHQInternationalization.isResourceKeyValid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +49,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class AgingMilestoneTest {
@@ -171,5 +174,12 @@ class AgingMilestoneTest {
                     attribute.name() +
                     " and age: " +
                     age);
+    }
+
+    @ParameterizedTest
+    @EnumSource(AgingMilestone.class)
+    void testGetLabel(AgingMilestone milestone) {
+        String label = milestone.getLabel();
+        assertTrue(isResourceKeyValid(label), "Invalid resource key for milestone: " + label);
     }
 }


### PR DESCRIPTION
Fix #7261
Fix #7318
Fix #7319
Fix #7320

This PR improves the birthday reports to highlight when characters are eligible to attend specific education tiers (junior school, and high school) - if education is enabled. When they 'come of age' (in case that life event is disabled). When they hit retirement age - if turnover is enabled). And when they reach specific aging effects Milestones - if aging effects are enabled.

It also adjusts the 'always announce 18th birthdays' option to now read 'always announce child birthdays'.
