### PR TITLE
Improvement: Removed Refund Clause for Mercenary Auctions

### DIFF
--- a/MekHQ/resources/mekhq/resources/MercenaryAuctionDialog.properties
+++ b/MekHQ/resources/mekhq/resources/MercenaryAuctionDialog.properties
@@ -16,7 +16,7 @@ auction.ooc.hasFunds=The minimum bid was set at {0} {0, choice, 0#Support Points
   \ and you have {1} {1, choice, 0#Support Points|1#Support Point|2#Support Points} available. Each\
   \ tier of bidding will set you back {0} {0, choice, 0#Support Points|1#Support Point|2#Support Points}\
   \ and increase your chance of winning the bid by {2}%.\
-  <p>If your bid does not succeed, <b>all bid Support Points will be lost</b>.</p>
+  <p>All bid Support Points will be deducted regardless of auction outcome.</p>
 
 auction.ic.noFunds={0}, an auction just opened, and there''s a single {1} up for sale that could''ve\
   \ been a valuable pickup. Unfortunately, we''re unable to afford the minimum bid.\

--- a/MekHQ/resources/mekhq/resources/MercenaryAuctionDialog.properties
+++ b/MekHQ/resources/mekhq/resources/MercenaryAuctionDialog.properties
@@ -15,8 +15,8 @@ auction.ic.hasFunds=I just got word that an auction is happening in the next few
 auction.ooc.hasFunds=The minimum bid was set at {0} {0, choice, 0#Support Points|1#Support Point|2#Support Points}\
   \ and you have {1} {1, choice, 0#Support Points|1#Support Point|2#Support Points} available. Each\
   \ tier of bidding will set you back {0} {0, choice, 0#Support Points|1#Support Point|2#Support Points}\
-  \ and increase your chance of winning the bid by {2}%. If your bid does not succeed, no resources\
-  \ will be spent.
+  \ and increase your chance of winning the bid by {2}%.\
+  <p>If your bid does not succeed, <b>all bid Support Points will be lost</b>.</p>
 
 auction.ic.noFunds={0}, an auction just opened, and there''s a single {1} up for sale that could''ve\
   \ been a valuable pickup. Unfortunately, we''re unable to afford the minimum bid.\

--- a/MekHQ/src/mekhq/campaign/randomEvents/MercenaryAuction.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/MercenaryAuction.java
@@ -131,8 +131,7 @@ public class MercenaryAuction {
               maximumBid,
               AUCTION_TIER_SUCCESS_PERCENT,
               max(requiredCombatTeams, 1));
-        int bidSuccessChance = (mercenaryAuctionDialog.getSpinnerValue() / Math.max(1, minimumBid)) *
-                                          AUCTION_TIER_SUCCESS_PERCENT;
+        int bidSuccessChance = (mercenaryAuctionDialog.getSpinnerValue() / minimumBid) * AUCTION_TIER_SUCCESS_PERCENT;
 
         // If the player confirmed the auction, then check whether they were successful,
         // deliver the unit, and deduct funds.
@@ -140,11 +139,9 @@ public class MercenaryAuction {
             return;
         }
 
-        // The use of <= is important here as it ensures that even if the user bids 50 %, they can
-        // still win.
-        if (randomInt(100) <= bidSuccessChance) {
-            campaignState.changeSupportPoints(-mercenaryAuctionDialog.getSpinnerValue());
+        campaignState.changeSupportPoints(-mercenaryAuctionDialog.getSpinnerValue());
 
+        if (randomInt(100) < bidSuccessChance) {
             // The delivery time is so that the unit addition is picked up by the 'mothball'
             // campaign option. It also makes sense the unit wouldn't magically materialize in your
             // hangar and has to get there.


### PR DESCRIPTION
The concept behind the Mercenary Auction system was to provide the player a way to get ahold of desirable units for free in exchange for a risk-reward. The risk being reduced Support Points.

However, with the reduced cost of this event combined with its frequency, the risk of _maybe you'll not have enough SP to reinforce_ was mitigated by the fact that you didn't lose your bid if you lost.

This PR changes now, now your bid is lost even if unsuccessful. This drives home the risk-reward nature of this event.