### PR TITLE
Fix: Stopped 'Welcome to Faction' Dialog Appearing on Every New Year for Existing Campaigns

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5842,7 +5842,7 @@ public class Campaign implements ITechManager {
     private void performFactionStandingChecks(boolean isFirstOfMonth, boolean isNewYear) {
         String campaignFactionCode = faction.getShortName();
         if (isNewYear && campaignFactionCode.equals(MERCENARY_FACTION_CODE)) {
-            checkForNewMercenaryOrganizationStartUp(false);
+            checkForNewMercenaryOrganizationStartUp(false, false);
         }
 
         if (!campaignOptions.isTrackFactionStanding()) {
@@ -5909,6 +5909,14 @@ public class Campaign implements ITechManager {
     }
 
     /**
+     * Use {@link #checkForNewMercenaryOrganizationStartUp(boolean, boolean)} instead
+     */
+    @Deprecated(since = "0.50.07", forRemoval = true)
+    public void checkForNewMercenaryOrganizationStartUp(boolean bypassStartYear) {
+        checkForNewMercenaryOrganizationStartUp(bypassStartYear, false);
+    }
+
+    /**
      * Checks if a new mercenary organization is starting up in the current game year, and, if so, triggers a welcome
      * dialog introducing the organization's representative.
      *
@@ -5928,7 +5936,7 @@ public class Campaign implements ITechManager {
      * @author Illiani
      * @since 0.50.07
      */
-    public void checkForNewMercenaryOrganizationStartUp(boolean bypassStartYear) {
+    public void checkForNewMercenaryOrganizationStartUp(boolean bypassStartYear, boolean isStartUp) {
         Factions factions = Factions.getInstance();
         int currentYear = getGameYear();
         Faction[] possibleFactions = new Faction[] {
@@ -5955,7 +5963,9 @@ public class Campaign implements ITechManager {
             chosenFaction = factions.getFaction("MG"); // fallback
         }
 
-        if (chosenFaction != null && chosenFaction.isMercenaryOrganization()) {
+        if (chosenFaction != null
+                  && (chosenFaction.getStartYear() == currentYear || isStartUp)
+                  && chosenFaction.isMercenaryOrganization()) {
             PersonnelRole role = chosenFaction.isClan() ? PersonnelRole.MERCHANT : PersonnelRole.MILITARY_LIAISON;
             Person speaker = newPerson(role, chosenFaction.getShortName(), Gender.RANDOMIZE);
             new FactionJudgmentDialog(this, speaker, getCommander(),

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5971,6 +5971,8 @@ public class Campaign implements ITechManager {
             new FactionJudgmentDialog(this, speaker, getCommander(),
                   "HELLO", chosenFaction,
                   FactionStandingJudgmentType.WELCOME, ImmersiveDialogWidth.MEDIUM, null, null);
+        } else if (chosenFaction == null) {
+            logger.warn("Unable to find a suitable faction for a new mercenary organization start up");
         }
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/CompanyGenerationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CompanyGenerationDialog.java
@@ -159,7 +159,7 @@ public class CompanyGenerationDialog extends AbstractMHQValidationButtonDialog {
         Faction campaignFaction = campaign.getFaction();
         String campaignFactionCode = campaignFaction.getShortName();
         if (campaignFactionCode.equals("MERC")) {
-            campaign.checkForNewMercenaryOrganizationStartUp(true);
+            campaign.checkForNewMercenaryOrganizationStartUp(true, true);
             return;
         } else if (campaignFactionCode.equals(PIRATE_FACTION_CODE)) {
             return;


### PR DESCRIPTION
The 'welcome to faction' dialog for mercenary organizations was incorrectly triggered at the beginning of each year, instead of only during company generation or the year the organization came into existence. This PR addresses that oversight.