### PR TITLE
Improvement: Converted StratCon Reinforcement Dialog to the Immersive Format

### DIFF
--- a/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
@@ -17,22 +17,22 @@ StratConReinforcementsConfirmationDialog.outOfCharacter.transport=Having an <b>I
   results (this is an RP effect only).\
   <p>Reinforcing costs 1 <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and a check using the above <b>Target \
   Number</b>. If the check is failed your reinforcements may be <b>Intercepted</b>! If an Interception attempt is \
-  made the commander of your reinforcements will need to make a <b>Tactics</b> skill check to evade the \
+  made, the commander of your reinforcements will need to make a <b>Tactics</b> skill check to evade the \
   interception.</p>\
   <p>You can improve the chances your attempt succeeds by changing the reinforcing unit to the Auxiliary or Maneuver \
-  role. Or by paying additional <b>Support Points</b>. Each additional Support Point spent reduces the Target Number \
-  by 2.</p>\
+  <a href='GLOSSARY:COMBAT_ROLES'>Combat Roles</a>. Or by paying additional <b>Support Points</b>. Each additional \
+  Support Point spent reduces the Target Number by 2.</p>\
   <p>If the situation is truly dire, you can choose to <b>Reinforce Instantly</b>. This doubles all <b>Support \
   Points</b> paid and may take you into negative Support Points.</p>\
   <p>If reinforcing using an option marked ''(GM)'' the reinforcement attempt is both free and automatically \
   succeeds.</p>
 StratConReinforcementsConfirmationDialog.outOfCharacter.tactical=Reinforcing costs 1 \
   <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and a check using the above <b>Target Number</b>. If the check is\
-  \ failed your reinforcements may be <b>Intercepted</b>! If an Interception attempt is made the commander of your \
+  \ failed your reinforcements may be <b>Intercepted</b>! If an Interception attempt is made, the commander of your \
   reinforcements will need to make a <b>Tactics</b> skill check to evade the interception.\
   <p>You can improve the chances your attempt succeeds by changing the reinforcing unit to the Auxiliary or Maneuver \
-  role. Or by paying additional <b>Support Points</b>. Each additional Support Point spent reduces the Target Number \
-  by 2.</p>\
+  <a href='GLOSSARY:COMBAT_ROLES'>Combat Roles</a>. Or by paying additional <b>Support Points</b>. Each additional \
+  Support Point spent reduces the Target Number by 2.</p>\
   <p>If the situation is truly dire, you can choose to <b>Reinforce Instantly</b>. This doubles all <b>Support \
   Points</b> paid and may take you into negative Support Points.</p>\
   <p>If reinforcing using an option marked ''(GM)'' the reinforcement attempt is both free and automatically \

--- a/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
@@ -1,0 +1,39 @@
+# Buttons
+StratConReinforcementsConfirmationDialog.button.cancel=Cancel Attempt
+StratConReinforcementsConfirmationDialog.button.reinforce=Reinforce
+StratConReinforcementsConfirmationDialog.button.reinforce.instantly=Reinforce Instantly
+StratConReinforcementsConfirmationDialog.button.reinforce.gm=Reinforce (GM)
+StratConReinforcementsConfirmationDialog.button.reinforce.gm.instantly=Reinforce Instantly (GM)
+# Text
+StratConReinforcementsConfirmationDialog.inCharacter.transport={0}, I''ve had the computer break down our likelihood \
+  of success.\
+  <p>We really should hire a specialist for this kind of thing...</p>
+StratConReinforcementsConfirmationDialog.inCharacter.tactical={0}, I''ve run the numbers. If we reinforce now, here''s \
+  our likelihood of success:
+StratConReinforcementsConfirmationDialog.inCharacter.supportPoints=Support Points:
+StratConReinforcementsConfirmationDialog.inCharacter.total=<br><br><b>Target Number:</b> {0}
+StratConReinforcementsConfirmationDialog.outOfCharacter.transport=Having an <b>Intelligence Analyst</b>, <b>Military \
+  Analyst</b>, <b>Military Theorist</b>, or <b>Tactical Analyst</b> employed by the unit will give more reliable \
+  results (this is an RP effect only).\
+  <p>Reinforcing costs 1 <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and check using the above <b>Target \
+  Number</b>. If the check is failed your reinforcements may be <b>Intercepted</b>! If an Interception attempt is \
+  made the commander of your reinforcements will need to make a <b>Tactics</b> skill check to evade the \
+  interception.</p>\
+  <p>You can improve the chances your attempt succeeds by changing the reinforcing unit to the Auxiliary or Maneuver \
+  role. Or by paying additional <b>Support Points</b>. Each additional Support Point spent reduces the Target Number \
+  by 2.</p>\
+  <p>If the situation is truly dire, you can choose to <b>Reinforce Instantly</b>. This doubles all <b>Support \
+  Points</b> paid and may take you into negative Support Points.</p>\
+  <p>If reinforcing using an option marked ''(GM)'' the reinforcement attempt is both free and automatically \
+  succeeds.</p>
+StratConReinforcementsConfirmationDialog.outOfCharacter.tactical=Reinforcing costs 1 \
+  <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and check using the above <b>Target Number</b>. If the check is\
+  \ failed your reinforcements may be <b>Intercepted</b>! If an Interception attempt is made the commander of your \
+  reinforcements will need to make a <b>Tactics</b> skill check to evade the interception.\
+  <p>You can improve the chances your attempt succeeds by changing the reinforcing unit to the Auxiliary or Maneuver \
+  role. Or by paying additional <b>Support Points</b>. Each additional Support Point spent reduces the Target Number \
+  by 2.</p>\
+  <p>If the situation is truly dire, you can choose to <b>Reinforce Instantly</b>. This doubles all <b>Support \
+  Points</b> paid and may take you into negative Support Points.</p>\
+  <p>If reinforcing using an option marked ''(GM)'' the reinforcement attempt is both free and automatically \
+  succeeds.</p>

--- a/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
@@ -24,7 +24,7 @@ StratConReinforcementsConfirmationDialog.outOfCharacter.transport=Having an <b>I
   Support Point spent reduces the Target Number by 2.</p>\
   <p>If the situation is truly dire, you can choose to <b>Reinforce Instantly</b>. This doubles all <b>Support \
   Points</b> paid and may take you into negative Support Points.</p>\
-  <p>If reinforcing using an option marked ''(GM)'' the reinforcement attempt is both free and automatically \
+  <p>If reinforcing using an option marked '(GM)' the reinforcement attempt is both free and automatically \
   succeeds.</p>
 StratConReinforcementsConfirmationDialog.outOfCharacter.tactical=Reinforcing costs 1 \
   <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and a check using the above <b>Target Number</b>. If the check is\
@@ -35,5 +35,5 @@ StratConReinforcementsConfirmationDialog.outOfCharacter.tactical=Reinforcing cos
   Support Point spent reduces the Target Number by 2.</p>\
   <p>If the situation is truly dire, you can choose to <b>Reinforce Instantly</b>. This doubles all <b>Support \
   Points</b> paid and may take you into negative Support Points.</p>\
-  <p>If reinforcing using an option marked ''(GM)'' the reinforcement attempt is both free and automatically \
+  <p>If reinforcing using an option marked '(GM)' the reinforcement attempt is both free and automatically \
   succeeds.</p>

--- a/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
@@ -15,7 +15,7 @@ StratConReinforcementsConfirmationDialog.inCharacter.total=<br><br><b>Target Num
 StratConReinforcementsConfirmationDialog.outOfCharacter.transport=Having an <b>Intelligence Analyst</b>, <b>Military \
   Analyst</b>, <b>Military Theorist</b>, or <b>Tactical Analyst</b> employed by the unit will give more reliable \
   results (this is an RP effect only).\
-  <p>Reinforcing costs 1 <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and check using the above <b>Target \
+  <p>Reinforcing costs 1 <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and a check using the above <b>Target \
   Number</b>. If the check is failed your reinforcements may be <b>Intercepted</b>! If an Interception attempt is \
   made the commander of your reinforcements will need to make a <b>Tactics</b> skill check to evade the \
   interception.</p>\
@@ -27,7 +27,7 @@ StratConReinforcementsConfirmationDialog.outOfCharacter.transport=Having an <b>I
   <p>If reinforcing using an option marked ''(GM)'' the reinforcement attempt is both free and automatically \
   succeeds.</p>
 StratConReinforcementsConfirmationDialog.outOfCharacter.tactical=Reinforcing costs 1 \
-  <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and check using the above <b>Target Number</b>. If the check is\
+  <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and a check using the above <b>Target Number</b>. If the check is\
   \ failed your reinforcements may be <b>Intercepted</b>! If an Interception attempt is made the commander of your \
   reinforcements will need to make a <b>Tactics</b> skill check to evade the interception.\
   <p>You can improve the chances your attempt succeeds by changing the reinforcing unit to the Auxiliary or Maneuver \

--- a/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.dialog;
+
+import static megamek.client.ui.util.UIUtil.scaleForGUI;
+import static mekhq.campaign.personnel.enums.PersonnelRole.INTELLIGENCE_ANALYST;
+import static mekhq.campaign.personnel.enums.PersonnelRole.MILITARY_ANALYST;
+import static mekhq.campaign.personnel.enums.PersonnelRole.MILITARY_THEORIST;
+import static mekhq.campaign.personnel.enums.PersonnelRole.TACTICAL_ANALYST;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+
+import megamek.common.TargetRoll;
+import megamek.common.TargetRollModifier;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelRole;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
+
+/**
+ * {@link StratConReinforcementsConfirmationDialog} displays a confirmation dialog for the player to deploy
+ * reinforcements to StratCon scenarios. It allows the player to select the number of Support Points to spend and
+ * handles the calculation of target number difficulties and summary breakdowns.
+ *
+ * @author Illiani
+ * @since 0.50.07
+ */
+public class StratConReinforcementsConfirmationDialog {
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.StratConReinforcementsConfirmationDialog";
+
+    /** The modifier applied per support point spent. */
+    private final static int SUPPORT_POINTS_MODIFIER = -2;
+
+    /** Indicates if a tactical officer is available for dialog flavor. */
+    private boolean hasTacticalOfficer = false;
+    /** The number of support points selected by the user. */
+    private int supportPoints = 0;
+    /** The result value for the dialog (type of action chosen). */
+    private final ReinforcementDialogResponseType reinforcementDialogResponseType;
+    /** Spinner component for selecting support points. */
+    private JSpinner spnSupportPoints;
+    /** Label for target number breakdown. */
+    private JLabel lblBreakdown;
+
+    /**
+     * Types of responses that can be selected from the dialog.
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public enum ReinforcementDialogResponseType {
+        /** The dialog was canceled. */
+        CANCEL,
+        /** Standard request for reinforcements. */
+        REINFORCE,
+        /** Instant request for reinforcements. */
+        REINFORCE_INSTANTLY,
+        /** GM reinforcements. */
+        REINFORCE_GM,
+        /** Instant GM reinforcements. */
+        REINFORCE_GM_INSTANTLY;
+    }
+
+    /**
+     * Gets the response type selected by the user.
+     *
+     * @return the {@link ReinforcementDialogResponseType} chosen
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public ReinforcementDialogResponseType getResponseType() {
+        return reinforcementDialogResponseType;
+    }
+
+    /**
+     * Gets the number of support points selected by the player.
+     *
+     * @return the number of support points chosen
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public int getSupportPoints() {
+        return supportPoints;
+    }
+
+    /**
+     * Constructs and displays the StratCon reinforcements confirmation dialog.
+     *
+     * @param campaign             the current campaign context
+     * @param targetNumber         the base {@link TargetRoll} representing the reaction difficulty
+     * @param maximumSupportPoints the maximum number of support points that can be spent
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public StratConReinforcementsConfirmationDialog(Campaign campaign, TargetRoll targetNumber,
+          int maximumSupportPoints) {
+        final String commanderAddress = campaign.getCommanderAddress();
+
+        ImmersiveDialogCore dialog = new ImmersiveDialogCore(campaign,
+              getSpeaker(campaign),
+              null,
+              getInCharacterMessage(commanderAddress),
+              getButtons(campaign.isGM()),
+              getOutOfCharacterMessage(),
+              null,
+              false,
+              getSpinnerPanel(maximumSupportPoints, targetNumber),
+              null,
+              true);
+
+        reinforcementDialogResponseType = switch (dialog.getDialogChoice()) {
+            case 0 -> ReinforcementDialogResponseType.CANCEL;
+            case 1 -> ReinforcementDialogResponseType.REINFORCE;
+            case 2 -> ReinforcementDialogResponseType.REINFORCE_INSTANTLY;
+            case 3 -> ReinforcementDialogResponseType.REINFORCE_GM;
+            case 4 -> ReinforcementDialogResponseType.REINFORCE_GM_INSTANTLY;
+            default -> throw new IllegalStateException("Unexpected value: " + dialog.getDialogChoice());
+        };
+    }
+
+    /**
+     * Determines the appropriate speaker (either a tactical officer or command admin) to display as the source of the
+     * dialog's in-character text.
+     *
+     * @param campaign the current campaign
+     *
+     * @return the selected speaker {@link Person}
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private Person getSpeaker(Campaign campaign) {
+        final List<PersonnelRole> TACTICAL_PROFESSIONS = List.of(MILITARY_ANALYST, MILITARY_THEORIST,
+              TACTICAL_ANALYST, INTELLIGENCE_ANALYST);
+        Person speaker = null;
+        for (Person potentialSpeaker : campaign.getActivePersonnel(false)) {
+            if (!potentialSpeaker.isEmployed()) {
+                continue;
+            }
+
+            if (!TACTICAL_PROFESSIONS.contains(potentialSpeaker.getPrimaryRole())
+                      && !TACTICAL_PROFESSIONS.contains(potentialSpeaker.getSecondaryRole())) {
+                continue;
+            }
+
+            if (speaker == null) {
+                speaker = potentialSpeaker;
+                continue;
+            }
+
+            if (potentialSpeaker.outRanksUsingSkillTiebreaker(campaign, speaker)) {
+                speaker = potentialSpeaker;
+            }
+        }
+
+        if (speaker != null) {
+            hasTacticalOfficer = true;
+            return speaker;
+        }
+
+        return campaign.getSeniorAdminPerson(Campaign.AdministratorSpecialization.COMMAND);
+    }
+
+    /**
+     * Generates the in-character message to use in the dialog, based on the available speaker type.
+     *
+     * @param commanderAddress the address or title of the commander
+     *
+     * @return the formatted, localized in-character message
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private String getInCharacterMessage(String commanderAddress) {
+        final String key = "StratConReinforcementsConfirmationDialog.inCharacter."
+                                 + (hasTacticalOfficer ? "tactical" : "transport");
+
+        return getFormattedTextAt(RESOURCE_BUNDLE, key, commanderAddress);
+    }
+
+    /**
+     * Builds the list of button definitions for the dialog, including any GM-specific options.
+     *
+     * @param isGM true if the player is a GM, showing more buttons
+     *
+     * @return list of button/tooltip pairs to show in the dialog
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private List<ImmersiveDialogCore.ButtonLabelTooltipPair> getButtons(boolean isGM) {
+        List<ImmersiveDialogCore.ButtonLabelTooltipPair> buttons = new ArrayList<>();
+
+        String label = getTextAt(RESOURCE_BUNDLE,
+              "StratConReinforcementsConfirmationDialog.button.cancel");
+        buttons.add(new ImmersiveDialogCore.ButtonLabelTooltipPair(label, null));
+
+        label = getTextAt(RESOURCE_BUNDLE,
+              "StratConReinforcementsConfirmationDialog.button.reinforce");
+        buttons.add(new ImmersiveDialogCore.ButtonLabelTooltipPair(label, null));
+
+        label = getTextAt(RESOURCE_BUNDLE,
+              "StratConReinforcementsConfirmationDialog.button.reinforce.instantly");
+        buttons.add(new ImmersiveDialogCore.ButtonLabelTooltipPair(label, null));
+
+        if (isGM) {
+            label = getTextAt(RESOURCE_BUNDLE,
+                  "StratConReinforcementsConfirmationDialog.button.reinforce.gm");
+            buttons.add(new ImmersiveDialogCore.ButtonLabelTooltipPair(label, null));
+
+            label = getTextAt(RESOURCE_BUNDLE,
+                  "StratConReinforcementsConfirmationDialog.button.reinforce.gm.instantly");
+            buttons.add(new ImmersiveDialogCore.ButtonLabelTooltipPair(label, null));
+        }
+
+        return buttons;
+    }
+
+    /**
+     * Generates the out-of-character message for the dialog, describing the mechanics.
+     *
+     * @return a localized out-of-character description string
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private String getOutOfCharacterMessage() {
+        final String key = "StratConReinforcementsConfirmationDialog.outOfCharacter."
+                                 + (hasTacticalOfficer ? "tactical" : "transport");
+        return getTextAt(RESOURCE_BUNDLE, key);
+    }
+
+    /**
+     * Builds the panel containing the spinner for support point selection and a breakdown of the resulting target
+     * number calculation.
+     *
+     * @param maximumSupportPoints the max allowed support points
+     * @param targetNumber         the base target number (before modifiers)
+     *
+     * @return a {@link JPanel} for embedding in the main dialog
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private JPanel getSpinnerPanel(int maximumSupportPoints, TargetRoll targetNumber) {
+        final int PADDING = scaleForGUI(10);
+
+        lblBreakdown = new JLabel("<html>" + getTargetNumberBreakdown(targetNumber) + "</html>");
+
+        JLabel lblSupportPoints = new JLabel(getTextAt(RESOURCE_BUNDLE,
+              "StratConReinforcementsConfirmationDialog.inCharacter.supportPoints"));
+        spnSupportPoints = new JSpinner(new SpinnerNumberModel(0, 0, maximumSupportPoints, 1));
+        spnSupportPoints.addChangeListener(e -> {
+            supportPoints = (int) spnSupportPoints.getValue();
+            lblBreakdown.setText("<html>" + getTargetNumberBreakdown(targetNumber) + "</html>");
+        });
+
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.gridwidth = 2; // The label takes up two spaces horizontally
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.insets = new Insets(PADDING, 0, PADDING, 0);
+        panel.add(lblBreakdown, gbc);
+
+        gbc.gridwidth = 1;
+        gbc.gridy = 1;
+        panel.add(lblSupportPoints, gbc);
+
+        gbc.gridx = 1;
+        panel.add(spnSupportPoints, gbc);
+
+        return panel;
+    }
+
+    /**
+     * Produces a formatted HTML breakdown of the target number calculation, including all relevant modifiers and the
+     * effect of current support point selection.
+     *
+     * @param targetNumber base target roll object
+     *
+     * @return breakdown string in HTML format
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private String getTargetNumberBreakdown(TargetRoll targetNumber) {
+        StringBuilder breakdown = new StringBuilder();
+        for (TargetRollModifier modifier : targetNumber.getModifiers()) {
+            breakdown.append("<br><b>").append(modifier.getDesc()).append(":</b> ").append(modifier.getValue());
+        }
+
+        breakdown.append("<br><b>")
+              .append(getTextAt(RESOURCE_BUNDLE,
+                    "StratConReinforcementsConfirmationDialog.inCharacter.supportPoints"))
+              .append(" </b> ")
+              .append(supportPoints * SUPPORT_POINTS_MODIFIER);
+
+        breakdown.append(getFormattedTextAt(RESOURCE_BUNDLE,
+              "StratConReinforcementsConfirmationDialog.inCharacter.total",
+              targetNumber.getValue() + (supportPoints * SUPPORT_POINTS_MODIFIER)));
+
+        return breakdown.toString();
+    }
+
+}

--- a/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
@@ -157,7 +157,9 @@ public class StratConReinforcementsConfirmationDialog {
             case 2 -> ReinforcementDialogResponseType.REINFORCE_INSTANTLY;
             case 3 -> ReinforcementDialogResponseType.REINFORCE_GM;
             case 4 -> ReinforcementDialogResponseType.REINFORCE_GM_INSTANTLY;
-            default -> throw new IllegalStateException("Unexpected value: " + dialog.getDialogChoice());
+            default -> throw new IllegalStateException("Unexpected dialog choice value: " 
+                    + dialog.getDialogChoice() 
+                    + ". Valid choices are 0-4 (or 0-2 for non-GM users). This may occur if an invalid dialog choice is returned.");
         };
     }
 

--- a/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratcon/StratconScenarioWizard.java
@@ -32,7 +32,6 @@
  */
 package mekhq.gui.stratcon;
 
-import static megamek.utilities.ImageUtilities.scaleImageIcon;
 import static mekhq.campaign.mission.AtBDynamicScenarioFactory.scaleObjectiveTimeLimits;
 import static mekhq.campaign.mission.AtBDynamicScenarioFactory.translateTemplateObjectives;
 import static mekhq.campaign.personnel.skills.SkillType.S_LEADER;
@@ -49,29 +48,29 @@ import static mekhq.campaign.stratcon.StratconRulesManager.processReinforcementD
 import static mekhq.campaign.stratcon.StratconScenario.ScenarioState.PRIMARY_FORCES_COMMITTED;
 import static mekhq.campaign.stratcon.StratconScenario.ScenarioState.REINFORCEMENTS_COMMITTED;
 import static mekhq.campaign.utilities.CampaignTransportUtilities.getLeadershipDropdownVectorPair;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerDescription;
-import static mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore.getSpeakerIcon;
 
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
-import java.awt.Component;
-import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.*;
 import java.util.stream.Collectors;
-import javax.swing.*;
+import javax.swing.DefaultListModel;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ListSelectionModel;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
-import megamek.client.ui.util.UIUtil;
 import megamek.common.Minefield;
 import megamek.common.TargetRoll;
-import megamek.common.TargetRollModifier;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
@@ -88,6 +87,7 @@ import mekhq.campaign.stratcon.StratconScenario;
 import mekhq.campaign.stratcon.StratconTrackState;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.StratconPanel;
+import mekhq.gui.dialog.StratConReinforcementsConfirmationDialog;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
 import mekhq.utilities.MHQInternationalization;
 import mekhq.utilities.ReportingUtilities;
@@ -688,7 +688,7 @@ public class StratconScenarioWizard extends JDialog {
      *                         <li>When {@code isPrimaryForce} is {@code true}:
      *                             <ul>
      *                               <li>The "Commit" button invokes the
-     *                               {@link #btnCommitClicked(ActionEvent, Integer, boolean, boolean)}
+     *                               {@link #btnCommitClicked(Integer, boolean, boolean)}
      *                                   method to directly complete the action.</li>
      *                             </ul>
      *                         </li>
@@ -709,7 +709,7 @@ public class StratconScenarioWizard extends JDialog {
         btnCommit = new JButton(MHQInternationalization.getTextAt(resourcePath, "leadershipCommit.text"));
         btnCommit.setActionCommand("COMMIT_CLICK");
         if (isPrimaryForce) {
-            btnCommit.addActionListener(evt -> btnCommitClicked(evt, null, false, true));
+            btnCommit.addActionListener(evt -> btnCommitClicked(null, false, true));
         } else {
             btnCommit.addActionListener(evt -> reinforcementConfirmDialog());
         }
@@ -781,200 +781,40 @@ public class StratconScenarioWizard extends JDialog {
      * </ul>
      */
     private void reinforcementConfirmDialog() {
-        final int LEFT_WIDTH = UIUtil.scaleForGUI(200);
-        final int RIGHT_WIDTH = UIUtil.scaleForGUI(400);
+        // Hide the old dialog until we're done.
+        // The dialog will be 'disposed' if the confirmation dialog is confirmed and re-shown if the dialog is canceled
+        setVisible(false);
+        final int SUPPORT_POINTS_MODIFIER = -2;
 
-        JDialog dialog = new JDialog();
-        dialog.setTitle(resources.getString("incomingTransmission.title"));
-        dialog.setLayout(new BorderLayout());
-
-        // Main Panel to hold left and right boxes
-        JPanel mainPanel = new JPanel(new GridBagLayout());
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.insets = new Insets(10, 10, 10, 10);
-        gbc.fill = GridBagConstraints.BOTH;
-        gbc.weighty = 1;
-
-        // Left box (commandLiaison details)
-        JPanel leftBox = new JPanel();
-        leftBox.setLayout(new BoxLayout(leftBox, BoxLayout.Y_AXIS));
-        leftBox.setAlignmentX(Component.LEFT_ALIGNMENT);
-
-        // Get commandLiaison details
         Person commandLiaison = campaign.getSeniorAdminPerson(AdministratorSpecialization.COMMAND);
-        String speakerName = (commandLiaison != null) ? commandLiaison.getFullTitle() : campaign.getName();
-
-        // Add commandLiaison image (icon)
-        ImageIcon speakerIcon = getSpeakerIcon(campaign, commandLiaison);
-        if (speakerIcon != null) {
-            speakerIcon = scaleImageIcon(speakerIcon, 100, true);
-        }
-        JLabel imageLabel = new JLabel();
-        imageLabel.setIcon(speakerIcon);
-        imageLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
-
-        // Speaker description (below the icon)
-        StringBuilder speakerDescription = getSpeakerDescription(campaign, commandLiaison, speakerName);
-        JLabel leftDescription = new JLabel(String.format(
-              "<html><div style='width: %s; text-align:center;'>%s</div></html>",
-              LEFT_WIDTH,
-              speakerDescription));
-        leftDescription.setAlignmentX(Component.CENTER_ALIGNMENT);
-
-        // Add components to leftBox
-        leftBox.add(imageLabel);
-        leftBox.add(Box.createRigidArea(new Dimension(0, 10))); // Add spacing
-        leftBox.add(leftDescription);
-
-        // Add leftBox to mainPanel
-        gbc.gridx = 0;
-        gbc.gridy = 0;
-        gbc.weightx = 0;
-        mainPanel.add(leftBox, gbc);
-
-        // Right box (message details)
-        JPanel rightBox = new JPanel(new BorderLayout());
-        rightBox.setBorder(BorderFactory.createEtchedBorder());
-
-        TargetRoll reinforcementTargetNumber = calculateReinforcementTargetNumber(commandLiaison,
+        TargetRoll targetNumber = calculateReinforcementTargetNumber(commandLiaison,
               currentCampaignState.getContract());
-        int targetNumber = reinforcementTargetNumber.getValue();
+        // The -1 is due to the default cost for reinforcing
+        int availableSupportPoints = currentCampaignState.getSupportPoints() - 1;
 
-        StringBuilder rightDescriptionMessage = new StringBuilder();
-        rightDescriptionMessage.append(String.format(resources.getString("reinforcementConfirmation.introduction"),
-              campaign.getCommanderAddress()));
-        rightDescriptionMessage.append(resources.getString("reinforcementConfirmation.breakdown"));
-
-        StringBuilder breakdownContents = new StringBuilder();
-        for (TargetRollModifier modifier : reinforcementTargetNumber.getModifiers()) {
-            breakdownContents.append(String.format("%s: %d<br>", modifier.getDesc(), modifier.getValue()));
+        StratConReinforcementsConfirmationDialog dialog = new StratConReinforcementsConfirmationDialog(campaign,
+              targetNumber, availableSupportPoints);
+        StratConReinforcementsConfirmationDialog.ReinforcementDialogResponseType responseType =
+              dialog.getResponseType();
+        switch (responseType) {
+            case CANCEL -> setVisible(true);
+            case REINFORCE -> {
+                int supportPointsSpent = dialog.getSupportPoints();
+                int supportPointModifier = supportPointsSpent * SUPPORT_POINTS_MODIFIER;
+                int finalTargetNumber = targetNumber.getValue() + supportPointModifier;
+                currentCampaignState.changeSupportPoints(-(supportPointsSpent + 1));
+                btnCommitClicked(finalTargetNumber, false, false);
+            }
+            case REINFORCE_INSTANTLY -> {
+                int supportPointsSpent = dialog.getSupportPoints();
+                int supportPointModifier = supportPointsSpent * SUPPORT_POINTS_MODIFIER;
+                int finalTargetNumber = targetNumber.getValue() + supportPointModifier;
+                currentCampaignState.changeSupportPoints(-(supportPointsSpent + 1) * 2);
+                btnCommitClicked(finalTargetNumber, false, true);
+            }
+            case REINFORCE_GM -> btnCommitClicked(0, true, false);
+            case REINFORCE_GM_INSTANTLY -> btnCommitClicked(0, true, true);
         }
-        breakdownContents.append(String.format("<b>%s:</b> %s",
-              resources.getString("reinforcementConfirmation.breakdown.total"),
-              reinforcementTargetNumber.getValue())).append('+');
-        rightDescriptionMessage.append(breakdownContents);
-
-        JLabel rightDescription = new JLabel(String.format(
-              "<html><div style='width: %s; text-align:center;'>%s</div></html>",
-              RIGHT_WIDTH,
-              rightDescriptionMessage));
-        rightBox.add(rightDescription);
-
-        // Add rightBox to mainPanel
-        gbc.gridx = 1;
-        gbc.weightx = 1; // Allow horizontal stretching
-        mainPanel.add(rightBox, gbc);
-
-        // Add mainPanel to dialog
-        dialog.add(mainPanel, BorderLayout.CENTER);
-
-        // Spinner Panel (Support Points)
-        JPanel spinnerPanel = new JPanel();
-        spinnerPanel.setLayout(new BoxLayout(spinnerPanel, BoxLayout.X_AXIS));
-        JLabel lblSpinner = new JLabel(String.format("%s: ",
-              resources.getString("reinforcementConfirmation.spinnerLabel")));
-        lblSpinner.setToolTipText(resources.getString("reinforcementConfirmation.spinnerLabel.tooltip"));
-        lblSpinner.setAlignmentY(Component.CENTER_ALIGNMENT);
-
-        int availableSupportPoints = currentCampaignState.getSupportPoints();
-        JSpinner spnSupportPointCost = new JSpinner(new SpinnerNumberModel(availableSupportPoints > 0 ? 1 : 0,
-              availableSupportPoints > 0 ? 1 : 0,
-              availableSupportPoints,
-              1));
-        spnSupportPointCost.setToolTipText(resources.getString("reinforcementConfirmation.spinnerLabel.tooltip"));
-        spnSupportPointCost.setMaximumSize(spnSupportPointCost.getPreferredSize());
-        spnSupportPointCost.setAlignmentY(Component.CENTER_ALIGNMENT);
-        spinnerPanel.add(lblSpinner);
-        spinnerPanel.add(spnSupportPointCost);
-        spinnerPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
-
-        // Combine spinnerPanel and checkboxPanel into a vertical layout panel
-        JPanel subPanel = new JPanel();
-        subPanel.setLayout(new BoxLayout(subPanel, BoxLayout.Y_AXIS));
-        subPanel.add(spinnerPanel);
-        subPanel.add(Box.createRigidArea(new Dimension(0, 10))); // Add spacing between sections
-
-        // Buttons panel
-        JPanel buttonPanel = new JPanel();
-
-        JButton reinforceButton = new JButton(resources.getString("reinforcementConfirmation.confirmButton"));
-        reinforceButton.setToolTipText(resources.getString("reinforcementConfirmation.confirmButton.tooltip"));
-        reinforceButton.addActionListener(evt -> {
-            int spentSupportPoints = (int) spnSupportPointCost.getValue();
-            int finalTargetNumber = targetNumber - ((spentSupportPoints - 1) * 2);
-
-            currentCampaignState.setSupportPoints(currentCampaignState.getSupportPoints() - spentSupportPoints);
-
-            btnCommitClicked(evt, finalTargetNumber, false, false);
-            dialog.dispose();
-        });
-        reinforceButton.setEnabled(availableSupportPoints > 0);
-
-        JButton reinforceButtonInstant = new JButton(resources.getString(
-              "reinforcementConfirmation.confirmButton.instant"));
-        reinforceButtonInstant.setToolTipText(resources.getString(
-              "reinforcementConfirmation.confirmButton.instant.tooltip"));
-        reinforceButtonInstant.addActionListener(evt -> {
-            int spentSupportPoints = (int) spnSupportPointCost.getValue() * 2;
-            int finalTargetNumber = targetNumber - ((spentSupportPoints - 1) * 2);
-
-            currentCampaignState.setSupportPoints(currentCampaignState.getSupportPoints() - spentSupportPoints);
-
-            btnCommitClicked(evt, finalTargetNumber, false, true);
-            dialog.dispose();
-        });
-        reinforceButtonInstant.setEnabled(availableSupportPoints > 0);
-
-        JButton reinforceButtonGM = new JButton(resources.getString("reinforcementConfirmation.confirmButton.gm"));
-        reinforceButtonGM.setToolTipText(resources.getString("reinforcementConfirmation.confirmButton.gm.tooltip"));
-        reinforceButtonGM.addActionListener(evt -> {
-            btnCommitClicked(evt, 0, true, false);
-            dialog.dispose();
-        });
-        reinforceButtonGM.setVisible(campaign.isGM());
-
-        JButton reinforceButtonGMInstant = new JButton(resources.getString(
-              "reinforcementConfirmation.confirmButton.gm.instant"));
-        reinforceButtonGMInstant.setToolTipText(resources.getString(
-              "reinforcementConfirmation.confirmButton.gm.instant.tooltip"));
-        reinforceButtonGMInstant.addActionListener(evt -> {
-            btnCommitClicked(evt, 0, true, true);
-            dialog.dispose();
-        });
-        reinforceButtonGMInstant.setVisible(campaign.isGM());
-
-        JButton cancelButton = new JButton(resources.getString("reinforcementConfirmation.cancelButton"));
-        cancelButton.addActionListener(evt -> dialog.dispose());
-        buttonPanel.add(reinforceButton);
-        buttonPanel.add(reinforceButtonInstant);
-        buttonPanel.add(reinforceButtonGM);
-        buttonPanel.add(reinforceButtonGMInstant);
-        buttonPanel.add(cancelButton);
-
-        // Info label panel
-        JPanel infoPanel = new JPanel(new BorderLayout());
-        JLabel lblInfo = new JLabel(String.format("<html><div style='width: %s; text-align:center;'>%s</div></html>",
-              RIGHT_WIDTH + LEFT_WIDTH,
-              String.format(resources.getString("reinforcementConfirmation.addendum"))));
-        lblInfo.setHorizontalAlignment(SwingConstants.CENTER);
-        infoPanel.add(lblInfo, BorderLayout.CENTER);
-        infoPanel.setBorder(BorderFactory.createEtchedBorder());
-
-        // South Panel
-        JPanel southPanel = new JPanel(new BorderLayout());
-        southPanel.add(subPanel, BorderLayout.NORTH);
-        southPanel.add(buttonPanel, BorderLayout.CENTER);
-        southPanel.add(infoPanel, BorderLayout.SOUTH);
-
-        // Add southPanel to the dialog
-        dialog.add(southPanel, BorderLayout.SOUTH);
-
-        // Dialog settings
-        dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
-        dialog.setModal(true);
-        dialog.setLocationRelativeTo(null);
-        dialog.pack();
-        dialog.setVisible(true);
     }
 
     /**
@@ -991,15 +831,14 @@ public class StratconScenarioWizard extends JDialog {
      *   <li>Publishes scenarios to the campaign and allows immediate play if forces have been committed.</li>
      * </ul>
      *
-     * @param evt                       the {@link ActionEvent} triggered by the button press
      * @param reinforcementTargetNumber the number representing the reinforcement target threshold used when processing
      *                                  reinforcement deployment
      * @param isGMReinforcement         {@code true} if the player is using GM powers to bypass the reinforcement check,
      *                                  {@code false} otherwise.
      * @param isInstantlyDeployed       {@code true} if the player is deploying instantly
      */
-    private void btnCommitClicked(ActionEvent evt, @Nullable Integer reinforcementTargetNumber,
-          boolean isGMReinforcement, boolean isInstantlyDeployed) {
+    private void btnCommitClicked(@Nullable Integer reinforcementTargetNumber, boolean isGMReinforcement,
+          boolean isInstantlyDeployed) {
         if (parent != null) {
             parent.setCommitForces(true);
         }


### PR DESCRIPTION
This PR replaces the old proto-Immersive Dialog used by the StratCon reinforcement dialog with a proper immersive dialog. This dialog predated the immersive dialog system which is why immersive dialog wasn't originally used.

Unlike the original dialog the Target Number breakdown will update based on the number of additional Support Points dedicated to the attempt.

## Old
<img width="644" height="360" alt="image" src="https://github.com/user-attachments/assets/adaa45ab-2a67-4a35-bc82-e03470bc95af" />

## New
<img width="765" height="656" alt="image" src="https://github.com/user-attachments/assets/58af673b-d706-4d1c-b67f-31d818a84153" />
