### PR TITLE
Improvement: Implemented Illiterate & Scrounge SPAs

### DIFF
--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -1459,6 +1459,16 @@ While this SPA does exist in ATOW, these effects are unique to MekHQ.]]></desc>
     <weight>1</weight>
     <skillPrereq />
     </ability>
+    <ability>
+    <lookupName>flaw_illiterate</lookupName>
+    <displayName>Illiterate (ATOW)</displayName>
+    <desc><![CDATA[The character suffers a -4 (untrained) penalty to all Intelligence-based skill checks.
+
+This penalty is removed once the character acquires level 4 in the Language/Any skill.]]></desc>
+    <xpCost>-100</xpCost>
+    <weight>1</weight>
+    <skillPrereq />
+    </ability>
 
     <!-- OTHER SPA -->
     <ability>

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2465,63 +2465,64 @@ public class Campaign implements ITechManager {
         int bloodnameTarget = 6;
         PersonnelOptions options = person.getOptions();
         Attributes attributes = person.getATOWAttributes();
+        boolean isIlliterate = person.isIlliterate();
         if (!ignoreDice) {
             switch (person.getPhenotype()) {
                 case MEKWARRIOR: {
                     bloodnameTarget += person.hasSkill(SkillType.S_GUN_MEK) ?
                                              person.getSkill(SkillType.S_GUN_MEK)
-                                                   .getFinalSkillValue(options, attributes) :
+                                                   .getFinalSkillValue(options, attributes, isIlliterate) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     bloodnameTarget += person.hasSkill(SkillType.S_PILOT_MEK) ?
                                              person.getSkill(SkillType.S_PILOT_MEK)
-                                                   .getFinalSkillValue(options, attributes) :
+                                                   .getFinalSkillValue(options, attributes, isIlliterate) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     break;
                 }
                 case AEROSPACE: {
                     bloodnameTarget += person.hasSkill(SkillType.S_GUN_AERO) ?
                                              person.getSkill(SkillType.S_GUN_AERO)
-                                                   .getFinalSkillValue(options, attributes) :
+                                                   .getFinalSkillValue(options, attributes, isIlliterate) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     bloodnameTarget += person.hasSkill(SkillType.S_PILOT_AERO) ?
                                              person.getSkill(SkillType.S_PILOT_AERO)
-                                                   .getFinalSkillValue(options, attributes) :
+                                                   .getFinalSkillValue(options, attributes, isIlliterate) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     break;
                 }
                 case ELEMENTAL: {
                     bloodnameTarget += person.hasSkill(SkillType.S_GUN_BA) ?
                                              person.getSkill(SkillType.S_GUN_BA)
-                                                   .getFinalSkillValue(options, attributes) :
+                                                   .getFinalSkillValue(options, attributes, isIlliterate) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     bloodnameTarget += person.hasSkill(SkillType.S_ANTI_MEK) ?
                                              person.getSkill(SkillType.S_ANTI_MEK)
-                                                   .getFinalSkillValue(options, attributes) :
+                                                   .getFinalSkillValue(options, attributes, isIlliterate) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     break;
                 }
                 case VEHICLE: {
                     bloodnameTarget += person.hasSkill(SkillType.S_GUN_VEE) ?
                                              person.getSkill(SkillType.S_GUN_VEE)
-                                                   .getFinalSkillValue(options, attributes) :
+                                                   .getFinalSkillValue(options, attributes, isIlliterate) :
                                              TargetRoll.AUTOMATIC_FAIL;
                     switch (person.getPrimaryRole()) {
                         case GROUND_VEHICLE_DRIVER:
                             bloodnameTarget += person.hasSkill(SkillType.S_PILOT_GVEE) ?
                                                      person.getSkill(SkillType.S_PILOT_GVEE)
-                                                           .getFinalSkillValue(options, attributes) :
+                                                           .getFinalSkillValue(options, attributes, isIlliterate) :
                                                      TargetRoll.AUTOMATIC_FAIL;
                             break;
                         case NAVAL_VEHICLE_DRIVER:
                             bloodnameTarget += person.hasSkill(SkillType.S_PILOT_NVEE) ?
                                                      person.getSkill(SkillType.S_PILOT_NVEE)
-                                                           .getFinalSkillValue(options, attributes) :
+                                                           .getFinalSkillValue(options, attributes, isIlliterate) :
                                                      TargetRoll.AUTOMATIC_FAIL;
                             break;
                         case VTOL_PILOT:
                             bloodnameTarget += person.hasSkill(SkillType.S_PILOT_VTOL) ?
                                                      person.getSkill(SkillType.S_PILOT_VTOL)
-                                                           .getFinalSkillValue(options, attributes) :
+                                                           .getFinalSkillValue(options, attributes, isIlliterate) :
                                                      TargetRoll.AUTOMATIC_FAIL;
                             break;
                         default:
@@ -2533,7 +2534,7 @@ public class Campaign implements ITechManager {
                     bloodnameTarget += 2 *
                                              (person.hasSkill(SkillType.S_GUN_PROTO) ?
                                                     person.getSkill(SkillType.S_GUN_PROTO)
-                                                          .getFinalSkillValue(options, attributes) :
+                                                          .getFinalSkillValue(options, attributes, isIlliterate) :
                                                     TargetRoll.AUTOMATIC_FAIL);
                     break;
                 }
@@ -2543,28 +2544,36 @@ public class Campaign implements ITechManager {
                             bloodnameTarget += 2 *
                                                      (person.hasSkill(SkillType.S_PILOT_SPACE) ?
                                                             person.getSkill(SkillType.S_PILOT_SPACE)
-                                                                  .getFinalSkillValue(options, attributes) :
+                                                                  .getFinalSkillValue(options,
+                                                                        attributes,
+                                                                        isIlliterate) :
                                                             TargetRoll.AUTOMATIC_FAIL);
                             break;
                         case VESSEL_GUNNER:
                             bloodnameTarget += 2 *
                                                      (person.hasSkill(SkillType.S_GUN_SPACE) ?
                                                             person.getSkill(SkillType.S_GUN_SPACE)
-                                                                  .getFinalSkillValue(options, attributes) :
+                                                                  .getFinalSkillValue(options,
+                                                                        attributes,
+                                                                        isIlliterate) :
                                                             TargetRoll.AUTOMATIC_FAIL);
                             break;
                         case VESSEL_CREW:
                             bloodnameTarget += 2 *
                                                      (person.hasSkill(SkillType.S_TECH_VESSEL) ?
                                                             person.getSkill(SkillType.S_TECH_VESSEL)
-                                                                  .getFinalSkillValue(options, attributes) :
+                                                                  .getFinalSkillValue(options,
+                                                                        attributes,
+                                                                        isIlliterate) :
                                                             TargetRoll.AUTOMATIC_FAIL);
                             break;
                         case VESSEL_NAVIGATOR:
                             bloodnameTarget += 2 *
                                                      (person.hasSkill(SkillType.S_NAVIGATION) ?
                                                             person.getSkill(SkillType.S_NAVIGATION)
-                                                                  .getFinalSkillValue(options, attributes) :
+                                                                  .getFinalSkillValue(options,
+                                                                        attributes,
+                                                                        isIlliterate) :
                                                             TargetRoll.AUTOMATIC_FAIL);
                             break;
                         default:
@@ -3223,6 +3232,7 @@ public class Campaign implements ITechManager {
                   isClanCampaign,
                   currentDay,
                   person.getRankNumeric());
+            boolean isIlliterate = person.isIlliterate();
 
             if (((person.getPrimaryRole() == role) || (person.getSecondaryRole() == role)) &&
                       (person.getSkill(primary) != null)) {
@@ -3232,7 +3242,8 @@ public class Campaign implements ITechManager {
                 if (primarySkill != null) {
                     currentSkillLevel = primarySkill.getTotalSkillLevel(person.getOptions(),
                           person.getATOWAttributes(),
-                          adjustedReputation);
+                          adjustedReputation,
+                          isIlliterate);
                 }
 
                 if (bestInRole == null || currentSkillLevel > highest) {
@@ -3247,7 +3258,8 @@ public class Campaign implements ITechManager {
 
                     currentSkillLevel = secondarySkill.getTotalSkillLevel(person.getOptions(),
                           person.getATOWAttributes(),
-                          adjustedReputation);
+                          adjustedReputation,
+                          isIlliterate);
 
                     int bestInRoleSecondarySkill = Integer.MIN_VALUE;
                     if (bestInRole.hasSkill(secondary)) {
@@ -3257,7 +3269,8 @@ public class Campaign implements ITechManager {
                               bestInRole.getRankNumeric());
                         bestInRoleSecondarySkill = secondarySkill.getTotalSkillLevel(bestInRole.getOptions(),
                               bestInRole.getATOWAttributes(),
-                              bestInRoleAdjustedReputation);
+                              bestInRoleAdjustedReputation,
+                              isIlliterate);
                     }
 
                     if (currentSkillLevel > bestInRoleSecondarySkill) {
@@ -3293,13 +3306,15 @@ public class Campaign implements ITechManager {
                   isClanCampaign(),
                   currentDay,
                   person.getRankNumeric());
+            boolean isIlliterate = person.isIlliterate();
             Skill skill = person.getSkill(skillName);
 
             int totalSkillLevel = Integer.MIN_VALUE;
             if (skill != null) {
                 totalSkillLevel = skill.getTotalSkillLevel(person.getOptions(),
                       person.getATOWAttributes(),
-                      adjustedReputation);
+                      adjustedReputation,
+                      isIlliterate);
             }
 
             if (totalSkillLevel > highest) {
@@ -3472,6 +3487,10 @@ public class Campaign implements ITechManager {
                 int effectiveMaxAcquisitions = defaultMaxAcquisitions;
 
                 PersonnelOptions options = person.getOptions();
+                if (options.booleanOption(ADMIN_SCROUNGE)) {
+                    effectiveMaxAcquisitions++;
+                }
+
                 if (isIneligibleToPerformProcurement(person, acquisitionCategory)) {
                     continue;
                 }
@@ -3488,9 +3507,10 @@ public class Campaign implements ITechManager {
 
                 int totalSkillLevel = Integer.MIN_VALUE;
                 if (skill != null) {
-                    totalSkillLevel = skill.getTotalSkillLevel(person.getOptions(),
+                    totalSkillLevel = skill.getTotalSkillLevel(options,
                           person.getATOWAttributes(),
-                          adjustedReputation);
+                          adjustedReputation,
+                          person.isIlliterate());
                 }
 
                 if (totalSkillLevel > bestSkill) {
@@ -3502,6 +3522,11 @@ public class Campaign implements ITechManager {
             for (Person person : getActivePersonnel(false)) {
                 int effectiveMaxAcquisitions = defaultMaxAcquisitions;
 
+                PersonnelOptions options = person.getOptions();
+                if (options.booleanOption(ADMIN_SCROUNGE)) {
+                    effectiveMaxAcquisitions++;
+                }
+
                 if (isIneligibleToPerformProcurement(person, acquisitionCategory)) {
                     continue;
                 }
@@ -3518,9 +3543,10 @@ public class Campaign implements ITechManager {
 
                 int totalSkillLevel = Integer.MIN_VALUE;
                 if (skill != null) {
-                    totalSkillLevel = skill.getTotalSkillLevel(person.getOptions(),
+                    totalSkillLevel = skill.getTotalSkillLevel(options,
                           person.getATOWAttributes(),
-                          adjustedReputation);
+                          adjustedReputation,
+                          person.isIlliterate());
                 }
 
                 if (totalSkillLevel > bestSkill) {
@@ -3743,6 +3769,8 @@ public class Campaign implements ITechManager {
 
             // Sort by their skill level, descending.
             logisticsPersonnel.sort((person1, person2) -> {
+                boolean isIlliterate1 = person1.isIlliterate();
+                boolean isIlliterate2 = person2.isIlliterate();
                 if (skillName.equals(S_TECH)) {
                     // Person 1
                     int adjustedReputation = person1.getAdjustedReputation(campaignOptions.isUseAgeEffects(),
@@ -3755,7 +3783,7 @@ public class Campaign implements ITechManager {
                     if (skill != null) {
                         person1SkillLevel = skill.getTotalSkillLevel(person1.getOptions(),
                               person1.getATOWAttributes(),
-                              adjustedReputation);
+                              adjustedReputation, isIlliterate1);
                     }
 
                     // Person 2
@@ -3769,7 +3797,7 @@ public class Campaign implements ITechManager {
                     if (skill != null) {
                         person2SkillLevel = skill.getTotalSkillLevel(person2.getOptions(),
                               person2.getATOWAttributes(),
-                              adjustedReputation);
+                              adjustedReputation, isIlliterate2);
                     }
 
                     return Integer.compare(person1SkillLevel, person2SkillLevel);
@@ -3785,7 +3813,7 @@ public class Campaign implements ITechManager {
                     if (skill != null) {
                         person1SkillLevel = skill.getTotalSkillLevel(person1.getOptions(),
                               person1.getATOWAttributes(),
-                              adjustedReputation);
+                              adjustedReputation, isIlliterate1);
                     }
 
                     // Person 2
@@ -3799,7 +3827,7 @@ public class Campaign implements ITechManager {
                     if (skill != null) {
                         person2SkillLevel = skill.getTotalSkillLevel(person2.getOptions(),
                               person2.getATOWAttributes(),
-                              adjustedReputation);
+                              adjustedReputation, isIlliterate2);
                     }
 
                     return Integer.compare(person1SkillLevel, person2SkillLevel);
@@ -4807,7 +4835,8 @@ public class Campaign implements ITechManager {
             int actualSkillLevel = EXP_NONE;
 
             if (relevantSkill != null) {
-                actualSkillLevel = relevantSkill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes());
+                actualSkillLevel = relevantSkill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes(),
+                      tech.isEngineer());
             }
             int effectiveSkillLevel = actualSkillLevel - modePenalty;
             if (getCampaignOptions().isDestroyByMargin()) {
@@ -8104,7 +8133,9 @@ public class Campaign implements ITechManager {
 
         int actualSkillLevel = EXP_NONE;
         if (skill != null) {
-            actualSkillLevel = skill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes());
+            actualSkillLevel = skill.getExperienceLevel(tech.getOptions(),
+                  tech.getATOWAttributes(),
+                  tech.isIlliterate());
         }
         int effectiveSkillLevel = actualSkillLevel - modePenalty;
 
@@ -8151,7 +8182,8 @@ public class Campaign implements ITechManager {
 
         // this is ugly, if the mode penalty drops you to green, you drop two
         // levels instead of two
-        int value = skill.getFinalSkillValue(tech.getOptions(), tech.getATOWAttributes()) + modePenalty;
+        int value = skill.getFinalSkillValue(tech.getOptions(), tech.getATOWAttributes(), tech.isIlliterate()) +
+                          modePenalty;
         if ((modePenalty > 0) && (SkillType.EXP_GREEN == effectiveSkillLevel)) {
             value++;
         }
@@ -8208,8 +8240,9 @@ public class Campaign implements ITechManager {
         if (null != tech) {
             Skill skill = tech.getSkillForWorkingOn(partWork);
             if (null != skill) {
-                value = skill.getFinalSkillValue(tech.getOptions(), tech.getATOWAttributes());
-                skillLevel = skill.getSkillLevel(tech.getOptions(), tech.getATOWAttributes()).toString();
+                boolean isIlliterate = tech.isIlliterate();
+                value = skill.getFinalSkillValue(tech.getOptions(), tech.getATOWAttributes(), isIlliterate);
+                skillLevel = skill.getSkillLevel(tech.getOptions(), tech.getATOWAttributes(), isIlliterate).toString();
             }
         }
 
@@ -8383,9 +8416,13 @@ public class Campaign implements ITechManager {
               isClanCampaign(),
               currentDay,
               person.getRankNumeric());
+        boolean isIlliterate = person.isIlliterate();
 
-        TargetRoll target = new TargetRoll(skill.getFinalSkillValue(person.getOptions(), person.getATOWAttributes()),
-              skill.getSkillLevel(person.getOptions(), person.getATOWAttributes(), adjustedReputation).toString());
+        TargetRoll target = new TargetRoll(skill.getFinalSkillValue(person.getOptions(),
+              person.getATOWAttributes(),
+              isIlliterate),
+              skill.getSkillLevel(person.getOptions(), person.getATOWAttributes(), adjustedReputation, isIlliterate)
+                    .toString());
         target.append(acquisition.getAllAcquisitionMods());
 
         if (getCampaignOptions().isUseAtB() && getCampaignOptions().isRestrictPartsByMission()) {
@@ -8804,7 +8841,9 @@ public class Campaign implements ITechManager {
 
         Skill strategy = commander.getSkill(S_STRATEGY);
 
-        return strategy.getTotalSkillLevel(commander.getOptions(), commander.getATOWAttributes());
+        return strategy.getTotalSkillLevel(commander.getOptions(),
+              commander.getATOWAttributes(),
+              commander.isIlliterate());
     }
 
     public RandomSkillPreferences getRandomSkillPreferences() {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -4836,7 +4836,7 @@ public class Campaign implements ITechManager {
 
             if (relevantSkill != null) {
                 actualSkillLevel = relevantSkill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes(),
-                      tech.isEngineer());
+                      tech.isIlliterate());
             }
             int effectiveSkillLevel = actualSkillLevel - modePenalty;
             if (getCampaignOptions().isDestroyByMargin()) {

--- a/MekHQ/src/mekhq/campaign/MercRosterAccess.java
+++ b/MekHQ/src/mekhq/campaign/MercRosterAccess.java
@@ -658,6 +658,7 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                 PersonnelOptions options = person.getOptions();
                 Attributes attributes = person.getATOWAttributes();
                 int reputation = person.getReputation();
+                boolean isIlliterate = person.isIlliterate();
                 for (int i = 0; i < SkillType.skillList.length; i++) {
                     if (person.hasSkill(SkillType.skillList[i])) {
                         Skill skill = person.getSkill(SkillType.skillList[i]);
@@ -666,7 +667,8 @@ public class MercRosterAccess extends SwingWorker<Void, Void> {
                                                                            ".skills (person, skill, value) VALUES (?, ?, ?)");
                         preparedStatement.setInt(1, id);
                         preparedStatement.setInt(2, i + 1);
-                        preparedStatement.setInt(3, skill.getFinalSkillValue(options, attributes, reputation));
+                        preparedStatement.setInt(3,
+                              skill.getFinalSkillValue(options, attributes, reputation, isIlliterate));
                         preparedStatement.executeUpdate();
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
+++ b/MekHQ/src/mekhq/campaign/againstTheBot/AtBConfiguration.java
@@ -366,7 +366,8 @@ public class AtBConfiguration {
         int experienceLevel = EXP_ULTRA_GREEN;
         if (logisticsAdmin != null && logisticsAdmin.hasSkill(S_ADMIN)) {
             Skill skill = logisticsAdmin.getSkill(S_ADMIN);
-            experienceLevel = skill.getExperienceLevel(logisticsAdmin.getOptions(), logisticsAdmin.getATOWAttributes());
+            experienceLevel = skill.getExperienceLevel(logisticsAdmin.getOptions(),
+                  logisticsAdmin.getATOWAttributes(), logisticsAdmin.isIlliterate());
         }
 
         target.addModifier(SkillType.EXP_REGULAR - experienceLevel, "Admin/Logistics");

--- a/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/PersonnelMarket.java
@@ -560,7 +560,8 @@ public class PersonnelMarket {
         int experienceLevel = EXP_ULTRA_GREEN;
         if (logisticsAdmin != null && logisticsAdmin.hasSkill(S_ADMIN)) {
             Skill skill = logisticsAdmin.getSkill(S_ADMIN);
-            experienceLevel = skill.getExperienceLevel(logisticsAdmin.getOptions(), logisticsAdmin.getATOWAttributes());
+            experienceLevel = skill.getExperienceLevel(logisticsAdmin.getOptions(),
+                  logisticsAdmin.getATOWAttributes(), logisticsAdmin.isIlliterate());
         }
 
         target.addModifier(SkillType.EXP_REGULAR - experienceLevel, "Admin/Logistics");

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -758,7 +758,10 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                         today,
                       adminCommand.getRankNumeric());
 
-                adminCommandExp = skill.getExperienceLevel(options, attributes, adjustedReputation);
+                adminCommandExp = skill.getExperienceLevel(options,
+                      attributes,
+                      adjustedReputation,
+                      adminCommand.isIlliterate());
             }
         }
         int adminTransportExp = SkillType.EXP_NONE;
@@ -772,7 +775,10 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                         today,
                       adminTransport.getRankNumeric());
 
-                adminTransportExp = skill.getExperienceLevel(options, attributes, adjustedReputation);
+                adminTransportExp = skill.getExperienceLevel(options,
+                      attributes,
+                      adjustedReputation,
+                      adminTransport.isIlliterate());
             }
         }
         int adminLogisticsExp = SkillType.EXP_NONE;
@@ -786,7 +792,10 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                         today,
                       adminLogistics.getRankNumeric());
 
-                adminLogisticsExp = skill.getExperienceLevel(options, attributes, adjustedReputation);
+                adminLogisticsExp = skill.getExperienceLevel(options,
+                      attributes,
+                      adjustedReputation,
+                      adminLogistics.isIlliterate());
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -436,7 +436,9 @@ public class AtBDynamicScenario extends AtBScenario {
         if ((commander != null) &&
                 commander.hasSkill(skillType)) {
             skillValue = commander.getSkill(skillType)
-                               .getTotalSkillLevel(commander.getOptions(), commander.getATOWAttributes());
+                               .getTotalSkillLevel(commander.getOptions(),
+                                     commander.getATOWAttributes(),
+                                     commander.isIlliterate());
         }
 
         return skillValue;

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -380,7 +380,8 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             return;
         }
 
-        rerollsRemaining = tactics.getTotalSkillLevel(commander.getOptions(), commander.getATOWAttributes());
+        rerollsRemaining = tactics.getTotalSkillLevel(commander.getOptions(), commander.getATOWAttributes(),
+              commander.isIlliterate());
     }
 
     public int getModifiedTemperature() {

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -797,7 +797,8 @@ public class Resupply {
                       negotiator.getRankNumeric());
                 int skillLevel = skill.getFinalSkillValue(negotiator.getOptions(),
                       negotiator.getATOWAttributes(),
-                      reputation);
+                      reputation,
+                      negotiator.isIlliterate());
                 negotiatorSkill = skill.getType().getExperienceLevel(skillLevel);
             }
         }

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4341,6 +4341,7 @@ public class Person {
               campaign.isClanCampaign(),
               campaign.getLocalDate(),
               rank);
+        final boolean isIlliterate = isIlliterate();
 
         // Optional skills such as Admin for Techs are not counted towards the character's experience level, except
         // in the special case of Vehicle Gunners. So we only want to fetch the base professions.
@@ -4354,12 +4355,12 @@ public class Person {
                           adjustedReputation);
                 } else {
                     if ((hasSkill(S_GUN_VEE)) && (hasSkill(S_ARTILLERY))) {
-                        yield Math.max((getSkill(S_GUN_VEE).getExperienceLevel(options, atowAttributes)),
-                              (getSkill(S_ARTILLERY).getExperienceLevel(options, atowAttributes)));
+                        yield Math.max((getSkill(S_GUN_VEE).getExperienceLevel(options, atowAttributes, isIlliterate)),
+                              (getSkill(S_ARTILLERY).getExperienceLevel(options, atowAttributes, isIlliterate)));
                     } else if (hasSkill(S_GUN_VEE)) {
-                        yield getSkill(S_GUN_VEE).getExperienceLevel(options, atowAttributes);
+                        yield getSkill(S_GUN_VEE).getExperienceLevel(options, atowAttributes, isIlliterate);
                     } else if (hasSkill(S_ARTILLERY)) {
-                        yield getSkill(S_ARTILLERY).getExperienceLevel(options, atowAttributes);
+                        yield getSkill(S_ARTILLERY).getExperienceLevel(options, atowAttributes, isIlliterate);
                     } else {
                         yield EXP_NONE;
                     }
@@ -4386,7 +4387,7 @@ public class Person {
                         continue;
                     }
 
-                    int currentExperienceLevel = skill.getExperienceLevel(options, atowAttributes);
+                    int currentExperienceLevel = skill.getExperienceLevel(options, atowAttributes, isIlliterate);
                     if (currentExperienceLevel > highestExperienceLevel) {
                         highestExperienceLevel = currentExperienceLevel;
                     }
@@ -4480,11 +4481,14 @@ public class Person {
                 return EXP_NONE;
             }
 
-            int individualSkillLevel = skill.getTotalSkillLevel(options, atowAttributes, adjustedReputation);
+            int individualSkillLevel = skill.getTotalSkillLevel(options,
+                  atowAttributes,
+                  adjustedReputation,
+                  isIlliterate());
             totalSkillLevel += individualSkillLevel;
 
             if (isAlternativeQualityAveraging) {
-                int expLevel = skill.getExperienceLevel(options, atowAttributes, adjustedReputation);
+                int expLevel = skill.getExperienceLevel(options, atowAttributes, adjustedReputation, isIlliterate());
                 if (expectedExperienceLevel == null) {
                     expectedExperienceLevel = expLevel;
                 } else if (!expectedExperienceLevel.equals(expLevel)) {
@@ -4681,7 +4685,7 @@ public class Person {
     @Deprecated(since = "0.50.06", forRemoval = true)
     public int getSkillLevel(final String skillName) {
         final Skill skill = getSkill(skillName);
-        return (skill == null) ? 0 : skill.getExperienceLevel(options, atowAttributes);
+        return (skill == null) ? 0 : skill.getExperienceLevel(options, atowAttributes, isIlliterate());
     }
 
     /**
@@ -4704,7 +4708,9 @@ public class Person {
 
         int adjustedReputation = getAdjustedReputation(isUseAgingEffects, isClanCampaign, today, rank);
 
-        return (skill == null) ? 0 : skill.getExperienceLevel(options, atowAttributes, adjustedReputation);
+        return (skill == null) ?
+                     0 :
+                     skill.getExperienceLevel(options, atowAttributes, adjustedReputation, isIlliterate());
     }
 
     /**
@@ -4720,7 +4726,7 @@ public class Person {
      */
     public int getSkillLevelOrNegative(final String skillName) {
         if (hasSkill(skillName)) {
-            return getSkill(skillName).getExperienceLevel(options, atowAttributes);
+            return getSkill(skillName).getExperienceLevel(options, atowAttributes, isIlliterate());
         } else {
             return -1;
         }
@@ -5496,20 +5502,25 @@ public class Person {
         Skill skill = null;
         int level = EXP_NONE;
 
-        if (hasSkill(S_TECH_MEK) && getSkill(S_TECH_MEK).getExperienceLevel(options, atowAttributes) > level) {
+        boolean isIlliterate = isIlliterate();
+
+        if (hasSkill(S_TECH_MEK) &&
+                  getSkill(S_TECH_MEK).getExperienceLevel(options, atowAttributes, isIlliterate) > level) {
             skill = getSkill(S_TECH_MEK);
-            level = getSkill(S_TECH_MEK).getExperienceLevel(options, atowAttributes);
+            level = getSkill(S_TECH_MEK).getExperienceLevel(options, atowAttributes, isIlliterate);
         }
-        if (hasSkill(S_TECH_AERO) && getSkill(S_TECH_AERO).getExperienceLevel(options, atowAttributes) > level) {
+        if (hasSkill(S_TECH_AERO) &&
+                  getSkill(S_TECH_AERO).getExperienceLevel(options, atowAttributes, isIlliterate) > level) {
             skill = getSkill(S_TECH_AERO);
-            level = getSkill(S_TECH_AERO).getExperienceLevel(options, atowAttributes);
+            level = getSkill(S_TECH_AERO).getExperienceLevel(options, atowAttributes, isIlliterate);
         }
         if (hasSkill(S_TECH_MECHANIC) &&
-                  getSkill(S_TECH_MECHANIC).getExperienceLevel(options, atowAttributes) > level) {
+                  getSkill(S_TECH_MECHANIC).getExperienceLevel(options, atowAttributes, isIlliterate) > level) {
             skill = getSkill(S_TECH_MECHANIC);
-            level = getSkill(S_TECH_MECHANIC).getExperienceLevel(options, atowAttributes);
+            level = getSkill(S_TECH_MECHANIC).getExperienceLevel(options, atowAttributes, isIlliterate);
         }
-        if (hasSkill(S_TECH_BA) && getSkill(S_TECH_BA).getExperienceLevel(options, atowAttributes) > level) {
+        if (hasSkill(S_TECH_BA) &&
+                  getSkill(S_TECH_BA).getExperienceLevel(options, atowAttributes, isIlliterate) > level) {
             skill = getSkill(S_TECH_BA);
         }
         return skill;
@@ -5589,7 +5600,7 @@ public class Person {
         int experienceLevel = SkillLevel.NONE.getExperienceLevel();
 
         if (administration != null) {
-            experienceLevel = administration.getExperienceLevel(options, atowAttributes);
+            experienceLevel = administration.getExperienceLevel(options, atowAttributes, isIlliterate());
         }
 
         administrationMultiplier += experienceLevel * TECH_ADMINISTRATION_MULTIPLIER;
@@ -5637,7 +5648,7 @@ public class Person {
         int experienceLevel = SkillLevel.NONE.getExperienceLevel();
 
         if (administration != null) {
-            experienceLevel = administration.getExperienceLevel(options, atowAttributes);
+            experienceLevel = administration.getExperienceLevel(options, atowAttributes, isIlliterate());
         }
 
         administrationMultiplier += experienceLevel * DOCTOR_ADMINISTRATION_MULTIPLIER;
@@ -5677,34 +5688,47 @@ public class Person {
             skill = getSkill(S_TECH_MEK);
         }
 
+        boolean isIlliterate = isIlliterate();
         if (part.isRightTechType(S_TECH_BA) && hasSkill(S_TECH_BA)) {
             if ((skill == null) ||
-                      (skill.getFinalSkillValue(options, atowAttributes, reputation) >
-                             getSkill(S_TECH_BA).getFinalSkillValue(options, atowAttributes, reputation))) {
+                      (skill.getFinalSkillValue(options, atowAttributes, reputation, isIlliterate) >
+                             getSkill(S_TECH_BA).getFinalSkillValue(options,
+                                   atowAttributes,
+                                   reputation,
+                                   isIlliterate))) {
                 skill = getSkill(S_TECH_BA);
             }
         }
 
         if (part.isRightTechType(S_TECH_AERO) && hasSkill(S_TECH_AERO)) {
             if ((skill == null) ||
-                      (skill.getFinalSkillValue(options, atowAttributes, reputation) >
-                             getSkill(S_TECH_AERO).getFinalSkillValue(options, atowAttributes, reputation))) {
+                      (skill.getFinalSkillValue(options, atowAttributes, reputation, isIlliterate) >
+                             getSkill(S_TECH_AERO).getFinalSkillValue(options,
+                                   atowAttributes,
+                                   reputation,
+                                   isIlliterate))) {
                 skill = getSkill(S_TECH_AERO);
             }
         }
 
         if (part.isRightTechType(S_TECH_MECHANIC) && hasSkill(S_TECH_MECHANIC)) {
             if ((skill == null) ||
-                      (skill.getFinalSkillValue(options, atowAttributes, reputation) >
-                             getSkill(S_TECH_MECHANIC).getFinalSkillValue(options, atowAttributes, reputation))) {
+                      (skill.getFinalSkillValue(options, atowAttributes, reputation, isIlliterate) >
+                             getSkill(S_TECH_MECHANIC).getFinalSkillValue(options,
+                                   atowAttributes,
+                                   reputation,
+                                   isIlliterate))) {
                 skill = getSkill(S_TECH_MECHANIC);
             }
         }
 
         if (part.isRightTechType(S_TECH_VESSEL) && hasSkill(S_TECH_VESSEL)) {
             if ((skill == null) ||
-                      (skill.getFinalSkillValue(options, atowAttributes, reputation) >
-                             getSkill(S_TECH_VESSEL).getFinalSkillValue(options, atowAttributes, reputation))) {
+                      (skill.getFinalSkillValue(options, atowAttributes, reputation, isIlliterate) >
+                             getSkill(S_TECH_VESSEL).getFinalSkillValue(options,
+                                   atowAttributes,
+                                   reputation,
+                                   isIlliterate))) {
                 skill = getSkill(S_TECH_VESSEL);
             }
         }
@@ -5721,24 +5745,33 @@ public class Person {
 
         if (hasSkill(S_TECH_BA)) {
             if ((skill == null) ||
-                      (skill.getFinalSkillValue(options, atowAttributes, reputation) >
-                             getSkill(S_TECH_BA).getFinalSkillValue(options, atowAttributes, reputation))) {
+                      (skill.getFinalSkillValue(options, atowAttributes, reputation, isIlliterate) >
+                             getSkill(S_TECH_BA).getFinalSkillValue(options,
+                                   atowAttributes,
+                                   reputation,
+                                   isIlliterate))) {
                 skill = getSkill(S_TECH_BA);
             }
         }
 
         if (hasSkill(S_TECH_MECHANIC)) {
             if ((skill == null) ||
-                      (skill.getFinalSkillValue(options, atowAttributes, reputation) >
-                             getSkill(S_TECH_MECHANIC).getFinalSkillValue(options, atowAttributes, reputation))) {
+                      (skill.getFinalSkillValue(options, atowAttributes, reputation, isIlliterate) >
+                             getSkill(S_TECH_MECHANIC).getFinalSkillValue(options,
+                                   atowAttributes,
+                                   reputation,
+                                   isIlliterate))) {
                 skill = getSkill(S_TECH_MECHANIC);
             }
         }
 
         if (hasSkill(S_TECH_AERO)) {
             if ((skill == null) ||
-                      (skill.getFinalSkillValue(options, atowAttributes, reputation) >
-                             getSkill(S_TECH_AERO).getFinalSkillValue(options, atowAttributes, reputation))) {
+                      (skill.getFinalSkillValue(options, atowAttributes, reputation, isIlliterate) >
+                             getSkill(S_TECH_AERO).getFinalSkillValue(options,
+                                   atowAttributes,
+                                   reputation,
+                                   isIlliterate))) {
                 skill = getSkill(S_TECH_AERO);
             }
         }
@@ -7457,5 +7490,27 @@ public class Person {
             potentialVictims.remove(victim);
             victims.add(victim);
         }
+    }
+
+    /**
+     * Determines whether the character is considered illiterate.
+     *
+     * <p>A person is regarded as illiterate if they possess the {@link PersonnelOptions#FLAW_ILLITERATE} flaw, and
+     * their base level in the {@link SkillType#S_LANGUAGES} skill is below
+     * {@link PersonnelOptions#ILLITERACY_LANGUAGES_THRESHOLD}.</p>
+     *
+     * @return {@code true} if the person is considered illiterate; {@code false} otherwise.
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public boolean isIlliterate() {
+        if (!options.booleanOption(FLAW_ILLITERATE)) {
+            return false;
+        }
+
+        Skill languages = skills.getSkill(S_LANGUAGES);
+        int level = languages.getLevel();
+        return level < ILLITERACY_LANGUAGES_THRESHOLD;
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -88,6 +88,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String FLAW_GREMLINS = "flaw_gremlins";
     public static final String ATOW_TECH_EMPATHY = "atow_tech_empathy";
     public static final String FLAW_TRANSIT_DISORIENTATION_SYNDROME = "flaw_transit_disorientation_syndrome";
+    public static final String FLAW_ILLITERATE = "flaw_illiterate";
 
     public static final String MUTATION_FREAKISH_STRENGTH = "mutation_freakish_strength";
     public static final String MUTATION_EXCEPTIONAL_IMMUNE_SYSTEM = "mutation_exceptional_immune_system";
@@ -111,6 +112,7 @@ public class PersonnelOptions extends PilotOptions {
     public static final String ADMIN_TETRIS_MASTER = "admin_tetris_master";
     public static final String ADMIN_NETWORKER = "admin_networker";
     public static final String ADMIN_INTERSTELLAR_NEGOTIATOR = "admin_interstellar_negotiator";
+    public static final String ADMIN_SCROUNGE = "admin_scrounge";
 
     public static final String COMPULSION_UNPLEASANT_PERSONALITY = "compulsion_unpleasant_personality";
     public static final String COMPULSION_MILD_PARANOIA = "compulsion_mild_paranoia";
@@ -139,6 +141,8 @@ public class PersonnelOptions extends PilotOptions {
     public static final int COMPULSION_CHECK_MODIFIER_MAJOR = 4; // ATOW pg 110
     public static final int COMPULSION_CHECK_MODIFIER_SEVERE = 7; // ATOW pg 110
     public static final int COMPULSION_CHECK_MODIFIER_EXTREME = 10; // ATOW pg 110
+
+    public static final int ILLITERACY_LANGUAGES_THRESHOLD = 4; // ATOW pg 120
 
     @Override
     public void initialize() {
@@ -208,6 +212,8 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, FLAW_GREMLINS, false);
         addOption(l3a, ATOW_TECH_EMPATHY, false);
         addOption(l3a, FLAW_TRANSIT_DISORIENTATION_SYNDROME, false);
+        addOption(l3a, FLAW_ILLITERATE, false);
+
         addOption(l3a, MUTATION_FREAKISH_STRENGTH, false);
         addOption(l3a, MUTATION_EXCEPTIONAL_IMMUNE_SYSTEM, false);
         addOption(l3a, MUTATION_EXOTIC_APPEARANCE, false);
@@ -230,6 +236,7 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, ADMIN_TETRIS_MASTER, false);
         addOption(l3a, ADMIN_NETWORKER, false);
         addOption(l3a, ADMIN_INTERSTELLAR_NEGOTIATOR, false);
+        addOption(l3a, ADMIN_SCROUNGE, false);
 
         addOption(l3a, COMPULSION_UNPLEASANT_PERSONALITY, false);
         addOption(l3a, COMPULSION_MILD_PARANOIA, false);

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -291,7 +291,9 @@ public class TrainingCombatTeams {
                       spanOpeningWithCustomColor(ReportingUtilities.getPositiveColor()),
                       CLOSING_SPAN_TAG,
                       targetSkill.getType().getName(),
-                      targetSkill.getFinalSkillValue(trainee.getOptions(), trainee.getATOWAttributes())));
+                      targetSkill.getFinalSkillValue(trainee.getOptions(),
+                            trainee.getATOWAttributes(),
+                            trainee.isIlliterate())));
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillCheckUtility.java
@@ -494,7 +494,8 @@ public class SkillCheckUtility {
             Skill skill = person.getSkill(skillName);
             int skillValue = skill.getFinalSkillValue(person.getOptions(),
                   person.getATOWAttributes(),
-                  person.getAdjustedReputation(isUseAgingEffects, isClanCampaign, today, person.getRankNumeric()));
+                  person.getAdjustedReputation(isUseAgingEffects, isClanCampaign, today, person.getRankNumeric()),
+                  person.isIlliterate());
             targetNumber.addModifier(skillValue, skillName);
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -229,7 +229,8 @@ public class RetirementDefectionTracker {
                     if (commander != null && commander.hasSkill((SkillType.S_LEADER))) {
                         modifier -= commander.getSkill(SkillType.S_LEADER)
                                           .getFinalSkillValue(commander.getOptions(),
-                                                commander.getATOWAttributes());
+                                                commander.getATOWAttributes(),
+                                                commander.isIlliterate());
                     }
                 } else {
                     modifier -= getManagementSkillModifier(person);
@@ -630,7 +631,9 @@ public class RetirementDefectionTracker {
     private static int getIndividualCommanderLeadership(Person commander) {
         if (commander.hasSkill(SkillType.S_LEADER)) {
             return commander.getSkill(SkillType.S_LEADER)
-                         .getFinalSkillValue(commander.getOptions(), commander.getATOWAttributes());
+                         .getFinalSkillValue(commander.getOptions(),
+                               commander.getATOWAttributes(),
+                               commander.isIlliterate());
         } else {
             return 0;
         }
@@ -731,7 +734,8 @@ public class RetirementDefectionTracker {
                   person.getRankNumeric());
             int skillLevel = skill.getTotalSkillLevel(person.getOptions(),
                   person.getATOWAttributes(),
-                  adjustedReputation);
+                  adjustedReputation,
+                  person.isIlliterate());
 
             combinedSkillValues += skillLevel + mediatorModifier;
         }

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
@@ -154,7 +154,9 @@ public class AverageExperienceRating {
                 if (person.hasSkill(SkillType.S_GUN_PROTO)) {
                     totalExperience += max(0,
                           person.getSkill(SkillType.S_GUN_PROTO)
-                                .getFinalSkillValue(person.getOptions(), person.getATOWAttributes()));
+                                .getFinalSkillValue(person.getOptions(),
+                                      person.getATOWAttributes(),
+                                      person.isIlliterate()));
                 }
 
                 personnelCount++;
@@ -230,12 +232,13 @@ public class AverageExperienceRating {
 
         PersonnelOptions options = person.getOptions();
         Attributes attributes = person.getATOWAttributes();
+        boolean isIlliterate = person.isIlliterate();
         if (unit.isDriver(person)) {
             skillType = SkillType.getDrivingSkillFor(entity);
             Skill skill = person.getSkill(skillType);
 
             if (skill != null) {
-                skillValue += max(0, skill.getFinalSkillValue(options, attributes));
+                skillValue += max(0, skill.getFinalSkillValue(options, attributes, isIlliterate));
                 skillCount++;
             } else {
                 logger.warn("(calculateRegularExperience) unable to fetch diving skill {} for {}. Skipping",
@@ -249,7 +252,7 @@ public class AverageExperienceRating {
 
             Skill skill = person.getSkill(skillType);
             if (skill != null) {
-                skillValue += max(0, skill.getFinalSkillValue(options, attributes));
+                skillValue += max(0, skill.getFinalSkillValue(options, attributes, isIlliterate));
                 skillCount++;
             } else {
                 logger.warn("(calculateRegularExperience) unable to fetch gunnery skill {} for {}. Skipping",

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -316,7 +316,8 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
         int highestSkill = SkillType.EXP_ULTRA_GREEN;
         for (String skillname : skillNames) {
             if (tech.hasSkill(skillname)) {
-                int rank = tech.getSkill(skillname).getExperienceLevel(tech.getOptions(), tech.getATOWAttributes());
+                int rank = tech.getSkill(skillname).getExperienceLevel(tech.getOptions(), tech.getATOWAttributes(),
+                      tech.isIlliterate());
                 if (rank > highestSkill) {
                     highestSkill = rank;
                 }
@@ -338,7 +339,8 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
         if (doctorSkill == null) {
             return;
         }
-        int hours = getSupportHours(doctorSkill.getExperienceLevel(doctor.getOptions(), doctor.getATOWAttributes()));
+        int hours = getSupportHours(doctorSkill.getExperienceLevel(doctor.getOptions(), doctor.getATOWAttributes(),
+              doctor.isIlliterate()));
         if (doctor.getSecondaryRole().isDoctor()) {
             hours = (int) Math.floor(hours / 2.0);
         }
@@ -353,7 +355,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
             return;
         }
         int hours = getSupportHours(adminSkill.getExperienceLevel(administrator.getOptions(),
-              administrator.getATOWAttributes()));
+              administrator.getATOWAttributes(), administrator.isIlliterate()));
         if (administrator.getSecondaryRole().isAdministrator()) {
             hours = (int) Math.floor(hours / 2.0);
         }

--- a/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/StratconRulesManager.java
@@ -1790,7 +1790,7 @@ public class StratconRulesManager {
             skillModifier = REGULAR.getExperienceLevel();
         } else {
             skillModifier = REGULAR.getExperienceLevel() - skill.getExperienceLevel(commandLiaison.getOptions(),
-             commandLiaison.getATOWAttributes());
+                  commandLiaison.getATOWAttributes(), commandLiaison.isIlliterate());
         }
 
         // Admin Skill Modifier

--- a/MekHQ/src/mekhq/campaign/stratcon/SupportPointNegotiation.java
+++ b/MekHQ/src/mekhq/campaign/stratcon/SupportPointNegotiation.java
@@ -200,7 +200,8 @@ public class SupportPointNegotiation {
             Person admin = iterator.next();
             int rollResult = Compute.d6(2) + modifier;
 
-            int adminSkill = admin.getSkill(S_ADMIN).getFinalSkillValue(admin.getOptions(), admin.getATOWAttributes());
+            int adminSkill = admin.getSkill(S_ADMIN).getFinalSkillValue(admin.getOptions(), admin.getATOWAttributes(),
+                  admin.isIlliterate());
             if (rollResult >= adminSkill) {
                 negotiatedSupportPoints++;
             }
@@ -327,7 +328,8 @@ public class SupportPointNegotiation {
         Skill skill = person.getSkill(S_ADMIN);
         return skill.getTotalSkillLevel(person.getOptions(),
               person.getATOWAttributes(),
-              person.getAdjustedReputation(isUseAgingEffects, isClanCampaign, today, rankIndex));
+              person.getAdjustedReputation(isUseAgingEffects, isClanCampaign, today, rankIndex),
+              person.isIlliterate());
     }
 
     /**
@@ -336,6 +338,6 @@ public class SupportPointNegotiation {
     @Deprecated(since = "0.50.06", forRemoval = true)
     private static int getSkillValue(Person person) {
         Skill skill = person.getSkill(S_ADMIN);
-        return skill.getTotalSkillLevel(person.getOptions(), person.getATOWAttributes(), 0);
+        return skill.getTotalSkillLevel(person.getOptions(), person.getATOWAttributes(), 0, person.isIlliterate());
     }
 }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4499,7 +4499,7 @@ public class Unit implements ITechnology {
                       .setCommandBonus(commander.getSkill(SkillType.S_TACTICS)
                                              .getTotalSkillLevel(commander.getOptions(),
                                                    commander.getATOWAttributes(),
-                                                   0));
+                                                   0, commander.isIlliterate()));
             }
         }
 
@@ -4711,11 +4711,12 @@ public class Unit implements ITechnology {
         for (Person person : drivers) {
             PersonnelOptions options = person.getOptions();
             Attributes attributes = person.getATOWAttributes();
+            boolean isIlliterate = person.isIlliterate();
             if (person.getHits() > 0 && !usesSoloPilot()) {
                 continue;
             }
             if (person.hasSkill(driveType)) {
-                sumPiloting += person.getSkill(driveType).getFinalSkillValue(options, attributes);
+                sumPiloting += person.getSkill(driveType).getFinalSkillValue(options, attributes, isIlliterate);
                 nDrivers++;
             } else if (entity instanceof Infantry) {
                 // For infantry, we need to assign an 8 if they have no anti-mek skill
@@ -4724,7 +4725,7 @@ public class Unit implements ITechnology {
             }
 
             if (entity instanceof Tank && Compute.getFullCrewSize(entity) == 1 && person.hasSkill(gunType)) {
-                sumGunnery += person.getSkill(gunType).getFinalSkillValue(options, attributes);
+                sumGunnery += person.getSkill(gunType).getFinalSkillValue(options, attributes, isIlliterate);
                 nGunners++;
             }
             if (getCampaign().getCampaignOptions().isUseAdvancedMedical()) {
@@ -4734,16 +4735,19 @@ public class Unit implements ITechnology {
         for (Person person : gunners) {
             PersonnelOptions options = person.getOptions();
             Attributes attributes = person.getATOWAttributes();
+            boolean isIlliterate = person.isIlliterate();
             if (person.getHits() > 0 && !usesSoloPilot()) {
                 continue;
             }
             if (person.hasSkill(gunType)) {
-                sumGunnery += person.getSkill(gunType).getFinalSkillValue(options, attributes);
+                sumGunnery += person.getSkill(gunType).getFinalSkillValue(options, attributes, isIlliterate);
                 nGunners++;
             }
             if (person.hasSkill(SkillType.S_ARTILLERY) &&
-                      person.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue(options, attributes) < artillery) {
-                artillery = person.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue(options, attributes);
+                      person.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue(options, attributes, isIlliterate) <
+                            artillery) {
+                artillery = person.getSkill(SkillType.S_ARTILLERY)
+                                  .getFinalSkillValue(options, attributes, isIlliterate);
             }
             if (getCampaign().getCampaignOptions().isUseAdvancedMedical()) {
                 sumGunnery += person.getInjuryModifiers(false);
@@ -4872,20 +4876,21 @@ public class Unit implements ITechnology {
 
         PersonnelOptions options = pilot.getOptions();
         Attributes attributes = pilot.getATOWAttributes();
+        boolean isIlliterate = pilot.isIlliterate();
         if (pilot.hasSkill(SkillType.S_PILOT_MEK)) {
-            pilotingMek = pilot.getSkill(SkillType.S_PILOT_MEK).getFinalSkillValue(options, attributes);
+            pilotingMek = pilot.getSkill(SkillType.S_PILOT_MEK).getFinalSkillValue(options, attributes, isIlliterate);
         }
         if (pilot.hasSkill(SkillType.S_GUN_MEK)) {
-            gunneryMek = pilot.getSkill(SkillType.S_GUN_MEK).getFinalSkillValue(options, attributes);
+            gunneryMek = pilot.getSkill(SkillType.S_GUN_MEK).getFinalSkillValue(options, attributes, isIlliterate);
         }
         if (pilot.hasSkill(SkillType.S_PILOT_AERO)) {
-            pilotingAero = pilot.getSkill(SkillType.S_PILOT_AERO).getFinalSkillValue(options, attributes);
+            pilotingAero = pilot.getSkill(SkillType.S_PILOT_AERO).getFinalSkillValue(options, attributes, isIlliterate);
         }
         if (pilot.hasSkill(SkillType.S_GUN_AERO)) {
-            gunneryAero = pilot.getSkill(SkillType.S_GUN_AERO).getFinalSkillValue(options, attributes);
+            gunneryAero = pilot.getSkill(SkillType.S_GUN_AERO).getFinalSkillValue(options, attributes, isIlliterate);
         }
         if (pilot.hasSkill(SkillType.S_ARTILLERY)) {
-            artillery = pilot.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue(options, attributes);
+            artillery = pilot.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue(options, attributes, isIlliterate);
         }
 
         if (getCampaign().getCampaignOptions().isUseAdvancedMedical()) {
@@ -4916,6 +4921,7 @@ public class Unit implements ITechnology {
     private void assignToCrewSlot(Person person, int slot, String gunType, String driveType) {
         PersonnelOptions options = person.getOptions();
         Attributes attributes = person.getATOWAttributes();
+        boolean isIlliterate = person.isIlliterate();
         entity.getCrew().setName(person.getFullTitle(), slot);
         entity.getCrew().setNickname(person.getCallsign(), slot);
         entity.getCrew().setGender(person.getGender(), slot);
@@ -4926,17 +4932,18 @@ public class Unit implements ITechnology {
         int artillery = 7;
         int piloting = 8;
         if (person.hasSkill(gunType)) {
-            gunnery = person.getSkill(gunType).getFinalSkillValue(options, attributes);
+            gunnery = person.getSkill(gunType).getFinalSkillValue(options, attributes, isIlliterate);
         }
         if (getCampaign().getCampaignOptions().isUseAdvancedMedical()) {
             gunnery += person.getInjuryModifiers(false);
         }
         if (person.hasSkill(driveType)) {
-            piloting = person.getSkill(driveType).getFinalSkillValue(options, attributes);
+            piloting = person.getSkill(driveType).getFinalSkillValue(options, attributes, isIlliterate);
         }
         if (person.hasSkill(SkillType.S_ARTILLERY) &&
-                  person.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue(options, attributes) < artillery) {
-            artillery = person.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue(options, attributes);
+                  person.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue(options, attributes, isIlliterate) <
+                        artillery) {
+            artillery = person.getSkill(SkillType.S_ARTILLERY).getFinalSkillValue(options, attributes, isIlliterate);
         }
         entity.getCrew().setPiloting(Math.min(max(piloting, 0), 8), slot);
         entity.getCrew().setGunnery(Math.min(max(gunnery, 0), 8), slot);

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2125,7 +2125,7 @@ public class CampaignGUI extends JPanel {
                              ", " +
                              getExperienceLevelName(tech.getSkillForWorkingOn(unit)
                                                           .getExperienceLevel(tech.getOptions(),
-                                                                tech.getATOWAttributes())) +
+                                                                tech.getATOWAttributes(), tech.isIlliterate())) +
                              " (" +
                              time +
                              "min)";

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -787,7 +787,9 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
                 } else {
                     return getCampaign().getCampaignOptions().isDestroyByMargin() ||
                                  (part.getSkillMin() <=
-                                        (skill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes()) -
+                                        (skill.getExperienceLevel(tech.getOptions(),
+                                              tech.getATOWAttributes(),
+                                              tech.isIlliterate()) -
                                                modePenalty));
                 }
             }

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -534,7 +534,9 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
                 } else {
                     return getCampaign().getCampaignOptions().isDestroyByMargin() ||
                                  (part.getSkillMin() <=
-                                        (skill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes()) -
+                                        (skill.getExperienceLevel(tech.getOptions(),
+                                              tech.getATOWAttributes(),
+                                              tech.isIlliterate()) -
                                                modePenalty));
                 }
             }

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -653,7 +653,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                       skillType.getName(),
                       skill.toString(selectedPerson.getOptions(),
                             selectedPerson.getATOWAttributes(),
-                            adjustedReputation));
+                            adjustedReputation,
+                            selectedPerson.isIlliterate()));
                 getCampaign().addReport(String.format(resources.getString("improved.format"),
                       selectedPerson.getHyperlinkedName(),
                       type));
@@ -1784,7 +1785,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 Skill skill = person.getSkill(S_SURGERY);
 
                 if (skill != null &&
-                          skill.getFinalSkillValue(person.getOptions(), person.getATOWAttributes()) >=
+                          skill.getFinalSkillValue(person.getOptions(),
+                                person.getATOWAttributes(),
+                                person.isIlliterate()) >=
                                 REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5) {
                     suitableDoctors.add(person);
                 }
@@ -3213,7 +3216,8 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
                             String tooltip = wordWrap(skill.getTooltip(person.getOptions(),
                                   person.getATOWAttributes(),
-                                  adjustedReputation));
+                                  adjustedReputation,
+                                  person.isIlliterate()));
                             menuItem.setToolTipText(tooltip);
 
                             SkillSubType subType = skillType.getSubType();

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -400,7 +400,10 @@ public final class BatchXPDialog extends JDialog {
                       campaign.getLocalDate(),
                       person.getSkill(skillName).getType().getName(),
                       person.getSkill(skillName)
-                            .toString(person.getOptions(), person.getATOWAttributes(), adjustedReputation));
+                            .toString(person.getOptions(),
+                                  person.getATOWAttributes(),
+                                  adjustedReputation,
+                                  person.isIlliterate()));
                 campaign.personUpdated(person);
             }
 

--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -1189,7 +1189,8 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
                 lblValue.setText(person.getSkill(type)
                                        .toString(person.getOptions(),
                                              person.getATOWAttributes(),
-                                             person.getReputation()));
+                                             person.getReputation(),
+                                             person.isIlliterate()));
             } else {
                 lblValue.setText("-");
             }

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1548,7 +1548,8 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
                 lblValue.setText(person.getSkill(type)
                                        .toString(person.getOptions(),
                                              person.getATOWAttributes(),
-                                             person.getReputation()));
+                                             person.getReputation(),
+                                             person.isIlliterate()));
             } else {
                 lblValue.setText("-");
             }

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -553,6 +553,7 @@ public enum PersonnelTableModelColumn {
           final boolean loadAssignmentFromMarket, final boolean groupByUnit) {
         final PersonnelOptions options = person.getOptions();
         final Attributes attributes = person.getATOWAttributes();
+        final boolean isIlliterate = person.isIlliterate();
 
         // We define these here, as they're used in multiple cases
         int currentAttributeValue;
@@ -721,132 +722,132 @@ public enum PersonnelTableModelColumn {
             case MEK:
                 return (person.hasSkill(SkillType.S_GUN_MEK) ?
                               Integer.toString(person.getSkill(SkillType.S_GUN_MEK)
-                                                     .getFinalSkillValue(options, attributes)) :
+                                                     .getFinalSkillValue(options, attributes, isIlliterate)) :
                               "-") +
                              '/' +
                              (person.hasSkill(SkillType.S_PILOT_MEK) ?
                                     Integer.toString(person.getSkill(SkillType.S_PILOT_MEK)
-                                                           .getFinalSkillValue(options, attributes)) :
+                                                           .getFinalSkillValue(options, attributes, isIlliterate)) :
                                     "-");
             case GROUND_VEHICLE:
                 return (person.hasSkill(SkillType.S_GUN_VEE) ?
                               Integer.toString(person.getSkill(SkillType.S_GUN_VEE)
-                                                     .getFinalSkillValue(options, attributes)) :
+                                                     .getFinalSkillValue(options, attributes, isIlliterate)) :
                               "-") +
                              '/' +
                              (person.hasSkill(SkillType.S_PILOT_GVEE) ?
                                     Integer.toString(person.getSkill(SkillType.S_PILOT_GVEE)
-                                                           .getFinalSkillValue(options, attributes)) :
+                                                           .getFinalSkillValue(options, attributes, isIlliterate)) :
                                     "-");
             case NAVAL_VEHICLE:
                 return (person.hasSkill(SkillType.S_GUN_VEE) ?
                               Integer.toString(person.getSkill(SkillType.S_GUN_VEE)
-                                                     .getFinalSkillValue(options, attributes)) :
+                                                     .getFinalSkillValue(options, attributes, isIlliterate)) :
                               "-") +
                              '/' +
                              (person.hasSkill(SkillType.S_PILOT_NVEE) ?
                                     Integer.toString(person.getSkill(SkillType.S_PILOT_NVEE)
-                                                           .getFinalSkillValue(options, attributes)) :
+                                                           .getFinalSkillValue(options, attributes, isIlliterate)) :
                                     "-");
             case VTOL:
                 return (person.hasSkill(SkillType.S_GUN_VEE) ?
                               Integer.toString(person.getSkill(SkillType.S_GUN_VEE)
-                                                     .getFinalSkillValue(options, attributes)) :
+                                                     .getFinalSkillValue(options, attributes, isIlliterate)) :
                               "-") +
                              '/' +
                              (person.hasSkill(SkillType.S_PILOT_VTOL) ?
                                     Integer.toString(person.getSkill(SkillType.S_PILOT_VTOL)
-                                                           .getFinalSkillValue(options, attributes)) :
+                                                           .getFinalSkillValue(options, attributes, isIlliterate)) :
                                     "-");
             case AEROSPACE:
                 return (person.hasSkill(SkillType.S_GUN_AERO) ?
                               Integer.toString(person.getSkill(SkillType.S_GUN_AERO)
-                                                     .getFinalSkillValue(options, attributes)) :
+                                                     .getFinalSkillValue(options, attributes, isIlliterate)) :
                               "-") +
                              '/' +
                              (person.hasSkill(SkillType.S_PILOT_AERO) ?
                                     Integer.toString(person.getSkill(SkillType.S_PILOT_AERO)
-                                                           .getFinalSkillValue(options, attributes)) :
+                                                           .getFinalSkillValue(options, attributes, isIlliterate)) :
                                     "-");
             case CONVENTIONAL_AIRCRAFT:
                 return (person.hasSkill(SkillType.S_GUN_JET) ?
                               Integer.toString(person.getSkill(SkillType.S_GUN_JET)
-                                                     .getFinalSkillValue(options, attributes)) :
+                                                     .getFinalSkillValue(options, attributes, isIlliterate)) :
                               "-") +
                              '/' +
                              (person.hasSkill(SkillType.S_PILOT_JET) ?
                                     Integer.toString(person.getSkill(SkillType.S_PILOT_JET)
-                                                           .getFinalSkillValue(options, attributes)) :
+                                                           .getFinalSkillValue(options, attributes, isIlliterate)) :
                                     "-");
             case VESSEL:
                 return (person.hasSkill(SkillType.S_GUN_SPACE) ?
                               Integer.toString(person.getSkill(SkillType.S_GUN_SPACE)
-                                                     .getFinalSkillValue(options, attributes)) :
+                                                     .getFinalSkillValue(options, attributes, isIlliterate)) :
                               "-") +
                              '/' +
                              (person.hasSkill(SkillType.S_PILOT_SPACE) ?
                                     Integer.toString(person.getSkill(SkillType.S_PILOT_SPACE)
-                                                           .getFinalSkillValue(options, attributes)) :
+                                                           .getFinalSkillValue(options, attributes, isIlliterate)) :
                                     "-");
             case BATTLE_ARMOUR:
                 return person.hasSkill(SkillType.S_GUN_BA) ?
                              Integer.toString(person.getSkill(SkillType.S_GUN_BA)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case ANTI_MEK:
                 return person.hasSkill(SkillType.S_ANTI_MEK) ?
                              Integer.toString(person.getSkill(SkillType.S_ANTI_MEK)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case SMALL_ARMS:
                 return person.hasSkill(SkillType.S_SMALL_ARMS) ?
                              Integer.toString(person.getSkill(SkillType.S_SMALL_ARMS)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case ARTILLERY:
                 return person.hasSkill(SkillType.S_ARTILLERY) ?
                              Integer.toString(person.getSkill(SkillType.S_ARTILLERY)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case TACTICS:
                 return person.hasSkill(SkillType.S_TACTICS) ?
                              Integer.toString(person.getSkill(SkillType.S_TACTICS)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case STRATEGY:
                 return person.hasSkill(SkillType.S_STRATEGY) ?
                              Integer.toString(person.getSkill(SkillType.S_STRATEGY)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case LEADERSHIP:
                 return person.hasSkill(SkillType.S_LEADER) ?
                              Integer.toString(person.getSkill(SkillType.S_LEADER)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case TECH_MEK:
                 return person.hasSkill(SkillType.S_TECH_MEK) ?
                              Integer.toString(person.getSkill(SkillType.S_TECH_MEK)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case TECH_AERO:
                 return person.hasSkill(SkillType.S_TECH_AERO) ?
                              Integer.toString(person.getSkill(SkillType.S_TECH_AERO)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case TECH_MECHANIC:
                 return person.hasSkill(SkillType.S_TECH_MECHANIC) ?
                              Integer.toString(person.getSkill(SkillType.S_TECH_MECHANIC)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case TECH_BA:
                 return person.hasSkill(SkillType.S_TECH_BA) ?
                              Integer.toString(person.getSkill(SkillType.S_TECH_BA)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case TECH_VESSEL:
                 return person.hasSkill(SkillType.S_TECH_VESSEL) ?
                              Integer.toString(person.getSkill(SkillType.S_TECH_VESSEL)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case TECH_MINUTES:
                 if (person.isTechExpanded()) {
@@ -857,7 +858,7 @@ public enum PersonnelTableModelColumn {
             case MEDICAL:
                 return person.hasSkill(SkillType.S_SURGERY) ?
                              Integer.toString(person.getSkill(SkillType.S_SURGERY)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case MEDICAL_CAPACITY:
                 if (person.isDoctor()) {
@@ -868,7 +869,7 @@ public enum PersonnelTableModelColumn {
             case ADMINISTRATION:
                 return person.hasSkill(SkillType.S_ADMIN) ?
                              Integer.toString(person.getSkill(SkillType.S_ADMIN)
-                                                    .getFinalSkillValue(options, attributes)) :
+                                                    .getFinalSkillValue(options, attributes, isIlliterate)) :
                              "-";
             case NEGOTIATION:
                 return person.hasSkill(SkillType.S_NEGOTIATION) ?
@@ -878,7 +879,8 @@ public enum PersonnelTableModelColumn {
                                                           person.getAdjustedReputation(isUseAgeEffects,
                                                                 isClanCampaign,
                                                                 today,
-                                                                person.getRankNumeric()))) :
+                                                                person.getRankNumeric()),
+                                                          isIlliterate)) :
                              "-";
             case INJURIES:
                 if (campaign.getCampaignOptions().isUseAdvancedMedical()) {

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToTechMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToTechMenu.java
@@ -107,7 +107,7 @@ public class AssignUnitToTechMenu extends JScrollableMenu {
                                                         SkillLevel.NONE :
                                                         tech.getSkillForWorkingOn(units[0])
                                                               .getSkillLevel(tech.getOptions(),
-                                                                    tech.getATOWAttributes());
+                                                                    tech.getATOWAttributes(), tech.isIlliterate());
 
                     final JScrollableMenu subMenu = switch (skillLevel) {
                         case LEGENDARY -> legendaryMenu;

--- a/MekHQ/src/mekhq/gui/model/CrewListModel.java
+++ b/MekHQ/src/mekhq/gui/model/CrewListModel.java
@@ -157,11 +157,13 @@ public class CrewListModel extends AbstractListModel<Person> {
                               // Shooting and driving don't benefit from Reputation, so no need to pass that in.
                               +
                               (person.hasSkill(gunSkill) ?
-                                     person.getSkill(gunSkill).getFinalSkillValue(options, attributes, 0) :
+                                     person.getSkill(gunSkill)
+                                           .getFinalSkillValue(options, attributes, 0, person.isIlliterate()) :
                                      "-") +
                               '/' +
                               (person.hasSkill(driveSkill) ?
-                                     person.getSkill(driveSkill).getFinalSkillValue(options, attributes, 0) :
+                                     person.getSkill(driveSkill)
+                                           .getFinalSkillValue(options, attributes, 0, person.isIlliterate()) :
                                      "-") +
                               ")</font></html>";
             setHtmlText(sb);

--- a/MekHQ/src/mekhq/gui/model/DocTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/DocTableModel.java
@@ -89,7 +89,9 @@ public class DocTableModel extends DataTableModel {
 
         Skill skill = doctor.getSkill(SkillType.S_SURGERY);
         if (null != skill) {
-            int experienceLevel = skill.getExperienceLevel(doctor.getOptions(), doctor.getATOWAttributes());
+            int experienceLevel = skill.getExperienceLevel(doctor.getOptions(),
+                  doctor.getATOWAttributes(),
+                  doctor.isIlliterate());
 
             toReturn.append("<b>").append(getColoredExperienceLevelName(experienceLevel))
                     .append("</b> " + SkillType.S_SURGERY);

--- a/MekHQ/src/mekhq/gui/model/TechTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TechTableModel.java
@@ -157,7 +157,9 @@ public class TechTableModel extends DataTableModel {
                 toReturn.append("; ");
             }
 
-            int experienceLevel = skill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes());
+            int experienceLevel = skill.getExperienceLevel(tech.getOptions(),
+                  tech.getATOWAttributes(),
+                  tech.isIlliterate());
 
             toReturn.append("<b>")
                     .append(SkillType.getColoredExperienceLevelName(experienceLevel))

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1894,7 +1894,7 @@ public class PersonViewPanel extends JScrollablePanel {
                   skillName.replaceAll(Pattern.quote(RP_ONLY_TAG), "")));
 
             int attributeModifier = getTotalAttributeModifier(new TargetRoll(), attributes, skill.getType());
-            int spaModifier = skill.getSPAModifiers(options, adjustedReputation);
+            int spaModifier = skill.getSPAModifiers(options, adjustedReputation, person.isIlliterate());
             int ageModifier = skill.getAgingModifier();
             int totalModifier = attributeModifier + spaModifier + ageModifier;
 
@@ -1912,11 +1912,12 @@ public class PersonViewPanel extends JScrollablePanel {
                 adjustment = String.format(" %s%s%s", spanOpeningWithCustomColor(color), icon, CLOSING_SPAN_TAG);
             }
 
+            boolean isIlliterate = person.isIlliterate();
             JLabel lblValue = new JLabel(String.format("<html>%s%s</html>",
-                  skill.toString(options, attributes, adjustedReputation),
+                  skill.toString(options, attributes, adjustedReputation, isIlliterate),
                   adjustment));
             lblName.setLabelFor(lblValue);
-            String tooltip = wordWrap(skill.getTooltip(options, attributes, adjustedReputation));
+            String tooltip = wordWrap(skill.getTooltip(options, attributes, adjustedReputation, isIlliterate));
             lblName.setToolTipText(tooltip);
             lblValue.setToolTipText(tooltip);
 

--- a/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
+++ b/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
@@ -140,7 +140,8 @@ public class AtBEventProcessor {
         Skill adminSkill = adminHR.getSkill(S_ADMIN);
         int adminExperienceLevel = EXP_NONE;
         if (adminSkill != null) {
-            adminExperienceLevel = adminSkill.getExperienceLevel(adminHR.getOptions(), adminHR.getATOWAttributes());
+            adminExperienceLevel = adminSkill.getExperienceLevel(adminHR.getOptions(), adminHR.getATOWAttributes(),
+                  adminHR.isIlliterate());
         }
 
         modifier += adminExperienceLevel - 2;

--- a/MekHQ/src/mekhq/module/atb/PersonnelMarketAtB.java
+++ b/MekHQ/src/mekhq/module/atb/PersonnelMarketAtB.java
@@ -134,7 +134,7 @@ public class PersonnelMarketAtB implements PersonnelMarketMethod {
                 if (adminHR != null && adminHR.hasSkill(S_ADMIN)) {
                     Skill adminSkill = adminHR.getSkill(S_ADMIN);
                     adminExperienceLevel = adminSkill.getExperienceLevel(adminHR.getOptions(),
-                            adminHR.getATOWAttributes());
+                          adminHR.getATOWAttributes(), adminHR.isIlliterate());
                 }
 
                 int gunneryMod = 0;

--- a/MekHQ/src/mekhq/service/mrms/MRMSService.java
+++ b/MekHQ/src/mekhq/service/mrms/MRMSService.java
@@ -749,7 +749,9 @@ public class MRMSService {
 
         for (Person tech : techs) {
             Skill skill = tech.getSkillForWorkingOn(partWork);
-            int experienceLevel = skill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes());
+            int experienceLevel = skill.getExperienceLevel(tech.getOptions(),
+                  tech.getATOWAttributes(),
+                  tech.isIlliterate());
 
             if (experienceLevel > highestAvailableTechSkill) {
                 highestAvailableTechSkill = experienceLevel;
@@ -1089,16 +1091,17 @@ public class MRMSService {
 
             PersonnelOptions options = tech.getOptions();
             Attributes attributes = tech.getATOWAttributes();
+            boolean isIlliterate = tech.isIlliterate();
 
-            if (mrmsOption.getSkillMin() > skill.getExperienceLevel(options, attributes)) {
+            if (mrmsOption.getSkillMin() > skill.getExperienceLevel(options, attributes, isIlliterate)) {
                 continue;
             }
 
-            if (mrmsOption.getSkillMax() < skill.getExperienceLevel(options, attributes)) {
+            if (mrmsOption.getSkillMax() < skill.getExperienceLevel(options, attributes, isIlliterate)) {
                 continue;
             }
 
-            if (partWork.getSkillMin() > skill.getExperienceLevel(options, attributes)) {
+            if (partWork.getSkillMin() > skill.getExperienceLevel(options, attributes, isIlliterate)) {
                 continue;
             }
 
@@ -1170,7 +1173,8 @@ public class MRMSService {
                 int modePenalty = partWork.getMode().expReduction;
 
                 if (partWork.getSkillMin() >
-                          (skill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes()) - modePenalty)) {
+                          (skill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes(), tech.isIlliterate()) -
+                                 modePenalty)) {
                     debugLog(
                           "...... ending calculateNewMRMSWorktime with previousWorkTime due time reduction skill mod now being less that required skill - %s ns",
                           "calculateNewMRMSWorktime",
@@ -1192,7 +1196,7 @@ public class MRMSService {
                 if (targetRoll.getValue() <= mrmsOption.getTargetNumberMax()) {
                     wtc.setWorkTime(previousNewWorkTime);
                 }
-                if (skill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes()) >=
+                if (skill.getExperienceLevel(tech.getOptions(), tech.getATOWAttributes(), tech.isIlliterate()) >=
                           highestAvailableTechSkill) {
                     wtc.setReachedMaxSkill(true);
                 }
@@ -1309,8 +1313,8 @@ public class MRMSService {
             }
 
             int experienceCompare = Integer.compare(skill1.getTotalSkillLevel(tech1.getOptions(),
-                            tech1.getATOWAttributes()),
-                    skill2.getTotalSkillLevel(tech2.getOptions(), tech2.getATOWAttributes()));
+                        tech1.getATOWAttributes(), tech1.isIlliterate()),
+                  skill2.getTotalSkillLevel(tech2.getOptions(), tech2.getATOWAttributes(), tech2.isIlliterate()));
             if (experienceCompare != 0) {
                 return experienceCompare;
             }

--- a/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
@@ -106,9 +106,9 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockDoctor.getOptions()).thenReturn(new PersonnelOptions());
         when(mockDoctor.getATOWAttributes()).thenReturn(new Attributes());
         when(mockDoctorSkillRegular.getExperienceLevel(mockDoctor.getOptions(),
-              mockDoctor.getATOWAttributes())).thenReturn(SkillType.EXP_REGULAR);
+              mockDoctor.getATOWAttributes(), false)).thenReturn(SkillType.EXP_REGULAR);
         when(mockDoctorSkillGreen.getExperienceLevel(mockDoctor.getOptions(),
-              mockDoctor.getATOWAttributes())).thenReturn(SkillType.EXP_GREEN);
+              mockDoctor.getATOWAttributes(), false)).thenReturn(SkillType.EXP_GREEN);
         when(mockDoctor.getPrimaryRole()).thenReturn(PersonnelRole.DOCTOR);
         when(mockDoctor.isDoctor()).thenReturn(true);
         when(mockDoctor.getPrimaryRole()).thenReturn(PersonnelRole.DOCTOR);
@@ -124,9 +124,9 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockTech.getOptions()).thenReturn(new PersonnelOptions());
         when(mockTech.getATOWAttributes()).thenReturn(new Attributes());
         when(mockMekTechSkillVeteran.getExperienceLevel(mockTech.getOptions(),
-              mockTech.getATOWAttributes())).thenReturn(SkillType.EXP_VETERAN);
+              mockTech.getATOWAttributes(), false)).thenReturn(SkillType.EXP_VETERAN);
         when(mockMekTechSkillRegular.getExperienceLevel(mockTech.getOptions(),
-              mockTech.getATOWAttributes())).thenReturn(SkillType.EXP_REGULAR);
+              mockTech.getATOWAttributes(), false)).thenReturn(SkillType.EXP_REGULAR);
         when(mockTech.getPrimaryRole()).thenReturn(PersonnelRole.MEK_TECH);
         when(mockTech.isTech()).thenReturn(true);
         when(mockTech.getPrimaryRole()).thenReturn(PersonnelRole.MEK_TECH);
@@ -139,9 +139,9 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockTech.isEmployed()).thenReturn(true);
 
         when(mockMedicSkill.getExperienceLevel(new PersonnelOptions(),
-              new Attributes())).thenReturn(SkillType.EXP_REGULAR);
+              new Attributes(), false)).thenReturn(SkillType.EXP_REGULAR);
         when(mockAstechSkill.getExperienceLevel(new PersonnelOptions(),
-              new Attributes())).thenReturn(SkillType.EXP_REGULAR);
+              new Attributes(), false)).thenReturn(SkillType.EXP_REGULAR);
 
         mockPersonnelList.add(mockDoctor);
         mockPersonnelList.add(mockTech);
@@ -365,7 +365,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockMekwarrior.getOptions()).thenReturn(new PersonnelOptions());
         when(mockMekwarrior.getATOWAttributes()).thenReturn(new Attributes());
         when(mockDoctorSkillGreen.getExperienceLevel(mockMekwarrior.getOptions(),
-              mockMekwarrior.getATOWAttributes())).thenReturn(SkillType.EXP_GREEN);
+              mockMekwarrior.getATOWAttributes(), false)).thenReturn(SkillType.EXP_GREEN);
         when(mockMekwarrior.getPrimaryRole()).thenReturn(PersonnelRole.MEKWARRIOR);
         when(mockMekwarrior.getSecondaryRole()).thenReturn(PersonnelRole.DOCTOR);
         when(mockMekwarrior.isDoctor()).thenReturn(true);
@@ -420,7 +420,7 @@ public class FieldManualMercRevDragoonsRatingTest {
         when(mockMekwarrior.getOptions()).thenReturn(new PersonnelOptions());
         when(mockMekwarrior.getATOWAttributes()).thenReturn(new Attributes());
         when(mockMekTechSkillRegular.getExperienceLevel(mockMekwarrior.getOptions(),
-              mockMekwarrior.getATOWAttributes())).thenReturn(SkillType.EXP_REGULAR);
+              mockMekwarrior.getATOWAttributes(), false)).thenReturn(SkillType.EXP_REGULAR);
         when(mockMekwarrior.getPrimaryRole()).thenReturn(PersonnelRole.MEKWARRIOR);
         when(mockMekwarrior.getSecondaryRole()).thenReturn(PersonnelRole.MEK_TECH);
         when(mockMekwarrior.isTech()).thenReturn(true);


### PR DESCRIPTION
-4 to Intelligence linked skill checks unless the character's Languages/Any skill level is 4 or greater.

![](https://i.imgflip.com/a0pfxw.jpg)

Scrounge was partially implemented, so I finished it up while working on this PR as they interacted.
