### PR TITLE
Fix: #7103 Fixed Dates Loading Incorrectly in Campaign Options Causing Faction and Aging Effects Weirdness

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsDialog.java
@@ -233,7 +233,7 @@ public class CampaignOptionsDialog extends AbstractMHQButtonDialog {
         final CampaignOptionsPresetPicker campaignOptionsPresetPicker = new CampaignOptionsPresetPicker(getFrame(),
               false);
         if (!campaignOptionsPresetPicker.wasCanceled()) {
-            campaignOptionsPane.applyPreset(campaignOptionsPresetPicker.getSelectedPreset());
+            campaignOptionsPane.applyPreset(campaignOptionsPresetPicker.getSelectedPreset(), false);
         }
     }
 
@@ -244,7 +244,7 @@ public class CampaignOptionsDialog extends AbstractMHQButtonDialog {
      * @param preset the {@link CampaignPreset} instance to apply
      */
     public void applyPreset(CampaignPreset preset) {
-        campaignOptionsPane.applyPreset(preset);
+        campaignOptionsPane.applyPreset(preset, true);
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -565,20 +565,34 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     }
 
     /**
+     * Use {@link #applyPreset(CampaignPreset, boolean)} instead
+     */
+    @Deprecated(since = "0.50.07", forRemoval = true)
+    public void applyPreset(@Nullable CampaignPreset campaignPreset) {
+        applyPreset(campaignPreset, false);
+    }
+
+    /**
      * Applies the values from a {@link CampaignPreset} to all tabs in the dialog. This propagates preset-specific
      * configuration to all associated components and sub-tabs, including campaign-related properties such as dates,
      * factions, and skills.
      *
      * @param campaignPreset the {@link CampaignPreset} containing the preset options to apply
+     * @param isStartUp      {@code true} if the preset is being loaded during new campaign startup
      */
-    public void applyPreset(@Nullable CampaignPreset campaignPreset) {
+    public void applyPreset(@Nullable CampaignPreset campaignPreset, boolean isStartUp) {
         if (campaignPreset == null) {
             return;
         }
 
         CampaignOptions presetCampaignOptions = campaignPreset.getCampaignOptions();
-        LocalDate presetDate = campaignPreset.getDate();
-        Faction presetFaction = campaignPreset.getFaction();
+
+        LocalDate presetDate = campaign.getLocalDate();
+        Faction presetFaction = campaign.getFaction();
+        if (isStartUp) {
+            presetDate = campaignPreset.getDate();
+            presetFaction = campaignPreset.getFaction();
+        }
 
         generalTab.loadValuesFromCampaignOptions(presetDate, presetFaction);
 


### PR DESCRIPTION
Fix #7103

When a campaign preset is loaded campaign options is updated to use that preset's set date. However, if the preset is loaded _over_ an existing save the campaign date is temporarily overwritten. Then, when we check the date in use, elsewhere in campaign options, we use this temporary date.

This will cause issues if the date of the preset and the current campaign date are vastly different. For example, displaying factions long dead, or the wrong system ownership for factions. Or, as was the case in the attached report, treating every character as if they were 100 years older than they actually are.

This problem is made insidious by the fact that the temporary date overwriting makes no visual changes to the campaign itself. If you didn't know to look for the problem, you would never know it was there.