### PR TITLE
Improvement: Added A Time of War Tab to Campaign Options

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1316,11 +1316,6 @@ lblNewFinancialYearFinancesToCSVExportBox.tooltip=This writes the finance table 
   \ the first day of a new financial term, right before the table is carried over to the next period.
 lblSimulateGrayMonday.text=Simulate Gray Monday
 lblSimulateGrayMonday.tooltip=Simulate the economic and social upheaval of Gray Monday.
-lblAllowMonthlyReinvestment.text=Allow Monthly Reinvestment of Wealth
-lblAllowMonthlyReinvestment.tooltip=Each month the campaign commander will use their Wealth trait to\
-  \ reinvest money back into the campaign.\
-  <br>\
-  <br>This is based on the Wealth Trait Check rules from the A Time of War:Companion.
 # createSalesPanel
 lblSalesPanel.text=Sales
 lblSellUnitsBox.text=Enable the Sale of Units
@@ -1386,6 +1381,37 @@ lblCancelledOrderRefundMultiplier.tooltip=The decimal percentage of the original
   \ that is refunded when an order is canceled.
 # Systems Tab
 systemsContentTabs.title=Systems
+atowTab.title=A Time of War
+lblATimeOfWarTab.text=A Time of War Options
+atowTab.border="It is only those who have neither fired a shot nor heard the shrieks and groans of the wounded who \
+  cry aloud for blood, more vengeance, more desolation. War is hell."\
+  <br><i>General William Sherman\
+  <br>Address at the Michigan Military Academy, Pre-Spaceflight Terra</i>
+lblATOWAttributesPanel.text=Traits and Attributes
+lblUseAttributes.text=Use Attributes \u26A0
+lblUseAttributes.tooltip=If checked, characters will be generated with <i>A Time of War</i> Attribute scores.\
+  <br>\
+  <br><b>Warning:</b> If enabled (or disabled) mid-campaign, you need to navigate to the personnel tab, and (while in\
+  \ GM Mode) you should use the right-click menu to reset attribute scores for all personnel.
+lblRandomizeAttributes.text=Random Attributes
+lblRandomizeAttributes.tooltip=If checked, a d6 is rolled for each of the character's ATOW Attributes.\
+  <br>\
+  <br>On a roll of a 6 the Attribute is increased by 1. On a roll of a 6 the Attribute is decreased\
+  \ by 1.
+lblRandomizeTraits.text=Randomize Traits
+lblRandomizeTraits.tooltip=If checked, a newly created character's Connections, Wealth, Reputation, and Unlucky scores\
+  \ are randomized.\
+  <br>\
+  <br>- For <b>Connections</b> there is a 1-in-6 chance the character has rank 1.\
+  <br>- For <b>Wealth</b> and <b>Reputation</b> there is a 1-in-6 chance the character has rank 1 and 1-in-6 they have \
+  rank -1.\
+  <br>- For <b>Unlucky</b> there is a 1-in-20 chance the character has rank 1\
+  <br>- For <b>Bloodmark</b> there is a 1-in-100 chance the character has rank 1. Increased to 1-in-50 for pirates.
+lblAllowMonthlyReinvestment.text=Allow Monthly Reinvestment of Wealth
+lblAllowMonthlyReinvestment.tooltip=Each month the campaign commander will use their Wealth trait to\
+  \ reinvest money back into the campaign.\
+  <br>\
+  <br>This is based on the Wealth Trait Check rules from the A Time of War:Companion.
 reputationTab.title=Reputation
 lblReputationTab.text=Reputation Options
 reputationTab.border="Reputation opens doors\u2014or gets them slammed in your face. In this business, it's as\
@@ -1431,7 +1457,7 @@ lblReputationPerformanceModifierCutOff.tooltip=When using CamOps Reputation all 
   <br>\
   <br><b>Recommended</b>: This option helps ensure Force Reputation doesn't spiral out of control. Leave\
   \ enabled.
-factionStanding.title=Faction Standing
+factionStandingTab.title=Faction Standing
 lblFactionStandingTab.text=Faction Standing Options
 factionStanding.border="Here a question arises: whether it is better to be loved than feared or the reverse. The answer\
   \ is, of course, that it would be best to be both loved and feared. But since the two rarely come together, anyone\
@@ -1916,28 +1942,6 @@ lblComingOfAgeRPSkills.text=Award Coming of Age RP Skills \u26A0 <span style="co
 lblComingOfAgeRPSkills.tooltip=If checked, all characters will be awarded random RP skills SPA when they turn 16.\
   <br>\
   <br><b>Warning:</b> This option relies on the RP skill chances found in the 'Secondary Skills' panel.
-lblATOWAttributesPanel.text=A Time of War Traits and Attributes
-lblUseAttributes.text=Use Attributes \u26A0
-lblUseAttributes.tooltip=If checked, characters will be generated with <i>A Time of War</i> Attribute scores.\
-  <br>\
-  <br><b>Warning:</b> If enabled (or disabled) mid-campaign, you need to navigate to the personnel tab, and (while in\
-  \ GM Mode) you should use the right-click menu to reset attribute scores for all personnel.
-lblRandomizeAttributes.text=Random Attributes
-lblRandomizeAttributes.tooltip=If checked, a d6 is rolled for each of the character's ATOW Attributes.\
-  <br>\
-  <br>On a roll of a 6 the Attribute is increased by 1. On a roll of a 6 the Attribute is decreased\
-  \ by 1.
-lblRandomizeTraits.text=Randomize Traits
-lblRandomizeTraits.tooltip=If checked, a newly created character's Connections, Wealth, Reputation, and Unlucky scores\
-  \ are randomized.\
-  <br>\
-  <br>For <b>Connections</b> a d6 is rolled, on a roll of 6 the character's Connections score becomes 1.\
-  <br>\
-  <br>For <b>Wealth</b> and <b>Reputation</b> a d6 is rolled (for each), on a roll of 6 the character's score becomes 1.\
-  \ While a roll of 1 causes their score to become -1.\
-  <br>\
-  <br>For <b>Unlucky</b> a d20 is rolled, on a roll of 1 the character's score becomes 1. A high Unlucky score is a bad\
-  \ thing.
 lblPhenotypesPanel.text=Clan Trueborn Percentages
 lblMekWarrior.text=MekWarrior
 lblMekWarrior.tooltip=What percentage of Clan MekWarriors should have a Trueborn phenotype?

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1438,37 +1438,37 @@ factionStanding.border="Here a question arises: whether it is better to be loved
   \ compelled to choose will find greater security in being feared than in being loved."\
   <br><i>Niccolo Machiavelli,\
   <br>The Prince</i>
-lblTrackFactionStanding.text=Enable Faction Standing \u270E \u2318 <span style="color:#00008b;">\u2605</span>
+lblTrackFactionStanding.text=Enable Faction Standing \u270E \u2318 <span style="color:#C344C3;">\u2605</span>
 lblTrackFactionStanding.tooltip=This option enables the tracking of Faction Standing. Faction Standing represents how\
   \ liked you are across the Inner Sphere. Actions such as taking contracts can increase or deminish your Standing. Full\
   \ documentation can be found in the docs folder.
-lblUseFactionStandingNegotiation.text=Standing Affects Negotiations <span style="color:#00008b;">\u2605</span>
+lblUseFactionStandingNegotiation.text=Standing Affects Negotiations <span style="color:#C344C3;">\u2605</span>
 lblUseFactionStandingNegotiation.tooltip=If enabled, contract negotiations will be influenced by your Standing with the\
   \ employing Faction.
-lblUseFactionStandingResupply.text=Standings Affects Resupplies <span style="color:#00008b;">\u2605</span>
+lblUseFactionStandingResupply.text=Standings Affects Resupplies <span style="color:#C344C3;">\u2605</span>
 lblUseFactionStandingResupply.tooltip=If enabled, the size of monthly Resupplies will be influenced by your Standing\
   \ with your employer.
-lblUseFactionStandingCommandCircuit.text=Enable Command Circuit <span style="color:#00008b;">\u2605</span>
+lblUseFactionStandingCommandCircuit.text=Enable Command Circuit <span style="color:#C344C3;">\u2605</span>
 lblUseFactionStandingCommandCircuit.tooltip=At high enough Standing, you will be granted access to a faction's Command\
   \ Circuit. This significantly decreases travel time while in their territory.
-lblUseFactionStandingOutlawed.text=Enable Outlawing <span style="color:#00008b;">\u2605</span>
+lblUseFactionStandingOutlawed.text=Enable Outlawing <span style="color:#C344C3;">\u2605</span>
 lblUseFactionStandingOutlawed.tooltip=At very low Standing, a faction may declare you an Outlaw, preventing you from\
   \ landing on their planets (unless on a contract against them).
-lblUseFactionStandingBatchallRestrictions.text=Enable Batchall Restrictions <span style="color:#00008b;">\u2605</span>
+lblUseFactionStandingBatchallRestrictions.text=Enable Batchall Restrictions <span style="color:#C344C3;">\u2605</span>
 lblUseFactionStandingBatchallRestrictions.tooltip=If your Standing with a Clan faction falls low enough, they will stop\
   \ offering you Batchalls.
-lblUseFactionStandingRecruitment.text=Standings Affects Recruitment <span style="color:#00008b;">\u2605</span>
+lblUseFactionStandingRecruitment.text=Standings Affects Recruitment <span style="color:#C344C3;">\u2605</span>
 lblUseFactionStandingRecruitment.tooltip=Your Standing with a faction influences how willing their people are to join\
   \ your campaign and the number of recruits available on their planets.
-lblUseFactionStandingBarracksCosts.text=Standing Affects Food & Housing <span style="color:#00008b;">\u2605</span>
+lblUseFactionStandingBarracksCosts.text=Standing Affects Food & Housing <span style="color:#C344C3;">\u2605</span>
 lblUseFactionStandingBarracksCosts.tooltip=Your Standing with a faction influences the cost of food and housing while on\
   \ their planets and while performing contracts for them.
-lblUseFactionStandingUnitMarket.text=Standing Affects the Unit Market <span style="color:#00008b;">\u2605</span>
+lblUseFactionStandingUnitMarket.text=Standing Affects the Unit Market <span style="color:#C344C3;">\u2605</span>
 lblUseFactionStandingUnitMarket.tooltip=Standing with a faction influences how many units appear in the 'Employer Market'\
   \ portion of the Unit Market.
-lblUseFactionStandingContractPay.text=Standing Affects Contract Pay <span style="color:#00008b;">\u2605</span>
+lblUseFactionStandingContractPay.text=Standing Affects Contract Pay <span style="color:#C344C3;">\u2605</span>
 lblUseFactionStandingContractPay.tooltip=If enabled, Standing will slightly affect contract pay.
-lblUseFactionStandingSupportPoints.text=Standing Affects Support Points <span style="color:#00008b;">\u2605</span>
+lblUseFactionStandingSupportPoints.text=Standing Affects Support Points <span style="color:#C344C3;">\u2605</span>
 lblUseFactionStandingSupportPoints.tooltip=If enabled, your Standing with a faction influences Support Point generation\
   \ while on contract for that faction.
 # Markets Tab

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1399,8 +1399,8 @@ lblRandomizeAttributes.tooltip=If checked, a d6 is rolled for each of the charac
   <br>On a roll of a 6 the Attribute is increased by 1. On a roll of a 6 the Attribute is decreased\
   \ by 1.
 lblRandomizeTraits.text=Randomize Traits
-lblRandomizeTraits.tooltip=If checked, a newly created character's Connections, Wealth, Reputation, and Unlucky scores\
-  \ are randomized.\
+lblRandomizeTraits.tooltip=If checked, a newly created character's Connections, Wealth, Reputation, Unlucky, and \
+  Bloodmark scores are randomized.\
   <br>\
   <br>- For <b>Connections</b> there is a 1-in-6 chance the character has rank 1.\
   <br>- For <b>Wealth</b> and <b>Reputation</b> there is a 1-in-6 chance the character has rank 1 and 1-in-6 they have \

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1386,7 +1386,7 @@ lblATimeOfWarTab.text=A Time of War Options
 atowTab.border="It is only those who have neither fired a shot nor heard the shrieks and groans of the wounded who \
   cry aloud for blood, more vengeance, more desolation. War is hell."\
   <br><i>General William Sherman\
-  <br>Address at the Michigan Military Academy, Pre-Spaceflight Terra</i>
+  <br>Address at the Michigan Military Academy, June 19th 1879</i>
 lblATOWAttributesPanel.text=Traits and Attributes
 lblUseAttributes.text=Use Attributes \u26A0
 lblUseAttributes.tooltip=If checked, characters will be generated with <i>A Time of War</i> Attribute scores.\

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -245,8 +245,6 @@ public class CampaignOptions {
     private boolean displayMedicalRecord;
     private boolean displayAssignmentRecord;
     private boolean displayPerformanceRecord;
-    private boolean rewardComingOfAgeAbilities;
-    private boolean rewardComingOfAgeRPSkills;
 
     // Expanded Personnel Information
     private boolean useTimeInService;
@@ -339,6 +337,10 @@ public class CampaignOptions {
     private boolean showLifeEventDialogBirths;
     private boolean showLifeEventDialogComingOfAge;
     private boolean showLifeEventDialogCelebrations;
+
+    // Coming of Age
+    private boolean rewardComingOfAgeAbilities;
+    private boolean rewardComingOfAgeRPSkills;
 
     // Marriage
     private boolean useManualMarriages;

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -447,10 +447,10 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         // Systems
         systemsTab = new SystemsTab(campaign);
 
-        JTabbedPane systemsContentTabs = createSubTabs(Map.of("reputationTab",
-              systemsTab.createReputationTab(),
-              "factionStanding",
-              systemsTab.createFactionStandingTab()));
+        JTabbedPane systemsContentTabs = createSubTabs(Map.of(
+              "reputationTab", systemsTab.createReputationTab(),
+              "factionStandingTab", systemsTab.createFactionStandingTab(),
+              "atowTab", systemsTab.createATOWTab()));
         systemsTab.loadValuesFromCampaignOptions();
 
         // Rulesets
@@ -529,7 +529,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         rulesetsTab.applyCampaignOptionsToCampaign(options);
 
         boolean oldIsTrackFactionStanding = options.isTrackFactionStanding();
-        systemsTab.applyCampaignOptionsToCampaign(options);
+        systemsTab.applyCampaignOptionsToCampaign(options, presetRandomSkillPreferences);
 
         // Tidy up
         if (preset == null) {
@@ -618,6 +618,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         financesTab.loadValuesFromCampaignOptions(presetCampaignOptions);
         marketsTab.loadValuesFromCampaignOptions(presetCampaignOptions);
         rulesetsTab.loadValuesFromCampaignOptions(presetCampaignOptions);
-        systemsTab.loadValuesFromCampaignOptions(presetCampaignOptions);
+        systemsTab.loadValuesFromCampaignOptions(presetCampaignOptions, campaignPreset.getRandomSkillPreferences());
     }
 }

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
@@ -121,8 +121,6 @@ public class AdvancementTab {
     //start Skill Randomization Tab
     private CampaignOptionsHeaderPanel skillRandomizationHeader;
     private JCheckBox chkExtraRandomness;
-    private JCheckBox chkComingOfAgeSPAs;
-    private JCheckBox chkRewardComingOfAgeRPSkills;
 
     private JPanel pnlPhenotype;
     private JLabel[] phenotypeLabels;
@@ -577,8 +575,6 @@ public class AdvancementTab {
 
         pnlATOWAttributes = new JPanel();
         chkRandomizeTraits = new JCheckBox();
-        chkComingOfAgeSPAs = new JCheckBox();
-        chkRewardComingOfAgeRPSkills = new JCheckBox();
 
         pnlPhenotype = new JPanel();
         phenotypeLabels = new JLabel[] {}; // This will be initialized properly later
@@ -667,13 +663,6 @@ public class AdvancementTab {
         chkExtraRandomness = new CampaignOptionsCheckBox("ExtraRandomness");
         chkExtraRandomness.addMouseListener(createTipPanelUpdater(skillRandomizationHeader, "ExtraRandomness"));
 
-        chkComingOfAgeSPAs = new CampaignOptionsCheckBox("ComingOfAgeAbilities");
-        chkComingOfAgeSPAs.addMouseListener(createTipPanelUpdater(skillRandomizationHeader, "ComingOfAgeAbilities"));
-
-        chkRewardComingOfAgeRPSkills = new CampaignOptionsCheckBox("ComingOfAgeRPSkills");
-        chkRewardComingOfAgeRPSkills.addMouseListener(createTipPanelUpdater(skillRandomizationHeader,
-              "ComingOfAgeRPSkills"));
-
         pnlPhenotype = createPhenotypePanel();
         pnlRandomAbilities = createAbilityPanel();
         pnlSkillGroups = createSkillGroupPanel();
@@ -689,12 +678,6 @@ public class AdvancementTab {
         layout.gridy++;
         layout.gridwidth = 1;
         panel.add(chkExtraRandomness, layout);
-
-        layout.gridy++;
-        panel.add(chkComingOfAgeSPAs, layout);
-
-        layout.gridy++;
-        panel.add(chkRewardComingOfAgeRPSkills, layout);
 
         layout.gridx = 0;
         layout.gridy++;
@@ -1288,8 +1271,6 @@ public class AdvancementTab {
         chkUseAttributes.setSelected(skillPreferences.isUseAttributes());
         chkRandomizeAttributes.setSelected(skillPreferences.isRandomizeAttributes());
         chkRandomizeTraits.setSelected(skillPreferences.isRandomizeTraits());
-        chkComingOfAgeSPAs.setSelected(options.isRewardComingOfAgeAbilities());
-        chkRewardComingOfAgeRPSkills.setSelected(options.isRewardComingOfAgeRPSkills());
         final int[] phenotypeProbabilities = options.getPhenotypeProbabilities();
         for (int i = 0; i < phenotypeSpinners.length; i++) {
             phenotypeSpinners[i].setValue(phenotypeProbabilities[i]);
@@ -1382,8 +1363,6 @@ public class AdvancementTab {
         options.setContractNegotiationXP((int) spnContractNegotiationXP.getValue());
         options.setAdminXP((int) spnAdminWeeklyXP.getValue());
         options.setAdminXPPeriod((int) spnAdminWeeklyXPPeriod.getValue());
-        options.setRewardComingOfAgeAbilities(chkComingOfAgeSPAs.isSelected());
-        options.setRewardComingOfAgeRPSkills(chkRewardComingOfAgeRPSkills.isSelected());
 
         //start Skill Randomization Tab
         skillPreferences.setRandomizeSkill(chkExtraRandomness.isSelected());

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AdvancementTab.java
@@ -181,11 +181,6 @@ public class AdvancementTab {
     private JSpinner spnSecondBonus;
     private JLabel lblRoleplaySkillsModifier;
     private JSpinner spnRoleplaySkillsModifier;
-
-    private JPanel pnlATOWAttributes;
-    private JCheckBox chkUseAttributes;
-    private JCheckBox chkRandomizeAttributes;
-    private JCheckBox chkRandomizeTraits;
     //end Skill Randomization Tab
 
     //start Recruitment Bonus Tab
@@ -570,11 +565,6 @@ public class AdvancementTab {
      */
     private void initializeSkillRandomizationTab() {
         chkExtraRandomness = new JCheckBox();
-        chkUseAttributes = new JCheckBox();
-        chkRandomizeAttributes = new JCheckBox();
-
-        pnlATOWAttributes = new JPanel();
-        chkRandomizeTraits = new JCheckBox();
 
         pnlPhenotype = new JPanel();
         phenotypeLabels = new JLabel[] {}; // This will be initialized properly later
@@ -692,40 +682,6 @@ public class AdvancementTab {
 
         // Create Parent Panel and return
         return createParentPanel(panel, "XpAwardsTab");
-    }
-
-    /**
-     * Creates and returns the ATOW panel, which allows users to configure settings for attribute and traits
-     * probabilities.
-     *
-     * @return A {@code JPanel} containing configuration options for phenotype probabilities.
-     */
-    private JPanel createATOWAttributesPanel() {
-        // Contents
-        chkUseAttributes = new CampaignOptionsCheckBox("UseAttributes");
-        chkUseAttributes.addMouseListener(createTipPanelUpdater(skillRandomizationHeader, "UseAttributes"));
-        chkRandomizeAttributes = new CampaignOptionsCheckBox("RandomizeAttributes");
-        chkRandomizeAttributes.addMouseListener(createTipPanelUpdater(skillRandomizationHeader, "RandomizeAttributes"));
-        chkRandomizeTraits = new CampaignOptionsCheckBox("RandomizeTraits");
-        chkRandomizeTraits.addMouseListener(createTipPanelUpdater(skillRandomizationHeader, "RandomizeTraits"));
-
-        final JPanel panel = new CampaignOptionsStandardPanel("ATOWAttributesPanel", true, "ATOWAttributesPanel");
-        final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
-        layout.gridwidth = 1;
-        layout.gridx = 0;
-        layout.gridy = 0;
-
-        layout.gridy++;
-        panel.add(chkUseAttributes, layout);
-
-        layout.gridx++;
-        panel.add(chkRandomizeTraits, layout);
-
-        layout.gridx = 0;
-        layout.gridy++;
-        panel.add(chkRandomizeAttributes, layout);
-
-        return panel;
     }
 
     /**
@@ -861,7 +817,6 @@ public class AdvancementTab {
         pnlArtillery = createArtilleryPanel();
         pnlSmallArms = createSmallArmsPanel();
         pnlSecondarySkills = createSecondarySkillPanel();
-        pnlATOWAttributes = createATOWAttributesPanel();
 
         // Layout the Panel
         final JPanel panel = new CampaignOptionsStandardPanel("SkillGroupsPanel");
@@ -878,10 +833,6 @@ public class AdvancementTab {
         panel.add(pnlArtillery, layout);
         layout.gridx++;
         panel.add(pnlSmallArms, layout);
-
-        layout.gridx = 0;
-        layout.gridy++;
-        panel.add(pnlATOWAttributes, layout);
 
         return panel;
     }
@@ -1268,9 +1219,6 @@ public class AdvancementTab {
 
         //start Skill Randomization Tab
         chkExtraRandomness.setSelected(skillPreferences.randomizeSkill());
-        chkUseAttributes.setSelected(skillPreferences.isUseAttributes());
-        chkRandomizeAttributes.setSelected(skillPreferences.isRandomizeAttributes());
-        chkRandomizeTraits.setSelected(skillPreferences.isRandomizeTraits());
         final int[] phenotypeProbabilities = options.getPhenotypeProbabilities();
         for (int i = 0; i < phenotypeSpinners.length; i++) {
             phenotypeSpinners[i].setValue(phenotypeProbabilities[i]);
@@ -1366,9 +1314,6 @@ public class AdvancementTab {
 
         //start Skill Randomization Tab
         skillPreferences.setRandomizeSkill(chkExtraRandomness.isSelected());
-        skillPreferences.setUseAttributes(chkUseAttributes.isSelected());
-        skillPreferences.setRandomizeAttributes(chkRandomizeAttributes.isSelected());
-        skillPreferences.setRandomizeTraits(chkRandomizeTraits.isSelected());
         for (int i = 0; i < phenotypeSpinners.length; i++) {
             options.setPhenotypeProbability(i, (int) phenotypeSpinners[i].getValue());
         }

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -119,6 +119,9 @@ public class BiographyTab {
     private JCheckBox chkShowLifeEventDialogBirths;
     private JCheckBox chkShowLifeEventDialogComingOfAge;
     private JCheckBox chkShowLifeEventDialogCelebrations;
+    private JPanel pnlComingOfAge;
+    private JCheckBox chkComingOfAgeSPAs;
+    private JCheckBox chkRewardComingOfAgeRPSkills;
     //end General Tab
 
     //start Backgrounds Tab
@@ -392,6 +395,10 @@ public class BiographyTab {
         chkShowLifeEventDialogBirths = new JCheckBox();
         chkShowLifeEventDialogComingOfAge = new JCheckBox();
         chkShowLifeEventDialogCelebrations = new JCheckBox();
+
+        pnlComingOfAge = new JPanel();
+        chkComingOfAgeSPAs = new JCheckBox();
+        chkRewardComingOfAgeRPSkills = new JCheckBox();
     }
 
     /**
@@ -451,6 +458,8 @@ public class BiographyTab {
 
         pnlLifeEvents = createLifeEventsPanel();
 
+        pnlComingOfAge = createComingOfAgePanel();
+
         // Layout the Panel
         final JPanel panelLeft = new CampaignOptionsStandardPanel("BiographyGeneralTabLeft", true);
         final GridBagConstraints layoutLeft = new CampaignOptionsGridBagConstraints(panelLeft);
@@ -492,12 +501,12 @@ public class BiographyTab {
         layoutParent.gridy++;
         layoutParent.gridwidth = 1;
         panelParent.add(panelLeft, layoutParent);
-        layoutParent.gridx++;
-        panelParent.add(pnlAnniversariesPanel, layoutParent);
 
         layoutParent.gridx = 0;
         layoutParent.gridy++;
         panelParent.add(pnlLifeEvents, layoutParent);
+        layoutParent.gridx++;
+        panelParent.add(pnlComingOfAge, layoutParent);
 
         // Create Parent Panel and return
         return createParentPanel(panelParent, "BiographyGeneralTab");
@@ -572,6 +581,30 @@ public class BiographyTab {
         layoutParent.gridx = 0;
         layoutParent.gridy++;
         panel.add(chkShowLifeEventDialogCelebrations, layoutParent);
+
+        return panel;
+    }
+
+    private JPanel createComingOfAgePanel() {
+        // Contents
+        chkComingOfAgeSPAs = new CampaignOptionsCheckBox("ComingOfAgeAbilities");
+        chkComingOfAgeSPAs.addMouseListener(createTipPanelUpdater(generalHeader, "ComingOfAgeAbilities"));
+
+        chkRewardComingOfAgeRPSkills = new CampaignOptionsCheckBox("ComingOfAgeRPSkills");
+        chkRewardComingOfAgeRPSkills.addMouseListener(createTipPanelUpdater(generalHeader,
+              "ComingOfAgeRPSkills"));
+
+        // Layout the Panel
+        final JPanel panel = new CampaignOptionsStandardPanel("LifeEventsPanel", true, "LifeEventsPanel");
+        final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
+
+        layoutParent.gridwidth = 1;
+        layoutParent.gridx = 0;
+        layoutParent.gridy = 0;
+        panel.add(chkComingOfAgeSPAs, layoutParent);
+
+        layoutParent.gridy++;
+        panel.add(chkRewardComingOfAgeRPSkills, layoutParent);
 
         return panel;
     }
@@ -1500,6 +1533,8 @@ public class BiographyTab {
         chkShowLifeEventDialogBirths.setSelected(options.isShowLifeEventDialogBirths());
         chkShowLifeEventDialogComingOfAge.setSelected(options.isShowLifeEventDialogComingOfAge());
         chkShowLifeEventDialogCelebrations.setSelected(options.isShowLifeEventDialogCelebrations());
+        chkComingOfAgeSPAs.setSelected(options.isRewardComingOfAgeAbilities());
+        chkRewardComingOfAgeRPSkills.setSelected(options.isRewardComingOfAgeRPSkills());
 
         // Backgrounds
         chkUseRandomPersonalities.setSelected(options.isUseRandomPersonalities());
@@ -1599,6 +1634,8 @@ public class BiographyTab {
         options.setShowLifeEventDialogBirths(chkShowLifeEventDialogBirths.isSelected());
         options.setShowLifeEventDialogComingOfAge(chkShowLifeEventDialogComingOfAge.isSelected());
         options.setShowLifeEventDialogCelebrations(chkShowLifeEventDialogCelebrations.isSelected());
+        options.setRewardComingOfAgeAbilities(chkComingOfAgeSPAs.isSelected());
+        options.setRewardComingOfAgeRPSkills(chkRewardComingOfAgeRPSkills.isSelected());
 
         // Backgrounds
         options.setUseRandomPersonalities(chkUseRandomPersonalities.isSelected());

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -595,7 +595,7 @@ public class BiographyTab {
               "ComingOfAgeRPSkills"));
 
         // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("LifeEventsPanel", true, "LifeEventsPanel");
+        final JPanel panel = new CampaignOptionsStandardPanel("ComingOfAgePanel", true, "ComingOfAgePanel");
         final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
 
         layoutParent.gridwidth = 1;

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/FinancesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/FinancesTab.java
@@ -83,7 +83,6 @@ public class FinancesTab {
     private MMComboBox<FinancialYearDuration> comboFinancialYearDuration;
     private JCheckBox newFinancialYearFinancesToCSVExportBox;
     private JCheckBox chkSimulateGrayMonday;
-    private JCheckBox chkAllowMonthlyReinvestment;
 
     private JPanel pnlPayments;
     private JCheckBox payForPartsBox;
@@ -192,7 +191,6 @@ public class FinancesTab {
         newFinancialYearFinancesToCSVExportBox = new JCheckBox();
 
         chkSimulateGrayMonday = new JCheckBox();
-        chkAllowMonthlyReinvestment = new JCheckBox();
 
         // Payments
         pnlPayments = new JPanel();
@@ -408,9 +406,6 @@ public class FinancesTab {
 
         chkSimulateGrayMonday = new CampaignOptionsCheckBox("SimulateGrayMonday");
         chkSimulateGrayMonday.addMouseListener(createTipPanelUpdater(financesGeneralOptions, "SimulateGrayMonday"));
-        chkAllowMonthlyReinvestment = new CampaignOptionsCheckBox("AllowMonthlyReinvestment");
-        chkAllowMonthlyReinvestment.addMouseListener(createTipPanelUpdater(financesGeneralOptions,
-              "AllowMonthlyReinvestment"));
 
         // Layout the Panel
         final JPanel panel = new CampaignOptionsStandardPanel("GeneralOptionsPanel");
@@ -446,9 +441,6 @@ public class FinancesTab {
 
         layout.gridy++;
         panel.add(chkSimulateGrayMonday, layout);
-
-        layout.gridy++;
-        panel.add(chkAllowMonthlyReinvestment, layout);
 
         return panel;
     }
@@ -864,7 +856,6 @@ public class FinancesTab {
         options.setFinancialYearDuration(comboFinancialYearDuration.getSelectedItem());
         options.setNewFinancialYearFinancesToCSVExport(newFinancialYearFinancesToCSVExportBox.isSelected());
         options.setSimulateGrayMonday(chkSimulateGrayMonday.isSelected());
-        options.setAllowMonthlyReinvestment(chkAllowMonthlyReinvestment.isSelected());
         options.setPayForParts(payForPartsBox.isSelected());
         options.setPayForRepairs(payForRepairsBox.isSelected());
         options.setPayForUnits(payForUnitsBox.isSelected());
@@ -932,7 +923,6 @@ public class FinancesTab {
         comboFinancialYearDuration.setSelectedItem(options.getFinancialYearDuration());
         newFinancialYearFinancesToCSVExportBox.setSelected(options.isNewFinancialYearFinancesToCSVExport());
         chkSimulateGrayMonday.setSelected(options.isSimulateGrayMonday());
-        chkAllowMonthlyReinvestment.setSelected(options.isAllowMonthlyReinvestment());
         payForPartsBox.setSelected(options.isPayForParts());
         payForRepairsBox.setSelected(options.isPayForRepairs());
         payForUnitsBox.setSelected(options.isPayForUnits());

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
@@ -284,7 +284,6 @@ public class MarketsTab {
         // Contents
         lblPersonnelMarketStyle = new CampaignOptionsLabel("PersonnelMarketStyle");
         lblPersonnelMarketStyle.addMouseListener(createTipPanelUpdater(personnelMarketHeader, "PersonnelMarketStyle"));
-        comboPersonnelMarketStyle = new MMComboBox<>("comboPersonnelMarketStyle", PersonnelMarketStyle.values());
         comboPersonnelMarketStyle.addMouseListener(createTipPanelUpdater(personnelMarketHeader,
                 "PersonnelMarketStyle"));
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
@@ -246,7 +246,7 @@ public class MarketsTab {
     public JPanel createPersonnelMarketTab() {
         // Header
         personnelMarketHeader = new CampaignOptionsHeaderPanel("PersonnelMarketTab",
-              getImageDirectory() + "logo_st_ives_compact.png", 3);
+                getImageDirectory() + "logo_st_ives_compact.png", 11);
 
         // Contents
         pnlPersonnelMarketGeneralOptions = createPersonnelMarketGeneralOptionsPanel();
@@ -283,6 +283,10 @@ public class MarketsTab {
     private JPanel createPersonnelMarketGeneralOptionsPanel() {
         // Contents
         lblPersonnelMarketStyle = new CampaignOptionsLabel("PersonnelMarketStyle");
+        lblPersonnelMarketStyle.addMouseListener(createTipPanelUpdater(personnelMarketHeader, "PersonnelMarketStyle"));
+        comboPersonnelMarketStyle = new MMComboBox<>("comboPersonnelMarketStyle", PersonnelMarketStyle.values());
+        comboPersonnelMarketStyle.addMouseListener(createTipPanelUpdater(personnelMarketHeader,
+                "PersonnelMarketStyle"));
 
         lblPersonnelMarketType = new CampaignOptionsLabel("PersonnelMarketType");
         lblPersonnelMarketType.addMouseListener(createTipPanelUpdater(personnelMarketHeader, "PersonnelMarketType"));

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SystemsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SystemsTab.java
@@ -392,10 +392,10 @@ public class SystemsTab {
     }
 
     /**
-     * Creates the Faction Standing tab panel, containing grouped UI elements for Faction Standing options and its
+     * Creates the ATOW tab panel, containing grouped UI elements for configuring ATOW-related options and its
      * header.
      *
-     * @return a {@link JPanel} component representing the entire Faction Standing tab UI
+     * @return a {@link JPanel} component representing the entire ATOW tab UI
      *
      * @author Illiani
      * @since 0.50.07

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SystemsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SystemsTab.java
@@ -48,6 +48,7 @@ import megamek.client.ui.comboBoxes.MMComboBox;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignOptions;
+import mekhq.campaign.personnel.skills.RandomSkillPreferences;
 import mekhq.campaign.rating.UnitRatingMethod;
 import mekhq.gui.campaignOptions.components.CampaignOptionsCheckBox;
 import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
@@ -70,6 +71,7 @@ import mekhq.gui.campaignOptions.components.CampaignOptionsStandardPanel;
 public class SystemsTab {
     private final Campaign campaign;
     private final CampaignOptions campaignOptions;
+    private final RandomSkillPreferences randomSkillPreferences;
 
     // Reputation Tab
     private CampaignOptionsHeaderPanel reputationHeader;
@@ -102,6 +104,15 @@ public class SystemsTab {
     private JCheckBox chkUseFactionStandingContractPay;
     private JCheckBox chkUseFactionStandingSupportPoints;
 
+    // A Time of War Tab
+    private CampaignOptionsHeaderPanel atowHeader;
+
+    private JPanel pnlATOWAttributes;
+    private JCheckBox chkUseAttributes;
+    private JCheckBox chkRandomizeAttributes;
+    private JCheckBox chkRandomizeTraits;
+    private JCheckBox chkAllowMonthlyReinvestment;
+
     /**
      * Constructs a new {@code SystemsTab} for the specified campaign.
      *
@@ -113,6 +124,7 @@ public class SystemsTab {
     public SystemsTab(Campaign campaign) {
         this.campaign = campaign;
         this.campaignOptions = campaign.getCampaignOptions();
+        this.randomSkillPreferences = campaign.getRandomSkillPreferences();
     }
 
     /**
@@ -380,6 +392,79 @@ public class SystemsTab {
     }
 
     /**
+     * Creates the Faction Standing tab panel, containing grouped UI elements for Faction Standing options and its
+     * header.
+     *
+     * @return a {@link JPanel} component representing the entire Faction Standing tab UI
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public JPanel createATOWTab() {
+        // Header
+        atowHeader = new CampaignOptionsHeaderPanel("ATimeOfWarTab",
+              getImageDirectory() + "logo_elysian_fields.png",
+              9);
+
+        // Contents
+        pnlATOWAttributes = createATOWAttributesPanel();
+
+        // Layout the Panel
+        final JPanel panel = new CampaignOptionsStandardPanel("ATimeOfWarTab", true);
+        final GridBagConstraints layoutParent = new CampaignOptionsGridBagConstraints(panel);
+
+        layoutParent.gridwidth = 5;
+        layoutParent.gridx = 0;
+        layoutParent.gridy = 0;
+        panel.add(atowHeader, layoutParent);
+
+        layoutParent.gridy++;
+        layoutParent.gridwidth = 1;
+        panel.add(pnlATOWAttributes, layoutParent);
+
+        // Create Parent Panel and return
+        return createParentPanel(panel, "ATimeOfWarTab");
+    }
+
+    /**
+     * Creates and returns the ATOW panel, which allows users to configure settings for attribute and traits
+     * probabilities.
+     *
+     * @return A {@code JPanel} containing configuration options for phenotype probabilities.
+     */
+    private JPanel createATOWAttributesPanel() {
+        // Contents
+        chkUseAttributes = new CampaignOptionsCheckBox("UseAttributes");
+        chkUseAttributes.addMouseListener(createTipPanelUpdater(atowHeader, "UseAttributes"));
+        chkRandomizeAttributes = new CampaignOptionsCheckBox("RandomizeAttributes");
+        chkRandomizeAttributes.addMouseListener(createTipPanelUpdater(atowHeader, "RandomizeAttributes"));
+        chkRandomizeTraits = new CampaignOptionsCheckBox("RandomizeTraits");
+        chkRandomizeTraits.addMouseListener(createTipPanelUpdater(atowHeader, "RandomizeTraits"));
+        chkAllowMonthlyReinvestment = new CampaignOptionsCheckBox("AllowMonthlyReinvestment");
+        chkAllowMonthlyReinvestment.addMouseListener(createTipPanelUpdater(atowHeader,
+              "AllowMonthlyReinvestment"));
+
+        final JPanel panel = new CampaignOptionsStandardPanel("ATOWAttributesPanel", true, "ATOWAttributesPanel");
+        final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
+        layout.gridwidth = 1;
+        layout.gridx = 0;
+        layout.gridy = 0;
+
+        layout.gridy++;
+        panel.add(chkUseAttributes, layout);
+        layout.gridx++;
+        panel.add(chkRandomizeAttributes, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(chkRandomizeTraits, layout);
+        layout.gridx++;
+        panel.add(chkAllowMonthlyReinvestment, layout);
+
+        return panel;
+    }
+
+    /**
      * Loads values from the current campaign or an optional preset campaign options into the UI components, updating
      * their states to match the data.
      *
@@ -387,7 +472,7 @@ public class SystemsTab {
      * @since 0.50.07
      */
     public void loadValuesFromCampaignOptions() {
-        loadValuesFromCampaignOptions(null);
+        loadValuesFromCampaignOptions(null, null);
     }
 
     /**
@@ -396,14 +481,22 @@ public class SystemsTab {
      *
      * @param presetCampaignOptions an alternative {@link CampaignOptions}, or {@code null} to use the current
      *                              campaign's options
+     * @param presetRandomSkillPreferences Optional {@code RandomSkillPreferences} object to load values from; if
+     *                                     {@code null}, values are loaded from the current skill preferences.
      *
      * @author Illiani
      * @since 0.50.07
      */
-    public void loadValuesFromCampaignOptions(@Nullable CampaignOptions presetCampaignOptions) {
+    public void loadValuesFromCampaignOptions(@Nullable CampaignOptions presetCampaignOptions,
+          @Nullable RandomSkillPreferences presetRandomSkillPreferences) {
         CampaignOptions options = presetCampaignOptions;
         if (presetCampaignOptions == null) {
             options = this.campaignOptions;
+        }
+
+        RandomSkillPreferences skillPreferences = presetRandomSkillPreferences;
+        if (skillPreferences == null) {
+            skillPreferences = this.randomSkillPreferences;
         }
 
         // Reputation
@@ -426,6 +519,12 @@ public class SystemsTab {
         chkUseFactionStandingUnitMarket.setSelected(options.isUseFactionStandingUnitMarket());
         chkUseFactionStandingContractPay.setSelected(options.isUseFactionStandingContractPay());
         chkUseFactionStandingSupportPoints.setSelected(options.isUseFactionStandingSupportPoints());
+
+        // A Time of War
+        chkUseAttributes.setSelected(skillPreferences.isUseAttributes());
+        chkRandomizeAttributes.setSelected(skillPreferences.isRandomizeAttributes());
+        chkRandomizeTraits.setSelected(skillPreferences.isRandomizeTraits());
+        chkAllowMonthlyReinvestment.setSelected(options.isAllowMonthlyReinvestment());
     }
 
     /**
@@ -434,14 +533,22 @@ public class SystemsTab {
      *
      * @param presetCampaignOptions an alternative {@link CampaignOptions} object to update, or {@code null} to update
      *                              the campaign's own options
+     * @param presetRandomSkillPreferences Optional {@code RandomSkillPreferences} object to set values to; if
+     *                                     {@code null}, values are applied to the current skill preferences.
      *
      * @author Illiani
      * @since 0.50.07
      */
-    public void applyCampaignOptionsToCampaign(@Nullable CampaignOptions presetCampaignOptions) {
+    public void applyCampaignOptionsToCampaign(@Nullable CampaignOptions presetCampaignOptions,
+          @Nullable RandomSkillPreferences presetRandomSkillPreferences) {
         CampaignOptions options = presetCampaignOptions;
         if (presetCampaignOptions == null) {
             options = this.campaignOptions;
+        }
+
+        RandomSkillPreferences skillPreferences = presetRandomSkillPreferences;
+        if (skillPreferences == null) {
+            skillPreferences = this.randomSkillPreferences;
         }
 
         // Reputation
@@ -470,5 +577,11 @@ public class SystemsTab {
         options.setUseFactionStandingUnitMarket(chkUseFactionStandingUnitMarket.isSelected());
         options.setUseFactionStandingContractPay(chkUseFactionStandingContractPay.isSelected());
         options.setUseFactionStandingSupportPoints(chkUseFactionStandingSupportPoints.isSelected());
+
+        // A Time of War
+        skillPreferences.setUseAttributes(chkUseAttributes.isSelected());
+        skillPreferences.setRandomizeAttributes(chkRandomizeAttributes.isSelected());
+        skillPreferences.setRandomizeTraits(chkRandomizeTraits.isSelected());
+        options.setAllowMonthlyReinvestment(chkAllowMonthlyReinvestment.isSelected());
     }
 }


### PR DESCRIPTION
With the recent push for more ATOW content - and our future plans - it made sense to move the existing ATOW options to their own tab and also to prep for additional options.

While I was doing this I also stumbled across two bugs:
- The color of the 'new option' iconography for Campaign Options was the wrong color
- The new personnel market wasn't hooked up to the tooltip panel.