### PR TITLE
Feature: Added Dark Secret SPA (ATOW)

### DIFF
--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -1526,7 +1526,7 @@ A severe Dark Secret represents a morally or ethically damning secret that would
 
 If the character also possesses the Alternate ID SPA, their Dark Secret is only recovered on a roll of 12.
 
-Once the characters' Dark Secret has been revealed, they permanently reduce their Reputation by 5 and Connections by 3
+Once the characters' Dark Secret has been revealed, they permanently reduce their Reputation by 5 and Connections by 3.
 
 An extreme Dark Secret represents a grave betrayal or atrocity that should lead to exile, imprisonment, or execution if exposed (not modeled in MekHQ).]]></desc>
     <xpCost>-500</xpCost>

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -550,7 +550,7 @@ They can make one additional procurement attempt per day.]]></desc>
         <displayName>Alternate ID (ATOW)</displayName>
         <desc><![CDATA[A low Reputation trait infers a penalty to Negotiation, Streetwise, and Protocols skill checks. While ranks in the Bloodmark trait cause the character to be hunted by assassins.
 
-This SPA reduces the penalty from low Reputation by 2 and reduces the chance of an assassination attempt occurring by half.
+This SPA reduces the penalty from low Reputation by 2 and reduces the chance of an assassination attempt occurring by half. It also decreases the chance of a Dark Secret SPA being revealed.
 
 While this SPA does exist in ATOW (and that's where you'll find its description), these effects are unique to MekHQ.]]></desc>
         <xpCost>200</xpCost>
@@ -1471,6 +1471,7 @@ Once the characters' Dark Secret has been revealed, they permanently reduce thei
 A trivial Dark Secret represents a personal lapse or dishonorable act that could harm the character's reputation if revealed.]]></desc>
     <xpCost>-100</xpCost>
     <weight>1</weight>
+    <invalidAbilities>dark_secret_significant::dark_secret_major::dark_secret_severe::dark_secret_extreme</invalidAbilities>
     <skillPrereq />
     </ability>
     <ability>
@@ -1485,6 +1486,7 @@ Once the characters' Dark Secret has been revealed, they permanently reduce thei
 A significant Dark Secret represents a concealed wrongdoing that would damage key relationships or the character's career.]]></desc>
     <xpCost>-200</xpCost>
     <weight>1</weight>
+    <invalidAbilities>dark_secret_trivial::dark_secret_major::dark_secret_severe::dark_secret_extreme</invalidAbilities>
     <skillPrereq />
     </ability>
     <ability>
@@ -1499,6 +1501,7 @@ Once the characters' Dark Secret has been revealed, they permanently reduce thei
 A major Dark Secret represents a serious violation of law, duty, or trust that could lead to legal or social consequences.]]></desc>
     <xpCost>-300</xpCost>
     <weight>1</weight>
+    <invalidAbilities>dark_secret_trivial::dark_secret_significant::dark_secret_severe::dark_secret_extreme</invalidAbilities>
     <skillPrereq />
     </ability>
     <ability>
@@ -1513,6 +1516,7 @@ Once the characters' Dark Secret has been revealed, they permanently reduce thei
 A severe Dark Secret represents a morally or ethically damning secret that would provoke outrage or condemnation.]]></desc>
     <xpCost>-400</xpCost>
     <weight>1</weight>
+    <invalidAbilities>dark_secret_trivial::dark_secret_significant::dark_secret_major::dark_secret_extreme</invalidAbilities>
     <skillPrereq />
     </ability>
     <ability>
@@ -1527,6 +1531,7 @@ Once the characters' Dark Secret has been revealed, they permanently reduce thei
 An extreme Dark Secret represents a grave betrayal or atrocity that should lead to exile, imprisonment, or execution if exposed (not modeled in MekHQ).]]></desc>
     <xpCost>-500</xpCost>
     <weight>1</weight>
+    <invalidAbilities>dark_secret_trivial::dark_secret_significant::dark_secret_major::dark_secret_severe</invalidAbilities>
     <skillPrereq />
     </ability>
 

--- a/MekHQ/data/universe/defaultspa.xml
+++ b/MekHQ/data/universe/defaultspa.xml
@@ -1459,6 +1459,76 @@ While this SPA does exist in ATOW, these effects are unique to MekHQ.]]></desc>
     <weight>1</weight>
     <skillPrereq />
     </ability>
+    <ability>
+    <lookupName>dark_secret_trivial</lookupName>
+    <displayName>Dark Secret - Trivial (ATOW)</displayName>
+    <desc><![CDATA[Once every three months 2d6 is rolled, on a roll of 10+ the character's Dark Secret is revealed.
+
+If the character also possesses the Alternate ID SPA, their Dark Secret is only recovered on a roll of 12.
+
+Once the characters' Dark Secret has been revealed, they permanently reduce their Reputation by 1 and Connections by 1.
+
+A trivial Dark Secret represents a personal lapse or dishonorable act that could harm the character's reputation if revealed.]]></desc>
+    <xpCost>-100</xpCost>
+    <weight>1</weight>
+    <skillPrereq />
+    </ability>
+    <ability>
+    <lookupName>dark_secret_significant</lookupName>
+    <displayName>Dark Secret - Significant (ATOW)</displayName>
+    <desc><![CDATA[Once every three months 2d6 is rolled, on a roll of 10+ the character's Dark Secret is revealed.
+
+If the character also possesses the Alternate ID SPA, their Dark Secret is only recovered on a roll of 12.
+
+Once the characters' Dark Secret has been revealed, they permanently reduce their Reputation by 2 and Connections by 1.
+
+A significant Dark Secret represents a concealed wrongdoing that would damage key relationships or the character's career.]]></desc>
+    <xpCost>-200</xpCost>
+    <weight>1</weight>
+    <skillPrereq />
+    </ability>
+    <ability>
+    <lookupName>dark_secret_major</lookupName>
+    <displayName>Dark Secret - Major (ATOW)</displayName>
+    <desc><![CDATA[Once every three months 2d6 is rolled, on a roll of 10+ the character's Dark Secret is revealed.
+
+If the character also possesses the Alternate ID SPA, their Dark Secret is only recovered on a roll of 12.
+
+Once the characters' Dark Secret has been revealed, they permanently reduce their Reputation by 3 and Connections by 2.
+
+A major Dark Secret represents a serious violation of law, duty, or trust that could lead to legal or social consequences.]]></desc>
+    <xpCost>-300</xpCost>
+    <weight>1</weight>
+    <skillPrereq />
+    </ability>
+    <ability>
+    <lookupName>dark_secret_severe</lookupName>
+    <displayName>Dark Secret - Severe (ATOW)</displayName>
+    <desc><![CDATA[Once every three months 2d6 is rolled, on a roll of 10+ the character's Dark Secret is revealed.
+
+If the character also possesses the Alternate ID SPA, their Dark Secret is only recovered on a roll of 12.
+
+Once the characters' Dark Secret has been revealed, they permanently reduce their Reputation by 4 and Connections by 2.
+
+A severe Dark Secret represents a morally or ethically damning secret that would provoke outrage or condemnation.]]></desc>
+    <xpCost>-400</xpCost>
+    <weight>1</weight>
+    <skillPrereq />
+    </ability>
+    <ability>
+    <lookupName>dark_secret_extreme</lookupName>
+    <displayName>Dark Secret - Extreme (ATOW)</displayName>
+    <desc><![CDATA[Once every three months 2d6 is rolled, on a roll of 10+ the character's Dark Secret is revealed.
+
+If the character also possesses the Alternate ID SPA, their Dark Secret is only recovered on a roll of 12.
+
+Once the characters' Dark Secret has been revealed, they permanently reduce their Reputation by 5 and Connections by 3
+
+An extreme Dark Secret represents a grave betrayal or atrocity that should lead to exile, imprisonment, or execution if exposed (not modeled in MekHQ).]]></desc>
+    <xpCost>-500</xpCost>
+    <weight>1</weight>
+    <skillPrereq />
+    </ability>
 
     <!-- OTHER SPA -->
     <ability>

--- a/MekHQ/resources/mekhq/resources/Personnel.properties
+++ b/MekHQ/resources/mekhq/resources/Personnel.properties
@@ -469,6 +469,16 @@ compulsion.regression=%s suffered a %s<b>Personality Break</b>%s. They have regr
 compulsion.catatonia=%s suffered a %s<b>Personality Break</b>%s. They've entered a catatonic state.
 compulsion.berserker=%s suffered a %s<b>Personality Break</b>%s. They lashed out in a berserker fury, hurting \
   themselves and any nearby characters.
+darkSecret.revealed.trivial=%s<b>Trivial Dark Secret Revealed:</b>%s rumors of %s's past indiscretion have begun to \
+  circulate, casting a long shadow over their reputation.
+darkSecret.revealed.significant=%s<b>Significant Dark Secret Revealed:</b>%s %s's secret has come to light, straining \
+  old alliances and seeding distrust among their peers.
+darkSecret.revealed.major=%s<b>Major Dark Secret Revealed:</b>%s news of %s's misconduct has triggered formal \
+  scrutiny and driven a wedge through the unit.
+darkSecret.revealed.severe=%s<b>Severe Dark Secret Revealed:</b>%s the full extent of %s's past is now known, \
+  leaving their honor shattered and loyalties questioned.
+darkSecret.revealed.extreme=%s<b>Extreme Dark Secret Revealed:</b>%s %s's darkest secret has been exposed - now \
+  branded by their shame, they stand forsaken by all.
 # Loading Errors
 ineligibleForPrimaryRole=%s<b>WARNING:</b>%s %s was found to be ineligible for their <b>Primary</b> role. That role has\
   \ been removed, and they were assigned the <b>NONE</b> role. If the last time you saved this campaign predates 49.19.01,\

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5335,6 +5335,15 @@ public class Campaign implements ITechManager {
                         person.addBloodhuntDate(assassinationAttempt);
                     }
                 }
+
+                if (currentDay.getMonthValue() % 3 == 0) {
+                    if (person.hasDarkSecret()) {
+                        String report = person.isDarkSecretRevealed(true, false);
+                        if (report != null) {
+                            addReport(report);
+                        }
+                    }
+                }
             }
 
             if (isCommandersDay && !faction.isClan() && (peopleWhoCelebrateCommandersDay < commanderDayTargetNumber)) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -5898,6 +5898,8 @@ public class Person {
         boolean hasMildParanoia = options.booleanOption(COMPULSION_MILD_PARANOIA);
         modifiers += (hasMildParanoia ? -1 : 0);
 
+        modifiers += getDarkSecretModifier(false);
+
         return clamp(connections + modifiers, MINIMUM_CONNECTIONS, MAXIMUM_CONNECTIONS);
     }
 
@@ -6001,11 +6003,9 @@ public class Person {
         boolean hasXenophobia = options.booleanOption(COMPULSION_XENOPHOBIA);
         modifiers -= hasXenophobia ? 1 : 0;
 
-        return clamp(reputation + modifiers, MINIMUM_REPUTATION, MAXIMUM_REPUTATION);
-    }
+        modifiers += getDarkSecretModifier(true);
 
-    public void setReputation(final int reputation) {
-        this.reputation = clamp(reputation, MINIMUM_REPUTATION, MAXIMUM_REPUTATION);
+        return clamp(reputation + modifiers, MINIMUM_REPUTATION, MAXIMUM_REPUTATION);
     }
 
     /**
@@ -7565,5 +7565,35 @@ public class Person {
                      || options.booleanOption(DARK_SECRET_MAJOR)
                      || options.booleanOption(DARK_SECRET_SEVERE)
                      || options.booleanOption(DARK_SECRET_EXTREME);
+    }
+
+    /**
+     * Calculates the modifier associated with a character's Dark Secret.
+     *
+     * <p>If the dark secret is not revealed and the character does not have a dark secret, the modifier is 0.
+     * Otherwise, returns a value based on enabled options and the type of modifier requested (reputation or
+     * other).</p>
+     *
+     * @param isReputation {@code true} to retrieve the Reputation modifier; {@code false} to retrieve the Connections
+     *                     modifier.
+     *
+     * @return the appropriate Dark Secret modifier, or 0 if no relevant option is enabled or the secret is not
+     *       present/revealed.
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public int getDarkSecretModifier(final boolean isReputation) {
+        if (!darkSecretRevealed && !hasDarkSecret()) {
+            return 0;
+        }
+
+        for (Map.Entry<String, int[]> entry : DARK_SECRET_MODIFIERS.entrySet()) {
+            if (options.booleanOption(entry.getKey())) {
+                return isReputation ? entry.getValue()[0] : entry.getValue()[1];
+            }
+        }
+
+        return 0;
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -383,7 +383,7 @@ public class Person {
 
     private final static ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
           MekHQ.getMHQOptions().getLocale());
-    private static final MMLogger logger = MMLogger.create(Person.class);
+    private static final MMLogger LOGGER = MMLogger.create(Person.class);
 
     // initializes the AtB ransom values
     static {
@@ -3272,7 +3272,7 @@ public class Person {
                 extraData.writeToXml(pw);
             }
         } catch (Exception ex) {
-            logger.error(ex, "Failed to write {} to the XML File", getFullName());
+            LOGGER.error(ex, "Failed to write {} to the XML File", getFullName());
             throw ex; // we want to rethrow to ensure that the save fails
         }
         return indent;
@@ -3322,7 +3322,7 @@ public class Person {
                         }
                         person.originPlanet = p;
                     } catch (NullPointerException e) {
-                        logger.error("Error loading originPlanet for {}, {}", systemId, planetId, e);
+                        LOGGER.error("Error loading originPlanet for {}, {}", systemId, planetId, e);
                     }
                 } else if (nodeName.equalsIgnoreCase("becomingBondsmanEndDate")) {
                     person.becomingBondsmanEndDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
@@ -3457,7 +3457,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("attemptDate")) {
-                            logger.error("(techUnitIds) Unknown node type not loaded in bloodhuntSchedule nodes: {}",
+                            LOGGER.error("(techUnitIds) Unknown node type not loaded in bloodhuntSchedule nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3482,7 +3482,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("id")) {
-                            logger.error("(techUnitIds) Unknown node type not loaded in techUnitIds nodes: {}",
+                            LOGGER.error("(techUnitIds) Unknown node type not loaded in techUnitIds nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3498,7 +3498,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            logger.error("(personnelLog) Unknown node type not loaded in personnel logEntry nodes: {}",
+                            LOGGER.error("(personnelLog) Unknown node type not loaded in personnel logEntry nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3565,7 +3565,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            logger.error("(medicalLog) Unknown node type not loaded in personnel logEntry nodes: {}",
+                            LOGGER.error("(medicalLog) Unknown node type not loaded in personnel logEntry nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3585,7 +3585,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            logger.error("Unknown node type not loaded in scenario logEntry nodes: {}",
+                            LOGGER.error("Unknown node type not loaded in scenario logEntry nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3605,7 +3605,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            logger.error("(assignmentLog) Unknown node type not loaded in scenario logEntry nodes: {}",
+                            LOGGER.error("(assignmentLog) Unknown node type not loaded in scenario logEntry nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3625,7 +3625,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            logger.error("(performanceLog) Unknown node type not loaded in scenario logEntry nodes: {}",
+                            LOGGER.error("(performanceLog) Unknown node type not loaded in scenario logEntry nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3644,7 +3644,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("award")) {
-                            logger.error("Unknown node type not loaded in personnel award log nodes: {}",
+                            LOGGER.error("Unknown node type not loaded in personnel award log nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3662,7 +3662,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("injury")) {
-                            logger.error("Unknown node type not loaded in injury nodes: {}", wn3.getNodeName());
+                            LOGGER.error("Unknown node type not loaded in injury nodes: {}", wn3.getNodeName());
                             continue;
                         }
                         person.injuries.add(Injury.generateInstanceFromXML(wn3));
@@ -3836,7 +3836,7 @@ public class Person {
                     try {
                         person.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        logger.warn("Error restoring advantage: {}", adv);
+                        LOGGER.warn("Error restoring advantage: {}", adv);
                     }
                 }
             }
@@ -3861,7 +3861,7 @@ public class Person {
                     try {
                         person.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        logger.error("Error restoring implants: {}", adv);
+                        LOGGER.error("Error restoring implants: {}", adv);
                     }
                 }
             }
@@ -3895,7 +3895,7 @@ public class Person {
                       person.getHyperlinkedFullTitle()));
             }
         } catch (Exception e) {
-            logger.error(e, "Failed to read person {} from file", person.getFullName());
+            LOGGER.error(e, "Failed to read person {} from file", person.getFullName());
             person = null;
         }
 
@@ -4051,7 +4051,7 @@ public class Person {
                 retVal.getOptions().getOption(triggerName).setValue(value);
                 edgeOptionList.remove(triggerName);
             } catch (Exception e) {
-                logger.error("Error restoring edge trigger: {}", trigger);
+                LOGGER.error("Error restoring edge trigger: {}", trigger);
             }
         }
     }
@@ -4069,7 +4069,7 @@ public class Person {
             try {
                 retVal.getOptions().getOption(advName).setValue(false);
             } catch (Exception e) {
-                logger.error("Error disabling edge trigger: {}", edgeTrigger);
+                LOGGER.error("Error disabling edge trigger: {}", edgeTrigger);
             }
         }
     }
@@ -4495,7 +4495,7 @@ public class Person {
 
             SkillType skillType = getType(skillName);
             if (skillType == null) {
-                logger.warn("Unable to find skill type for {}. Experience level assessment aborted", skillName);
+                LOGGER.warn("Unable to find skill type for {}. Experience level assessment aborted", skillName);
                 return EXP_NONE;
             }
 
@@ -6093,7 +6093,7 @@ public class Person {
      */
     public void setAttributeScore(final SkillAttribute attribute, final int newScore) {
         if (attribute == null || attribute == SkillAttribute.NONE) {
-            logger.warn("(setAttributeScore) SkillAttribute is null or NONE.");
+            LOGGER.warn("(setAttributeScore) SkillAttribute is null or NONE.");
             return;
         }
 
@@ -6112,7 +6112,7 @@ public class Person {
      */
     public int getAttributeScore(final SkillAttribute attribute) {
         if (attribute == null || attribute.isNone()) {
-            logger.error("(getAttributeScore) SkillAttribute is null or NONE.");
+            LOGGER.error("(getAttributeScore) SkillAttribute is null or NONE.");
             return DEFAULT_ATTRIBUTE_SCORE;
         }
 
@@ -6175,7 +6175,7 @@ public class Person {
      */
     public int getAttributeCap(final SkillAttribute attribute) {
         if (attribute == null || attribute.isNone()) {
-            logger.warn("(getAttributeCap) SkillAttribute is null or NONE.");
+            LOGGER.warn("(getAttributeCap) SkillAttribute is null or NONE.");
             return MAXIMUM_ATTRIBUTE_SCORE;
         }
 
@@ -6216,7 +6216,7 @@ public class Person {
      */
     public void changeAttributeScore(final SkillAttribute attribute, final int delta) {
         if (attribute == null || attribute.isNone()) {
-            logger.warn("(changeAttributeScore) SkillAttribute is null or NONE.");
+            LOGGER.warn("(changeAttributeScore) SkillAttribute is null or NONE.");
             return;
         }
 
@@ -6595,7 +6595,7 @@ public class Person {
             final UUID id = unit.getId();
             unit = campaign.getUnit(id);
             if (unit == null) {
-                logger.error("Person {} ('{}') references missing unit {}", getId(), getFullName(), id);
+                LOGGER.error("Person {} ('{}') references missing unit {}", getId(), getFullName(), id);
             }
         }
 
@@ -6606,7 +6606,7 @@ public class Person {
                 if (realUnit != null) {
                     techUnits.set(ii, realUnit);
                 } else {
-                    logger.error("Person {} ('{}') techs missing unit {}", getId(), getFullName(), techUnit.getId());
+                    LOGGER.error("Person {} ('{}') techs missing unit {}", getId(), getFullName(), techUnit.getId());
                     techUnits.remove(ii);
                 }
             }
@@ -7475,6 +7475,78 @@ public class Person {
             Person victim = ObjectUtility.getRandomItem(potentialVictims);
             potentialVictims.remove(victim);
             victims.add(victim);
+        }
+    }
+
+    /**
+     * Determines whether a character's dark secret is revealed based on a dice roll, configured modifiers, and campaign
+     * options.
+     *
+     * <p>If the character does not have a dark secret, an empty string is returned. Otherwise, a target number is
+     * assembled using base and optional modifiers, and a 2d6 roll is made.</p>
+     *
+     * <p>If the roll meets or exceeds the target, the dark secret is revealed, relevant state is updated, and a
+     * formatted report message is returned (with content and styling based on the severity of the secret).</p>
+     *
+     * <p>If the secret is not revealed, returns an empty string.</p>
+     *
+     * @param hasDarkSecret {@code true} if the character has a dark secret, otherwise {@code false}
+     * @param forceReveal   {@code true} if the reveal should be forced without a dice roll.
+     *
+     * @return a formatted HTML string with the reveal message if the secret is revealed, or an empty string otherwise
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public String isDarkSecretRevealed(boolean hasDarkSecret, boolean forceReveal) {
+        // This boolean is here to ensure that we only ever pass in valid personnel
+        if (!hasDarkSecret) {
+            return "";
+        } else {
+            final int BASE_TARGET_NUMBER = 10;
+            final int ALTERNATE_ID_MODIFIER = 2;
+
+            TargetRoll targetRoll = new TargetRoll();
+            targetRoll.addModifier(BASE_TARGET_NUMBER, "BASE_TARGET_NUMBER");
+
+            if (options.booleanOption(ATOW_ALTERNATE_ID)) {
+                targetRoll.addModifier(ALTERNATE_ID_MODIFIER, "ALTERNATE_ID_MODIFIER");
+            }
+
+            int roll = d6(2);
+            int targetNumber = targetRoll.getValue();
+
+            LOGGER.info("Dark Secret reveal roll for {}: {} vs. target number: {}", getFullTitle(), roll, targetNumber);
+
+            boolean isDarkSecretRevealed = forceReveal || (roll >= targetNumber);
+
+            String report = "";
+            if (isDarkSecretRevealed) {
+                LOGGER.info("Dark Secret revealed for {}!", getFullTitle());
+                darkSecretRevealed = true;
+
+                String dialogKey = "darkSecret.revealed.";
+                String color = getWarningColor();
+                if (options.booleanOption(DARK_SECRET_TRIVIAL)) {
+                    dialogKey += "trivial";
+                } else if (options.booleanOption(DARK_SECRET_SIGNIFICANT)) {
+                    dialogKey += "significant";
+                } else if (options.booleanOption(DARK_SECRET_MAJOR)) {
+                    dialogKey += "major";
+                    color = getNegativeColor();
+                } else if (options.booleanOption(DARK_SECRET_SEVERE)) {
+                    dialogKey += "severe";
+                    color = getNegativeColor();
+                } else {
+                    dialogKey += "extreme";
+                    color = getNegativeColor();
+                }
+
+                report = String.format(resources.getString(dialogKey), spanOpeningWithCustomColor(color),
+                      CLOSING_SPAN_TAG, getHyperlinkedFullTitle());
+            }
+
+            return report;
         }
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7505,7 +7505,7 @@ public class Person {
      */
     public String isDarkSecretRevealed(boolean hasDarkSecret, boolean forceReveal) {
         // This boolean is here to ensure that we only ever pass in valid personnel
-        if (!hasDarkSecret) {
+        if (!hasDarkSecret || darkSecretRevealed) {
             return "";
         } else {
             final int BASE_TARGET_NUMBER = 10;

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -6008,6 +6008,10 @@ public class Person {
         return clamp(reputation + modifiers, MINIMUM_REPUTATION, MAXIMUM_REPUTATION);
     }
 
+    public void setReputation(final int reputation) {
+        this.reputation = clamp(reputation, MINIMUM_REPUTATION, MAXIMUM_REPUTATION);
+    }
+
     /**
      * Adjusts the person's reputation by the specified amount.
      *

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -340,7 +340,7 @@ public class Person {
     private String personalityInterviewNotes;
     // endregion Personality
 
-    // region Compulsions
+    // region SPAs
     private String storedGivenName;
     private String storedSurname;
     private int storedLoyalty;
@@ -358,7 +358,8 @@ public class Person {
     private Reasoning storedReasoning;
     private int storedReasoningDescriptionIndex;
     private boolean sufferingFromClinicalParanoia;
-    // endregion Compulsions
+    private boolean darkSecretRevealed;
+    // endregion SPAs
 
     // region Flags
     private boolean clanPersonnel;
@@ -567,6 +568,7 @@ public class Person {
         storedReasoning = Reasoning.AVERAGE;
         storedReasoningDescriptionIndex = 0;
         sufferingFromClinicalParanoia = false;
+        darkSecretRevealed = false;
 
         // This assigns minutesLeft and overtimeLeft. Must be after skills to avoid an NPE.
         if (campaign != null) {
@@ -2663,6 +2665,14 @@ public class Person {
         this.sufferingFromClinicalParanoia = sufferingFromClinicalParanoia;
     }
 
+    public boolean isDarkSecretRevealed() {
+        return darkSecretRevealed;
+    }
+
+    public void setDarkSecretRevealed(final boolean darkSecretRevealed) {
+        this.darkSecretRevealed = darkSecretRevealed;
+    }
+
     // region Flags
     public boolean isClanPersonnel() {
         return clanPersonnel;
@@ -3239,6 +3249,13 @@ public class Person {
                       sufferingFromClinicalParanoia);
             }
 
+            if (darkSecretRevealed) {
+                MHQXMLUtility.writeSimpleXMLTag(pw,
+                      indent,
+                      "darkSecretRevealed",
+                      darkSecretRevealed);
+            }
+
             // region Flags
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "clanPersonnel", isClanPersonnel());
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "commander", commander);
@@ -3777,6 +3794,8 @@ public class Person {
                     person.storedReasoningDescriptionIndex = MathUtility.parseInt(wn2.getTextContent().trim());
                 } else if (nodeName.equalsIgnoreCase("sufferingFromClinicalParanoia")) {
                     person.setSufferingFromClinicalParanoia(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (nodeName.equalsIgnoreCase("darkSecretRevealed")) {
+                    person.setDarkSecretRevealed(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("clanPersonnel")) {
                     person.setClanPersonnel(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("commander")) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7588,10 +7588,17 @@ public class Person {
      * @since 0.50.07
      */
     public int getDarkSecretModifier(final boolean isReputation) {
+        // If the dark secret is not revealed and the character does not have a dark secret, return 0
         if (!darkSecretRevealed && !hasDarkSecret()) {
             return 0;
         }
 
+        // If the character has a dark secret but it is not revealed, return a default modifier (e.g., -1)
+        if (!darkSecretRevealed && hasDarkSecret()) {
+            return -1; // Default modifier for unrevealed dark secrets
+        }
+
+        // If the dark secret is revealed, calculate the appropriate modifier
         for (Map.Entry<String, int[]> entry : DARK_SECRET_MODIFIERS.entrySet()) {
             if (options.booleanOption(entry.getKey())) {
                 return isReputation ? entry.getValue()[0] : entry.getValue()[1];

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7490,7 +7490,8 @@ public class Person {
      *
      * <p>If the secret is not revealed, returns an empty string.</p>
      *
-     * @param hasDarkSecret {@code true} if the character has a dark secret, otherwise {@code false}
+     * @param hasDarkSecret {@code true} if the character has a dark secret. Should be the return value of
+     * {@link #hasDarkSecret()}
      * @param forceReveal   {@code true} if the reveal should be forced without a dice roll.
      *
      * @return a formatted HTML string with the reveal message if the secret is revealed, or an empty string otherwise
@@ -7548,5 +7549,21 @@ public class Person {
 
             return report;
         }
+    }
+
+    /**
+     * Determines whether any dark secret options are enabled for this entity.
+     *
+     * @return {@code true} if the entity has any dark secret SPA enabled; {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public boolean hasDarkSecret() {
+        return options.booleanOption(DARK_SECRET_TRIVIAL)
+                     || options.booleanOption(DARK_SECRET_SIGNIFICANT)
+                     || options.booleanOption(DARK_SECRET_MAJOR)
+                     || options.booleanOption(DARK_SECRET_SEVERE)
+                     || options.booleanOption(DARK_SECRET_EXTREME);
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -89,6 +89,12 @@ public class PersonnelOptions extends PilotOptions {
     public static final String ATOW_TECH_EMPATHY = "atow_tech_empathy";
     public static final String FLAW_TRANSIT_DISORIENTATION_SYNDROME = "flaw_transit_disorientation_syndrome";
 
+    public static final String DARK_SECRET_TRIVIAL = "dark_secret_trivial";
+    public static final String DARK_SECRET_SIGNIFICANT = "dark_secret_significant";
+    public static final String DARK_SECRET_MAJOR = "dark_secret_major";
+    public static final String DARK_SECRET_SEVERE = "dark_secret_severe";
+    public static final String DARK_SECRET_EXTREME = "dark_secret_extreme";
+
     public static final String MUTATION_FREAKISH_STRENGTH = "mutation_freakish_strength";
     public static final String MUTATION_EXCEPTIONAL_IMMUNE_SYSTEM = "mutation_exceptional_immune_system";
     public static final String MUTATION_EXOTIC_APPEARANCE = "mutation_exotic_appearance";
@@ -208,6 +214,13 @@ public class PersonnelOptions extends PilotOptions {
         addOption(l3a, FLAW_GREMLINS, false);
         addOption(l3a, ATOW_TECH_EMPATHY, false);
         addOption(l3a, FLAW_TRANSIT_DISORIENTATION_SYNDROME, false);
+
+        addOption(l3a, DARK_SECRET_TRIVIAL, false);
+        addOption(l3a, DARK_SECRET_SIGNIFICANT, false);
+        addOption(l3a, DARK_SECRET_MAJOR, false);
+        addOption(l3a, DARK_SECRET_SEVERE, false);
+        addOption(l3a, DARK_SECRET_EXTREME, false);
+
         addOption(l3a, MUTATION_FREAKISH_STRENGTH, false);
         addOption(l3a, MUTATION_EXCEPTIONAL_IMMUNE_SYSTEM, false);
         addOption(l3a, MUTATION_EXOTIC_APPEARANCE, false);

--- a/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
+++ b/MekHQ/src/mekhq/campaign/personnel/PersonnelOptions.java
@@ -30,6 +30,7 @@ package mekhq.campaign.personnel;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import megamek.common.annotations.Nullable;
@@ -145,6 +146,16 @@ public class PersonnelOptions extends PilotOptions {
     public static final int COMPULSION_CHECK_MODIFIER_MAJOR = 4; // ATOW pg 110
     public static final int COMPULSION_CHECK_MODIFIER_SEVERE = 7; // ATOW pg 110
     public static final int COMPULSION_CHECK_MODIFIER_EXTREME = 10; // ATOW pg 110
+
+    // ATOW pg 112 (Reputation, Connections)
+    public static final Map<String, int[]> DARK_SECRET_MODIFIERS = Map.of(
+          DARK_SECRET_TRIVIAL, new int[] { -1, -1 },
+          DARK_SECRET_SIGNIFICANT, new int[] { -2, -1 },
+          DARK_SECRET_MAJOR, new int[] { -3, -2 },
+          DARK_SECRET_SEVERE, new int[] { -4, -2 },
+          DARK_SECRET_EXTREME, new int[] { -5, -3 }
+    );
+
 
     @Override
     public void initialize() {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1122,6 +1122,13 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             comboReasoning = new MMComboBox<>("comboReasoning", Reasoning.values());
             comboReasoning.setSelectedItem(person.getReasoning());
 
+            gridBagConstraints.gridx = 1;
+            gridBagConstraints.gridy = y++;
+            gridBagConstraints.gridwidth = 2;
+            gridBagConstraints.anchor = GridBagConstraints.WEST;
+            gridBagConstraints.insets = new Insets(0, 5, 0, 0);
+            panDemog.add(comboReasoning, gridBagConstraints);
+
             y++;
         }
 

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -183,6 +183,9 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
     private MMComboBox<PersonalityQuirk> comboPersonalityQuirk;
     private MMComboBox<Reasoning> comboReasoning;
 
+    // Other
+    private JCheckBox chkDarkSecretRevealed;
+
     private final Campaign campaign;
 
     private final transient ResourceBundle resourceMap = ResourceBundle.getBundle(
@@ -1119,17 +1122,23 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             comboReasoning = new MMComboBox<>("comboReasoning", Reasoning.values());
             comboReasoning.setSelectedItem(person.getReasoning());
 
-            gridBagConstraints.gridx = 1;
-            gridBagConstraints.gridy = y++;
-            gridBagConstraints.gridwidth = 2;
-            gridBagConstraints.anchor = GridBagConstraints.WEST;
-            gridBagConstraints.insets = new Insets(0, 5, 0, 0);
-            panDemog.add(comboReasoning, gridBagConstraints);
-
             y++;
         }
 
-        y++;
+        if (person.hasDarkSecret()) {
+            chkDarkSecretRevealed = new JCheckBox("Dark Secret Revealed");
+            chkDarkSecretRevealed.setSelected(person.isDarkSecretRevealed());
+            gridBagConstraints = new GridBagConstraints();
+            gridBagConstraints.gridx = 0;
+            gridBagConstraints.gridy = y;
+            gridBagConstraints.gridwidth = 1;
+            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+            gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+            gridBagConstraints.insets = new Insets(5, 5, 0, 0);
+            panDemog.add(chkDarkSecretRevealed, gridBagConstraints);
+
+            y++;
+        }
 
         txtBio = new MarkdownEditorPanel("Biography");
         txtBio.setMinimumSize(UIUtil.scaleForGUI(400, 200));
@@ -1472,6 +1481,20 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
             person.setReasoning(comboReasoning.getSelectedItem());
             writePersonalityDescription(person);
             writeInterviewersNotes(person);
+        }
+
+        if (person.hasDarkSecret()) {
+            boolean darkSecretRevealed = chkDarkSecretRevealed.isSelected();
+            if (darkSecretRevealed != person.isDarkSecretRevealed()) {
+                if (!darkSecretRevealed) {
+                    person.setDarkSecretRevealed(false);
+                } else {
+                    String report = person.isDarkSecretRevealed(true, true);
+                    if (!report.isBlank()) {
+                        campaign.addReport(report);
+                    }
+                }
+            }
         }
 
         setSkills();


### PR DESCRIPTION
This PR adds 5 levels of Dark Secret SPA (Trivial, Significant, Major, Severe, and Extreme).

For each level the mechanics are identical. Every three months 2d6 is rolled to determine whether the secret is revealed. The TN is normally 10, but is increased to 12 if the character also possesses the Alternate ID SPA.

If the roll is equal or higher than the TN, the character's secret is revealed and they suffer the Reputation and Connections penalties outlined in ATOW pg 112.

The reveal state of a Dark Secret can be toggled in Edit Person.

When a Dark Secret is revealed a daily report message is posed, adjusted based on the severity of the Dark Secret.

<img width="366" height="334" alt="image" src="https://github.com/user-attachments/assets/0dee12e8-7227-40fe-a985-a882a5296210" />
