### PR TITLE
Feature: #7360 Added the Ability to Perform Single-Attribute and Double-Attribute ATOW Attribute Checks

### DIFF
--- a/MekHQ/resources/mekhq/resources/AttributeCheckUtility.properties
+++ b/MekHQ/resources/mekhq/resources/AttributeCheckUtility.properties
@@ -1,0 +1,11 @@
+# suppress inspection "UnusedProperty" for the whole file
+AttributeCheck.results={0} {1}<b>{2}</b>{3} {4} {5} check with a roll of <b>{6}</b> vs. a target number of <b>{7}</b>.
+AttributeCheck.results.success=Passed
+AttributeCheck.results.failure=Failed
+AttributeCheck.rerolled={0} used a point of <b>Edge</b> when making this check.
+AttributeCheck.nullSkillName=ERROR: first Attribute is null. Please report this bug to the MegaMek team.
+AttributeCheck.nullPerson=ERROR: Person is null. Please report this bug to the MegaMek team.
+# Target Roll Modifiers
+AttributeCheck.twoLinkedAttributes=Target Number (Two Linked Attributes)
+AttributeCheck.oneLinkedAttribute=Target Number (One Linked Attribute)
+AttributeCheck.miscModifier=Misc Modifier

--- a/MekHQ/resources/mekhq/resources/AttributeCheckUtility.properties
+++ b/MekHQ/resources/mekhq/resources/AttributeCheckUtility.properties
@@ -3,7 +3,7 @@ AttributeCheck.results={0} {1}<b>{2}</b>{3} {4} {5} check with a roll of <b>{6}<
 AttributeCheck.results.success=Passed
 AttributeCheck.results.failure=Failed
 AttributeCheck.rerolled={0} used a point of <b>Edge</b> when making this check.
-AttributeCheck.nullSkillName=ERROR: first Attribute is null. Please report this bug to the MegaMek team.
+AttributeCheck.nullAttributeName=ERROR: first Attribute is null. Please report this bug to the MegaMek team.
 AttributeCheck.nullPerson=ERROR: Person is null. Please report this bug to the MegaMek team.
 # Target Roll Modifiers
 AttributeCheck.twoLinkedAttributes=Target Number (Two Linked Attributes)

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -89,6 +89,7 @@ enterNewCallsign.text=Enter new callsign
 editCallsign.text=Edit Callsign
 changeSalary.text=Change Salary (-1 to remove custom salary)
 makeSkillCheck.text=Perform Skill Check
+makeAttributeCheck.text=Perform Attribute Check
 viewMedicalRecords.text=View Medical Records
 changeRank.text=Change Rank
 changeRankSystem.text=Change Rank System

--- a/MekHQ/resources/mekhq/resources/SkillCheckDialog.properties
+++ b/MekHQ/resources/mekhq/resources/SkillCheckDialog.properties
@@ -9,8 +9,15 @@ message.ooc=Select the skill you want to use and enter any modifiers, then click
   \ use Edge. This will perform the check as usual, but if the check fails, the character will spend 1 Edge to make a\
   \ second attempt.</p>\
   <p>The result of the second attempt will be kept, even if it is worse than the original.</p>
+message.ooc.attribute=Select the attribute (or attribute pair) you want to use and enter any modifiers, then click \
+  "Accept."\
+  <p>If Edge is enabled in Campaign Options and the selected character has more than 0 Edge available, you can choose\
+  \ to use Edge. This will perform the check as usual, but if the check fails, the character will spend 1 Edge to \
+  make a second attempt.</p>\
+  <p>The result of the second attempt will be kept, even if it is worse than the original.</p>
 ## Supplemental panel
 component.combo=Skill
+component.combo.attribute=Attributes
 component.spinner=Modifier
 ## In Character Variants
 message.ic.0=Nothing ventured, nothing gained. Let''s see if luck''s still on our side.

--- a/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
@@ -447,11 +447,11 @@ public class AttributeCheckUtility {
      */
     private static void getAttributeModifiers(SkillAttribute firstSkillAttribute, SkillAttribute secondSkillAttribute,
           Attributes characterAttributes, TargetRoll targetNumber) {
-        int firstAttributeModifier = characterAttributes.getAttributeModifier(firstSkillAttribute);
+        int firstAttributeModifier = characterAttributes.getAttributeScore(firstSkillAttribute);
         targetNumber.addModifier(firstAttributeModifier, firstSkillAttribute.getLabel());
 
         if (secondSkillAttribute != null) {
-            int secondAttributeModifier = characterAttributes.getAttributeModifier(secondSkillAttribute);
+            int secondAttributeModifier = characterAttributes.getAttributeScore(secondSkillAttribute);
             targetNumber.addModifier(secondAttributeModifier, secondSkillAttribute.getLabel());
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
@@ -447,11 +447,11 @@ public class AttributeCheckUtility {
      */
     private static void getAttributeModifiers(SkillAttribute firstSkillAttribute, SkillAttribute secondSkillAttribute,
           Attributes characterAttributes, TargetRoll targetNumber) {
-        int firstAttributeModifier = characterAttributes.getAttributeScore(firstSkillAttribute);
+        int firstAttributeModifier = -characterAttributes.getAttributeScore(firstSkillAttribute);
         targetNumber.addModifier(firstAttributeModifier, firstSkillAttribute.getLabel());
 
         if (secondSkillAttribute != null) {
-            int secondAttributeModifier = characterAttributes.getAttributeScore(secondSkillAttribute);
+            int secondAttributeModifier = -characterAttributes.getAttributeScore(secondSkillAttribute);
             targetNumber.addModifier(secondAttributeModifier, secondSkillAttribute.getLabel());
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
@@ -1,0 +1,600 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.skills;
+
+import static megamek.common.Compute.d6;
+import static mekhq.campaign.personnel.enums.GenderDescriptors.HIS_HER_THEIR;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.BARELY_MADE_IT;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.DISASTROUS;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessObjectFromMarginValue;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginOfSuccessString;
+import static mekhq.campaign.personnel.skills.enums.MarginOfSuccess.getMarginValue;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
+
+import java.util.List;
+
+import megamek.common.TargetRoll;
+import megamek.common.TargetRollModifier;
+import megamek.common.annotations.Nullable;
+import megamek.logging.MMLogger;
+import mekhq.MekHQ;
+import mekhq.campaign.event.PersonChangedEvent;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
+import mekhq.campaign.personnel.skills.enums.SkillAttribute;
+import mekhq.utilities.ReportingUtilities;
+
+/**
+ * Utility class for executing attribute checks.
+ *
+ * <p>The {@link AttributeCheckUtility} class encapsulates the logic needed to perform attribute checks, including
+ * calculating target numbers based on supplied attributes, applying external and miscellaneous modifiers, optionally
+ * handling re-rolls using the Edge mechanic, and generating detailed results including margin of success or failure. It
+ * supports both single-attribute and double-attribute checks and can generate localized, formatted result text suitable
+ * for UI feedback or logs.</p>
+ *
+ * @author Illiani
+ * @since 0.50.07
+ */
+public class AttributeCheckUtility {
+    private static final MMLogger logger = MMLogger.create(AttributeCheckUtility.class);
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.AttributeCheckUtility";
+
+    /**
+     * The target number for an attribute check with one attribute.
+     */
+    protected static final int TARGET_NUMBER_ONE_LINKED_ATTRIBUTE = 12; // ATOW pg 43
+
+    /**
+     * The target number for an attribute check with two attributes.
+     */
+    protected static final int TARGET_NUMBER_TWO_LINKED_ATTRIBUTES = 18; // ATOW pg 43
+
+    private final Person person;
+    private final SkillAttribute firstSkillAttribute;
+    private final SkillAttribute secondSkillAttribute;
+    private int marginOfSuccess;
+    private String resultsText;
+    private TargetRoll targetNumber;
+    boolean isCountUp;
+    private int roll;
+    private boolean usedEdge;
+
+
+    /**
+     * Executes an attribute check for the specified person and attribute type(s).
+     *
+     * <p>This constructor creates a {@link AttributeCheckUtility} instance which calculates the target number for
+     * the attribute check and performs the roll, determining the outcome based on factors such as the person's
+     * attribute levels, external modifiers, miscellaneous modifiers, and whether edge is used.</p>
+     *
+     * <p>External modifiers can optionally influence the target number, while miscellaneous modifiers alter the
+     * target based on whether the attribute is classified as 'count up' or not. Using edge allows the person to attempt
+     * a re-roll if the initial roll fails. Additionally, the constructor can include margins of success text as part of
+     * the results, if desired.</p>
+     *
+     * <p><b>Usage:</b> This constructor offers detailed control over the attribute check process. For simpler
+     * use-cases, the {@link #performQuickAttributeCheck(Person, SkillAttribute, SkillAttribute, List, int)} provides a
+     * more streamlined approach.</p>
+     *
+     * @param person                      the {@link Person} performing the attribute check
+     * @param firstSkillAttribute         the primary attribute to be used in the check.
+     * @param secondSkillAttribute        the secondary optional attribute to be used in the check. Can be null.
+     * @param externalModifiers           an optional list of {@link TargetRollModifier}s that affect the target number
+     * @param miscModifier                a miscellaneous modifier that affects the target number:
+     *                                    <ul>
+     *                                        <li>For 'count up' attributes, this value is subtracted from
+     *                                            the target number (i.e., negative values are bonuses,
+     *                                            positive values are penalties).</li>
+     *                                        <li>For non-'count up' attributes, this value is added to the
+     *                                            target number (i.e., positive values are penalties).</li>
+     *                                    </ul>
+     * @param useEdge                     whether the person should use edge to re-roll if the initial attempt fails
+     * @param includeMarginsOfSuccessText whether to include detailed margins of success information in the results
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public AttributeCheckUtility(final Person person, final SkillAttribute firstSkillAttribute,
+          final @Nullable SkillAttribute secondSkillAttribute, @Nullable List<TargetRollModifier> externalModifiers,
+          final int miscModifier, final boolean useEdge, final boolean includeMarginsOfSuccessText) {
+        this.person = person;
+        this.firstSkillAttribute = firstSkillAttribute;
+        this.secondSkillAttribute = secondSkillAttribute;
+
+        if (isPersonNull()) {
+            return;
+        }
+
+        targetNumber = determineTargetNumber(person, firstSkillAttribute, secondSkillAttribute, miscModifier);
+
+        if (externalModifiers != null) {
+            for (TargetRollModifier modifier : externalModifiers) {
+                targetNumber.addModifier(modifier);
+            }
+        }
+
+        performCheck(useEdge, includeMarginsOfSuccessText);
+    }
+
+    /**
+     * Performs a quick and simple attribute check for a person based on the specified attributes.
+     *
+     * <p>This method evaluates whether the given {@link Person} successfully performs a specified attribute check by
+     * creating a {@link AttributeCheckUtility} instance to handle the calculations. The attribute check's success or
+     * failure is determined based on the person's attribute levels, the provided modifiers (if any), and any
+     * campaign-specific rules.</p>
+     *
+     * <p><b>Usage:</b> This method is designed for common use cases and provides a streamlined approach to attribute
+     * checks. For cases that require greater customization, such as support for edge re-rolls or detailed success
+     * metrics, use the {@link AttributeCheckUtility} constructor instead.</p>
+     *
+     * <p>This method is often the preferred choice for attribute checks in MekHQ due to its simplicity.</p>
+     *
+     * @param person               the {@link Person} performing the Attribute check
+     * @param firstSkillAttribute  the primary attribute to be used in the check.
+     * @param secondSkillAttribute the secondary optional attribute to be used in the check. Can be null.
+     * @param externalModifiers    an optional list of {@link TargetRollModifier}s to apply additional adjustments to
+     *                             the target number
+     * @param miscModifier         a miscellaneous modifier that affects the target number:
+     *                             <ul>
+     *                                 <li>For 'count up' Attributes, this value is subtracted from the target number
+     *                                     (i.e., negative values are bonuses, positive values are penalties).</li>
+     *                                 <li>For non-'count up' Attributes, this value is added to the target number
+     *                                     (i.e., positive values are penalties).</li>
+     *                             </ul>
+     *
+     * @return {@code true} if the Attribute check succeeds, {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public static boolean performQuickAttributeCheck(final Person person, final SkillAttribute firstSkillAttribute,
+          final @Nullable SkillAttribute secondSkillAttribute,
+          final @Nullable List<TargetRollModifier> externalModifiers,
+          final int miscModifier) {
+        AttributeCheckUtility AttributeCheck = new AttributeCheckUtility(person,
+              firstSkillAttribute,
+              secondSkillAttribute,
+              externalModifiers,
+              miscModifier,
+              false,
+              false);
+        return AttributeCheck.isSuccess();
+    }
+
+    /**
+     * Checks if the {@code person} object is {@code null} and handles the null case by auto-failing the check with
+     * obviously wrong results.
+     *
+     * <p>If the {@code person} is {@code null}, the method logs a debug message, sets a {@code DISASTROUS} failure
+     * margin, and assigns out-of-range values to the {@code targetNumber} and {@code roll} to make the issue easily
+     * identifiable.</p>
+     *
+     * @return {@code true} if the {@code person} is {@code null}, {@code false} otherwise.
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private boolean isPersonNull() {
+        if (person == null) {
+            logger.debug("Null person passed into AttributeCheckUtility." +
+                               " Auto-failing check with bogus results so the bug stands out.");
+
+            marginOfSuccess = getMarginValue(DISASTROUS);
+            resultsText = getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.nullPerson");
+            targetNumber = new TargetRoll(Integer.MAX_VALUE, "ERROR");
+            roll = Integer.MIN_VALUE;
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Generates a formatted and localized results text describing the outcome of an Attribute check.
+     *
+     * <p>This method produces a detailed summary of the Attribute check results, including:</p>
+     * <ul>
+     *   <li>The person's title, name, and gender-based pronoun</li>
+     *   <li>The name of the Attribute being checked</li>
+     *   <li>The dice roll, target number, and margin of success or failure</li>
+     *   <li>A status message indicating success or failure</li>
+     *   <li>Use of edge (if applicable)</li>
+     * </ul>
+     *
+     * <p>The result text is color-coded using custom span tags based on the margin of success:
+     * <ul>
+     *   <li><b>Neutral Margin:</b> Displayed using a warning color (e.g., yellow).</li>
+     *   <li><b>Failure:</b> Displayed using a negative color (e.g., red).</li>
+     *   <li><b>Success:</b> Displayed using a positive color (e.g., green).</li>
+     * </ul>
+     * </p>
+     *
+     * <p>If edge was used to reroll the Attribute check, the results will include an additional note with
+     * information about the reroll. If the caller requests it, margin of success details can also be appended to the
+     * result text.</p>
+     *
+     * <p>If the first Attribute name is {@code null}, the method returns a localized error message indicating that the
+     * Attribute name could not be resolved and that an error occurred during the result generation process.</p>
+     *
+     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the result text
+     *
+     * @return a localized and formatted {@link String} representing the outcomes of the Attribute check:
+     *       <ul>
+     *         <li>If successful, the string provides details of the roll, Attribute, and margin of success.</li>
+     *         <li>If edge was used, additional information about the reroll is included.</li>
+     *         <li>If the first Attribute name is {@code null}, an error message is returned instead.</li>
+     *       </ul>
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private String generateResultsText(boolean includeMarginsOfSuccessText) {
+        if (firstSkillAttribute == null) {
+            return getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.nullAttributeName");
+        }
+
+        String fullTitle = person.getHyperlinkedFullTitle();
+        String firstName = person.getFirstName();
+        String genderedReferenced = HIS_HER_THEIR.getDescriptor(person.getGender());
+
+        String colorOpen;
+        int neutralMarginValue = getMarginValue(BARELY_MADE_IT);
+        if (marginOfSuccess == neutralMarginValue) {
+            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getWarningColor());
+        } else if (marginOfSuccess < neutralMarginValue) {
+            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor());
+        } else {
+            colorOpen = spanOpeningWithCustomColor(ReportingUtilities.getPositiveColor());
+        }
+        String status = getFormattedTextAt(RESOURCE_BUNDLE,
+              "AttributeCheck.results." + (isSuccess() ? "success" : "failure"));
+        String label = getAttributeCheckLabel();
+        String mainMessage = getFormattedTextAt(RESOURCE_BUNDLE,
+              "AttributeCheck.results",
+              fullTitle,
+              colorOpen,
+              status,
+              CLOSING_SPAN_TAG,
+              genderedReferenced,
+              label,
+              roll,
+              targetNumber.getValue());
+
+        String edgeUseText = !usedEdge ? "" : getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.rerolled", firstName);
+
+        if (!edgeUseText.isBlank()) {
+            mainMessage = mainMessage + "<p>" + edgeUseText + "</p>";
+        }
+
+        if (includeMarginsOfSuccessText) {
+            MarginOfSuccess marginOfSuccessObject = getMarginOfSuccessObjectFromMarginValue(marginOfSuccess);
+            String marginOfSuccessText = getMarginOfSuccessString(marginOfSuccessObject);
+            return mainMessage + "<p>" + marginOfSuccessText + "</p>";
+        } else {
+            return mainMessage;
+        }
+    }
+
+    /**
+     * Gets the calculated margin of success for this attribute check.
+     *
+     * <p>The margin of success represents how much better (or worse) the roll was compared to the target number.</p>
+     *
+     * <p><b>Usage:</b> You want to call this method whenever you care about how well a check was passed. Or how
+     * badly it was failed. If you only care whether the check was passed or failed use {@link #isSuccess()}
+     * instead.</p>
+     *
+     * @return the margin of success
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public int getMarginOfSuccess() {
+        return marginOfSuccess;
+    }
+
+    /**
+     * Determines whether the Attribute check was successful.
+     *
+     * <p>An attribute check is considered successful if the calculated margin of success is greater than or equal to
+     * the margin value of {@link MarginOfSuccess#BARELY_MADE_IT}.</p>
+     *
+     * <p><b>Usage:</b> You want to call this method whenever you only care whether the check was passed or failed.
+     * If you want to know how well the character did use {@link #getMarginOfSuccess()} instead.</p>
+     *
+     * @return {@code true} if the attribute check succeeded, {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public boolean isSuccess() {
+        return marginOfSuccess >= getMarginValue(BARELY_MADE_IT);
+    }
+
+    /**
+     * Gets the result text for the margin of success.
+     *
+     * <p>This is a descriptive string representing the outcome of the attribute check, based on the calculated
+     * margin of success.</p>
+     *
+     * @return the results text for the attribute check
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public String getResultsText() {
+        return resultsText;
+    }
+
+    /**
+     * Gets the target number for the attribute check.
+     *
+     * <p>The target number represents the value that the rolled number must meet or exceed for the attribute check to
+     * succeed.</p>
+     *
+     * @return the target number for the attribute check
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public TargetRoll getTargetNumber() {
+        return targetNumber;
+    }
+
+    /**
+     * Gets the roll result for the attribute check.
+     *
+     * <p>The roll is the result of the dice roll used to determine whether the attribute check succeeded or
+     * failed.</p>
+     *
+     * @return the roll result for the attribute check
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public int getRoll() {
+        return roll;
+    }
+
+    /**
+     * Checks whether edge was used during the attribute check.
+     *
+     * <p>Edge provides the opportunity to re-roll if the initial attribute check fails, allowing a chance to improve
+     * the outcome.</p>
+     *
+     * @return {@code true} if edge was used during the attribute check, {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public boolean isUsedEdge() {
+        return usedEdge;
+    }
+
+    /**
+     * Determines the target number for a roll based on the given person's attributes, the requested attributes, and a
+     * miscellaneous modifier.
+     *
+     * @param person               the person whose attributes will be used to calculate the target number
+     * @param firstSkillAttribute  the primary skill attribute to be used for calculations can be null
+     * @param secondSkillAttribute the secondary skill attribute to be used for calculations
+     * @param miscModifier         an additional modifier to be applied to the target number
+     *
+     * @return a {@link TargetRoll} object containing the calculated target number
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public static TargetRoll determineTargetNumber(Person person, @Nullable SkillAttribute firstSkillAttribute,
+          SkillAttribute secondSkillAttribute, int miscModifier) {
+        final Attributes characterAttributes = person.getATOWAttributes();
+
+        TargetRoll targetNumber = new TargetRoll();
+
+        getBaseTargetNumber(targetNumber, secondSkillAttribute != null);
+        getAttributeModifiers(firstSkillAttribute, secondSkillAttribute, characterAttributes, targetNumber);
+
+        targetNumber.addModifier(miscModifier, getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.miscModifier"));
+
+        return targetNumber;
+    }
+
+    /**
+     * Calculates and applies attribute modifiers to the target roll based on the provided skill attributes and
+     * character attributes. If the second skill attribute is not null, it also calculates and applies its modifier.
+     *
+     * @param firstSkillAttribute  the first skill attribute used for modifier calculation
+     * @param secondSkillAttribute the second skill attribute used for modifier calculation; can be null
+     * @param characterAttributes  the set of character attributes that provide the modifiers
+     * @param targetNumber         the target roll object to which the calculated modifiers will be added
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private static void getAttributeModifiers(SkillAttribute firstSkillAttribute, SkillAttribute secondSkillAttribute,
+          Attributes characterAttributes, TargetRoll targetNumber) {
+        int firstAttributeModifier = characterAttributes.getAttributeModifier(firstSkillAttribute);
+        targetNumber.addModifier(firstAttributeModifier, firstSkillAttribute.getLabel());
+
+        if (secondSkillAttribute != null) {
+            int secondAttributeModifier = characterAttributes.getAttributeModifier(secondSkillAttribute);
+            targetNumber.addModifier(secondAttributeModifier, secondSkillAttribute.getLabel());
+        }
+    }
+
+    /**
+     * Modifies the base target number based on whether a single or double attribute check is performed.
+     *
+     * @param targetNumber           the {@link TargetRoll} object to which the modifier will be added
+     * @param isDoubleAttributeCheck a boolean indicating whether the check involves two linked attributes (true) or one
+     *                               linked attribute (false)
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private static void getBaseTargetNumber(TargetRoll targetNumber, boolean isDoubleAttributeCheck) {
+        if (isDoubleAttributeCheck) {
+            targetNumber.addModifier(TARGET_NUMBER_TWO_LINKED_ATTRIBUTES,
+                  getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.twoLinkedAttributes"));
+        } else {
+            targetNumber.addModifier(TARGET_NUMBER_ONE_LINKED_ATTRIBUTE,
+                  getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.oneLinkedAttribute"));
+        }
+    }
+
+    /**
+     * Performs an attribute check for a specified person, determining the outcome based on dice rolls and optionally
+     * allowing the use of edge points for a re-roll upon failure.
+     *
+     * <p>This method begins by rolling two six-sided dice (2d6) and comparing the result against a pre-calculated
+     * target number. If the initial roll meets or exceeds the target number, the Attribute check succeeds, and the
+     * results are calculated and stored. If the initial roll fails, and edge use is enabled and available, one edge
+     * point is consumed, and a re-roll is performed.</p>
+     *
+     * <p>The method concludes by storing the final Attribute check results, including the margin of success and
+     * optional descriptive text, for later use.</p>
+     *
+     * <p>When edge is used, the method records this information and updates the results accordingly to reflect the
+     * additional roll.</p>
+     *
+     * @param useEdge                     whether to allow the person to use an edge point to re-roll if the initial
+     *                                    roll fails. Edge use is conditional on the person's current edge
+     *                                    availability.
+     * @param includeMarginsOfSuccessText whether to include detailed information about the margin of success in the
+     *                                    final results text
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private void performCheck(boolean useEdge, boolean includeMarginsOfSuccessText) {
+        roll = d6(2);
+        if (performInitialRoll(useEdge, includeMarginsOfSuccessText)) {
+            return;
+        }
+
+        roll = d6(2);
+        rollWithEdge(includeMarginsOfSuccessText);
+    }
+
+    /**
+     * Handles the initial dice roll in the Attribute check and determines whether the check is resolved or if further
+     * action (re-roll with edge) is required.
+     *
+     * <p>This method evaluates the outcome of the initial roll by comparing it against the target number. If the
+     * roll meets or exceeds the target number, the Attribute check is deemed successful, and the results are finalized.
+     * If the roll fails, the method decides whether Edge can or should be used to perform a re-roll. Edge use is
+     * allowed only if the {@code useEdge} parameter is {@code true} and there are available edge points for the
+     * person.</p>
+     *
+     * <p>The method stores key results from the initial roll, including:</p>
+     * <ul>
+     *   <li>The margin of success or failure, calculated based on the target number and roll</li>
+     *   <li>A descriptive results text, optionally including margin details if requested</li>
+     * </ul>
+     *
+     * <p>If the roll does not succeed and edge use is feasible, the method signals the need for a re-roll, otherwise
+     * finalizes the results based on the initial roll.</p>
+     *
+     * @param useEdge                     whether to allow using edge points for a re-roll if the initial roll fails
+     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the result text
+     *
+     * @return {@code true} if the Attribute check is resolved using the initial roll (success or no edge re-roll
+     *       possible); {@code false} if a re-roll using edge is required
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    boolean performInitialRoll(boolean useEdge, boolean includeMarginsOfSuccessText) {
+        int availableEdge = person.getCurrentEdge();
+        int targetNumberValue = targetNumber.getValue();
+
+        if (roll >= targetNumberValue || !useEdge || availableEdge < 1) {
+            int difference = isCountUp ? targetNumberValue - roll : roll - targetNumberValue;
+
+            String label = getAttributeCheckLabel();
+            logger.info(getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.results"),
+                  label,
+                  roll,
+                  targetNumber,
+                  difference);
+
+            marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(difference);
+            resultsText = generateResultsText(includeMarginsOfSuccessText);
+            return true;
+        }
+        return false;
+    }
+
+    private String getAttributeCheckLabel() {
+        String label = firstSkillAttribute.getLabel();
+        if (secondSkillAttribute != null) {
+            label = label + "-" + secondSkillAttribute.getLabel();
+        }
+
+        return label;
+    }
+
+    /**
+     * Executes the re-roll logic for an Attribute check when edge is used, updating the person's edge points and
+     * recalculating the outcome based on the new roll.
+     *
+     * <p>This method is invoked only after the failure of the initial roll, provided edge usage is allowed and the
+     * person has at least one edge point available. When called, it decrements the person's edge points by one,
+     * triggers an event to update the game state reflecting this change, and marks that edge was used for this
+     * Attribute check. The results of the Attribute check are then recalculated based on the new roll, including the
+     * margin of success and the corresponding results text.</p>
+     *
+     * <p>The result text can optionally include detailed information about the margin of success, depending on the
+     * value of the {@code includeMarginsOfSuccessText} parameter.</p>
+     *
+     * @param includeMarginsOfSuccessText whether to include detailed margin of success information in the result text
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private void rollWithEdge(boolean includeMarginsOfSuccessText) {
+        person.changeCurrentEdge(-1);
+        MekHQ.triggerEvent(new PersonChangedEvent(person));
+        usedEdge = true;
+
+        int targetNumberValue = targetNumber.getValue();
+
+        int difference = isCountUp ? targetNumberValue - roll : roll - targetNumberValue;
+        marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(difference);
+        resultsText = generateResultsText(includeMarginsOfSuccessText);
+    }
+}

--- a/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
@@ -69,7 +69,7 @@ import mekhq.utilities.ReportingUtilities;
  * @since 0.50.07
  */
 public class AttributeCheckUtility {
-    private static final MMLogger logger = MMLogger.create(AttributeCheckUtility.class);
+    private static final MMLogger LOGGER = MMLogger.create(AttributeCheckUtility.class);
     private static final String RESOURCE_BUNDLE = "mekhq.resources.AttributeCheckUtility";
 
     /**
@@ -210,7 +210,7 @@ public class AttributeCheckUtility {
      */
     private boolean isPersonNull() {
         if (person == null) {
-            logger.debug("Null person passed into AttributeCheckUtility." +
+            LOGGER.debug("Null person passed into AttributeCheckUtility." +
                                " Auto-failing check with bogus results so the bug stands out.");
 
             marginOfSuccess = getMarginValue(DISASTROUS);
@@ -545,15 +545,10 @@ public class AttributeCheckUtility {
         if (roll >= targetNumberValue || !useEdge || availableEdge < 1) {
             int difference = isCountUp ? targetNumberValue - roll : roll - targetNumberValue;
 
-            String label = getAttributeCheckLabel();
-            logger.info(getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.results"),
-                  label,
-                  roll,
-                  targetNumber,
-                  difference);
-
             marginOfSuccess = MarginOfSuccess.getMarginOfSuccess(difference);
             resultsText = generateResultsText(includeMarginsOfSuccessText);
+
+            LOGGER.info(resultsText);
             return true;
         }
         return false;

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -171,6 +171,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
     // region Variable Declarations
     private static final String CMD_SKILL_CHECK = "SKILL_CHECK";
+    private static final String CMD_ATTRIBUTE_CHECK = "ATTRIBUTE_CHECK";
     private static final String CMD_MEDICAL_RECORDS = "MEDICAL_RECORDS";
     private static final String CMD_RANKSYSTEM = "RANKSYSTEM";
     private static final String CMD_RANK = "RANK";
@@ -364,6 +365,12 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             case CMD_SKILL_CHECK: {
                 for (final Person person : people) {
                     new SkillCheckDialog(getCampaign(), person);
+                }
+                break;
+            }
+            case CMD_ATTRIBUTE_CHECK: {
+                for (final Person person : people) {
+                    new AttributeCheckDialog(getCampaign(), person);
                 }
                 break;
             }
@@ -1939,6 +1946,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         // lets fill the pop up menu
         menuItem = new JMenuItem(resources.getString("makeSkillCheck.text"));
         menuItem.setActionCommand(makeCommand(CMD_SKILL_CHECK));
+        menuItem.addActionListener(this);
+        popup.add(menuItem);
+
+        menuItem = new JMenuItem(resources.getString("makeAttributeCheck.text"));
+        menuItem.setActionCommand(makeCommand(CMD_ATTRIBUTE_CHECK));
         menuItem.addActionListener(this);
         popup.add(menuItem);
 

--- a/MekHQ/src/mekhq/gui/dialog/AttributeCheckDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AttributeCheckDialog.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package mekhq.gui.dialog;
+
+import static megamek.common.Compute.randomInt;
+import static mekhq.campaign.personnel.skills.AttributeCheckUtility.determineTargetNumber;
+import static mekhq.campaign.personnel.skills.enums.SkillAttribute.BODY;
+import static mekhq.campaign.personnel.skills.enums.SkillAttribute.CHARISMA;
+import static mekhq.campaign.personnel.skills.enums.SkillAttribute.DEXTERITY;
+import static mekhq.campaign.personnel.skills.enums.SkillAttribute.INTELLIGENCE;
+import static mekhq.campaign.personnel.skills.enums.SkillAttribute.REFLEXES;
+import static mekhq.campaign.personnel.skills.enums.SkillAttribute.STRENGTH;
+import static mekhq.campaign.personnel.skills.enums.SkillAttribute.WILLPOWER;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.ImageIcon;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+
+import megamek.client.ui.comboBoxes.MMComboBox;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.skills.AttributeCheckUtility;
+import mekhq.campaign.personnel.skills.enums.SkillAttribute;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.ButtonLabelTooltipPair;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
+
+/**
+ * A dialog that facilitates Attribute checks for a character.
+ *
+ * <p>This dialog allows the user to perform Attribute checks for specific Attributes by selecting the Attribute,
+ * applying modifiers, and choosing whether to use Edge. It consists of an initial dialog to gather input, executes the
+ * Attribute check, and then presents the result in a result dialog.</p>
+ *
+ * @author Illiani
+ * @since 0.50.07
+ */
+public class AttributeCheckDialog {
+    final static String RESOURCE_BUNDLE = "mekhq.resources.SkillCheckDialog";
+
+    final static String DIALOG_IMAGE_FILENAME_DEFAULT = "data/images/misc/skill_check_default.png";
+    final static String DIALOG_IMAGE_FILENAME_PASS = "data/images/misc/skill_check_pass.png";
+    final static String DIALOG_IMAGE_FILENAME_FAIL = "data/images/misc/skill_check_fail.png";
+
+    final static int DIALOG_CANCEL_INDEX = 0;
+    final static int DIALOG_USE_EDGE_INDEX = 2;
+
+    /**
+     * A static list of attribute check options used within the dialog.
+     *
+     * <p>Each entry in the list corresponds to a combination of one or two skill attributes, represented by their
+     * localized labels. This allows for the composition of various attribute checks based on predefined attribute
+     * combinations, such as single attributes (e.g., "Body") or paired attributes (e.g., "Body-Charisma").</p>
+     *
+     * <p>The labels for these options are dynamically generated using the {@code getLabel} method of
+     * {@link SkillAttribute}, retrieving localized strings defined in resource bundles.</p>
+     */
+    final static List<String> ATTRIBUTE_CHECK_OPTIONS = List.of(
+          BODY.getLabel(),
+          CHARISMA.getLabel(),
+          DEXTERITY.getLabel(),
+          INTELLIGENCE.getLabel(),
+          REFLEXES.getLabel(),
+          STRENGTH.getLabel(),
+          BODY.getLabel() + "-" + CHARISMA.getLabel(),
+          BODY.getLabel() + "-" + DEXTERITY.getLabel(),
+          BODY.getLabel() + "-" + INTELLIGENCE.getLabel(),
+          BODY.getLabel() + "-" + REFLEXES.getLabel(),
+          BODY.getLabel() + "-" + STRENGTH.getLabel(),
+          BODY.getLabel() + "-" + WILLPOWER.getLabel(),
+          CHARISMA.getLabel() + "-" + DEXTERITY.getLabel(),
+          CHARISMA.getLabel() + "-" + INTELLIGENCE.getLabel(),
+          CHARISMA.getLabel() + "-" + REFLEXES.getLabel(),
+          CHARISMA.getLabel() + "-" + STRENGTH.getLabel(),
+          CHARISMA.getLabel() + "-" + WILLPOWER.getLabel(),
+          DEXTERITY.getLabel() + "-" + INTELLIGENCE.getLabel(),
+          DEXTERITY.getLabel() + "-" + REFLEXES.getLabel(),
+          DEXTERITY.getLabel() + "-" + STRENGTH.getLabel(),
+          DEXTERITY.getLabel() + "-" + WILLPOWER.getLabel(),
+          INTELLIGENCE.getLabel() + "-" + REFLEXES.getLabel(),
+          INTELLIGENCE.getLabel() + "-" + STRENGTH.getLabel(),
+          INTELLIGENCE.getLabel() + "-" + WILLPOWER.getLabel(),
+          REFLEXES.getLabel() + "-" + STRENGTH.getLabel(),
+          REFLEXES.getLabel() + "-" + WILLPOWER.getLabel(),
+          STRENGTH.getLabel() + "-" + WILLPOWER.getLabel());
+
+    private final Campaign campaign;
+    private final Person character;
+    boolean isSuccess = false;
+
+
+    /**
+     * Constructs a {@code AttributeCheckDialog} for the specified character.
+     *
+     * <p>This constructor initializes the dialog, processes the selected attribute check, and displays the results. If
+     * the user cancels the attribute check, no further action is taken.</p>
+     *
+     * @param campaign  the {@link Campaign} containing the current game state
+     * @param character the {@link Person} performing the attribute check
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public AttributeCheckDialog(Campaign campaign, Person character) {
+        this.campaign = campaign;
+        this.character = character;
+
+        // Initial Dialog
+        ImmersiveDialogCore dialog = getInitialDialog();
+        int choiceIndex = dialog.getDialogChoice();
+
+        if (choiceIndex == DIALOG_CANCEL_INDEX) {
+            return;
+        }
+
+        // Perform Check
+        String results = performAttributeCheck(dialog.getComboBoxChoiceIndex(), dialog.getSpinnerValue(), choiceIndex);
+
+        // Results Dialog
+        campaign.addReport(results.replaceAll("<p>", "<br><br>").replaceAll("</p>", ""));
+        showResultsDialog(results);
+    }
+
+
+    /**
+     * Creates and returns the initial dialog for Attribute check configuration.
+     *
+     * <p>This dialog gathers user input for the Attribute, modifier, and whether to use Edge or not.</p>
+     *
+     * @return an {@link ImmersiveDialogCore} instance for the initial dialog
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private ImmersiveDialogCore getInitialDialog() {
+        return new ImmersiveDialogCore(campaign,
+              character,
+              null,
+              getInCharacterMessage(),
+              getButtons(character.getCurrentEdge() > 0, campaign.getCampaignOptions().isUseEdge()),
+              getFormattedTextAt(RESOURCE_BUNDLE, "message.ooc.attribute"),
+              null,
+              false,
+              getSupplementalPanel(),
+              new ImageIcon(DIALOG_IMAGE_FILENAME_DEFAULT),
+              true);
+    }
+
+    /**
+     * Performs the Attribute check and returns the result as a string.
+     *
+     * @param selectedOption   the index of the attribute(s) selected in the ComboBox
+     * @param selectedModifier the modifier applied to the roll
+     * @param choiceIndex      the user's choice (e.g., whether to use Edge or not)
+     *
+     * @return a {@code String} containing the result of the Attribute check
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private String performAttributeCheck(int selectedOption, int selectedModifier, int choiceIndex) {
+        List<SkillAttribute> attributes = deriveAttributesFromOption(ATTRIBUTE_CHECK_OPTIONS.get(selectedOption));
+        SkillAttribute firstAttribute = attributes.get(0);
+        SkillAttribute secondAttribute = attributes.size() > 1 ? attributes.get(1) : null;
+        boolean useEdge = choiceIndex == DIALOG_USE_EDGE_INDEX;
+        AttributeCheckUtility utility = new AttributeCheckUtility(character, firstAttribute, secondAttribute, null,
+              selectedModifier, useEdge, true);
+        isSuccess = utility.isSuccess();
+
+        return utility.getResultsText();
+    }
+
+
+    /**
+     * Displays the results of the Attribute check in a results dialog.
+     *
+     * @param results the results text to display
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private void showResultsDialog(String results) {
+        new ImmersiveDialogSimple(campaign,
+              character,
+              null,
+              results,
+              null,
+              null,
+              new ImageIcon(isSuccess ? DIALOG_IMAGE_FILENAME_PASS : DIALOG_IMAGE_FILENAME_FAIL),
+              false);
+    }
+
+    /**
+     * Retrieves the in-character message to display in the dialog.
+     *
+     * @return a {@code String} containing the in-character message
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private String getInCharacterMessage() {
+        int variant = randomInt(50);
+        return getFormattedTextAt(RESOURCE_BUNDLE, "message.ic." + variant);
+    }
+
+    /**
+     * Retrieves the list of buttons for the dialog.
+     *
+     * <p>The buttons include Cancel, Attempt, and optionally Use Edge (if applicable).</p>
+     *
+     * @param hasEdge    whether the character has any Edge points available
+     * @param allowsEdge whether the campaign allows Edge usage
+     *
+     * @return a {@code List} of {@link ButtonLabelTooltipPair} instances for dialog buttons
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private List<ButtonLabelTooltipPair> getButtons(boolean hasEdge, boolean allowsEdge) {
+        List<ButtonLabelTooltipPair> buttons = new ArrayList<>();
+        buttons.add(new ButtonLabelTooltipPair(getFormattedTextAt(RESOURCE_BUNDLE, "button.cancel"), null));
+        buttons.add(new ButtonLabelTooltipPair(getFormattedTextAt(RESOURCE_BUNDLE, "button.attempt"), null));
+
+        if (hasEdge && allowsEdge) {
+            buttons.add(new ButtonLabelTooltipPair(getFormattedTextAt(RESOURCE_BUNDLE, "button.edge"), null));
+        }
+
+        return buttons;
+    }
+
+
+    /**
+     * Creates and returns the supplemental panel for the dialog.
+     *
+     * <p>This panel includes a {@link MMComboBox} for selecting Attributes and a {@link JSpinner} for adding
+     * modifiers.</p>
+     *
+     * @return a {@link JPanel} with additional input fields
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private JPanel getSupplementalPanel() {
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints constraints = createBaseConstraints();
+
+        // Add label for ComboBox
+        JLabel lblAttributes = new JLabel(getFormattedTextAt(RESOURCE_BUNDLE, "component.combo.attribute"));
+        addComponent(panel, lblAttributes, constraints, 0, 0, 1, GridBagConstraints.NONE);
+
+        // Add ComboBox
+        MMComboBox<String> cboAttributes = new MMComboBox<>("cboAttributes", getComboListItems());
+        addComponent(panel, cboAttributes, constraints, 1, 0, 2, GridBagConstraints.HORIZONTAL);
+
+        // Add label for spinner
+        JLabel lblModifiers = new JLabel(getFormattedTextAt(RESOURCE_BUNDLE, "component.spinner"));
+        addComponent(panel, lblModifiers, constraints, 0, 1, 1, GridBagConstraints.NONE);
+
+        // Add spinner
+        JSpinner spnModifiers = new JSpinner(new SpinnerNumberModel(0, -30, 10, 1));
+        addComponent(panel, spnModifiers, constraints, 1, 1, 1, GridBagConstraints.NONE);
+
+        return panel;
+    }
+
+
+    /**
+     * Creates and returns the base {@link GridBagConstraints} for use in laying out the supplemental panel.
+     *
+     * @return a {@link GridBagConstraints} object with pre-configured values
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private GridBagConstraints createBaseConstraints() {
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.insets = new Insets(5, 5, 5, 5);
+        constraints.anchor = GridBagConstraints.WEST;
+        return constraints;
+    }
+
+
+    /**
+     * Adds a component to the supplemental panel with specified layout constraints.
+     *
+     * @param panel       the {@link JPanel} to add the component to
+     * @param component   the {@link JComponent} to add
+     * @param constraints the {@link GridBagConstraints} to control layout
+     * @param gridX       the grid X-coordinate
+     * @param gridY       the grid Y-coordinate
+     * @param gridWidth   the width of the component in terms of grid cells
+     * @param fill        the fill style (e.g., {@link GridBagConstraints#HORIZONTAL})
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private void addComponent(JPanel panel, JComponent component, GridBagConstraints constraints, int gridX, int gridY,
+          int gridWidth, int fill) {
+        constraints.gridx = gridX;
+        constraints.gridy = gridY;
+        constraints.gridwidth = gridWidth;
+        constraints.fill = fill;
+        panel.add(component, constraints);
+    }
+
+    /**
+     * Generates a list of Attributes with formatted labels for display in the ComboBox.
+     *
+     * <p>Each label includes the Attribute name (bolded), target number, and any relevant modifiers.</p>
+     *
+     * @return a {@code String[]} containing the formatted Attribute labels
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private String[] getComboListItems() {
+        List<String> options = new ArrayList<>();
+
+        for (String attributeOption : ATTRIBUTE_CHECK_OPTIONS) {
+            List<SkillAttribute> attributes = deriveAttributesFromOption(attributeOption);
+            SkillAttribute firstAttribute = attributes.get(0);
+            SkillAttribute secondAttribute = attributes.size() > 1 ? attributes.get(1) : null;
+            int targetNumber = determineTargetNumber(character, firstAttribute, secondAttribute, 0).getValue();
+
+            // Build the label with the target number
+            String formattedAttributeName = "<html><b>" + attributeOption + "</b>";
+            String label = formattedAttributeName + " (" + targetNumber + "+)</html>";
+
+            options.add(label);
+        }
+
+        // Convert the list to a String array and return it
+        return options.toArray(new String[0]);
+    }
+
+    /**
+     * Derives a list of {@link SkillAttribute} instances from the given option string.
+     *
+     * <p>The method checks the provided option to identify and collect all {@code SkillAttribute} values whose
+     * labels are contained within the given string.</p>
+     *
+     * @param option the {@link String} representing the option to parse for attribute labels
+     *
+     * @return a {@link List} of {@link SkillAttribute} instances matching the labels found in the option string
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private List<SkillAttribute> deriveAttributesFromOption(String option) {
+        List<SkillAttribute> attributes = new ArrayList<>();
+
+        for (SkillAttribute attribute : SkillAttribute.values()) {
+            if (option.contains(attribute.getLabel())) {
+                attributes.add(attribute);
+            }
+        }
+
+        return attributes;
+    }
+}


### PR DESCRIPTION
Fix #7360

This PR creates a spin-off from the skill check utility and dialog, one that allows users and developers to make single-attribute and double-attribute checks.