### PR TITLE
Improvement: Moved Resupplies to the End of the 1st of Each Month, Rather Than End of Month

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5140,7 +5140,6 @@ public class Campaign implements ITechManager {
                 rating.reInitialize();
             }
 
-            boolean hasHadResupply = false;
             for (AtBContract contract : getActiveAtBContracts()) {
                 AtBMoraleLevel oldMorale = contract.getMoraleLevel();
 
@@ -5160,19 +5159,30 @@ public class Campaign implements ITechManager {
                 if (!report.isBlank()) {
                     addReport(report);
                 }
+            }
+        }
 
-                // Resupply
-                if (getCampaignOptions().isUseStratCon()) {
+        // Resupply
+        if (currentDay.getDayOfMonth() == 2) {
+            // This occurs at the end of the 1st day, each month to avoid an awkward mechanics interaction where
+            // personnel might quit or get taken out of fatigue without the player having any opportunity to
+            // intervene before their resupply attempt becomes active.
+            List<AtBContract> activeContracts = getActiveAtBContracts();
+            AtBContract firstNonSubcontract = null;
+            for (AtBContract contract : activeContracts) {
+                if (!contract.isSubcontract()) {
+                    firstNonSubcontract = contract;
+                    break;
+                }
+            }
+
+            if (firstNonSubcontract != null) {
+                if (campaignOptions.isUseStratCon()) {
                     boolean inLocation = location.isOnPlanet() &&
-                                               location.getCurrentSystem().equals(contract.getSystem());
-
-                    if (contract.isSubcontract() || hasHadResupply) {
-                        continue;
-                    }
+                                               location.getCurrentSystem().equals(firstNonSubcontract.getSystem());
 
                     if (inLocation) {
-                        processResupply(contract);
-                        hasHadResupply = true;
+                        processResupply(firstNonSubcontract);
                     }
                 }
             }


### PR DESCRIPTION
As both Resupplies and Turnover occurred at the end of the month, it was possible for the following play experience to occur:

- Turnover causes convoy personnel to quit.
- Convoy now has one or more uncrewed units.
- Unscrewed units are not considered valid for Resupply
- Player does not get a Resupply

To solve this issue Resupplies now occur at the end of the 1st of each month, rather than at the end of each month. This gives players a day to fix any personnel issues before the attempt goes out.