### PR TITLE
Fix: Fixed Resupplies Not Triggering Smuggler Events for Pirate Campaigns

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5220,17 +5220,17 @@ public class Campaign implements ITechManager {
 
     /**
      * Processes the resupply operation for a given contract.
-     * <p>
-     * This method checks if the contract type is not Guerrilla Warfare or if a d6 roll is greater than 4. If any of
+     * <p>This method checks if the contract type is not Guerrilla Warfare or if a d6 roll is greater than 4. If any of
      * these conditions is met, it calculates the maximum resupply size based on the contract's required lances, creates
-     * an instance of the {@link Resupply} class, and initiates a resupply action.
+     * an instance of the {@link Resupply} class, and initiates a resupply action.</p>
      *
      * @param contract The relevant {@link AtBContract}
      */
     private void processResupply(AtBContract contract) {
-        boolean isGuerrilla = contract.getContractType().isGuerrillaWarfare();
+        boolean isGuerrilla = contract.getContractType().isGuerrillaWarfare()
+                                    || (PIRATE_FACTION_CODE).equals(contract.getEmployerCode());
 
-        if (!isGuerrilla || d6(1) > 4) {
+        if (!isGuerrilla || randomInt(4) == 0) {
             ResupplyType resupplyType = isGuerrilla ? ResupplyType.RESUPPLY_SMUGGLER : ResupplyType.RESUPPLY_NORMAL;
             Resupply resupply = new Resupply(this, contract, resupplyType);
             performResupply(resupply, contract);

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5228,7 +5228,7 @@ public class Campaign implements ITechManager {
      */
     private void processResupply(AtBContract contract) {
         boolean isGuerrilla = contract.getContractType().isGuerrillaWarfare()
-                                    || (PIRATE_FACTION_CODE).equals(contract.getEmployerCode());
+                                    || PIRATE_FACTION_CODE.equals(contract.getEmployerCode());
 
         if (!isGuerrilla || randomInt(4) == 0) {
             ResupplyType resupplyType = isGuerrilla ? ResupplyType.RESUPPLY_SMUGGLER : ResupplyType.RESUPPLY_NORMAL;

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5220,7 +5220,7 @@ public class Campaign implements ITechManager {
 
     /**
      * Processes the resupply operation for a given contract.
-     * <p>This method checks if the contract type is not Guerrilla Warfare or if a d6 roll is greater than 4. If any of
+     * <p>This method checks if the contract type is not Guerrilla Warfare or if randomInt(4) == 0. If any of
      * these conditions is met, it calculates the maximum resupply size based on the contract's required lances, creates
      * an instance of the {@link Resupply} class, and initiates a resupply action.</p>
      *

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/PerformResupply.java
@@ -48,6 +48,7 @@ import static mekhq.campaign.mission.resupplyAndCaches.Resupply.ResupplyType.RES
 import static mekhq.campaign.personnel.enums.PersonnelRole.GROUND_VEHICLE_DRIVER;
 import static mekhq.campaign.stratcon.StratconContractInitializer.getUnoccupiedCoords;
 import static mekhq.campaign.stratcon.StratconRulesManager.generateExternalScenario;
+import static mekhq.campaign.universe.Faction.PIRATE_FACTION_CODE;
 import static mekhq.gui.dialog.resupplyAndCaches.DialogItinerary.itineraryDialog;
 import static mekhq.utilities.EntityUtilities.getEntityFromUnitId;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
@@ -159,13 +160,14 @@ public class PerformResupply {
 
         final boolean isIndependent = contract.getCommandRights().isIndependent();
         final boolean isGuerrilla = contract.getContractType().isGuerrillaWarfare();
+        final boolean isPirate = PIRATE_FACTION_CODE.equals(contract.getEmployerCode());
         final ResupplyType resupplyType = resupply.getResupplyType();
 
         // If appropriate, prompt the player to use their own convoys
         if (!resupplyType.equals(RESUPPLY_LOOT) && !resupplyType.equals(RESUPPLY_CONTRACT_END)) {
             // If we're on a guerrilla contract, the player may be approached by smugglers, instead,
             // which won't use player convoys.
-            if (!isGuerrilla) {
+            if (!isGuerrilla && !isPirate) {
                 new DialogPlayerConvoyOption(resupply, isIndependent);
 
                 // If the player is on an Independent contract and refuses to use their own transports,

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -42,6 +42,7 @@ import static mekhq.MHQConstants.BATTLE_OF_TUKAYYID;
 import static mekhq.campaign.force.ForceType.CONVOY;
 import static mekhq.campaign.force.ForceType.STANDARD;
 import static mekhq.campaign.market.procurement.Procurement.getTechFaction;
+import static mekhq.campaign.universe.Faction.PIRATE_FACTION_CODE;
 import static mekhq.utilities.EntityUtilities.getEntityFromUnitId;
 
 import java.time.LocalDate;
@@ -782,7 +783,7 @@ public class Resupply {
         Person negotiator;
         negotiatorSkill = NONE.ordinal();
 
-        if (contract.getContractType().isGuerrillaWarfare()) {
+        if (contract.getContractType().isGuerrillaWarfare() || PIRATE_FACTION_CODE.equals(contract.getEmployerCode())) {
             negotiator = campaign.getCommander();
         } else {
             negotiator = null;


### PR DESCRIPTION
Pirate campaigns are always meant to receive smuggler events (or no resupply). Instead they were being prompted for normal resupplies.