### PR TITLE
Improvement: Expanded Functionality of the Connections Trait Based on ATOW

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1412,6 +1412,11 @@ lblAllowMonthlyReinvestment.tooltip=Each month the campaign commander will use t
   \ reinvest money back into the campaign.\
   <br>\
   <br>This is based on the Wealth Trait Check rules from the A Time of War:Companion.
+lblAllowMonthlyConnections.text=Allow Monthly Connections Checks
+lblAllowMonthlyConnections.tooltip=Each month the campaign commander will use their Connections trait to\
+  \ generate money for the campaign. If the new Personnel Market is enabled, Connections will also be used to increase\
+  \ the number of recruits each month. A check can result in the character temporarily losing their levels in \
+  Connections. See the Glossary for more information.
 reputationTab.title=Reputation
 lblReputationTab.text=Reputation Options
 reputationTab.border="Reputation opens doors\u2014or gets them slammed in your face. In this business, it's as\

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -83,11 +83,11 @@ AUTOINFIRMARY.definition=AutoInfirmary lets you instantly assign all injured per
  \ (unless that alert has been disabled in MekHQ Options).</p>
 ### B
 BLOODMARK.title=Bloodmark
-BLOODMARK.definition=Bloodmarks are a type of <a href='GLOSSARY:ATOW_TRAITS'>Trait</a>. The higher a character''s \
+BLOODMARK.definition=Bloodmarks are a type of <a href='GLOSSARY:ATOW_TRAITS'>Trait</a>. The higher a character's \
   'Bloodmark' the greater the chance a 'Bloodhunt' occurs. When this happens, a bounty hunter will make an attempt on \
-  the character''s life. This may result in them escaping, getting injured, or even being killed.\
+  the character's life. This may result in them escaping, getting injured, or even being killed.\
   <p>Bloodhunt frequencies can be found in the 'Bloodmark' section of <b>A Time of War</b>. Purchasing the \
-  ''Alternative ID'' SPA halves the chance of a Bloodhunt occurring.</p>
+  'Alternative ID' SPA halves the chance of a Bloodhunt occurring.</p>
 ### C
 CAPITAL_SYSTEMS.title=Capital Systems
 CAPITAL_SYSTEMS.definition=On the interstellar map, a faction's capital system is marked by a special ring. Each faction\
@@ -178,6 +178,56 @@ COMPLETE_MISSION_GUIDANCE.definition=When you select 'Complete Mission,' you are
  <br>- <b>Failure</b>: if all Strategic Objectives were failed, the contract is a failure.\
  <br>- <b>Contract Breach</b>: if you're ending the contract early but haven't completed all Strategic Objectives, it\
  \ should count as a Contract Breach. Avoid doing this where possible.</p>
+CONNECTIONS.title=Connections
+CONNECTIONS.definition=Connections are a type of <a href='GLOSSARY:ATOW_TRAITS'>Trait</a> that applies multiple \
+  benefits if the character is the campaign commander.\
+  <h2>Force Reputation</h2>\
+  <p>The unit's <a href='GLOSSARY:FORCE_REPUTATION'>Force Reputation</a> is increased by however many points the \
+  commander has in Connections.</p>\
+  <h2>Monthly Checks</h2>\
+  <p>If monthly Connections rolls are enabled in Campaign Options, each month the commander will make roll 2d6, on \
+  4+ the commander's contacts will donate funds to the campaign.</p>\
+  <p>The amount of funds donated is based on the character's Connections score:</p>\
+  <p>- <b>1:</b> 1,000 C-Bills\
+  <br>- <b>2:</b> 2,500 C-Bills\
+  <br>- <b>3:</b> 5,000 C-Bills\
+  <br>- <b>4:</b> 10,000 C-Bills\
+  <br>- <b>5:</b> 25,000 C-Bills\
+  <br>- <b>6:</b> 50,000 C-Bills\
+  <br>- <b>7:</b> 100,000 C-Bills\
+  <br>- <b>8:</b> 250,000 C-Bills\
+  <br>- <b>9:</b> 500,000 C-Bills\
+  <br>- <b>10:</b> 1,000,000 C-Bills</p>\
+  <p>Furthermore, if both monthly rolls and the new Personnel Market are enabled, each month the commander will make \
+  roll 2d6. On a 4+ the commander's contacts will hook them up with additional recruits in the personnel market. \
+  This will increase the chance of seeing rare personnel, such as Elite characters or characters with unusual \
+  professions.</p>\
+  <p>The number of recruits added to the market is based on the character's Connections score:</p>\
+  <p>- <b>1:</b> 0 recruits\
+  <br>- <b>2:</b> 0 recruits\
+  <br>- <b>3:</b> 0 recruits\
+  <br>- <b>4:</b> 1 recruits\
+  <br>- <b>5:</b> 2 recruits\
+  <br>- <b>6:</b> 3 recruits\
+  <br>- <b>7:</b> 4 recruits\
+  <br>- <b>8:</b> 6 recruits\
+  <br>- <b>9:</b> 7 recruits\
+  <br>- <b>10:</b> 10 recruits</p>\
+  <p>Finally, each month a check is made to determine if the character loses contact with their Connections. If the \
+  character loses contact, they temporarily lose all levels in Connections for d6 months. This could reflect \
+  something happening to the character's contact, the contact just not being available, or the contact not being \
+  willing to extend support to the campaign.</p>\
+  <p>The chance of losing access to a character's contacts is based on the character's Connections score:</p>\
+  <p>- <b>1:</b> 7 or less on 2d6\
+  <br>- <b>2:</b> 7 or less on 2d6\
+  <br>- <b>3:</b> 6 or less on 2d6\
+  <br>- <b>4:</b> 6 or less on 2d6\
+  <br>- <b>5:</b> 5 or less on 2d6\
+  <br>- <b>6:</b> 5 or less on 2d6\
+  <br>- <b>7:</b> 4 or less on 2d6\
+  <br>- <b>8:</b> 4 or less on 2d6\
+  <br>- <b>9:</b> 3 or less on 2d6\
+  <br>- <b>10:</b> 3 or less on 2d6</p>
 CONTRACT_VICTORY_POINTS.title=Contract Victory Points
 CONTRACT_VICTORY_POINTS.definition=Contract Victory Points (CVP) represent an abstract measure of your contract's overall\
   \ strategic success. Most contracts require a positive CVP to be considered\

--- a/MekHQ/resources/mekhq/resources/Personnel.properties
+++ b/MekHQ/resources/mekhq/resources/Personnel.properties
@@ -469,6 +469,10 @@ compulsion.regression=%s suffered a %s<b>Personality Break</b>%s. They have regr
 compulsion.catatonia=%s suffered a %s<b>Personality Break</b>%s. They've entered a catatonic state.
 compulsion.berserker=%s suffered a %s<b>Personality Break</b>%s. They lashed out in a berserker fury, hurting \
   themselves and any nearby characters.
+connections.reestablished=%s has %s<b>Reestablished Contact</b>%s with their <b>Connections</b>.
+connections.burned=%s has %s<b>Lost Contact</b>%s with their <b>Connections</b>.
+connections.wealth=%s has received a %s<b>Generous Donation</b>%s of %s C-Bills from their <b>Connections</b>.
+connections.transaction=A generous donation.
 # Loading Errors
 ineligibleForPrimaryRole=%s<b>WARNING:</b>%s %s was found to be ineligible for their <b>Primary</b> role. That role has\
   \ been removed, and they were assigned the <b>NONE</b> role. If the last time you saved this campaign predates 49.19.01,\

--- a/MekHQ/resources/mekhq/resources/PersonnelMarket.properties
+++ b/MekHQ/resources/mekhq/resources/PersonnelMarket.properties
@@ -30,3 +30,5 @@ hint.personnelMarket.noInterest=<html>{0}<b>Unable to Recruit{1}:</b> No Local I
 hint.personnelMarket.onContract=<html>{0}<b>Unable to Recruit{1}:</b> On Military Maneuvers.</html>
 # Other
 hyperlink.personnelMarket.report=<a href='PERSONNEL_MARKET'>Personnel Market Updated</a>
+connections.recruits={0} was able to leverage their <b>Connections</b> to link up with {1} {2}<b>Additional \
+  Recruits</b>{3}.

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5941,16 +5941,16 @@ public class Campaign implements ITechManager {
 
         location.newDay(this);
 
+        updateFieldKitchenCapacity();
+
+        processNewDayPersonnel();
+
         // Manage the Markets
         refreshPersonnelMarkets();
 
         // TODO : AbstractContractMarket : Uncomment
         // getContractMarket().processNewDay(this);
         unitMarket.processNewDay(this);
-
-        updateFieldKitchenCapacity();
-
-        processNewDayPersonnel();
 
         // Needs to be before 'processNewDayATB' so that Dependents can't leave the
         // moment they arrive via AtB Bonus Events

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -484,6 +484,7 @@ public class CampaignOptions {
     private boolean newFinancialYearFinancesToCSVExport;
     private boolean simulateGrayMonday;
     private boolean allowMonthlyReinvestment;
+    private boolean allowMonthlyConnections;
 
     // Price Multipliers
     private double commonPartPriceMultiplier;
@@ -1108,6 +1109,7 @@ public class CampaignOptions {
         newFinancialYearFinancesToCSVExport = false;
         simulateGrayMonday = false;
         allowMonthlyReinvestment = false;
+        allowMonthlyConnections = false;
 
         // Price Multipliers
         setCommonPartPriceMultiplier(1.0);
@@ -3497,6 +3499,14 @@ public class CampaignOptions {
         this.allowMonthlyReinvestment = allowMonthlyReinvestment;
     }
 
+    public boolean isAllowMonthlyConnections() {
+        return allowMonthlyConnections;
+    }
+
+    public void setAllowMonthlyConnections(final boolean allowMonthlyConnections) {
+        this.allowMonthlyConnections = allowMonthlyConnections;
+    }
+
     // region Price Multipliers
     public double getCommonPartPriceMultiplier() {
         return commonPartPriceMultiplier;
@@ -5409,6 +5419,7 @@ public class CampaignOptions {
               newFinancialYearFinancesToCSVExport);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "simulateGrayMonday", simulateGrayMonday);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "allowMonthlyReinvestment", allowMonthlyReinvestment);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "allowMonthlyConnections", allowMonthlyConnections);
 
         // region Price Multipliers
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "commonPartPriceMultiplier", getCommonPartPriceMultiplier());
@@ -6425,6 +6436,8 @@ public class CampaignOptions {
                     campaignOptions.simulateGrayMonday = Boolean.parseBoolean(nodeContents);
                 } else if (nodeName.equalsIgnoreCase("allowMonthlyReinvestment")) {
                     campaignOptions.allowMonthlyReinvestment = Boolean.parseBoolean(nodeContents);
+                } else if (nodeName.equalsIgnoreCase("allowMonthlyConnections")) {
+                    campaignOptions.allowMonthlyConnections = Boolean.parseBoolean(nodeContents);
 
                     // region Price Multipliers
                 } else if (nodeName.equalsIgnoreCase("commonPartPriceMultiplier")) {

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
@@ -273,6 +273,8 @@ public class NewPersonnelMarket {
             int additionalRecruitRolls = connectionsLevel.getRecruits();
             if (additionalRecruitRolls > 0) {
                 int roll = d6(2);
+                logger.info("Rolling to use connections to get extra recruits {} {} vs. {}",
+                      commander.getFullTitle(), roll, CONNECTIONS_TARGET_NUMBER);
                 if (roll >= CONNECTIONS_TARGET_NUMBER) {
                     campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE, "connections.recruits",
                             commander.getHyperlinkedFullTitle(), additionalRecruitRolls,

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketCamOpsRevised.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketCamOpsRevised.java
@@ -175,7 +175,7 @@ public class PersonnelMarketCamOpsRevised extends NewPersonnelMarket {
         int rolls = getToday().getMonth().length(getToday().isLeapYear());
 
         if (getCampaign().getCampaignOptions().isAllowMonthlyConnections()) {
-            int additionalRecruits = performConnectionsRecruitsCheck(getToday());
+            int additionalRecruits = performConnectionsRecruitsCheck();
             rolls += additionalRecruits;
         }
 

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketCamOpsRevised.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketCamOpsRevised.java
@@ -173,6 +173,12 @@ public class PersonnelMarketCamOpsRevised extends NewPersonnelMarket {
      */
     private void calculateNumberOfRecruitmentRolls() {
         int rolls = getToday().getMonth().length(getToday().isLeapYear());
+
+        if (getCampaign().getCampaignOptions().isAllowMonthlyConnections()) {
+            int additionalRecruits = performConnectionsRecruitsCheck(getToday());
+            rolls += additionalRecruits;
+        }
+
         setRecruitmentRolls(rolls);
     }
 }

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -337,7 +337,7 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
         }
 
         if (campaignOptions.isAllowMonthlyConnections()) {
-            int additionalRecruits = performConnectionsRecruitsCheck(getToday());
+            int additionalRecruits = performConnectionsRecruitsCheck();
             rolls += additionalRecruits;
         }
 

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -54,6 +54,7 @@ import megamek.common.Compute;
 import megamek.common.enums.Gender;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.CampaignOptions;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.market.personnelMarket.records.PersonnelMarketEntry;
 import mekhq.campaign.market.personnelMarket.yaml.PersonnelMarketLibraries;
@@ -330,8 +331,14 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
         rolls = clamp((int) round(rolls * getSystemPopulationRecruitmentMultiplier()), 1, rolls);
         getLogger().debug("Rolls modified for population: {}", rolls);
 
-        if (getCampaign().getCampaignOptions().isUseFactionStandingRecruitmentSafe()) {
+        CampaignOptions campaignOptions = getCampaign().getCampaignOptions();
+        if (campaignOptions.isUseFactionStandingRecruitmentSafe()) {
             rolls += getFactionStandingsRecruitmentModifier();
+        }
+
+        if (campaignOptions.isAllowMonthlyConnections()) {
+            int additionalRecruits = performConnectionsRecruitsCheck(getToday());
+            rolls += additionalRecruits;
         }
 
         setRecruitmentRolls(rolls);

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -358,6 +358,7 @@ public class Person {
     private Reasoning storedReasoning;
     private int storedReasoningDescriptionIndex;
     private boolean sufferingFromClinicalParanoia;
+    private LocalDate burnedConnectionsEndDate;
     // endregion Compulsions
 
     // region Flags
@@ -567,6 +568,7 @@ public class Person {
         storedReasoning = Reasoning.AVERAGE;
         storedReasoningDescriptionIndex = 0;
         sufferingFromClinicalParanoia = false;
+        burnedConnectionsEndDate = null;
 
         // This assigns minutesLeft and overtimeLeft. Must be after skills to avoid an NPE.
         if (campaign != null) {
@@ -2663,6 +2665,14 @@ public class Person {
         this.sufferingFromClinicalParanoia = sufferingFromClinicalParanoia;
     }
 
+    public @Nullable LocalDate getBurnedConnectionsEndDate() {
+        return burnedConnectionsEndDate;
+    }
+
+    public void setBurnedConnectionsEndDate(final @Nullable LocalDate burnedConnectionsEndDate) {
+        this.burnedConnectionsEndDate = burnedConnectionsEndDate;
+    }
+
     // region Flags
     public boolean isClanPersonnel() {
         return clanPersonnel;
@@ -3239,6 +3249,13 @@ public class Person {
                       sufferingFromClinicalParanoia);
             }
 
+            if (burnedConnectionsEndDate != null) {
+                MHQXMLUtility.writeSimpleXMLTag(pw,
+                      indent,
+                      "burnedConnectionsEndDate",
+                      burnedConnectionsEndDate);
+            }
+
             // region Flags
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "clanPersonnel", isClanPersonnel());
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "commander", commander);
@@ -3777,6 +3794,8 @@ public class Person {
                     person.storedReasoningDescriptionIndex = MathUtility.parseInt(wn2.getTextContent().trim());
                 } else if (nodeName.equalsIgnoreCase("sufferingFromClinicalParanoia")) {
                     person.setSufferingFromClinicalParanoia(Boolean.parseBoolean(wn2.getTextContent().trim()));
+                } else if (nodeName.equalsIgnoreCase("burnedConnectionsEndDate")) {
+                    person.setBurnedConnectionsEndDate(LocalDate.parse(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("clanPersonnel")) {
                     person.setClanPersonnel(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("commander")) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -176,7 +176,7 @@ public class Person {
     public static final int MINIMUM_BLOODMARK = 0;
     public static final int MAXIMUM_BLOODMARK = 5;
 
-    public static final int CONNECTIONS_TARGET_NUMBER = 10;
+    public static final int CONNECTIONS_TARGET_NUMBER = 4; // Arbitary value
 
     private static final String DELIMITER = "::";
 
@@ -387,7 +387,7 @@ public class Person {
 
     private final static ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
           MekHQ.getMHQOptions().getLocale());
-    private static final MMLogger logger = MMLogger.create(Person.class);
+    private static final MMLogger LOGGER = MMLogger.create(Person.class);
 
     // initializes the AtB ransom values
     static {
@@ -3276,7 +3276,7 @@ public class Person {
                 extraData.writeToXml(pw);
             }
         } catch (Exception ex) {
-            logger.error(ex, "Failed to write {} to the XML File", getFullName());
+            LOGGER.error(ex, "Failed to write {} to the XML File", getFullName());
             throw ex; // we want to rethrow to ensure that the save fails
         }
         return indent;
@@ -3326,7 +3326,7 @@ public class Person {
                         }
                         person.originPlanet = p;
                     } catch (NullPointerException e) {
-                        logger.error("Error loading originPlanet for {}, {}", systemId, planetId, e);
+                        LOGGER.error("Error loading originPlanet for {}, {}", systemId, planetId, e);
                     }
                 } else if (nodeName.equalsIgnoreCase("becomingBondsmanEndDate")) {
                     person.becomingBondsmanEndDate = MHQXMLUtility.parseDate(wn2.getTextContent().trim());
@@ -3461,7 +3461,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("attemptDate")) {
-                            logger.error("(techUnitIds) Unknown node type not loaded in bloodhuntSchedule nodes: {}",
+                            LOGGER.error("(techUnitIds) Unknown node type not loaded in bloodhuntSchedule nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3486,7 +3486,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("id")) {
-                            logger.error("(techUnitIds) Unknown node type not loaded in techUnitIds nodes: {}",
+                            LOGGER.error("(techUnitIds) Unknown node type not loaded in techUnitIds nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3502,7 +3502,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            logger.error("(personnelLog) Unknown node type not loaded in personnel logEntry nodes: {}",
+                            LOGGER.error("(personnelLog) Unknown node type not loaded in personnel logEntry nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3569,7 +3569,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            logger.error("(medicalLog) Unknown node type not loaded in personnel logEntry nodes: {}",
+                            LOGGER.error("(medicalLog) Unknown node type not loaded in personnel logEntry nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3589,7 +3589,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            logger.error("Unknown node type not loaded in scenario logEntry nodes: {}",
+                            LOGGER.error("Unknown node type not loaded in scenario logEntry nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3609,7 +3609,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            logger.error("(assignmentLog) Unknown node type not loaded in scenario logEntry nodes: {}",
+                            LOGGER.error("(assignmentLog) Unknown node type not loaded in scenario logEntry nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3629,7 +3629,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("logEntry")) {
-                            logger.error("(performanceLog) Unknown node type not loaded in scenario logEntry nodes: {}",
+                            LOGGER.error("(performanceLog) Unknown node type not loaded in scenario logEntry nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3648,7 +3648,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("award")) {
-                            logger.error("Unknown node type not loaded in personnel award log nodes: {}",
+                            LOGGER.error("Unknown node type not loaded in personnel award log nodes: {}",
                                   wn3.getNodeName());
                             continue;
                         }
@@ -3666,7 +3666,7 @@ public class Person {
                         }
 
                         if (!wn3.getNodeName().equalsIgnoreCase("injury")) {
-                            logger.error("Unknown node type not loaded in injury nodes: {}", wn3.getNodeName());
+                            LOGGER.error("Unknown node type not loaded in injury nodes: {}", wn3.getNodeName());
                             continue;
                         }
                         person.injuries.add(Injury.generateInstanceFromXML(wn3));
@@ -3840,7 +3840,7 @@ public class Person {
                     try {
                         person.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        logger.warn("Error restoring advantage: {}", adv);
+                        LOGGER.warn("Error restoring advantage: {}", adv);
                     }
                 }
             }
@@ -3865,7 +3865,7 @@ public class Person {
                     try {
                         person.getOptions().getOption(advName).setValue(value);
                     } catch (Exception e) {
-                        logger.error("Error restoring implants: {}", adv);
+                        LOGGER.error("Error restoring implants: {}", adv);
                     }
                 }
             }
@@ -3899,7 +3899,7 @@ public class Person {
                       person.getHyperlinkedFullTitle()));
             }
         } catch (Exception e) {
-            logger.error(e, "Failed to read person {} from file", person.getFullName());
+            LOGGER.error(e, "Failed to read person {} from file", person.getFullName());
             person = null;
         }
 
@@ -4055,7 +4055,7 @@ public class Person {
                 retVal.getOptions().getOption(triggerName).setValue(value);
                 edgeOptionList.remove(triggerName);
             } catch (Exception e) {
-                logger.error("Error restoring edge trigger: {}", trigger);
+                LOGGER.error("Error restoring edge trigger: {}", trigger);
             }
         }
     }
@@ -4073,7 +4073,7 @@ public class Person {
             try {
                 retVal.getOptions().getOption(advName).setValue(false);
             } catch (Exception e) {
-                logger.error("Error disabling edge trigger: {}", edgeTrigger);
+                LOGGER.error("Error disabling edge trigger: {}", edgeTrigger);
             }
         }
     }
@@ -4499,7 +4499,7 @@ public class Person {
 
             SkillType skillType = getType(skillName);
             if (skillType == null) {
-                logger.warn("Unable to find skill type for {}. Experience level assessment aborted", skillName);
+                LOGGER.warn("Unable to find skill type for {}. Experience level assessment aborted", skillName);
                 return EXP_NONE;
             }
 
@@ -6103,7 +6103,7 @@ public class Person {
      */
     public void setAttributeScore(final SkillAttribute attribute, final int newScore) {
         if (attribute == null || attribute == SkillAttribute.NONE) {
-            logger.warn("(setAttributeScore) SkillAttribute is null or NONE.");
+            LOGGER.warn("(setAttributeScore) SkillAttribute is null or NONE.");
             return;
         }
 
@@ -6122,7 +6122,7 @@ public class Person {
      */
     public int getAttributeScore(final SkillAttribute attribute) {
         if (attribute == null || attribute.isNone()) {
-            logger.error("(getAttributeScore) SkillAttribute is null or NONE.");
+            LOGGER.error("(getAttributeScore) SkillAttribute is null or NONE.");
             return DEFAULT_ATTRIBUTE_SCORE;
         }
 
@@ -6185,7 +6185,7 @@ public class Person {
      */
     public int getAttributeCap(final SkillAttribute attribute) {
         if (attribute == null || attribute.isNone()) {
-            logger.warn("(getAttributeCap) SkillAttribute is null or NONE.");
+            LOGGER.warn("(getAttributeCap) SkillAttribute is null or NONE.");
             return MAXIMUM_ATTRIBUTE_SCORE;
         }
 
@@ -6226,7 +6226,7 @@ public class Person {
      */
     public void changeAttributeScore(final SkillAttribute attribute, final int delta) {
         if (attribute == null || attribute.isNone()) {
-            logger.warn("(changeAttributeScore) SkillAttribute is null or NONE.");
+            LOGGER.warn("(changeAttributeScore) SkillAttribute is null or NONE.");
             return;
         }
 
@@ -6605,7 +6605,7 @@ public class Person {
             final UUID id = unit.getId();
             unit = campaign.getUnit(id);
             if (unit == null) {
-                logger.error("Person {} ('{}') references missing unit {}", getId(), getFullName(), id);
+                LOGGER.error("Person {} ('{}') references missing unit {}", getId(), getFullName(), id);
             }
         }
 
@@ -6616,7 +6616,7 @@ public class Person {
                 if (realUnit != null) {
                     techUnits.set(ii, realUnit);
                 } else {
-                    logger.error("Person {} ('{}') techs missing unit {}", getId(), getFullName(), techUnit.getId());
+                    LOGGER.error("Person {} ('{}') techs missing unit {}", getId(), getFullName(), techUnit.getId());
                     techUnits.remove(ii);
                 }
             }
@@ -7488,30 +7488,21 @@ public class Person {
         }
     }
 
-    public String performConnectionsWealthCheck(LocalDate today, Finances campaignFinances,
-          ConnectionsLevel connectionsLevel) {
-        // Non-commanders can't use their connections to generate wealth
-        if (!commander) {
-            return "";
-        }
-
-        if (!ConnectionsLevel.CONNECTIONS_ZERO.equals(connectionsLevel)) {
-            Money donation = connectionsLevel.getWealth();
-            if (donation.isPositive()) {
-                int roll = d6(2);
-                if (roll >= CONNECTIONS_TARGET_NUMBER) {
-                    campaignFinances.credit(TransactionType.WEALTH, today, donation,
-                          resources.getString("connections.transaction"));
-                    return String.format(resources.getString("connections.wealth"), getHyperlinkedFullTitle(),
-                          spanOpeningWithCustomColor(getPositiveColor()), CLOSING_SPAN_TAG, donation.toAmountString());
-                }
-            }
-        }
-
-        return "";
-    }
-
-    private String checkForConnectionsReestablishContact(LocalDate today) {
+    /**
+     * Reestablishes connections if the cooldown has expired.
+     *
+     * <p>If burned connections exist and the specified date is after the cooldown period, this method clears the
+     * burned connections state and returns a formatted message  indicating that connections have been
+     * reestablished.</p>
+     *
+     * @param today the current date to check against the cooldown period
+     *
+     * @return a formatted message if connections are reestablished, or an empty string if not
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public String checkForConnectionsReestablishContact(LocalDate today) {
         if (burnedConnectionsEndDate != null && burnedConnectionsEndDate.isBefore(today)) {
             burnedConnectionsEndDate = null;
 
@@ -7521,13 +7512,81 @@ public class Person {
         return "";
     }
 
-    private String checkForBurnedContacts(LocalDate today, ConnectionsLevel connectionsLevel) {
+    /**
+     * Attempts to generate wealth using connections for the given date and campaign finances.
+     *
+     * <p>Only commanders with active connections are eligible. If successful, a random roll is made to determine if
+     * wealth is generated, which is then added to the provided finances. Returns a formatted message if a wealth gain
+     * occurs, or an empty string if no wealth is generated.</p>
+     *
+     * @param today            the current date for the wealth check
+     * @param campaignFinances the finances object in which to credit any gained wealth
+     *
+     * @return a formatted message if wealth is gained, or an empty string if not
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public String performConnectionsWealthCheck(LocalDate today, Finances campaignFinances) {
+        // Non-commanders can't use their connections to generate wealth
+        if (!commander) {
+            return "";
+        }
+
+        if (burnedConnectionsEndDate != null) {
+            LOGGER.info("Connections burned for {} unable to gain Connections wealth", getFullTitle());
+            return "";
+        }
+
+        int adjustedConnections = getAdjustedConnections();
+        ConnectionsLevel connectionsLevel = ConnectionsLevel.parseConnectionsLevelFromInt(adjustedConnections);
+
+        if (!ConnectionsLevel.CONNECTIONS_ZERO.equals(connectionsLevel)) {
+            Money donation = connectionsLevel.getWealth();
+            if (donation.isPositive()) {
+                int roll = d6(2);
+                LOGGER.info("Rolling to use connections to gain money {} {} vs. {}", getFullTitle(), roll,
+                      CONNECTIONS_TARGET_NUMBER);
+                if (roll >= CONNECTIONS_TARGET_NUMBER) {
+                    campaignFinances.credit(TransactionType.WEALTH, today, donation,
+                          resources.getString("connections.transaction"));
+                    return String.format(resources.getString("connections.wealth"), getHyperlinkedFullTitle(),
+                          spanOpeningWithCustomColor(getPositiveColor()), CLOSING_SPAN_TAG, donation.toAmountString());
+                }
+            } else {
+                LOGGER.info("Connections too low to generate Wealth");
+            }
+        }
+
+        return "";
+    }
+
+    /**
+     * Checks if there is a chance for the connections to be burned on the given date.
+     *
+     * <p>If the person has non-zero connections, a burn roll is performed. If the roll is equal to or below the burn
+     * chance, the connections are burned for a random number of months starting from the given date. Returns a
+     * formatted message if connections are burned, or an empty string otherwise.</p>
+     *
+     * @param today the current date to perform the burn check
+     *
+     * @return a formatted message if connections are burned, or an empty string if not
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public String checkForBurnedContacts(LocalDate today) {
+        int adjustedConnections = getAdjustedConnections();
+        ConnectionsLevel connectionsLevel = ConnectionsLevel.parseConnectionsLevelFromInt(adjustedConnections);
+
         if (!ConnectionsLevel.CONNECTIONS_ZERO.equals(connectionsLevel)) {
             int roll = d6(2);
+            int burnChance = connectionsLevel.getBurnChance();
+            LOGGER.info("Rolling to burn connections for {} {} vs. {}", getFullTitle(), roll, burnChance);
             if (roll <= connectionsLevel.getBurnChance()) {
                 burnedConnectionsEndDate = today.plusMonths(d6(1));
                 return String.format(resources.getString("connections.burned"), getHyperlinkedFullTitle(),
-                      spanOpeningWithCustomColor(getWarningColor()), CLOSING_SPAN_TAG);
+                      spanOpeningWithCustomColor(getNegativeColor()), CLOSING_SPAN_TAG);
             }
         }
         return "";

--- a/MekHQ/src/mekhq/campaign/personnel/enums/ConnectionsLevel.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ConnectionsLevel.java
@@ -46,6 +46,8 @@ import mekhq.campaign.finances.Money;
  * {@link Integer} values to their corresponding {@code ConnectionsLevel}.</p>
  */
 public enum ConnectionsLevel {
+    // If these values are changed, you must update the CONNECTIONS glossary entry.
+
     /** Burn chance: 10 - Wealth: 0 - Recruits: 0 */
     CONNECTIONS_ZERO(0, 10, Money.of(0), 0),
     /** Burn chance: 7 - Wealth: 1000 - Recruits: 0 */

--- a/MekHQ/src/mekhq/campaign/personnel/enums/ConnectionsLevel.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/ConnectionsLevel.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.enums;
+
+import megamek.logging.MMLogger;
+import mekhq.campaign.finances.Money;
+
+/**
+ * {@code ConnectionsLevel} represents various degrees of connections that a character may possess.
+ *
+ * <p>Each level is characterized by an associated numeric level, a chance for the connection to "burn" (go into
+ * 'cooldown'), a pool of wealth available, and the maximum number of recruits that can be influenced by this
+ * connection.</p>
+ *
+ * <p> This enum provides convenient getters for each property, as well as a static parser for converting
+ * {@link Integer} values to their corresponding {@code ConnectionsLevel}.</p>
+ */
+public enum ConnectionsLevel {
+    /** Burn chance: 10 - Wealth: 0 - Recruits: 0 */
+    CONNECTIONS_ZERO(0, 10, Money.of(0), 0),
+    /** Burn chance: 7 - Wealth: 1000 - Recruits: 0 */
+    CONNECTIONS_ONE(1, 7, Money.of(1000), 0),
+    /** Burn chance: 7 - Wealth: 2500 - Recruits: 0 */
+    CONNECTIONS_TWO(2, 7, Money.of(2500), 0),
+    /** Burn chance: 6 - Wealth: 5000 - Recruits: 0 */
+    CONNECTIONS_THREE(3, 6, Money.of(5000), 0),
+    /** Burn Chance: 6 - Wealth: 10,000 - Recruits: 1 */
+    CONNECTIONS_FOUR(4, 6, Money.of(10000), 1),
+    /** Burn chance: 5 - Wealth: 25,000 - Recruits: 2 */
+    CONNECTIONS_FIVE(5, 5, Money.of(25000), 2),
+    /** Burn Chance: 5 - Wealth: 50,000 - Recruits: 3 */
+    CONNECTIONS_SIX(6, 5, Money.of(50000), 3),
+    /** Burn chance: 4 - Wealth: 100,000 - Recruits: 4 */
+    CONNECTIONS_SEVEN(7, 4, Money.of(100000), 4),
+    /** Burn chance: 4 - Wealth: 250,000 - Recruits: 6 */
+    CONNECTIONS_EIGHT(8, 4, Money.of(250000), 6),
+    /** Burn chance: 3 - Wealth: 500,000 - Recruits: 8 */
+    CONNECTIONS_NINE(9, 3, Money.of(500000), 8),
+    /** Burn chance: 3 - Wealth: 1,000,000 - Recruits: 10 */
+    CONNECTIONS_TEN(10, 3, Money.of(1000000), 10);
+
+    private static final MMLogger LOGGER = MMLogger.create(ConnectionsLevel.class);
+
+    private final int level;
+    private final int burnChance;
+    private final Money wealth;
+    private final int recruits;
+
+    /**
+     * Constructs a new {@link ConnectionsLevel} enum constant.
+     *
+     * @param level      the numeric level of connection
+     * @param burnChance the chance that the connection will "burn" (typically lower is better)
+     * @param wealth     the wealth or resources represented by this level
+     * @param recruits   the maximum number of recruits accessible with this level of connection
+     */
+    ConnectionsLevel(int level, int burnChance, Money wealth, int recruits) {
+        this.level = level;
+        this.burnChance = burnChance;
+        this.wealth = wealth;
+        this.recruits = recruits;
+    }
+
+    /**
+     * Gets the unique numeric level representing the Connection.
+     *
+     * @return the connection level as an integer
+     */
+    public int getLevel() {
+        return level;
+    }
+
+    /**
+     * Gets the burn chance associated with this Connections level.
+     *
+     * <p>A lower value indicates a more reliable, less likely to be "burned" connection.</p>
+     *
+     * @return the burn chance value
+     */
+    public int getBurnChance() {
+        return burnChance;
+    }
+
+    /**
+     * Gets the wealth pool associated with this Connections level.
+     *
+     * @return the {@link Money} instance for this level
+     */
+    public Money getWealth() {
+        return wealth;
+    }
+
+    /**
+     * Gets the maximum number of additional recruits accessible at this connection level.
+     *
+     * @return the number of potential recruits
+     */
+    public int getRecruits() {
+        return recruits;
+    }
+
+    /**
+     * Attempts to retrieve a {@link ConnectionsLevel} by its numeric level value.
+     *
+     * <p>If no matching level is found, {@link #CONNECTIONS_ZERO} is returned and a warning is logged.</p>
+     *
+     * @param value the numeric level to parse
+     *
+     * @return the corresponding {@link ConnectionsLevel}
+     */
+    public static ConnectionsLevel parseConnectionsLevelFromInt(int value) {
+        for (ConnectionsLevel connectionsLevel : ConnectionsLevel.values()) {
+            if (connectionsLevel.level == value) {
+                return connectionsLevel;
+            }
+        }
+
+        LOGGER.warn("Failed to parse ConnectionsData from int: {} - returning CONNECTIONS_ZERO", value);
+        return CONNECTIONS_ZERO;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
+++ b/MekHQ/src/mekhq/campaign/utilities/glossary/GlossaryEntry.java
@@ -132,7 +132,8 @@ public enum GlossaryEntry {
     UNABLE_TO_START_SCENARIO("UNABLE_TO_START_SCENARIO"),
     VOCATIONAL_XP("VOCATIONAL_XP"),
     WINTER_HOLIDAY("WINTER_HOLIDAY"),
-    BLOODMARK("BLOODMARK");
+    BLOODMARK("BLOODMARK"),
+    CONNECTIONS("CONNECTIONS");
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.GlossaryEntry";
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SystemsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SystemsTab.java
@@ -112,6 +112,7 @@ public class SystemsTab {
     private JCheckBox chkRandomizeAttributes;
     private JCheckBox chkRandomizeTraits;
     private JCheckBox chkAllowMonthlyReinvestment;
+    private JCheckBox chkAllowMonthlyConnections;
 
     /**
      * Constructs a new {@code SystemsTab} for the specified campaign.
@@ -443,6 +444,9 @@ public class SystemsTab {
         chkAllowMonthlyReinvestment = new CampaignOptionsCheckBox("AllowMonthlyReinvestment");
         chkAllowMonthlyReinvestment.addMouseListener(createTipPanelUpdater(atowHeader,
               "AllowMonthlyReinvestment"));
+        chkAllowMonthlyConnections = new CampaignOptionsCheckBox("AllowMonthlyConnections");
+        chkAllowMonthlyConnections.addMouseListener(createTipPanelUpdater(atowHeader,
+              "AllowMonthlyConnections"));
 
         final JPanel panel = new CampaignOptionsStandardPanel("ATOWAttributesPanel", true, "ATOWAttributesPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
@@ -454,12 +458,14 @@ public class SystemsTab {
         panel.add(chkUseAttributes, layout);
         layout.gridx++;
         panel.add(chkRandomizeAttributes, layout);
+        layout.gridx++;
+        panel.add(chkRandomizeTraits, layout);
 
         layout.gridx = 0;
         layout.gridy++;
-        panel.add(chkRandomizeTraits, layout);
-        layout.gridx++;
         panel.add(chkAllowMonthlyReinvestment, layout);
+        layout.gridx++;
+        panel.add(chkAllowMonthlyConnections, layout);
 
         return panel;
     }
@@ -525,6 +531,7 @@ public class SystemsTab {
         chkRandomizeAttributes.setSelected(skillPreferences.isRandomizeAttributes());
         chkRandomizeTraits.setSelected(skillPreferences.isRandomizeTraits());
         chkAllowMonthlyReinvestment.setSelected(options.isAllowMonthlyReinvestment());
+        chkAllowMonthlyConnections.setSelected(options.isAllowMonthlyConnections());
     }
 
     /**
@@ -583,5 +590,6 @@ public class SystemsTab {
         skillPreferences.setRandomizeAttributes(chkRandomizeAttributes.isSelected());
         skillPreferences.setRandomizeTraits(chkRandomizeTraits.isSelected());
         options.setAllowMonthlyReinvestment(chkAllowMonthlyReinvestment.isSelected());
+        options.setAllowMonthlyConnections(chkAllowMonthlyConnections.isSelected());
     }
 }

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/ConnectionsLevelTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/ConnectionsLevelTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.enums;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import mekhq.campaign.finances.Money;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class ConnectionsLevelTest {
+    @Test
+    void testParseConnectionsLevelFromInt_ValidLevel() {
+        int inputValue = 5;
+        ConnectionsLevel expected = ConnectionsLevel.CONNECTIONS_FIVE;
+
+        ConnectionsLevel result = ConnectionsLevel.parseConnectionsLevelFromInt(inputValue);
+
+        assertEquals(expected, result, "Expected the parsed level to be CONNECTIONS_FIVE");
+    }
+
+    @Test
+    void testParseConnectionsLevelFromInt_ZeroLevel() {
+        int inputValue = 0;
+        ConnectionsLevel expected = ConnectionsLevel.CONNECTIONS_ZERO;
+
+        ConnectionsLevel result = ConnectionsLevel.parseConnectionsLevelFromInt(inputValue);
+
+        assertEquals(expected, result, "Expected the parsed level to be CONNECTIONS_ZERO");
+    }
+
+    @Test
+    void testParseConnectionsLevelFromInt_InvalidHighLevel() {
+        int inputValue = 11;
+        ConnectionsLevel expected = ConnectionsLevel.CONNECTIONS_ZERO;
+
+        ConnectionsLevel result = ConnectionsLevel.parseConnectionsLevelFromInt(inputValue);
+
+        assertEquals(expected, result, "Expected the parsed level to be CONNECTIONS_ZERO for invalid high level");
+    }
+
+    @Test
+    void testParseConnectionsLevelFromInt_NegativeLevel() {
+        int inputValue = -1;
+        ConnectionsLevel expected = ConnectionsLevel.CONNECTIONS_ZERO;
+
+        ConnectionsLevel result = ConnectionsLevel.parseConnectionsLevelFromInt(inputValue);
+
+        assertEquals(expected, result, "Expected the parsed level to be CONNECTIONS_ZERO for negative level");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ConnectionsLevel.class)
+    void testAllLevelsAreUnique(ConnectionsLevel connectionsLevel) {
+        for (ConnectionsLevel otherLevel : ConnectionsLevel.values()) {
+            if (otherLevel.equals(connectionsLevel)) {
+                continue;
+            }
+
+            int levelValue = connectionsLevel.getLevel();
+            int otherLevelValue = otherLevel.getLevel();
+
+            assertNotEquals(levelValue,
+                  otherLevelValue,
+                  "Duplicate Connections Level: " + connectionsLevel.name() + ", " + otherLevel.name());
+        }
+    }
+
+    @Test
+    void testAllBurnChancesAreDecremental() {
+        int iterations = ConnectionsLevel.values().length;
+
+        int lastBurnChance = Integer.MAX_VALUE;
+        for (int i = 0; i < iterations; i++) {
+            ConnectionsLevel connectionsLevel = ConnectionsLevel.parseConnectionsLevelFromInt(i);
+
+            int currentBurnChance = connectionsLevel.getBurnChance();
+
+            assertTrue(currentBurnChance <= lastBurnChance,
+                  "Burn Chance is not decremental for " + connectionsLevel.name());
+
+            lastBurnChance = currentBurnChance;
+        }
+    }
+
+    @Test
+    void testAllWealthValuesAreIncremental() {
+        int iterations = ConnectionsLevel.values().length;
+
+        Money lastWealth = Money.of(-1);
+        for (int i = 0; i < iterations; i++) {
+            ConnectionsLevel connectionsLevel = ConnectionsLevel.parseConnectionsLevelFromInt(i);
+
+            Money currentWealth = connectionsLevel.getWealth();
+
+            assertTrue(currentWealth.isGreaterThan(lastWealth),
+                  "Wealth is not incremental for " + connectionsLevel.name());
+
+            lastWealth = currentWealth;
+        }
+    }
+
+    @Test
+    void testAllRecruitValuesAreIncremental() {
+        int iterations = ConnectionsLevel.values().length;
+
+        int lastRecruits = 0;
+        for (int i = 0; i < iterations; i++) {
+            ConnectionsLevel connectionsLevel = ConnectionsLevel.parseConnectionsLevelFromInt(i);
+
+            int currentRecruits = connectionsLevel.getRecruits();
+
+            assertTrue(currentRecruits >= lastRecruits,
+                  "Recruits is not incremental for " + connectionsLevel.name());
+
+            lastRecruits = currentRecruits;
+        }
+    }
+}


### PR DESCRIPTION
## Connections (Trait)

Connections are a type of [Trait](GLOSSARY:ATOW_TRAITS) that applies multiple benefits if the character is the campaign commander.

---

### Force Reputation

The unit's [Force Reputation](GLOSSARY:FORCE_REPUTATION) is increased by however many points the commander has in Connections.

---

### Monthly Checks

If monthly Connections rolls are enabled in Campaign Options, each month the commander rolls 2d6. On a result of 4+, the commander's contacts will donate funds to the campaign.

**Donated Funds by Connections Score:**

| Connections | C-Bills Donated |
|-------------|------------------|
| 1           | 1,000            |
| 2           | 2,500            |
| 3           | 5,000            |
| 4           | 10,000           |
| 5           | 25,000           |
| 6           | 50,000           |
| 7           | 100,000          |
| 8           | 250,000          |
| 9           | 500,000          |
| 10          | 1,000,000        |

---

If both monthly rolls and the **Personnel Market** are enabled, each month the commander rolls 2d6. On a 4+, the commander's contacts will provide additional recruits in the personnel market. This increases the chance of seeing rare personnel such as Elite characters or those with unusual professions.

**Recruits Added by Connections Score:**

| Connections | Recruits Added |
|-------------|----------------|
| 1           | 0              |
| 2           | 0              |
| 3           | 0              |
| 4           | 1              |
| 5           | 2              |
| 6           | 3              |
| 7           | 4              |
| 8           | 6              |
| 9           | 7              |
| 10          | 10             |

---

Each month, a check is also made to determine if the commander loses contact with their Connections. If contact is lost, all levels in Connections are temporarily lost for **d6 months**. This could reflect a contact being unavailable, unwilling to help, or suffering personal issues.

**Loss Chance by Connections Score:**

| Connections | Lose Contact On |
|-------------|------------------|
| 1           | 7 or less (2d6)  |
| 2           | 7 or less (2d6)  |
| 3           | 6 or less (2d6)  |
| 4           | 6 or less (2d6)  |
| 5           | 5 or less (2d6)  |
| 6           | 5 or less (2d6)  |
| 7           | 4 or less (2d6)  |
| 8           | 4 or less (2d6)  |
| 9           | 3 or less (2d6)  |
| 10          | 3 or less (2d6)  |
