### PR TITLE
Improvement: Added Version History to Campaign Save

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -291,6 +291,7 @@ public class Campaign implements ITechManager {
 
     private UUID id;
     private Version version; // this is dynamically populated on load and doesn't need to be saved
+    private final List<Version> pastVersions = new ArrayList<>();
 
     // we have three things to track: (1) teams, (2) units, (3) repair tasks
     // we will use the same basic system (borrowed from MegaMek) for tracking
@@ -577,6 +578,14 @@ public class Campaign implements ITechManager {
 
     public @Nullable Version getVersion() {
         return version;
+    }
+
+    public List<Version> getPastVersions() {
+        return pastVersions;
+    }
+
+    public void addPastVersion(Version pastVersion) {
+        this.pastVersions.add(pastVersion);
     }
 
     public String getName() {
@@ -7256,6 +7265,11 @@ public class Campaign implements ITechManager {
 
         // Start the XML root.
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "campaign", "version", MHQConstants.VERSION);
+        MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "pastVersions");
+        for (final Version pastVersion : pastVersions) {
+            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "pastVersion", pastVersion.toString());
+        }
+        MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "pastVersions");
 
         // region Basic Campaign Info
         MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "info");

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -76,6 +76,7 @@ import megamek.common.annotations.Nullable;
 import megamek.common.icons.Camouflage;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.logging.MMLogger;
+import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.NullEntityException;
 import mekhq.Utilities;
@@ -301,7 +302,9 @@ public class CampaignXmlParser {
                 // Okay, so what element is it?
                 String nodeName = workingNode.getNodeName();
 
-                if (nodeName.equalsIgnoreCase("randomSkillPreferences")) {
+                if (nodeName.equalsIgnoreCase("pastVersions")) {
+                    processPastVersionNodes(campaign, workingNode);
+                } else if (nodeName.equalsIgnoreCase("randomSkillPreferences")) {
                     campaign.setRandomSkillPreferences(RandomSkillPreferences.generateRandomSkillPreferencesFromXml(
                           workingNode,
                           version));
@@ -917,6 +920,57 @@ public class CampaignXmlParser {
             if (combatTeam != null) {
                 campaign.addCombatTeam(combatTeam);
             }
+        }
+    }
+
+    /**
+     * Processes the child nodes of a given XML node to extract and register past version information in the specified
+     * campaign.
+     * <p>
+     * This method iterates through all child nodes of the supplied {@code workingNode}, identifies elements named
+     * "pastVersion", and creates {@link Version} objects from their text content. Each parsed version is added to the
+     * campaign's list of past versions if it is not already present. Unknown node types encountered in this context are
+     * logged as errors.
+     * <p>
+     * After processing, if the campaign's list of past versions is empty, a warning is logged. The method also ensures
+     * the current application version is included in the list if it was not already present.
+     *
+     * @param campaign    the {@link Campaign} instance to be updated with past version information
+     * @param workingNode the XML {@link Node} whose child nodes contain past version data to be processed
+     */
+    private static void processPastVersionNodes(Campaign campaign, Node workingNode) {
+        NodeList childNodes = workingNode.getChildNodes();
+
+        // Iterate through the children (past versions)
+        for (int x = 0; x < childNodes.getLength(); x++) {
+            Node childNode = childNodes.item(x);
+
+            // If it's not an element node, we ignore it.
+            if (childNode.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+
+            // If the node name isn't correct, we ignore it.
+            if (!childNode.getNodeName().equalsIgnoreCase("pastVersion")) {
+                LOGGER.error("Incorrect node loaded in Past Version nodes: {}", childNode.getNodeName());
+                continue;
+            }
+
+            // Otherwise, we add it to the list of past versions
+            Version pastVersion = new Version(childNode.getTextContent());
+            if (!campaign.getPastVersions().contains(pastVersion)) {
+                campaign.addPastVersion(pastVersion);
+            }
+        }
+        List<Version> pastVersions = campaign.getPastVersions();
+        if (pastVersions.isEmpty()) {
+            LOGGER.info("No past versions found in campaign file.");
+        }
+
+        // Add the current version (if it's missing)
+        if (!pastVersions.contains(MHQConstants.VERSION)) {
+            LOGGER.info("Current version {} not found in past versions list. Adding it.", MHQConstants.VERSION);
+            campaign.addPastVersion(MHQConstants.VERSION);
         }
     }
 


### PR DESCRIPTION
This was a request from @HammerGS.

All this PR does is keep a log of what versions a campaign was saved into, preserved in the campaign save.

<img width="306" height="101" alt="image" src="https://github.com/user-attachments/assets/a037f123-33fa-4e8d-b8b2-ea0f6a8e3c7f" />

This allows developers, at a glance, see how old a campaign is when debugging.

Nothing is done with this information, it is purely for ease of reference.

I should add that this function will not have any memory prior to the campaign being saved in 50.07, the screenshot is for illustration purposes only.