### PR TITLE
Fix: Fixed Clans Incorrectly Being Considered Honor:None by Default

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/Faction.java
+++ b/MekHQ/src/mekhq/campaign/universe/Faction.java
@@ -145,9 +145,14 @@ public class Faction {
             end = Objects.requireNonNullElse(active.get(active.size() - 1).end, 9999);
         }
         HonorRating preInvasion = faction2.getPreInvasionHonorRating();
-        preInvasionHonorRating = (preInvasion != null) ? preInvasion : HonorRating.STRICT;
         HonorRating postInvasion = faction2.getPostInvasionHonorRating();
-        postInvasionHonorRating = (postInvasion != null) ? postInvasion : HonorRating.OPPORTUNISTIC;
+        if (isClan()) {
+            preInvasionHonorRating = (preInvasion != HonorRating.NONE) ? preInvasion : HonorRating.STRICT;
+            postInvasionHonorRating = (postInvasion != HonorRating.NONE) ? postInvasion : HonorRating.OPPORTUNISTIC;
+        } else {
+            preInvasionHonorRating = HonorRating.NONE;
+            postInvasionHonorRating = HonorRating.NONE;
+        }
     }
     // endregion Constructors
 


### PR DESCRIPTION
# See Also: https://github.com/MegaMek/megamek/pull/7340

If a Clan does not have an honor entry it's meant to fallback to Strict/Opportunistic based on the current game year (and some RNG). However, if the faction doesn't have an honor entry the code that is meant to handle the fallback never gets triggered, resulting in the Clan having an honor rating of None.

This had massive repercussions for the Clan bidding system, as it caused the Clan to have a bidding budget of 0 BV2. That caused the Clan to bid away their entire force, running into another bug (solved elsewhere) that would then cause the Clan to rebid their entire force - the one they just bid away.

This issue also impacted prisoners, though to a lesser extent.