### PR TITLE
Fix: Fixed Soft-Lock in Faction Standings When Both Employer and Enemy Are Untracked Factions

### DIFF
--- a/MekHQ/resources/mekhq/resources/FactionStandings.properties
+++ b/MekHQ/resources/mekhq/resources/FactionStandings.properties
@@ -30,6 +30,7 @@ simulateContractDialog.label.enemy=Enemy
 simulateContractDialog.combo.untracked=Untracked
 simulateContractDialog.label.status=Mission Status
 simulateContractDialog.button.confirm=Confirm
+simulateContractDialog.button.skip=Skip
 simulateContractDialog.confirmation.success=Factional relationships have been updated.\
   <p>If the Faction Standings Report is currently opened, it will not visually update until re-opened.</p>
 simulateContractDialog.confirmation.failure=Factional relationship update failed.\

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/manualMissionDialogs/SimulateMissionDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/manualMissionDialogs/SimulateMissionDialog.java
@@ -495,16 +495,16 @@ public class SimulateMissionDialog extends JDialog {
     private JPanel populateButtonPanel() {
         JPanel pnlButton = new JPanel(new FlowLayout(FlowLayout.CENTER, PADDING, PADDING));
 
-        String label = getTextAt(RESOURCE_BUNDLE, "simulateContractDialog.button.confirm");
-        RoundedJButton btnConfirm = new RoundedJButton(label);
+        String lblConfirm = getTextAt(RESOURCE_BUNDLE, "simulateContractDialog.button.confirm");
+        RoundedJButton btnConfirm = new RoundedJButton(lblConfirm);
         btnConfirm.addActionListener(evt -> {
             int employerChoiceIndex = comboEmployerFaction.getSelectedIndex();
-            if (employerChoiceIndex != UNTRACKED_FACTION_INDEX) { // If it's untracked leave the choice null
+            if (employerChoiceIndex != UNTRACKED_FACTION_INDEX) { // If it's untracked, leave the choice null
                 employerChoice = allFactions.get(employerChoiceIndex);
             }
 
             int enemyChoiceIndex = comboEnemyFaction.getSelectedIndex();
-            if (enemyChoiceIndex != UNTRACKED_FACTION_INDEX) { // If it's untracked leave the choice null
+            if (enemyChoiceIndex != UNTRACKED_FACTION_INDEX) { // If it's untracked, leave the choice null
                 enemyChoice = allFactions.get(enemyChoiceIndex);
             }
 
@@ -536,6 +536,11 @@ public class SimulateMissionDialog extends JDialog {
         });
 
         pnlButton.add(btnConfirm);
+
+        String lblSkip = getTextAt(RESOURCE_BUNDLE, "simulateContractDialog.button.skip");
+        RoundedJButton btnSkip = new RoundedJButton(lblSkip);
+        btnSkip.addActionListener(evt -> dispose());
+        pnlButton.add(btnSkip);
 
         return pnlButton;
     }


### PR DESCRIPTION
If, while manually resolving a non-AtB Contract, both the employer and enemy were untracked factions the player would be stuck in a loop of constantly being told the update was invalid.

Now we have a skip button.