### PR TITLE
Improvement: Updated Support Point Generation to be By-Weekly, Not Weekly

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -440,6 +440,14 @@ public class Campaign implements ITechManager {
     FactionStandingUltimatumsLibrary factionStandingUltimatumsLibrary;
 
     /**
+     * A constant that provides the ISO-8601 definition of week-based fields.
+     *
+     * <p>This includes the first day of the week set to Monday and the minimal number of days in the first week of
+     * the year set to 4.</p>
+     */
+    private static final WeekFields WEEK_FIELDS = WeekFields.ISO;
+
+    /**
      * Represents the different types of administrative specializations. Each specialization corresponds to a distinct
      * administrative role within the organization.
      *
@@ -5179,7 +5187,7 @@ public class Campaign implements ITechManager {
             }
         }
 
-        int weekOfYear = currentDay.get(WeekFields.of(Locale.getDefault()).weekOfYear());
+        int weekOfYear = currentDay.get(WEEK_FIELDS.weekOfYear());
         boolean isOddWeek = (weekOfYear % 2 == 1);
         if (campaignOptions.isUseStratCon()
                   && (currentDay.getDayOfWeek() == DayOfWeek.MONDAY)

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -101,6 +101,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.WeekFields;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -5178,7 +5179,11 @@ public class Campaign implements ITechManager {
             }
         }
 
-        if (campaignOptions.isUseStratCon() && (currentDay.getDayOfWeek() == DayOfWeek.MONDAY)) {
+        int weekOfYear = currentDay.get(WeekFields.of(Locale.getDefault()).weekOfYear());
+        boolean isOddWeek = (weekOfYear % 2 == 1);
+        if (campaignOptions.isUseStratCon()
+                  && (currentDay.getDayOfWeek() == DayOfWeek.MONDAY)
+                  && isOddWeek) {
             negotiateAdditionalSupportPoints(this);
         }
 


### PR DESCRIPTION
With this change support points are generated on each odd numbered week, while on contract, rather than weekly.

This change has been made in response to the reduced BV budgets in scenarios (see elsewhere). With the reduced BV budget the current Support Point economics would have resulted in players able to reinforce every week, resulting in a 'win more' condition.