### PR TITLE
Improvement: Added the Ability to Only Consider the SPAs of a Unit's Commander, When Determining What SPAs a Multi-Crewed Unit Has

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -374,6 +374,9 @@ lblUseArtillery.tooltip=Characters can possess the Artillery skill which is used
   \ for specific weapons.
 lblUseAbilities.text=Use Special Pilot Abilities (SPAs)
 lblUseAbilities.tooltip=Characters can purchase and benefit from SPAs.
+lblUseCommanderAbilitiesOnly.text=Commander SPAs Only <span style="color:#C344C3;">\u2605</span>
+lblUseCommanderAbilitiesOnly.tooltip=For multi-personnel units, only count the SPAs owned by the unit commander. If \
+  disabled, at least 50% of the unit's crew must possess the SPA for it to be made available in scenarios.
 lblUseEdge.text=Use Edge
 lblUseEdge.tooltip=Characters can purchase and benefit from Edge, which allows them to re-roll\
   \ certain undesirable results.

--- a/MekHQ/src/mekhq/campaign/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/CampaignOptions.java
@@ -229,6 +229,7 @@ public class CampaignOptions {
     private boolean useRandomToughness;
     private boolean useArtillery;
     private boolean useAbilities;
+    private boolean useCommanderAbilitiesOnly;
     private boolean useEdge;
     private boolean useSupportEdge;
     private boolean useImplants;
@@ -791,6 +792,7 @@ public class CampaignOptions {
         setUseRandomToughness(false);
         setUseArtillery(false);
         setUseAbilities(false);
+        setUseCommanderAbilitiesOnly(false);
         setUseEdge(false);
         setUseSupportEdge(false);
         setUseImplants(false);
@@ -1585,6 +1587,14 @@ public class CampaignOptions {
 
     public void setUseAbilities(final boolean useAbilities) {
         this.useAbilities = useAbilities;
+    }
+
+    public boolean isUseCommanderAbilitiesOnly() {
+        return useCommanderAbilitiesOnly;
+    }
+
+    public void setUseCommanderAbilitiesOnly(final boolean useCommanderAbilitiesOnly) {
+        this.useCommanderAbilitiesOnly = useCommanderAbilitiesOnly;
     }
 
     public boolean isUseEdge() {
@@ -5067,6 +5077,7 @@ public class CampaignOptions {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useRandomToughness", isUseRandomToughness());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useArtillery", isUseArtillery());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useAbilities", isUseAbilities());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useCommanderAbilitiesOnly", isUseCommanderAbilitiesOnly());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useEdge", isUseEdge());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useSupportEdge", isUseSupportEdge());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useImplants", isUseImplants());
@@ -5889,6 +5900,8 @@ public class CampaignOptions {
                     campaignOptions.setUseArtillery(Boolean.parseBoolean(nodeContents));
                 } else if (nodeName.equalsIgnoreCase("useAbilities")) {
                     campaignOptions.setUseAbilities(Boolean.parseBoolean(nodeContents));
+                } else if (nodeName.equalsIgnoreCase("useCommanderAbilitiesOnly")) {
+                    campaignOptions.setUseCommanderAbilitiesOnly(Boolean.parseBoolean(nodeContents));
                 } else if (nodeName.equalsIgnoreCase("useEdge")) {
                     campaignOptions.setUseEdge(Boolean.parseBoolean(nodeContents));
                 } else if (nodeName.equalsIgnoreCase("useSupportEdge")) {

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4531,16 +4531,17 @@ public class Unit implements ITechnology {
                 }
             }
 
-            // For crew-served units, let's look at the abilities of the group. If more than
-            // half the crew
-            // (gunners and pilots only, for spacecraft) have an ability, grant the benefit
-            // to the unit
+            boolean commanderOnly = campaign.getCampaignOptions().isUseCommanderAbilitiesOnly();
+
+            // For crew-served units, let's look at the abilities of the group. If more than half the crew (gunners
+            // and pilots only, for spacecraft) have an ability, grant the benefit to the unit
             // TODO : Mobile structures, large naval support vehicles
-            if (entity.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT) ||
+            if (!commanderOnly &&
+                      (entity.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT) ||
                       entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP) ||
                       entity.hasETypeFlag(Entity.ETYPE_TANK) ||
                       entity.hasETypeFlag(Entity.ETYPE_INFANTRY) ||
-                      entity.hasETypeFlag(Entity.ETYPE_TRIPOD_MEK)) {
+                             entity.hasETypeFlag(Entity.ETYPE_TRIPOD_MEK))) {
                 // If there is no crew, there's nothing left to do here.
                 if (null == commander) {
                     return;
@@ -4652,7 +4653,6 @@ public class Unit implements ITechnology {
                 // question
                 // of what to do with extra crew quarters and crewmember assignments beyond the
                 // minimum.
-
             } else {
                 // For other unit types, just use the unit commander's abilities.
                 PilotOptions cdrOptions = new PilotOptions(); // MegaMek-style as it is sent to MegaMek

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
@@ -103,6 +103,7 @@ public class PersonnelTab {
     private JCheckBox chkUseRandomToughness;
     private JCheckBox chkUseArtillery;
     private JCheckBox chkUseAbilities;
+    private JCheckBox chkUseCommanderAbilitiesOnly;
     private JCheckBox chkUseEdge;
     private JCheckBox chkUseSupportEdge;
     private JCheckBox chkUseImplants;
@@ -356,6 +357,7 @@ public class PersonnelTab {
         chkUseRandomToughness = new JCheckBox();
         chkUseArtillery = new JCheckBox();
         chkUseAbilities = new JCheckBox();
+        chkUseCommanderAbilitiesOnly = new JCheckBox();
         chkUseEdge = new JCheckBox();
         chkUseSupportEdge = new JCheckBox();
         chkUseImplants = new JCheckBox();
@@ -438,6 +440,9 @@ public class PersonnelTab {
         chkUseArtillery.addMouseListener(createTipPanelUpdater(generalHeader, "UseArtillery"));
         chkUseAbilities = new CampaignOptionsCheckBox("UseAbilities");
         chkUseAbilities.addMouseListener(createTipPanelUpdater(generalHeader, "UseAbilities"));
+        chkUseCommanderAbilitiesOnly = new CampaignOptionsCheckBox("UseCommanderAbilitiesOnly");
+        chkUseCommanderAbilitiesOnly.addMouseListener(createTipPanelUpdater(generalHeader,
+              "UseCommanderAbilitiesOnly"));
         chkUseEdge = new CampaignOptionsCheckBox("UseEdge");
         chkUseEdge.addMouseListener(createTipPanelUpdater(generalHeader, "UseEdge"));
         chkUseSupportEdge = new CampaignOptionsCheckBox("UseSupportEdge");
@@ -470,6 +475,9 @@ public class PersonnelTab {
 
         layout.gridy++;
         panel.add(chkUseAbilities, layout);
+
+        layout.gridy++;
+        panel.add(chkUseCommanderAbilitiesOnly, layout);
 
         layout.gridy++;
         panel.add(chkUseEdge, layout);
@@ -1277,6 +1285,7 @@ public class PersonnelTab {
         chkUseRandomToughness.setSelected(options.isUseRandomToughness());
         chkUseArtillery.setSelected(options.isUseArtillery());
         chkUseAbilities.setSelected(options.isUseAbilities());
+        chkUseCommanderAbilitiesOnly.setSelected(options.isUseCommanderAbilitiesOnly());
         chkUseEdge.setSelected(options.isUseEdge());
         chkUseSupportEdge.setSelected(options.isUseSupportEdge());
         chkUseImplants.setSelected(options.isUseImplants());
@@ -1368,6 +1377,7 @@ public class PersonnelTab {
         options.setUseRandomToughness(chkUseRandomToughness.isSelected());
         options.setUseArtillery(chkUseArtillery.isSelected());
         options.setUseAbilities(chkUseAbilities.isSelected());
+        options.setUseCommanderAbilitiesOnly(chkUseCommanderAbilitiesOnly.isSelected());
         options.setUseEdge(chkUseEdge.isSelected());
         options.setUseSupportEdge(chkUseSupportEdge.isSelected());
         options.setUseImplants(chkUseImplants.isSelected());


### PR DESCRIPTION
This addresses a long term pain point that exists with multi-crewed units, making it much easier to acquire SPAs for those units.

There are a lot of balancing concerns with this option that were raised when I brought up the idea in 50.04. It mostly revolves around it making it much easier to 'complete' the SPAs needed for a unit. Ultimately, I decided to ignore that as a problem in favor of user experience. By keeping this as a Campaign Option we ensure that players can pick whichever experience best suits their play style.

That this will mean a single character, in a crew, may be required to skill into gunnery/piloting skills that are not required for their role - to gain access to the various SPAs - is a feature, not a bug. It helps mitigate the decreased SPAing-up costs, now that SPAs are only required by a single character.

Close #6934