### PR TITLE
Feature: Added ATOW Bloodmark Trait

### DIFF
--- a/MekHQ/resources/mekhq/resources/Bloodmark.properties
+++ b/MekHQ/resources/mekhq/resources/Bloodmark.properties
@@ -1,0 +1,6 @@
+Bloodmark.assassinationAttempt.assassinated=<b>The Bounty Hunter</b> known as <b>{0}</b> has {1}<b>Assassinated</b>{2} \
+  {3} and claimed the bounty on their head.
+Bloodmark.assassinationAttempt.wounded=<b>The Bounty Hunter</b> known as <b>{0}</b> has {1}<b>Wounded</b>{2} {3}, but \
+  was unable to claim the bounty on their head.
+Bloodmark.assassinationAttempt.unsuccessful={0} successfully {1}<b>Evaded</b>{2} an attempt on their life by the \
+  <b>Bounty Hunter</b> known as <b>{3}</b>.

--- a/MekHQ/resources/mekhq/resources/CreateCharacterDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CreateCharacterDialog.properties
@@ -13,6 +13,7 @@ lblConnections.text=Connections:
 lblWealth.text=Wealth:
 lblReputation.text=Reputation:
 lblUnlucky.text=Unlucky:
+lblBloodmark.text=Bloodmark:
 lblEducationLevel.text=Education:
 lblFatigue.text=Fatigue:
 lblLoyalty.text=Loyalty:

--- a/MekHQ/resources/mekhq/resources/CustomizePersonDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CustomizePersonDialog.properties
@@ -13,6 +13,7 @@ lblConnections.text=Connections:
 lblWealth.text=Wealth:
 lblReputation.text=Reputation:
 lblUnlucky.text=Unlucky:
+lblBloodmark.text=Bloodmark:
 lblEducationLevel.text=Education:
 lblFatigue.text=Fatigue:
 lblLoyalty.text=Loyalty:

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -176,6 +176,8 @@ spendOnWealth.tooltip=Raising this trait to at least rank 7 will improve unit Re
   \ beginning of each month.
 spendOnUnlucky.text=Unlucky -> %s (%s xp)
 spendOnUnlucky.tooltip=Decreases the character's available Edge by %s.
+spendOnBloodmark.text=Bloodmark -> %s (%s xp)
+spendOnBloodmark.tooltip=Increases the character's Bloodmark (bounty) and the rate of assassination attempts.
 spendOnAttributes.increase=Increase Attribute Scores
 spendOnAttributes.set=Set Attribute Score
 spendOnAttributes.format=%s %s -> %s (%s xp)
@@ -986,6 +988,7 @@ PersonnelTableModelColumn.CONNECTIONS.text=Connections
 PersonnelTableModelColumn.WEALTH.text=Wealth
 PersonnelTableModelColumn.REPUTATION.text=Reputation
 PersonnelTableModelColumn.UNLUCKY.text=Unlucky
+PersonnelTableModelColumn.BLOODMARK.text=Bloodmark
 PersonnelTableModelColumn.FATIGUE.text=Fatigue
 PersonnelTableModelColumn.EDGE.text=Edge
 PersonnelTableModelColumn.SPA_COUNT.text=SPA Count

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -82,6 +82,11 @@ AUTOINFIRMARY.definition=AutoInfirmary lets you instantly assign all injured per
  \ manually assign doctors. If you find yourself without enough hospital beds, MekHQ will warn you with a daily alert\
  \ (unless that alert has been disabled in MekHQ Options).</p>
 ### B
+BLOODMARK.title=Bloodmark
+BLOODMARK.definition=Bloodmarks are a type of <a href='GLOSSARY:ATOW_TRAITS'>Trait</a>. The higher a character''s \
+  'Bloodmark' the greater the chance a 'Bloodhunt' occurs. When this happens, a bounty hunter will make an attempt on \
+  the character''s life. This may result in them escaping, getting injured, or even being killed.\
+  <p>Bloodhunt frequencies can be found in the 'Bloodmark' section of <b>A Time of War</b>.</p>
 ### C
 CAPITAL_SYSTEMS.title=Capital Systems
 CAPITAL_SYSTEMS.definition=On the interstellar map, a faction's capital system is marked by a special ring. Each faction\

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -53,12 +53,14 @@ import static mekhq.campaign.mission.resupplyAndCaches.PerformResupply.performRe
 import static mekhq.campaign.mission.resupplyAndCaches.Resupply.isProhibitedUnitType;
 import static mekhq.campaign.mission.resupplyAndCaches.ResupplyUtilities.processAbandonedConvoy;
 import static mekhq.campaign.parts.enums.PartQuality.QUALITY_A;
+import static mekhq.campaign.personnel.Bloodmark.getBloodhuntSchedule;
 import static mekhq.campaign.personnel.DiscretionarySpending.performDiscretionarySpending;
 import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_INTERSTELLAR_NEGOTIATOR;
 import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_LOGISTICIAN;
 import static mekhq.campaign.personnel.backgrounds.BackgroundsController.randomMercenaryCompanyNameGenerator;
 import static mekhq.campaign.personnel.education.EducationController.getAcademy;
 import static mekhq.campaign.personnel.education.TrainingCombatTeams.processTrainingCombatTeams;
+import static mekhq.campaign.personnel.enums.BloodmarkLevel.BLOODMARK_ZERO;
 import static mekhq.campaign.personnel.lifeEvents.CommandersDayAnnouncement.isCommandersDay;
 import static mekhq.campaign.personnel.lifeEvents.FreedomDayAnnouncement.isFreedomDay;
 import static mekhq.campaign.personnel.lifeEvents.NewYearsDayAnnouncement.isNewYear;
@@ -180,6 +182,7 @@ import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.HeatSink;
 import mekhq.campaign.parts.equipment.JumpJet;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
+import mekhq.campaign.personnel.Bloodmark;
 import mekhq.campaign.personnel.Bloodname;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
@@ -191,6 +194,7 @@ import mekhq.campaign.personnel.divorce.AbstractDivorce;
 import mekhq.campaign.personnel.divorce.DisabledRandomDivorce;
 import mekhq.campaign.personnel.education.Academy;
 import mekhq.campaign.personnel.education.EducationController;
+import mekhq.campaign.personnel.enums.BloodmarkLevel;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.enums.Phenotype;
@@ -5243,6 +5247,7 @@ public class Campaign implements ITechManager {
         boolean isCommandersDay = isCommandersDay(currentDay) &&
                                         getCommander() != null &&
                                         campaignOptions.isShowLifeEventDialogCelebrations();
+        boolean isCampaignPlanetside = location.isOnPlanet();
         for (Person person : personnel) {
             if (person.getStatus().isDepartedUnit()) {
                 continue;
@@ -5309,12 +5314,32 @@ public class Campaign implements ITechManager {
                 }
 
                 person.setHasPerformedExtremeExpenditure(false);
+
+                int bloodmarkLevel = person.getBloodmark();
+                if (bloodmarkLevel > BLOODMARK_ZERO.getLevel()) {
+                    BloodmarkLevel bloodmark = BloodmarkLevel.parseBloodmarkLevelFromInt(bloodmarkLevel);
+                    List<LocalDate> bloodmarkSchedule = getBloodhuntSchedule(bloodmark, currentDay);
+                    for (LocalDate assassinationAttempt : bloodmarkSchedule) {
+                        person.addBloodhuntDate(assassinationAttempt);
+                    }
+                }
             }
 
             if (isCommandersDay && !faction.isClan() && (peopleWhoCelebrateCommandersDay < commanderDayTargetNumber)) {
                 int age = person.getAge(currentDay);
                 if (age >= 6 && age <= 12) {
                     peopleWhoCelebrateCommandersDay++;
+                }
+            }
+
+            List<LocalDate> scheduledBloodhunts = person.getBloodhuntSchedule();
+            if (!scheduledBloodhunts.isEmpty()) {
+                boolean isDayOfBloodhunt = Bloodmark.checkForAssassinationAttempt(person,
+                      currentDay,
+                      isCampaignPlanetside);
+
+                if (isDayOfBloodhunt) {
+                    Bloodmark.performAssassinationAttempt(this, person, currentDay);
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/personnel/Bloodmark.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Bloodmark.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel;
+
+import static java.lang.Math.ceil;
+import static megamek.common.Compute.d6;
+import static megamek.common.Compute.randomInt;
+import static mekhq.campaign.personnel.PersonnelOptions.ATOW_TOUGHNESS;
+import static mekhq.campaign.personnel.PersonnelOptions.FLAW_GLASS_JAW;
+import static mekhq.campaign.personnel.enums.BloodmarkLevel.BLOODMARK_ZERO;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.getNegativeColor;
+import static mekhq.utilities.ReportingUtilities.getPositiveColor;
+import static mekhq.utilities.ReportingUtilities.getWarningColor;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import megamek.client.generator.RandomCallsignGenerator;
+import megamek.logging.MMLogger;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.event.PersonChangedEvent;
+import mekhq.campaign.personnel.enums.BloodmarkLevel;
+import mekhq.campaign.personnel.enums.PersonnelStatus;
+import mekhq.campaign.personnel.medical.advancedMedical.InjuryUtil;
+
+/**
+ * Handles Bloodmark-related logic for characters, including assassination attempt scheduling and execution.
+ *
+ * <p>A Bloodmark in MekHQ represents a standing bounty or vendetta against a person, triggering periodic
+ * assassination attempts ("bloodhunts") against them based on their {@link BloodmarkLevel}.</p>
+ *
+ * <p>This class provides static utility methods to:</p>
+ * <ul>
+ *     <li>Generate future dates for possible bloodhunts depending on bloodmark severity</li>
+ *     <li>Check whether an attempt should occur on a given date and whether the target is eligible</li>
+ *     <li>Execute an assassination attempt: calculating results, inflicting wounds or injuries, and updating reports
+ *     and character status accordingly</li>
+ *     <li>Handle special modifiers like the Toughness or Glass Jaw traits, advanced vs. basic medical handling, and
+ *     generate appropriately formatted feedback for the campaign event log</li>
+ * </ul>
+ *
+ * <p>The class also encapsulates internal utility logic for wounds calculation, bounty hunter name generation, and
+ * formatting of result reports.</p>
+ *
+ * @author Illiani
+ * @since 0.50.07
+ */
+public class Bloodmark {
+    private static final MMLogger LOGGER = MMLogger.create(Bloodmark.class);
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.Bloodmark";
+
+    /** A default name assigned to the bounty hunter when a randomly generated name is unavailable. */
+    private static final String DEFAULT_BOUNTY_HUNTER_NAME = "DOG";
+
+    /**
+     * Generates a schedule of future dates for assassination attempts ("bloodhunts") based on the provided
+     * {@link BloodmarkLevel} and current date.
+     *
+     * <p>The frequency and number of attempts are determined by the properties of the given level. If no bloodhunt
+     * is active or parameters indicate none should occur, returns an empty list. Each returned {@link LocalDate}
+     * represents a scheduled day for an attempt, spaced randomly by 1d6 days.</p>
+     *
+     * <p><b>Usage:</b> this method should be run once a month, per character with a {@link BloodmarkLevel} greater
+     * than 0.</p>
+     *
+     * @param level the {@link BloodmarkLevel} used to determine scheduling and attempt frequency
+     * @param today the starting date from which to schedule the bloodhunt attempts
+     *
+     * @return a list of {@link LocalDate} objects, one for each scheduled assassination attempt; or an empty list if no
+     *       bloodhunt should be scheduled
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public static List<LocalDate> getBloodhuntSchedule(final BloodmarkLevel level, LocalDate today) {
+        LocalDate currentDate = today;
+
+        // How often do bloodhunts occur?
+        int frequency = level.getRollFrequency();
+        if (frequency == 0) {
+            return List.of();
+        }
+
+        // Is there an active bloodhunt?
+        int bloodhuntRoll = randomInt(frequency);
+        boolean isBloodhuntActive = bloodhuntRoll == 0;
+        if (!isBloodhuntActive) {
+            return List.of();
+        }
+
+        // How many assassination attempts should occur?
+        int divisor = level.getRollDivisor();
+        if (divisor == 0) {
+            return List.of();
+        }
+
+        int assassinationAttempts = d6(1) / divisor; // The loss of precision here is deliberate
+
+        // Schedule the assassination attempts (this is very polite of the assassins)
+        List<LocalDate> assassinationSchedule = new ArrayList<>();
+        for (int attempt = 0; attempt < assassinationAttempts; attempt++) {
+            int lag = d6(1);
+            currentDate = currentDate.plusDays(lag); // We don't want multiple attempts on the same day
+            assassinationSchedule.add(currentDate);
+        }
+
+        return assassinationSchedule;
+    }
+
+    /**
+     * Checks whether an assassination attempt should be triggered for the specified person on the given date.
+     *
+     * <p>This method examines the person's bloodhunt schedule. If the current date matches a scheduled bloodhunt,
+     * the date is removed from the schedule regardless of further checks (representing a missed opportunity or a failed
+     * attempt). The method then verifies if the campaign is planetside (or the target is absent from the campaign), and
+     * the target is not currently deployed.</p>
+     *
+     * @param target               the person who may be the target of an assassination attempt
+     * @param today                the date to check for a scheduled bloodhunt
+     * @param isCampaignPlanetside {@code true} if the campaign is currently planetside, allowing an attempt;
+     *                             {@code false} otherwise
+     *
+     * @return {@code true} if an assassination attempt should occur; {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public static boolean checkForAssassinationAttempt(Person target, LocalDate today, boolean isCampaignPlanetside) {
+        List<LocalDate> bloodhuntSchedule = target.getBloodhuntSchedule();
+        if (bloodhuntSchedule.isEmpty()) {
+            return false;
+        }
+
+        if (!bloodhuntSchedule.contains(today)) {
+            return false;
+        }
+
+        // Whether the Bloodhunt occurs, or not, we remove it from the array so that we're not parsing over old dates.
+        // Removing the date even if the hunt is skips is a way of representing the character getting lucky and just
+        // not being accessible when the bounty hunter makes their move.
+        target.removeBloodhuntDate(today);
+
+        if (!isCampaignPlanetside && !target.getStatus().isAbsent()) {
+            return false;
+        }
+
+        // We check that the target is not deployed to avoid any weirdness that might come from the character
+        // suddenly dying without the player having any reasonable way of recalling their unit.
+        return !target.isDeployed();
+    }
+
+    /**
+     * Performs an assassination attempt on a specified person based on their bloodmark level.
+     *
+     * <p>If the person's bloodmark indicates no threat, the attempt is skipped. Otherwise, the method:</p>
+     * <ul>
+     *   <li>Generates a bounty hunter with the appropriate skill level and name based on the
+     *   {@link BloodmarkLevel}.</li>
+     *   <li>Determines if the assassination attempt is successful by calculating wounds.</li>
+     *   <li>If the person escapes (zero wounds), adds a report to the campaign and exits.</li>
+     *   <li>If wounded, applies any special adjustments, processes the wounds, and reports the outcome.</li>
+     * </ul>
+     *
+     * @param campaign the {@link Campaign} in which the event takes place
+     * @param person   the {@link Person} targeted by the assassination attempt
+     * @param today    the current {@link LocalDate} to associate with the event
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public static void performAssassinationAttempt(Campaign campaign, Person person, LocalDate today) {
+        int level = person.getBloodmark();
+        BloodmarkLevel bloodmark = BloodmarkLevel.parseBloodmarkLevelFromInt(level);
+        if (bloodmark == BLOODMARK_ZERO) {
+            LOGGER.info("An assassination attempt was made on a character with no bloodmark. Skipping the hunt.");
+            return;
+        }
+
+        // Generate the bounty hunter
+        int bountyHunterSkill = bloodmark.getBountyHunterSkill();
+        String bountyHunterName = getBountyHunterName();
+
+        // Check whether the assassination attempt was successful
+        int wounds = getWounds(bountyHunterSkill);
+
+        // If wounds are 0, the character escaped the assassination attempt
+        if (wounds == 0) {
+            String report = getFormattedTextAt(RESOURCE_BUNDLE,
+                  "Bloodmark.assassinationAttempt.unsuccessful",
+                  person.getHyperlinkedFullTitle(),
+                  spanOpeningWithCustomColor(getPositiveColor()),
+                  CLOSING_SPAN_TAG,
+                  bountyHunterName);
+            campaign.addReport(report);
+            return;
+        }
+
+        // Inflict injuries or wounds as appropriate
+        wounds = adjustmentWoundsForSPAs(person, wounds);
+        processWounds(campaign, person, today, wounds);
+
+        String report = getReport(person.getStatus().isDead(), person.getHyperlinkedFullTitle(), bountyHunterName);
+        campaign.addReport(report);
+
+        MekHQ.triggerEvent(new PersonChangedEvent(person));
+    }
+
+    /**
+     * Calculates the total number of wounds based on the given bounty hunter skill.
+     *
+     * <p>This method repeatedly rolls a random value based on the provided skill. For each roll that results in
+     * zero, a die is rolled and its result is added to the wound total. The process continues until the random roll is
+     * non-zero, increasing the number of wounds with each iteration.</p>
+     *
+     * @param bountyHunterSkill the skill value used to determine wound severity
+     *
+     * @return the total number of wounds determined by the skill-based rolls
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    static int getWounds(int bountyHunterSkill) {
+        int wounds = 0;
+        int bountyHunterRoll = randomInt(bountyHunterSkill);
+        while (bountyHunterRoll == 0) { // Increase severity with each successful loop
+            wounds += d6(1);
+            bountyHunterRoll = randomInt(bountyHunterSkill);
+        }
+        return wounds;
+    }
+
+    /**
+     * Returns a randomly generated bounty hunter name in uppercase letters.
+     *
+     * <p>If a random name cannot be generated, the default bounty hunter name, {@link #DEFAULT_BOUNTY_HUNTER_NAME},
+     * is returned instead.</p>
+     *
+     * @return an uppercase bounty hunter name, either randomly generated or the default if generation fails
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private static String getBountyHunterName() {
+        String bountyHunterName = RandomCallsignGenerator.getInstance().generate();
+        if (bountyHunterName == null) {
+            return DEFAULT_BOUNTY_HUNTER_NAME;
+        }
+
+        bountyHunterName = bountyHunterName.toUpperCase();
+        return bountyHunterName;
+    }
+
+    /**
+     * Adjusts the number of wounds based on the target person's special personnel abilities (SPAs).
+     * <ul>
+     *     <li>If the person has the {@code Glass Jaw} flaw (and not {@code Toughness}), the wounds are doubled.</li>
+     *     <li>If the person has the {@code Toughness} ability (and not {@code Glass Jaw}), the wounds are reduced to
+     *     75% of the original amount, rounded up.</li>
+     *     <li>If the person has both or neither, the wounds remain unchanged.</li>
+     * </ul>
+     *
+     * @param person the person whose SPA modifiers should be checked
+     * @param wounds the initial number of wounds to adjust
+     *
+     * @return the adjusted number of wounds after applying SPA effects
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    static int adjustmentWoundsForSPAs(Person person, int wounds) {
+        boolean hasGlassJaw = person.getOptions().booleanOption(FLAW_GLASS_JAW);
+        boolean hasToughness = person.getOptions().booleanOption(ATOW_TOUGHNESS);
+
+        if (hasGlassJaw && hasToughness) {
+            return wounds;
+        }
+
+        if (hasGlassJaw) {
+            return wounds * 2;
+        } else if (hasToughness) {
+            return (int) ceil(wounds * 0.75);
+        }
+
+        return wounds;
+    }
+
+    /**
+     * Generates a formatted report string describing the outcome of an assassination attempt.
+     *
+     * <p>The message content depends on whether the target was killed or only wounded in the attempt. The report
+     * includes the bounty hunter's name and the target's hyperlinked full title and uses appropriately styled
+     * formatting to indicate success or failure.</p>
+     *
+     * @param isDead               {@code true} if the target was killed; {@code false} if only wounded
+     * @param hyperlinkedFullTitle the formatted full title of the target person
+     * @param bountyHunterName     the name of the bounty hunter
+     *
+     * @return a formatted report string summarizing the assassination attempt outcome
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private static String getReport(boolean isDead, String hyperlinkedFullTitle, String bountyHunterName) {
+        if (isDead) {
+            return getFormattedTextAt(RESOURCE_BUNDLE, "Bloodmark.assassinationAttempt.assassinated",
+                  bountyHunterName, spanOpeningWithCustomColor(getNegativeColor()), CLOSING_SPAN_TAG,
+                  hyperlinkedFullTitle);
+        } else {
+            return getFormattedTextAt(RESOURCE_BUNDLE, "Bloodmark.assassinationAttempt.wounded",
+                  bountyHunterName, spanOpeningWithCustomColor(getWarningColor()), CLOSING_SPAN_TAG,
+                  hyperlinkedFullTitle);
+        }
+    }
+
+    /**
+     * Processes the injuries or hits a {@link Person} receives from an assassination attempt.
+     *
+     * <p>This method applies wounds to the target based on campaign options:</p>
+     * <ul>
+     *   <li>If Advanced Medical is enabled, wounds are converted to injuries, and the person's medical status is
+     *   updated accordingly. If six or more injuries are present after processing, the person is marked as deceased
+     *   via {@code PersonnelStatus.HOMICIDE}.</li>
+     *   <li>If Advanced Medical is not enabled, wounds are added to the person's hit count, with a maximum of
+     *   six. If the resulting hit count reaches six, the person is marked as deceased.</li>
+     * </ul>
+     *
+     * @param campaign the campaign context in which the event occurs
+     * @param person   the target who has received wounds or injuries
+     * @param today    the date of the incident, used for status updates
+     * @param wounds   the number of wounds to apply as a result of the assassination attempt
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    static void processWounds(Campaign campaign, Person person, LocalDate today, int wounds) {
+        boolean isUseAdvancedMedical = campaign.getCampaignOptions().isUseAdvancedMedical();
+        if (isUseAdvancedMedical) {
+            // We want an injury count between 1 and 5 (inclusive), so use randomInt instead of d6.
+            // At 6 injuries, the character should be dead, and we don't want to kill anyone.
+            if (wounds > 0) {
+                InjuryUtil.resolveCombatDamage(campaign, person, wounds);
+            }
+            if (person.getInjuries().size() >= 6) {
+                person.changeStatus(campaign, today, PersonnelStatus.HOMICIDE);
+            }
+        } else {
+            int currentWounds = person.getHits();
+            int newWounds = currentWounds + wounds;
+            if (newWounds >= 6) {
+                newWounds = 6;
+                person.changeStatus(campaign, today, PersonnelStatus.HOMICIDE);
+            }
+            person.setHits(newWounds);
+        }
+    }
+}

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -154,6 +154,11 @@ public class Person {
     public static final String UNLUCKY_LABEL = "UNLUCKY";
     public static final int MINIMUM_UNLUCKY = 0;
     public static final int MAXIMUM_UNLUCKY = 5;
+
+    public static final String BLOODMARK_LABEL = "BLOODMARK";
+    public static final int MINIMUM_BLOODMARK = 0;
+    public static final int MAXIMUM_BLOODMARK = 5;
+
     private static final String DELIMITER = "::";
 
 
@@ -220,6 +225,8 @@ public class Person {
     private boolean hasPerformedExtremeExpenditure;
     private int reputation;
     private int unlucky;
+    private int bloodmark;
+    private List<LocalDate> bloodhuntSchedule;
     private Attributes atowAttributes;
 
     private PersonnelStatus status;
@@ -457,6 +464,8 @@ public class Person {
         hasPerformedExtremeExpenditure = false;
         reputation = 0;
         unlucky = 0;
+        bloodmark = 0;
+        bloodhuntSchedule = new ArrayList<>();
         atowAttributes = new Attributes();
         dateOfDeath = null;
         recruitment = null;
@@ -2636,6 +2645,18 @@ public class Person {
                 MHQXMLUtility.writeSimpleXMLTag(pw, indent, "unlucky", unlucky);
             }
 
+            if (bloodmark != 0) {
+                MHQXMLUtility.writeSimpleXMLTag(pw, indent, "bloodmark", bloodmark);
+            }
+
+            if (!bloodhuntSchedule.isEmpty()) {
+                MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "bloodhuntSchedule");
+                for (LocalDate attemptDate : bloodhuntSchedule) {
+                    MHQXMLUtility.writeSimpleXMLTag(pw, indent, "attemptDate", attemptDate);
+                }
+                MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "bloodhuntSchedule");
+            }
+
             MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "atowAttributes");
             atowAttributes.writeAttributesToXML(pw, indent);
             MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "atowAttributes");
@@ -3054,6 +3075,24 @@ public class Person {
                     person.reputation = MathUtility.parseInt(wn2.getTextContent());
                 } else if (nodeName.equalsIgnoreCase("unlucky")) {
                     person.unlucky = MathUtility.parseInt(wn2.getTextContent());
+                } else if (nodeName.equalsIgnoreCase("bloodmark")) {
+                    person.bloodmark = MathUtility.parseInt(wn2.getTextContent());
+                } else if (nodeName.equalsIgnoreCase("bloodhuntSchedule")) {
+                    NodeList nl2 = wn2.getChildNodes();
+                    for (int y = 0; y < nl2.getLength(); y++) {
+                        Node wn3 = nl2.item(y);
+                        // If it's not an element node, we ignore it.
+                        if (wn3.getNodeType() != Node.ELEMENT_NODE) {
+                            continue;
+                        }
+
+                        if (!wn3.getNodeName().equalsIgnoreCase("attemptDate")) {
+                            logger.error("(techUnitIds) Unknown node type not loaded in bloodhuntSchedule nodes: {}",
+                                  wn3.getNodeName());
+                            continue;
+                        }
+                        person.addBloodhuntDate(LocalDate.parse(wn3.getTextContent().trim()));
+                    }
                 } else if (nodeName.equalsIgnoreCase("atowAttributes")) {
                     person.atowAttributes = new Attributes().generateAttributesFromXML(wn2);
                 } else if (nodeName.equalsIgnoreCase("pilotHits")) {
@@ -5518,6 +5557,35 @@ public class Person {
     public void changeUnlucky(final int delta) {
         int newValue = unlucky + delta;
         unlucky = clamp(newValue, MINIMUM_UNLUCKY, MAXIMUM_UNLUCKY);
+    }
+
+    public int getBloodmark() {
+        return bloodmark;
+    }
+
+    public Money getBloodmarkValue() {
+        return Money.of(bloodmark);
+    }
+
+    public void setBloodmark(final int unlucky) {
+        this.bloodmark = clamp(unlucky, MINIMUM_BLOODMARK, MAXIMUM_BLOODMARK);
+    }
+
+    public void changeBloodmark(final int delta) {
+        int newValue = bloodmark + delta;
+        bloodmark = clamp(newValue, MINIMUM_BLOODMARK, MAXIMUM_BLOODMARK);
+    }
+
+    public List<LocalDate> getBloodhuntSchedule() {
+        return bloodhuntSchedule;
+    }
+
+    public void addBloodhuntDate(final LocalDate date) {
+        bloodhuntSchedule.add(date);
+    }
+
+    public void removeBloodhuntDate(final LocalDate date) {
+        bloodhuntSchedule.remove(date);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/enums/BloodmarkLevel.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/BloodmarkLevel.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.enums;
+
+import megamek.logging.MMLogger;
+import mekhq.campaign.finances.Money;
+
+/**
+ * Represents the different Bloodmark levels available to a character, including bounties, bounty hunter skill, and
+ * rules for roll checks.
+ *
+ * @author Illiani
+ * @since 0.50.07
+ */
+public enum BloodmarkLevel {
+    /** 0 TP, no bounty, no encounters. */
+    BLOODMARK_ZERO(0, Money.of(0), 20, 0, 0),
+    /** 1 TP, 10,000 C-Bill bounty, 1d6/3 (rounded down) encounters every 6 months (on average). */
+    BLOODMARK_ONE(1, Money.of(10000), 20, 3, 6),
+    /** 2 TP, 37,500 C-Bill bounty, 1d6/2 (rounded down) encounters every 3 months (on average). */
+    BLOODMARK_TWO(2, Money.of(37500), 20, 2, 3),
+    /** 3 TP, 125,000 C-Bill bounty, 1d6/3 (rounded down) encounters a month (on average). */
+    BLOODMARK_THREE(3, Money.of(125000), 10, 3, 1),
+    /** 4 TP, 500,000 C-Bill bounty, 1d6/2 (rounded down) encounters a month (on average). */
+    BLOODMARK_FOUR(4, Money.of(500000), 10, 2, 1),
+    /** 5 TP, 1,000,000 C-Bill bounty, 1d6 encounters a month (on average). */
+    BLOODMARK_FIVE(5, Money.of(1000000), 5, 1, 1);
+
+    private static final MMLogger LOGGER = MMLogger.create(BloodmarkLevel.class);
+
+    private final int level;
+    private final Money bounty;
+    private final int bountyHunterSkill;
+    private final int rollDivisor;
+    private final int rollFrequency;
+
+    /**
+     * Constructs a {@link BloodmarkLevel} enum constant with the specified properties.
+     *
+     * @param level             the trait training point value for this bloodmark
+     * @param bounty            the monetary bounty awarded for this bloodmark
+     * @param bountyHunterSkill the skill of the character attempting to collect on the bounty
+     * @param rollDivisor       divisor used in roll calculations
+     * @param rollFrequency     how often rolls for this bloodmark occur
+     */
+    BloodmarkLevel(int level, Money bounty, int bountyHunterSkill, int rollDivisor, int rollFrequency) {
+        this.level = level;
+        this.bounty = bounty;
+        this.bountyHunterSkill = bountyHunterSkill;
+        this.rollDivisor = rollDivisor;
+        this.rollFrequency = rollFrequency;
+    }
+
+    /**
+     * Returns the level value associated with this bloodmark.
+     *
+     * @return the level as an {@link Integer}
+     */
+    public int getLevel() {
+        return level;
+    }
+
+    /**
+     * Returns the bounty, in {@link Money}, associated with this bloodmark level.
+     *
+     * @return the {@link Money} bounty value
+     */
+    public Money getBounty() {
+        return bounty;
+    }
+
+    /**
+     * Returns the chance a bounty collection is successful.
+     *
+     * <p>This is equal to 1-in-n, where n is the value here.</p>
+     *
+     * @return the bounty hunter skill
+     */
+    public int getBountyHunterSkill() {
+        return bountyHunterSkill;
+    }
+
+    /**
+     * Returns the divisor used in roll calculations for this bloodmark level.
+     *
+     * @return the roll divisor value
+     */
+    public int getRollDivisor() {
+        return rollDivisor;
+    }
+
+    /**
+     * Returns how frequently rolls occur at this bloodmark level.
+     *
+     * @return the roll frequency value
+     */
+    public int getRollFrequency() {
+        return rollFrequency;
+    }
+
+    /**
+     * Attempts to parse a {@link BloodmarkLevel} constant from a supplied int value.
+     *
+     * <p>If the value does not map directly to an enum value, {@link #BLOODMARK_ZERO} is returned and a warning is
+     * logged.</p>
+     *
+     * @param value the integer value to parse
+     *
+     * @return the corresponding {@link BloodmarkLevel}, or {@link #BLOODMARK_ZERO} if invalid
+     */
+    public static BloodmarkLevel parseBloodmarkLevelFromInt(int value) {
+        for (BloodmarkLevel bloodmarkLevel : BloodmarkLevel.values()) {
+            if (bloodmarkLevel.level == value) {
+                return bloodmarkLevel;
+            }
+        }
+
+        LOGGER.warn("Failed to parse BloodmarkData from int: {} - returning BLOODMARK_ZERO", value);
+        return BLOODMARK_ZERO;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultSkillGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultSkillGenerator.java
@@ -242,5 +242,14 @@ public class DefaultSkillGenerator extends AbstractSkillGenerator {
         } else {
             person.setUnlucky(0);
         }
+
+        // Bloodmark
+        // We want the chance of a Bloodmark to be low as it can be quite disruptive
+        roll = randomInt(person.getOriginFaction().isPirate() ? 50 : 100);
+        if (roll == 0) {
+            person.setBloodmark(1);
+        } else {
+            person.setBloodmark(0);
+        }
     }
 }

--- a/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
+++ b/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
@@ -32,11 +32,11 @@
  */
 package mekhq.campaign.utilities.glossary;
 
-import megamek.common.annotations.Nullable;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.util.List;
 
-import static mekhq.utilities.MHQInternationalization.getTextAt;
+import megamek.common.annotations.Nullable;
 
 /**
  * The {@code GlossaryEntry} enum represents individual glossary entries used within MekHQ.
@@ -131,7 +131,8 @@ public enum GlossaryEntry {
     TURNOVER("TURNOVER"),
     UNABLE_TO_START_SCENARIO("UNABLE_TO_START_SCENARIO"),
     VOCATIONAL_XP("VOCATIONAL_XP"),
-    WINTER_HOLIDAY("WINTER_HOLIDAY");
+    WINTER_HOLIDAY("WINTER_HOLIDAY"),
+    BLOODMARK("BLOODMARK");
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.GlossaryEntry";
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -668,6 +668,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                     case REPUTATION_LABEL -> selectedPerson.setReputation(target);
                     case WEALTH_LABEL -> selectedPerson.setWealth(target);
                     case UNLUCKY_LABEL -> selectedPerson.setUnlucky(target);
+                    case BLOODMARK_LABEL -> selectedPerson.setBloodmark(target);
                     default -> logger.error("Invalid trait type: {}", type);
                 }
 
@@ -3350,6 +3351,20 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                   String.valueOf(target)));
             menuItem.addActionListener(this);
             menuItem.setEnabled(target < MAXIMUM_UNLUCKY);
+            traitsMenu.add(menuItem);
+            menu.add(traitsMenu);
+
+            // Bloodmark
+            int bloodmark = person.getBloodmark();
+            target = bloodmark + 1;
+            menuItem = new JMenuItem(String.format(resources.getString("spendOnBloodmark.text"), target, -traitCost));
+            menuItem.setToolTipText(String.format(resources.getString("spendOnBloodmark.tooltip"), target));
+            menuItem.setActionCommand(makeCommand(CMD_BUY_TRAIT,
+                  BLOODMARK_LABEL,
+                  String.valueOf(-traitCost),
+                  String.valueOf(target)));
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(target < MAXIMUM_BLOODMARK);
             traitsMenu.add(menuItem);
             menu.add(traitsMenu);
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -3282,7 +3282,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                   String.valueOf(traitCost),
                   String.valueOf(target)));
             menuItem.addActionListener(this);
-            menuItem.setEnabled(target < MAXIMUM_CONNECTIONS && person.getXP() >= traitCost);
+            menuItem.setEnabled(target <= MAXIMUM_CONNECTIONS && person.getXP() >= traitCost);
             traitsMenu.add(menuItem);
 
             // Reputation
@@ -3300,7 +3300,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                   String.valueOf(traitCost),
                   String.valueOf(target)));
             menuItem.addActionListener(this);
-            menuItem.setEnabled(target < MAXIMUM_REPUTATION && person.getXP() >= traitCost);
+            menuItem.setEnabled(target <= MAXIMUM_REPUTATION && person.getXP() >= traitCost);
             traitsMenu.add(menuItem);
 
             target = reputation - 1;
@@ -3313,7 +3313,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                   String.valueOf(-traitCost),
                   String.valueOf(target)));
             menuItem.addActionListener(this);
-            menuItem.setEnabled(target > MINIMUM_REPUTATION);
+            menuItem.setEnabled(target >= MINIMUM_REPUTATION);
             traitsMenu.add(menuItem);
 
             // Wealth
@@ -3326,7 +3326,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                   String.valueOf(traitCost),
                   String.valueOf(target)));
             menuItem.addActionListener(this);
-            menuItem.setEnabled(target < MAXIMUM_WEALTH && person.getXP() >= traitCost);
+            menuItem.setEnabled(target <= MAXIMUM_WEALTH && person.getXP() >= traitCost);
             traitsMenu.add(menuItem);
 
             target = wealth - 1;
@@ -3337,7 +3337,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                   String.valueOf(-traitCost),
                   String.valueOf(target)));
             menuItem.addActionListener(this);
-            menuItem.setEnabled(target > MINIMUM_WEALTH);
+            menuItem.setEnabled(target >= MINIMUM_WEALTH);
             traitsMenu.add(menuItem);
 
             // Unlucky
@@ -3350,12 +3350,23 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                   String.valueOf(-traitCost),
                   String.valueOf(target)));
             menuItem.addActionListener(this);
-            menuItem.setEnabled(target < MAXIMUM_UNLUCKY);
+            menuItem.setEnabled(target <= MAXIMUM_UNLUCKY);
             traitsMenu.add(menuItem);
-            menu.add(traitsMenu);
+
+            target = unlucky - 1;
+            menuItem = new JMenuItem(String.format(resources.getString("spendOnUnlucky.text"), target, traitCost));
+            menuItem.setToolTipText(String.format(resources.getString("spendOnUnlucky.tooltip"), target));
+            menuItem.setActionCommand(makeCommand(CMD_BUY_TRAIT,
+                  UNLUCKY_LABEL,
+                  String.valueOf(traitCost),
+                  String.valueOf(target)));
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(target >= MINIMUM_UNLUCKY && person.getXP() >= traitCost);
+            traitsMenu.add(menuItem);
 
             // Bloodmark
             int bloodmark = person.getBloodmark();
+
             target = bloodmark + 1;
             menuItem = new JMenuItem(String.format(resources.getString("spendOnBloodmark.text"), target, -traitCost));
             menuItem.setToolTipText(String.format(resources.getString("spendOnBloodmark.tooltip"), target));
@@ -3364,8 +3375,20 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                   String.valueOf(-traitCost),
                   String.valueOf(target)));
             menuItem.addActionListener(this);
-            menuItem.setEnabled(target < MAXIMUM_BLOODMARK);
+            menuItem.setEnabled(target <= MAXIMUM_BLOODMARK);
             traitsMenu.add(menuItem);
+
+            target = bloodmark - 1;
+            menuItem = new JMenuItem(String.format(resources.getString("spendOnBloodmark.text"), target, traitCost));
+            menuItem.setToolTipText(String.format(resources.getString("spendOnBloodmark.tooltip"), target));
+            menuItem.setActionCommand(makeCommand(CMD_BUY_TRAIT,
+                  BLOODMARK_LABEL,
+                  String.valueOf(traitCost),
+                  String.valueOf(target)));
+            menuItem.addActionListener(this);
+            menuItem.setEnabled(target >= MINIMUM_BLOODMARK && person.getXP() >= traitCost);
+            traitsMenu.add(menuItem);
+
             menu.add(traitsMenu);
 
             JMenu attributesMenuIncrease = new JMenu(resources.getString("spendOnAttributes.increase"));

--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -35,14 +35,7 @@ package mekhq.gui.dialog;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static megamek.codeUtilities.MathUtility.clamp;
-import static mekhq.campaign.personnel.Person.MAXIMUM_CONNECTIONS;
-import static mekhq.campaign.personnel.Person.MAXIMUM_REPUTATION;
-import static mekhq.campaign.personnel.Person.MAXIMUM_UNLUCKY;
-import static mekhq.campaign.personnel.Person.MAXIMUM_WEALTH;
-import static mekhq.campaign.personnel.Person.MINIMUM_CONNECTIONS;
-import static mekhq.campaign.personnel.Person.MINIMUM_REPUTATION;
-import static mekhq.campaign.personnel.Person.MINIMUM_UNLUCKY;
-import static mekhq.campaign.personnel.Person.MINIMUM_WEALTH;
+import static mekhq.campaign.personnel.Person.*;
 import static mekhq.campaign.personnel.skills.Aging.updateAllSkillAgeModifiers;
 import static mekhq.campaign.personnel.skills.Skill.getCountDownMaxValue;
 import static mekhq.campaign.personnel.skills.Skill.getCountUpMaxValue;
@@ -73,12 +66,12 @@ import javax.swing.*;
 
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomNameGenerator;
+import megamek.client.ui.clientGUI.DialogOptionListener;
 import megamek.client.ui.comboBoxes.MMComboBox;
 import megamek.client.ui.dialogs.iconChooser.PortraitChooserDialog;
+import megamek.client.ui.panels.DialogOptionComponentYPanel;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.client.ui.panels.DialogOptionComponentYPanel;
-import megamek.client.ui.clientGUI.DialogOptionListener;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.Crew;
 import megamek.common.EquipmentType;
@@ -155,6 +148,7 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
     private JTextField textWealth;
     private JTextField textReputation;
     private JTextField textUnlucky;
+    private JTextField textBloodmark;
     private JComboBox<EducationLevel> textEducationLevel;
     private JTextField textLoyalty;
 
@@ -265,6 +259,8 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
         JLabel lblReputation = new JLabel();
         textUnlucky = new JTextField();
         JLabel lblUnlucky = new JLabel();
+        textBloodmark = new JTextField();
+        JLabel lblBloodmark = new JLabel();
         textEducationLevel = new JComboBox<>();
         textLoyalty = new JTextField();
         JLabel lblLoyalty = new JLabel();
@@ -746,6 +742,27 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         demogPanel.add(textUnlucky, gridBagConstraints);
+
+        y++;
+
+        lblBloodmark.setText(resourceMap.getString("lblBloodmark.text"));
+        lblReputation.setName("lblBloodmark");
+
+        textBloodmark.setText(Integer.toString(person.getBloodmark()));
+        textBloodmark.setName("textBloodmark");
+
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = y;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(0, 5, 0, 0);
+        demogPanel.add(lblBloodmark, gridBagConstraints);
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = y;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        demogPanel.add(textBloodmark, gridBagConstraints);
 
         y++;
 
@@ -1670,6 +1687,9 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
 
         newValue = MathUtility.parseInt(textUnlucky.getText(), person.getUnlucky());
         person.setUnlucky(clamp(newValue, MINIMUM_UNLUCKY, MAXIMUM_UNLUCKY));
+
+        newValue = MathUtility.parseInt(textBloodmark.getText(), person.getBloodmark());
+        person.setBloodmark(clamp(newValue, MINIMUM_BLOODMARK, MAXIMUM_BLOODMARK));
 
         person.setLoyalty(MathUtility.parseInt(textLoyalty.getText(), person.getLoyalty()));
 

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -35,14 +35,7 @@ package mekhq.gui.dialog;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static megamek.codeUtilities.MathUtility.clamp;
-import static mekhq.campaign.personnel.Person.MAXIMUM_CONNECTIONS;
-import static mekhq.campaign.personnel.Person.MAXIMUM_REPUTATION;
-import static mekhq.campaign.personnel.Person.MAXIMUM_UNLUCKY;
-import static mekhq.campaign.personnel.Person.MAXIMUM_WEALTH;
-import static mekhq.campaign.personnel.Person.MINIMUM_CONNECTIONS;
-import static mekhq.campaign.personnel.Person.MINIMUM_REPUTATION;
-import static mekhq.campaign.personnel.Person.MINIMUM_UNLUCKY;
-import static mekhq.campaign.personnel.Person.MINIMUM_WEALTH;
+import static mekhq.campaign.personnel.Person.*;
 import static mekhq.campaign.personnel.skills.Aging.getAgeModifier;
 import static mekhq.campaign.personnel.skills.Aging.getMilestone;
 import static mekhq.campaign.personnel.skills.Aging.updateAllSkillAgeModifiers;
@@ -71,11 +64,11 @@ import javax.swing.*;
 
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomNameGenerator;
+import megamek.client.ui.clientGUI.DialogOptionListener;
 import megamek.client.ui.comboBoxes.MMComboBox;
+import megamek.client.ui.panels.DialogOptionComponentYPanel;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.client.ui.panels.DialogOptionComponentYPanel;
-import megamek.client.ui.clientGUI.DialogOptionListener;
 import megamek.client.ui.util.UIUtil;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.Crew;
@@ -156,6 +149,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     private JTextField textWealth;
     private JTextField textReputation;
     private JTextField textUnlucky;
+    private JTextField textBloodmark;
     private JTextField textFatigue;
     private JComboBox<EducationLevel> textEducationLevel;
     private JTextField textLoyalty;
@@ -255,6 +249,8 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         JLabel lblReputation = new JLabel();
         textUnlucky = new JTextField();
         JLabel lblUnlucky = new JLabel();
+        textBloodmark = new JTextField();
+        JLabel lblBloodmark = new JLabel();
         textFatigue = new JTextField();
         JLabel lblLoyalty = new JLabel();
         textLoyalty = new JTextField();
@@ -787,7 +783,7 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         y++;
 
         lblUnlucky.setText(resourceMap.getString("lblUnlucky.text"));
-        lblReputation.setName("lblUnlucky");
+        lblUnlucky.setName("lblUnlucky");
 
         textUnlucky.setText(Integer.toString(person.getUnlucky()));
         textUnlucky.setName("textUnlucky");
@@ -804,6 +800,27 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         gridBagConstraints.anchor = GridBagConstraints.WEST;
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         panDemog.add(textUnlucky, gridBagConstraints);
+
+        y++;
+
+        lblBloodmark.setText(resourceMap.getString("lblBloodmark.text"));
+        lblBloodmark.setName("lblBloodmark");
+
+        textBloodmark.setText(Integer.toString(person.getBloodmark()));
+        textBloodmark.setName("textBloodmark");
+
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = y;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.insets = new Insets(0, 5, 0, 0);
+        panDemog.add(lblBloodmark, gridBagConstraints);
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = y;
+        gridBagConstraints.anchor = GridBagConstraints.WEST;
+        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+        panDemog.add(textBloodmark, gridBagConstraints);
 
         y++;
 
@@ -1419,6 +1436,10 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         currentValue = person.getUnlucky();
         newValue = MathUtility.parseInt(textUnlucky.getText(), currentValue);
         person.setUnlucky(clamp(newValue, MINIMUM_UNLUCKY, MAXIMUM_UNLUCKY));
+
+        currentValue = person.getBloodmark();
+        newValue = MathUtility.parseInt(textBloodmark.getText(), currentValue);
+        person.setBloodmark(clamp(newValue, MINIMUM_BLOODMARK, MAXIMUM_BLOODMARK));
 
         if (campaign.getCampaignOptions().isUseEducationModule()) {
             person.setEduHighestEducation((EducationLevel) textEducationLevel.getSelectedItem());

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -146,6 +146,7 @@ public enum PersonnelTableModelColumn {
     WEALTH("PersonnelTableModelColumn.WEALTH.text"),
     REPUTATION("PersonnelTableModelColumn.REPUTATION.text"),
     UNLUCKY("PersonnelTableModelColumn.UNLUCKY.text"),
+    BLOODMARK("PersonnelTableModelColumn.BLOODMARK.text"),
     FATIGUE("PersonnelTableModelColumn.FATIGUE.text"),
     EDGE("PersonnelTableModelColumn.EDGE.text"),
     SPA_COUNT("PersonnelTableModelColumn.SPA_COUNT.text"),
@@ -450,6 +451,10 @@ public enum PersonnelTableModelColumn {
 
     public boolean isUnlucky() {
         return this == UNLUCKY;
+    }
+
+    public boolean isBloodmark() {
+        return this == BLOODMARK;
     }
 
     public boolean isFatigue() {
@@ -939,6 +944,8 @@ public enum PersonnelTableModelColumn {
                       person.getRankLevel()));
             case UNLUCKY:
                 return Integer.toString(person.getUnlucky());
+            case BLOODMARK:
+                return Integer.toString(person.getBloodmark());
             case FATIGUE:
                 return Integer.toString(getEffectiveFatigue(person.getFatigue(),
                       person.isClanPersonnel(),
@@ -1197,7 +1204,7 @@ public enum PersonnelTableModelColumn {
                 default -> false;
             };
             case TRAITS -> switch (this) {
-                case RANK, FIRST_NAME, LAST_NAME, CONNECTIONS, WEALTH, REPUTATION, UNLUCKY -> true;
+                case RANK, FIRST_NAME, LAST_NAME, CONNECTIONS, WEALTH, REPUTATION, UNLUCKY, BLOODMARK -> true;
                 case EDGE -> campaign.getCampaignOptions().isUseEdge();
                 default -> false;
             };
@@ -1263,6 +1270,7 @@ public enum PersonnelTableModelColumn {
                  WEALTH,
                  REPUTATION,
                  UNLUCKY,
+                 BLOODMARK,
                  EDGE,
                  SPA_COUNT,
                  IMPLANT_COUNT,

--- a/MekHQ/unittests/mekhq/campaign/personnel/BloodmarkTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/BloodmarkTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel;
+
+import static mekhq.campaign.personnel.PersonnelOptions.ATOW_TOUGHNESS;
+import static mekhq.campaign.personnel.PersonnelOptions.FLAW_GLASS_JAW;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.Hangar;
+import mekhq.campaign.Warehouse;
+import mekhq.campaign.personnel.enums.BloodmarkLevel;
+import mekhq.campaign.personnel.enums.PersonnelStatus;
+import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.Faction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class BloodmarkTest {
+    final static LocalDate CURRENT_DATE = LocalDate.of(3151, 1, 1);
+
+    private Campaign campaign;
+    private CampaignOptions campaignOptions;
+    private Person target;
+
+    @BeforeEach
+    void beforeEach() {
+        campaign = mock(Campaign.class);
+        campaignOptions = mock(CampaignOptions.class);
+        Faction campaignFaction = mock(Faction.class);
+        Hangar campaignHangar = mock(Hangar.class);
+        Warehouse campaignWarehouse = mock(Warehouse.class);
+
+        when(campaign.getCampaignOptions()).thenReturn(campaignOptions);
+        when(campaign.getFaction()).thenReturn(campaignFaction);
+        when(campaignFaction.getShortName()).thenReturn("MERC");
+        when(campaign.getHangar()).thenReturn(campaignHangar);
+        when(campaign.getWarehouse()).thenReturn(campaignWarehouse);
+
+        target = new Person(campaign);
+    }
+
+    @Test
+    void testGetBloodhuntSchedule_NoBloodhuntDueToZeroFrequency() {
+        BloodmarkLevel level = BloodmarkLevel.BLOODMARK_ZERO;
+
+        List<LocalDate> result = Bloodmark.getBloodhuntSchedule(level, CURRENT_DATE);
+
+        assertTrue(result.isEmpty(), "Expected no assassination schedule for BLOODMARK_ZERO level.");
+    }
+
+    @Test
+    void testGetBloodhuntSchedule_BloodhuntSkippedByRoll() {
+        BloodmarkLevel level = BloodmarkLevel.BLOODMARK_ONE;
+
+        try (MockedStatic<megamek.common.Compute> mockedCompute = mockStatic(megamek.common.Compute.class)) {
+            mockedCompute.when(() -> megamek.common.Compute.randomInt(level.getRollFrequency())).thenReturn(1);
+
+            List<LocalDate> result = Bloodmark.getBloodhuntSchedule(level, CURRENT_DATE);
+
+            assertTrue(result.isEmpty(), "Expected no assassination schedule when the bloodhunt roll is not zero.");
+        }
+    }
+
+    @Test
+    void testGetBloodhuntSchedule_NoAssassinationsDueToZeroDivisor() {
+        BloodmarkLevel level = BloodmarkLevel.BLOODMARK_ONE;
+
+        try (MockedStatic<megamek.common.Compute> mockedCompute = mockStatic(megamek.common.Compute.class)) {
+            mockedCompute.when(() -> megamek.common.Compute.randomInt(level.getRollFrequency())).thenReturn(0);
+            mockedCompute.when(() -> megamek.common.Compute.d6(1)).thenReturn(0); // Divisor should prevent attempts
+
+            List<LocalDate> result = Bloodmark.getBloodhuntSchedule(level, CURRENT_DATE);
+
+            assertTrue(result.isEmpty(), "Expected no assassination schedule due to zero divisor.");
+        }
+    }
+
+    @Test
+    void testGetBloodhuntSchedule_SingleAssassination() {
+        BloodmarkLevel level = BloodmarkLevel.BLOODMARK_TWO;
+
+        try (MockedStatic<megamek.common.Compute> mockedCompute = mockStatic(megamek.common.Compute.class)) {
+            mockedCompute.when(() -> megamek.common.Compute.randomInt(level.getRollFrequency())).thenReturn(0);
+            mockedCompute.when(() -> megamek.common.Compute.d6(1)).thenReturn(2, 3); // One attempt with 3-day lag
+
+            List<LocalDate> result = Bloodmark.getBloodhuntSchedule(level, CURRENT_DATE);
+
+            assertEquals(1, result.size(), "Expected one assassination attempt.");
+            assertEquals(CURRENT_DATE.plusDays(3), result.get(0), "Incorrect date for assassination attempt.");
+        }
+    }
+
+    @Test
+    void testGetBloodhuntSchedule_MultipleAssassinations() {
+        BloodmarkLevel level = BloodmarkLevel.BLOODMARK_THREE;
+
+        try (MockedStatic<megamek.common.Compute> mockedCompute = mockStatic(megamek.common.Compute.class)) {
+            mockedCompute.when(() -> megamek.common.Compute.randomInt(level.getRollFrequency())).thenReturn(0);
+            mockedCompute.when(() -> megamek.common.Compute.d6(1)).thenReturn(6, 2, 3); // 2 assassination attempts
+
+            List<LocalDate> result = Bloodmark.getBloodhuntSchedule(level, CURRENT_DATE);
+
+            assertEquals(2, result.size(), "Expected two assassination attempts.");
+            assertEquals(CURRENT_DATE.plusDays(2), result.get(0), "Incorrect date for first assassination attempt.");
+            assertEquals(CURRENT_DATE.plusDays(2 + 3),
+                  result.get(1),
+                  "Incorrect date for second assassination attempt.");
+        }
+    }
+
+    @Test
+    void testCheckForAssassinationAttempt_returnsFalseIfBloodhuntScheduleIsEmpty() {
+        boolean result = Bloodmark.checkForAssassinationAttempt(target, CURRENT_DATE, true);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testCheckForAssassinationAttempt_returnsFalseIfBloodhuntScheduleDoesNotContainToday() {
+        LocalDate futureDate = CURRENT_DATE.plusDays(1);
+        target.addBloodhuntDate(futureDate);
+
+        boolean result = Bloodmark.checkForAssassinationAttempt(target, CURRENT_DATE, true);
+
+        // Future bloodhunts should remain in the schedule
+        assertTrue(target.getBloodhuntSchedule().contains(futureDate));
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testCheckForAssassinationAttempt_returnsFalseIfNotCampaignPlanetside() {
+        target.addBloodhuntDate(CURRENT_DATE);
+        target.setStatus(PersonnelStatus.ACTIVE);
+
+        boolean result = Bloodmark.checkForAssassinationAttempt(target, CURRENT_DATE, false);
+
+        // removeBloodhuntDate should be called even if later checks fail
+        assertFalse(target.getBloodhuntSchedule().contains(CURRENT_DATE));
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testCheckForAssassinationAttempt_returnsTrueIfNotCampaignPlanetsideButTargetIsAbsent() {
+        target.addBloodhuntDate(CURRENT_DATE);
+        target.setStatus(PersonnelStatus.ON_LEAVE);
+
+        boolean result = Bloodmark.checkForAssassinationAttempt(target, CURRENT_DATE, false);
+
+        // removeBloodhuntDate should be called even if later checks fail
+        assertFalse(target.getBloodhuntSchedule().contains(CURRENT_DATE));
+
+        assertTrue(result);
+    }
+
+    @Test
+    void testCheckForAssassinationAttempt_returnsFalseIfTargetIsDeployed() {
+        target.addBloodhuntDate(CURRENT_DATE);
+        target.setStatus(PersonnelStatus.ACTIVE);
+
+        Unit mockUnit = mock(Unit.class);
+        target.setUnit(mockUnit);
+        when(mockUnit.getScenarioId()).thenReturn(1);
+
+        boolean result = Bloodmark.checkForAssassinationAttempt(target, CURRENT_DATE, true);
+
+        // removeBloodhuntDate should be called even if later checks fail
+        assertFalse(target.getBloodhuntSchedule().contains(CURRENT_DATE));
+
+        assertFalse(result);
+    }
+
+    @Test
+    void testCheckForAssassinationAttempt_returnsTrueWhenAllCriteriaMet() {
+        target.addBloodhuntDate(CURRENT_DATE);
+        target.setStatus(PersonnelStatus.ACTIVE);
+
+        Unit mockUnit = mock(Unit.class);
+        target.setUnit(mockUnit);
+        when(mockUnit.getScenarioId()).thenReturn(-1);
+
+        boolean result = Bloodmark.checkForAssassinationAttempt(target, CURRENT_DATE, true);
+
+        // removeBloodhuntDate should be called even if later checks fail
+        assertFalse(target.getBloodhuntSchedule().contains(CURRENT_DATE));
+
+        assertTrue(result);
+    }
+
+    @Test
+    void testProcessWounds_AdvancedMedicalEnabled_JustWounded() {
+        when(campaignOptions.isUseAdvancedMedical()).thenReturn(true);
+
+        // Due to the way AM works, it's not reasonable to fully test this process. So instead we're setting up
+        // the test so that the character doesn't qualify for death when the 'injuries' would be applied. However,
+        // the new injuries are set to 0 to avoid NPEs
+        for (int i = 0; i < 3; i++) {
+            target.addInjury(new Injury());
+        }
+
+        Bloodmark.processWounds(campaign, target, CURRENT_DATE, 0);
+
+        assertFalse(target.getStatus().isDead());
+    }
+
+    @Test
+    void testProcessWounds_AdvancedMedicalEnabled_Killed() {
+        when(campaignOptions.isUseAdvancedMedical()).thenReturn(true);
+
+        // Due to the way AM works, it's not reasonable to fully test this process. So instead we're setting up
+        // the test so that the character qualifies for death when the 'injuries' would be applied. However, the new
+        // injuries are set to 0 to avoid NPEs
+        for (int i = 0; i < 6; i++) {
+            target.addInjury(new Injury());
+        }
+
+        Bloodmark.processWounds(campaign, target, CURRENT_DATE, 0);
+
+        assertTrue(target.getStatus().isDead());
+    }
+
+    @Test
+    void testProcessWounds_AdvancedMedicalDisabled_JustWounded() {
+        when(campaignOptions.isUseAdvancedMedical()).thenReturn(false);
+        target.setHits(0);
+
+        Bloodmark.processWounds(campaign, target, CURRENT_DATE, 2);
+
+        assertFalse(target.getStatus().isDead());
+    }
+
+    @Test
+    void testProcessWounds_AdvancedMedicalDisabled_KilledDueToPriorHits() {
+        when(campaignOptions.isUseAdvancedMedical()).thenReturn(false);
+        target.setHits(4);
+
+        Bloodmark.processWounds(campaign, target, CURRENT_DATE, 3);
+
+        assertTrue(target.getStatus().isDead());
+    }
+
+    @Test
+    void testProcessWounds_AdvancedMedicalDisabled_KilledFromNewHits() {
+        when(campaignOptions.isUseAdvancedMedical()).thenReturn(false);
+        target.setHits(0);
+
+        Bloodmark.processWounds(campaign, target, CURRENT_DATE, 6);
+
+        assertTrue(target.getStatus().isDead());
+    }
+
+    @Test
+    void testAdjustmentWoundsForSPAs_NoSPAs_WoundsUnchanged() {
+        assertEquals(3, Bloodmark.adjustmentWoundsForSPAs(target, 3));
+    }
+
+    @Test
+    void testAdjustmentWoundsForSPAs_GlassJawOnly_WoundsDoubled() {
+        PersonnelOptions options = target.getOptions();
+        options.acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, FLAW_GLASS_JAW, true);
+        assertEquals(8, Bloodmark.adjustmentWoundsForSPAs(target, 4));
+    }
+
+    @Test
+    void testAdjustmentWoundsForSPAs_ToughnessOnly_WoundsReduced() {
+        PersonnelOptions options = target.getOptions();
+        options.acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, ATOW_TOUGHNESS, true);
+        assertEquals(2, Bloodmark.adjustmentWoundsForSPAs(target, 2));
+        assertEquals(4, Bloodmark.adjustmentWoundsForSPAs(target, 5)); // 5*.75=3.75->4
+    }
+
+    @Test
+    void testAdjustmentWoundsForSPAs_BothGlassJawAndToughness_WoundsUnchanged() {
+        PersonnelOptions options = target.getOptions();
+        options.acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, FLAW_GLASS_JAW, true);
+        options.acquireAbility(PersonnelOptions.LVL3_ADVANTAGES, ATOW_TOUGHNESS, true);
+        assertEquals(5, Bloodmark.adjustmentWoundsForSPAs(target, 5));
+    }
+}

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/BloodmarkLevelTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/BloodmarkLevelTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.enums;
+
+import static mekhq.campaign.personnel.Person.MAXIMUM_BLOODMARK;
+import static mekhq.campaign.personnel.Person.MINIMUM_BLOODMARK;
+import static mekhq.campaign.personnel.enums.BloodmarkLevel.BLOODMARK_ZERO;
+import static mekhq.campaign.personnel.enums.BloodmarkLevel.parseBloodmarkLevelFromInt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import mekhq.campaign.finances.Money;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class BloodmarkLevelTest {
+    @Test
+    void test_allLevelsAreUnique() {
+        List<Integer> allLevels = new ArrayList<>();
+        for (BloodmarkLevel bloodmarkLevel : BloodmarkLevel.values()) {
+            int level = bloodmarkLevel.getLevel();
+            assertFalse(allLevels.contains(level), "Duplicate Bloodmark Level: " + level);
+            allLevels.add(level);
+        }
+    }
+
+    @Test
+    void test_allLevelsAreValid() {
+        for (int level = MINIMUM_BLOODMARK; level < MAXIMUM_BLOODMARK; level++) {
+            BloodmarkLevel bloodmark = parseBloodmarkLevelFromInt(level);
+            int bloodmarkLevel = bloodmark.getLevel();
+            assertEquals(level, bloodmarkLevel, "Invalid Bloodmark Level: " + level);
+        }
+    }
+
+    @Test
+    void test_allBountiesAreIncremental() {
+        Money lastBounty = Money.of(-1);
+        for (BloodmarkLevel bloodmarkLevel : BloodmarkLevel.values()) {
+            Money bounty = bloodmarkLevel.getBounty();
+            assertTrue(bounty.isGreaterThan(lastBounty), "Bounty is not incremental for " + bloodmarkLevel.name());
+            lastBounty = bounty;
+        }
+    }
+
+    @Test
+    void test_allBountyHunterSkillsAreDecremental() {
+        int lastHunterSkill = Integer.MAX_VALUE;
+        for (BloodmarkLevel bloodmarkLevel : BloodmarkLevel.values()) {
+            int hunterSkill = bloodmarkLevel.getBountyHunterSkill();
+            assertTrue(hunterSkill <= lastHunterSkill,
+                  "Bounty Hunter Skill is not decremental for " + bloodmarkLevel.name());
+            lastHunterSkill = hunterSkill;
+        }
+    }
+
+    @Test
+    void test_allRollFrequenciesAreDecremental() {
+        int lastRollFrequency = Integer.MAX_VALUE;
+        for (BloodmarkLevel bloodmarkLevel : BloodmarkLevel.values()) {
+            if (bloodmarkLevel == BLOODMARK_ZERO) {
+                continue;
+            }
+
+            int rollFrequency = bloodmarkLevel.getRollFrequency();
+            assertTrue(rollFrequency <= lastRollFrequency,
+                  "Roll frequency is not decremental for " + bloodmarkLevel.name());
+            lastRollFrequency = rollFrequency;
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BloodmarkLevel.class)
+    void test_allBountiesAreValid(BloodmarkLevel bloodmarkLevel) {
+        if (bloodmarkLevel == BLOODMARK_ZERO) {
+            assertEquals(Money.zero(), bloodmarkLevel.getBounty(),
+                  "Invalid Bounty for " + bloodmarkLevel.name() + ". Should be 0");
+        } else {
+            assertTrue(bloodmarkLevel.getBounty().isPositive(),
+                  "Invalid Bounty for " + bloodmarkLevel.name() + ". Should be greater than 0");
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BloodmarkLevel.class)
+    void test_allRollFrequenciesAreValid(BloodmarkLevel bloodmarkLevel) {
+        if (bloodmarkLevel == BLOODMARK_ZERO) {
+            assertEquals(0, bloodmarkLevel.getRollFrequency(),
+                  "Invalid Roll Frequency for " + bloodmarkLevel.name() + ". Should be 0");
+        } else {
+            assertTrue(bloodmarkLevel.getRollFrequency() > 0,
+                  "Invalid Roll Frequency for " + bloodmarkLevel.name() + ". Should be greater than 0");
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BloodmarkLevel.class)
+    void test_allRollDivisorsAreValid(BloodmarkLevel bloodmarkLevel) {
+        if (bloodmarkLevel == BLOODMARK_ZERO) {
+            assertEquals(0, bloodmarkLevel.getRollDivisor(),
+                  "Invalid Roll Divisor for " + bloodmarkLevel.name() + ". Should be 0");
+        } else {
+            assertTrue(bloodmarkLevel.getRollDivisor() > 0,
+                  "Invalid Roll Divisor for " + bloodmarkLevel.name() + ". Should be greater than 0");
+        }
+    }
+}

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -878,6 +878,7 @@ public class PersonnelTableModelColumnTest {
                      WEALTH,
                      REPUTATION,
                      UNLUCKY,
+                     BLOODMARK,
                      EDGE,
                      SPA_COUNT,
                      IMPLANT_COUNT,


### PR DESCRIPTION
This PR adds the ATOW Bloodmark Trait, adapted for MekHQ.

This Trait can be purchased (awarding 100xp per rank) and each month dice rolls are made to determine whether one or more assassination attempts are made. If an attempt is made the target can escape, get wounded, or even killed - based on the skill of the Bounty Hunter.

<img width="720" height="96" alt="image" src="https://github.com/user-attachments/assets/4f813c3c-a1dc-4777-89ea-5c9a98214688" />

As with ATOW, Bloodmark ranges from 0-5.

While I was implementing this, I also stumbled across a handful of bugs with the purchasing of Traits. Including the missing ability to 'pay off' ranks in the Unlucky Trait. This PR addresses those oversights.