### PR TITLE
Improvement: Tightened Up FactionStanding Faction Fetching Logic for Manual Mission Resolution

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -94,6 +94,7 @@ import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.AtBDynamicScenarioFactory;
 import mekhq.campaign.mission.AtBScenario;
 import mekhq.campaign.mission.BotForce;
+import mekhq.campaign.mission.Contract;
 import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.mission.atb.AtBScenarioFactory;
@@ -548,12 +549,7 @@ public final class BriefingTab extends CampaignGuiTab {
                 reports = factionStandings.processContractCompletion(getCampaign().getFaction(), employer, today,
                       status);
             } else {
-                SimulateMissionDialog dialog = new ManualMissionDialog(getFrame(),
-                      getCampaign().getCampaignFactionIcon(),
-                      getCampaign().getFaction(),
-                      getCampaign().getLocalDate(),
-                      status,
-                      mission.getName());
+                SimulateMissionDialog dialog = getSimulateMissionDialog(mission, status);
 
                 Faction employerChoice = dialog.getEmployerChoice();
                 Faction enemyChoice = dialog.getEnemyChoice();
@@ -600,6 +596,49 @@ public final class BriefingTab extends CampaignGuiTab {
 
         final List<Mission> missions = getCampaign().getSortedMissions();
         comboMission.setSelectedItem(missions.isEmpty() ? null : missions.get(0));
+    }
+
+    /**
+     * Creates and returns a {@link SimulateMissionDialog} for the given mission and status.
+     *
+     * <p>Determines the start date for the dialog as follows:</p>
+     *
+     * <ul>
+     *   <li>If the mission is a contract, the contract's start date is used; otherwise, {@code null} is assigned.</li>
+     *   <li>If the start date equals the campaign's current local date, the method iterates through the mission's
+     *   scenarios and uses the earliest scenario date found.</li>
+     * </ul>
+     *
+     * <p>The returned dialog is initialized with campaign and mission details.</p>
+     *
+     * @param mission the mission for which the simulation dialog is created
+     * @param status  the status to preselect in the dialog
+     *
+     * @return a configured {@code ManualMissionDialog} for the mission
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private SimulateMissionDialog getSimulateMissionDialog(Mission mission, MissionStatus status) {
+        LocalDate startDate = mission instanceof Contract
+                                    ? ((Contract) mission).getStartDate()
+                                    : null;
+
+        if (startDate == getCampaign().getLocalDate()) {
+            for (Scenario scenario : mission.getScenarios()) {
+                LocalDate scenarioDate = scenario.getDate();
+                if (scenarioDate.isBefore(startDate)) {
+                    startDate = scenarioDate;
+                }
+            }
+        }
+
+        return new ManualMissionDialog(getFrame(),
+              getCampaign().getCampaignFactionIcon(),
+              getCampaign().getFaction(),
+              startDate,
+              status,
+              mission.getName());
     }
 
     /**


### PR DESCRIPTION
The manual mission resolution will now show factions available at the start of the mission, rather than current campaign date.