### PR TITLE
Improvement: Further Optimized Campaign Options Loading

### DIFF
--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -33,13 +33,15 @@
  */
 package mekhq.campaign.campaignOptions;
 
+import static java.lang.Boolean.parseBoolean;
+import static megamek.codeUtilities.MathUtility.parseDouble;
+import static megamek.codeUtilities.MathUtility.parseInt;
 import static mekhq.gui.campaignOptions.enums.ProcurementPersonnelPick.ALL;
 import static mekhq.gui.campaignOptions.enums.ProcurementPersonnelPick.SUPPORT;
 
 import java.util.EnumMap;
 
 import megamek.Version;
-import megamek.codeUtilities.MathUtility;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
 import mekhq.Utilities;
@@ -101,80 +103,72 @@ public class CampaignOptionsUnmarshaller {
     private static void parseNodeName(Version version, String nodeName, CampaignOptions campaignOptions,
           String nodeContents, Node childNode) {
         switch (nodeName) {
-            case "checkMaintenance" -> campaignOptions.setCheckMaintenance(Boolean.parseBoolean(nodeContents));
-            case "maintenanceCycleDays" -> campaignOptions.setMaintenanceCycleDays(Integer.parseInt(nodeContents));
-            case "maintenanceBonus" -> campaignOptions.setMaintenanceBonus(Integer.parseInt(nodeContents));
-            case "useQualityMaintenance" ->
-                  campaignOptions.setUseQualityMaintenance(Boolean.parseBoolean(nodeContents));
-            case "reverseQualityNames" -> campaignOptions.setReverseQualityNames(Boolean.parseBoolean(nodeContents));
-            case "useRandomUnitQualities" ->
-                  campaignOptions.setUseRandomUnitQualities(Boolean.parseBoolean(nodeContents));
-            case "usePlanetaryModifiers" ->
-                  campaignOptions.setUsePlanetaryModifiers(Boolean.parseBoolean(nodeContents));
-            case "useUnofficialMaintenance" -> campaignOptions.setUseUnofficialMaintenance(Boolean.parseBoolean(
+            case "checkMaintenance" -> campaignOptions.setCheckMaintenance(parseBoolean(nodeContents));
+            case "maintenanceCycleDays" -> campaignOptions.setMaintenanceCycleDays(parseInt(nodeContents));
+            case "maintenanceBonus" -> campaignOptions.setMaintenanceBonus(parseInt(nodeContents));
+            case "useQualityMaintenance" -> campaignOptions.setUseQualityMaintenance(parseBoolean(nodeContents));
+            case "reverseQualityNames" -> campaignOptions.setReverseQualityNames(parseBoolean(nodeContents));
+            case "useRandomUnitQualities" -> campaignOptions.setUseRandomUnitQualities(parseBoolean(nodeContents));
+            case "usePlanetaryModifiers" -> campaignOptions.setUsePlanetaryModifiers(parseBoolean(nodeContents));
+            case "useUnofficialMaintenance" -> campaignOptions.setUseUnofficialMaintenance(parseBoolean(
                   nodeContents));
-            case "logMaintenance" -> campaignOptions.setLogMaintenance(Boolean.parseBoolean(nodeContents));
-            case "defaultMaintenanceTime" -> campaignOptions.setDefaultMaintenanceTime(Integer.parseInt(nodeContents));
-            case "mrmsUseRepair" -> campaignOptions.setMRMSUseRepair(Boolean.parseBoolean(nodeContents));
-            case "mrmsUseSalvage" -> campaignOptions.setMRMSUseSalvage(Boolean.parseBoolean(nodeContents));
-            case "mrmsUseExtraTime" -> campaignOptions.setMRMSUseExtraTime(Boolean.parseBoolean(nodeContents));
-            case "mrmsUseRushJob" -> campaignOptions.setMRMSUseRushJob(Boolean.parseBoolean(nodeContents));
-            case "mrmsAllowCarryover" -> campaignOptions.setMRMSAllowCarryover(Boolean.parseBoolean(nodeContents));
-            case "mrmsOptimizeToCompleteToday" -> campaignOptions.setMRMSOptimizeToCompleteToday(Boolean.parseBoolean(
+            case "logMaintenance" -> campaignOptions.setLogMaintenance(parseBoolean(nodeContents));
+            case "defaultMaintenanceTime" -> campaignOptions.setDefaultMaintenanceTime(parseInt(nodeContents));
+            case "mrmsUseRepair" -> campaignOptions.setMRMSUseRepair(parseBoolean(nodeContents));
+            case "mrmsUseSalvage" -> campaignOptions.setMRMSUseSalvage(parseBoolean(nodeContents));
+            case "mrmsUseExtraTime" -> campaignOptions.setMRMSUseExtraTime(parseBoolean(nodeContents));
+            case "mrmsUseRushJob" -> campaignOptions.setMRMSUseRushJob(parseBoolean(nodeContents));
+            case "mrmsAllowCarryover" -> campaignOptions.setMRMSAllowCarryover(parseBoolean(nodeContents));
+            case "mrmsOptimizeToCompleteToday" -> campaignOptions.setMRMSOptimizeToCompleteToday(parseBoolean(
                   nodeContents));
-            case "mrmsScrapImpossible" -> campaignOptions.setMRMSScrapImpossible(Boolean.parseBoolean(nodeContents));
-            case "mrmsUseAssignedTechsFirst" -> campaignOptions.setMRMSUseAssignedTechsFirst(Boolean.parseBoolean(
+            case "mrmsScrapImpossible" -> campaignOptions.setMRMSScrapImpossible(parseBoolean(nodeContents));
+            case "mrmsUseAssignedTechsFirst" -> campaignOptions.setMRMSUseAssignedTechsFirst(parseBoolean(
                   nodeContents));
-            case "mrmsReplacePod" -> campaignOptions.setMRMSReplacePod(Boolean.parseBoolean(nodeContents));
+            case "mrmsReplacePod" -> campaignOptions.setMRMSReplacePod(parseBoolean(nodeContents));
             case "mrmsOptions" -> campaignOptions.setMRMSOptions(MRMSOption.parseListFromXML(childNode, version));
-            case "useFactionForNames" ->
-                  campaignOptions.setUseOriginFactionForNames(Boolean.parseBoolean(nodeContents));
-            case "useEraMods" -> campaignOptions.setEraMods(Boolean.parseBoolean(nodeContents));
-            case "assignedTechFirst" -> campaignOptions.setAssignedTechFirst(Boolean.parseBoolean(nodeContents));
-            case "resetToFirstTech" -> campaignOptions.setResetToFirstTech(Boolean.parseBoolean(nodeContents));
-            case "techsUseAdministration" ->
-                  campaignOptions.setTechsUseAdministration(Boolean.parseBoolean(nodeContents));
-            case "useQuirks" -> campaignOptions.setQuirks(Boolean.parseBoolean(nodeContents));
-            case "xpCostMultiplier" -> campaignOptions.setXpCostMultiplier(Double.parseDouble(nodeContents));
-            case "scenarioXP" -> campaignOptions.setScenarioXP(Integer.parseInt(nodeContents));
-            case "killsForXP" -> campaignOptions.setKillsForXP(Integer.parseInt(nodeContents));
-            case "killXPAward" -> campaignOptions.setKillXPAward(Integer.parseInt(nodeContents));
-            case "nTasksXP" -> campaignOptions.setNTasksXP(Integer.parseInt(nodeContents));
-            case "tasksXP" -> campaignOptions.setTaskXP(Integer.parseInt(nodeContents));
-            case "successXP" -> campaignOptions.setSuccessXP(Integer.parseInt(nodeContents));
-            case "mistakeXP" -> campaignOptions.setMistakeXP(Integer.parseInt(nodeContents));
-            case "vocationalXP" -> campaignOptions.setVocationalXP(Integer.parseInt(nodeContents));
-            case "vocationalXPTargetNumber" ->
-                  campaignOptions.setVocationalXPTargetNumber(Integer.parseInt(nodeContents));
-            case "vocationalXPCheckFrequency" -> campaignOptions.setVocationalXPCheckFrequency(Integer.parseInt(
+            case "useFactionForNames" -> campaignOptions.setUseOriginFactionForNames(parseBoolean(nodeContents));
+            case "useEraMods" -> campaignOptions.setEraMods(parseBoolean(nodeContents));
+            case "assignedTechFirst" -> campaignOptions.setAssignedTechFirst(parseBoolean(nodeContents));
+            case "resetToFirstTech" -> campaignOptions.setResetToFirstTech(parseBoolean(nodeContents));
+            case "techsUseAdministration" -> campaignOptions.setTechsUseAdministration(parseBoolean(nodeContents));
+            case "useQuirks" -> campaignOptions.setQuirks(parseBoolean(nodeContents));
+            case "xpCostMultiplier" -> campaignOptions.setXpCostMultiplier(parseDouble(nodeContents));
+            case "scenarioXP" -> campaignOptions.setScenarioXP(parseInt(nodeContents));
+            case "killsForXP" -> campaignOptions.setKillsForXP(parseInt(nodeContents));
+            case "killXPAward" -> campaignOptions.setKillXPAward(parseInt(nodeContents));
+            case "nTasksXP" -> campaignOptions.setNTasksXP(parseInt(nodeContents));
+            case "tasksXP" -> campaignOptions.setTaskXP(parseInt(nodeContents));
+            case "successXP" -> campaignOptions.setSuccessXP(parseInt(nodeContents));
+            case "mistakeXP" -> campaignOptions.setMistakeXP(parseInt(nodeContents));
+            case "vocationalXP" -> campaignOptions.setVocationalXP(parseInt(nodeContents));
+            case "vocationalXPTargetNumber" -> campaignOptions.setVocationalXPTargetNumber(parseInt(nodeContents));
+            case "vocationalXPCheckFrequency" -> campaignOptions.setVocationalXPCheckFrequency(parseInt(
                   nodeContents));
-            case "contractNegotiationXP" -> campaignOptions.setContractNegotiationXP(Integer.parseInt(nodeContents));
-            case "adminWeeklyXP" -> campaignOptions.setAdminXP(Integer.parseInt(nodeContents));
-            case "adminXPPeriod" -> campaignOptions.setAdminXPPeriod(Integer.parseInt(nodeContents));
-            case "missionXpFail" -> campaignOptions.setMissionXpFail(Integer.parseInt(nodeContents));
-            case "missionXpSuccess" -> campaignOptions.setMissionXpSuccess(Integer.parseInt(nodeContents));
-            case "missionXpOutstandingSuccess" -> campaignOptions.setMissionXpOutstandingSuccess(Integer.parseInt(
+            case "contractNegotiationXP" -> campaignOptions.setContractNegotiationXP(parseInt(nodeContents));
+            case "adminWeeklyXP" -> campaignOptions.setAdminXP(parseInt(nodeContents));
+            case "adminXPPeriod" -> campaignOptions.setAdminXPPeriod(parseInt(nodeContents));
+            case "missionXpFail" -> campaignOptions.setMissionXpFail(parseInt(nodeContents));
+            case "missionXpSuccess" -> campaignOptions.setMissionXpSuccess(parseInt(nodeContents));
+            case "missionXpOutstandingSuccess" -> campaignOptions.setMissionXpOutstandingSuccess(parseInt(
                   nodeContents));
-            case "edgeCost" -> campaignOptions.setEdgeCost(Integer.parseInt(nodeContents));
-            case "waitingPeriod" -> campaignOptions.setWaitingPeriod(Integer.parseInt(nodeContents));
+            case "edgeCost" -> campaignOptions.setEdgeCost(parseInt(nodeContents));
+            case "waitingPeriod" -> campaignOptions.setWaitingPeriod(parseInt(nodeContents));
             case "acquisitionSkill" -> campaignOptions.setAcquisitionSkill(nodeContents);
-            case "unitTransitTime" -> campaignOptions.setUnitTransitTime(Integer.parseInt(nodeContents));
-            case "clanAcquisitionPenalty" -> campaignOptions.setClanAcquisitionPenalty(Integer.parseInt(nodeContents));
-            case "isAcquisitionPenalty" -> campaignOptions.setIsAcquisitionPenalty(Integer.parseInt(nodeContents));
-            case "usePlanetaryAcquisition" ->
-                  campaignOptions.setPlanetaryAcquisition(Boolean.parseBoolean(nodeContents));
+            case "unitTransitTime" -> campaignOptions.setUnitTransitTime(parseInt(nodeContents));
+            case "clanAcquisitionPenalty" -> campaignOptions.setClanAcquisitionPenalty(parseInt(nodeContents));
+            case "isAcquisitionPenalty" -> campaignOptions.setIsAcquisitionPenalty(parseInt(nodeContents));
+            case "usePlanetaryAcquisition" -> campaignOptions.setPlanetaryAcquisition(parseBoolean(nodeContents));
             case "planetAcquisitionFactionLimit" ->
                   campaignOptions.setPlanetAcquisitionFactionLimit(PlanetaryAcquisitionFactionLimit.parseFromString(
                         nodeContents));
             case "planetAcquisitionNoClanCrossover" ->
-                  campaignOptions.setDisallowPlanetAcquisitionClanCrossover(Boolean.parseBoolean(
+                  campaignOptions.setDisallowPlanetAcquisitionClanCrossover(parseBoolean(
                         nodeContents));
-            case "noClanPartsFromIS" -> campaignOptions.setDisallowClanPartsFromIS(Boolean.parseBoolean(nodeContents));
-            case "penaltyClanPartsFromIS" -> campaignOptions.setPenaltyClanPartsFromIS(Integer.parseInt(nodeContents));
-            case "planetAcquisitionVerbose" ->
-                  campaignOptions.setPlanetAcquisitionVerboseReporting(Boolean.parseBoolean(
+            case "noClanPartsFromIS" -> campaignOptions.setDisallowClanPartsFromIS(parseBoolean(nodeContents));
+            case "penaltyClanPartsFromIS" -> campaignOptions.setPenaltyClanPartsFromIS(parseInt(nodeContents));
+            case "planetAcquisitionVerbose" -> campaignOptions.setPlanetAcquisitionVerboseReporting(parseBoolean(
                         nodeContents));
-            case "maxJumpsPlanetaryAcquisition" -> campaignOptions.setMaxJumpsPlanetaryAcquisition(Integer.parseInt(
+            case "maxJumpsPlanetaryAcquisition" -> campaignOptions.setMaxJumpsPlanetaryAcquisition(parseInt(
                   nodeContents));
             case "planetTechAcquisitionBonus" -> {
                 EnumMap<PlanetarySophistication, Integer> acquisitionBonuses = campaignOptions.getAllPlanetTechAcquisitionBonuses();
@@ -182,15 +176,15 @@ public class CampaignOptionsUnmarshaller {
                 String[] values = nodeContents.split(",");
                 if (values.length == 6) {
                     // < 0.50.07 compatibility handler
-                    acquisitionBonuses.put(PlanetarySophistication.A, Integer.parseInt(values[0]));
-                    acquisitionBonuses.put(PlanetarySophistication.B, Integer.parseInt(values[1]));
-                    acquisitionBonuses.put(PlanetarySophistication.C, Integer.parseInt(values[2]));
-                    acquisitionBonuses.put(PlanetarySophistication.D, Integer.parseInt(values[3]));
-                    acquisitionBonuses.put(PlanetarySophistication.F, Integer.parseInt(values[5]));
+                    acquisitionBonuses.put(PlanetarySophistication.A, parseInt(values[0]));
+                    acquisitionBonuses.put(PlanetarySophistication.B, parseInt(values[1]));
+                    acquisitionBonuses.put(PlanetarySophistication.C, parseInt(values[2]));
+                    acquisitionBonuses.put(PlanetarySophistication.D, parseInt(values[3]));
+                    acquisitionBonuses.put(PlanetarySophistication.F, parseInt(values[5]));
                 } else if (values.length == PlanetarySophistication.values().length) {
                     // >= 0.50.07 compatibility handler
                     for (int i = 0; i < values.length; i++) {
-                        acquisitionBonuses.put(PlanetarySophistication.fromIndex(i), Integer.parseInt(values[i]));
+                        acquisitionBonuses.put(PlanetarySophistication.fromIndex(i), parseInt(values[i]));
                     }
                 } else {
                     LOGGER.error("Invalid number of values for planetTechAcquisitionBonus: {}", values.length);
@@ -202,15 +196,15 @@ public class CampaignOptionsUnmarshaller {
                 String[] values = nodeContents.split(",");
                 if (values.length == 6) {
                     // < 0.50.07 compatibility handler
-                    acquisitionBonuses.put(PlanetaryRating.A, Integer.parseInt(values[0]));
-                    acquisitionBonuses.put(PlanetaryRating.B, Integer.parseInt(values[1]));
-                    acquisitionBonuses.put(PlanetaryRating.C, Integer.parseInt(values[2]));
-                    acquisitionBonuses.put(PlanetaryRating.D, Integer.parseInt(values[3]));
-                    acquisitionBonuses.put(PlanetaryRating.F, Integer.parseInt(values[5]));
+                    acquisitionBonuses.put(PlanetaryRating.A, parseInt(values[0]));
+                    acquisitionBonuses.put(PlanetaryRating.B, parseInt(values[1]));
+                    acquisitionBonuses.put(PlanetaryRating.C, parseInt(values[2]));
+                    acquisitionBonuses.put(PlanetaryRating.D, parseInt(values[3]));
+                    acquisitionBonuses.put(PlanetaryRating.F, parseInt(values[5]));
                 } else if (values.length == PlanetaryRating.values().length) {
                     // >= 0.50.07 compatibility handler
                     for (int i = 0; i < values.length; i++) {
-                        acquisitionBonuses.put(PlanetaryRating.fromIndex(i), Integer.parseInt(values[i]));
+                        acquisitionBonuses.put(PlanetaryRating.fromIndex(i), parseInt(values[i]));
                     }
                 } else {
                     LOGGER.error("Invalid number of values for planetIndustryAcquisitionBonus: {}", values.length);
@@ -222,178 +216,165 @@ public class CampaignOptionsUnmarshaller {
                 String[] values = nodeContents.split(",");
                 if (values.length == 6) {
                     // < 0.50.07 compatibility handler
-                    acquisitionBonuses.put(PlanetaryRating.A, Integer.parseInt(values[0]));
-                    acquisitionBonuses.put(PlanetaryRating.B, Integer.parseInt(values[1]));
-                    acquisitionBonuses.put(PlanetaryRating.C, Integer.parseInt(values[2]));
-                    acquisitionBonuses.put(PlanetaryRating.D, Integer.parseInt(values[3]));
-                    acquisitionBonuses.put(PlanetaryRating.F, Integer.parseInt(values[5]));
+                    acquisitionBonuses.put(PlanetaryRating.A, parseInt(values[0]));
+                    acquisitionBonuses.put(PlanetaryRating.B, parseInt(values[1]));
+                    acquisitionBonuses.put(PlanetaryRating.C, parseInt(values[2]));
+                    acquisitionBonuses.put(PlanetaryRating.D, parseInt(values[3]));
+                    acquisitionBonuses.put(PlanetaryRating.F, parseInt(values[5]));
                 } else if (values.length == PlanetaryRating.values().length) {
                     // >= 0.50.07 compatibility handler
                     for (int i = 0; i < values.length; i++) {
-                        acquisitionBonuses.put(PlanetaryRating.fromIndex(i), Integer.parseInt(values[i]));
+                        acquisitionBonuses.put(PlanetaryRating.fromIndex(i), parseInt(values[i]));
                     }
                 } else {
                     LOGGER.error("Invalid number of values for planetOutputAcquisitionBonus: {}", values.length);
                 }
             }
-            case "equipmentContractPercent" -> campaignOptions.setEquipmentContractPercent(Double.parseDouble(
+            case "equipmentContractPercent" -> campaignOptions.setEquipmentContractPercent(parseDouble(
                   nodeContents));
-            case "dropShipContractPercent" ->
-                  campaignOptions.setDropShipContractPercent(Double.parseDouble(nodeContents));
-            case "jumpShipContractPercent" ->
-                  campaignOptions.setJumpShipContractPercent(Double.parseDouble(nodeContents));
-            case "warShipContractPercent" ->
-                  campaignOptions.setWarShipContractPercent(Double.parseDouble(nodeContents));
-            case "equipmentContractBase" ->
-                  campaignOptions.setEquipmentContractBase(Boolean.parseBoolean(nodeContents));
-            case "equipmentContractSaleValue" -> campaignOptions.setEquipmentContractSaleValue(Boolean.parseBoolean(
+            case "dropShipContractPercent" -> campaignOptions.setDropShipContractPercent(parseDouble(nodeContents));
+            case "jumpShipContractPercent" -> campaignOptions.setJumpShipContractPercent(parseDouble(nodeContents));
+            case "warShipContractPercent" -> campaignOptions.setWarShipContractPercent(parseDouble(nodeContents));
+            case "equipmentContractBase" -> campaignOptions.setEquipmentContractBase(parseBoolean(nodeContents));
+            case "equipmentContractSaleValue" -> campaignOptions.setEquipmentContractSaleValue(parseBoolean(
                   nodeContents));
-            case "blcSaleValue" -> campaignOptions.setBLCSaleValue(Boolean.parseBoolean(nodeContents));
-            case "overageRepaymentInFinalPayment" ->
-                  campaignOptions.setOverageRepaymentInFinalPayment(Boolean.parseBoolean(
+            case "blcSaleValue" -> campaignOptions.setBLCSaleValue(parseBoolean(nodeContents));
+            case "overageRepaymentInFinalPayment" -> campaignOptions.setOverageRepaymentInFinalPayment(parseBoolean(
                         nodeContents));
-            case "acquisitionSupportStaffOnly" -> campaignOptions.setAcquisitionPersonnelCategory(Boolean.parseBoolean(
+            case "acquisitionSupportStaffOnly" -> campaignOptions.setAcquisitionPersonnelCategory(parseBoolean(
                   nodeContents) ? SUPPORT : ALL);
             case "acquisitionPersonnelCategory" ->
                   campaignOptions.setAcquisitionPersonnelCategory(ProcurementPersonnelPick.fromString(
                         nodeContents));
-            case "limitByYear" -> campaignOptions.setLimitByYear(Boolean.parseBoolean(nodeContents));
-            case "disallowExtinctStuff" -> campaignOptions.setDisallowExtinctStuff(Boolean.parseBoolean(nodeContents));
-            case "allowClanPurchases" -> campaignOptions.setAllowClanPurchases(Boolean.parseBoolean(nodeContents));
-            case "allowISPurchases" -> campaignOptions.setAllowISPurchases(Boolean.parseBoolean(nodeContents));
-            case "allowCanonOnly" -> campaignOptions.setAllowCanonOnly(Boolean.parseBoolean(nodeContents));
-            case "allowCanonRefitOnly" -> campaignOptions.setAllowCanonRefitOnly(Boolean.parseBoolean(nodeContents));
-            case "useAmmoByType" -> campaignOptions.setUseAmmoByType(Boolean.parseBoolean(nodeContents));
-            case "variableTechLevel" -> campaignOptions.setVariableTechLevel(Boolean.parseBoolean(nodeContents));
-            case "factionIntroDate" -> campaignOptions.setIsUseFactionIntroDate(Boolean.parseBoolean(nodeContents));
-            case "techLevel" -> campaignOptions.setTechLevel(Integer.parseInt(nodeContents));
+            case "limitByYear" -> campaignOptions.setLimitByYear(parseBoolean(nodeContents));
+            case "disallowExtinctStuff" -> campaignOptions.setDisallowExtinctStuff(parseBoolean(nodeContents));
+            case "allowClanPurchases" -> campaignOptions.setAllowClanPurchases(parseBoolean(nodeContents));
+            case "allowISPurchases" -> campaignOptions.setAllowISPurchases(parseBoolean(nodeContents));
+            case "allowCanonOnly" -> campaignOptions.setAllowCanonOnly(parseBoolean(nodeContents));
+            case "allowCanonRefitOnly" -> campaignOptions.setAllowCanonRefitOnly(parseBoolean(nodeContents));
+            case "useAmmoByType" -> campaignOptions.setUseAmmoByType(parseBoolean(nodeContents));
+            case "variableTechLevel" -> campaignOptions.setVariableTechLevel(parseBoolean(nodeContents));
+            case "factionIntroDate" -> campaignOptions.setIsUseFactionIntroDate(parseBoolean(nodeContents));
+            case "techLevel" -> campaignOptions.setTechLevel(parseInt(nodeContents));
             case "unitRatingMethod", "dragoonsRatingMethod" ->
                   campaignOptions.setUnitRatingMethod(UnitRatingMethod.parseFromString(
                         nodeContents));
-            case "manualUnitRatingModifier" ->
-                  campaignOptions.setManualUnitRatingModifier(Integer.parseInt(nodeContents));
-            case "clampReputationPayMultiplier" -> campaignOptions.setClampReputationPayMultiplier(Boolean.parseBoolean(
+            case "manualUnitRatingModifier" -> campaignOptions.setManualUnitRatingModifier(parseInt(nodeContents));
+            case "clampReputationPayMultiplier" -> campaignOptions.setClampReputationPayMultiplier(parseBoolean(
                   nodeContents));
             case "reduceReputationPerformanceModifier" ->
-                  campaignOptions.setReduceReputationPerformanceModifier(Boolean.parseBoolean(
+                  campaignOptions.setReduceReputationPerformanceModifier(parseBoolean(
                         nodeContents));
             case "reputationPerformanceModifierCutOff" ->
-                  campaignOptions.setReputationPerformanceModifierCutOff(Boolean.parseBoolean(
+                  campaignOptions.setReputationPerformanceModifierCutOff(parseBoolean(
                         nodeContents));
             case "usePortraitForType" -> {
                 String[] values = nodeContents.split(",");
                 for (int i = 0; i < values.length; i++) {
-                    campaignOptions.setUsePortraitForRole(i, Boolean.parseBoolean(values[i].trim()));
+                    campaignOptions.setUsePortraitForRole(i, parseBoolean(values[i].trim()));
                 }
             }
-            case "assignPortraitOnRoleChange" -> campaignOptions.setAssignPortraitOnRoleChange(Boolean.parseBoolean(
+            case "assignPortraitOnRoleChange" -> campaignOptions.setAssignPortraitOnRoleChange(parseBoolean(
                   nodeContents));
-            case "allowDuplicatePortraits" -> campaignOptions.setAllowDuplicatePortraits(Boolean.parseBoolean(
+            case "allowDuplicatePortraits" -> campaignOptions.setAllowDuplicatePortraits(parseBoolean(
                   nodeContents));
-            case "destroyByMargin" -> campaignOptions.setDestroyByMargin(Boolean.parseBoolean(nodeContents));
-            case "destroyMargin" -> campaignOptions.setDestroyMargin(Integer.parseInt(nodeContents));
-            case "destroyPartTarget" -> campaignOptions.setDestroyPartTarget(Integer.parseInt(nodeContents));
-            case "useAeroSystemHits" -> campaignOptions.setUseAeroSystemHits(Boolean.parseBoolean(nodeContents));
-            case "maxAcquisitions" -> campaignOptions.setMaxAcquisitions(Integer.parseInt(nodeContents));
-            case "autoLogisticsHeatSink" ->
-                  campaignOptions.setAutoLogisticsHeatSink(MathUtility.parseInt(nodeContents));
-            case "autoLogisticsMekHead" -> campaignOptions.setAutoLogisticsMekHead(MathUtility.parseInt(nodeContents));
-            case "autoLogisticsMekLocation" -> campaignOptions.setAutoLogisticsMekLocation(MathUtility.parseInt(
+            case "destroyByMargin" -> campaignOptions.setDestroyByMargin(parseBoolean(nodeContents));
+            case "destroyMargin" -> campaignOptions.setDestroyMargin(parseInt(nodeContents));
+            case "destroyPartTarget" -> campaignOptions.setDestroyPartTarget(parseInt(nodeContents));
+            case "useAeroSystemHits" -> campaignOptions.setUseAeroSystemHits(parseBoolean(nodeContents));
+            case "maxAcquisitions" -> campaignOptions.setMaxAcquisitions(parseInt(nodeContents));
+            case "autoLogisticsHeatSink" -> campaignOptions.setAutoLogisticsHeatSink(parseInt(nodeContents));
+            case "autoLogisticsMekHead" -> campaignOptions.setAutoLogisticsMekHead(parseInt(nodeContents));
+            case "autoLogisticsMekLocation" -> campaignOptions.setAutoLogisticsMekLocation(parseInt(
                   nodeContents));
-            case "autoLogisticsNonRepairableLocation" ->
-                  campaignOptions.setAutoLogisticsNonRepairableLocation(MathUtility.parseInt(
+            case "autoLogisticsNonRepairableLocation" -> campaignOptions.setAutoLogisticsNonRepairableLocation(parseInt(
                         nodeContents));
-            case "autoLogisticsArmor" -> campaignOptions.setAutoLogisticsArmor(MathUtility.parseInt(nodeContents));
-            case "autoLogisticsAmmunition" -> campaignOptions.setAutoLogisticsAmmunition(MathUtility.parseInt(
+            case "autoLogisticsArmor" -> campaignOptions.setAutoLogisticsArmor(parseInt(nodeContents));
+            case "autoLogisticsAmmunition" -> campaignOptions.setAutoLogisticsAmmunition(parseInt(
                   nodeContents));
-            case "autoLogisticsActuators" ->
-                  campaignOptions.setAutoLogisticsActuators(MathUtility.parseInt(nodeContents));
-            case "autoLogisticsJumpJets" ->
-                  campaignOptions.setAutoLogisticsJumpJets(MathUtility.parseInt(nodeContents));
-            case "autoLogisticsEngines" -> campaignOptions.setAutoLogisticsEngines(MathUtility.parseInt(nodeContents));
-            case "autoLogisticsWeapons" -> campaignOptions.setAutoLogisticsWeapons(MathUtility.parseInt(nodeContents));
-            case "autoLogisticsOther" -> campaignOptions.setAutoLogisticsOther(MathUtility.parseInt(nodeContents));
-            case "useTactics" -> campaignOptions.setUseTactics(Boolean.parseBoolean(nodeContents));
-            case "useInitiativeBonus" -> campaignOptions.setUseInitiativeBonus(Boolean.parseBoolean(nodeContents));
-            case "useToughness" -> campaignOptions.setUseToughness(Boolean.parseBoolean(nodeContents));
-            case "useRandomToughness" -> campaignOptions.setUseRandomToughness(Boolean.parseBoolean(nodeContents));
-            case "useArtillery" -> campaignOptions.setUseArtillery(Boolean.parseBoolean(nodeContents));
-            case "useAbilities" -> campaignOptions.setUseAbilities(Boolean.parseBoolean(nodeContents));
-            case "useCommanderAbilitiesOnly" -> campaignOptions.setUseCommanderAbilitiesOnly(Boolean.parseBoolean(
+            case "autoLogisticsActuators" -> campaignOptions.setAutoLogisticsActuators(parseInt(nodeContents));
+            case "autoLogisticsJumpJets" -> campaignOptions.setAutoLogisticsJumpJets(parseInt(nodeContents));
+            case "autoLogisticsEngines" -> campaignOptions.setAutoLogisticsEngines(parseInt(nodeContents));
+            case "autoLogisticsWeapons" -> campaignOptions.setAutoLogisticsWeapons(parseInt(nodeContents));
+            case "autoLogisticsOther" -> campaignOptions.setAutoLogisticsOther(parseInt(nodeContents));
+            case "useTactics" -> campaignOptions.setUseTactics(parseBoolean(nodeContents));
+            case "useInitiativeBonus" -> campaignOptions.setUseInitiativeBonus(parseBoolean(nodeContents));
+            case "useToughness" -> campaignOptions.setUseToughness(parseBoolean(nodeContents));
+            case "useRandomToughness" -> campaignOptions.setUseRandomToughness(parseBoolean(nodeContents));
+            case "useArtillery" -> campaignOptions.setUseArtillery(parseBoolean(nodeContents));
+            case "useAbilities" -> campaignOptions.setUseAbilities(parseBoolean(nodeContents));
+            case "useCommanderAbilitiesOnly" -> campaignOptions.setUseCommanderAbilitiesOnly(parseBoolean(
                   nodeContents));
-            case "useEdge" -> campaignOptions.setUseEdge(Boolean.parseBoolean(nodeContents));
-            case "useSupportEdge" -> campaignOptions.setUseSupportEdge(Boolean.parseBoolean(nodeContents));
-            case "useImplants" -> campaignOptions.setUseImplants(Boolean.parseBoolean(nodeContents));
-            case "alternativeQualityAveraging" -> campaignOptions.setAlternativeQualityAveraging(Boolean.parseBoolean(
+            case "useEdge" -> campaignOptions.setUseEdge(parseBoolean(nodeContents));
+            case "useSupportEdge" -> campaignOptions.setUseSupportEdge(parseBoolean(nodeContents));
+            case "useImplants" -> campaignOptions.setUseImplants(parseBoolean(nodeContents));
+            case "alternativeQualityAveraging" -> campaignOptions.setAlternativeQualityAveraging(parseBoolean(
                   nodeContents));
-            case "useAgeEffects" -> campaignOptions.setUseAgeEffects(Boolean.parseBoolean(nodeContents));
-            case "useTransfers" -> campaignOptions.setUseTransfers(Boolean.parseBoolean(nodeContents));
-            case "useExtendedTOEForceName" -> campaignOptions.setUseExtendedTOEForceName(Boolean.parseBoolean(
+            case "useAgeEffects" -> campaignOptions.setUseAgeEffects(parseBoolean(nodeContents));
+            case "useTransfers" -> campaignOptions.setUseTransfers(parseBoolean(nodeContents));
+            case "useExtendedTOEForceName" -> campaignOptions.setUseExtendedTOEForceName(parseBoolean(
                   nodeContents));
-            case "personnelLogSkillGain" ->
-                  campaignOptions.setPersonnelLogSkillGain(Boolean.parseBoolean(nodeContents));
-            case "personnelLogAbilityGain" -> campaignOptions.setPersonnelLogAbilityGain(Boolean.parseBoolean(
+            case "personnelLogSkillGain" -> campaignOptions.setPersonnelLogSkillGain(parseBoolean(nodeContents));
+            case "personnelLogAbilityGain" -> campaignOptions.setPersonnelLogAbilityGain(parseBoolean(
                   nodeContents));
-            case "personnelLogEdgeGain" -> campaignOptions.setPersonnelLogEdgeGain(Boolean.parseBoolean(nodeContents));
-            case "displayPersonnelLog" -> campaignOptions.setDisplayPersonnelLog(Boolean.parseBoolean(nodeContents));
-            case "displayScenarioLog" -> campaignOptions.setDisplayScenarioLog(Boolean.parseBoolean(nodeContents));
-            case "displayKillRecord" -> campaignOptions.setDisplayKillRecord(Boolean.parseBoolean(nodeContents));
-            case "displayMedicalRecord" -> campaignOptions.setDisplayMedicalRecord(Boolean.parseBoolean(nodeContents));
-            case "displayAssignmentRecord" -> campaignOptions.setDisplayAssignmentRecord(Boolean.parseBoolean(
+            case "personnelLogEdgeGain" -> campaignOptions.setPersonnelLogEdgeGain(parseBoolean(nodeContents));
+            case "displayPersonnelLog" -> campaignOptions.setDisplayPersonnelLog(parseBoolean(nodeContents));
+            case "displayScenarioLog" -> campaignOptions.setDisplayScenarioLog(parseBoolean(nodeContents));
+            case "displayKillRecord" -> campaignOptions.setDisplayKillRecord(parseBoolean(nodeContents));
+            case "displayMedicalRecord" -> campaignOptions.setDisplayMedicalRecord(parseBoolean(nodeContents));
+            case "displayAssignmentRecord" -> campaignOptions.setDisplayAssignmentRecord(parseBoolean(
                   nodeContents));
-            case "displayPerformanceRecord" -> campaignOptions.setDisplayPerformanceRecord(Boolean.parseBoolean(
+            case "displayPerformanceRecord" -> campaignOptions.setDisplayPerformanceRecord(parseBoolean(
                   nodeContents));
-            case "rewardComingOfAgeAbilities" -> campaignOptions.setRewardComingOfAgeAbilities(Boolean.parseBoolean(
+            case "rewardComingOfAgeAbilities" -> campaignOptions.setRewardComingOfAgeAbilities(parseBoolean(
                   nodeContents));
-            case "rewardComingOfAgeRPSkills" -> campaignOptions.setRewardComingOfAgeRPSkills(Boolean.parseBoolean(
+            case "rewardComingOfAgeRPSkills" -> campaignOptions.setRewardComingOfAgeRPSkills(parseBoolean(
                   nodeContents));
-            case "useTimeInService" -> campaignOptions.setUseTimeInService(Boolean.parseBoolean(nodeContents));
+            case "useTimeInService" -> campaignOptions.setUseTimeInService(parseBoolean(nodeContents));
             case "timeInServiceDisplayFormat" ->
                   campaignOptions.setTimeInServiceDisplayFormat(TimeInDisplayFormat.valueOf(
                         nodeContents));
-            case "useTimeInRank" -> campaignOptions.setUseTimeInRank(Boolean.parseBoolean(nodeContents));
+            case "useTimeInRank" -> campaignOptions.setUseTimeInRank(parseBoolean(nodeContents));
             case "timeInRankDisplayFormat" -> campaignOptions.setTimeInRankDisplayFormat(TimeInDisplayFormat.valueOf(
                   nodeContents));
-            case "trackTotalEarnings" -> campaignOptions.setTrackTotalEarnings(Boolean.parseBoolean(nodeContents));
-            case "trackTotalXPEarnings" -> campaignOptions.setTrackTotalXPEarnings(Boolean.parseBoolean(nodeContents));
-            case "showOriginFaction" -> campaignOptions.setShowOriginFaction(Boolean.parseBoolean(nodeContents));
-            case "adminsHaveNegotiation" ->
-                  campaignOptions.setAdminsHaveNegotiation(Boolean.parseBoolean(nodeContents));
+            case "trackTotalEarnings" -> campaignOptions.setTrackTotalEarnings(parseBoolean(nodeContents));
+            case "trackTotalXPEarnings" -> campaignOptions.setTrackTotalXPEarnings(parseBoolean(nodeContents));
+            case "showOriginFaction" -> campaignOptions.setShowOriginFaction(parseBoolean(nodeContents));
+            case "adminsHaveNegotiation" -> campaignOptions.setAdminsHaveNegotiation(parseBoolean(nodeContents));
             case "adminExperienceLevelIncludeNegotiation" ->
-                  campaignOptions.setAdminExperienceLevelIncludeNegotiation(Boolean.parseBoolean(
+                  campaignOptions.setAdminExperienceLevelIncludeNegotiation(parseBoolean(
                         nodeContents));
-            case "useAdvancedMedical" -> campaignOptions.setUseAdvancedMedical(Boolean.parseBoolean(nodeContents));
-            case "healWaitingPeriod" -> campaignOptions.setHealingWaitingPeriod(Integer.parseInt(nodeContents));
-            case "naturalHealingWaitingPeriod" -> campaignOptions.setNaturalHealingWaitingPeriod(Integer.parseInt(
+            case "useAdvancedMedical" -> campaignOptions.setUseAdvancedMedical(parseBoolean(nodeContents));
+            case "healWaitingPeriod" -> campaignOptions.setHealingWaitingPeriod(parseInt(nodeContents));
+            case "naturalHealingWaitingPeriod" -> campaignOptions.setNaturalHealingWaitingPeriod(parseInt(
                   nodeContents));
-            case "minimumHitsForVehicles" -> campaignOptions.setMinimumHitsForVehicles(Integer.parseInt(nodeContents));
-            case "useRandomHitsForVehicles" -> campaignOptions.setUseRandomHitsForVehicles(Boolean.parseBoolean(
+            case "minimumHitsForVehicles" -> campaignOptions.setMinimumHitsForVehicles(parseInt(nodeContents));
+            case "useRandomHitsForVehicles" -> campaignOptions.setUseRandomHitsForVehicles(parseBoolean(
                   nodeContents));
-            case "tougherHealing" -> campaignOptions.setTougherHealing(Boolean.parseBoolean(nodeContents));
-            case "maximumPatients" -> campaignOptions.setMaximumPatients(Integer.parseInt(nodeContents));
-            case "doctorsUseAdministration" -> campaignOptions.setDoctorsUseAdministration(Boolean.parseBoolean(
+            case "tougherHealing" -> campaignOptions.setTougherHealing(parseBoolean(nodeContents));
+            case "maximumPatients" -> campaignOptions.setMaximumPatients(parseInt(nodeContents));
+            case "doctorsUseAdministration" -> campaignOptions.setDoctorsUseAdministration(parseBoolean(
                   nodeContents));
             case "prisonerCaptureStyle" -> campaignOptions.setPrisonerCaptureStyle(PrisonerCaptureStyle.fromString(
                   nodeContents));
-            case "useRandomDependentAddition" -> campaignOptions.setUseRandomDependentAddition(Boolean.parseBoolean(
+            case "useRandomDependentAddition" -> campaignOptions.setUseRandomDependentAddition(parseBoolean(
                   nodeContents));
-            case "useRandomDependentRemoval" -> campaignOptions.setUseRandomDependentRemoval(Boolean.parseBoolean(
+            case "useRandomDependentRemoval" -> campaignOptions.setUseRandomDependentRemoval(parseBoolean(
                   nodeContents));
-            case "dependentProfessionDieSize" -> campaignOptions.setDependentProfessionDieSize(MathUtility.parseInt(
+            case "dependentProfessionDieSize" -> campaignOptions.setDependentProfessionDieSize(parseInt(
                   nodeContents, 4));
-            case "civilianProfessionDieSize" -> campaignOptions.setCivilianProfessionDieSize(MathUtility.parseInt(
+            case "civilianProfessionDieSize" -> campaignOptions.setCivilianProfessionDieSize(parseInt(
                   nodeContents, 2));
-            case "usePersonnelRemoval" -> campaignOptions.setUsePersonnelRemoval(Boolean.parseBoolean(nodeContents));
-            case "useRemovalExemptCemetery" -> campaignOptions.setUseRemovalExemptCemetery(Boolean.parseBoolean(
+            case "usePersonnelRemoval" -> campaignOptions.setUsePersonnelRemoval(parseBoolean(nodeContents));
+            case "useRemovalExemptCemetery" -> campaignOptions.setUseRemovalExemptCemetery(parseBoolean(
                   nodeContents));
-            case "useRemovalExemptRetirees" -> campaignOptions.setUseRemovalExemptRetirees(Boolean.parseBoolean(
+            case "useRemovalExemptRetirees" -> campaignOptions.setUseRemovalExemptRetirees(parseBoolean(
                   nodeContents));
-            case "disableSecondaryRoleSalary" -> campaignOptions.setDisableSecondaryRoleSalary(Boolean.parseBoolean(
+            case "disableSecondaryRoleSalary" -> campaignOptions.setDisableSecondaryRoleSalary(parseBoolean(
                   nodeContents));
-            case "salaryAntiMekMultiplier" ->
-                  campaignOptions.setSalaryAntiMekMultiplier(Double.parseDouble(nodeContents));
+            case "salaryAntiMekMultiplier" -> campaignOptions.setSalaryAntiMekMultiplier(parseDouble(nodeContents));
             case "salarySpecialistInfantryMultiplier" ->
-                  campaignOptions.setSalarySpecialistInfantryMultiplier(Double.parseDouble(
+                  campaignOptions.setSalarySpecialistInfantryMultiplier(parseDouble(
                         nodeContents));
             case "salaryXPMultipliers" -> {
                 if (!childNode.hasChildNodes()) {
@@ -407,7 +388,7 @@ public class CampaignOptionsUnmarshaller {
                     }
                     campaignOptions.getSalaryXPMultipliers()
                           .put(SkillLevel.valueOf(wn3.getNodeName().trim()),
-                                Double.parseDouble(wn3.getTextContent().trim()));
+                                parseDouble(wn3.getTextContent().trim()));
                 }
             }
             case "salaryTypeBase" -> {
@@ -430,31 +411,30 @@ public class CampaignOptionsUnmarshaller {
                 campaignOptions.setRoleBaseSalaries(mergedSalaries);
             }
             case "awardBonusStyle" -> campaignOptions.setAwardBonusStyle(AwardBonus.valueOf(nodeContents));
-            case "enableAutoAwards" -> campaignOptions.setEnableAutoAwards(Boolean.parseBoolean(nodeContents));
-            case "issuePosthumousAwards" ->
-                  campaignOptions.setIssuePosthumousAwards(Boolean.parseBoolean(nodeContents));
-            case "issueBestAwardOnly" -> campaignOptions.setIssueBestAwardOnly(Boolean.parseBoolean(nodeContents));
-            case "ignoreStandardSet" -> campaignOptions.setIgnoreStandardSet(Boolean.parseBoolean(nodeContents));
-            case "awardTierSize" -> campaignOptions.setAwardTierSize(Integer.parseInt(nodeContents));
-            case "enableContractAwards" -> campaignOptions.setEnableContractAwards(Boolean.parseBoolean(nodeContents));
-            case "enableFactionHunterAwards" -> campaignOptions.setEnableFactionHunterAwards(Boolean.parseBoolean(
+            case "enableAutoAwards" -> campaignOptions.setEnableAutoAwards(parseBoolean(nodeContents));
+            case "issuePosthumousAwards" -> campaignOptions.setIssuePosthumousAwards(parseBoolean(nodeContents));
+            case "issueBestAwardOnly" -> campaignOptions.setIssueBestAwardOnly(parseBoolean(nodeContents));
+            case "ignoreStandardSet" -> campaignOptions.setIgnoreStandardSet(parseBoolean(nodeContents));
+            case "awardTierSize" -> campaignOptions.setAwardTierSize(parseInt(nodeContents));
+            case "enableContractAwards" -> campaignOptions.setEnableContractAwards(parseBoolean(nodeContents));
+            case "enableFactionHunterAwards" -> campaignOptions.setEnableFactionHunterAwards(parseBoolean(
                   nodeContents));
-            case "enableInjuryAwards" -> campaignOptions.setEnableInjuryAwards(Boolean.parseBoolean(nodeContents));
-            case "enableIndividualKillAwards" -> campaignOptions.setEnableIndividualKillAwards(Boolean.parseBoolean(
+            case "enableInjuryAwards" -> campaignOptions.setEnableInjuryAwards(parseBoolean(nodeContents));
+            case "enableIndividualKillAwards" -> campaignOptions.setEnableIndividualKillAwards(parseBoolean(
                   nodeContents));
-            case "enableFormationKillAwards" -> campaignOptions.setEnableFormationKillAwards(Boolean.parseBoolean(
+            case "enableFormationKillAwards" -> campaignOptions.setEnableFormationKillAwards(parseBoolean(
                   nodeContents));
-            case "enableRankAwards" -> campaignOptions.setEnableRankAwards(Boolean.parseBoolean(nodeContents));
-            case "enableScenarioAwards" -> campaignOptions.setEnableScenarioAwards(Boolean.parseBoolean(nodeContents));
-            case "enableSkillAwards" -> campaignOptions.setEnableSkillAwards(Boolean.parseBoolean(nodeContents));
-            case "enableTheatreOfWarAwards" -> campaignOptions.setEnableTheatreOfWarAwards(Boolean.parseBoolean(
+            case "enableRankAwards" -> campaignOptions.setEnableRankAwards(parseBoolean(nodeContents));
+            case "enableScenarioAwards" -> campaignOptions.setEnableScenarioAwards(parseBoolean(nodeContents));
+            case "enableSkillAwards" -> campaignOptions.setEnableSkillAwards(parseBoolean(nodeContents));
+            case "enableTheatreOfWarAwards" -> campaignOptions.setEnableTheatreOfWarAwards(parseBoolean(
                   nodeContents));
-            case "enableTimeAwards" -> campaignOptions.setEnableTimeAwards(Boolean.parseBoolean(nodeContents));
-            case "enableTrainingAwards" -> campaignOptions.setEnableTrainingAwards(Boolean.parseBoolean(nodeContents));
-            case "enableMiscAwards" -> campaignOptions.setEnableMiscAwards(Boolean.parseBoolean(nodeContents));
+            case "enableTimeAwards" -> campaignOptions.setEnableTimeAwards(parseBoolean(nodeContents));
+            case "enableTrainingAwards" -> campaignOptions.setEnableTrainingAwards(parseBoolean(nodeContents));
+            case "enableMiscAwards" -> campaignOptions.setEnableMiscAwards(parseBoolean(nodeContents));
             case "awardSetFilterList" -> campaignOptions.setAwardSetFilterList(nodeContents);
-            case "useDylansRandomXP" -> campaignOptions.setUseDylansRandomXP(Boolean.parseBoolean(nodeContents));
-            case "nonBinaryDiceSize" -> campaignOptions.setNonBinaryDiceSize(Integer.parseInt(nodeContents));
+            case "useDylansRandomXP" -> campaignOptions.setUseDylansRandomXP(parseBoolean(nodeContents));
+            case "nonBinaryDiceSize" -> campaignOptions.setNonBinaryDiceSize(parseInt(nodeContents));
             case "randomOriginOptions" -> {
                 if (!childNode.hasChildNodes()) {
                     return;
@@ -466,43 +446,36 @@ public class CampaignOptionsUnmarshaller {
                 }
                 campaignOptions.setRandomOriginOptions(randomOriginOptions);
             }
-            case "useRandomPersonalities" ->
-                  campaignOptions.setUseRandomPersonalities(Boolean.parseBoolean(nodeContents));
-            case "useRandomPersonalityReputation" ->
-                  campaignOptions.setUseRandomPersonalityReputation(Boolean.parseBoolean(
+            case "useRandomPersonalities" -> campaignOptions.setUseRandomPersonalities(parseBoolean(nodeContents));
+            case "useRandomPersonalityReputation" -> campaignOptions.setUseRandomPersonalityReputation(parseBoolean(
                         nodeContents));
-            case "useReasoningXpMultiplier" -> campaignOptions.setUseReasoningXpMultiplier(Boolean.parseBoolean(
+            case "useReasoningXpMultiplier" -> campaignOptions.setUseReasoningXpMultiplier(parseBoolean(
                   nodeContents));
-            case "useSimulatedRelationships" -> campaignOptions.setUseSimulatedRelationships(Boolean.parseBoolean(
+            case "useSimulatedRelationships" -> campaignOptions.setUseSimulatedRelationships(parseBoolean(
                   nodeContents));
             case "familyDisplayLevel" ->
                   campaignOptions.setFamilyDisplayLevel(FamilialRelationshipDisplayLevel.parseFromString(
                         nodeContents));
-            case "announceBirthdays" -> campaignOptions.setAnnounceBirthdays(Boolean.parseBoolean(nodeContents));
-            case "announceRecruitmentAnniversaries" ->
-                  campaignOptions.setAnnounceRecruitmentAnniversaries(Boolean.parseBoolean(
+            case "announceBirthdays" -> campaignOptions.setAnnounceBirthdays(parseBoolean(nodeContents));
+            case "announceRecruitmentAnniversaries" -> campaignOptions.setAnnounceRecruitmentAnniversaries(parseBoolean(
                         nodeContents));
-            case "announceOfficersOnly" -> campaignOptions.setAnnounceOfficersOnly(Boolean.parseBoolean(nodeContents));
-            case "announceChildBirthdays" ->
-                  campaignOptions.setAnnounceChildBirthdays(Boolean.parseBoolean(nodeContents));
-            case "showLifeEventDialogBirths" -> campaignOptions.setShowLifeEventDialogBirths(Boolean.parseBoolean(
+            case "announceOfficersOnly" -> campaignOptions.setAnnounceOfficersOnly(parseBoolean(nodeContents));
+            case "announceChildBirthdays" -> campaignOptions.setAnnounceChildBirthdays(parseBoolean(nodeContents));
+            case "showLifeEventDialogBirths" -> campaignOptions.setShowLifeEventDialogBirths(parseBoolean(
                   nodeContents));
-            case "showLifeEventDialogComingOfAge" ->
-                  campaignOptions.setShowLifeEventDialogComingOfAge(Boolean.parseBoolean(
+            case "showLifeEventDialogComingOfAge" -> campaignOptions.setShowLifeEventDialogComingOfAge(parseBoolean(
                         nodeContents));
-            case "showLifeEventDialogCelebrations" ->
-                  campaignOptions.setShowLifeEventDialogCelebrations(Boolean.parseBoolean(
+            case "showLifeEventDialogCelebrations" -> campaignOptions.setShowLifeEventDialogCelebrations(parseBoolean(
                         nodeContents));
-            case "useManualMarriages" -> campaignOptions.setUseManualMarriages(Boolean.parseBoolean(nodeContents));
-            case "useClanPersonnelMarriages" -> campaignOptions.setUseClanPersonnelMarriages(Boolean.parseBoolean(
+            case "useManualMarriages" -> campaignOptions.setUseManualMarriages(parseBoolean(nodeContents));
+            case "useClanPersonnelMarriages" -> campaignOptions.setUseClanPersonnelMarriages(parseBoolean(
                   nodeContents));
-            case "usePrisonerMarriages" -> campaignOptions.setUsePrisonerMarriages(Boolean.parseBoolean(nodeContents));
-            case "checkMutualAncestorsDepth" -> campaignOptions.setCheckMutualAncestorsDepth(Integer.parseInt(
+            case "usePrisonerMarriages" -> campaignOptions.setUsePrisonerMarriages(parseBoolean(nodeContents));
+            case "checkMutualAncestorsDepth" -> campaignOptions.setCheckMutualAncestorsDepth(parseInt(
                   nodeContents));
-            case "noInterestInMarriageDiceSize" -> campaignOptions.setNoInterestInMarriageDiceSize(Integer.parseInt(
+            case "noInterestInMarriageDiceSize" -> campaignOptions.setNoInterestInMarriageDiceSize(parseInt(
                   nodeContents));
-            case "logMarriageNameChanges" ->
-                  campaignOptions.setLogMarriageNameChanges(Boolean.parseBoolean(nodeContents));
+            case "logMarriageNameChanges" -> campaignOptions.setLogMarriageNameChanges(parseBoolean(nodeContents));
             case "marriageSurnameWeights" -> {
                 if (!childNode.hasChildNodes()) {
                     return;
@@ -515,26 +488,25 @@ public class CampaignOptionsUnmarshaller {
                     }
                     campaignOptions.getMarriageSurnameWeights()
                           .put(MergingSurnameStyle.parseFromString(wn3.getNodeName().trim()),
-                                Integer.parseInt(wn3.getTextContent().trim()));
+                                parseInt(wn3.getTextContent().trim()));
                 }
             }
             case "randomMarriageMethod" -> campaignOptions.setRandomMarriageMethod(RandomMarriageMethod.fromString(
                   nodeContents));
-            case "useRandomClanPersonnelMarriages" ->
-                  campaignOptions.setUseRandomClanPersonnelMarriages(Boolean.parseBoolean(
+            case "useRandomClanPersonnelMarriages" -> campaignOptions.setUseRandomClanPersonnelMarriages(parseBoolean(
                         nodeContents));
-            case "useRandomPrisonerMarriages" -> campaignOptions.setUseRandomPrisonerMarriages(Boolean.parseBoolean(
+            case "useRandomPrisonerMarriages" -> campaignOptions.setUseRandomPrisonerMarriages(parseBoolean(
                   nodeContents));
-            case "randomMarriageAgeRange" -> campaignOptions.setRandomMarriageAgeRange(Integer.parseInt(nodeContents));
-            case "randomMarriageDiceSize" -> campaignOptions.setRandomMarriageDiceSize(Integer.parseInt(nodeContents));
-            case "randomSameSexMarriageDiceSize" -> campaignOptions.setRandomSameSexMarriageDiceSize(Integer.parseInt(
+            case "randomMarriageAgeRange" -> campaignOptions.setRandomMarriageAgeRange(parseInt(nodeContents));
+            case "randomMarriageDiceSize" -> campaignOptions.setRandomMarriageDiceSize(parseInt(nodeContents));
+            case "randomSameSexMarriageDiceSize" -> campaignOptions.setRandomSameSexMarriageDiceSize(parseInt(
                   nodeContents));
-            case "randomNewDependentMarriage" -> campaignOptions.setRandomNewDependentMarriage(Integer.parseInt(
+            case "randomNewDependentMarriage" -> campaignOptions.setRandomNewDependentMarriage(parseInt(
                   nodeContents));
-            case "useManualDivorce" -> campaignOptions.setUseManualDivorce(Boolean.parseBoolean(nodeContents));
-            case "useClanPersonnelDivorce" -> campaignOptions.setUseClanPersonnelDivorce(Boolean.parseBoolean(
+            case "useManualDivorce" -> campaignOptions.setUseManualDivorce(parseBoolean(nodeContents));
+            case "useClanPersonnelDivorce" -> campaignOptions.setUseClanPersonnelDivorce(parseBoolean(
                   nodeContents));
-            case "usePrisonerDivorce" -> campaignOptions.setUsePrisonerDivorce(Boolean.parseBoolean(nodeContents));
+            case "usePrisonerDivorce" -> campaignOptions.setUsePrisonerDivorce(parseBoolean(nodeContents));
             case "divorceSurnameWeights" -> {
                 if (!childNode.hasChildNodes()) {
                     return;
@@ -547,82 +519,77 @@ public class CampaignOptionsUnmarshaller {
                     }
                     campaignOptions.getDivorceSurnameWeights()
                           .put(SplittingSurnameStyle.valueOf(wn3.getNodeName().trim()),
-                                Integer.parseInt(wn3.getTextContent().trim()));
+                                parseInt(wn3.getTextContent().trim()));
                 }
             }
             case "randomDivorceMethod" -> campaignOptions.setRandomDivorceMethod(RandomDivorceMethod.fromString(
                   nodeContents));
-            case "useRandomOppositeSexDivorce" -> campaignOptions.setUseRandomOppositeSexDivorce(Boolean.parseBoolean(
+            case "useRandomOppositeSexDivorce" -> campaignOptions.setUseRandomOppositeSexDivorce(parseBoolean(
                   nodeContents));
-            case "useRandomSameSexDivorce" -> campaignOptions.setUseRandomSameSexDivorce(Boolean.parseBoolean(
+            case "useRandomSameSexDivorce" -> campaignOptions.setUseRandomSameSexDivorce(parseBoolean(
                   nodeContents));
-            case "useRandomClanPersonnelDivorce" ->
-                  campaignOptions.setUseRandomClanPersonnelDivorce(Boolean.parseBoolean(
+            case "useRandomClanPersonnelDivorce" -> campaignOptions.setUseRandomClanPersonnelDivorce(parseBoolean(
                         nodeContents));
-            case "useRandomPrisonerDivorce" -> campaignOptions.setUseRandomPrisonerDivorce(Boolean.parseBoolean(
+            case "useRandomPrisonerDivorce" -> campaignOptions.setUseRandomPrisonerDivorce(parseBoolean(
                   nodeContents));
-            case "randomDivorceDiceSize" -> campaignOptions.setRandomDivorceDiceSize(Integer.parseInt(nodeContents));
-            case "useManualProcreation" -> campaignOptions.setUseManualProcreation(Boolean.parseBoolean(nodeContents));
-            case "useClanPersonnelProcreation" -> campaignOptions.setUseClanPersonnelProcreation(Boolean.parseBoolean(
+            case "randomDivorceDiceSize" -> campaignOptions.setRandomDivorceDiceSize(parseInt(nodeContents));
+            case "useManualProcreation" -> campaignOptions.setUseManualProcreation(parseBoolean(nodeContents));
+            case "useClanPersonnelProcreation" -> campaignOptions.setUseClanPersonnelProcreation(parseBoolean(
                   nodeContents));
-            case "usePrisonerProcreation" ->
-                  campaignOptions.setUsePrisonerProcreation(Boolean.parseBoolean(nodeContents));
-            case "multiplePregnancyOccurrences" -> campaignOptions.setMultiplePregnancyOccurrences(Integer.parseInt(
+            case "usePrisonerProcreation" -> campaignOptions.setUsePrisonerProcreation(parseBoolean(nodeContents));
+            case "multiplePregnancyOccurrences" -> campaignOptions.setMultiplePregnancyOccurrences(parseInt(
                   nodeContents));
             case "babySurnameStyle" ->
                   campaignOptions.setBabySurnameStyle(BabySurnameStyle.parseFromString(nodeContents));
             case "assignNonPrisonerBabiesFounderTag" ->
-                  campaignOptions.setAssignNonPrisonerBabiesFounderTag(Boolean.parseBoolean(
+                  campaignOptions.setAssignNonPrisonerBabiesFounderTag(parseBoolean(
                         nodeContents));
             case "assignChildrenOfFoundersFounderTag" ->
-                  campaignOptions.setAssignChildrenOfFoundersFounderTag(Boolean.parseBoolean(
+                  campaignOptions.setAssignChildrenOfFoundersFounderTag(parseBoolean(
                         nodeContents));
-            case "useMaternityLeave" -> campaignOptions.setUseMaternityLeave(Boolean.parseBoolean(nodeContents));
-            case "determineFatherAtBirth" ->
-                  campaignOptions.setDetermineFatherAtBirth(Boolean.parseBoolean(nodeContents));
-            case "displayTrueDueDate" -> campaignOptions.setDisplayTrueDueDate(Boolean.parseBoolean(nodeContents));
-            case "noInterestInChildrenDiceSize" -> campaignOptions.setNoInterestInChildrenDiceSize(Integer.parseInt(
+            case "useMaternityLeave" -> campaignOptions.setUseMaternityLeave(parseBoolean(nodeContents));
+            case "determineFatherAtBirth" -> campaignOptions.setDetermineFatherAtBirth(parseBoolean(nodeContents));
+            case "displayTrueDueDate" -> campaignOptions.setDisplayTrueDueDate(parseBoolean(nodeContents));
+            case "noInterestInChildrenDiceSize" -> campaignOptions.setNoInterestInChildrenDiceSize(parseInt(
                   nodeContents));
-            case "logProcreation" -> campaignOptions.setLogProcreation(Boolean.parseBoolean(nodeContents));
+            case "logProcreation" -> campaignOptions.setLogProcreation(parseBoolean(nodeContents));
             case "randomProcreationMethod" ->
                   campaignOptions.setRandomProcreationMethod(RandomProcreationMethod.fromString(
                         nodeContents));
             case "useRelationshiplessRandomProcreation" ->
-                  campaignOptions.setUseRelationshiplessRandomProcreation(Boolean.parseBoolean(
+                  campaignOptions.setUseRelationshiplessRandomProcreation(parseBoolean(
                         nodeContents));
             case "useRandomClanPersonnelProcreation" ->
-                  campaignOptions.setUseRandomClanPersonnelProcreation(Boolean.parseBoolean(
+                  campaignOptions.setUseRandomClanPersonnelProcreation(parseBoolean(
                         nodeContents));
-            case "useRandomPrisonerProcreation" -> campaignOptions.setUseRandomPrisonerProcreation(Boolean.parseBoolean(
+            case "useRandomPrisonerProcreation" -> campaignOptions.setUseRandomPrisonerProcreation(parseBoolean(
                   nodeContents));
             case "randomProcreationRelationshipDiceSize" ->
-                  campaignOptions.setRandomProcreationRelationshipDiceSize(Integer.parseInt(
+                  campaignOptions.setRandomProcreationRelationshipDiceSize(parseInt(
                         nodeContents));
             case "randomProcreationRelationshiplessDiceSize" ->
-                  campaignOptions.setRandomProcreationRelationshiplessDiceSize(Integer.parseInt(
+                  campaignOptions.setRandomProcreationRelationshiplessDiceSize(parseInt(
                         nodeContents));
-            case "useEducationModule" -> campaignOptions.setUseEducationModule(Boolean.parseBoolean(nodeContents));
-            case "curriculumXpRate" -> campaignOptions.setCurriculumXpRate(Integer.parseInt(nodeContents));
-            case "maximumJumpCount" -> campaignOptions.setMaximumJumpCount(Integer.parseInt(nodeContents));
-            case "useReeducationCamps" -> campaignOptions.setUseReeducationCamps(Boolean.parseBoolean(nodeContents));
-            case "enableLocalAcademies" -> campaignOptions.setEnableLocalAcademies(Boolean.parseBoolean(nodeContents));
-            case "enablePrestigiousAcademies" -> campaignOptions.setEnablePrestigiousAcademies(Boolean.parseBoolean(
+            case "useEducationModule" -> campaignOptions.setUseEducationModule(parseBoolean(nodeContents));
+            case "curriculumXpRate" -> campaignOptions.setCurriculumXpRate(parseInt(nodeContents));
+            case "maximumJumpCount" -> campaignOptions.setMaximumJumpCount(parseInt(nodeContents));
+            case "useReeducationCamps" -> campaignOptions.setUseReeducationCamps(parseBoolean(nodeContents));
+            case "enableLocalAcademies" -> campaignOptions.setEnableLocalAcademies(parseBoolean(nodeContents));
+            case "enablePrestigiousAcademies" -> campaignOptions.setEnablePrestigiousAcademies(parseBoolean(
                   nodeContents));
-            case "enableUnitEducation" -> campaignOptions.setEnableUnitEducation(Boolean.parseBoolean(nodeContents));
-            case "enableOverrideRequirements" -> campaignOptions.setEnableOverrideRequirements(Boolean.parseBoolean(
+            case "enableUnitEducation" -> campaignOptions.setEnableUnitEducation(parseBoolean(nodeContents));
+            case "enableOverrideRequirements" -> campaignOptions.setEnableOverrideRequirements(parseBoolean(
                   nodeContents));
-            case "enableShowIneligibleAcademies" ->
-                  campaignOptions.setEnableShowIneligibleAcademies(Boolean.parseBoolean(
+            case "enableShowIneligibleAcademies" -> campaignOptions.setEnableShowIneligibleAcademies(parseBoolean(
                         nodeContents));
-            case "entranceExamBaseTargetNumber" -> campaignOptions.setEntranceExamBaseTargetNumber(Integer.parseInt(
+            case "entranceExamBaseTargetNumber" -> campaignOptions.setEntranceExamBaseTargetNumber(parseInt(
                   nodeContents));
-            case "facultyXpRate" -> campaignOptions.setFacultyXpRate(Double.parseDouble(nodeContents));
-            case "enableBonuses" -> campaignOptions.setEnableBonuses(Boolean.parseBoolean(nodeContents));
-            case "adultDropoutChance" -> campaignOptions.setAdultDropoutChance(Integer.parseInt(nodeContents));
-            case "childrenDropoutChance" -> campaignOptions.setChildrenDropoutChance(Integer.parseInt(nodeContents));
-            case "allAges" -> campaignOptions.setAllAges(Boolean.parseBoolean(nodeContents));
-            case "militaryAcademyAccidents" ->
-                  campaignOptions.setMilitaryAcademyAccidents(Integer.parseInt(nodeContents));
+            case "facultyXpRate" -> campaignOptions.setFacultyXpRate(parseDouble(nodeContents));
+            case "enableBonuses" -> campaignOptions.setEnableBonuses(parseBoolean(nodeContents));
+            case "adultDropoutChance" -> campaignOptions.setAdultDropoutChance(parseInt(nodeContents));
+            case "childrenDropoutChance" -> campaignOptions.setChildrenDropoutChance(parseInt(nodeContents));
+            case "allAges" -> campaignOptions.setAllAges(parseBoolean(nodeContents));
+            case "militaryAcademyAccidents" -> campaignOptions.setMilitaryAcademyAccidents(parseInt(nodeContents));
             case "enabledRandomDeathAgeGroups" -> {
                 if (!childNode.hasChildNodes()) {
                     return;
@@ -633,142 +600,126 @@ public class CampaignOptionsUnmarshaller {
                     try {
                         campaignOptions.getEnabledRandomDeathAgeGroups()
                               .put(AgeGroup.valueOf(wn3.getNodeName()),
-                                    Boolean.parseBoolean(wn3.getTextContent().trim()));
+                                    parseBoolean(wn3.getTextContent().trim()));
                     } catch (Exception ignored) {
 
                     }
                 }
             }
-            case "useRandomDeathSuicideCause" -> campaignOptions.setUseRandomDeathSuicideCause(Boolean.parseBoolean(
+            case "useRandomDeathSuicideCause" -> campaignOptions.setUseRandomDeathSuicideCause(parseBoolean(
                   nodeContents));
-            case "randomDeathMultiplier" -> campaignOptions.setRandomDeathMultiplier(Double.parseDouble(nodeContents));
-            case "useRandomRetirement" -> campaignOptions.setUseRandomRetirement(Boolean.parseBoolean(nodeContents));
-            case "turnoverBaseTn" -> campaignOptions.setTurnoverFixedTargetNumber(Integer.parseInt(nodeContents));
+            case "randomDeathMultiplier" -> campaignOptions.setRandomDeathMultiplier(parseDouble(nodeContents));
+            case "useRandomRetirement" -> campaignOptions.setUseRandomRetirement(parseBoolean(nodeContents));
+            case "turnoverBaseTn" -> campaignOptions.setTurnoverFixedTargetNumber(parseInt(nodeContents));
             case "turnoverFrequency" -> campaignOptions.setTurnoverFrequency(TurnoverFrequency.valueOf(nodeContents));
-            case "trackOriginalUnit" -> campaignOptions.setTrackOriginalUnit(Boolean.parseBoolean(nodeContents));
-            case "aeroRecruitsHaveUnits" ->
-                  campaignOptions.setAeroRecruitsHaveUnits(Boolean.parseBoolean(nodeContents));
+            case "trackOriginalUnit" -> campaignOptions.setTrackOriginalUnit(parseBoolean(nodeContents));
+            case "aeroRecruitsHaveUnits" -> campaignOptions.setAeroRecruitsHaveUnits(parseBoolean(nodeContents));
             case "useContractCompletionRandomRetirement" ->
-                  campaignOptions.setUseContractCompletionRandomRetirement(Boolean.parseBoolean(
+                  campaignOptions.setUseContractCompletionRandomRetirement(parseBoolean(
                         nodeContents));
-            case "useRandomFounderTurnover" -> campaignOptions.setUseRandomFounderTurnover(Boolean.parseBoolean(
+            case "useRandomFounderTurnover" -> campaignOptions.setUseRandomFounderTurnover(parseBoolean(
                   nodeContents));
-            case "useFounderRetirement" -> campaignOptions.setUseFounderRetirement(Boolean.parseBoolean(nodeContents));
-            case "useSubContractSoldiers" ->
-                  campaignOptions.setUseSubContractSoldiers(Boolean.parseBoolean(nodeContents));
-            case "serviceContractDuration" ->
-                  campaignOptions.setServiceContractDuration(Integer.parseInt(nodeContents));
-            case "serviceContractModifier" ->
-                  campaignOptions.setServiceContractModifier(Integer.parseInt(nodeContents));
-            case "payBonusDefault" -> campaignOptions.setPayBonusDefault(Boolean.parseBoolean(nodeContents));
-            case "payBonusDefaultThreshold" ->
-                  campaignOptions.setPayBonusDefaultThreshold(Integer.parseInt(nodeContents));
-            case "useCustomRetirementModifiers" -> campaignOptions.setUseCustomRetirementModifiers(Boolean.parseBoolean(
+            case "useFounderRetirement" -> campaignOptions.setUseFounderRetirement(parseBoolean(nodeContents));
+            case "useSubContractSoldiers" -> campaignOptions.setUseSubContractSoldiers(parseBoolean(nodeContents));
+            case "serviceContractDuration" -> campaignOptions.setServiceContractDuration(parseInt(nodeContents));
+            case "serviceContractModifier" -> campaignOptions.setServiceContractModifier(parseInt(nodeContents));
+            case "payBonusDefault" -> campaignOptions.setPayBonusDefault(parseBoolean(nodeContents));
+            case "payBonusDefaultThreshold" -> campaignOptions.setPayBonusDefaultThreshold(parseInt(nodeContents));
+            case "useCustomRetirementModifiers" -> campaignOptions.setUseCustomRetirementModifiers(parseBoolean(
                   nodeContents));
-            case "useFatigueModifiers" -> campaignOptions.setUseFatigueModifiers(Boolean.parseBoolean(nodeContents));
-            case "useSkillModifiers" -> campaignOptions.setUseSkillModifiers(Boolean.parseBoolean(nodeContents));
-            case "useAgeModifiers" -> campaignOptions.setUseAgeModifiers(Boolean.parseBoolean(nodeContents));
-            case "useUnitRatingModifiers" ->
-                  campaignOptions.setUseUnitRatingModifiers(Boolean.parseBoolean(nodeContents));
-            case "useFactionModifiers" -> campaignOptions.setUseFactionModifiers(Boolean.parseBoolean(nodeContents));
-            case "useMissionStatusModifiers" -> campaignOptions.setUseMissionStatusModifiers(Boolean.parseBoolean(
+            case "useFatigueModifiers" -> campaignOptions.setUseFatigueModifiers(parseBoolean(nodeContents));
+            case "useSkillModifiers" -> campaignOptions.setUseSkillModifiers(parseBoolean(nodeContents));
+            case "useAgeModifiers" -> campaignOptions.setUseAgeModifiers(parseBoolean(nodeContents));
+            case "useUnitRatingModifiers" -> campaignOptions.setUseUnitRatingModifiers(parseBoolean(nodeContents));
+            case "useFactionModifiers" -> campaignOptions.setUseFactionModifiers(parseBoolean(nodeContents));
+            case "useMissionStatusModifiers" -> campaignOptions.setUseMissionStatusModifiers(parseBoolean(
                   nodeContents));
-            case "useHostileTerritoryModifiers" -> campaignOptions.setUseHostileTerritoryModifiers(Boolean.parseBoolean(
+            case "useHostileTerritoryModifiers" -> campaignOptions.setUseHostileTerritoryModifiers(parseBoolean(
                   nodeContents));
-            case "useFamilyModifiers" -> campaignOptions.setUseFamilyModifiers(Boolean.parseBoolean(nodeContents));
-            case "useLoyaltyModifiers" -> campaignOptions.setUseLoyaltyModifiers(Boolean.parseBoolean(nodeContents));
-            case "useHideLoyalty" -> campaignOptions.setUseHideLoyalty(Boolean.parseBoolean(nodeContents));
-            case "payoutRateOfficer" -> campaignOptions.setPayoutRateOfficer(Integer.parseInt(nodeContents));
-            case "payoutRateEnlisted" -> campaignOptions.setPayoutRateEnlisted(Integer.parseInt(nodeContents));
-            case "payoutRetirementMultiplier" -> campaignOptions.setPayoutRetirementMultiplier(Integer.parseInt(
+            case "useFamilyModifiers" -> campaignOptions.setUseFamilyModifiers(parseBoolean(nodeContents));
+            case "useLoyaltyModifiers" -> campaignOptions.setUseLoyaltyModifiers(parseBoolean(nodeContents));
+            case "useHideLoyalty" -> campaignOptions.setUseHideLoyalty(parseBoolean(nodeContents));
+            case "payoutRateOfficer" -> campaignOptions.setPayoutRateOfficer(parseInt(nodeContents));
+            case "payoutRateEnlisted" -> campaignOptions.setPayoutRateEnlisted(parseInt(nodeContents));
+            case "payoutRetirementMultiplier" -> campaignOptions.setPayoutRetirementMultiplier(parseInt(
                   nodeContents));
-            case "usePayoutServiceBonus" ->
-                  campaignOptions.setUsePayoutServiceBonus(Boolean.parseBoolean(nodeContents));
-            case "payoutServiceBonusRate" -> campaignOptions.setPayoutServiceBonusRate(Integer.parseInt(nodeContents));
+            case "usePayoutServiceBonus" -> campaignOptions.setUsePayoutServiceBonus(parseBoolean(nodeContents));
+            case "payoutServiceBonusRate" -> campaignOptions.setPayoutServiceBonusRate(parseInt(nodeContents));
             // 'useAdministrativeStrain' is <50.07
-            case "UseHRStrain", "useAdministrativeStrain" ->
-                  campaignOptions.setUseHRStrain(Boolean.parseBoolean(nodeContents));
+            case "UseHRStrain", "useAdministrativeStrain" -> campaignOptions.setUseHRStrain(parseBoolean(nodeContents));
             // 'administrativeStrain' is <50.07
-            case "hrStrain", "administrativeStrain" ->
-                  campaignOptions.setHRCapacity(MathUtility.parseInt(nodeContents));
-            case "useManagementSkill" -> campaignOptions.setUseManagementSkill(Boolean.parseBoolean(nodeContents));
-            case "useCommanderLeadershipOnly" -> campaignOptions.setUseCommanderLeadershipOnly(Boolean.parseBoolean(
+            case "hrStrain", "administrativeStrain" -> campaignOptions.setHRCapacity(parseInt(nodeContents));
+            case "useManagementSkill" -> campaignOptions.setUseManagementSkill(parseBoolean(nodeContents));
+            case "useCommanderLeadershipOnly" -> campaignOptions.setUseCommanderLeadershipOnly(parseBoolean(
                   nodeContents));
-            case "managementSkillPenalty" -> campaignOptions.setManagementSkillPenalty(Integer.parseInt(nodeContents));
-            case "useFatigue" -> campaignOptions.setUseFatigue(Boolean.parseBoolean(nodeContents));
-            case "fatigueRate" -> campaignOptions.setFatigueRate(Integer.parseInt(nodeContents));
-            case "useInjuryFatigue" -> campaignOptions.setUseInjuryFatigue(Boolean.parseBoolean(nodeContents));
-            case "fieldKitchenCapacity" -> campaignOptions.setFieldKitchenCapacity(Integer.parseInt(nodeContents));
-            case "fieldKitchenIgnoreNonCombatants" ->
-                  campaignOptions.setFieldKitchenIgnoreNonCombatants(Boolean.parseBoolean(
+            case "managementSkillPenalty" -> campaignOptions.setManagementSkillPenalty(parseInt(nodeContents));
+            case "useFatigue" -> campaignOptions.setUseFatigue(parseBoolean(nodeContents));
+            case "fatigueRate" -> campaignOptions.setFatigueRate(parseInt(nodeContents));
+            case "useInjuryFatigue" -> campaignOptions.setUseInjuryFatigue(parseBoolean(nodeContents));
+            case "fieldKitchenCapacity" -> campaignOptions.setFieldKitchenCapacity(parseInt(nodeContents));
+            case "fieldKitchenIgnoreNonCombatants" -> campaignOptions.setFieldKitchenIgnoreNonCombatants(parseBoolean(
                         nodeContents));
-            case "fatigueLeaveThreshold" -> campaignOptions.setFatigueLeaveThreshold(Integer.parseInt(nodeContents));
-            case "payForParts" -> campaignOptions.setPayForParts(Boolean.parseBoolean(nodeContents));
-            case "payForRepairs" -> campaignOptions.setPayForRepairs(Boolean.parseBoolean(nodeContents));
-            case "payForUnits" -> campaignOptions.setPayForUnits(Boolean.parseBoolean(nodeContents));
-            case "payForSalaries" -> campaignOptions.setPayForSalaries(Boolean.parseBoolean(nodeContents));
-            case "payForOverhead" -> campaignOptions.setPayForOverhead(Boolean.parseBoolean(nodeContents));
-            case "payForMaintain" -> campaignOptions.setPayForMaintain(Boolean.parseBoolean(nodeContents));
-            case "payForTransport" -> campaignOptions.setPayForTransport(Boolean.parseBoolean(nodeContents));
-            case "sellUnits" -> campaignOptions.setSellUnits(Boolean.parseBoolean(nodeContents));
-            case "sellParts" -> campaignOptions.setSellParts(Boolean.parseBoolean(nodeContents));
-            case "payForRecruitment" -> campaignOptions.setPayForRecruitment(Boolean.parseBoolean(nodeContents));
-            case "payForFood" -> campaignOptions.setPayForFood(Boolean.parseBoolean(nodeContents));
-            case "payForHousing" -> campaignOptions.setPayForHousing(Boolean.parseBoolean(nodeContents));
-            case "useLoanLimits" -> campaignOptions.setLoanLimits(Boolean.parseBoolean(nodeContents));
-            case "usePercentageMaint" -> campaignOptions.setUsePercentageMaint(Boolean.parseBoolean(nodeContents));
-            case "infantryDontCount" -> campaignOptions.setUseInfantryDontCount(Boolean.parseBoolean(nodeContents));
-            case "usePeacetimeCost" -> campaignOptions.setUsePeacetimeCost(Boolean.parseBoolean(nodeContents));
-            case "useExtendedPartsModifier" -> campaignOptions.setUseExtendedPartsModifier(Boolean.parseBoolean(
+            case "fatigueLeaveThreshold" -> campaignOptions.setFatigueLeaveThreshold(parseInt(nodeContents));
+            case "payForParts" -> campaignOptions.setPayForParts(parseBoolean(nodeContents));
+            case "payForRepairs" -> campaignOptions.setPayForRepairs(parseBoolean(nodeContents));
+            case "payForUnits" -> campaignOptions.setPayForUnits(parseBoolean(nodeContents));
+            case "payForSalaries" -> campaignOptions.setPayForSalaries(parseBoolean(nodeContents));
+            case "payForOverhead" -> campaignOptions.setPayForOverhead(parseBoolean(nodeContents));
+            case "payForMaintain" -> campaignOptions.setPayForMaintain(parseBoolean(nodeContents));
+            case "payForTransport" -> campaignOptions.setPayForTransport(parseBoolean(nodeContents));
+            case "sellUnits" -> campaignOptions.setSellUnits(parseBoolean(nodeContents));
+            case "sellParts" -> campaignOptions.setSellParts(parseBoolean(nodeContents));
+            case "payForRecruitment" -> campaignOptions.setPayForRecruitment(parseBoolean(nodeContents));
+            case "payForFood" -> campaignOptions.setPayForFood(parseBoolean(nodeContents));
+            case "payForHousing" -> campaignOptions.setPayForHousing(parseBoolean(nodeContents));
+            case "useLoanLimits" -> campaignOptions.setLoanLimits(parseBoolean(nodeContents));
+            case "usePercentageMaint" -> campaignOptions.setUsePercentageMaint(parseBoolean(nodeContents));
+            case "infantryDontCount" -> campaignOptions.setUseInfantryDontCount(parseBoolean(nodeContents));
+            case "usePeacetimeCost" -> campaignOptions.setUsePeacetimeCost(parseBoolean(nodeContents));
+            case "useExtendedPartsModifier" -> campaignOptions.setUseExtendedPartsModifier(parseBoolean(
                   nodeContents));
-            case "showPeacetimeCost" -> campaignOptions.setShowPeacetimeCost(Boolean.parseBoolean(nodeContents));
+            case "showPeacetimeCost" -> campaignOptions.setShowPeacetimeCost(parseBoolean(nodeContents));
             case "newFinancialYearFinancesToCSVExport" ->
-                  campaignOptions.setNewFinancialYearFinancesToCSVExport(Boolean.parseBoolean(
+                  campaignOptions.setNewFinancialYearFinancesToCSVExport(parseBoolean(
                         nodeContents));
             case "financialYearDuration" ->
                   campaignOptions.setFinancialYearDuration(FinancialYearDuration.parseFromString(
                         nodeContents));
-            case "simulateGrayMonday" -> campaignOptions.setSimulateGrayMonday(Boolean.parseBoolean(nodeContents));
-            case "allowMonthlyReinvestment" -> campaignOptions.setAllowMonthlyReinvestment(Boolean.parseBoolean(
+            case "simulateGrayMonday" -> campaignOptions.setSimulateGrayMonday(parseBoolean(nodeContents));
+            case "allowMonthlyReinvestment" -> campaignOptions.setAllowMonthlyReinvestment(parseBoolean(
                   nodeContents));
-            case "allowMonthlyConnections" -> campaignOptions.setAllowMonthlyConnections(Boolean.parseBoolean(
+            case "allowMonthlyConnections" -> campaignOptions.setAllowMonthlyConnections(parseBoolean(
                   nodeContents));
-            case "commonPartPriceMultiplier" -> campaignOptions.setCommonPartPriceMultiplier(Double.parseDouble(
+            case "commonPartPriceMultiplier" -> campaignOptions.setCommonPartPriceMultiplier(parseDouble(
                   nodeContents));
-            case "innerSphereUnitPriceMultiplier" ->
-                  campaignOptions.setInnerSphereUnitPriceMultiplier(Double.parseDouble(
+            case "innerSphereUnitPriceMultiplier" -> campaignOptions.setInnerSphereUnitPriceMultiplier(parseDouble(
                         nodeContents));
-            case "innerSpherePartPriceMultiplier" ->
-                  campaignOptions.setInnerSpherePartPriceMultiplier(Double.parseDouble(
+            case "innerSpherePartPriceMultiplier" -> campaignOptions.setInnerSpherePartPriceMultiplier(parseDouble(
                         nodeContents));
-            case "clanUnitPriceMultiplier" ->
-                  campaignOptions.setClanUnitPriceMultiplier(Double.parseDouble(nodeContents));
-            case "clanPartPriceMultiplier" ->
-                  campaignOptions.setClanPartPriceMultiplier(Double.parseDouble(nodeContents));
-            case "mixedTechUnitPriceMultiplier" -> campaignOptions.setMixedTechUnitPriceMultiplier(Double.parseDouble(
+            case "clanUnitPriceMultiplier" -> campaignOptions.setClanUnitPriceMultiplier(parseDouble(nodeContents));
+            case "clanPartPriceMultiplier" -> campaignOptions.setClanPartPriceMultiplier(parseDouble(nodeContents));
+            case "mixedTechUnitPriceMultiplier" -> campaignOptions.setMixedTechUnitPriceMultiplier(parseDouble(
                   nodeContents));
             case "usedPartPriceMultipliers" -> {
                 final String[] values = nodeContents.split(",");
                 for (int i = 0; i < values.length; i++) {
                     try {
-                        campaignOptions.getUsedPartPriceMultipliers()[i] = Double.parseDouble(values[i]);
+                        campaignOptions.getUsedPartPriceMultipliers()[i] = parseDouble(values[i]);
                     } catch (Exception ignored) {
 
                     }
                 }
             }
-            case "damagedPartsValueMultiplier" -> campaignOptions.setDamagedPartsValueMultiplier(Double.parseDouble(
+            case "damagedPartsValueMultiplier" -> campaignOptions.setDamagedPartsValueMultiplier(parseDouble(
                   nodeContents));
-            case "unrepairablePartsValueMultiplier" ->
-                  campaignOptions.setUnrepairablePartsValueMultiplier(Double.parseDouble(
+            case "unrepairablePartsValueMultiplier" -> campaignOptions.setUnrepairablePartsValueMultiplier(parseDouble(
                         nodeContents));
-            case "cancelledOrderRefundMultiplier" ->
-                  campaignOptions.setCancelledOrderRefundMultiplier(Double.parseDouble(
+            case "cancelledOrderRefundMultiplier" -> campaignOptions.setCancelledOrderRefundMultiplier(parseDouble(
                         nodeContents));
-            case "useTaxes" -> campaignOptions.setUseTaxes(Boolean.parseBoolean(nodeContents));
-            case "taxesPercentage" -> campaignOptions.setTaxesPercentage(Integer.parseInt(nodeContents));
-            case "useShareSystem" -> campaignOptions.setUseShareSystem(Boolean.parseBoolean(nodeContents));
-            case "sharesForAll" -> campaignOptions.setSharesForAll(Boolean.parseBoolean(nodeContents));
+            case "useTaxes" -> campaignOptions.setUseTaxes(parseBoolean(nodeContents));
+            case "taxesPercentage" -> campaignOptions.setTaxesPercentage(parseInt(nodeContents));
+            case "useShareSystem" -> campaignOptions.setUseShareSystem(parseBoolean(nodeContents));
+            case "sharesForAll" -> campaignOptions.setSharesForAll(parseBoolean(nodeContents));
             case "personnelMarketStyle" -> campaignOptions.setPersonnelMarketStyle(PersonnelMarketStyle.fromString(
                   nodeContents));
             case "personnelMarketName" -> {
@@ -779,7 +730,7 @@ public class CampaignOptionsUnmarshaller {
                 }
                 campaignOptions.setPersonnelMarketName(marketName);
             }
-            case "personnelMarketReportRefresh" -> campaignOptions.setPersonnelMarketReportRefresh(Boolean.parseBoolean(
+            case "personnelMarketReportRefresh" -> campaignOptions.setPersonnelMarketReportRefresh(parseBoolean(
                   nodeContents));
             case "personnelMarketRandomRemovalTargets" -> {
                 if (!childNode.hasChildNodes()) {
@@ -793,144 +744,128 @@ public class CampaignOptionsUnmarshaller {
                     }
                     campaignOptions.getPersonnelMarketRandomRemovalTargets()
                           .put(SkillLevel.valueOf(wn3.getNodeName().trim()),
-                                Integer.parseInt(wn3.getTextContent().trim()));
+                                parseInt(wn3.getTextContent().trim()));
                 }
             }
-            case "personnelMarketDylansWeight" -> campaignOptions.setPersonnelMarketDylansWeight(Double.parseDouble(
+            case "personnelMarketDylansWeight" -> campaignOptions.setPersonnelMarketDylansWeight(parseDouble(
                   nodeContents));
-            case "usePersonnelHireHiringHallOnly" ->
-                  campaignOptions.setUsePersonnelHireHiringHallOnly(Boolean.parseBoolean(
+            case "usePersonnelHireHiringHallOnly" -> campaignOptions.setUsePersonnelHireHiringHallOnly(parseBoolean(
                         nodeContents));
             case "unitMarketMethod" -> campaignOptions.setUnitMarketMethod(UnitMarketMethod.valueOf(nodeContents));
-            case "unitMarketRegionalMekVariations" ->
-                  campaignOptions.setUnitMarketRegionalMekVariations(Boolean.parseBoolean(
+            case "unitMarketRegionalMekVariations" -> campaignOptions.setUnitMarketRegionalMekVariations(parseBoolean(
                         nodeContents));
-            case "unitMarketSpecialUnitChance" -> campaignOptions.setUnitMarketSpecialUnitChance(Integer.parseInt(
+            case "unitMarketSpecialUnitChance" -> campaignOptions.setUnitMarketSpecialUnitChance(parseInt(
                   nodeContents));
-            case "unitMarketRarityModifier" ->
-                  campaignOptions.setUnitMarketRarityModifier(Integer.parseInt(nodeContents));
-            case "instantUnitMarketDelivery" -> campaignOptions.setInstantUnitMarketDelivery(Boolean.parseBoolean(
+            case "unitMarketRarityModifier" -> campaignOptions.setUnitMarketRarityModifier(parseInt(nodeContents));
+            case "instantUnitMarketDelivery" -> campaignOptions.setInstantUnitMarketDelivery(parseBoolean(
                   nodeContents));
-            case "mothballUnitMarketDeliveries" -> campaignOptions.setMothballUnitMarketDeliveries(Boolean.parseBoolean(
+            case "mothballUnitMarketDeliveries" -> campaignOptions.setMothballUnitMarketDeliveries(parseBoolean(
                   nodeContents));
-            case "unitMarketReportRefresh" -> campaignOptions.setUnitMarketReportRefresh(Boolean.parseBoolean(
+            case "unitMarketReportRefresh" -> campaignOptions.setUnitMarketReportRefresh(parseBoolean(
                   nodeContents));
             case "contractMarketMethod" -> campaignOptions.setContractMarketMethod(ContractMarketMethod.valueOf(
                   nodeContents));
-            case "contractSearchRadius" -> campaignOptions.setContractSearchRadius(Integer.parseInt(nodeContents));
-            case "variableContractLength" ->
-                  campaignOptions.setVariableContractLength(Boolean.parseBoolean(nodeContents));
-            case "useDynamicDifficulty" -> campaignOptions.setUseDynamicDifficulty(Boolean.parseBoolean(nodeContents));
-            case "contractMarketReportRefresh" -> campaignOptions.setContractMarketReportRefresh(Boolean.parseBoolean(
+            case "contractSearchRadius" -> campaignOptions.setContractSearchRadius(parseInt(nodeContents));
+            case "variableContractLength" -> campaignOptions.setVariableContractLength(parseBoolean(nodeContents));
+            case "useDynamicDifficulty" -> campaignOptions.setUseDynamicDifficulty(parseBoolean(nodeContents));
+            case "contractMarketReportRefresh" -> campaignOptions.setContractMarketReportRefresh(parseBoolean(
                   nodeContents));
-            case "contractMaxSalvagePercentage" -> campaignOptions.setContractMaxSalvagePercentage(Integer.parseInt(
+            case "contractMaxSalvagePercentage" -> campaignOptions.setContractMaxSalvagePercentage(parseInt(
                   nodeContents));
-            case "dropShipBonusPercentage" ->
-                  campaignOptions.setDropShipBonusPercentage(Integer.parseInt(nodeContents));
-            case "useStaticRATs" -> campaignOptions.setUseStaticRATs(Boolean.parseBoolean(nodeContents));
+            case "dropShipBonusPercentage" -> campaignOptions.setDropShipBonusPercentage(parseInt(nodeContents));
+            case "useStaticRATs" -> campaignOptions.setUseStaticRATs(parseBoolean(nodeContents));
             case "rats" -> campaignOptions.setRATs(MHQXMLUtility.unEscape(nodeContents).split(","));
-            case "ignoreRATEra" -> campaignOptions.setIgnoreRATEra(Boolean.parseBoolean(nodeContents));
+            case "ignoreRATEra" -> campaignOptions.setIgnoreRATEra(parseBoolean(nodeContents));
             case "skillLevel" -> campaignOptions.setSkillLevel(SkillLevel.parseFromString(nodeContents));
             case "autoResolveMethod" -> campaignOptions.setAutoResolveMethod(AutoResolveMethod.valueOf(nodeContents));
-            case "autoResolveVictoryChanceEnabled" ->
-                  campaignOptions.setAutoResolveVictoryChanceEnabled(Boolean.parseBoolean(
+            case "autoResolveVictoryChanceEnabled" -> campaignOptions.setAutoResolveVictoryChanceEnabled(parseBoolean(
                         nodeContents));
-            case "autoResolveNumberOfScenarios" -> campaignOptions.setAutoResolveNumberOfScenarios(Integer.parseInt(
+            case "autoResolveNumberOfScenarios" -> campaignOptions.setAutoResolveNumberOfScenarios(parseInt(
                   nodeContents));
             case "autoResolveUseExperimentalPacarGui" ->
-                  campaignOptions.setAutoResolveExperimentalPacarGuiEnabled(Boolean.parseBoolean(
+                  campaignOptions.setAutoResolveExperimentalPacarGuiEnabled(parseBoolean(
                         nodeContents));
             case "strategicViewTheme" -> campaignOptions.setStrategicViewTheme(nodeContents);
             case "phenotypeProbabilities" -> {
                 String[] values = nodeContents.split(",");
                 for (int i = 0; i < values.length; i++) {
-                    campaignOptions.setPhenotypeProbability(i, Integer.parseInt(values[i]));
+                    campaignOptions.setPhenotypeProbability(i, parseInt(values[i]));
                 }
             }
-            case "useAtB" -> campaignOptions.setUseAtB(Boolean.parseBoolean(nodeContents));
-            case "useStratCon" -> campaignOptions.setUseStratCon(Boolean.parseBoolean(nodeContents));
-            case "useAero" -> campaignOptions.setUseAero(Boolean.parseBoolean(nodeContents));
-            case "useVehicles" -> campaignOptions.setUseVehicles(Boolean.parseBoolean(nodeContents));
-            case "clanVehicles" -> campaignOptions.setClanVehicles(Boolean.parseBoolean(nodeContents));
-            case "useGenericBattleValue" ->
-                  campaignOptions.setUseGenericBattleValue(Boolean.parseBoolean(nodeContents));
-            case "useVerboseBidding" -> campaignOptions.setUseVerboseBidding(Boolean.parseBoolean(nodeContents));
-            case "doubleVehicles" -> campaignOptions.setDoubleVehicles(Boolean.parseBoolean(nodeContents));
-            case "adjustPlayerVehicles" -> campaignOptions.setAdjustPlayerVehicles(Boolean.parseBoolean(nodeContents));
-            case "opForLanceTypeMeks" -> campaignOptions.setOpForLanceTypeMeks(Integer.parseInt(nodeContents));
-            case "opForLanceTypeMixed" -> campaignOptions.setOpForLanceTypeMixed(Integer.parseInt(nodeContents));
-            case "opForLanceTypeVehicles" -> campaignOptions.setOpForLanceTypeVehicles(Integer.parseInt(nodeContents));
-            case "opForUsesVTOLs" -> campaignOptions.setOpForUsesVTOLs(Boolean.parseBoolean(nodeContents));
-            case "useDropShips" -> campaignOptions.setUseDropShips(Boolean.parseBoolean(nodeContents));
-            case "mercSizeLimited" -> campaignOptions.setMercSizeLimited(Boolean.parseBoolean(nodeContents));
-            case "regionalMekVariations" ->
-                  campaignOptions.setRegionalMekVariations(Boolean.parseBoolean(nodeContents));
-            case "attachedPlayerCamouflage" -> campaignOptions.setAttachedPlayerCamouflage(Boolean.parseBoolean(
+            case "useAtB" -> campaignOptions.setUseAtB(parseBoolean(nodeContents));
+            case "useStratCon" -> campaignOptions.setUseStratCon(parseBoolean(nodeContents));
+            case "useAero" -> campaignOptions.setUseAero(parseBoolean(nodeContents));
+            case "useVehicles" -> campaignOptions.setUseVehicles(parseBoolean(nodeContents));
+            case "clanVehicles" -> campaignOptions.setClanVehicles(parseBoolean(nodeContents));
+            case "useGenericBattleValue" -> campaignOptions.setUseGenericBattleValue(parseBoolean(nodeContents));
+            case "useVerboseBidding" -> campaignOptions.setUseVerboseBidding(parseBoolean(nodeContents));
+            case "doubleVehicles" -> campaignOptions.setDoubleVehicles(parseBoolean(nodeContents));
+            case "adjustPlayerVehicles" -> campaignOptions.setAdjustPlayerVehicles(parseBoolean(nodeContents));
+            case "opForLanceTypeMeks" -> campaignOptions.setOpForLanceTypeMeks(parseInt(nodeContents));
+            case "opForLanceTypeMixed" -> campaignOptions.setOpForLanceTypeMixed(parseInt(nodeContents));
+            case "opForLanceTypeVehicles" -> campaignOptions.setOpForLanceTypeVehicles(parseInt(nodeContents));
+            case "opForUsesVTOLs" -> campaignOptions.setOpForUsesVTOLs(parseBoolean(nodeContents));
+            case "useDropShips" -> campaignOptions.setUseDropShips(parseBoolean(nodeContents));
+            case "mercSizeLimited" -> campaignOptions.setMercSizeLimited(parseBoolean(nodeContents));
+            case "regionalMekVariations" -> campaignOptions.setRegionalMekVariations(parseBoolean(nodeContents));
+            case "attachedPlayerCamouflage" -> campaignOptions.setAttachedPlayerCamouflage(parseBoolean(
                   nodeContents));
-            case "playerControlsAttachedUnits" -> campaignOptions.setPlayerControlsAttachedUnits(Boolean.parseBoolean(
+            case "playerControlsAttachedUnits" -> campaignOptions.setPlayerControlsAttachedUnits(parseBoolean(
                   nodeContents));
             case "atbBattleChance" -> {
                 String[] values = nodeContents.split(",");
                 for (int i = 0; i < values.length; i++) {
                     try {
-                        campaignOptions.setAtBBattleChance(i, Integer.parseInt(values[i]));
+                        campaignOptions.setAtBBattleChance(i, parseInt(values[i]));
                     } catch (Exception ignored) {
                         // Badly coded, but this is to migrate devs and their games as the swap was done before a
                         // release and is thus better to handle this way than through a more code complex method
-                        campaignOptions.setAtBBattleChance(i, (int) Math.round(Double.parseDouble(values[i])));
+                        campaignOptions.setAtBBattleChance(i, (int) Math.round(parseDouble(values[i])));
                     }
                 }
             }
-            case "generateChases" -> campaignOptions.setGenerateChases(Boolean.parseBoolean(nodeContents));
-            case "useWeatherConditions" -> campaignOptions.setUseWeatherConditions(Boolean.parseBoolean(nodeContents));
-            case "useLightConditions" -> campaignOptions.setUseLightConditions(Boolean.parseBoolean(nodeContents));
-            case "usePlanetaryConditions" ->
-                  campaignOptions.setUsePlanetaryConditions(Boolean.parseBoolean(nodeContents));
-            case "restrictPartsByMission" ->
-                  campaignOptions.setRestrictPartsByMission(Boolean.parseBoolean(nodeContents));
-            case "allowOpForLocalUnits" -> campaignOptions.setAllowOpForLocalUnits(Boolean.parseBoolean(nodeContents));
-            case "allowOpForAeros" -> campaignOptions.setAllowOpForAeros(Boolean.parseBoolean(nodeContents));
-            case "opForAeroChance" -> campaignOptions.setOpForAeroChance(Integer.parseInt(nodeContents));
-            case "opForLocalUnitChance" -> campaignOptions.setOpForLocalUnitChance(Integer.parseInt(nodeContents));
-            case "fixedMapChance" -> campaignOptions.setFixedMapChance(Integer.parseInt(nodeContents));
-            case "spaUpgradeIntensity" -> campaignOptions.setSpaUpgradeIntensity(Integer.parseInt(nodeContents));
-            case "scenarioModMax" -> campaignOptions.setScenarioModMax(Integer.parseInt(nodeContents));
-            case "scenarioModChance" -> campaignOptions.setScenarioModChance(Integer.parseInt(nodeContents));
-            case "scenarioModBV" -> campaignOptions.setScenarioModBV(Integer.parseInt(nodeContents));
-            case "autoConfigMunitions" -> campaignOptions.setAutoConfigMunitions(Boolean.parseBoolean(nodeContents));
-            case "autoGenerateOpForCallsigns" -> campaignOptions.setAutoGenerateOpForCallsigns(Boolean.parseBoolean(
+            case "generateChases" -> campaignOptions.setGenerateChases(parseBoolean(nodeContents));
+            case "useWeatherConditions" -> campaignOptions.setUseWeatherConditions(parseBoolean(nodeContents));
+            case "useLightConditions" -> campaignOptions.setUseLightConditions(parseBoolean(nodeContents));
+            case "usePlanetaryConditions" -> campaignOptions.setUsePlanetaryConditions(parseBoolean(nodeContents));
+            case "restrictPartsByMission" -> campaignOptions.setRestrictPartsByMission(parseBoolean(nodeContents));
+            case "allowOpForLocalUnits" -> campaignOptions.setAllowOpForLocalUnits(parseBoolean(nodeContents));
+            case "allowOpForAeros" -> campaignOptions.setAllowOpForAeros(parseBoolean(nodeContents));
+            case "opForAeroChance" -> campaignOptions.setOpForAeroChance(parseInt(nodeContents));
+            case "opForLocalUnitChance" -> campaignOptions.setOpForLocalUnitChance(parseInt(nodeContents));
+            case "fixedMapChance" -> campaignOptions.setFixedMapChance(parseInt(nodeContents));
+            case "spaUpgradeIntensity" -> campaignOptions.setSpaUpgradeIntensity(parseInt(nodeContents));
+            case "scenarioModMax" -> campaignOptions.setScenarioModMax(parseInt(nodeContents));
+            case "scenarioModChance" -> campaignOptions.setScenarioModChance(parseInt(nodeContents));
+            case "scenarioModBV" -> campaignOptions.setScenarioModBV(parseInt(nodeContents));
+            case "autoConfigMunitions" -> campaignOptions.setAutoConfigMunitions(parseBoolean(nodeContents));
+            case "autoGenerateOpForCallsigns" -> campaignOptions.setAutoGenerateOpForCallsigns(parseBoolean(
                   nodeContents));
             case "minimumCallsignSkillLevel" -> campaignOptions.setMinimumCallsignSkillLevel(SkillLevel.parseFromString(
                   nodeContents));
-            case "trackFactionStanding" -> campaignOptions.setTrackFactionStanding(Boolean.parseBoolean(nodeContents));
-            case "useFactionStandingNegotiation" ->
-                  campaignOptions.setUseFactionStandingNegotiation(Boolean.parseBoolean(
+            case "trackFactionStanding" -> campaignOptions.setTrackFactionStanding(parseBoolean(nodeContents));
+            case "useFactionStandingNegotiation" -> campaignOptions.setUseFactionStandingNegotiation(parseBoolean(
                         nodeContents));
-            case "useFactionStandingResupply" -> campaignOptions.setUseFactionStandingResupply(Boolean.parseBoolean(
+            case "useFactionStandingResupply" -> campaignOptions.setUseFactionStandingResupply(parseBoolean(
                   nodeContents));
-            case "useFactionStandingCommandCircuit" ->
-                  campaignOptions.setUseFactionStandingCommandCircuit(Boolean.parseBoolean(
+            case "useFactionStandingCommandCircuit" -> campaignOptions.setUseFactionStandingCommandCircuit(parseBoolean(
                         nodeContents));
-            case "useFactionStandingOutlawed" -> campaignOptions.setUseFactionStandingOutlawed(Boolean.parseBoolean(
+            case "useFactionStandingOutlawed" -> campaignOptions.setUseFactionStandingOutlawed(parseBoolean(
                   nodeContents));
             case "useFactionStandingBatchallRestrictions" ->
-                  campaignOptions.setUseFactionStandingBatchallRestrictions(Boolean.parseBoolean(
+                  campaignOptions.setUseFactionStandingBatchallRestrictions(parseBoolean(
                         nodeContents));
-            case "useFactionStandingRecruitment" ->
-                  campaignOptions.setUseFactionStandingRecruitment(Boolean.parseBoolean(
+            case "useFactionStandingRecruitment" -> campaignOptions.setUseFactionStandingRecruitment(parseBoolean(
                         nodeContents));
-            case "useFactionStandingBarracksCosts" ->
-                  campaignOptions.setUseFactionStandingBarracksCosts(Boolean.parseBoolean(
+            case "useFactionStandingBarracksCosts" -> campaignOptions.setUseFactionStandingBarracksCosts(parseBoolean(
                         nodeContents));
-            case "useFactionStandingUnitMarket" -> campaignOptions.setUseFactionStandingUnitMarket(Boolean.parseBoolean(
+            case "useFactionStandingUnitMarket" -> campaignOptions.setUseFactionStandingUnitMarket(parseBoolean(
                   nodeContents));
-            case "useFactionStandingContractPay" ->
-                  campaignOptions.setUseFactionStandingContractPay(Boolean.parseBoolean(
+            case "useFactionStandingContractPay" -> campaignOptions.setUseFactionStandingContractPay(parseBoolean(
                         nodeContents));
-            case "useFactionStandingSupportPoints" ->
-                  campaignOptions.setUseFactionStandingSupportPoints(Boolean.parseBoolean(
+            case "useFactionStandingSupportPoints" -> campaignOptions.setUseFactionStandingSupportPoints(parseBoolean(
                         nodeContents));
-            case "factionStandingGainMultiplier" -> campaignOptions.setRegardMultiplier(MathUtility.parseDouble(
+            case "factionStandingGainMultiplier" -> campaignOptions.setRegardMultiplier(parseDouble(
                   nodeContents, 1.0));
             default -> throw new IllegalStateException("Potentially unexpected entry in campaign options: " + nodeName);
         }

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -42,20 +42,16 @@ import megamek.Version;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.enums.SkillLevel;
 import megamek.logging.MMLogger;
-import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.RandomOriginOptions;
 import mekhq.campaign.autoresolve.AutoResolveMethod;
 import mekhq.campaign.enums.PlanetaryAcquisitionFactionLimit;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.FinancialYearDuration;
-import mekhq.campaign.market.PersonnelMarket;
 import mekhq.campaign.market.enums.ContractMarketMethod;
 import mekhq.campaign.market.enums.UnitMarketMethod;
 import mekhq.campaign.market.personnelMarket.enums.PersonnelMarketStyle;
-import mekhq.campaign.mission.enums.CombatRole;
 import mekhq.campaign.personnel.enums.*;
-import mekhq.campaign.personnel.skills.Skills;
 import mekhq.campaign.randomEvents.prisoners.enums.PrisonerCaptureStyle;
 import mekhq.campaign.rating.UnitRatingMethod;
 import mekhq.campaign.universe.PlanetarySystem.PlanetaryRating;
@@ -66,9 +62,6 @@ import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-/**
- * @author natit
- */
 public class CampaignOptionsUnmarshaller {
     private static final MMLogger LOGGER = MMLogger.create(CampaignOptionsUnmarshaller.class);
 
@@ -79,1288 +72,867 @@ public class CampaignOptionsUnmarshaller {
         CampaignOptions campaignOptions = new CampaignOptions();
         NodeList childNodes = parentNod.getChildNodes();
 
-        // Okay, let's iterate through the children, eh?
-        for (int node = 0; node < childNodes.getLength(); node++) {
-            Node childNode = childNodes.item(node);
-            String nodeName = childNode.getNodeName();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node childNode = childNodes.item(i);
 
             // If it's not an element node, we ignore it.
             if (childNode.getNodeType() != Node.ELEMENT_NODE) {
                 continue;
             }
 
+            String nodeName = childNode.getNodeName();
             String nodeContents = childNode.getTextContent().trim();
 
-            LOGGER.debug("{}\n\t{}", nodeName, nodeContents);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("{}\n\t{}", nodeName, nodeContents);
+            }
+
             try {
-                // region Repair and Maintenance Tab
-                if (nodeName.equalsIgnoreCase("checkMaintenance")) {
-                    campaignOptions.setCheckMaintenance(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("maintenanceCycleDays")) {
-                    campaignOptions.setMaintenanceCycleDays(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("maintenanceBonus")) {
-                    campaignOptions.setMaintenanceBonus(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useQualityMaintenance")) {
-                    campaignOptions.setUseQualityMaintenance(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("reverseQualityNames")) {
-                    campaignOptions.setReverseQualityNames(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomUnitQualities")) {
-                    campaignOptions.setUseRandomUnitQualities(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePlanetaryModifiers")) {
-                    campaignOptions.setUsePlanetaryModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useUnofficialMaintenance")) {
-                    campaignOptions.setUseUnofficialMaintenance(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("logMaintenance")) {
-                    campaignOptions.setLogMaintenance(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("defaultMaintenanceTime")) {
-                    campaignOptions.setDefaultMaintenanceTime(Integer.parseInt(nodeContents));
-
-                    // region Mass Repair / Mass Salvage
-                } else if (nodeName.equalsIgnoreCase("mrmsUseRepair")) {
-                    campaignOptions.setMRMSUseRepair(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mrmsUseSalvage")) {
-                    campaignOptions.setMRMSUseSalvage(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mrmsUseExtraTime")) {
-                    campaignOptions.setMRMSUseExtraTime(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mrmsUseRushJob")) {
-                    campaignOptions.setMRMSUseRushJob(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mrmsAllowCarryover")) {
-                    campaignOptions.setMRMSAllowCarryover(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mrmsOptimizeToCompleteToday")) {
-                    campaignOptions.setMRMSOptimizeToCompleteToday(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mrmsScrapImpossible")) {
-                    campaignOptions.setMRMSScrapImpossible(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mrmsUseAssignedTechsFirst")) {
-                    campaignOptions.setMRMSUseAssignedTechsFirst(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mrmsReplacePod")) {
-                    campaignOptions.setMRMSReplacePod(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mrmsOptions")) {
-                    campaignOptions.setMRMSOptions(MRMSOption.parseListFromXML(childNode, version));
-                    // endregion Mass Repair / Mass Salvage
-                    // endregion Repair and Maintenance Tab
-
-                } else if (nodeName.equalsIgnoreCase("useFactionForNames")) {
-                    campaignOptions.setUseOriginFactionForNames(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useEraMods")) {
-                    campaignOptions.setEraMods(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("assignedTechFirst")) {
-                    campaignOptions.setAssignedTechFirst(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("resetToFirstTech")) {
-                    campaignOptions.setResetToFirstTech(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("techsUseAdministration")) {
-                    campaignOptions.setTechsUseAdministration(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useQuirks")) {
-                    campaignOptions.setQuirks(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("xpCostMultiplier")) {
-                    campaignOptions.setXpCostMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("scenarioXP")) {
-                    campaignOptions.setScenarioXP(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("killsForXP")) {
-                    campaignOptions.setKillsForXP(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("killXPAward")) {
-                    campaignOptions.setKillXPAward(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("nTasksXP")) {
-                    campaignOptions.setNTasksXP(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("tasksXP")) {
-                    campaignOptions.setTaskXP(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("successXP")) {
-                    campaignOptions.setSuccessXP(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mistakeXP")) {
-                    campaignOptions.setMistakeXP(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("vocationalXP")) {
-                    campaignOptions.setVocationalXP(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("vocationalXPTargetNumber")) {
-                    campaignOptions.setVocationalXPTargetNumber(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("vocationalXPCheckFrequency")) {
-                    campaignOptions.setVocationalXPCheckFrequency(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("contractNegotiationXP")) {
-                    campaignOptions.setContractNegotiationXP(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("adminWeeklyXP")) {
-                    campaignOptions.setAdminXP(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("adminXPPeriod")) {
-                    campaignOptions.setAdminXPPeriod(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("missionXpFail")) {
-                    campaignOptions.setMissionXpFail(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("missionXpSuccess")) {
-                    campaignOptions.setMissionXpSuccess(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("missionXpOutstandingSuccess")) {
-                    campaignOptions.setMissionXpOutstandingSuccess(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("edgeCost")) {
-                    campaignOptions.setEdgeCost(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("waitingPeriod")) {
-                    campaignOptions.setWaitingPeriod(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("acquisitionSkill")) {
-                    campaignOptions.setAcquisitionSkill(nodeContents);
-                } else if (nodeName.equalsIgnoreCase("unitTransitTime")) {
-                    campaignOptions.setUnitTransitTime(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("clanAcquisitionPenalty")) {
-                    campaignOptions.setClanAcquisitionPenalty(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("isAcquisitionPenalty")) {
-                    campaignOptions.setIsAcquisitionPenalty(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePlanetaryAcquisition")) {
-                    campaignOptions.setPlanetaryAcquisition(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("planetAcquisitionFactionLimit")) {
-                    campaignOptions.setPlanetAcquisitionFactionLimit(PlanetaryAcquisitionFactionLimit.parseFromString(
-                          nodeContents));
-                } else if (nodeName.equalsIgnoreCase("planetAcquisitionNoClanCrossover")) {
-                    campaignOptions.setDisallowPlanetAcquisitionClanCrossover(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("noClanPartsFromIS")) {
-                    campaignOptions.setDisallowClanPartsFromIS(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("penaltyClanPartsFromIS")) {
-                    campaignOptions.setPenaltyClanPartsFromIS(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("planetAcquisitionVerbose")) {
-                    campaignOptions.setPlanetAcquisitionVerboseReporting(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("maxJumpsPlanetaryAcquisition")) {
-                    campaignOptions.setMaxJumpsPlanetaryAcquisition(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("planetTechAcquisitionBonus")) {
-                    EnumMap<PlanetarySophistication, Integer> acquisitionBonuses = campaignOptions.getAllPlanetTechAcquisitionBonuses();
-
-                    String[] values = nodeContents.split(",");
-                    if (values.length == 6) {
-                        // < 0.50.07 compatibility handler
-                        acquisitionBonuses.put(PlanetarySophistication.A, Integer.parseInt(values[0]));
-                        acquisitionBonuses.put(PlanetarySophistication.B, Integer.parseInt(values[1]));
-                        acquisitionBonuses.put(PlanetarySophistication.C, Integer.parseInt(values[2]));
-                        acquisitionBonuses.put(PlanetarySophistication.D, Integer.parseInt(values[3]));
-                        acquisitionBonuses.put(PlanetarySophistication.F, Integer.parseInt(values[5]));
-                    } else if (values.length == PlanetarySophistication.values().length) {
-                        // >= 0.50.07 compatibility handler
-                        for (int i = 0; i < values.length; i++) {
-                            acquisitionBonuses.put(PlanetarySophistication.fromIndex(i), Integer.parseInt(values[i]));
-                        }
-                    } else {
-                        LOGGER.error("Invalid number of values for planetTechAcquisitionBonus: {}", values.length);
-                    }
-                } else if (nodeName.equalsIgnoreCase("planetIndustryAcquisitionBonus")) {
-                    EnumMap<PlanetaryRating, Integer> acquisitionBonuses = campaignOptions.getAllPlanetIndustryAcquisitionBonuses();
-
-                    String[] values = nodeContents.split(",");
-                    if (values.length == 6) {
-                        // < 0.50.07 compatibility handler
-                        acquisitionBonuses.put(PlanetaryRating.A, Integer.parseInt(values[0]));
-                        acquisitionBonuses.put(PlanetaryRating.B, Integer.parseInt(values[1]));
-                        acquisitionBonuses.put(PlanetaryRating.C, Integer.parseInt(values[2]));
-                        acquisitionBonuses.put(PlanetaryRating.D, Integer.parseInt(values[3]));
-                        acquisitionBonuses.put(PlanetaryRating.F, Integer.parseInt(values[5]));
-                    } else if (values.length == PlanetaryRating.values().length) {
-                        // >= 0.50.07 compatibility handler
-                        for (int i = 0; i < values.length; i++) {
-                            acquisitionBonuses.put(PlanetaryRating.fromIndex(i), Integer.parseInt(values[i]));
-                        }
-                    } else {
-                        LOGGER.error("Invalid number of values for planetIndustryAcquisitionBonus: {}", values.length);
-                    }
-                } else if (nodeName.equalsIgnoreCase("planetOutputAcquisitionBonus")) {
-                    EnumMap<PlanetaryRating, Integer> acquisitionBonuses = campaignOptions.getAllPlanetOutputAcquisitionBonuses();
-
-                    String[] values = nodeContents.split(",");
-                    if (values.length == 6) {
-                        // < 0.50.07 compatibility handler
-                        acquisitionBonuses.put(PlanetaryRating.A, Integer.parseInt(values[0]));
-                        acquisitionBonuses.put(PlanetaryRating.B, Integer.parseInt(values[1]));
-                        acquisitionBonuses.put(PlanetaryRating.C, Integer.parseInt(values[2]));
-                        acquisitionBonuses.put(PlanetaryRating.D, Integer.parseInt(values[3]));
-                        acquisitionBonuses.put(PlanetaryRating.F, Integer.parseInt(values[5]));
-                    } else if (values.length == PlanetaryRating.values().length) {
-                        // >= 0.50.07 compatibility handler
-                        for (int i = 0; i < values.length; i++) {
-                            acquisitionBonuses.put(PlanetaryRating.fromIndex(i), Integer.parseInt(values[i]));
-                        }
-                    } else {
-                        LOGGER.error("Invalid number of values for planetOutputAcquisitionBonus: {}", values.length);
-                    }
-                } else if (nodeName.equalsIgnoreCase("equipmentContractPercent")) {
-                    campaignOptions.setEquipmentContractPercent(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("dropShipContractPercent")) {
-                    campaignOptions.setDropShipContractPercent(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("jumpShipContractPercent")) {
-                    campaignOptions.setJumpShipContractPercent(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("warShipContractPercent")) {
-                    campaignOptions.setWarShipContractPercent(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("equipmentContractBase")) {
-                    campaignOptions.setEquipmentContractBase(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("equipmentContractSaleValue")) {
-                    campaignOptions.setEquipmentContractSaleValue(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("blcSaleValue")) {
-                    campaignOptions.setBLCSaleValue(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("overageRepaymentInFinalPayment")) {
-                    campaignOptions.setOverageRepaymentInFinalPayment(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("acquisitionSupportStaffOnly")) {
-                    campaignOptions.setAcquisitionPersonnelCategory(Boolean.parseBoolean(nodeContents) ? SUPPORT : ALL);
-                } else if (nodeName.equalsIgnoreCase("acquisitionPersonnelCategory")) {
-                    campaignOptions.setAcquisitionPersonnelCategory(ProcurementPersonnelPick.fromString(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("limitByYear")) {
-                    campaignOptions.setLimitByYear(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("disallowExtinctStuff")) {
-                    campaignOptions.setDisallowExtinctStuff(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("allowClanPurchases")) {
-                    campaignOptions.setAllowClanPurchases(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("allowISPurchases")) {
-                    campaignOptions.setAllowISPurchases(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("allowCanonOnly")) {
-                    campaignOptions.setAllowCanonOnly(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("allowCanonRefitOnly")) {
-                    campaignOptions.setAllowCanonRefitOnly(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useAmmoByType")) {
-                    campaignOptions.setUseAmmoByType(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("variableTechLevel")) {
-                    campaignOptions.setVariableTechLevel(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("factionIntroDate")) {
-                    campaignOptions.setIsUseFactionIntroDate(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("techLevel")) {
-                    campaignOptions.setTechLevel(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("unitRatingMethod") ||
-                                 nodeName.equalsIgnoreCase("dragoonsRatingMethod")) {
-                    campaignOptions.setUnitRatingMethod(UnitRatingMethod.parseFromString(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("manualUnitRatingModifier")) {
-                    campaignOptions.setManualUnitRatingModifier(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("clampReputationPayMultiplier")) {
-                    campaignOptions.setClampReputationPayMultiplier(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("reduceReputationPerformanceModifier")) {
-                    campaignOptions.setReduceReputationPerformanceModifier(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("reputationPerformanceModifierCutOff")) {
-                    campaignOptions.setReputationPerformanceModifierCutOff(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePortraitForType")) {
-                    String[] values = nodeContents.split(",");
-                    for (int i = 0; i < values.length; i++) {
-                        campaignOptions.setUsePortraitForRole(i, Boolean.parseBoolean(values[i].trim()));
-                    }
-                } else if (nodeName.equalsIgnoreCase("assignPortraitOnRoleChange")) {
-                    campaignOptions.setAssignPortraitOnRoleChange(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("allowDuplicatePortraits")) {
-                    campaignOptions.setAllowDuplicatePortraits(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("destroyByMargin")) {
-                    campaignOptions.setDestroyByMargin(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("destroyMargin")) {
-                    campaignOptions.setDestroyMargin(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("destroyPartTarget")) {
-                    campaignOptions.setDestroyPartTarget(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useAeroSystemHits")) {
-                    campaignOptions.setUseAeroSystemHits(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("maxAcquisitions")) {
-                    campaignOptions.setMaxAcquisitions(Integer.parseInt(nodeContents));
-
-                    // autoLogistics
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsHeatSink")) {
-                    campaignOptions.setAutoLogisticsHeatSink(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsMekHead")) {
-                    campaignOptions.setAutoLogisticsMekHead(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsMekLocation")) {
-                    campaignOptions.setAutoLogisticsMekLocation(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsNonRepairableLocation")) {
-                    campaignOptions.setAutoLogisticsNonRepairableLocation(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsArmor")) {
-                    campaignOptions.setAutoLogisticsArmor(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsAmmunition")) {
-                    campaignOptions.setAutoLogisticsAmmunition(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsActuators")) {
-                    campaignOptions.setAutoLogisticsActuators(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsJumpJets")) {
-                    campaignOptions.setAutoLogisticsJumpJets(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsEngines")) {
-                    campaignOptions.setAutoLogisticsEngines(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsWeapons")) {
-                    campaignOptions.setAutoLogisticsWeapons(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoLogisticsOther")) {
-                    campaignOptions.setAutoLogisticsOther(MathUtility.parseInt(nodeContents));
-
-                    // region Personnel Tab
-                    // region General Personnel
-                } else if (nodeName.equalsIgnoreCase("useTactics")) {
-                    campaignOptions.setUseTactics(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useInitiativeBonus")) {
-                    campaignOptions.setUseInitiativeBonus(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useToughness")) {
-                    campaignOptions.setUseToughness(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomToughness")) {
-                    campaignOptions.setUseRandomToughness(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useArtillery")) {
-                    campaignOptions.setUseArtillery(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useAbilities")) {
-                    campaignOptions.setUseAbilities(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useCommanderAbilitiesOnly")) {
-                    campaignOptions.setUseCommanderAbilitiesOnly(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useEdge")) {
-                    campaignOptions.setUseEdge(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useSupportEdge")) {
-                    campaignOptions.setUseSupportEdge(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useImplants")) {
-                    campaignOptions.setUseImplants(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("alternativeQualityAveraging")) {
-                    campaignOptions.setAlternativeQualityAveraging(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useAgeEffects")) {
-                    campaignOptions.setUseAgeEffects(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useTransfers")) {
-                    campaignOptions.setUseTransfers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useExtendedTOEForceName")) {
-                    campaignOptions.setUseExtendedTOEForceName(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("personnelLogSkillGain")) {
-                    campaignOptions.setPersonnelLogSkillGain(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("personnelLogAbilityGain")) {
-                    campaignOptions.setPersonnelLogAbilityGain(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("personnelLogEdgeGain")) {
-                    campaignOptions.setPersonnelLogEdgeGain(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("displayPersonnelLog")) {
-                    campaignOptions.setDisplayPersonnelLog(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("displayScenarioLog")) {
-                    campaignOptions.setDisplayScenarioLog(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("displayKillRecord")) {
-                    campaignOptions.setDisplayKillRecord(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("displayMedicalRecord")) {
-                    campaignOptions.setDisplayMedicalRecord(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("displayAssignmentRecord")) {
-                    campaignOptions.setDisplayAssignmentRecord(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("displayPerformanceRecord")) {
-                    campaignOptions.setDisplayPerformanceRecord(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("rewardComingOfAgeAbilities")) {
-                    campaignOptions.setRewardComingOfAgeAbilities(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("rewardComingOfAgeRPSkills")) {
-                    campaignOptions.setRewardComingOfAgeRPSkills(Boolean.parseBoolean(nodeContents));
-                    // endregion General Personnel
-
-                    // region Expanded Personnel Information
-                } else if (nodeName.equalsIgnoreCase("useTimeInService")) {
-                    campaignOptions.setUseTimeInService(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("timeInServiceDisplayFormat")) {
-                    campaignOptions.setTimeInServiceDisplayFormat(TimeInDisplayFormat.valueOf(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useTimeInRank")) {
-                    campaignOptions.setUseTimeInRank(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("timeInRankDisplayFormat")) {
-                    campaignOptions.setTimeInRankDisplayFormat(TimeInDisplayFormat.valueOf(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("trackTotalEarnings")) {
-                    campaignOptions.setTrackTotalEarnings(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("trackTotalXPEarnings")) {
-                    campaignOptions.setTrackTotalXPEarnings(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("showOriginFaction")) {
-                    campaignOptions.setShowOriginFaction(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("adminsHaveNegotiation")) {
-                    campaignOptions.setAdminsHaveNegotiation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("adminExperienceLevelIncludeNegotiation")) {
-                    campaignOptions.setAdminExperienceLevelIncludeNegotiation(Boolean.parseBoolean(nodeContents));
-                    // endregion Expanded Personnel Information
-
-                    // region Medical
-                } else if (nodeName.equalsIgnoreCase("useAdvancedMedical")) {
-                    campaignOptions.setUseAdvancedMedical(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("healWaitingPeriod")) {
-                    campaignOptions.setHealingWaitingPeriod(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("naturalHealingWaitingPeriod")) {
-                    campaignOptions.setNaturalHealingWaitingPeriod(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("minimumHitsForVehicles")) {
-                    campaignOptions.setMinimumHitsForVehicles(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomHitsForVehicles")) {
-                    campaignOptions.setUseRandomHitsForVehicles(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("tougherHealing")) {
-                    campaignOptions.setTougherHealing(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("maximumPatients")) {
-                    campaignOptions.setMaximumPatients(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("doctorsUseAdministration")) {
-                    campaignOptions.setDoctorsUseAdministration(Boolean.parseBoolean(nodeContents));
-                    // endregion Medical
-
-                    // region Prisoners
-                } else if (nodeName.equalsIgnoreCase("prisonerCaptureStyle")) {
-                    campaignOptions.setPrisonerCaptureStyle(PrisonerCaptureStyle.fromString(nodeContents));
-                    // endregion Prisoners
-
-                    // region Dependent
-                } else if (nodeName.equalsIgnoreCase("useRandomDependentAddition")) {
-                    campaignOptions.setUseRandomDependentAddition(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomDependentRemoval")) {
-                    campaignOptions.setUseRandomDependentRemoval(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("dependentProfessionDieSize")) {
-                    campaignOptions.setDependentProfessionDieSize(MathUtility.parseInt(nodeContents, 4));
-                } else if (nodeName.equalsIgnoreCase("civilianProfessionDieSize")) {
-                    campaignOptions.setCivilianProfessionDieSize(MathUtility.parseInt(nodeContents, 2));
-                    // endregion Dependent
-
-                    // region Personnel Removal
-                } else if (nodeName.equalsIgnoreCase("usePersonnelRemoval")) {
-                    campaignOptions.setUsePersonnelRemoval(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRemovalExemptCemetery")) {
-                    campaignOptions.setUseRemovalExemptCemetery(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRemovalExemptRetirees")) {
-                    campaignOptions.setUseRemovalExemptRetirees(Boolean.parseBoolean(nodeContents));
-                    // endregion Personnel Removal
-
-                    // region Salary
-                } else if (nodeName.equalsIgnoreCase("disableSecondaryRoleSalary")) {
-                    campaignOptions.setDisableSecondaryRoleSalary(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("salaryAntiMekMultiplier")) {
-                    campaignOptions.setSalaryAntiMekMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("salarySpecialistInfantryMultiplier")) {
-                    campaignOptions.setSalarySpecialistInfantryMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("salaryXPMultipliers")) {
-                    if (!childNode.hasChildNodes()) {
-                        continue;
-                    }
-                    final NodeList nl2 = childNode.getChildNodes();
-                    for (int j = 0; j < nl2.getLength(); j++) {
-                        final Node wn3 = nl2.item(j);
-                        if (wn3.getNodeType() != Node.ELEMENT_NODE) {
-                            continue;
-                        }
-                        campaignOptions.getSalaryXPMultipliers()
-                              .put(SkillLevel.valueOf(wn3.getNodeName().trim()),
-                                    Double.parseDouble(wn3.getTextContent().trim()));
-                    }
-                } else if (nodeName.equalsIgnoreCase("salaryTypeBase")) {
-                    Money[] defaultSalaries = campaignOptions.getRoleBaseSalaries();
-                    Money[] newSalaries = Utilities.readMoneyArray(childNode);
-
-                    Money[] mergedSalaries = new Money[PersonnelRole.values().length];
-                    for (int i = 0; i < mergedSalaries.length; i++) {
-                        try {
-                            mergedSalaries[i] = (newSalaries[i] != null) ? newSalaries[i] : defaultSalaries[i];
-                        } catch (Exception e) {
-                            // This will happen if we ever add a new profession, as it will exceed the entries in
-                            // the child node
-                            mergedSalaries[i] = defaultSalaries[i];
-                        }
-                    }
-
-                    campaignOptions.setRoleBaseSalaries(mergedSalaries);
-                    // endregion Salary
-
-                    // region Awards
-                } else if (nodeName.equalsIgnoreCase("awardBonusStyle")) {
-                    campaignOptions.setAwardBonusStyle(AwardBonus.valueOf(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableAutoAwards")) {
-                    campaignOptions.setEnableAutoAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("issuePosthumousAwards")) {
-                    campaignOptions.setIssuePosthumousAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("issueBestAwardOnly")) {
-                    campaignOptions.setIssueBestAwardOnly(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("ignoreStandardSet")) {
-                    campaignOptions.setIgnoreStandardSet(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("awardTierSize")) {
-                    campaignOptions.setAwardTierSize(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableContractAwards")) {
-                    campaignOptions.setEnableContractAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableFactionHunterAwards")) {
-                    campaignOptions.setEnableFactionHunterAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableInjuryAwards")) {
-                    campaignOptions.setEnableInjuryAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableIndividualKillAwards")) {
-                    campaignOptions.setEnableIndividualKillAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableFormationKillAwards")) {
-                    campaignOptions.setEnableFormationKillAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableRankAwards")) {
-                    campaignOptions.setEnableRankAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableScenarioAwards")) {
-                    campaignOptions.setEnableScenarioAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableSkillAwards")) {
-                    campaignOptions.setEnableSkillAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableTheatreOfWarAwards")) {
-                    campaignOptions.setEnableTheatreOfWarAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableTimeAwards")) {
-                    campaignOptions.setEnableTimeAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableTrainingAwards")) {
-                    campaignOptions.setEnableTrainingAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableMiscAwards")) {
-                    campaignOptions.setEnableMiscAwards(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("awardSetFilterList")) {
-                    campaignOptions.setAwardSetFilterList(nodeContents);
-                    // endregion Awards
-                    // endregion Personnel Tab
-
-                    // region Life Paths Tab
-                    // region Personnel Randomization
-                } else if (nodeName.equalsIgnoreCase("useDylansRandomXP")) {
-                    campaignOptions.setUseDylansRandomXP(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("nonBinaryDiceSize")) {
-                    campaignOptions.setNonBinaryDiceSize(Integer.parseInt(nodeContents));
-                    // endregion Personnel Randomization
-
-                    // region Random Histories
-                } else if (nodeName.equalsIgnoreCase("randomOriginOptions")) {
-                    if (!childNode.hasChildNodes()) {
-                        continue;
-                    }
-                    final RandomOriginOptions randomOriginOptions = RandomOriginOptions.parseFromXML(childNode.getChildNodes(),
-                          true);
-                    if (randomOriginOptions == null) {
-                        continue;
-                    }
-                    campaignOptions.setRandomOriginOptions(randomOriginOptions);
-                } else if (nodeName.equalsIgnoreCase("useRandomPersonalities")) {
-                    campaignOptions.setUseRandomPersonalities(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomPersonalityReputation")) {
-                    campaignOptions.setUseRandomPersonalityReputation(Boolean.parseBoolean(nodeContents));
-                } else if ((nodeName.equalsIgnoreCase("useReasoningXpMultiplier"))) {
-                    campaignOptions.setUseReasoningXpMultiplier(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useSimulatedRelationships")) {
-                    campaignOptions.setUseSimulatedRelationships(Boolean.parseBoolean(nodeContents));
-                    // endregion Random Histories
-
-                    // region Family
-                } else if (nodeName.equalsIgnoreCase("familyDisplayLevel")) {
-                    campaignOptions.setFamilyDisplayLevel(FamilialRelationshipDisplayLevel.parseFromString(nodeContents));
-                    // endregion Family
-
-                    // region anniversaries
-                } else if (nodeName.equalsIgnoreCase("announceBirthdays")) {
-                    campaignOptions.setAnnounceBirthdays(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("announceRecruitmentAnniversaries")) {
-                    campaignOptions.setAnnounceRecruitmentAnniversaries(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("announceOfficersOnly")) {
-                    campaignOptions.setAnnounceOfficersOnly(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("announceChildBirthdays")) {
-                    campaignOptions.setAnnounceChildBirthdays(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("showLifeEventDialogBirths")) {
-                    campaignOptions.setShowLifeEventDialogBirths(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("showLifeEventDialogComingOfAge")) {
-                    campaignOptions.setShowLifeEventDialogComingOfAge(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("showLifeEventDialogCelebrations")) {
-                    campaignOptions.setShowLifeEventDialogCelebrations(Boolean.parseBoolean(nodeContents));
-                    // endregion anniversaries
-
-                    // region Marriage
-                } else if (nodeName.equalsIgnoreCase("useManualMarriages")) {
-                    campaignOptions.setUseManualMarriages(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useClanPersonnelMarriages")) {
-                    campaignOptions.setUseClanPersonnelMarriages(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePrisonerMarriages")) {
-                    campaignOptions.setUsePrisonerMarriages(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("checkMutualAncestorsDepth")) {
-                    campaignOptions.setCheckMutualAncestorsDepth(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("noInterestInMarriageDiceSize")) {
-                    campaignOptions.setNoInterestInMarriageDiceSize(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("logMarriageNameChanges")) {
-                    campaignOptions.setLogMarriageNameChanges(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("marriageSurnameWeights")) {
-                    if (!childNode.hasChildNodes()) {
-                        continue;
-                    }
-                    final NodeList nl2 = childNode.getChildNodes();
-                    for (int j = 0; j < nl2.getLength(); j++) {
-                        final Node wn3 = nl2.item(j);
-                        if (wn3.getNodeType() != Node.ELEMENT_NODE) {
-                            continue;
-                        }
-                        campaignOptions.getMarriageSurnameWeights()
-                              .put(MergingSurnameStyle.parseFromString(wn3.getNodeName().trim()),
-                                    Integer.parseInt(wn3.getTextContent().trim()));
-                    }
-                } else if (nodeName.equalsIgnoreCase("randomMarriageMethod")) {
-                    campaignOptions.setRandomMarriageMethod(RandomMarriageMethod.fromString(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomClanPersonnelMarriages")) {
-                    campaignOptions.setUseRandomClanPersonnelMarriages(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomPrisonerMarriages")) {
-                    campaignOptions.setUseRandomPrisonerMarriages(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomMarriageAgeRange")) {
-                    campaignOptions.setRandomMarriageAgeRange(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomMarriageDiceSize")) {
-                    campaignOptions.setRandomMarriageDiceSize(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomSameSexMarriageDiceSize")) {
-                    campaignOptions.setRandomSameSexMarriageDiceSize(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomSameSexMarriages")) { // Legacy, pre-50.01
-                    if (!Boolean.parseBoolean(nodeContents)) {
-                        campaignOptions.setRandomSameSexMarriageDiceSize(0);
-                    }
-                } else if (nodeName.equalsIgnoreCase("randomNewDependentMarriage")) {
-                    campaignOptions.setRandomNewDependentMarriage(Integer.parseInt(nodeContents));
-                    // endregion Marriage
-
-                    // region Divorce
-                } else if (nodeName.equalsIgnoreCase("useManualDivorce")) {
-                    campaignOptions.setUseManualDivorce(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useClanPersonnelDivorce")) {
-                    campaignOptions.setUseClanPersonnelDivorce(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePrisonerDivorce")) {
-                    campaignOptions.setUsePrisonerDivorce(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("divorceSurnameWeights")) {
-                    if (!childNode.hasChildNodes()) {
-                        continue;
-                    }
-                    final NodeList nl2 = childNode.getChildNodes();
-                    for (int j = 0; j < nl2.getLength(); j++) {
-                        final Node wn3 = nl2.item(j);
-                        if (wn3.getNodeType() != Node.ELEMENT_NODE) {
-                            continue;
-                        }
-                        campaignOptions.getDivorceSurnameWeights()
-                              .put(SplittingSurnameStyle.valueOf(wn3.getNodeName().trim()),
-                                    Integer.parseInt(wn3.getTextContent().trim()));
-                    }
-                } else if (nodeName.equalsIgnoreCase("randomDivorceMethod")) {
-                    campaignOptions.setRandomDivorceMethod(RandomDivorceMethod.fromString(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomOppositeSexDivorce")) {
-                    campaignOptions.setUseRandomOppositeSexDivorce(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomSameSexDivorce")) {
-                    campaignOptions.setUseRandomSameSexDivorce(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomClanPersonnelDivorce")) {
-                    campaignOptions.setUseRandomClanPersonnelDivorce(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomPrisonerDivorce")) {
-                    campaignOptions.setUseRandomPrisonerDivorce(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomDivorceDiceSize")) {
-                    campaignOptions.setRandomDivorceDiceSize(Integer.parseInt(nodeContents));
-                    // endregion Divorce
-
-                    // region Procreation
-                } else if (nodeName.equalsIgnoreCase("useManualProcreation")) {
-                    campaignOptions.setUseManualProcreation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useClanPersonnelProcreation")) {
-                    campaignOptions.setUseClanPersonnelProcreation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePrisonerProcreation")) {
-                    campaignOptions.setUsePrisonerProcreation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("multiplePregnancyOccurrences")) {
-                    campaignOptions.setMultiplePregnancyOccurrences(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("babySurnameStyle")) {
-                    campaignOptions.setBabySurnameStyle(BabySurnameStyle.parseFromString(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("assignNonPrisonerBabiesFounderTag")) {
-                    campaignOptions.setAssignNonPrisonerBabiesFounderTag(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("assignChildrenOfFoundersFounderTag")) {
-                    campaignOptions.setAssignChildrenOfFoundersFounderTag(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useMaternityLeave")) {
-                    campaignOptions.setUseMaternityLeave(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("determineFatherAtBirth")) {
-                    campaignOptions.setDetermineFatherAtBirth(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("displayTrueDueDate")) {
-                    campaignOptions.setDisplayTrueDueDate(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("noInterestInChildrenDiceSize")) {
-                    campaignOptions.setNoInterestInChildrenDiceSize(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("logProcreation")) {
-                    campaignOptions.setLogProcreation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomProcreationMethod")) {
-                    campaignOptions.setRandomProcreationMethod(RandomProcreationMethod.fromString(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRelationshiplessRandomProcreation")) {
-                    campaignOptions.setUseRelationshiplessRandomProcreation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomClanPersonnelProcreation")) {
-                    campaignOptions.setUseRandomClanPersonnelProcreation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomPrisonerProcreation")) {
-                    campaignOptions.setUseRandomPrisonerProcreation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomProcreationRelationshipDiceSize")) {
-                    campaignOptions.setRandomProcreationRelationshipDiceSize(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomProcreationRelationshiplessDiceSize")) {
-                    campaignOptions.setRandomProcreationRelationshiplessDiceSize(Integer.parseInt(nodeContents));
-                    // endregion Procreation
-
-                    // region Education
-                } else if (nodeName.equalsIgnoreCase("useEducationModule")) {
-                    campaignOptions.setUseEducationModule(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("curriculumXpRate")) {
-                    campaignOptions.setCurriculumXpRate(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("maximumJumpCount")) {
-                    campaignOptions.setMaximumJumpCount(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useReeducationCamps")) {
-                    campaignOptions.setUseReeducationCamps(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableLocalAcademies")) {
-                    campaignOptions.setEnableLocalAcademies(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enablePrestigiousAcademies")) {
-                    campaignOptions.setEnablePrestigiousAcademies(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableUnitEducation")) {
-                    campaignOptions.setEnableUnitEducation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableOverrideRequirements")) {
-                    campaignOptions.setEnableOverrideRequirements(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableShowIneligibleAcademies")) {
-                    campaignOptions.setEnableShowIneligibleAcademies(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("entranceExamBaseTargetNumber")) {
-                    campaignOptions.setEntranceExamBaseTargetNumber(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("facultyXpRate")) {
-                    campaignOptions.setFacultyXpRate(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("enableBonuses")) {
-                    campaignOptions.setEnableBonuses(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("adultDropoutChance")) {
-                    campaignOptions.setAdultDropoutChance(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("childrenDropoutChance")) {
-                    campaignOptions.setChildrenDropoutChance(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("allAges")) {
-                    campaignOptions.setAllAges(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("militaryAcademyAccidents")) {
-                    campaignOptions.setMilitaryAcademyAccidents(Integer.parseInt(nodeContents));
-                    // endregion Education
-                } else if (nodeName.equalsIgnoreCase("enabledRandomDeathAgeGroups")) {
-                    if (!childNode.hasChildNodes()) {
-                        continue;
-                    }
-                    final NodeList nl2 = childNode.getChildNodes();
-                    for (int i = 0; i < nl2.getLength(); i++) {
-                        final Node wn3 = nl2.item(i);
-                        try {
-                            campaignOptions.getEnabledRandomDeathAgeGroups()
-                                  .put(AgeGroup.valueOf(wn3.getNodeName()),
-                                        Boolean.parseBoolean(wn3.getTextContent().trim()));
-                        } catch (Exception ignored) {
-
-                        }
-                    }
-                } else if (nodeName.equalsIgnoreCase("useRandomDeathSuicideCause")) {
-                    campaignOptions.setUseRandomDeathSuicideCause(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomDeathMultiplier")) {
-                    campaignOptions.setRandomDeathMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomRetirement")) {
-                    campaignOptions.setUseRandomRetirement(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("turnoverBaseTn")) {
-                    campaignOptions.setTurnoverFixedTargetNumber(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("turnoverFrequency")) {
-                    campaignOptions.setTurnoverFrequency(TurnoverFrequency.valueOf(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("trackOriginalUnit")) {
-                    campaignOptions.setTrackOriginalUnit(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("aeroRecruitsHaveUnits")) {
-                    campaignOptions.setAeroRecruitsHaveUnits(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useContractCompletionRandomRetirement")) {
-                    campaignOptions.setUseContractCompletionRandomRetirement(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomFounderTurnover")) {
-                    campaignOptions.setUseRandomFounderTurnover(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFounderRetirement")) {
-                    campaignOptions.setUseFounderRetirement(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useSubContractSoldiers")) {
-                    campaignOptions.setUseSubContractSoldiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("serviceContractDuration")) {
-                    campaignOptions.setServiceContractDuration(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("serviceContractModifier")) {
-                    campaignOptions.setServiceContractModifier(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payBonusDefault")) {
-                    campaignOptions.setPayBonusDefault(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payBonusDefaultThreshold")) {
-                    campaignOptions.setPayBonusDefaultThreshold(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useCustomRetirementModifiers")) {
-                    campaignOptions.setUseCustomRetirementModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFatigueModifiers")) {
-                    campaignOptions.setUseFatigueModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useSkillModifiers")) {
-                    campaignOptions.setUseSkillModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useAgeModifiers")) {
-                    campaignOptions.setUseAgeModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useUnitRatingModifiers")) {
-                    campaignOptions.setUseUnitRatingModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionModifiers")) {
-                    campaignOptions.setUseFactionModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useMissionStatusModifiers")) {
-                    campaignOptions.setUseMissionStatusModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useHostileTerritoryModifiers")) {
-                    campaignOptions.setUseHostileTerritoryModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFamilyModifiers")) {
-                    campaignOptions.setUseFamilyModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useLoyaltyModifiers")) {
-                    campaignOptions.setUseLoyaltyModifiers(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useHideLoyalty")) {
-                    campaignOptions.setUseHideLoyalty(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payoutRateOfficer")) {
-                    campaignOptions.setPayoutRateOfficer(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payoutRateEnlisted")) {
-                    campaignOptions.setPayoutRateEnlisted(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payoutRetirementMultiplier")) {
-                    campaignOptions.setPayoutRetirementMultiplier(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePayoutServiceBonus")) {
-                    campaignOptions.setUsePayoutServiceBonus(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payoutServiceBonusRate")) {
-                    campaignOptions.setPayoutServiceBonusRate(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("UseHRStrain")) {
-                    campaignOptions.setUseHRStrain(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("hrStrain")) {
-                    campaignOptions.setHRCapacity(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("administrativeStrain")) { // Legacy <50.07
-                    campaignOptions.setHRCapacity(MathUtility.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useManagementSkill")) {
-                    campaignOptions.setUseManagementSkill(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useCommanderLeadershipOnly")) {
-                    campaignOptions.setUseCommanderLeadershipOnly(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("managementSkillPenalty")) {
-                    campaignOptions.setManagementSkillPenalty(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFatigue")) {
-                    campaignOptions.setUseFatigue(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("fatigueRate")) {
-                    campaignOptions.setFatigueRate(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useInjuryFatigue")) {
-                    campaignOptions.setUseInjuryFatigue(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("fieldKitchenCapacity")) {
-                    campaignOptions.setFieldKitchenCapacity(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("fieldKitchenIgnoreNonCombatants")) {
-                    campaignOptions.setFieldKitchenIgnoreNonCombatants(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("fatigueLeaveThreshold")) {
-                    campaignOptions.setFatigueLeaveThreshold(Integer.parseInt(nodeContents));
-                    // endregion Turnover and Retention
-
-                    // region Finances Tab
-                } else if (nodeName.equalsIgnoreCase("payForParts")) {
-                    campaignOptions.setPayForParts(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payForRepairs")) {
-                    campaignOptions.setPayForRepairs(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payForUnits")) {
-                    campaignOptions.setPayForUnits(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payForSalaries")) {
-                    campaignOptions.setPayForSalaries(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payForOverhead")) {
-                    campaignOptions.setPayForOverhead(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payForMaintain")) {
-                    campaignOptions.setPayForMaintain(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payForTransport")) {
-                    campaignOptions.setPayForTransport(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("sellUnits")) {
-                    campaignOptions.setSellUnits(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("sellParts")) {
-                    campaignOptions.setSellParts(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payForRecruitment")) {
-                    campaignOptions.setPayForRecruitment(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payForFood")) {
-                    campaignOptions.setPayForFood(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("payForHousing")) {
-                    campaignOptions.setPayForHousing(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useLoanLimits")) {
-                    campaignOptions.setLoanLimits(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePercentageMaint")) {
-                    campaignOptions.setUsePercentageMaint(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("infantryDontCount")) {
-                    campaignOptions.setUseInfantryDontCount(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePeacetimeCost")) {
-                    campaignOptions.setUsePeacetimeCost(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useExtendedPartsModifier")) {
-                    campaignOptions.setUseExtendedPartsModifier(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("showPeacetimeCost")) {
-                    campaignOptions.setShowPeacetimeCost(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("newFinancialYearFinancesToCSVExport")) {
-                    campaignOptions.setNewFinancialYearFinancesToCSVExport(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("financialYearDuration")) {
-                    campaignOptions.setFinancialYearDuration(FinancialYearDuration.parseFromString(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("simulateGrayMonday")) {
-                    campaignOptions.setSimulateGrayMonday(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("allowMonthlyReinvestment")) {
-                    campaignOptions.setAllowMonthlyReinvestment(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("allowMonthlyConnections")) {
-                    campaignOptions.setAllowMonthlyConnections(Boolean.parseBoolean(nodeContents));
-
-                    // region Price Multipliers
-                } else if (nodeName.equalsIgnoreCase("commonPartPriceMultiplier")) {
-                    campaignOptions.setCommonPartPriceMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("innerSphereUnitPriceMultiplier")) {
-                    campaignOptions.setInnerSphereUnitPriceMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("innerSpherePartPriceMultiplier")) {
-                    campaignOptions.setInnerSpherePartPriceMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("clanUnitPriceMultiplier")) {
-                    campaignOptions.setClanUnitPriceMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("clanPartPriceMultiplier")) {
-                    campaignOptions.setClanPartPriceMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mixedTechUnitPriceMultiplier")) {
-                    campaignOptions.setMixedTechUnitPriceMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usedPartPriceMultipliers")) {
-                    final String[] values = nodeContents.split(",");
-                    for (int i = 0; i < values.length; i++) {
-                        try {
-                            campaignOptions.getUsedPartPriceMultipliers()[i] = Double.parseDouble(values[i]);
-                        } catch (Exception ignored) {
-
-                        }
-                    }
-                } else if (nodeName.equalsIgnoreCase("damagedPartsValueMultiplier")) {
-                    campaignOptions.setDamagedPartsValueMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("unrepairablePartsValueMultiplier")) {
-                    campaignOptions.setUnrepairablePartsValueMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("cancelledOrderRefundMultiplier")) {
-                    campaignOptions.setCancelledOrderRefundMultiplier(Double.parseDouble(nodeContents));
-                    // endregion Price Multipliers
-
-                    // region Taxes
-                } else if (nodeName.equalsIgnoreCase("useTaxes")) {
-                    campaignOptions.setUseTaxes(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("taxesPercentage")) {
-                    campaignOptions.setTaxesPercentage(Integer.parseInt(nodeContents));
-                    // endregion Taxes
-                    // endregion Finances Tab
-
-                    // Shares
-                } else if (nodeName.equalsIgnoreCase("useShareSystem")) {
-                    campaignOptions.setUseShareSystem(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("sharesForAll")) {
-                    campaignOptions.setSharesForAll(Boolean.parseBoolean(nodeContents));
-                    // endregion Price Multipliers
-                    // endregion Finances Tab
-
-                    // region Markets Tab
-                    // region Personnel Market
-                } else if (nodeName.equalsIgnoreCase("personnelMarketStyle")) {
-                    campaignOptions.setPersonnelMarketStyle(PersonnelMarketStyle.fromString(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("personnelMarketName")) {
-                    String marketName = nodeContents;
-                    // Backwards compatibility with saves from before these rules moved to Camops
-                    if (marketName.equals("Strat Ops")) {
-                        marketName = "Campaign Ops";
-                    }
-                    campaignOptions.setPersonnelMarketName(marketName);
-                } else if (nodeName.equalsIgnoreCase("personnelMarketReportRefresh")) {
-                    campaignOptions.setPersonnelMarketReportRefresh(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("personnelMarketRandomRemovalTargets")) {
-                    if (!childNode.hasChildNodes()) {
-                        continue;
-                    }
-                    final NodeList nl2 = childNode.getChildNodes();
-                    for (int j = 0; j < nl2.getLength(); j++) {
-                        final Node wn3 = nl2.item(j);
-                        if (wn3.getNodeType() != Node.ELEMENT_NODE) {
-                            continue;
-                        }
-                        campaignOptions.getPersonnelMarketRandomRemovalTargets()
-                              .put(SkillLevel.valueOf(wn3.getNodeName().trim()),
-                                    Integer.parseInt(wn3.getTextContent().trim()));
-                    }
-                } else if (nodeName.equalsIgnoreCase("personnelMarketDylansWeight")) {
-                    campaignOptions.setPersonnelMarketDylansWeight(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePersonnelHireHiringHallOnly")) {
-                    campaignOptions.setUsePersonnelHireHiringHallOnly(Boolean.parseBoolean(nodeContents));
-                    // endregion Personnel Market
-
-                    // region Unit Market
-                } else if (nodeName.equalsIgnoreCase("unitMarketMethod")) {
-                    campaignOptions.setUnitMarketMethod(UnitMarketMethod.valueOf(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("unitMarketRegionalMekVariations")) {
-                    campaignOptions.setUnitMarketRegionalMekVariations(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("unitMarketSpecialUnitChance")) {
-                    campaignOptions.setUnitMarketSpecialUnitChance(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("unitMarketRarityModifier")) {
-                    campaignOptions.setUnitMarketRarityModifier(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("instantUnitMarketDelivery")) {
-                    campaignOptions.setInstantUnitMarketDelivery(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mothballUnitMarketDeliveries")) {
-                    campaignOptions.setMothballUnitMarketDeliveries(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("unitMarketReportRefresh")) {
-                    campaignOptions.setUnitMarketReportRefresh(Boolean.parseBoolean(nodeContents));
-                    // endregion Unit Market
-
-                    // region Contract Market
-                } else if (nodeName.equalsIgnoreCase("contractMarketMethod")) {
-                    campaignOptions.setContractMarketMethod(ContractMarketMethod.valueOf(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("contractSearchRadius")) {
-                    campaignOptions.setContractSearchRadius(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("variableContractLength")) {
-                    campaignOptions.setVariableContractLength(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useDynamicDifficulty")) {
-                    campaignOptions.setUseDynamicDifficulty(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("contractMarketReportRefresh")) {
-                    campaignOptions.setContractMarketReportRefresh(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("contractMaxSalvagePercentage")) {
-                    campaignOptions.setContractMaxSalvagePercentage(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("dropShipBonusPercentage")) {
-                    campaignOptions.setDropShipBonusPercentage(Integer.parseInt(nodeContents));
-                    // endregion Contract Market
-                    // endregion Markets Tab
-
-                    // region RATs Tab
-                } else if (nodeName.equals("useStaticRATs")) {
-                    campaignOptions.setUseStaticRATs(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("rats")) {
-                    campaignOptions.setRATs(MHQXMLUtility.unEscape(nodeContents).split(","));
-                } else if (nodeName.equals("ignoreRATEra")) {
-                    campaignOptions.setIgnoreRATEra(Boolean.parseBoolean(nodeContents));
-                    // endregion RATs Tab
-
-                    // region AtB Tab
-                } else if (nodeName.equalsIgnoreCase("skillLevel")) {
-                    campaignOptions.setSkillLevel(SkillLevel.parseFromString(nodeContents));
-                    // region ACAR Tab
-                } else if (nodeName.equalsIgnoreCase("autoResolveMethod")) {
-                    campaignOptions.setAutoResolveMethod(AutoResolveMethod.valueOf(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoResolveVictoryChanceEnabled")) {
-                    campaignOptions.setAutoResolveVictoryChanceEnabled(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoResolveNumberOfScenarios")) {
-                    campaignOptions.setAutoResolveNumberOfScenarios(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoResolveUseExperimentalPacarGui")) {
-                    campaignOptions.setAutoResolveExperimentalPacarGuiEnabled(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("strategicViewTheme")) {
-                    campaignOptions.setStrategicViewTheme(nodeContents);
-                    // endregion ACAR Tab
-                    // endregion AtB Tab
-                } else if (nodeName.equalsIgnoreCase("phenotypeProbabilities")) {
-                    String[] values = nodeContents.split(",");
-                    for (int i = 0; i < values.length; i++) {
-                        campaignOptions.setPhenotypeProbability(i, Integer.parseInt(values[i]));
-                    }
-                } else if (nodeName.equalsIgnoreCase("useAtB")) {
-                    campaignOptions.setUseAtB(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useStratCon")) {
-                    campaignOptions.setUseStratCon(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useAero")) {
-                    campaignOptions.setUseAero(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useVehicles")) {
-                    campaignOptions.setUseVehicles(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("clanVehicles")) {
-                    campaignOptions.setClanVehicles(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useGenericBattleValue")) {
-                    campaignOptions.setUseGenericBattleValue(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useVerboseBidding")) {
-                    campaignOptions.setUseVerboseBidding(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("doubleVehicles")) {
-                    campaignOptions.setDoubleVehicles(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("adjustPlayerVehicles")) {
-                    campaignOptions.setAdjustPlayerVehicles(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("opForLanceTypeMeks")) {
-                    campaignOptions.setOpForLanceTypeMeks(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("opForLanceTypeMixed")) {
-                    campaignOptions.setOpForLanceTypeMixed(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("opForLanceTypeVehicles")) {
-                    campaignOptions.setOpForLanceTypeVehicles(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("opForUsesVTOLs")) {
-                    campaignOptions.setOpForUsesVTOLs(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useDropShips")) {
-                    campaignOptions.setUseDropShips(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("mercSizeLimited")) {
-                    campaignOptions.setMercSizeLimited(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("regionalMekVariations")) {
-                    campaignOptions.setRegionalMekVariations(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("attachedPlayerCamouflage")) {
-                    campaignOptions.setAttachedPlayerCamouflage(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("playerControlsAttachedUnits")) {
-                    campaignOptions.setPlayerControlsAttachedUnits(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("atbBattleChance")) {
-                    String[] values = nodeContents.split(",");
-                    for (int i = 0; i < values.length; i++) {
-                        try {
-                            campaignOptions.setAtBBattleChance(i, Integer.parseInt(values[i]));
-                        } catch (Exception ignored) {
-                            // Badly coded, but this is to migrate devs and their games as the swap was done before a
-                            // release and is thus better to handle this way than through a more code complex method
-                            campaignOptions.setAtBBattleChance(i, (int) Math.round(Double.parseDouble(values[i])));
-                        }
-                    }
-                } else if (nodeName.equalsIgnoreCase("generateChases")) {
-                    campaignOptions.setGenerateChases(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useWeatherConditions")) {
-                    campaignOptions.setUseWeatherConditions(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useLightConditions")) {
-                    campaignOptions.setUseLightConditions(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("usePlanetaryConditions")) {
-                    campaignOptions.setUsePlanetaryConditions(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("restrictPartsByMission")) {
-                    campaignOptions.setRestrictPartsByMission(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("allowOpForLocalUnits")) {
-                    campaignOptions.setAllowOpForLocalUnits(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("allowOpForAeros")) {
-                    campaignOptions.setAllowOpForAeros(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("opForAeroChance")) {
-                    campaignOptions.setOpForAeroChance(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("opForLocalUnitChance")) {
-                    campaignOptions.setOpForLocalUnitChance(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("fixedMapChance")) {
-                    campaignOptions.setFixedMapChance(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("spaUpgradeIntensity")) {
-                    campaignOptions.setSpaUpgradeIntensity(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("scenarioModMax")) {
-                    campaignOptions.setScenarioModMax(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("scenarioModChance")) {
-                    campaignOptions.setScenarioModChance(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("scenarioModBV")) {
-                    campaignOptions.setScenarioModBV(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoConfigMunitions")) {
-                    campaignOptions.setAutoConfigMunitions(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("autoGenerateOpForCallsigns")) {
-                    campaignOptions.setAutoGenerateOpForCallsigns(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("minimumCallsignSkillLevel")) {
-                    campaignOptions.setMinimumCallsignSkillLevel(SkillLevel.parseFromString(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("trackFactionStanding")) {
-                    campaignOptions.setTrackFactionStanding(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionStandingNegotiation")) {
-                    campaignOptions.setUseFactionStandingNegotiation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionStandingResupply")) {
-                    campaignOptions.setUseFactionStandingResupply(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionStandingCommandCircuit")) {
-                    campaignOptions.setUseFactionStandingCommandCircuit(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionStandingOutlawed")) {
-                    campaignOptions.setUseFactionStandingOutlawed(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionStandingBatchallRestrictions")) {
-                    campaignOptions.setUseFactionStandingBatchallRestrictions(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionStandingRecruitment")) {
-                    campaignOptions.setUseFactionStandingRecruitment(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionStandingBarracksCosts")) {
-                    campaignOptions.setUseFactionStandingBarracksCosts(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionStandingUnitMarket")) {
-                    campaignOptions.setUseFactionStandingUnitMarket(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionStandingContractPay")) {
-                    campaignOptions.setUseFactionStandingContractPay(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useFactionStandingSupportPoints")) {
-                    campaignOptions.setUseFactionStandingSupportPoints(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("factionStandingGainMultiplier")) {
-                    campaignOptions.setRegardMultiplier(MathUtility.parseDouble(nodeContents, 1.0));
-
-                    // region Legacy
-                    // Removed in 0.49.*
-                } else if (nodeName.equalsIgnoreCase("salaryXPMultiplier")) { // Legacy, 0.49.12 removal
-                    String[] values = nodeContents.split(",");
-                    for (int i = 0; i < values.length; i++) {
-                        campaignOptions.getSalaryXPMultipliers()
-                              .put(Skills.SKILL_LEVELS[i + 1], Double.parseDouble(values[i]));
-                    }
-                } else if (nodeName.equalsIgnoreCase("personnelMarketRandomEliteRemoval")) { // Legacy, 0.49.12
-                    // removal
-                    campaignOptions.getPersonnelMarketRandomRemovalTargets()
-                          .put(SkillLevel.ELITE, Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("personnelMarketRandomVeteranRemoval")) { // Legacy,
-                    // 0.49.12
-                    // removal
-                    campaignOptions.getPersonnelMarketRandomRemovalTargets()
-                          .put(SkillLevel.VETERAN, Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("personnelMarketRandomRegularRemoval")) { // Legacy,
-                    // 0.49.12
-                    // removal
-                    campaignOptions.getPersonnelMarketRandomRemovalTargets()
-                          .put(SkillLevel.REGULAR, Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("personnelMarketRandomGreenRemoval")) { // Legacy, 0.49.12
-                    // removal
-                    campaignOptions.getPersonnelMarketRandomRemovalTargets()
-                          .put(SkillLevel.GREEN, Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("personnelMarketRandomUltraGreenRemoval")) { // Legacy,
-                    // 0.49.12
-                    // removal
-                    campaignOptions.getPersonnelMarketRandomRemovalTargets()
-                          .put(SkillLevel.ULTRA_GREEN, Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomizeOrigin")) { // Legacy, 0.49.7 Removal
-                    campaignOptions.getRandomOriginOptions().setRandomizeOrigin(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomizeDependentOrigin")) { // Legacy, 0.49.7 Removal
-                    campaignOptions.getRandomOriginOptions()
-                          .setRandomizeDependentOrigin(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("originSearchRadius")) { // Legacy, 0.49.7 Removal
-                    campaignOptions.getRandomOriginOptions().setOriginSearchRadius(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("extraRandomOrigin")) { // Legacy, 0.49.7 Removal
-                    campaignOptions.getRandomOriginOptions().setExtraRandomOrigin(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("originDistanceScale")) { // Legacy, 0.49.7 Removal
-                    campaignOptions.getRandomOriginOptions().setOriginDistanceScale(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("dependentsNeverLeave")) { // Legacy - 0.49.7 Removal
-                    campaignOptions.setUseRandomDependentRemoval(!Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("marriageAgeRange")) { // Legacy - 0.49.6 Removal
-                    campaignOptions.setRandomMarriageAgeRange(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useRandomMarriages")) { // Legacy - 0.49.6 Removal
-                    campaignOptions.setRandomMarriageMethod(Boolean.parseBoolean(nodeContents) ?
-                                                                  RandomMarriageMethod.DICE_ROLL :
-                                                                  RandomMarriageMethod.NONE);
-                } else if (nodeName.equalsIgnoreCase("logMarriageNameChange")) { // Legacy - 0.49.6 Removal
-                    campaignOptions.setLogMarriageNameChanges(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("randomMarriageSurnameWeights")) { // Legacy - 0.49.6
-                    // Removal
-                    final String[] values = nodeContents.split(",");
-                    if (values.length == 13) {
-                        final MergingSurnameStyle[] marriageSurnameStyles = MergingSurnameStyle.values();
-                        for (int i = 0; i < values.length; i++) {
-                            campaignOptions.getMarriageSurnameWeights()
-                                  .put(marriageSurnameStyles[i], Integer.parseInt(values[i]));
-                        }
-                    } else if (values.length == 9) {
-                        migrateMarriageSurnameWeights(campaignOptions, values);
-                    } else {
-                        LOGGER.error("Unknown length of randomMarriageSurnameWeights");
-                    }
-                } else if (nodeName.equalsIgnoreCase("logConception")) { // Legacy - 0.49.4 Removal
-                    campaignOptions.setLogProcreation(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("staticRATs")) { // Legacy - 0.49.4 Removal
-                    campaignOptions.setUseStaticRATs(true);
-                } else if (nodeName.equalsIgnoreCase("ignoreRatEra")) { // Legacy - 0.49.4 Removal
-                    campaignOptions.setIgnoreRATEra(true);
-                } else if (nodeName.equalsIgnoreCase("clanPriceModifier")) { // Legacy - 0.49.3 Removal
-                    final double value = Double.parseDouble(nodeContents);
-                    campaignOptions.setClanUnitPriceMultiplier(value);
-                    campaignOptions.setClanPartPriceMultiplier(value);
-                } else if (nodeName.equalsIgnoreCase("usedPartsValueA")) { // Legacy - 0.49.3 Removal
-                    campaignOptions.getUsedPartPriceMultipliers()[0] = Double.parseDouble(nodeContents);
-                } else if (nodeName.equalsIgnoreCase("usedPartsValueB")) { // Legacy - 0.49.3 Removal
-                    campaignOptions.getUsedPartPriceMultipliers()[1] = Double.parseDouble(nodeContents);
-                } else if (nodeName.equalsIgnoreCase("usedPartsValueC")) { // Legacy - 0.49.3 Removal
-                    campaignOptions.getUsedPartPriceMultipliers()[2] = Double.parseDouble(nodeContents);
-                } else if (nodeName.equalsIgnoreCase("usedPartsValueD")) { // Legacy - 0.49.3 Removal
-                    campaignOptions.getUsedPartPriceMultipliers()[3] = Double.parseDouble(nodeContents);
-                } else if (nodeName.equalsIgnoreCase("usedPartsValueE")) { // Legacy - 0.49.3 Removal
-                    campaignOptions.getUsedPartPriceMultipliers()[4] = Double.parseDouble(nodeContents);
-                } else if (nodeName.equalsIgnoreCase("usedPartsValueF")) { // Legacy - 0.49.3 Removal
-                    campaignOptions.getUsedPartPriceMultipliers()[5] = Double.parseDouble(nodeContents);
-                } else if (nodeName.equalsIgnoreCase("damagedPartsValue")) { // Legacy - 0.49.3 Removal
-                    campaignOptions.setDamagedPartsValueMultiplier(Double.parseDouble(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("canceledOrderReimbursement")) { // Legacy - 0.49.3
-                    // Removal
-                    campaignOptions.setCancelledOrderRefundMultiplier(Double.parseDouble(nodeContents));
-
-                    // Removed in 0.47.*
-                } else if (nodeName.equalsIgnoreCase("personnelMarketType")) { // Legacy
-                    campaignOptions.setPersonnelMarketName(PersonnelMarket.getTypeName(Integer.parseInt(nodeContents)));
-                } else if (nodeName.equalsIgnoreCase("intensity")) { // Legacy
-                    double intensity = Double.parseDouble(nodeContents);
-
-                    campaignOptions.setAtBBattleChance(CombatRole.MANEUVER.ordinal(),
-                          (int) Math.round(((40.0 * intensity) / (40.0 * intensity + 60.0)) * 100.0 + 0.5));
-                    campaignOptions.setAtBBattleChance(CombatRole.FRONTLINE.ordinal(),
-                          (int) Math.round(((20.0 * intensity) / (20.0 * intensity + 80.0)) * 100.0 + 0.5));
-                    campaignOptions.setAtBBattleChance(CombatRole.PATROL.ordinal(),
-                          (int) Math.round(((60.0 * intensity) / (60.0 * intensity + 40.0)) * 100.0 + 0.5));
-                    campaignOptions.setAtBBattleChance(CombatRole.TRAINING.ordinal(),
-                          (int) Math.round(((10.0 * intensity) / (10.0 * intensity + 90.0)) * 100.0 + 0.5));
-                } else if (nodeName.equalsIgnoreCase("personnelMarketType")) { // Legacy
-                    campaignOptions.setPersonnelMarketName(PersonnelMarket.getTypeName(Integer.parseInt(nodeContents)));
-                } else if (nodeName.equalsIgnoreCase("startGameDelay")) { // Legacy
-                    MekHQ.getMHQOptions().setStartGameDelay(Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("historicalDailyLog")) { // Legacy
-                    MekHQ.getMHQOptions().setHistoricalDailyLog(Boolean.parseBoolean(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("useUnitRating") // Legacy
-                                 || nodeName.equalsIgnoreCase("useDragoonRating")) { // Legacy
-                    if (!Boolean.parseBoolean(nodeContents)) {
-                        campaignOptions.setUnitRatingMethod(UnitRatingMethod.NONE);
-                    }
-                } else if (nodeName.equalsIgnoreCase("probPhenoMW")) { // Legacy
-                    campaignOptions.setPhenotypeProbability(Phenotype.MEKWARRIOR.ordinal(),
-                          Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("probPhenoBA")) { // Legacy
-                    campaignOptions.setPhenotypeProbability(Phenotype.ELEMENTAL.ordinal(),
-                          Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("probPhenoAero")) { // Legacy
-                    campaignOptions.setPhenotypeProbability(Phenotype.AEROSPACE.ordinal(),
-                          Integer.parseInt(nodeContents));
-                } else if (nodeName.equalsIgnoreCase("probPhenoVee")) { // Legacy
-                    campaignOptions.setPhenotypeProbability(Phenotype.VEHICLE.ordinal(),
-                          Integer.parseInt(nodeContents));
-                }
+                parseNodeName(version, nodeName, campaignOptions, nodeContents, childNode);
             } catch (Exception ex) {
-                LOGGER.error(ex, "Unknown Exception: generationCampaignOptionsFromXML");
+                LOGGER.error(ex, "Exception parsing campaign option node: {}", nodeName);
             }
         }
 
         LOGGER.debug("Load Campaign Options Complete!");
-
         return campaignOptions;
     }
 
-    /**
-     * This is annoyingly required for the case of anyone having changed the surname weights. The code is not nice, but
-     * will nicely handle the cases where anyone has made changes
-     *
-     * @param values the values to migrate
-     */
-    private static void migrateMarriageSurnameWeights(final CampaignOptions campaignOptions, final String... values) {
-        int[] weights = new int[values.length];
+    private static void parseNodeName(Version version, String nodeName, CampaignOptions campaignOptions,
+          String nodeContents, Node childNode) {
+        switch (nodeName) {
+            case "checkMaintenance" -> campaignOptions.setCheckMaintenance(Boolean.parseBoolean(nodeContents));
+            case "maintenanceCycleDays" -> campaignOptions.setMaintenanceCycleDays(Integer.parseInt(nodeContents));
+            case "maintenanceBonus" -> campaignOptions.setMaintenanceBonus(Integer.parseInt(nodeContents));
+            case "useQualityMaintenance" ->
+                  campaignOptions.setUseQualityMaintenance(Boolean.parseBoolean(nodeContents));
+            case "reverseQualityNames" -> campaignOptions.setReverseQualityNames(Boolean.parseBoolean(nodeContents));
+            case "useRandomUnitQualities" ->
+                  campaignOptions.setUseRandomUnitQualities(Boolean.parseBoolean(nodeContents));
+            case "usePlanetaryModifiers" ->
+                  campaignOptions.setUsePlanetaryModifiers(Boolean.parseBoolean(nodeContents));
+            case "useUnofficialMaintenance" -> campaignOptions.setUseUnofficialMaintenance(Boolean.parseBoolean(
+                  nodeContents));
+            case "logMaintenance" -> campaignOptions.setLogMaintenance(Boolean.parseBoolean(nodeContents));
+            case "defaultMaintenanceTime" -> campaignOptions.setDefaultMaintenanceTime(Integer.parseInt(nodeContents));
+            case "mrmsUseRepair" -> campaignOptions.setMRMSUseRepair(Boolean.parseBoolean(nodeContents));
+            case "mrmsUseSalvage" -> campaignOptions.setMRMSUseSalvage(Boolean.parseBoolean(nodeContents));
+            case "mrmsUseExtraTime" -> campaignOptions.setMRMSUseExtraTime(Boolean.parseBoolean(nodeContents));
+            case "mrmsUseRushJob" -> campaignOptions.setMRMSUseRushJob(Boolean.parseBoolean(nodeContents));
+            case "mrmsAllowCarryover" -> campaignOptions.setMRMSAllowCarryover(Boolean.parseBoolean(nodeContents));
+            case "mrmsOptimizeToCompleteToday" -> campaignOptions.setMRMSOptimizeToCompleteToday(Boolean.parseBoolean(
+                  nodeContents));
+            case "mrmsScrapImpossible" -> campaignOptions.setMRMSScrapImpossible(Boolean.parseBoolean(nodeContents));
+            case "mrmsUseAssignedTechsFirst" -> campaignOptions.setMRMSUseAssignedTechsFirst(Boolean.parseBoolean(
+                  nodeContents));
+            case "mrmsReplacePod" -> campaignOptions.setMRMSReplacePod(Boolean.parseBoolean(nodeContents));
+            case "mrmsOptions" -> campaignOptions.setMRMSOptions(MRMSOption.parseListFromXML(childNode, version));
+            case "useFactionForNames" ->
+                  campaignOptions.setUseOriginFactionForNames(Boolean.parseBoolean(nodeContents));
+            case "useEraMods" -> campaignOptions.setEraMods(Boolean.parseBoolean(nodeContents));
+            case "assignedTechFirst" -> campaignOptions.setAssignedTechFirst(Boolean.parseBoolean(nodeContents));
+            case "resetToFirstTech" -> campaignOptions.setResetToFirstTech(Boolean.parseBoolean(nodeContents));
+            case "techsUseAdministration" ->
+                  campaignOptions.setTechsUseAdministration(Boolean.parseBoolean(nodeContents));
+            case "useQuirks" -> campaignOptions.setQuirks(Boolean.parseBoolean(nodeContents));
+            case "xpCostMultiplier" -> campaignOptions.setXpCostMultiplier(Double.parseDouble(nodeContents));
+            case "scenarioXP" -> campaignOptions.setScenarioXP(Integer.parseInt(nodeContents));
+            case "killsForXP" -> campaignOptions.setKillsForXP(Integer.parseInt(nodeContents));
+            case "killXPAward" -> campaignOptions.setKillXPAward(Integer.parseInt(nodeContents));
+            case "nTasksXP" -> campaignOptions.setNTasksXP(Integer.parseInt(nodeContents));
+            case "tasksXP" -> campaignOptions.setTaskXP(Integer.parseInt(nodeContents));
+            case "successXP" -> campaignOptions.setSuccessXP(Integer.parseInt(nodeContents));
+            case "mistakeXP" -> campaignOptions.setMistakeXP(Integer.parseInt(nodeContents));
+            case "vocationalXP" -> campaignOptions.setVocationalXP(Integer.parseInt(nodeContents));
+            case "vocationalXPTargetNumber" ->
+                  campaignOptions.setVocationalXPTargetNumber(Integer.parseInt(nodeContents));
+            case "vocationalXPCheckFrequency" -> campaignOptions.setVocationalXPCheckFrequency(Integer.parseInt(
+                  nodeContents));
+            case "contractNegotiationXP" -> campaignOptions.setContractNegotiationXP(Integer.parseInt(nodeContents));
+            case "adminWeeklyXP" -> campaignOptions.setAdminXP(Integer.parseInt(nodeContents));
+            case "adminXPPeriod" -> campaignOptions.setAdminXPPeriod(Integer.parseInt(nodeContents));
+            case "missionXpFail" -> campaignOptions.setMissionXpFail(Integer.parseInt(nodeContents));
+            case "missionXpSuccess" -> campaignOptions.setMissionXpSuccess(Integer.parseInt(nodeContents));
+            case "missionXpOutstandingSuccess" -> campaignOptions.setMissionXpOutstandingSuccess(Integer.parseInt(
+                  nodeContents));
+            case "edgeCost" -> campaignOptions.setEdgeCost(Integer.parseInt(nodeContents));
+            case "waitingPeriod" -> campaignOptions.setWaitingPeriod(Integer.parseInt(nodeContents));
+            case "acquisitionSkill" -> campaignOptions.setAcquisitionSkill(nodeContents);
+            case "unitTransitTime" -> campaignOptions.setUnitTransitTime(Integer.parseInt(nodeContents));
+            case "clanAcquisitionPenalty" -> campaignOptions.setClanAcquisitionPenalty(Integer.parseInt(nodeContents));
+            case "isAcquisitionPenalty" -> campaignOptions.setIsAcquisitionPenalty(Integer.parseInt(nodeContents));
+            case "usePlanetaryAcquisition" ->
+                  campaignOptions.setPlanetaryAcquisition(Boolean.parseBoolean(nodeContents));
+            case "planetAcquisitionFactionLimit" ->
+                  campaignOptions.setPlanetAcquisitionFactionLimit(PlanetaryAcquisitionFactionLimit.parseFromString(
+                        nodeContents));
+            case "planetAcquisitionNoClanCrossover" ->
+                  campaignOptions.setDisallowPlanetAcquisitionClanCrossover(Boolean.parseBoolean(
+                        nodeContents));
+            case "noClanPartsFromIS" -> campaignOptions.setDisallowClanPartsFromIS(Boolean.parseBoolean(nodeContents));
+            case "penaltyClanPartsFromIS" -> campaignOptions.setPenaltyClanPartsFromIS(Integer.parseInt(nodeContents));
+            case "planetAcquisitionVerbose" ->
+                  campaignOptions.setPlanetAcquisitionVerboseReporting(Boolean.parseBoolean(
+                        nodeContents));
+            case "maxJumpsPlanetaryAcquisition" -> campaignOptions.setMaxJumpsPlanetaryAcquisition(Integer.parseInt(
+                  nodeContents));
+            case "planetTechAcquisitionBonus" -> {
+                EnumMap<PlanetarySophistication, Integer> acquisitionBonuses = campaignOptions.getAllPlanetTechAcquisitionBonuses();
 
-        for (int i = 0; i < weights.length; i++) {
-            try {
-                weights[i] = Integer.parseInt(values[i]);
-            } catch (Exception ex) {
-                LOGGER.error(ex, "Unknown Exception: migrateMarriageSurnameWeights47");
-                weights[i] = 0;
+                String[] values = nodeContents.split(",");
+                if (values.length == 6) {
+                    // < 0.50.07 compatibility handler
+                    acquisitionBonuses.put(PlanetarySophistication.A, Integer.parseInt(values[0]));
+                    acquisitionBonuses.put(PlanetarySophistication.B, Integer.parseInt(values[1]));
+                    acquisitionBonuses.put(PlanetarySophistication.C, Integer.parseInt(values[2]));
+                    acquisitionBonuses.put(PlanetarySophistication.D, Integer.parseInt(values[3]));
+                    acquisitionBonuses.put(PlanetarySophistication.F, Integer.parseInt(values[5]));
+                } else if (values.length == PlanetarySophistication.values().length) {
+                    // >= 0.50.07 compatibility handler
+                    for (int i = 0; i < values.length; i++) {
+                        acquisitionBonuses.put(PlanetarySophistication.fromIndex(i), Integer.parseInt(values[i]));
+                    }
+                } else {
+                    LOGGER.error("Invalid number of values for planetTechAcquisitionBonus: {}", values.length);
+                }
             }
-        }
+            case "planetIndustryAcquisitionBonus" -> {
+                EnumMap<PlanetaryRating, Integer> acquisitionBonuses = campaignOptions.getAllPlanetIndustryAcquisitionBonuses();
 
-        // Now we need to test it to figure out the weights have changed. If not, we
-        // will keep the
-        // new default values. If they have, we save their changes and add the new
-        // surname weights
-        if ((weights[0] != campaignOptions.getMarriageSurnameWeights().get(MergingSurnameStyle.NO_CHANGE)) ||
-                  (weights[1] != campaignOptions.getMarriageSurnameWeights().get(MergingSurnameStyle.YOURS) + 5) ||
-                  (weights[2] != campaignOptions.getMarriageSurnameWeights().get(MergingSurnameStyle.SPOUSE) + 5) ||
-                  (weights[3] !=
-                         campaignOptions.getMarriageSurnameWeights().get(MergingSurnameStyle.HYPHEN_SPOUSE) + 5) ||
-                  (weights[4] !=
-                         campaignOptions.getMarriageSurnameWeights().get(MergingSurnameStyle.BOTH_HYPHEN_SPOUSE) + 5) ||
-                  (weights[5] !=
-                         campaignOptions.getMarriageSurnameWeights().get(MergingSurnameStyle.HYPHEN_YOURS) + 5) ||
-                  (weights[6] !=
-                         campaignOptions.getMarriageSurnameWeights().get(MergingSurnameStyle.BOTH_HYPHEN_YOURS) + 5) ||
-                  (weights[7] != campaignOptions.getMarriageSurnameWeights().get(MergingSurnameStyle.MALE)) ||
-                  (weights[8] != campaignOptions.getMarriageSurnameWeights().get(MergingSurnameStyle.FEMALE))) {
-            campaignOptions.getMarriageSurnameWeights().put(MergingSurnameStyle.NO_CHANGE, weights[0]);
-            campaignOptions.getMarriageSurnameWeights().put(MergingSurnameStyle.YOURS, weights[1]);
-            campaignOptions.getMarriageSurnameWeights().put(MergingSurnameStyle.SPOUSE, weights[2]);
-            // SPACE_YOURS is newly added
-            // BOTH_SPACE_YOURS is newly added
-            campaignOptions.getMarriageSurnameWeights().put(MergingSurnameStyle.HYPHEN_YOURS, weights[3]);
-            campaignOptions.getMarriageSurnameWeights().put(MergingSurnameStyle.BOTH_HYPHEN_YOURS, weights[4]);
-            // SPACE_SPOUSE is newly added
-            // BOTH_SPACE_SPOUSE is newly added
-            campaignOptions.getMarriageSurnameWeights().put(MergingSurnameStyle.HYPHEN_SPOUSE, weights[5]);
-            campaignOptions.getMarriageSurnameWeights().put(MergingSurnameStyle.BOTH_HYPHEN_SPOUSE, weights[6]);
-            campaignOptions.getMarriageSurnameWeights().put(MergingSurnameStyle.MALE, weights[7]);
-            campaignOptions.getMarriageSurnameWeights().put(MergingSurnameStyle.FEMALE, weights[8]);
+                String[] values = nodeContents.split(",");
+                if (values.length == 6) {
+                    // < 0.50.07 compatibility handler
+                    acquisitionBonuses.put(PlanetaryRating.A, Integer.parseInt(values[0]));
+                    acquisitionBonuses.put(PlanetaryRating.B, Integer.parseInt(values[1]));
+                    acquisitionBonuses.put(PlanetaryRating.C, Integer.parseInt(values[2]));
+                    acquisitionBonuses.put(PlanetaryRating.D, Integer.parseInt(values[3]));
+                    acquisitionBonuses.put(PlanetaryRating.F, Integer.parseInt(values[5]));
+                } else if (values.length == PlanetaryRating.values().length) {
+                    // >= 0.50.07 compatibility handler
+                    for (int i = 0; i < values.length; i++) {
+                        acquisitionBonuses.put(PlanetaryRating.fromIndex(i), Integer.parseInt(values[i]));
+                    }
+                } else {
+                    LOGGER.error("Invalid number of values for planetIndustryAcquisitionBonus: {}", values.length);
+                }
+            }
+            case "planetOutputAcquisitionBonus" -> {
+                EnumMap<PlanetaryRating, Integer> acquisitionBonuses = campaignOptions.getAllPlanetOutputAcquisitionBonuses();
+
+                String[] values = nodeContents.split(",");
+                if (values.length == 6) {
+                    // < 0.50.07 compatibility handler
+                    acquisitionBonuses.put(PlanetaryRating.A, Integer.parseInt(values[0]));
+                    acquisitionBonuses.put(PlanetaryRating.B, Integer.parseInt(values[1]));
+                    acquisitionBonuses.put(PlanetaryRating.C, Integer.parseInt(values[2]));
+                    acquisitionBonuses.put(PlanetaryRating.D, Integer.parseInt(values[3]));
+                    acquisitionBonuses.put(PlanetaryRating.F, Integer.parseInt(values[5]));
+                } else if (values.length == PlanetaryRating.values().length) {
+                    // >= 0.50.07 compatibility handler
+                    for (int i = 0; i < values.length; i++) {
+                        acquisitionBonuses.put(PlanetaryRating.fromIndex(i), Integer.parseInt(values[i]));
+                    }
+                } else {
+                    LOGGER.error("Invalid number of values for planetOutputAcquisitionBonus: {}", values.length);
+                }
+            }
+            case "equipmentContractPercent" -> campaignOptions.setEquipmentContractPercent(Double.parseDouble(
+                  nodeContents));
+            case "dropShipContractPercent" ->
+                  campaignOptions.setDropShipContractPercent(Double.parseDouble(nodeContents));
+            case "jumpShipContractPercent" ->
+                  campaignOptions.setJumpShipContractPercent(Double.parseDouble(nodeContents));
+            case "warShipContractPercent" ->
+                  campaignOptions.setWarShipContractPercent(Double.parseDouble(nodeContents));
+            case "equipmentContractBase" ->
+                  campaignOptions.setEquipmentContractBase(Boolean.parseBoolean(nodeContents));
+            case "equipmentContractSaleValue" -> campaignOptions.setEquipmentContractSaleValue(Boolean.parseBoolean(
+                  nodeContents));
+            case "blcSaleValue" -> campaignOptions.setBLCSaleValue(Boolean.parseBoolean(nodeContents));
+            case "overageRepaymentInFinalPayment" ->
+                  campaignOptions.setOverageRepaymentInFinalPayment(Boolean.parseBoolean(
+                        nodeContents));
+            case "acquisitionSupportStaffOnly" -> campaignOptions.setAcquisitionPersonnelCategory(Boolean.parseBoolean(
+                  nodeContents) ? SUPPORT : ALL);
+            case "acquisitionPersonnelCategory" ->
+                  campaignOptions.setAcquisitionPersonnelCategory(ProcurementPersonnelPick.fromString(
+                        nodeContents));
+            case "limitByYear" -> campaignOptions.setLimitByYear(Boolean.parseBoolean(nodeContents));
+            case "disallowExtinctStuff" -> campaignOptions.setDisallowExtinctStuff(Boolean.parseBoolean(nodeContents));
+            case "allowClanPurchases" -> campaignOptions.setAllowClanPurchases(Boolean.parseBoolean(nodeContents));
+            case "allowISPurchases" -> campaignOptions.setAllowISPurchases(Boolean.parseBoolean(nodeContents));
+            case "allowCanonOnly" -> campaignOptions.setAllowCanonOnly(Boolean.parseBoolean(nodeContents));
+            case "allowCanonRefitOnly" -> campaignOptions.setAllowCanonRefitOnly(Boolean.parseBoolean(nodeContents));
+            case "useAmmoByType" -> campaignOptions.setUseAmmoByType(Boolean.parseBoolean(nodeContents));
+            case "variableTechLevel" -> campaignOptions.setVariableTechLevel(Boolean.parseBoolean(nodeContents));
+            case "factionIntroDate" -> campaignOptions.setIsUseFactionIntroDate(Boolean.parseBoolean(nodeContents));
+            case "techLevel" -> campaignOptions.setTechLevel(Integer.parseInt(nodeContents));
+            case "unitRatingMethod", "dragoonsRatingMethod" ->
+                  campaignOptions.setUnitRatingMethod(UnitRatingMethod.parseFromString(
+                        nodeContents));
+            case "manualUnitRatingModifier" ->
+                  campaignOptions.setManualUnitRatingModifier(Integer.parseInt(nodeContents));
+            case "clampReputationPayMultiplier" -> campaignOptions.setClampReputationPayMultiplier(Boolean.parseBoolean(
+                  nodeContents));
+            case "reduceReputationPerformanceModifier" ->
+                  campaignOptions.setReduceReputationPerformanceModifier(Boolean.parseBoolean(
+                        nodeContents));
+            case "reputationPerformanceModifierCutOff" ->
+                  campaignOptions.setReputationPerformanceModifierCutOff(Boolean.parseBoolean(
+                        nodeContents));
+            case "usePortraitForType" -> {
+                String[] values = nodeContents.split(",");
+                for (int i = 0; i < values.length; i++) {
+                    campaignOptions.setUsePortraitForRole(i, Boolean.parseBoolean(values[i].trim()));
+                }
+            }
+            case "assignPortraitOnRoleChange" -> campaignOptions.setAssignPortraitOnRoleChange(Boolean.parseBoolean(
+                  nodeContents));
+            case "allowDuplicatePortraits" -> campaignOptions.setAllowDuplicatePortraits(Boolean.parseBoolean(
+                  nodeContents));
+            case "destroyByMargin" -> campaignOptions.setDestroyByMargin(Boolean.parseBoolean(nodeContents));
+            case "destroyMargin" -> campaignOptions.setDestroyMargin(Integer.parseInt(nodeContents));
+            case "destroyPartTarget" -> campaignOptions.setDestroyPartTarget(Integer.parseInt(nodeContents));
+            case "useAeroSystemHits" -> campaignOptions.setUseAeroSystemHits(Boolean.parseBoolean(nodeContents));
+            case "maxAcquisitions" -> campaignOptions.setMaxAcquisitions(Integer.parseInt(nodeContents));
+            case "autoLogisticsHeatSink" ->
+                  campaignOptions.setAutoLogisticsHeatSink(MathUtility.parseInt(nodeContents));
+            case "autoLogisticsMekHead" -> campaignOptions.setAutoLogisticsMekHead(MathUtility.parseInt(nodeContents));
+            case "autoLogisticsMekLocation" -> campaignOptions.setAutoLogisticsMekLocation(MathUtility.parseInt(
+                  nodeContents));
+            case "autoLogisticsNonRepairableLocation" ->
+                  campaignOptions.setAutoLogisticsNonRepairableLocation(MathUtility.parseInt(
+                        nodeContents));
+            case "autoLogisticsArmor" -> campaignOptions.setAutoLogisticsArmor(MathUtility.parseInt(nodeContents));
+            case "autoLogisticsAmmunition" -> campaignOptions.setAutoLogisticsAmmunition(MathUtility.parseInt(
+                  nodeContents));
+            case "autoLogisticsActuators" ->
+                  campaignOptions.setAutoLogisticsActuators(MathUtility.parseInt(nodeContents));
+            case "autoLogisticsJumpJets" ->
+                  campaignOptions.setAutoLogisticsJumpJets(MathUtility.parseInt(nodeContents));
+            case "autoLogisticsEngines" -> campaignOptions.setAutoLogisticsEngines(MathUtility.parseInt(nodeContents));
+            case "autoLogisticsWeapons" -> campaignOptions.setAutoLogisticsWeapons(MathUtility.parseInt(nodeContents));
+            case "autoLogisticsOther" -> campaignOptions.setAutoLogisticsOther(MathUtility.parseInt(nodeContents));
+            case "useTactics" -> campaignOptions.setUseTactics(Boolean.parseBoolean(nodeContents));
+            case "useInitiativeBonus" -> campaignOptions.setUseInitiativeBonus(Boolean.parseBoolean(nodeContents));
+            case "useToughness" -> campaignOptions.setUseToughness(Boolean.parseBoolean(nodeContents));
+            case "useRandomToughness" -> campaignOptions.setUseRandomToughness(Boolean.parseBoolean(nodeContents));
+            case "useArtillery" -> campaignOptions.setUseArtillery(Boolean.parseBoolean(nodeContents));
+            case "useAbilities" -> campaignOptions.setUseAbilities(Boolean.parseBoolean(nodeContents));
+            case "useCommanderAbilitiesOnly" -> campaignOptions.setUseCommanderAbilitiesOnly(Boolean.parseBoolean(
+                  nodeContents));
+            case "useEdge" -> campaignOptions.setUseEdge(Boolean.parseBoolean(nodeContents));
+            case "useSupportEdge" -> campaignOptions.setUseSupportEdge(Boolean.parseBoolean(nodeContents));
+            case "useImplants" -> campaignOptions.setUseImplants(Boolean.parseBoolean(nodeContents));
+            case "alternativeQualityAveraging" -> campaignOptions.setAlternativeQualityAveraging(Boolean.parseBoolean(
+                  nodeContents));
+            case "useAgeEffects" -> campaignOptions.setUseAgeEffects(Boolean.parseBoolean(nodeContents));
+            case "useTransfers" -> campaignOptions.setUseTransfers(Boolean.parseBoolean(nodeContents));
+            case "useExtendedTOEForceName" -> campaignOptions.setUseExtendedTOEForceName(Boolean.parseBoolean(
+                  nodeContents));
+            case "personnelLogSkillGain" ->
+                  campaignOptions.setPersonnelLogSkillGain(Boolean.parseBoolean(nodeContents));
+            case "personnelLogAbilityGain" -> campaignOptions.setPersonnelLogAbilityGain(Boolean.parseBoolean(
+                  nodeContents));
+            case "personnelLogEdgeGain" -> campaignOptions.setPersonnelLogEdgeGain(Boolean.parseBoolean(nodeContents));
+            case "displayPersonnelLog" -> campaignOptions.setDisplayPersonnelLog(Boolean.parseBoolean(nodeContents));
+            case "displayScenarioLog" -> campaignOptions.setDisplayScenarioLog(Boolean.parseBoolean(nodeContents));
+            case "displayKillRecord" -> campaignOptions.setDisplayKillRecord(Boolean.parseBoolean(nodeContents));
+            case "displayMedicalRecord" -> campaignOptions.setDisplayMedicalRecord(Boolean.parseBoolean(nodeContents));
+            case "displayAssignmentRecord" -> campaignOptions.setDisplayAssignmentRecord(Boolean.parseBoolean(
+                  nodeContents));
+            case "displayPerformanceRecord" -> campaignOptions.setDisplayPerformanceRecord(Boolean.parseBoolean(
+                  nodeContents));
+            case "rewardComingOfAgeAbilities" -> campaignOptions.setRewardComingOfAgeAbilities(Boolean.parseBoolean(
+                  nodeContents));
+            case "rewardComingOfAgeRPSkills" -> campaignOptions.setRewardComingOfAgeRPSkills(Boolean.parseBoolean(
+                  nodeContents));
+            case "useTimeInService" -> campaignOptions.setUseTimeInService(Boolean.parseBoolean(nodeContents));
+            case "timeInServiceDisplayFormat" ->
+                  campaignOptions.setTimeInServiceDisplayFormat(TimeInDisplayFormat.valueOf(
+                        nodeContents));
+            case "useTimeInRank" -> campaignOptions.setUseTimeInRank(Boolean.parseBoolean(nodeContents));
+            case "timeInRankDisplayFormat" -> campaignOptions.setTimeInRankDisplayFormat(TimeInDisplayFormat.valueOf(
+                  nodeContents));
+            case "trackTotalEarnings" -> campaignOptions.setTrackTotalEarnings(Boolean.parseBoolean(nodeContents));
+            case "trackTotalXPEarnings" -> campaignOptions.setTrackTotalXPEarnings(Boolean.parseBoolean(nodeContents));
+            case "showOriginFaction" -> campaignOptions.setShowOriginFaction(Boolean.parseBoolean(nodeContents));
+            case "adminsHaveNegotiation" ->
+                  campaignOptions.setAdminsHaveNegotiation(Boolean.parseBoolean(nodeContents));
+            case "adminExperienceLevelIncludeNegotiation" ->
+                  campaignOptions.setAdminExperienceLevelIncludeNegotiation(Boolean.parseBoolean(
+                        nodeContents));
+            case "useAdvancedMedical" -> campaignOptions.setUseAdvancedMedical(Boolean.parseBoolean(nodeContents));
+            case "healWaitingPeriod" -> campaignOptions.setHealingWaitingPeriod(Integer.parseInt(nodeContents));
+            case "naturalHealingWaitingPeriod" -> campaignOptions.setNaturalHealingWaitingPeriod(Integer.parseInt(
+                  nodeContents));
+            case "minimumHitsForVehicles" -> campaignOptions.setMinimumHitsForVehicles(Integer.parseInt(nodeContents));
+            case "useRandomHitsForVehicles" -> campaignOptions.setUseRandomHitsForVehicles(Boolean.parseBoolean(
+                  nodeContents));
+            case "tougherHealing" -> campaignOptions.setTougherHealing(Boolean.parseBoolean(nodeContents));
+            case "maximumPatients" -> campaignOptions.setMaximumPatients(Integer.parseInt(nodeContents));
+            case "doctorsUseAdministration" -> campaignOptions.setDoctorsUseAdministration(Boolean.parseBoolean(
+                  nodeContents));
+            case "prisonerCaptureStyle" -> campaignOptions.setPrisonerCaptureStyle(PrisonerCaptureStyle.fromString(
+                  nodeContents));
+            case "useRandomDependentAddition" -> campaignOptions.setUseRandomDependentAddition(Boolean.parseBoolean(
+                  nodeContents));
+            case "useRandomDependentRemoval" -> campaignOptions.setUseRandomDependentRemoval(Boolean.parseBoolean(
+                  nodeContents));
+            case "dependentProfessionDieSize" -> campaignOptions.setDependentProfessionDieSize(MathUtility.parseInt(
+                  nodeContents, 4));
+            case "civilianProfessionDieSize" -> campaignOptions.setCivilianProfessionDieSize(MathUtility.parseInt(
+                  nodeContents, 2));
+            case "usePersonnelRemoval" -> campaignOptions.setUsePersonnelRemoval(Boolean.parseBoolean(nodeContents));
+            case "useRemovalExemptCemetery" -> campaignOptions.setUseRemovalExemptCemetery(Boolean.parseBoolean(
+                  nodeContents));
+            case "useRemovalExemptRetirees" -> campaignOptions.setUseRemovalExemptRetirees(Boolean.parseBoolean(
+                  nodeContents));
+            case "disableSecondaryRoleSalary" -> campaignOptions.setDisableSecondaryRoleSalary(Boolean.parseBoolean(
+                  nodeContents));
+            case "salaryAntiMekMultiplier" ->
+                  campaignOptions.setSalaryAntiMekMultiplier(Double.parseDouble(nodeContents));
+            case "salarySpecialistInfantryMultiplier" ->
+                  campaignOptions.setSalarySpecialistInfantryMultiplier(Double.parseDouble(
+                        nodeContents));
+            case "salaryXPMultipliers" -> {
+                if (!childNode.hasChildNodes()) {
+                    return;
+                }
+                final NodeList nl2 = childNode.getChildNodes();
+                for (int j = 0; j < nl2.getLength(); j++) {
+                    final Node wn3 = nl2.item(j);
+                    if (wn3.getNodeType() != Node.ELEMENT_NODE) {
+                        continue;
+                    }
+                    campaignOptions.getSalaryXPMultipliers()
+                          .put(SkillLevel.valueOf(wn3.getNodeName().trim()),
+                                Double.parseDouble(wn3.getTextContent().trim()));
+                }
+            }
+            case "salaryTypeBase" -> {
+                Money[] defaultSalaries = campaignOptions.getRoleBaseSalaries();
+                Money[] newSalaries = Utilities.readMoneyArray(childNode);
+
+                Money[] mergedSalaries = new Money[PersonnelRole.values().length];
+                for (int i = 0; i < mergedSalaries.length; i++) {
+                    try {
+                        mergedSalaries[i] = (newSalaries[i] != null) ? newSalaries[i] : defaultSalaries[i];
+                    } catch (Exception e) {
+                        // This will happen if we ever add a new profession, as it will exceed the entries in
+                        // the child node
+                        if (defaultSalaries != null) {
+                            mergedSalaries[i] = defaultSalaries[i];
+                        }
+                    }
+                }
+
+                campaignOptions.setRoleBaseSalaries(mergedSalaries);
+            }
+            case "awardBonusStyle" -> campaignOptions.setAwardBonusStyle(AwardBonus.valueOf(nodeContents));
+            case "enableAutoAwards" -> campaignOptions.setEnableAutoAwards(Boolean.parseBoolean(nodeContents));
+            case "issuePosthumousAwards" ->
+                  campaignOptions.setIssuePosthumousAwards(Boolean.parseBoolean(nodeContents));
+            case "issueBestAwardOnly" -> campaignOptions.setIssueBestAwardOnly(Boolean.parseBoolean(nodeContents));
+            case "ignoreStandardSet" -> campaignOptions.setIgnoreStandardSet(Boolean.parseBoolean(nodeContents));
+            case "awardTierSize" -> campaignOptions.setAwardTierSize(Integer.parseInt(nodeContents));
+            case "enableContractAwards" -> campaignOptions.setEnableContractAwards(Boolean.parseBoolean(nodeContents));
+            case "enableFactionHunterAwards" -> campaignOptions.setEnableFactionHunterAwards(Boolean.parseBoolean(
+                  nodeContents));
+            case "enableInjuryAwards" -> campaignOptions.setEnableInjuryAwards(Boolean.parseBoolean(nodeContents));
+            case "enableIndividualKillAwards" -> campaignOptions.setEnableIndividualKillAwards(Boolean.parseBoolean(
+                  nodeContents));
+            case "enableFormationKillAwards" -> campaignOptions.setEnableFormationKillAwards(Boolean.parseBoolean(
+                  nodeContents));
+            case "enableRankAwards" -> campaignOptions.setEnableRankAwards(Boolean.parseBoolean(nodeContents));
+            case "enableScenarioAwards" -> campaignOptions.setEnableScenarioAwards(Boolean.parseBoolean(nodeContents));
+            case "enableSkillAwards" -> campaignOptions.setEnableSkillAwards(Boolean.parseBoolean(nodeContents));
+            case "enableTheatreOfWarAwards" -> campaignOptions.setEnableTheatreOfWarAwards(Boolean.parseBoolean(
+                  nodeContents));
+            case "enableTimeAwards" -> campaignOptions.setEnableTimeAwards(Boolean.parseBoolean(nodeContents));
+            case "enableTrainingAwards" -> campaignOptions.setEnableTrainingAwards(Boolean.parseBoolean(nodeContents));
+            case "enableMiscAwards" -> campaignOptions.setEnableMiscAwards(Boolean.parseBoolean(nodeContents));
+            case "awardSetFilterList" -> campaignOptions.setAwardSetFilterList(nodeContents);
+            case "useDylansRandomXP" -> campaignOptions.setUseDylansRandomXP(Boolean.parseBoolean(nodeContents));
+            case "nonBinaryDiceSize" -> campaignOptions.setNonBinaryDiceSize(Integer.parseInt(nodeContents));
+            case "randomOriginOptions" -> {
+                if (!childNode.hasChildNodes()) {
+                    return;
+                }
+                final RandomOriginOptions randomOriginOptions = RandomOriginOptions.parseFromXML(childNode.getChildNodes(),
+                      true);
+                if (randomOriginOptions == null) {
+                    return;
+                }
+                campaignOptions.setRandomOriginOptions(randomOriginOptions);
+            }
+            case "useRandomPersonalities" ->
+                  campaignOptions.setUseRandomPersonalities(Boolean.parseBoolean(nodeContents));
+            case "useRandomPersonalityReputation" ->
+                  campaignOptions.setUseRandomPersonalityReputation(Boolean.parseBoolean(
+                        nodeContents));
+            case "useReasoningXpMultiplier" -> campaignOptions.setUseReasoningXpMultiplier(Boolean.parseBoolean(
+                  nodeContents));
+            case "useSimulatedRelationships" -> campaignOptions.setUseSimulatedRelationships(Boolean.parseBoolean(
+                  nodeContents));
+            case "familyDisplayLevel" ->
+                  campaignOptions.setFamilyDisplayLevel(FamilialRelationshipDisplayLevel.parseFromString(
+                        nodeContents));
+            case "announceBirthdays" -> campaignOptions.setAnnounceBirthdays(Boolean.parseBoolean(nodeContents));
+            case "announceRecruitmentAnniversaries" ->
+                  campaignOptions.setAnnounceRecruitmentAnniversaries(Boolean.parseBoolean(
+                        nodeContents));
+            case "announceOfficersOnly" -> campaignOptions.setAnnounceOfficersOnly(Boolean.parseBoolean(nodeContents));
+            case "announceChildBirthdays" ->
+                  campaignOptions.setAnnounceChildBirthdays(Boolean.parseBoolean(nodeContents));
+            case "showLifeEventDialogBirths" -> campaignOptions.setShowLifeEventDialogBirths(Boolean.parseBoolean(
+                  nodeContents));
+            case "showLifeEventDialogComingOfAge" ->
+                  campaignOptions.setShowLifeEventDialogComingOfAge(Boolean.parseBoolean(
+                        nodeContents));
+            case "showLifeEventDialogCelebrations" ->
+                  campaignOptions.setShowLifeEventDialogCelebrations(Boolean.parseBoolean(
+                        nodeContents));
+            case "useManualMarriages" -> campaignOptions.setUseManualMarriages(Boolean.parseBoolean(nodeContents));
+            case "useClanPersonnelMarriages" -> campaignOptions.setUseClanPersonnelMarriages(Boolean.parseBoolean(
+                  nodeContents));
+            case "usePrisonerMarriages" -> campaignOptions.setUsePrisonerMarriages(Boolean.parseBoolean(nodeContents));
+            case "checkMutualAncestorsDepth" -> campaignOptions.setCheckMutualAncestorsDepth(Integer.parseInt(
+                  nodeContents));
+            case "noInterestInMarriageDiceSize" -> campaignOptions.setNoInterestInMarriageDiceSize(Integer.parseInt(
+                  nodeContents));
+            case "logMarriageNameChanges" ->
+                  campaignOptions.setLogMarriageNameChanges(Boolean.parseBoolean(nodeContents));
+            case "marriageSurnameWeights" -> {
+                if (!childNode.hasChildNodes()) {
+                    return;
+                }
+                final NodeList nl2 = childNode.getChildNodes();
+                for (int j = 0; j < nl2.getLength(); j++) {
+                    final Node wn3 = nl2.item(j);
+                    if (wn3.getNodeType() != Node.ELEMENT_NODE) {
+                        continue;
+                    }
+                    campaignOptions.getMarriageSurnameWeights()
+                          .put(MergingSurnameStyle.parseFromString(wn3.getNodeName().trim()),
+                                Integer.parseInt(wn3.getTextContent().trim()));
+                }
+            }
+            case "randomMarriageMethod" -> campaignOptions.setRandomMarriageMethod(RandomMarriageMethod.fromString(
+                  nodeContents));
+            case "useRandomClanPersonnelMarriages" ->
+                  campaignOptions.setUseRandomClanPersonnelMarriages(Boolean.parseBoolean(
+                        nodeContents));
+            case "useRandomPrisonerMarriages" -> campaignOptions.setUseRandomPrisonerMarriages(Boolean.parseBoolean(
+                  nodeContents));
+            case "randomMarriageAgeRange" -> campaignOptions.setRandomMarriageAgeRange(Integer.parseInt(nodeContents));
+            case "randomMarriageDiceSize" -> campaignOptions.setRandomMarriageDiceSize(Integer.parseInt(nodeContents));
+            case "randomSameSexMarriageDiceSize" -> campaignOptions.setRandomSameSexMarriageDiceSize(Integer.parseInt(
+                  nodeContents));
+            case "randomNewDependentMarriage" -> campaignOptions.setRandomNewDependentMarriage(Integer.parseInt(
+                  nodeContents));
+            case "useManualDivorce" -> campaignOptions.setUseManualDivorce(Boolean.parseBoolean(nodeContents));
+            case "useClanPersonnelDivorce" -> campaignOptions.setUseClanPersonnelDivorce(Boolean.parseBoolean(
+                  nodeContents));
+            case "usePrisonerDivorce" -> campaignOptions.setUsePrisonerDivorce(Boolean.parseBoolean(nodeContents));
+            case "divorceSurnameWeights" -> {
+                if (!childNode.hasChildNodes()) {
+                    return;
+                }
+                final NodeList nl2 = childNode.getChildNodes();
+                for (int j = 0; j < nl2.getLength(); j++) {
+                    final Node wn3 = nl2.item(j);
+                    if (wn3.getNodeType() != Node.ELEMENT_NODE) {
+                        continue;
+                    }
+                    campaignOptions.getDivorceSurnameWeights()
+                          .put(SplittingSurnameStyle.valueOf(wn3.getNodeName().trim()),
+                                Integer.parseInt(wn3.getTextContent().trim()));
+                }
+            }
+            case "randomDivorceMethod" -> campaignOptions.setRandomDivorceMethod(RandomDivorceMethod.fromString(
+                  nodeContents));
+            case "useRandomOppositeSexDivorce" -> campaignOptions.setUseRandomOppositeSexDivorce(Boolean.parseBoolean(
+                  nodeContents));
+            case "useRandomSameSexDivorce" -> campaignOptions.setUseRandomSameSexDivorce(Boolean.parseBoolean(
+                  nodeContents));
+            case "useRandomClanPersonnelDivorce" ->
+                  campaignOptions.setUseRandomClanPersonnelDivorce(Boolean.parseBoolean(
+                        nodeContents));
+            case "useRandomPrisonerDivorce" -> campaignOptions.setUseRandomPrisonerDivorce(Boolean.parseBoolean(
+                  nodeContents));
+            case "randomDivorceDiceSize" -> campaignOptions.setRandomDivorceDiceSize(Integer.parseInt(nodeContents));
+            case "useManualProcreation" -> campaignOptions.setUseManualProcreation(Boolean.parseBoolean(nodeContents));
+            case "useClanPersonnelProcreation" -> campaignOptions.setUseClanPersonnelProcreation(Boolean.parseBoolean(
+                  nodeContents));
+            case "usePrisonerProcreation" ->
+                  campaignOptions.setUsePrisonerProcreation(Boolean.parseBoolean(nodeContents));
+            case "multiplePregnancyOccurrences" -> campaignOptions.setMultiplePregnancyOccurrences(Integer.parseInt(
+                  nodeContents));
+            case "babySurnameStyle" ->
+                  campaignOptions.setBabySurnameStyle(BabySurnameStyle.parseFromString(nodeContents));
+            case "assignNonPrisonerBabiesFounderTag" ->
+                  campaignOptions.setAssignNonPrisonerBabiesFounderTag(Boolean.parseBoolean(
+                        nodeContents));
+            case "assignChildrenOfFoundersFounderTag" ->
+                  campaignOptions.setAssignChildrenOfFoundersFounderTag(Boolean.parseBoolean(
+                        nodeContents));
+            case "useMaternityLeave" -> campaignOptions.setUseMaternityLeave(Boolean.parseBoolean(nodeContents));
+            case "determineFatherAtBirth" ->
+                  campaignOptions.setDetermineFatherAtBirth(Boolean.parseBoolean(nodeContents));
+            case "displayTrueDueDate" -> campaignOptions.setDisplayTrueDueDate(Boolean.parseBoolean(nodeContents));
+            case "noInterestInChildrenDiceSize" -> campaignOptions.setNoInterestInChildrenDiceSize(Integer.parseInt(
+                  nodeContents));
+            case "logProcreation" -> campaignOptions.setLogProcreation(Boolean.parseBoolean(nodeContents));
+            case "randomProcreationMethod" ->
+                  campaignOptions.setRandomProcreationMethod(RandomProcreationMethod.fromString(
+                        nodeContents));
+            case "useRelationshiplessRandomProcreation" ->
+                  campaignOptions.setUseRelationshiplessRandomProcreation(Boolean.parseBoolean(
+                        nodeContents));
+            case "useRandomClanPersonnelProcreation" ->
+                  campaignOptions.setUseRandomClanPersonnelProcreation(Boolean.parseBoolean(
+                        nodeContents));
+            case "useRandomPrisonerProcreation" -> campaignOptions.setUseRandomPrisonerProcreation(Boolean.parseBoolean(
+                  nodeContents));
+            case "randomProcreationRelationshipDiceSize" ->
+                  campaignOptions.setRandomProcreationRelationshipDiceSize(Integer.parseInt(
+                        nodeContents));
+            case "randomProcreationRelationshiplessDiceSize" ->
+                  campaignOptions.setRandomProcreationRelationshiplessDiceSize(Integer.parseInt(
+                        nodeContents));
+            case "useEducationModule" -> campaignOptions.setUseEducationModule(Boolean.parseBoolean(nodeContents));
+            case "curriculumXpRate" -> campaignOptions.setCurriculumXpRate(Integer.parseInt(nodeContents));
+            case "maximumJumpCount" -> campaignOptions.setMaximumJumpCount(Integer.parseInt(nodeContents));
+            case "useReeducationCamps" -> campaignOptions.setUseReeducationCamps(Boolean.parseBoolean(nodeContents));
+            case "enableLocalAcademies" -> campaignOptions.setEnableLocalAcademies(Boolean.parseBoolean(nodeContents));
+            case "enablePrestigiousAcademies" -> campaignOptions.setEnablePrestigiousAcademies(Boolean.parseBoolean(
+                  nodeContents));
+            case "enableUnitEducation" -> campaignOptions.setEnableUnitEducation(Boolean.parseBoolean(nodeContents));
+            case "enableOverrideRequirements" -> campaignOptions.setEnableOverrideRequirements(Boolean.parseBoolean(
+                  nodeContents));
+            case "enableShowIneligibleAcademies" ->
+                  campaignOptions.setEnableShowIneligibleAcademies(Boolean.parseBoolean(
+                        nodeContents));
+            case "entranceExamBaseTargetNumber" -> campaignOptions.setEntranceExamBaseTargetNumber(Integer.parseInt(
+                  nodeContents));
+            case "facultyXpRate" -> campaignOptions.setFacultyXpRate(Double.parseDouble(nodeContents));
+            case "enableBonuses" -> campaignOptions.setEnableBonuses(Boolean.parseBoolean(nodeContents));
+            case "adultDropoutChance" -> campaignOptions.setAdultDropoutChance(Integer.parseInt(nodeContents));
+            case "childrenDropoutChance" -> campaignOptions.setChildrenDropoutChance(Integer.parseInt(nodeContents));
+            case "allAges" -> campaignOptions.setAllAges(Boolean.parseBoolean(nodeContents));
+            case "militaryAcademyAccidents" ->
+                  campaignOptions.setMilitaryAcademyAccidents(Integer.parseInt(nodeContents));
+            case "enabledRandomDeathAgeGroups" -> {
+                if (!childNode.hasChildNodes()) {
+                    return;
+                }
+                final NodeList nl2 = childNode.getChildNodes();
+                for (int i = 0; i < nl2.getLength(); i++) {
+                    final Node wn3 = nl2.item(i);
+                    try {
+                        campaignOptions.getEnabledRandomDeathAgeGroups()
+                              .put(AgeGroup.valueOf(wn3.getNodeName()),
+                                    Boolean.parseBoolean(wn3.getTextContent().trim()));
+                    } catch (Exception ignored) {
+
+                    }
+                }
+            }
+            case "useRandomDeathSuicideCause" -> campaignOptions.setUseRandomDeathSuicideCause(Boolean.parseBoolean(
+                  nodeContents));
+            case "randomDeathMultiplier" -> campaignOptions.setRandomDeathMultiplier(Double.parseDouble(nodeContents));
+            case "useRandomRetirement" -> campaignOptions.setUseRandomRetirement(Boolean.parseBoolean(nodeContents));
+            case "turnoverBaseTn" -> campaignOptions.setTurnoverFixedTargetNumber(Integer.parseInt(nodeContents));
+            case "turnoverFrequency" -> campaignOptions.setTurnoverFrequency(TurnoverFrequency.valueOf(nodeContents));
+            case "trackOriginalUnit" -> campaignOptions.setTrackOriginalUnit(Boolean.parseBoolean(nodeContents));
+            case "aeroRecruitsHaveUnits" ->
+                  campaignOptions.setAeroRecruitsHaveUnits(Boolean.parseBoolean(nodeContents));
+            case "useContractCompletionRandomRetirement" ->
+                  campaignOptions.setUseContractCompletionRandomRetirement(Boolean.parseBoolean(
+                        nodeContents));
+            case "useRandomFounderTurnover" -> campaignOptions.setUseRandomFounderTurnover(Boolean.parseBoolean(
+                  nodeContents));
+            case "useFounderRetirement" -> campaignOptions.setUseFounderRetirement(Boolean.parseBoolean(nodeContents));
+            case "useSubContractSoldiers" ->
+                  campaignOptions.setUseSubContractSoldiers(Boolean.parseBoolean(nodeContents));
+            case "serviceContractDuration" ->
+                  campaignOptions.setServiceContractDuration(Integer.parseInt(nodeContents));
+            case "serviceContractModifier" ->
+                  campaignOptions.setServiceContractModifier(Integer.parseInt(nodeContents));
+            case "payBonusDefault" -> campaignOptions.setPayBonusDefault(Boolean.parseBoolean(nodeContents));
+            case "payBonusDefaultThreshold" ->
+                  campaignOptions.setPayBonusDefaultThreshold(Integer.parseInt(nodeContents));
+            case "useCustomRetirementModifiers" -> campaignOptions.setUseCustomRetirementModifiers(Boolean.parseBoolean(
+                  nodeContents));
+            case "useFatigueModifiers" -> campaignOptions.setUseFatigueModifiers(Boolean.parseBoolean(nodeContents));
+            case "useSkillModifiers" -> campaignOptions.setUseSkillModifiers(Boolean.parseBoolean(nodeContents));
+            case "useAgeModifiers" -> campaignOptions.setUseAgeModifiers(Boolean.parseBoolean(nodeContents));
+            case "useUnitRatingModifiers" ->
+                  campaignOptions.setUseUnitRatingModifiers(Boolean.parseBoolean(nodeContents));
+            case "useFactionModifiers" -> campaignOptions.setUseFactionModifiers(Boolean.parseBoolean(nodeContents));
+            case "useMissionStatusModifiers" -> campaignOptions.setUseMissionStatusModifiers(Boolean.parseBoolean(
+                  nodeContents));
+            case "useHostileTerritoryModifiers" -> campaignOptions.setUseHostileTerritoryModifiers(Boolean.parseBoolean(
+                  nodeContents));
+            case "useFamilyModifiers" -> campaignOptions.setUseFamilyModifiers(Boolean.parseBoolean(nodeContents));
+            case "useLoyaltyModifiers" -> campaignOptions.setUseLoyaltyModifiers(Boolean.parseBoolean(nodeContents));
+            case "useHideLoyalty" -> campaignOptions.setUseHideLoyalty(Boolean.parseBoolean(nodeContents));
+            case "payoutRateOfficer" -> campaignOptions.setPayoutRateOfficer(Integer.parseInt(nodeContents));
+            case "payoutRateEnlisted" -> campaignOptions.setPayoutRateEnlisted(Integer.parseInt(nodeContents));
+            case "payoutRetirementMultiplier" -> campaignOptions.setPayoutRetirementMultiplier(Integer.parseInt(
+                  nodeContents));
+            case "usePayoutServiceBonus" ->
+                  campaignOptions.setUsePayoutServiceBonus(Boolean.parseBoolean(nodeContents));
+            case "payoutServiceBonusRate" -> campaignOptions.setPayoutServiceBonusRate(Integer.parseInt(nodeContents));
+            // 'useAdministrativeStrain' is <50.07
+            case "UseHRStrain", "useAdministrativeStrain" ->
+                  campaignOptions.setUseHRStrain(Boolean.parseBoolean(nodeContents));
+            // 'administrativeStrain' is <50.07
+            case "hrStrain", "administrativeStrain" ->
+                  campaignOptions.setHRCapacity(MathUtility.parseInt(nodeContents));
+            case "useManagementSkill" -> campaignOptions.setUseManagementSkill(Boolean.parseBoolean(nodeContents));
+            case "useCommanderLeadershipOnly" -> campaignOptions.setUseCommanderLeadershipOnly(Boolean.parseBoolean(
+                  nodeContents));
+            case "managementSkillPenalty" -> campaignOptions.setManagementSkillPenalty(Integer.parseInt(nodeContents));
+            case "useFatigue" -> campaignOptions.setUseFatigue(Boolean.parseBoolean(nodeContents));
+            case "fatigueRate" -> campaignOptions.setFatigueRate(Integer.parseInt(nodeContents));
+            case "useInjuryFatigue" -> campaignOptions.setUseInjuryFatigue(Boolean.parseBoolean(nodeContents));
+            case "fieldKitchenCapacity" -> campaignOptions.setFieldKitchenCapacity(Integer.parseInt(nodeContents));
+            case "fieldKitchenIgnoreNonCombatants" ->
+                  campaignOptions.setFieldKitchenIgnoreNonCombatants(Boolean.parseBoolean(
+                        nodeContents));
+            case "fatigueLeaveThreshold" -> campaignOptions.setFatigueLeaveThreshold(Integer.parseInt(nodeContents));
+            case "payForParts" -> campaignOptions.setPayForParts(Boolean.parseBoolean(nodeContents));
+            case "payForRepairs" -> campaignOptions.setPayForRepairs(Boolean.parseBoolean(nodeContents));
+            case "payForUnits" -> campaignOptions.setPayForUnits(Boolean.parseBoolean(nodeContents));
+            case "payForSalaries" -> campaignOptions.setPayForSalaries(Boolean.parseBoolean(nodeContents));
+            case "payForOverhead" -> campaignOptions.setPayForOverhead(Boolean.parseBoolean(nodeContents));
+            case "payForMaintain" -> campaignOptions.setPayForMaintain(Boolean.parseBoolean(nodeContents));
+            case "payForTransport" -> campaignOptions.setPayForTransport(Boolean.parseBoolean(nodeContents));
+            case "sellUnits" -> campaignOptions.setSellUnits(Boolean.parseBoolean(nodeContents));
+            case "sellParts" -> campaignOptions.setSellParts(Boolean.parseBoolean(nodeContents));
+            case "payForRecruitment" -> campaignOptions.setPayForRecruitment(Boolean.parseBoolean(nodeContents));
+            case "payForFood" -> campaignOptions.setPayForFood(Boolean.parseBoolean(nodeContents));
+            case "payForHousing" -> campaignOptions.setPayForHousing(Boolean.parseBoolean(nodeContents));
+            case "useLoanLimits" -> campaignOptions.setLoanLimits(Boolean.parseBoolean(nodeContents));
+            case "usePercentageMaint" -> campaignOptions.setUsePercentageMaint(Boolean.parseBoolean(nodeContents));
+            case "infantryDontCount" -> campaignOptions.setUseInfantryDontCount(Boolean.parseBoolean(nodeContents));
+            case "usePeacetimeCost" -> campaignOptions.setUsePeacetimeCost(Boolean.parseBoolean(nodeContents));
+            case "useExtendedPartsModifier" -> campaignOptions.setUseExtendedPartsModifier(Boolean.parseBoolean(
+                  nodeContents));
+            case "showPeacetimeCost" -> campaignOptions.setShowPeacetimeCost(Boolean.parseBoolean(nodeContents));
+            case "newFinancialYearFinancesToCSVExport" ->
+                  campaignOptions.setNewFinancialYearFinancesToCSVExport(Boolean.parseBoolean(
+                        nodeContents));
+            case "financialYearDuration" ->
+                  campaignOptions.setFinancialYearDuration(FinancialYearDuration.parseFromString(
+                        nodeContents));
+            case "simulateGrayMonday" -> campaignOptions.setSimulateGrayMonday(Boolean.parseBoolean(nodeContents));
+            case "allowMonthlyReinvestment" -> campaignOptions.setAllowMonthlyReinvestment(Boolean.parseBoolean(
+                  nodeContents));
+            case "allowMonthlyConnections" -> campaignOptions.setAllowMonthlyConnections(Boolean.parseBoolean(
+                  nodeContents));
+            case "commonPartPriceMultiplier" -> campaignOptions.setCommonPartPriceMultiplier(Double.parseDouble(
+                  nodeContents));
+            case "innerSphereUnitPriceMultiplier" ->
+                  campaignOptions.setInnerSphereUnitPriceMultiplier(Double.parseDouble(
+                        nodeContents));
+            case "innerSpherePartPriceMultiplier" ->
+                  campaignOptions.setInnerSpherePartPriceMultiplier(Double.parseDouble(
+                        nodeContents));
+            case "clanUnitPriceMultiplier" ->
+                  campaignOptions.setClanUnitPriceMultiplier(Double.parseDouble(nodeContents));
+            case "clanPartPriceMultiplier" ->
+                  campaignOptions.setClanPartPriceMultiplier(Double.parseDouble(nodeContents));
+            case "mixedTechUnitPriceMultiplier" -> campaignOptions.setMixedTechUnitPriceMultiplier(Double.parseDouble(
+                  nodeContents));
+            case "usedPartPriceMultipliers" -> {
+                final String[] values = nodeContents.split(",");
+                for (int i = 0; i < values.length; i++) {
+                    try {
+                        campaignOptions.getUsedPartPriceMultipliers()[i] = Double.parseDouble(values[i]);
+                    } catch (Exception ignored) {
+
+                    }
+                }
+            }
+            case "damagedPartsValueMultiplier" -> campaignOptions.setDamagedPartsValueMultiplier(Double.parseDouble(
+                  nodeContents));
+            case "unrepairablePartsValueMultiplier" ->
+                  campaignOptions.setUnrepairablePartsValueMultiplier(Double.parseDouble(
+                        nodeContents));
+            case "cancelledOrderRefundMultiplier" ->
+                  campaignOptions.setCancelledOrderRefundMultiplier(Double.parseDouble(
+                        nodeContents));
+            case "useTaxes" -> campaignOptions.setUseTaxes(Boolean.parseBoolean(nodeContents));
+            case "taxesPercentage" -> campaignOptions.setTaxesPercentage(Integer.parseInt(nodeContents));
+            case "useShareSystem" -> campaignOptions.setUseShareSystem(Boolean.parseBoolean(nodeContents));
+            case "sharesForAll" -> campaignOptions.setSharesForAll(Boolean.parseBoolean(nodeContents));
+            case "personnelMarketStyle" -> campaignOptions.setPersonnelMarketStyle(PersonnelMarketStyle.fromString(
+                  nodeContents));
+            case "personnelMarketName" -> {
+                String marketName = nodeContents;
+                // Backwards compatibility with saves from before these rules moved to Camops
+                if (marketName.equals("Strat Ops")) {
+                    marketName = "Campaign Ops";
+                }
+                campaignOptions.setPersonnelMarketName(marketName);
+            }
+            case "personnelMarketReportRefresh" -> campaignOptions.setPersonnelMarketReportRefresh(Boolean.parseBoolean(
+                  nodeContents));
+            case "personnelMarketRandomRemovalTargets" -> {
+                if (!childNode.hasChildNodes()) {
+                    return;
+                }
+                final NodeList nl2 = childNode.getChildNodes();
+                for (int j = 0; j < nl2.getLength(); j++) {
+                    final Node wn3 = nl2.item(j);
+                    if (wn3.getNodeType() != Node.ELEMENT_NODE) {
+                        continue;
+                    }
+                    campaignOptions.getPersonnelMarketRandomRemovalTargets()
+                          .put(SkillLevel.valueOf(wn3.getNodeName().trim()),
+                                Integer.parseInt(wn3.getTextContent().trim()));
+                }
+            }
+            case "personnelMarketDylansWeight" -> campaignOptions.setPersonnelMarketDylansWeight(Double.parseDouble(
+                  nodeContents));
+            case "usePersonnelHireHiringHallOnly" ->
+                  campaignOptions.setUsePersonnelHireHiringHallOnly(Boolean.parseBoolean(
+                        nodeContents));
+            case "unitMarketMethod" -> campaignOptions.setUnitMarketMethod(UnitMarketMethod.valueOf(nodeContents));
+            case "unitMarketRegionalMekVariations" ->
+                  campaignOptions.setUnitMarketRegionalMekVariations(Boolean.parseBoolean(
+                        nodeContents));
+            case "unitMarketSpecialUnitChance" -> campaignOptions.setUnitMarketSpecialUnitChance(Integer.parseInt(
+                  nodeContents));
+            case "unitMarketRarityModifier" ->
+                  campaignOptions.setUnitMarketRarityModifier(Integer.parseInt(nodeContents));
+            case "instantUnitMarketDelivery" -> campaignOptions.setInstantUnitMarketDelivery(Boolean.parseBoolean(
+                  nodeContents));
+            case "mothballUnitMarketDeliveries" -> campaignOptions.setMothballUnitMarketDeliveries(Boolean.parseBoolean(
+                  nodeContents));
+            case "unitMarketReportRefresh" -> campaignOptions.setUnitMarketReportRefresh(Boolean.parseBoolean(
+                  nodeContents));
+            case "contractMarketMethod" -> campaignOptions.setContractMarketMethod(ContractMarketMethod.valueOf(
+                  nodeContents));
+            case "contractSearchRadius" -> campaignOptions.setContractSearchRadius(Integer.parseInt(nodeContents));
+            case "variableContractLength" ->
+                  campaignOptions.setVariableContractLength(Boolean.parseBoolean(nodeContents));
+            case "useDynamicDifficulty" -> campaignOptions.setUseDynamicDifficulty(Boolean.parseBoolean(nodeContents));
+            case "contractMarketReportRefresh" -> campaignOptions.setContractMarketReportRefresh(Boolean.parseBoolean(
+                  nodeContents));
+            case "contractMaxSalvagePercentage" -> campaignOptions.setContractMaxSalvagePercentage(Integer.parseInt(
+                  nodeContents));
+            case "dropShipBonusPercentage" ->
+                  campaignOptions.setDropShipBonusPercentage(Integer.parseInt(nodeContents));
+            case "useStaticRATs" -> campaignOptions.setUseStaticRATs(Boolean.parseBoolean(nodeContents));
+            case "rats" -> campaignOptions.setRATs(MHQXMLUtility.unEscape(nodeContents).split(","));
+            case "ignoreRATEra" -> campaignOptions.setIgnoreRATEra(Boolean.parseBoolean(nodeContents));
+            case "skillLevel" -> campaignOptions.setSkillLevel(SkillLevel.parseFromString(nodeContents));
+            case "autoResolveMethod" -> campaignOptions.setAutoResolveMethod(AutoResolveMethod.valueOf(nodeContents));
+            case "autoResolveVictoryChanceEnabled" ->
+                  campaignOptions.setAutoResolveVictoryChanceEnabled(Boolean.parseBoolean(
+                        nodeContents));
+            case "autoResolveNumberOfScenarios" -> campaignOptions.setAutoResolveNumberOfScenarios(Integer.parseInt(
+                  nodeContents));
+            case "autoResolveUseExperimentalPacarGui" ->
+                  campaignOptions.setAutoResolveExperimentalPacarGuiEnabled(Boolean.parseBoolean(
+                        nodeContents));
+            case "strategicViewTheme" -> campaignOptions.setStrategicViewTheme(nodeContents);
+            case "phenotypeProbabilities" -> {
+                String[] values = nodeContents.split(",");
+                for (int i = 0; i < values.length; i++) {
+                    campaignOptions.setPhenotypeProbability(i, Integer.parseInt(values[i]));
+                }
+            }
+            case "useAtB" -> campaignOptions.setUseAtB(Boolean.parseBoolean(nodeContents));
+            case "useStratCon" -> campaignOptions.setUseStratCon(Boolean.parseBoolean(nodeContents));
+            case "useAero" -> campaignOptions.setUseAero(Boolean.parseBoolean(nodeContents));
+            case "useVehicles" -> campaignOptions.setUseVehicles(Boolean.parseBoolean(nodeContents));
+            case "clanVehicles" -> campaignOptions.setClanVehicles(Boolean.parseBoolean(nodeContents));
+            case "useGenericBattleValue" ->
+                  campaignOptions.setUseGenericBattleValue(Boolean.parseBoolean(nodeContents));
+            case "useVerboseBidding" -> campaignOptions.setUseVerboseBidding(Boolean.parseBoolean(nodeContents));
+            case "doubleVehicles" -> campaignOptions.setDoubleVehicles(Boolean.parseBoolean(nodeContents));
+            case "adjustPlayerVehicles" -> campaignOptions.setAdjustPlayerVehicles(Boolean.parseBoolean(nodeContents));
+            case "opForLanceTypeMeks" -> campaignOptions.setOpForLanceTypeMeks(Integer.parseInt(nodeContents));
+            case "opForLanceTypeMixed" -> campaignOptions.setOpForLanceTypeMixed(Integer.parseInt(nodeContents));
+            case "opForLanceTypeVehicles" -> campaignOptions.setOpForLanceTypeVehicles(Integer.parseInt(nodeContents));
+            case "opForUsesVTOLs" -> campaignOptions.setOpForUsesVTOLs(Boolean.parseBoolean(nodeContents));
+            case "useDropShips" -> campaignOptions.setUseDropShips(Boolean.parseBoolean(nodeContents));
+            case "mercSizeLimited" -> campaignOptions.setMercSizeLimited(Boolean.parseBoolean(nodeContents));
+            case "regionalMekVariations" ->
+                  campaignOptions.setRegionalMekVariations(Boolean.parseBoolean(nodeContents));
+            case "attachedPlayerCamouflage" -> campaignOptions.setAttachedPlayerCamouflage(Boolean.parseBoolean(
+                  nodeContents));
+            case "playerControlsAttachedUnits" -> campaignOptions.setPlayerControlsAttachedUnits(Boolean.parseBoolean(
+                  nodeContents));
+            case "atbBattleChance" -> {
+                String[] values = nodeContents.split(",");
+                for (int i = 0; i < values.length; i++) {
+                    try {
+                        campaignOptions.setAtBBattleChance(i, Integer.parseInt(values[i]));
+                    } catch (Exception ignored) {
+                        // Badly coded, but this is to migrate devs and their games as the swap was done before a
+                        // release and is thus better to handle this way than through a more code complex method
+                        campaignOptions.setAtBBattleChance(i, (int) Math.round(Double.parseDouble(values[i])));
+                    }
+                }
+            }
+            case "generateChases" -> campaignOptions.setGenerateChases(Boolean.parseBoolean(nodeContents));
+            case "useWeatherConditions" -> campaignOptions.setUseWeatherConditions(Boolean.parseBoolean(nodeContents));
+            case "useLightConditions" -> campaignOptions.setUseLightConditions(Boolean.parseBoolean(nodeContents));
+            case "usePlanetaryConditions" ->
+                  campaignOptions.setUsePlanetaryConditions(Boolean.parseBoolean(nodeContents));
+            case "restrictPartsByMission" ->
+                  campaignOptions.setRestrictPartsByMission(Boolean.parseBoolean(nodeContents));
+            case "allowOpForLocalUnits" -> campaignOptions.setAllowOpForLocalUnits(Boolean.parseBoolean(nodeContents));
+            case "allowOpForAeros" -> campaignOptions.setAllowOpForAeros(Boolean.parseBoolean(nodeContents));
+            case "opForAeroChance" -> campaignOptions.setOpForAeroChance(Integer.parseInt(nodeContents));
+            case "opForLocalUnitChance" -> campaignOptions.setOpForLocalUnitChance(Integer.parseInt(nodeContents));
+            case "fixedMapChance" -> campaignOptions.setFixedMapChance(Integer.parseInt(nodeContents));
+            case "spaUpgradeIntensity" -> campaignOptions.setSpaUpgradeIntensity(Integer.parseInt(nodeContents));
+            case "scenarioModMax" -> campaignOptions.setScenarioModMax(Integer.parseInt(nodeContents));
+            case "scenarioModChance" -> campaignOptions.setScenarioModChance(Integer.parseInt(nodeContents));
+            case "scenarioModBV" -> campaignOptions.setScenarioModBV(Integer.parseInt(nodeContents));
+            case "autoConfigMunitions" -> campaignOptions.setAutoConfigMunitions(Boolean.parseBoolean(nodeContents));
+            case "autoGenerateOpForCallsigns" -> campaignOptions.setAutoGenerateOpForCallsigns(Boolean.parseBoolean(
+                  nodeContents));
+            case "minimumCallsignSkillLevel" -> campaignOptions.setMinimumCallsignSkillLevel(SkillLevel.parseFromString(
+                  nodeContents));
+            case "trackFactionStanding" -> campaignOptions.setTrackFactionStanding(Boolean.parseBoolean(nodeContents));
+            case "useFactionStandingNegotiation" ->
+                  campaignOptions.setUseFactionStandingNegotiation(Boolean.parseBoolean(
+                        nodeContents));
+            case "useFactionStandingResupply" -> campaignOptions.setUseFactionStandingResupply(Boolean.parseBoolean(
+                  nodeContents));
+            case "useFactionStandingCommandCircuit" ->
+                  campaignOptions.setUseFactionStandingCommandCircuit(Boolean.parseBoolean(
+                        nodeContents));
+            case "useFactionStandingOutlawed" -> campaignOptions.setUseFactionStandingOutlawed(Boolean.parseBoolean(
+                  nodeContents));
+            case "useFactionStandingBatchallRestrictions" ->
+                  campaignOptions.setUseFactionStandingBatchallRestrictions(Boolean.parseBoolean(
+                        nodeContents));
+            case "useFactionStandingRecruitment" ->
+                  campaignOptions.setUseFactionStandingRecruitment(Boolean.parseBoolean(
+                        nodeContents));
+            case "useFactionStandingBarracksCosts" ->
+                  campaignOptions.setUseFactionStandingBarracksCosts(Boolean.parseBoolean(
+                        nodeContents));
+            case "useFactionStandingUnitMarket" -> campaignOptions.setUseFactionStandingUnitMarket(Boolean.parseBoolean(
+                  nodeContents));
+            case "useFactionStandingContractPay" ->
+                  campaignOptions.setUseFactionStandingContractPay(Boolean.parseBoolean(
+                        nodeContents));
+            case "useFactionStandingSupportPoints" ->
+                  campaignOptions.setUseFactionStandingSupportPoints(Boolean.parseBoolean(
+                        nodeContents));
+            case "factionStandingGainMultiplier" -> campaignOptions.setRegardMultiplier(MathUtility.parseDouble(
+                  nodeContents, 1.0));
+            default -> throw new IllegalStateException("Potentially unexpected entry in campaign options: " + nodeName);
         }
     }
 }


### PR DESCRIPTION
# Requires https://github.com/MegaMek/megamek/pull/7330

https://github.com/MegaMek/mekhq/pull/7423 made some headway in reducing the heft of loading and unloading campaign options, however we're still seeing the unmarshalling method causing our automated tests to run out of memory.

In this PR I I went ahead and moved unmarshalling of specific entries to no longer use a truly massive chain of if-else statements, and instead moved it to using a far more economical (and aesthetically pleasing) switch statement.

I also removed the swathes of legacy parsers that were cluttering up the backend of the parser. Given our push to only support milestone -> milestone compatibility (and mid-milestone dev releases) I don't think we need to include compatibility handlers from v49.03 and earlier.

Finally, I replaced uses of `Integer.parseInt` and `Double.parseDouble` with their `MathUtility` alternatives.