### PR TITLE
Feature: Added Dialog That Triggers on Campaign Load to Inform the Player of What Milestones the Campaign Needs to be Saved in Before it Can Be Upgraded to the Current Version

### DIFF
--- a/MekHQ/mmconf/milestoneReleases.yml
+++ b/MekHQ/mmconf/milestoneReleases.yml
@@ -1,0 +1,15 @@
+# This file should NOT be edited by non-developers.
+# It WILL brick your game, and it won't be immediately obvious until it's too late.
+milestone_releases:
+  - label: "v0.48.0" # This is the user-facing label, it also corresponds to the tail-end of the GitHub download page
+    version: "0.48.0" # This is used to construct the version information used in MekHQ to verify compatibility.
+    useFallbackHyperlink: false # Set to 'true' in the event that a Web Page is unavailable for this release
+  - label: "v0.49.7"
+    version: "0.49.7"
+    useFallbackHyperlink: false
+  - label: "v0.49.19.1"
+    version: "0.49.19-01"
+    useFallbackHyperlink: false
+  - label: "v0.50.06"
+    version: "0.50.06"
+    useFallbackHyperlink: false

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1495,7 +1495,7 @@ MilestoneUpgradePathDialog.main=Your campaign is not compatible with the current
   <p>If you run into issues during the upgrade process, please reach out to the MekHQ team through our dedicated \
   <b>Discord</b>.</p>\
   <p>The version numbers, shown below, are hyperlinks that will take you straight to our <b>GitHub</b> where you can \
-  download the version by navigating to <b>'Assets'</b> section at the bottom of the changelist.</p>
+  download the version by navigating to <b>Assets</b> section at the bottom of the changelist.</p>
 MilestoneUpgradePathDialog.secondary=Some very old versions do not use a unified download.\
   <p>For those versions you will want to select the <b>.zip</b> download for Windows, and the <b>.tar</b> for all \
   other operating systems.</p>

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1493,7 +1493,7 @@ MilestoneUpgradePathDialog.main=Your campaign is not compatible with the current
   order they are shown.</p>\
   <p>All you need to do is open your campaign in each version, advance one day, and then save.</p>\
   <p>If you run into issues during the upgrade process, please reach out to the MekHQ team through our dedicated \
-  <b>Discord</b>. The address for our Discord server can be found on the <b>official MegaMek website</b>.</p>\
+  <b>Discord</b>.</p>\
   <p>The version numbers, shown below, are hyperlinks that will take you straight to our <b>GitHub</b> where you can \
   download the version by navigating to <b>'Assets'</b> section at the bottom of the changelist.</p>
 MilestoneUpgradePathDialog.secondary=Some very old versions do not use a unified download.\

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1499,3 +1499,4 @@ MilestoneUpgradePathDialog.main=Your campaign is not compatible with the current
 MilestoneUpgradePathDialog.secondary=Some very old versions do not use a unified download.\
   <p>For those versions you will want to select the <b>.zip</b> download for Windows, and the <b>.tar</b> for all \
   other operating systems.</p>
+MilestoneUpgradePathDialog.discord=Official Discord

--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -527,6 +527,10 @@ DataLoadingDialog.OutOfMemoryError.title=Not Enough Memory
 DataLoadingDialog.OutOfMemoryError.text=MekHQ ran out of memory attempting to load the campaign file. \nTry increasing the memory allocated to MekHQ and reloading. \nSee the FAQ at https://megamek.org/ for details.
 DataLoadingDialog.ExecutionException.title=Campaign Loading Error
 DataLoadingDialog.ExecutionException.text=The campaign file couldn't be loaded. \nPlease check the MekHQ.log file for details.
+DataLoadingDialog.IncompatibleVersion.title=Incompatible Version
+DataLoadingDialog.IncompatibleVersion.text=The campaign file couldn't be loaded.\
+  \nThe campaign must be saved in each of the following versions (in order).\
+  \n%s
 ### GMToolsDialog Class
 GMToolsDialog.title=GM Tools
 ## General Tab
@@ -1484,3 +1488,14 @@ AutoResolveMethod.ABSTRACT_COMBAT.text=Abstract Combat Auto Resolution (ACAR)
 AutoResolveMethod.ABSTRACT_COMBAT.toolTipText=ACAR, a fast simulation using a subset of the abstract combat system rules
 AutoResolveMethod.promptForAutoResolveMethod.text=Select the method to use for auto resolving the scenario.
 AutoResolveMethod.promptForAutoResolveMethod.title=Auto Resolve Method
+MilestoneUpgradePathDialog.main=Your campaign is not compatible with the current version of MekHQ.\
+  <p>To upgrade to version <b>{0}</b> you must first save the campaign in each <b>Milestone</b> listed below in the \
+  order they are shown.</p>\
+  <p>All you need to do is open your campaign in each version, advance one day, and then save.</p>\
+  <p>If you run into issues during the upgrade process, please reach out to the MekHQ team through our dedicated \
+  <b>Discord</b>. The address for our Discord server can be found on the <b>official MegaMek website</b>.</p>\
+  <p>The version numbers, shown below, are hyperlinks that will take you straight to our <b>GitHub</b> where you can \
+  download the version by navigating to <b>'Assets'</b> section at the bottom of the changelist.</p>
+MilestoneUpgradePathDialog.secondary=Some very old versions do not use a unified download.\
+  <p>For those versions you will want to select the <b>.zip</b> download for Windows, and the <b>.tar</b> for all \
+  other operating systems.</p>

--- a/MekHQ/src/mekhq/campaign/CampaignFactory.java
+++ b/MekHQ/src/mekhq/campaign/CampaignFactory.java
@@ -55,6 +55,10 @@ public class CampaignFactory {
     public enum CampaignProblemType {
         NONE,
         CANT_LOAD_FROM_NEWER_VERSION,
+        /**
+         * No longer in use
+         */
+        @Deprecated(since = "0.50.07", forRemoval = true)
         CANT_LOAD_FROM_OLDER_VERSION,
         /**
          * No longer in use
@@ -146,13 +150,6 @@ public class CampaignFactory {
         // Check if the campaign is from a newer version
         if (campaignVersion.isHigherThan(MHQConstants.VERSION)) {
             if (triggerProblemDialog(campaign, CampaignProblemType.CANT_LOAD_FROM_NEWER_VERSION)) {
-                return null;
-            }
-        }
-
-        // Check if the campaign is from an older, unsupported version
-        if (campaignVersion.isLowerThan(MHQConstants.LAST_MILESTONE)) {
-            if (triggerProblemDialog(campaign, CampaignProblemType.CANT_LOAD_FROM_OLDER_VERSION)) {
                 return null;
             }
         }

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -133,6 +133,7 @@ import mekhq.campaign.unit.cleanup.EquipmentUnscramblerResult;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
 import mekhq.campaign.universe.factionStanding.FactionStandings;
+import mekhq.gui.dialog.MilestoneUpgradePathDialog;
 import mekhq.io.idReferenceClasses.PersonIdReference;
 import mekhq.module.atb.AtBEventProcessor;
 import mekhq.utilities.MHQXMLUtility;
@@ -198,6 +199,12 @@ public class CampaignXmlParser {
             throw new CampaignXmlParseException(String.format("Illegal version of %s failed to parse",
                   campaignEle.getAttribute("version")));
         }
+        // Confirm the campaign version is compatible with the current MekHQ version. This function lives here so that
+        // we don't attempt to load incompatible campaigns and risk running into errors that might prevent the player
+        // from viewing this dialog
+        new MilestoneUpgradePathDialog(campaign, version);
+
+        // Assuming there is no upgrade path, we set version and continue parsing the campaign.
         campaign.setVersion(version);
 
         // Indicates whether or not new units were written to disk while

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -446,6 +446,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
 
                 unassignCrewFromUnsupportedUnits(campaign.getUnits());
 
+                // Campaign upgrading
                 if (campaign.getVersion().isLowerThan(MHQConstants.VERSION)) {
                     handleCampaignUpgrading(campaign);
                 }

--- a/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.dialog;
+
+import static megamek.client.ui.util.UIUtil.scaleForGUI;
+import static mekhq.utilities.MHQInternationalization.getFormattedText;
+import static mekhq.utilities.MHQInternationalization.getText;
+
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.Desktop;
+import java.awt.Dimension;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+
+import megamek.Version;
+import megamek.logging.MMLogger;
+import megamek.utilities.ImageUtilities;
+import megamek.utilities.MilestoneData;
+import mekhq.MHQConstants;
+import mekhq.campaign.Campaign;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
+import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
+
+/**
+ * Dialog responsible for displaying the upgrade path for a {@link Campaign} based on the current campaign version.
+ *
+ * <p>If upgrades are necessary, it presents a dialog listing the required upgrade milestones as interactive buttons
+ * that provide information and links. After acknowledgment, the application exits.</p>
+ *
+ * @author Illiani
+ * @since 0.50.07
+ */
+public class MilestoneUpgradePathDialog {
+    private final static MMLogger LOGGER = MMLogger.create(MilestoneUpgradePathDialog.class);
+
+    /**
+     * Displays the milestone upgrade path dialog if upgrades are needed for the supplied campaign.
+     *
+     * <p>If the dialog is shown, once it has been acknowledged, the application will exit.</p>
+     *
+     * @param campaign               the {@link Campaign} for which to check upgrade requirements
+     * @param currentCampaignVersion the current {@link Version} of the campaign
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public MilestoneUpgradePathDialog(Campaign campaign, Version currentCampaignVersion) {
+        // Are any upgrades necessary?
+        final List<MilestoneData> upgradePath = getUpgradePath(currentCampaignVersion);
+        if (upgradePath.isEmpty()) {
+            LOGGER.info("No upgrade path found for campaign {}", campaign.getName());
+            return;
+        }
+
+        // If upgrades are necessary, display the upgrade dialog
+        new ImmersiveDialogCore(campaign,
+              null,
+              null,
+              getFormattedText("MilestoneUpgradePathDialog.main", MHQConstants.VERSION.toString()),
+              createButton(),
+              getText("MilestoneUpgradePathDialog.secondary"),
+              ImmersiveDialogWidth.LARGE.getWidth(),
+              false,
+              getPanel(upgradePath),
+              getBanner(),
+              true);
+
+        // If upgrades were necessary, exit the app once the dialog has been confirmed
+        campaign.getApp().exit(false);
+    }
+
+    /**
+     * Determines the list of milestone releases that the given version must be upgraded through.
+     *
+     * @param currentVersion the current {@link Version} of the campaign
+     *
+     * @return a list of {@link MilestoneData} objects representing required upgrades
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private static List<MilestoneData> getUpgradePath(Version currentVersion) {
+        List<MilestoneData> allMilestoneReleases = MHQConstants.ALL_MILESTONE_RELEASES;
+
+        List<MilestoneData> upgradePath = new ArrayList<>();
+        for (MilestoneData milestone : allMilestoneReleases) {
+            if (currentVersion.isLowerThan(milestone.version())) {
+                upgradePath.add(milestone);
+            }
+        }
+        return upgradePath;
+    }
+
+    /**
+     * Loads and scales the banner image used in the upgrade path dialog.
+     *
+     * @return a scaled {@link ImageIcon} instance for the banner
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private static ImageIcon getBanner() {
+        ImageIcon banner = new ImageIcon("data/images/misc/megamek-splash.png");
+        return ImageUtilities.scaleImageIcon(banner, scaleForGUI(400), true);
+    }
+
+    /**
+     * Creates the acknowledgement button.
+     *
+     * @return a list of {@link ImmersiveDialogCore.ButtonLabelTooltipPair} for the dialog buttons
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private static List<ImmersiveDialogCore.ButtonLabelTooltipPair> createButton() {
+        return List.of(new ImmersiveDialogCore.ButtonLabelTooltipPair(getText("Understood.text"), null));
+    }
+
+    /**
+     * Builds a panel containing an interactive list of upgrade milestones, where each milestone is represented as a
+     * button. Buttons display the milestone label and open associated documentation URLs when clicked.
+     *
+     * @param upgradePath the list of {@link MilestoneData} milestones to display
+     *
+     * @return a {@link JPanel} containing the arranged milestone buttons
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private static JPanel getPanel(List<MilestoneData> upgradePath) {
+        JPanel pnlUpgrades = new JPanel();
+        pnlUpgrades.setAlignmentX(Component.CENTER_ALIGNMENT);
+        pnlUpgrades.setMaximumSize(new Dimension(Integer.MAX_VALUE, pnlUpgrades.getPreferredSize().height));
+
+        // Create a batch of labels, one per upgrade, that both look and act like hyperlinks
+        for (MilestoneData milestone : upgradePath) {
+            String milestoneLabel = milestone.label();
+            String milestoneUrl = milestone.getMekHQUrl();
+
+            JButton btnUpgrade = new RoundedJButton("<html><b>" + milestoneLabel + "</b></html>");
+            btnUpgrade.setName("upgrade" + milestoneLabel);
+            btnUpgrade.setToolTipText(milestoneUrl);
+            btnUpgrade.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+            btnUpgrade.setAlignmentX(Component.CENTER_ALIGNMENT);
+            btnUpgrade.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent evt) {
+                    if (Desktop.isDesktopSupported()) {
+                        try {
+                            URI uri = new URI(milestoneUrl);
+                            Desktop.getDesktop().browse(uri);
+                        } catch (Exception ex) {
+                            LOGGER.error(ex, "Failed to open URL: {}", milestoneUrl);
+                        }
+                    }
+                }
+            });
+            pnlUpgrades.add(btnUpgrade);
+        }
+        return pnlUpgrades;
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
@@ -71,6 +71,8 @@ import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 public class MilestoneUpgradePathDialog {
     private static final MMLogger LOGGER = MMLogger.create(MilestoneUpgradePathDialog.class);
 
+    private final static String DISCORD_LINK = "https://discord.gg/megamek";
+
     /**
      * Displays the milestone upgrade path dialog if upgrades are needed for the supplied campaign.
      *
@@ -175,6 +177,13 @@ public class MilestoneUpgradePathDialog {
         pnlUpgrades.setAlignmentX(Component.CENTER_ALIGNMENT);
         pnlUpgrades.setMaximumSize(new Dimension(Integer.MAX_VALUE, pnlUpgrades.getPreferredSize().height));
 
+
+        JButton btnDiscord = new RoundedJButton("<html><b>" +
+                                                      getText("MilestoneUpgradePathDialog.discord") +
+                                                      "</b></html>");
+        btnDiscord.setName("btnDiscord");
+        buildUrlButton(pnlUpgrades, btnDiscord, DISCORD_LINK);
+
         // Create a batch of labels, one per upgrade, that both look and act like hyperlinks
         for (MilestoneData milestone : upgradePath) {
             String milestoneLabel = milestone.label();
@@ -182,24 +191,43 @@ public class MilestoneUpgradePathDialog {
 
             JButton btnUpgrade = new RoundedJButton("<html><b>" + milestoneLabel + "</b></html>");
             btnUpgrade.setName("upgrade" + milestoneLabel);
-            btnUpgrade.setToolTipText(milestoneUrl);
-            btnUpgrade.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-            btnUpgrade.setAlignmentX(Component.CENTER_ALIGNMENT);
-            btnUpgrade.addMouseListener(new MouseAdapter() {
-                @Override
-                public void mouseClicked(MouseEvent evt) {
-                    if (Desktop.isDesktopSupported()) {
-                        try {
-                            URI uri = new URI(milestoneUrl);
-                            Desktop.getDesktop().browse(uri);
-                        } catch (Exception ex) {
-                            LOGGER.error(ex, "Failed to open URL: {}", milestoneUrl);
-                        }
-                    }
-                }
-            });
-            pnlUpgrades.add(btnUpgrade);
+            buildUrlButton(pnlUpgrades, btnUpgrade, milestoneUrl);
         }
         return pnlUpgrades;
+    }
+
+    /**
+     * Adds a button to a specified panel that, when clicked, attempts to open the given URL in the user's default web
+     * browser.
+     *
+     * <p>This method sets the button's tooltip to the provided URL, changes its cursor to a hand when hovered,
+     * centers its alignment, and attaches a mouse click listener. On click, if the current platform supports desktop
+     * browsing, it will attempt to open the URL. If an error occurs during this process, the exception is logged.</p>
+     *
+     * @param pnlUpgrades the {@link JPanel} to which the button will be added
+     * @param btnDiscord  the {@link JButton} that will serve as the clickable link
+     * @param discordLink the URL to be opened when the button is clicked
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private static void buildUrlButton(JPanel pnlUpgrades, JButton btnDiscord, String discordLink) {
+        btnDiscord.setToolTipText(discordLink);
+        btnDiscord.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        btnDiscord.setAlignmentX(Component.CENTER_ALIGNMENT);
+        btnDiscord.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent evt) {
+                if (Desktop.isDesktopSupported()) {
+                    try {
+                        URI uri = new URI(discordLink);
+                        Desktop.getDesktop().browse(uri);
+                    } catch (Exception ex) {
+                        LOGGER.error(ex, "Failed to open URL: {}", discordLink);
+                    }
+                }
+            }
+        });
+        pnlUpgrades.add(btnDiscord);
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
@@ -122,6 +122,11 @@ public class MilestoneUpgradePathDialog {
 
         List<MilestoneData> upgradePath = new ArrayList<>();
         for (MilestoneData milestone : allMilestoneReleases) {
+            // If the milestone and the current version are identical, the campaign can always load in
+            if (milestone.version().equals(MHQConstants.VERSION)) {
+                continue;
+            }
+
             if (currentVersion.isLowerThan(milestone.version())) {
                 upgradePath.add(milestone);
             }

--- a/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
@@ -50,9 +50,9 @@ import javax.swing.JButton;
 import javax.swing.JPanel;
 
 import megamek.Version;
+import megamek.common.util.milestoneReleaseInformation.MilestoneData;
 import megamek.logging.MMLogger;
 import megamek.utilities.ImageUtilities;
-import megamek.utilities.MilestoneData;
 import mekhq.MHQConstants;
 import mekhq.campaign.Campaign;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;

--- a/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
@@ -69,7 +69,7 @@ import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
  * @since 0.50.07
  */
 public class MilestoneUpgradePathDialog {
-    private final static MMLogger LOGGER = MMLogger.create(MilestoneUpgradePathDialog.class);
+    private static final MMLogger LOGGER = MMLogger.create(MilestoneUpgradePathDialog.class);
 
     /**
      * Displays the milestone upgrade path dialog if upgrades are needed for the supplied campaign.


### PR DESCRIPTION
# Requires https://github.com/MegaMek/megamek/pull/7331
# Requires https://github.com/MegaMek/megameklab/pull/1980

As the rather lengthy title explains, this PR retires the current 'you need to save in a Milestone' dialog with a far more user-friendly version.

<img width="823" height="468" alt="image" src="https://github.com/user-attachments/assets/4755c42e-3509-4313-b7b0-8f698c5fc902" />

This dialog fully explains the upgrade process, as well as providing version buttons that acts as hyperlinks. Taking the user directly to the GitHub download page for that version. This removes any ambiguity around what versions a campaign needs to be saved in, when upgrading through the Milestones.

The version buttons shown as specific to the load instance. In the image above a v48.0 campaign is attempting to load into v50.07. In the below image a v49.19.1 campaign is attempting to load into the same version...

<img width="823" height="471" alt="image" src="https://github.com/user-attachments/assets/f170ae58-36cb-419c-b352-4ea50cc2d6a3" />

As shown here, as the only Milestone upgrade needed for a 49.19.1 save is 50.06, only the button for 50.06 is shown.