### PR TITLE
Fix: #7338 Fixed Numerous Instances Where We Were Requesting all Units & Only Retrieving Those Units in Combat Forces

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5008,7 +5008,7 @@ public class Campaign implements ITechManager {
                         // If any unit in the force is under repair, don't deploy the force
                         // Merely removing the unit from deployment would break with user expectation
                         boolean forceUnderRepair = false;
-                        for (UUID uid : forceIds.get(forceId).getAllUnits(true)) {
+                        for (UUID uid : forceIds.get(forceId).getAllUnits(false)) {
                             Unit u = getHangar().getUnit(uid);
                             if ((u != null) && u.isUnderRepair()) {
                                 forceUnderRepair = true;

--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -148,7 +148,7 @@ public class ResolveScenarioTracker {
         entities = new HashMap<>();
         bayLoadedEntities = new HashMap<>();
         idMap = new HashMap<>();
-        for (UUID uid : scenario.getForces(campaign).getAllUnits(true)) {
+        for (UUID uid : scenario.getForces(campaign).getAllUnits(false)) {
             Unit u = campaign.getUnit(uid);
             if (null != u && null == u.checkDeployment()) {
                 units.add(u);

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1681,7 +1681,7 @@ public class AtBDynamicScenarioFactory {
             ScenarioForceTemplate forceTemplate = scenario.getPlayerForceTemplates().get(forceID);
 
             if ((forceTemplate != null) && forceTemplate.getContributesToUnitCount()) {
-                primaryUnitCount += campaign.getForce(forceID).getAllUnits(true).size();
+                primaryUnitCount += campaign.getForce(forceID).getAllUnits(false).size();
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -584,10 +584,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
      */
     @Override
     public boolean canDeploy(Unit unit, Campaign campaign) {
-        if (isBigBattle() && (getForces(campaign).getAllUnits(true).size() > 7)) {
+        if (isBigBattle() && (getForces(campaign).getAllUnits(false).size() > 7)) {
             return false;
         } else {
-            return !isSpecialScenario() || (getForces(campaign).getAllUnits(true).size() <= 0);
+            return !isSpecialScenario() || (getForces(campaign).getAllUnits(false).size() <= 0);
         }
     }
 
@@ -600,10 +600,10 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
      * @return true if the force is eligible to deploy, otherwise false
      */
     public boolean canDeploy(Force force, Campaign campaign) {
-        Vector<UUID> units = force.getAllUnits(true);
-        if (isBigBattle() && getForces(campaign).getAllUnits(true).size() + units.size() > 8) {
+        Vector<UUID> units = force.getAllUnits(false);
+        if (isBigBattle() && getForces(campaign).getAllUnits(false).size() + units.size() > 8) {
             return false;
-        } else if (isSpecialScenario() && getForces(campaign).getAllUnits(true).size() + units.size() > 0) {
+        } else if (isSpecialScenario() && getForces(campaign).getAllUnits(false).size() + units.size() > 0) {
             return false;
         }
         for (UUID id : units) {
@@ -625,9 +625,9 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     @Override
     public boolean canDeployUnits(Vector<Unit> units, Campaign campaign) {
         if (isBigBattle()) {
-            return getForces(campaign).getAllUnits(true).size() + units.size() <= 8;
+            return getForces(campaign).getAllUnits(false).size() + units.size() <= 8;
         } else if (isSpecialScenario()) {
-            return getForces(campaign).getAllUnits(true).size() + units.size() <= 1;
+            return getForces(campaign).getAllUnits(false).size() + units.size() <= 1;
         } else {
             return units.stream().allMatch(unit -> canDeploy(unit, campaign));
         }
@@ -645,12 +645,12 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
     public boolean canDeployForces(Vector<Force> forces, Campaign c) {
         int total = 0;
         for (Force force : forces) {
-            Vector<UUID> units = force.getAllUnits(true);
+            Vector<UUID> units = force.getAllUnits(false);
             total += units.size();
             if (isBigBattle()) {
-                return getForces(c).getAllUnits(true).size() + units.size() <= 8;
+                return getForces(c).getAllUnits(false).size() + units.size() <= 8;
             } else if (isSpecialScenario()) {
-                return getForces(c).getAllUnits(true).size() + units.size() <= 0;
+                return getForces(c).getAllUnits(false).size() + units.size() <= 0;
             }
             for (UUID id : units) {
                 if (!canDeploy(c.getUnit(id), c)) {
@@ -659,9 +659,9 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             }
         }
         if (isBigBattle()) {
-            return getForces(c).getAllUnits(true).size() + total <= 8;
+            return getForces(c).getAllUnits(false).size() + total <= 8;
         } else if (isSpecialScenario()) {
-            return getForces(c).getAllUnits(true).size() + total <= 0;
+            return getForces(c).getAllUnits(false).size() + total <= 0;
         }
         return true;
     }
@@ -677,7 +677,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             setObjectives(campaign, getContract(campaign));
             return;
         }
-        Vector<UUID> deployed = getForces(campaign).getAllUnits(true);
+        Vector<UUID> deployed = getForces(campaign).getAllUnits(false);
         if (isBigBattle()) {
             int numAllies = Math.min(4, 8 - deployed.size());
             alliesPlayer.clear();

--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -25,6 +25,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.mission;
 
@@ -64,8 +69,6 @@ import mekhq.campaign.mission.enums.ScenarioStatus;
 import mekhq.campaign.mission.enums.ScenarioType;
 import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -875,7 +878,7 @@ public class Scenario implements IPlayerSettings {
     public boolean canDeployForces(Vector<Force> forces, Campaign c) {
         int additionalQuantity = 0;
         for (Force force : forces) {
-            Vector<UUID> units = force.getAllUnits(true);
+            Vector<UUID> units = force.getAllUnits(false);
             for (UUID id : units) {
                 if (!canDeploy(c.getUnit(id), c)) {
                     return false;

--- a/MekHQ/src/mekhq/campaign/mission/ScenarioDeploymentLimit.java
+++ b/MekHQ/src/mekhq/campaign/mission/ScenarioDeploymentLimit.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.mission;
 
@@ -34,9 +39,6 @@ import java.util.UUID;
 import java.util.Vector;
 import java.util.stream.Collectors;
 
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import megamek.Version;
 import megamek.common.UnitType;
 import megamek.logging.MMLogger;
@@ -45,6 +47,8 @@ import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
 import mekhq.utilities.MHQXMLUtility;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * This class is optionally used by Scenario to determine any limits on the type
@@ -260,7 +264,7 @@ public class ScenarioDeploymentLimit {
     public int getForceQuantity(Force f, Campaign c) {
         int quantity = 0;
 
-        Vector<UUID> unitIds = f.getAllUnits(true);
+        Vector<UUID> unitIds = f.getAllUnits(false);
         for (UUID id : unitIds) {
             Unit u = c.getUnit(id);
             if ((null != u) && (null != u.getEntity()) && isAllowedType(u.getEntity().getUnitType())) {
@@ -377,7 +381,7 @@ public class ScenarioDeploymentLimit {
      *         is part of the force
      */
     public boolean isPersonInForce(UUID personId, Force force, Campaign c) {
-        Vector<UUID> unitIds = force.getAllUnits(true);
+        Vector<UUID> unitIds = force.getAllUnits(false);
         for (UUID unitId : unitIds) {
             Unit u = c.getUnit(unitId);
             for (Person p : u.getActiveCrew()) {
@@ -450,7 +454,7 @@ public class ScenarioDeploymentLimit {
      *         part of the force
      */
     public boolean isUnitInForce(UUID unitId, Force force, Campaign c) {
-        Vector<UUID> unitIds = force.getAllUnits(true);
+        Vector<UUID> unitIds = force.getAllUnits(false);
         for (UUID id : unitIds) {
             if (id.equals(unitId)) {
                 return true;

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.mission.atb;
 
@@ -294,11 +299,11 @@ public class AtBScenarioModifierApplicator {
                     // we can hide the "commander tactics skill" number of units, but we must keep
                     // at least one visible
                     // as the bot is unable to handle an invisible opfor at the moment.
-                    int maxHiddenUnits = Math.min(playerForce.getAllUnits(true).size() - 1,
+                    int maxHiddenUnits = Math.min(playerForce.getAllUnits(false).size() - 1,
                           scenario.getLanceCommanderSkill(SkillType.S_TACTICS, campaign));
                     int numHiddenUnits = 0;
 
-                    for (UUID unitID : playerForce.getAllUnits(true)) {
+                    for (UUID unitID : playerForce.getAllUnits(false)) {
                         if (numHiddenUnits >= maxHiddenUnits) {
                             break;
                         }

--- a/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/generators/companyGenerators/AbstractCompanyGenerator.java
@@ -51,7 +51,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import megamek.client.generator.RandomCallsignGenerator;
-import megamek.common.AmmoType;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
 import megamek.common.MekFileParser;
@@ -1340,7 +1339,7 @@ public abstract class AbstractCompanyGenerator {
      */
     private int determineForceWeightClass(final Campaign campaign, final Force force,
             final boolean isLance) {
-        double weight = force.getAllUnits(true).stream().map(campaign::getUnit)
+        double weight = force.getAllUnits(false).stream().map(campaign::getUnit)
                 .filter(unit -> (unit != null) && (unit.getEntity() != null))
                 .mapToDouble(unit -> unit.getEntity().getWeight()).sum();
         weight = weight * 4.0 / (getOptions().getLanceSize() * (isLance ? 1 : getOptions().getLancesPerCompany()));

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -770,7 +770,7 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         // First, we need to get all units assigned to the current scenario
-        final List<UUID> unitIds = scenario.getForces(getCampaign()).getAllUnits(true);
+        final List<UUID> unitIds = scenario.getForces(getCampaign()).getAllUnits(false);
 
         // Then, we need to convert the ids to units, and filter out any units that are
         // null and
@@ -996,7 +996,7 @@ public final class BriefingTab extends CampaignGuiTab {
 
 
     private List<Unit> playerUnits(Scenario scenario, StringBuilder undeployed) {
-        Vector<UUID> uids = scenario.getForces(getCampaign()).getAllUnits(true);
+        Vector<UUID> uids = scenario.getForces(getCampaign()).getAllUnits(false);
         if (uids.isEmpty()) {
             return Collections.emptyList();
         }
@@ -1368,7 +1368,7 @@ public final class BriefingTab extends CampaignGuiTab {
         if (scenario == null) {
             return;
         }
-        Vector<UUID> uids = scenario.getForces(getCampaign()).getAllUnits(true);
+        Vector<UUID> uids = scenario.getForces(getCampaign()).getAllUnits(false);
         if (uids.isEmpty()) {
             return;
         }
@@ -1423,7 +1423,7 @@ public final class BriefingTab extends CampaignGuiTab {
         }
 
         // First, we need to get all units assigned to the current scenario
-        final List<UUID> unitIds = scenario.getForces(getCampaign()).getAllUnits(true);
+        final List<UUID> unitIds = scenario.getForces(getCampaign()).getAllUnits(false);
 
         // Then, we need to convert the ids to units, and filter out any units that are
         // null and

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -174,7 +174,7 @@ public class ScenarioTableModel extends DataTableModel {
                 return MekHQ.getMHQOptions().getDisplayFormattedDate(scenario.getDate());
             }
         } else if (col == COL_ASSIGN) {
-            return scenario.getForces(getCampaign()).getAllUnits(true).size();
+            return scenario.getForces(getCampaign()).getAllUnits(false).size();
         } else if (col == COL_SECTOR) {
             if (campaign.getCampaignOptions().isUseStratCon()) {
                 if (scenario instanceof AtBScenario) {

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -52,7 +52,7 @@ public class StaticChecks {
 
     public static boolean areAllForcesUndeployed(final Campaign campaign, final List<Force> forces) {
         return forces.stream().noneMatch(Force::isDeployed)
-                && forces.stream().flatMap(force -> force.getAllUnits(true).stream())
+                     && forces.stream().flatMap(force -> force.getAllUnits(false).stream())
                         .map(campaign::getUnit).noneMatch(unit -> (unit != null) && unit.isDeployed());
     }
 

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -60,8 +60,8 @@ import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
-import megamek.client.ui.dialogs.buttonDialogs.BotConfigDialog;
 import megamek.client.ui.dialogs.UnitEditorDialog;
+import megamek.client.ui.dialogs.buttonDialogs.BotConfigDialog;
 import megamek.common.Entity;
 import megamek.common.IStartingPositions;
 import megamek.common.annotations.Nullable;
@@ -463,7 +463,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
                 // either from the list of bot units or from the list of player units
                 if (scenario.getExternalIDLookup().containsKey(associatedUnitID)) {
                     associatedUnitName = scenario.getExternalIDLookup().get(associatedUnitID).getShortName();
-                } else if (scenario.getForces(campaign).getAllUnits(true).contains(uid)) {
+                } else if (scenario.getForces(campaign).getAllUnits(false).contains(uid)) {
                     associatedUnitName = campaign.getUnit(uid).getEntity().getShortName();
                 }
 

--- a/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ScenarioViewPanel.java
@@ -24,8 +24,39 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.gui.view;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.UUID;
+import java.util.Vector;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.Icon;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextPane;
+import javax.swing.JTree;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreePath;
+import javax.swing.tree.TreeSelectionModel;
 
 import megamek.common.annotations.Nullable;
 import megamek.common.planetaryconditions.Atmosphere;
@@ -40,14 +71,6 @@ import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.mission.ScenarioObjective;
 import mekhq.gui.baseComponents.JScrollablePanel;
 import mekhq.gui.utilities.MarkdownRenderer;
-
-import javax.swing.*;
-import javax.swing.event.TreeModelListener;
-import javax.swing.tree.*;
-import java.awt.*;
-import java.text.DecimalFormat;
-import java.util.*;
-import java.util.List;
 
 /**
  * A custom panel that gets filled in with goodies from a scenario object
@@ -325,7 +348,7 @@ public class ScenarioViewPanel extends JScrollablePanel {
                 // either from the list of bot units or from the list of player units
                 if (scenario.getExternalIDLookup().containsKey(associatedUnitID)) {
                     associatedUnitName = scenario.getExternalIDLookup().get(associatedUnitID).getShortName();
-                } else if (scenario.getForces(campaign).getAllUnits(true).contains(uid)) {
+                } else if (scenario.getForces(campaign).getAllUnits(false).contains(uid)) {
                     associatedUnitName = campaign.getUnit(uid).getEntity().getShortName();
                 }
 

--- a/MekHQ/unittests/mekhq/campaign/force/ForceTest.java
+++ b/MekHQ/unittests/mekhq/campaign/force/ForceTest.java
@@ -24,15 +24,20 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package mekhq.campaign.force;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.UUID;
 import java.util.Vector;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 class ForceTest {
     @Test
@@ -45,7 +50,7 @@ class ForceTest {
         force.addUnit(unit2);
 
         // Act
-        Vector<UUID> allUnits = force.getAllUnits(true);
+        Vector<UUID> allUnits = force.getAllUnits(false);
 
         // Assert
         assertEquals(2, allUnits.size());
@@ -70,7 +75,7 @@ class ForceTest {
         childForce.addSubForce(childForce2, true);
 
         // Act
-        Vector<UUID> allUnits = force.getAllUnits(true);
+        Vector<UUID> allUnits = force.getAllUnits(false);
 
         // Assert
         assertEquals(3, allUnits.size());
@@ -177,7 +182,7 @@ class ForceTest {
         childForce.addSubForce(childForce3, true);
 
         // Act
-        Vector<UUID> allUnits = force.getAllUnits(true);
+        Vector<UUID> allUnits = force.getAllUnits(false);
 
         // Assert
         assertEquals(3, allUnits.size());


### PR DESCRIPTION
Fix #7338

Across the codebase we use a method called `getAllUnits` to fetch all units in a given force. However, in numerous cases we were explicitly requesting to only include units in combat forces.

This means that if a force passed into the method isn't a combat force - for example, a convoy - those units were not being always factored into several locations. Most noticeably the scenario resolution dialog. This PR addresses that.