### PR TITLE
Fix: Removed the Ability to Skip Paying for Golden Hello in Personnel Market if Golden Hello is Disabled After New Applicants Are Generated

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
@@ -102,6 +102,7 @@ public class NewPersonnelMarket {
     @SuppressWarnings(value = "unused")
     private List<Faction> applicantOriginFactions = new ArrayList<>();
     boolean offeringGoldenHello = true;
+    boolean wasOfferingGoldenHello = true;
     boolean hasRarePersonnel;
     List<PersonnelRole> rareProfessions = new ArrayList<>();
     int recruitmentRolls;
@@ -179,6 +180,8 @@ public class NewPersonnelMarket {
                 String nodeContents = childNode.getTextContent().trim();
                 if (nodeName.equalsIgnoreCase("associatedPersonnelMarketStyle")) {
                     personnelMarket.setAssociatedPersonnelMarketStyle(PersonnelMarketStyle.fromString(nodeContents));
+                } else if (nodeName.equalsIgnoreCase("wasOfferingGoldenHello")) {
+                    personnelMarket.setWasOfferingGoldenHello(Boolean.parseBoolean(nodeContents));
                 } else if (nodeName.equalsIgnoreCase("offeringGoldenHello")) {
                     personnelMarket.setOfferingGoldenHello(Boolean.parseBoolean(nodeContents));
                 } else if (nodeName.equalsIgnoreCase("hasRarePersonnel")) {
@@ -311,6 +314,7 @@ public class NewPersonnelMarket {
               indent,
               "associatedPersonnelMarketStyle",
               associatedPersonnelMarketStyle.name()); // this node must always be first
+        MHQXMLUtility.writeSimpleXMLTag(writer, indent, "wasOfferingGoldenHello", wasOfferingGoldenHello);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "offeringGoldenHello", offeringGoldenHello);
         MHQXMLUtility.writeSimpleXMLTag(writer, indent, "hasRarePersonnel", hasRarePersonnel);
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "rareProfessions");
@@ -653,6 +657,30 @@ public class NewPersonnelMarket {
     }
 
     /**
+     * Returns whether a golden hello (recruitment incentive) was being offered when applicants were generated.
+     *
+     * @return {@code true} if a golden hello was offered, {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.50.06
+     */
+    public boolean isWasOfferingGoldenHello() {
+        return wasOfferingGoldenHello;
+    }
+
+    /**
+     * Sets whether a golden hello (recruitment incentive) was being offered when applicants were generated.
+     *
+     * @param wasOfferingGoldenHello {@code true} if a golden hello was offered, {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public void setWasOfferingGoldenHello(boolean wasOfferingGoldenHello) {
+        this.wasOfferingGoldenHello = wasOfferingGoldenHello;
+    }
+
+    /**
      * Returns whether rare personnel are available on the market.
      *
      * @return {@code true} if rare personnel are present, otherwise {@code false}
@@ -773,6 +801,7 @@ public class NewPersonnelMarket {
         recruitmentRolls = 0;
         applicantOriginFactions = new ArrayList<>();
         currentApplicants = new ArrayList<>();
+        wasOfferingGoldenHello = isOfferingGoldenHello();
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
@@ -369,11 +369,11 @@ public class PersonnelMarketDialog extends JDialog {
         buttonPanel.add(closeButton);
 
         JButton hireButton = new JButton(getTextAt(RESOURCE_BUNDLE, "button.personnelMarket.hire.normal"));
-        hireButton.addActionListener(e -> hireActionListener(isGM));
+        hireButton.addActionListener(e -> hireActionListener(false));
         buttonPanel.add(hireButton);
 
         JButton addGMButton = new JButton(getTextAt(RESOURCE_BUNDLE, "button.personnelMarket.hire.gm"));
-        addGMButton.addActionListener(e -> hireActionListener(isGM));
+        addGMButton.addActionListener(e -> hireActionListener(true));
         addGMButton.setEnabled(isGM);
         buttonPanel.add(addGMButton);
 
@@ -509,17 +509,17 @@ public class PersonnelMarketDialog extends JDialog {
     /**
      * Performs the hiring action for the selected applicant.
      *
-     * @param isGM whether the hire action is performed by a game master
+     * @param isGMHire whether the hire action is performed as a GM Hire
      *
      * @author Illiani
      * @since 0.50.06
      */
-    private void hireActionListener(boolean isGM) {
+    private void hireActionListener(boolean isGMHire) {
         List<Person> recruitedPersons = new ArrayList<>(tablePanel.getSelectedApplicants());
 
         // Process recruitment and golden hello logic for all selected applicants
         for (Person applicant : recruitedPersons) {
-            if (!isGM && market.isOfferingGoldenHello()) {
+            if (!isGMHire && market.isWasOfferingGoldenHello()) {
                 campaign.getFinances()
                       .debit(RECRUITMENT,
                             campaign.getLocalDate(),
@@ -528,7 +528,7 @@ public class PersonnelMarketDialog extends JDialog {
                                   "finances.personnelMarket.hire",
                                   applicant.getFullTitle()));
             }
-            campaign.recruitPerson(applicant, isGM, true);
+            campaign.recruitPerson(applicant, isGMHire, true);
         }
 
         // Remove all recruited persons from the applicant list


### PR DESCRIPTION
As per title. If a player turned on Golden Hello - to increase their recruitment chances - and then disabled it before actually hiring new applicants they could skip out on the fee.

Similarly, we were unintentionally always considering hiring to be GM hire if the campaign had GM Mode enabled.

This PR fixes both of these issues.