### PR TITLE
Improvement: Adjusted the Force Generation Budget for 18 Scenario Types

### DIFF
--- a/MekHQ/data/scenariotemplates/Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Breakthrough.xml
@@ -68,7 +68,7 @@ Be advised: the enemy will control the field when this is over. Move fast, strik
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
+++ b/MekHQ/data/scenariotemplates/Critical Convoy Escort.xml
@@ -70,7 +70,7 @@ We will control the field at the end of the battle, giving you full authority to
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Decoy Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Engagement.xml
@@ -74,7 +74,7 @@ Hold the line, weather the storm, and outlast them. If they break, the field is 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.25</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Decoy Interception.xml
+++ b/MekHQ/data/scenariotemplates/Decoy Interception.xml
@@ -74,7 +74,7 @@ Stand firm, draw them in, and ensure they never reach their goal. If they break,
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.25</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Diversion Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Diversion Engagement.xml
@@ -65,7 +65,7 @@ Be advised: the enemy will control the field at the end of the engagement. There
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.25</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Frontline Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Breakthrough.xml
@@ -68,7 +68,7 @@ The enemy will control the battlefield once the engagement concludes, preventing
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Frontline Disruption.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Disruption.xml
@@ -69,7 +69,7 @@ We will control the battlefield at the conclusion of this engagement, ensuring t
                 <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Frontline Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Frontline Engagement.xml
@@ -72,7 +72,7 @@ The victor will control the battlefield at the end of the engagement, securing s
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.25</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Heavy Recon Evasion.xml
@@ -75,7 +75,7 @@ The enemy will control the field at the end of the engagement, meaning there wil
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Intercept Engagement.xml
+++ b/MekHQ/data/scenariotemplates/Intercept Engagement.xml
@@ -65,7 +65,7 @@ The enemy will control the battlefield at the end of the engagement, meaning no 
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.25</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Interception Defense.xml
+++ b/MekHQ/data/scenariotemplates/Interception Defense.xml
@@ -70,7 +70,7 @@ We will control the battlefield at the end of the engagement, securing any remai
                 <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
+++ b/MekHQ/data/scenariotemplates/Low-Atmosphere DropShip Escort.xml
@@ -68,7 +68,7 @@ The victor will control the battlefield at the end of the engagement, ensuring w
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
+++ b/MekHQ/data/scenariotemplates/Picket Line Breakthrough.xml
@@ -68,7 +68,7 @@ As you will be pushing into enemy territory, we will be unable to secure the bat
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Pivotal Battle.xml
+++ b/MekHQ/data/scenariotemplates/Pivotal Battle.xml
@@ -72,7 +72,7 @@ The victor will control the battlefield at the end of the engagement, ensuring w
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>3.0</forceMultiplier>
+                <forceMultiplier>1.5</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Recon Evasion.xml
+++ b/MekHQ/data/scenariotemplates/Recon Evasion.xml
@@ -75,7 +75,7 @@ The enemy will control the field at the end of the engagement, meaning there wil
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Space Blockade Run.xml
+++ b/MekHQ/data/scenariotemplates/Space Blockade Run.xml
@@ -107,7 +107,7 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>1</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>2.0</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
+++ b/MekHQ/data/scenariotemplates/Tactical Withdrawal.xml
@@ -68,7 +68,7 @@ The enemy will control the battlefield at the end of the engagement, meaning the
                 <destinationZone>5</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>

--- a/MekHQ/data/scenariotemplates/deprecatedTemplates/Skirmish Disruption.xml
+++ b/MekHQ/data/scenariotemplates/deprecatedTemplates/Skirmish Disruption.xml
@@ -63,7 +63,7 @@
                 <destinationZone>6</destinationZone>
                 <fixedUnitCount>0</fixedUnitCount>
                 <forceAlignment>2</forceAlignment>
-                <forceMultiplier>1.5</forceMultiplier>
+                <forceMultiplier>1.0</forceMultiplier>
                 <forceName>OpFor</forceName>
                 <generationMethod>1</generationMethod>
                 <generationOrder>5</generationOrder>


### PR DESCRIPTION
Since the onset of FG3, much earlier in the 50.x cycle, some work was done to make different scenario templates feel more distinct. As a part of that we adjusted the BV budget calculations by a few multipliers here and there. This was intended to create scenarios where the player would need to reinforce to win.

While the intent was pure, the play feel was not. Overbudgeted and impossible scenarios became a constant point of complaint and confusion among the player base.

Therefore, I have gone through and reduced all scenario budget multipliers from their original value down to x1. The sole exception being 'Pivotal Battle' which has been reduced to x1.5, from a frankly insane x3 - Blake knows what I was smoking that day.