### PR TITLE
Fix: #7087 Fixed Reputation Modifiers from Aging Being Incorrectly Multiplied by 150

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/Aging.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Aging.java
@@ -32,6 +32,7 @@
  */
 package mekhq.campaign.personnel.skills;
 
+import static java.lang.Math.round;
 import static megamek.common.options.PilotOptions.LVL3_ADVANTAGES;
 import static mekhq.campaign.personnel.PersonnelOptions.ATOW_FAST_LEARNER;
 import static mekhq.campaign.personnel.PersonnelOptions.ATOW_TOUGHNESS;
@@ -250,7 +251,9 @@ public class Aging {
             reputationMultiplier--;
         }
 
-        return reputationMultiplier * CLAN_REPUTATION_MULTIPLIER;
+        int modifier = reputationMultiplier * CLAN_REPUTATION_MULTIPLIER;
+        double totalModifier = (double) modifier / AGING_SKILL_MODIFIER_DIVIDER;
+        return (int) round(totalModifier);
     }
 
     /**
@@ -336,6 +339,6 @@ public class Aging {
      * @return the adjusted skill attribute modifier after applying aging rules
      */
     private static int applyAgingModifier(int modifierSum) {
-        return (int) Math.round((double) modifierSum / AGING_SKILL_MODIFIER_DIVIDER);
+        return (int) round((double) modifierSum / AGING_SKILL_MODIFIER_DIVIDER);
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/enums/AgingMilestone.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/enums/AgingMilestone.java
@@ -47,7 +47,7 @@ public enum AgingMilestone {
     SEVENTY_ONE(71, 81, -100, -125, 0, -100, 0, -50, -75, 2, true, true),
     EIGHTY_ONE(81, 91, -150, -150, -100, -100, -100, -50, -100, 2, true, true),
     NINETY_ONE(91, 101, -150, -175, -150, -125, -150, -100, -100, 2, true, true),
-    ONE_HUNDRED_ONE(101, MAX_VALUE, -200, -200, -200, -150, -200, -100, -1500, 2, true, true);
+    ONE_HUNDRED_ONE(101, MAX_VALUE, -200, -200, -200, -150, -200, -100, -150, 2, true, true);
 
     private static final MMLogger logger = MMLogger.create(AgingMilestone.class);
 


### PR DESCRIPTION
Fix #7087 

This issue was caused by a missing divisor. I also fixed a typo in Charisma penalty for very old characters.