### PR TITLE
Fix: Fixed Faction Standing Command Circuit Access Not Granting Command Circuit Access

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1571,6 +1571,17 @@ public class Campaign implements ITechManager {
         return false;
     }
 
+    /**
+     * Retrieves a list of {@link AtBContract} objects that have a start date after the current day.
+     *
+     * @return a list of future AtBContract objects whose start date is after the current day
+     */
+    public List<AtBContract> getFutureAtBContracts() {
+        return getAtBContracts().stream()
+                     .filter(c -> c.getStartDate().isAfter(currentDay))
+                     .collect(Collectors.toList());
+    }
+
     public List<AtBContract> getActiveAtBContracts() {
         return getActiveAtBContracts(false);
     }
@@ -7682,7 +7693,9 @@ public class Campaign implements ITechManager {
 
             boolean isUseCommandCircuits =
                   FactionStandingUtilities.isUseCommandCircuit(isOverridingCommandCircuitRequirements, gmMode,
-                  campaignOptions.isUseFactionStandingCommandCircuitSafe(), factionStandings, getActiveAtBContracts());
+                        campaignOptions.isUseFactionStandingCommandCircuitSafe(),
+                        factionStandings,
+                        getFutureAtBContracts());
 
             // Get current node's information
             double currentG = scoreG.get(current) + currentSystem.getRechargeTime(getLocalDate(), isUseCommandCircuits);

--- a/MekHQ/src/mekhq/campaign/CurrentLocation.java
+++ b/MekHQ/src/mekhq/campaign/CurrentLocation.java
@@ -256,7 +256,7 @@ public class CurrentLocation {
     public boolean isRecharging(Campaign campaign) {
         boolean isUseCommandCircuit = FactionStandingUtilities.isUseCommandCircuit(campaign.isOverridingCommandCircuitRequirements(),
               campaign.isGM(), campaign.getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
-              campaign.getFactionStandings(), campaign.getActiveAtBContracts());
+              campaign.getFactionStandings(), campaign.getFutureAtBContracts());
 
         return currentSystem.getRechargeTime(campaign.getLocalDate(), isUseCommandCircuit) > 0;
     }
@@ -269,7 +269,7 @@ public class CurrentLocation {
     public void setRecharged(Campaign campaign) {
         boolean isUseCommandCircuit = FactionStandingUtilities.isUseCommandCircuit(campaign.isOverridingCommandCircuitRequirements(),
               campaign.isGM(), campaign.getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
-              campaign.getFactionStandings(), campaign.getActiveAtBContracts());
+              campaign.getFactionStandings(), campaign.getFutureAtBContracts());
 
         rechargeTime = currentSystem.getRechargeTime(campaign.getLocalDate(), isUseCommandCircuit);
     }
@@ -282,7 +282,7 @@ public class CurrentLocation {
 
         boolean isUseCommandCircuit = FactionStandingUtilities.isUseCommandCircuit(campaign.isOverridingCommandCircuitRequirements(),
               campaign.isGM(), campaign.getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
-              campaign.getFactionStandings(), campaign.getActiveAtBContracts());
+              campaign.getFactionStandings(), campaign.getFutureAtBContracts());
 
         // recharge even if there is no jump path
         // because JumpShips don't go anywhere

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -495,7 +495,7 @@ public class Contract extends Mission {
                   FactionStandingUtilities.isUseCommandCircuit(campaign.isOverridingCommandCircuitRequirements(),
                         campaign.isGM(),
                         campaign.getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
-                        campaign.getFactionStandings(), campaign.getActiveAtBContracts());
+                        campaign.getFactionStandings(), campaign.getFutureAtBContracts());
 
             JumpPath jumpPath = getJumpPath(campaign);
             double days = Math.round(jumpPath.getTotalTime(campaign.getLocalDate(),
@@ -730,7 +730,7 @@ public class Contract extends Mission {
                   FactionStandingUtilities.isUseCommandCircuit(campaign.isOverridingCommandCircuitRequirements(),
                         campaign.isGM(),
                         campaign.getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
-                        campaign.getFactionStandings(), campaign.getActiveAtBContracts());
+                        campaign.getFactionStandings(), campaign.getFutureAtBContracts());
 
             int days = (int) Math.ceil(getJumpPath(campaign).getTotalTime(campaign.getLocalDate(),
                   campaign.getLocation().getTransitTime(), isUseCommandCircuit));

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1179,7 +1179,7 @@ public class CampaignGUI extends JPanel {
         boolean isUseCommandCircuit =
               FactionStandingUtilities.isUseCommandCircuit(getCampaign().isOverridingCommandCircuitRequirements(),
                     getCampaign().isGM(), getCampaign().getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
-                    getCampaign().getFactionStandings(), getCampaign().getActiveAtBContracts());
+                    getCampaign().getFactionStandings(), getCampaign().getFutureAtBContracts());
 
         lblLocation = new JLabel(getCampaign().getLocation()
                                        .getReport(getCampaign().getLocalDate(),
@@ -2745,7 +2745,7 @@ public class CampaignGUI extends JPanel {
         boolean isUseCommandCircuit =
               FactionStandingUtilities.isUseCommandCircuit(getCampaign().isOverridingCommandCircuitRequirements(),
                     getCampaign().isGM(), getCampaign().getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
-                    getCampaign().getFactionStandings(), getCampaign().getActiveAtBContracts());
+                    getCampaign().getFactionStandings(), getCampaign().getFutureAtBContracts());
 
         lblLocation.setText(getCampaign().getLocation()
                                   .getReport(getCampaign().getLocalDate(),

--- a/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/JumpPathViewPanel.java
@@ -126,7 +126,7 @@ public class JumpPathViewPanel extends JScrollablePanel {
               FactionStandingUtilities.isUseCommandCircuit(campaign.isOverridingCommandCircuitRequirements(),
                     campaign.isGM(),
                     campaign.getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
-                    campaign.getFactionStandings(), campaign.getActiveAtBContracts());
+                    campaign.getFactionStandings(), campaign.getFutureAtBContracts());
 
         for (PlanetarySystem system : path.getSystems()) {
             lblPlanet =
@@ -243,7 +243,7 @@ public class JumpPathViewPanel extends JScrollablePanel {
 
         boolean isUseCommandCircuit = FactionStandingUtilities.isUseCommandCircuit(campaign.isOverridingCommandCircuitRequirements(),
               campaign.isGM(), campaign.getCampaignOptions().isUseFactionStandingCommandCircuitSafe(),
-              campaign.getFactionStandings(), campaign.getActiveAtBContracts());
+              campaign.getFactionStandings(), campaign.getFutureAtBContracts());
 
         txtRechargeTime.setName("lblRechargeTime2");
         txtRechargeTime.setText("<html>" +


### PR DESCRIPTION
This bug was caused by a fun interaction. Command Circuit access is granted once a campaign reaches maximum Faction Standing with their parent faction. Then, when under contract with that faction, they get to use the command circuit.

However, to determine that last clause we were fetching all active AtB Contracts - to see if the campaign qualified. However, the contract the campaign was traveling to fulfill would not be returned by this method, because it hadn't started yet.

This PR adds a new method to fetch future contracts - those that have been selected, but not yet started - and uses those to qualify for command circuit access.