### PR TITLE
Fix: #7430 Fixed Incorrect Morale Messages While on Garrison Contracts

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5148,7 +5148,7 @@ public class Campaign implements ITechManager {
                 AtBMoraleLevel newMorale = contract.getMoraleLevel();
 
                 String report = "";
-                if (contract.getContractType().isGarrisonDuty()) {
+                if (contract.isPeaceful()) {
                     report = resources.getString("garrisonDutyRouted.text");
                 } else if (oldMorale != newMorale) {
                     report = String.format(resources.getString("contractMoraleReport.text"),

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -568,7 +568,7 @@ public class AtBContract extends Contract {
 
         // Additional morale updates if morale level is set to 'Routed' and contract type is a garrison type
         if (moraleLevel.isRouted()) {
-            if (contractType.isGarrisonType() || contractType.isReliefDuty()) {
+            if (contractType.isGarrisonType()) {
                 routEnd = today.plusMonths(max(1, d6() - 3)).minusDays(1);
 
                 PrisonerMissionEndEvent prisoners = new PrisonerMissionEndEvent(campaign, this);
@@ -1550,6 +1550,10 @@ public class AtBContract extends Contract {
 
     public void setMoraleLevel(final AtBMoraleLevel moraleLevel) {
         this.moraleLevel = moraleLevel;
+    }
+
+    public boolean isPeaceful() {
+        return getContractType().isGarrisonType() && getMoraleLevel().isRouted();
     }
 
     @Override


### PR DESCRIPTION
Fix #7430

We were incorrectly returning true for a single clause in the morale message checker.

This was a visual bug only.