### PR TITLE
Fix: #7172 Fixed NPE When Importing Married Personnel While Simulated Relationship Histories is Enabled

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2082,10 +2082,10 @@ public class Campaign implements ITechManager {
      *
      * @return {@code true} if recruitment was successful and the person was added or employed; {@code false} otherwise
      *
-     * @see #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean)
+     * @see #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean, boolean)
      */
     public boolean recruitPerson(Person person) {
-        return recruitPerson(person, person.getPrisonerStatus(), false, true, true);
+        return recruitPerson(person, person.getPrisonerStatus(), false, true, true, false);
     }
 
     /**
@@ -2110,10 +2110,10 @@ public class Campaign implements ITechManager {
      *
      * @return {@code true} if recruitment was successful and personnel was added or employed; {@code false} otherwise
      *
-     * @see #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean)
+     * @see #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean, boolean)
      */
     public boolean recruitPerson(Person person, boolean gmAdd, boolean employ) {
-        return recruitPerson(person, person.getPrisonerStatus(), gmAdd, true, employ);
+        return recruitPerson(person, person.getPrisonerStatus(), gmAdd, true, employ, false);
     }
 
     /**
@@ -2137,18 +2137,41 @@ public class Campaign implements ITechManager {
      *
      * @return {@code true} if recruitment was successful and personnel was added or employed; {@code false} otherwise
      *
-     * @see #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean)
+     * @see #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean, boolean)
      */
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean employ) {
-        return recruitPerson(person, prisonerStatus, false, true, employ);
+        return recruitPerson(person, prisonerStatus, false, true, employ, false);
     }
 
     /**
-     * @deprecated use {@link #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean)} instead.
+     * Attempts to recruit a given person into the campaign with the specified prisoner status.
+     *
+     * <p>This is a convenience method that calls
+     * {@link #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean, boolean)} with
+     * {@code bypassSimulateRelationships} set to {@code false}.</p>
+     *
+     * @param person         the {@link Person} to recruit
+     * @param prisonerStatus the {@link PrisonerStatus} applied to the recruited person
+     * @param gmAdd          if {@code true}, the person is added in GM Mode
+     * @param log            if {@code true}, the recruitment is logged
+     * @param employ         if {@code true}, the person is immediately employed
+     *
+     * @return {@code true} if the person was successfully recruited; {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean gmAdd, boolean log,
+          boolean employ) {
+        return recruitPerson(person, prisonerStatus, gmAdd, log, employ, false);
+    }
+
+    /**
+     * @deprecated use {@link #recruitPerson(Person, PrisonerStatus, boolean, boolean, boolean, boolean)} instead.
      */
     @Deprecated(since = "0.50.06", forRemoval = true)
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean gmAdd, boolean log) {
-        return recruitPerson(person, prisonerStatus, gmAdd, log, true);
+        return recruitPerson(person, prisonerStatus, gmAdd, log, true, false);
     }
 
     /**
@@ -2170,12 +2193,13 @@ public class Campaign implements ITechManager {
      *                       funds check)
      * @param log            if {@code true}, a record of the recruitment will be added to campaign logs
      * @param employ         if {@code true}, the person is marked as employed in the campaign
+     * @param bypassSimulateRelationships         if {@code true}, relationship simulation does not occur
      *
      * @return {@code true} if recruitment was successful and personnel was added or employed; {@code false} on failure
      *       or insufficient funds
      */
     public boolean recruitPerson(Person person, PrisonerStatus prisonerStatus, boolean gmAdd, boolean log,
-          boolean employ) {
+          boolean employ, boolean bypassSimulateRelationships) {
         if (person == null) {
             logger.warn("A null person was passed into recruitPerson.");
             return false;
@@ -2202,7 +2226,7 @@ public class Campaign implements ITechManager {
             person.setJoinedCampaign(currentDay);
             personnel.put(person.getId(), person);
 
-            if (getCampaignOptions().isUseSimulatedRelationships()) {
+            if (!bypassSimulateRelationships && getCampaignOptions().isUseSimulatedRelationships()) {
                 if ((prisonerStatus.isFree()) &&
                           (!person.getOriginFaction().isClan()) &&
                           // We don't simulate for civilians, otherwise MekHQ will try to simulate the entire

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2391,7 +2391,8 @@ public class CampaignGUI extends JPanel {
                 }
 
                 if (person != null) {
-                    getCampaign().recruitPerson(person, true, person.isEmployed());
+                    getCampaign().recruitPerson(person, person.getPrisonerStatus(), true, false, person.isEmployed(),
+                          true);
 
                     // Clear some values we no longer should have set in case this
                     // has transferred campaigns or things in the campaign have


### PR DESCRIPTION
Fix #7172

This PR stops mhq from attempting to run the historic relationship simulator when importing personnel.