### PR TITLE
Fix 2948: Keep ordered part numbers consistent across dialogs

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3183,10 +3183,10 @@ public class Campaign implements ITechManager {
         for (IAcquisitionWork maybePart : shoppingList.getPartList()) {
             PartInUse newPartInUse = getPartInUse((Part) maybePart);
             if (partInUse.equals(newPartInUse)) {
-                partInUse.setPlannedCount(partInUse.getPlannedCount() +
-                                                getQuantity((maybePart instanceof MissingPart) ?
-                                                                  ((MissingPart) maybePart).getNewPart() :
-                                                                  (Part) maybePart) * maybePart.getQuantity());
+                Part newPart = (maybePart instanceof MissingPart) ?
+                                        (((MissingPart) maybePart).getNewPart())
+                                        : (Part) maybePart;
+                partInUse.setPlannedCount(partInUse.getPlannedCount() + newPart.getTotalQuantity());
             }
         }
     }
@@ -3280,11 +3280,10 @@ public class Campaign implements ITechManager {
                 }
                 inUse.put(partInUse, partInUse);
             }
-            partInUse.setPlannedCount(partInUse.getPlannedCount() +
-                                            getQuantity((maybePart instanceof MissingPart) ?
-                                                              ((MissingPart) maybePart).getNewPart() :
-                                                              (Part) maybePart) * maybePart.getQuantity());
-
+            Part newPart = (maybePart instanceof MissingPart) ?
+                    (((MissingPart) maybePart).getNewPart())
+                    : (Part) maybePart;
+            partInUse.setPlannedCount(partInUse.getPlannedCount() + newPart.getTotalQuantity());
         }
         return inUse.keySet()
                      .stream()
@@ -9692,21 +9691,9 @@ public class Campaign implements ITechManager {
             }
             if (part.isSamePartType(p)) {
                 if (p.isPresent()) {
-                    if (p instanceof Armor) { // ProtomekArmor and BAArmor are derived from Armor
-                        nSupply += ((Armor) p).getAmount();
-                    } else if (p instanceof AmmoStorage) {
-                        nSupply += ((AmmoStorage) p).getShots();
-                    } else {
-                        nSupply += p.getQuantity();
-                    }
+                    nSupply += p.getTotalQuantity();
                 } else {
-                    if (p instanceof Armor) { // ProtomekArmor and BAArmor are derived from Armor
-                        nTransit += ((Armor) p).getAmount();
-                    } else if (p instanceof AmmoStorage) {
-                        nTransit += ((AmmoStorage) p).getShots();
-                    } else {
-                        nTransit += p.getQuantity();
-                    }
+                    nTransit += p.getTotalQuantity();
                 }
             }
         }
@@ -9717,13 +9704,7 @@ public class Campaign implements ITechManager {
         int nOrdered = 0;
         IAcquisitionWork onOrder = getShoppingList().getShoppingItem(part);
         if (null != onOrder) {
-            if (onOrder instanceof Armor) { // ProtoMek Armor and BAArmor are derived from Armor
-                nOrdered += ((Armor) onOrder).getAmount() * ((Armor) onOrder).getQuantity();
-            } else if (onOrder instanceof AmmoStorage) {
-                nOrdered += ((AmmoStorage) onOrder).getShots();
-            } else {
-                nOrdered += onOrder.getQuantity();
-            }
+            nOrdered += onOrder.getTotalQuantity();
         }
 
         inventory.setOrdered(nOrdered);

--- a/MekHQ/src/mekhq/campaign/market/ShoppingList.java
+++ b/MekHQ/src/mekhq/campaign/market/ShoppingList.java
@@ -139,6 +139,7 @@ public class ShoppingList {
                     shoppingItem.incrementQuantity();
                     quantity--;
                 }
+                MekHQ.triggerEvent(new ProcurementEvent(newWork));
                 return;
             }
         }

--- a/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
+++ b/MekHQ/src/mekhq/campaign/parts/AmmoStorage.java
@@ -139,6 +139,11 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
                      && Objects.equals(getType(), ((AmmoStorage) part).getType());
     }
 
+    @Override
+    public int getTotalQuantity() {
+        return getQuantity() * getShots();
+    }
+
     /**
      * Gets a value indicating whether or an {@code AmmoType} is the same as this instance's ammo.
      *
@@ -355,10 +360,7 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     }
 
     public AmmoStorage getNewPart() {
-        if (getType().getKgPerShot() > 0) {
-            return new AmmoStorage(1, getType(), (int) Math.ceil(1000 / getType().getKgPerShot()), campaign);
-        }
-        return new AmmoStorage(1, getType(), getType().getShots(), campaign);
+        return new AmmoStorage(1, getType(), getShotsPerTon(), campaign);
     }
 
     @Override
@@ -396,5 +398,16 @@ public class AmmoStorage extends EquipmentPart implements IAcquisitionWork {
     @Override
     public boolean isExtinctIn(int year, boolean clan, Faction techFaction) {
         return isExtinct(year, clan, techFaction);
+    }
+
+    protected int getShotsPerTon() {
+        AmmoType ammoType = getType();
+
+        if (ammoType.hasCustomKgPerShot()) {
+            return (int) Math.floor(1000.0 / ammoType.getKgPerShot());
+        }
+
+        // if not listed by kg per shot, we assume this is a single ton increment
+        return ammoType.getShots();
     }
 }

--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -716,6 +716,11 @@ public class Armor extends Part implements IAcquisitionWork {
         return true;
     }
 
+    @Override
+    public int getTotalQuantity() {
+        return getQuantity() * getAmount();
+    }
+
     public void changeType(int ty, boolean cl) {
         this.type = ty;
         this.clan = cl;

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -1358,6 +1358,10 @@ public abstract class Part implements IPartWork, ITechnology {
         return quantity;
     }
 
+    public int getTotalQuantity() {
+        return getQuantity();
+    }
+
     public int getSellableQuantity() {
         return getQuantity();
     }

--- a/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/AmmoBin.java
@@ -139,6 +139,11 @@ public class AmmoBin extends EquipmentPart implements IAcquisitionWork {
         return getFullShots() / (double) getType().getShots();
     }
 
+    @Override
+    public int getTotalQuantity() {
+        return getQuantity() * getType().getShots();
+    }
+
     public int getFullShots() {
         if (oneShot) {
             return 1;

--- a/MekHQ/src/mekhq/campaign/work/IAcquisitionWork.java
+++ b/MekHQ/src/mekhq/campaign/work/IAcquisitionWork.java
@@ -78,6 +78,14 @@ public interface IAcquisitionWork extends IWork {
 
     String getQuantityName(int quantity);
 
+    /**
+     * Gets the true number of parts represented by this AcquisitionWork. An ammo part that
+     * contains six shots should return six, not one.
+     */
+    default int getTotalQuantity() {
+        return getQuantity();
+    }
+
     void incrementQuantity();
 
     void decrementQuantity();

--- a/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
@@ -81,7 +81,8 @@ import mekhq.campaign.parts.protomeks.ProtoMekSensor;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.gui.CampaignGUI;
-import mekhq.gui.dialog.PartsStoreDialog.PartsTableModel.PartProxy;
+import mekhq.gui.model.PartsStoreModel;
+import mekhq.gui.model.PartsStoreModel.PartProxy;
 import mekhq.gui.sorter.PartsDetailSorter;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
 
@@ -111,11 +112,10 @@ public class PartsStoreDialog extends JDialog {
 
     private final Campaign campaign;
     private final CampaignGUI campaignGUI;
-    private final PartsTableModel partsModel;
-    private TableRowSorter<PartsTableModel> partsSorter;
+    private final PartsStoreModel partsModel;
+    private TableRowSorter<PartsStoreModel> partsSorter;
     private final boolean addToCampaign;
     private Part selectedPart;
-    private Person logisticsPerson;
 
     private JTable partsTable;
     private JTextField txtFilter;
@@ -137,7 +137,7 @@ public class PartsStoreDialog extends JDialog {
         this.campaignGUI = gui;
         this.campaign = campaign;
         this.addToCampaign = add;
-        partsModel = new PartsTableModel(campaign.getPartsStore().getInventory());
+        partsModel = new PartsStoreModel(gui, campaign.getPartsStore().getInventory());
         initComponents();
         filterParts();
         setLocationRelativeTo(frame);
@@ -155,10 +155,10 @@ public class PartsStoreDialog extends JDialog {
         partsTable = new JTable(partsModel);
         partsTable.setName("partsTable");
         partsSorter = new TableRowSorter<>(partsModel);
-        partsSorter.setComparator(PartsTableModel.COL_DETAIL, new PartsDetailSorter());
+        partsSorter.setComparator(PartsStoreModel.COL_DETAIL, new PartsDetailSorter());
         partsTable.setRowSorter(partsSorter);
         TableColumn column;
-        for (int i = 0; i < PartsTableModel.N_COL; i++) {
+        for (int i = 0; i < PartsStoreModel.N_COL; i++) {
             column = partsTable.getColumnModel().getColumn(i);
             column.setPreferredWidth(partsModel.getColumnWidth(i));
             column.setCellRenderer(partsModel.getRenderer());
@@ -248,13 +248,13 @@ public class PartsStoreDialog extends JDialog {
                         addPart(true, partProxy.getPart(), 1);
                         partProxy.updateTargetAndInventories();
                         partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                              PartsTableModel.COL_TARGET);
+                              PartsStoreModel.COL_TARGET);
                         partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                              PartsTableModel.COL_TRANSIT);
+                              PartsStoreModel.COL_TRANSIT);
                         partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                              PartsTableModel.COL_SUPPLY);
+                              PartsStoreModel.COL_SUPPLY);
                         partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                              PartsTableModel.COL_QUEUE);
+                              PartsStoreModel.COL_QUEUE);
                     }
                 }
             });
@@ -282,13 +282,13 @@ public class PartsStoreDialog extends JDialog {
                             addPart(true, partProxy.getPart(), quantity);
                             partProxy.updateTargetAndInventories();
                             partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                                  PartsTableModel.COL_TARGET);
+                                  PartsStoreModel.COL_TARGET);
                             partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                                  PartsTableModel.COL_TRANSIT);
+                                  PartsStoreModel.COL_TRANSIT);
                             partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                                  PartsTableModel.COL_SUPPLY);
+                                  PartsStoreModel.COL_SUPPLY);
                             partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                                  PartsTableModel.COL_QUEUE);
+                                  PartsStoreModel.COL_QUEUE);
                         }
                     }
                 }
@@ -306,13 +306,13 @@ public class PartsStoreDialog extends JDialog {
                         addPart(false, partProxy.getPart(), 1);
                         partProxy.updateTargetAndInventories();
                         partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                              PartsTableModel.COL_TARGET);
+                              PartsStoreModel.COL_TARGET);
                         partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                              PartsTableModel.COL_TRANSIT);
+                              PartsStoreModel.COL_TRANSIT);
                         partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                              PartsTableModel.COL_SUPPLY);
+                              PartsStoreModel.COL_SUPPLY);
                         partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                              PartsTableModel.COL_QUEUE);
+                              PartsStoreModel.COL_QUEUE);
                     }
                 }
             });
@@ -343,13 +343,13 @@ public class PartsStoreDialog extends JDialog {
                             addPart(false, partProxy.getPart(), quantity);
                             partProxy.updateTargetAndInventories();
                             partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                                  PartsTableModel.COL_TARGET);
+                                  PartsStoreModel.COL_TARGET);
                             partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                                  PartsTableModel.COL_TRANSIT);
+                                  PartsStoreModel.COL_TRANSIT);
                             partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                                  PartsTableModel.COL_SUPPLY);
+                                  PartsStoreModel.COL_SUPPLY);
                             partsModel.fireTableCellUpdated(partsTable.convertRowIndexToModel(i),
-                                  PartsTableModel.COL_QUEUE);
+                                  PartsStoreModel.COL_QUEUE);
                         }
                     }
                 }
@@ -407,10 +407,10 @@ public class PartsStoreDialog extends JDialog {
 
     public void filterParts() {
         final int nGroup = choiceParts.getSelectedIndex();
-        RowFilter<PartsTableModel, Integer> partsTypeFilter = new RowFilter<>() {
+        RowFilter<PartsStoreModel, Integer> partsTypeFilter = new RowFilter<>() {
             @Override
-            public boolean include(Entry<? extends PartsTableModel, ? extends Integer> entry) {
-                PartsTableModel partsModel = entry.getModel();
+            public boolean include(Entry<? extends PartsStoreModel, ? extends Integer> entry) {
+                PartsStoreModel partsModel = entry.getModel();
                 Part part = partsModel.getPartAt(entry.getIdentifier());
 
                 if (hideImpossible.isSelected()) {
@@ -548,470 +548,5 @@ public class PartsStoreDialog extends JDialog {
             case SG_OMNI_POD -> "Empty OmniPods";
             default -> "?";
         };
-    }
-
-    private Person getLogisticsPerson() {
-        if (null == logisticsPerson) {
-            logisticsPerson = campaign.getLogisticsPerson();
-        }
-        return logisticsPerson;
-    }
-
-    /**
-     * A table model for displaying parts - similar to the one in CampaignGUI, but not exactly
-     */
-    public class PartsTableModel extends AbstractTableModel {
-        protected String[] columnNames;
-        protected ArrayList<PartProxy> data;
-
-        public final static int COL_NAME = 0;
-        public final static int COL_DETAIL = 1;
-        public final static int COL_TECH_BASE = 2;
-        public final static int COL_COST = 3;
-        public final static int COL_TON = 4;
-        public final static int COL_TARGET = 5;
-        public final static int COL_SUPPLY = 6;
-        public final static int COL_TRANSIT = 7;
-        public final static int COL_QUEUE = 8;
-        public final static int N_COL = 9;
-
-        /**
-         * Provides a lazy view to a {@link TargetRoll} for use in a UI (e.g. sorting in a table).
-         */
-        public static class TargetProxy implements Comparable<TargetProxy> {
-            private final TargetRoll target;
-            private String details;
-            private String description;
-
-            /**
-             * Creates a new proxy object for a {@link TargetRoll}.
-             *
-             * @param t The {@link TargetRoll} to be proxied. May be null.
-             */
-            public TargetProxy(@Nullable TargetRoll t) {
-                target = t;
-            }
-
-            /**
-             * Gets the target roll.
-             *
-             * @return The target roll.
-             */
-            public TargetRoll getTargetRoll() {
-                return target;
-            }
-
-            /**
-             * Gets a description of the target roll.
-             *
-             * @return A description of the target roll.
-             */
-            @Nullable
-            public String getDescription() {
-                if (null == target) {
-                    return null;
-                }
-                if (null == description) {
-                    description = target.getDesc();
-                }
-                return description;
-            }
-
-            /**
-             * Gets a string representation of a {@link TargetRoll}.
-             *
-             * @return A string representation of a {@link TargetRoll}.
-             */
-            @Override
-            public String toString() {
-                if (null == target) {
-                    return "-";
-                }
-
-                if (null == details) {
-                    details = target.getValueAsString();
-                    if (target.getValue() != TargetRoll.IMPOSSIBLE &&
-                              target.getValue() != TargetRoll.AUTOMATIC_SUCCESS &&
-                              target.getValue() != TargetRoll.AUTOMATIC_FAIL) {
-                        details += "+";
-                    }
-                }
-
-                return details;
-            }
-
-            /**
-             * Converts a {@link TargetRoll} into an integer for comparisons.
-             *
-             * @return An integer representation of the {@link TargetRoll}.
-             */
-            private int coerceTargetRoll() {
-                int r = target.getValue();
-                if (r == TargetRoll.IMPOSSIBLE) {
-                    return Integer.MAX_VALUE;
-                } else if (r == TargetRoll.AUTOMATIC_FAIL) {
-                    return Integer.MAX_VALUE - 1;
-                } else if (r == TargetRoll.AUTOMATIC_SUCCESS) {
-                    return Integer.MIN_VALUE;
-                }
-                return r;
-            }
-
-            /**
-             * {@inheritDoc}
-             *
-             * @param o The {@link TargetProxy} to compare this instance to.
-             *
-             * @return {@inheritDoc}
-             */
-            @Override
-            public int compareTo(TargetProxy o) {
-                return Integer.compare(coerceTargetRoll(), o.coerceTargetRoll());
-            }
-        }
-
-        /**
-         * Provides a container for a value formatted for display and the value itself for sorting.
-         */
-        public record FormattedValue<T extends Comparable<T>>(T value, String formatted)
-              implements Comparable<FormattedValue<T>> {
-            /**
-             * Creates a wrapper around a value and a formatted string representing the value.
-             */
-            public FormattedValue {
-            }
-
-            /**
-             * Gets the wrapped value.
-             *
-             * @return The value.
-             */
-            @Override
-            public T value() {
-                return value;
-            }
-
-            /**
-             * Gets the formatted value.
-             *
-             * @return The formatted value.
-             */
-            @Override
-            @Nonnull
-            public String toString() {
-                return formatted;
-            }
-
-            /**
-             * {@inheritDoc}
-             *
-             * @return {@inheritDoc}
-             */
-            @Override
-            public int compareTo(@Nonnull FormattedValue<T> o) {
-                return value().compareTo(o.value());
-            }
-        }
-
-        /**
-         * Provides a lazy view to a {@link Part} for use in a UI (e.g. sorting in a table).
-         */
-        public class PartProxy {
-            private final Part part;
-            private String details;
-            private TargetProxy targetProxy;
-            private FormattedValue<Money> cost;
-            private PartInventory inventories;
-            private FormattedValue<Integer> ordered;
-            private FormattedValue<Integer> supply;
-            private FormattedValue<Integer> transit;
-
-            /**
-             * Initializes a new instance of the class to provide a proxy view into a part.
-             *
-             * @param p The part to proxy. Must not be null.
-             */
-            public PartProxy(Part p) {
-                part = Objects.requireNonNull(p);
-            }
-
-            /**
-             * Updates the proxied view of the properties which changed outside the proxy.
-             */
-            public void updateTargetAndInventories() {
-                targetProxy = null;
-                inventories = null;
-                ordered = null;
-                supply = null;
-                transit = null;
-            }
-
-            /**
-             * Gets the part being proxied.
-             *
-             * @return The part being proxied.
-             */
-            public Part getPart() {
-                return part;
-            }
-
-            /**
-             * Gets the part's name.
-             *
-             * @return The part's name.
-             */
-            public String getName() {
-                return part.getName();
-            }
-
-            /**
-             * Gets the part's details.
-             *
-             * @return The part's detailed.
-             */
-            public String getDetails() {
-                if (null == details) {
-                    details = part.getDetails();
-                }
-
-                return details;
-            }
-
-            /**
-             * Gets the part's cost, suitable for use in a UI element which requires both a display value and a sortable
-             * value.
-             *
-             * @return The part's cost as a {@link FormattedValue}
-             */
-            public FormattedValue<Money> getCost() {
-                if (null == cost) {
-                    Money actualValue = part.getActualValue();
-                    cost = new FormattedValue<>(actualValue, actualValue.toAmountString());
-                }
-                return cost;
-            }
-
-            /**
-             * Gets the part's tonnage.
-             *
-             * @return The part's tonnage.
-             */
-            public double getTonnage() {
-                return Math.round(part.getTonnage() * 100) / 100.0;
-            }
-
-            /**
-             * Gets the part's tech base.
-             *
-             * @return The part's tech base.
-             */
-            public String getTechBase() {
-                return part.getTechBaseName();
-            }
-
-            /**
-             * Gets the part's {@link TargetRoll}.
-             *
-             * @return A {@link TargetProxy} representing the target roll for the part.
-             */
-            public TargetProxy getTarget() {
-                if (null == targetProxy) {
-                    IAcquisitionWork shoppingItem = part.getMissingPart();
-                    if (null == shoppingItem && part instanceof IAcquisitionWork) {
-                        shoppingItem = (IAcquisitionWork) part;
-                    }
-                    if (null != shoppingItem) {
-                        TargetRoll target = campaign.getTargetForAcquisition(shoppingItem, getLogisticsPerson(), true);
-                        targetProxy = new TargetProxy(target);
-                    } else {
-                        targetProxy = new TargetProxy(null);
-                    }
-                }
-
-                return targetProxy;
-            }
-
-            /**
-             * Gets the part's quantity on order, suitable for use in a UI element which requires both a display value
-             * and a sortable value.
-             *
-             * @return The part's quantity on order as a {@link FormattedValue}
-             */
-            public FormattedValue<Integer> getOrdered() {
-                if (null == inventories) {
-                    inventories = campaign.getPartInventory(part);
-                }
-                if (null == ordered) {
-                    ordered = new FormattedValue<>(inventories.getOrdered(), inventories.orderedAsString());
-                }
-                return ordered;
-            }
-
-            /**
-             * Gets the part's quantity on hand, suitable for use in a UI element which requires both a display value
-             * and a sortable value.
-             *
-             * @return The part's quantity on hand as a {@link FormattedValue}
-             */
-            public FormattedValue<Integer> getSupply() {
-                if (null == inventories) {
-                    inventories = campaign.getPartInventory(part);
-                }
-                if (null == supply) {
-                    supply = new FormattedValue<>(inventories.getSupply(), inventories.supplyAsString());
-                }
-                return supply;
-            }
-
-            /**
-             * Gets the part's quantity in transit, suitable for use in a UI element which requires both a display value
-             * and a sortable value.
-             *
-             * @return The part's quantity in transit as a {@link FormattedValue}
-             */
-            public FormattedValue<Integer> getTransit() {
-                if (null == inventories) {
-                    inventories = campaign.getPartInventory(part);
-                }
-                if (null == transit) {
-                    transit = new FormattedValue<>(inventories.getTransit(), inventories.transitAsString());
-                }
-                return transit;
-            }
-        }
-
-        public PartsTableModel(ArrayList<Part> inventory) {
-            data = new ArrayList<>(inventory.size());
-            for (Part part : inventory) {
-                data.add(new PartProxy(part));
-            }
-        }
-
-        @Override
-        public int getRowCount() {
-            return data.size();
-        }
-
-        @Override
-        public int getColumnCount() {
-            return N_COL;
-        }
-
-        @Override
-        public String getColumnName(int column) {
-            return switch (column) {
-                case COL_NAME -> "Name";
-                case COL_DETAIL -> "Detail";
-                case COL_COST -> "Cost";
-                case COL_TON -> "Ton";
-                case COL_TECH_BASE -> "Tech";
-                case COL_TARGET -> "Target";
-                case COL_QUEUE -> "# Ordered";
-                case COL_SUPPLY -> "# Supply";
-                case COL_TRANSIT -> "# Transit";
-                default -> "?";
-            };
-        }
-
-        @Override
-        public Object getValueAt(int row, int col) {
-            PartProxy part;
-            if (data.isEmpty()) {
-                return "";
-            } else {
-                part = data.get(row);
-            }
-            if (col == COL_NAME) {
-                return part.getName();
-            }
-            if (col == COL_DETAIL) {
-                return part.getDetails();
-            }
-            if (col == COL_COST) {
-                return part.getCost();
-            }
-            if (col == COL_TON) {
-                return part.getTonnage();
-            }
-            if (col == COL_TECH_BASE) {
-                return part.getTechBase();
-            }
-            if (col == COL_TARGET) {
-                return part.getTarget();
-            }
-            if (col == COL_SUPPLY) {
-                return part.getSupply();
-            }
-            if (col == COL_TRANSIT) {
-                return part.getTransit();
-            }
-            if (col == COL_QUEUE) {
-                return part.getOrdered();
-            }
-            return "?";
-        }
-
-        @Override
-        public Class<?> getColumnClass(int c) {
-            return getValueAt(0, c).getClass();
-        }
-
-        public PartProxy getPartProxyAt(int row) {
-            return data.get(row);
-        }
-
-        public Part getPartAt(int row) {
-            return data.get(row).getPart();
-        }
-
-        public int getColumnWidth(int c) {
-            return switch (c) {
-                case COL_NAME, COL_DETAIL -> 100;
-                case COL_COST, COL_TARGET -> 40;
-                case COL_SUPPLY, COL_TRANSIT, COL_QUEUE -> 30;
-                default -> 15;
-            };
-        }
-
-        public int getAlignment(int col) {
-            return switch (col) {
-                case COL_COST, COL_TON -> SwingConstants.RIGHT;
-                case COL_TARGET -> SwingConstants.CENTER;
-                default -> SwingConstants.LEFT;
-            };
-        }
-
-        public String getTooltip(int row, int col) {
-            PartProxy part;
-            if (data.isEmpty()) {
-                return null;
-            } else {
-                part = data.get(row);
-            }
-            if (col == COL_TARGET) {
-                return part.getTarget().getDescription();
-            }
-            return null;
-        }
-
-        public Renderer getRenderer() {
-            return new Renderer();
-        }
-
-        public class Renderer extends DefaultTableCellRenderer {
-            @Override
-            public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
-                  boolean hasFocus, int row, int column) {
-                super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-                setOpaque(true);
-                int actualCol = table.convertColumnIndexToModel(column);
-                int actualRow = table.convertRowIndexToModel(row);
-                setHorizontalAlignment(getAlignment(actualCol));
-                setToolTipText(getTooltip(actualRow, actualCol));
-
-                return this;
-            }
-
-        }
     }
 }

--- a/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsInUseTableModel.java
@@ -417,5 +417,4 @@ public class PartsInUseTableModel extends DataTableModel<PartInUse> {
             super.setValueAt(value, rowIndex, columnIndex);
         }
     }
-
 }

--- a/MekHQ/src/mekhq/gui/model/PartsStoreModel.java
+++ b/MekHQ/src/mekhq/gui/model/PartsStoreModel.java
@@ -1,0 +1,523 @@
+/*
+ * Copyright (c) 2009 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
+ * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.model;
+
+import java.awt.Component;
+import java.util.ArrayList;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+import javax.swing.JTable;
+import javax.swing.SwingConstants;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+
+import megamek.common.annotations.Nullable;
+import megamek.common.rolls.TargetRoll;
+
+import mekhq.campaign.Campaign;
+import mekhq.campaign.finances.Money;
+import mekhq.campaign.parts.Part;
+import mekhq.campaign.parts.PartInventory;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.work.IAcquisitionWork;
+import mekhq.gui.CampaignGUI;
+
+/**
+ * A table model for displaying parts - similar to the one in CampaignGUI, but not exactly
+ */
+public class PartsStoreModel extends AbstractTableModel {
+    protected Campaign campaign;
+    protected String[] columnNames;
+    protected ArrayList<PartProxy> data;
+    protected Person logisticsPerson;
+
+    public final static int COL_NAME = 0;
+    public final static int COL_DETAIL = 1;
+    public final static int COL_TECH_BASE = 2;
+    public final static int COL_COST = 3;
+    public final static int COL_TON = 4;
+    public final static int COL_TARGET = 5;
+    public final static int COL_SUPPLY = 6;
+    public final static int COL_TRANSIT = 7;
+    public final static int COL_QUEUE = 8;
+    public final static int N_COL = 9;
+
+    /**
+     * Provides a lazy view to a {@link TargetRoll} for use in a UI (e.g. sorting in a table).
+     */
+    public static class TargetProxy implements Comparable<TargetProxy> {
+        private final TargetRoll target;
+        private String details;
+        private String description;
+
+        /**
+         * Creates a new proxy object for a {@link TargetRoll}.
+         *
+         * @param t The {@link TargetRoll} to be proxied. May be null.
+         */
+        public TargetProxy(@Nullable TargetRoll t) {
+            target = t;
+        }
+
+        /**
+         * Gets the target roll.
+         *
+         * @return The target roll.
+         */
+        public TargetRoll getTargetRoll() {
+            return target;
+        }
+
+        /**
+         * Gets a description of the target roll.
+         *
+         * @return A description of the target roll.
+         */
+        @Nullable
+        public String getDescription() {
+            if (null == target) {
+                return null;
+            }
+            if (null == description) {
+                description = target.getDesc();
+            }
+            return description;
+        }
+
+        /**
+         * Gets a string representation of a {@link TargetRoll}.
+         *
+         * @return A string representation of a {@link TargetRoll}.
+         */
+        @Override
+        public String toString() {
+            if (null == target) {
+                return "-";
+            }
+
+            if (null == details) {
+                details = target.getValueAsString();
+                if (target.getValue() != TargetRoll.IMPOSSIBLE &&
+                          target.getValue() != TargetRoll.AUTOMATIC_SUCCESS &&
+                          target.getValue() != TargetRoll.AUTOMATIC_FAIL) {
+                    details += "+";
+                }
+            }
+
+            return details;
+        }
+
+        /**
+         * Converts a {@link TargetRoll} into an integer for comparisons.
+         *
+         * @return An integer representation of the {@link TargetRoll}.
+         */
+        private int coerceTargetRoll() {
+            int r = target.getValue();
+            if (r == TargetRoll.IMPOSSIBLE) {
+                return Integer.MAX_VALUE;
+            } else if (r == TargetRoll.AUTOMATIC_FAIL) {
+                return Integer.MAX_VALUE - 1;
+            } else if (r == TargetRoll.AUTOMATIC_SUCCESS) {
+                return Integer.MIN_VALUE;
+            }
+            return r;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @param o The {@link TargetProxy} to compare this instance to.
+         *
+         * @return {@inheritDoc}
+         */
+        @Override
+        public int compareTo(TargetProxy o) {
+            return Integer.compare(coerceTargetRoll(), o.coerceTargetRoll());
+        }
+    }
+
+    /**
+     * Provides a container for a value formatted for display and the value itself for sorting.
+     */
+    public record FormattedValue<T extends Comparable<T>>(T value, String formatted)
+          implements Comparable<FormattedValue<T>> {
+        /**
+         * Creates a wrapper around a value and a formatted string representing the value.
+         */
+        public FormattedValue {
+        }
+
+        /**
+         * Gets the wrapped value.
+         *
+         * @return The value.
+         */
+        @Override
+        public T value() {
+            return value;
+        }
+
+        /**
+         * Gets the formatted value.
+         *
+         * @return The formatted value.
+         */
+        @Override
+        @Nonnull
+        public String toString() {
+            return formatted;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @return {@inheritDoc}
+         */
+        @Override
+        public int compareTo(@Nonnull FormattedValue<T> o) {
+            return value().compareTo(o.value());
+        }
+    }
+
+    /**
+     * Provides a lazy view to a {@link Part} for use in a UI (e.g. sorting in a table).
+     */
+    public class PartProxy {
+        private final Part part;
+        private String details;
+        private TargetProxy targetProxy;
+        private FormattedValue<Money> cost;
+        private PartInventory inventories;
+        private FormattedValue<Integer> ordered;
+        private FormattedValue<Integer> supply;
+        private FormattedValue<Integer> transit;
+
+        /**
+         * Initializes a new instance of the class to provide a proxy view into a part.
+         *
+         * @param p The part to proxy. Must not be null.
+         */
+        public PartProxy(Part p) {
+            part = Objects.requireNonNull(p);
+        }
+
+        /**
+         * Updates the proxied view of the properties which changed outside the proxy.
+         */
+        public void updateTargetAndInventories() {
+            targetProxy = null;
+            inventories = null;
+            ordered = null;
+            supply = null;
+            transit = null;
+        }
+
+        /**
+         * Gets the part being proxied.
+         *
+         * @return The part being proxied.
+         */
+        public Part getPart() {
+            return part;
+        }
+
+        /**
+         * Gets the part's name.
+         *
+         * @return The part's name.
+         */
+        public String getName() {
+            return part.getName();
+        }
+
+        /**
+         * Gets the part's details.
+         *
+         * @return The part's detailed.
+         */
+        public String getDetails() {
+            if (null == details) {
+                details = part.getDetails();
+            }
+
+            return details;
+        }
+
+        /**
+         * Gets the part's cost, suitable for use in a UI element which requires both a display value and a sortable
+         * value.
+         *
+         * @return The part's cost as a {@link FormattedValue}
+         */
+        public FormattedValue<Money> getCost() {
+            if (null == cost) {
+                Money actualValue = part.getActualValue();
+                cost = new FormattedValue<>(actualValue, actualValue.toAmountString());
+            }
+            return cost;
+        }
+
+        /**
+         * Gets the part's tonnage.
+         *
+         * @return The part's tonnage.
+         */
+        public double getTonnage() {
+            return Math.round(part.getTonnage() * 100) / 100.0;
+        }
+
+        /**
+         * Gets the part's tech base.
+         *
+         * @return The part's tech base.
+         */
+        public String getTechBase() {
+            return part.getTechBaseName();
+        }
+
+        /**
+         * Gets the part's {@link TargetRoll}.
+         *
+         * @return A {@link TargetProxy} representing the target roll for the part.
+         */
+        public TargetProxy getTarget() {
+            if (null == targetProxy) {
+                IAcquisitionWork shoppingItem = part.getMissingPart();
+                if (null == shoppingItem && part instanceof IAcquisitionWork) {
+                    shoppingItem = (IAcquisitionWork) part;
+                }
+                if (null != shoppingItem) {
+                    TargetRoll target = campaign.getTargetForAcquisition(shoppingItem, getLogisticsPerson(), true);
+                    targetProxy = new TargetProxy(target);
+                } else {
+                    targetProxy = new TargetProxy(null);
+                }
+            }
+
+            return targetProxy;
+        }
+
+        /**
+         * Gets the part's quantity on order, suitable for use in a UI element which requires both a display value
+         * and a sortable value.
+         *
+         * @return The part's quantity on order as a {@link FormattedValue}
+         */
+        public FormattedValue<Integer> getOrdered() {
+            if (null == inventories) {
+                inventories = campaign.getPartInventory(part);
+            }
+            if (null == ordered) {
+                ordered = new FormattedValue<>(inventories.getOrdered(), inventories.orderedAsString());
+            }
+            return ordered;
+        }
+
+        /**
+         * Gets the part's quantity on hand, suitable for use in a UI element which requires both a display value
+         * and a sortable value.
+         *
+         * @return The part's quantity on hand as a {@link FormattedValue}
+         */
+        public FormattedValue<Integer> getSupply() {
+            if (null == inventories) {
+                inventories = campaign.getPartInventory(part);
+            }
+            if (null == supply) {
+                supply = new FormattedValue<>(inventories.getSupply(), inventories.supplyAsString());
+            }
+            return supply;
+        }
+
+        /**
+         * Gets the part's quantity in transit, suitable for use in a UI element which requires both a display value
+         * and a sortable value.
+         *
+         * @return The part's quantity in transit as a {@link FormattedValue}
+         */
+        public FormattedValue<Integer> getTransit() {
+            if (null == inventories) {
+                inventories = campaign.getPartInventory(part);
+            }
+            if (null == transit) {
+                transit = new FormattedValue<>(inventories.getTransit(), inventories.transitAsString());
+            }
+            return transit;
+        }
+    }
+
+    public PartsStoreModel(CampaignGUI gui, ArrayList<Part> inventory) {
+        campaign = gui.getCampaign();
+        data = new ArrayList<>(inventory.size());
+        for (Part part : inventory) {
+            data.add(new PartProxy(part));
+        }
+    }
+
+    @Override
+    public int getRowCount() {
+        return data.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return N_COL;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return switch (column) {
+            case COL_NAME -> "Name";
+            case COL_DETAIL -> "Detail";
+            case COL_COST -> "Cost";
+            case COL_TON -> "Ton";
+            case COL_TECH_BASE -> "Tech";
+            case COL_TARGET -> "Target";
+            case COL_QUEUE -> "# Ordered";
+            case COL_SUPPLY -> "# Supply";
+            case COL_TRANSIT -> "# Transit";
+            default -> "?";
+        };
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        PartProxy part;
+        if (data.isEmpty()) {
+            return "";
+        } else {
+            part = data.get(row);
+        }
+        if (col == COL_NAME) {
+            return part.getName();
+        }
+        if (col == COL_DETAIL) {
+            return part.getDetails();
+        }
+        if (col == COL_COST) {
+            return part.getCost();
+        }
+        if (col == COL_TON) {
+            return part.getTonnage();
+        }
+        if (col == COL_TECH_BASE) {
+            return part.getTechBase();
+        }
+        if (col == COL_TARGET) {
+            return part.getTarget();
+        }
+        if (col == COL_SUPPLY) {
+            return part.getSupply();
+        }
+        if (col == COL_TRANSIT) {
+            return part.getTransit();
+        }
+        if (col == COL_QUEUE) {
+            return part.getOrdered();
+        }
+        return "?";
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return getValueAt(0, c).getClass();
+    }
+
+    public PartProxy getPartProxyAt(int row) {
+        return data.get(row);
+    }
+
+    public Part getPartAt(int row) {
+        return data.get(row).getPart();
+    }
+
+    public int getColumnWidth(int c) {
+        return switch (c) {
+            case COL_NAME, COL_DETAIL -> 100;
+            case COL_COST, COL_TARGET -> 40;
+            case COL_SUPPLY, COL_TRANSIT, COL_QUEUE -> 30;
+            default -> 15;
+        };
+    }
+
+    public int getAlignment(int col) {
+        return switch (col) {
+            case COL_COST, COL_TON -> SwingConstants.RIGHT;
+            case COL_TARGET -> SwingConstants.CENTER;
+            default -> SwingConstants.LEFT;
+        };
+    }
+
+    public String getTooltip(int row, int col) {
+        PartProxy part;
+        if (data.isEmpty()) {
+            return null;
+        } else {
+            part = data.get(row);
+        }
+        if (col == COL_TARGET) {
+            return part.getTarget().getDescription();
+        }
+        return null;
+    }
+
+    public Renderer getRenderer() {
+        return new Renderer();
+    }
+
+    public class Renderer extends DefaultTableCellRenderer {
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+              boolean hasFocus, int row, int column) {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            setOpaque(true);
+            int actualCol = table.convertColumnIndexToModel(column);
+            int actualRow = table.convertRowIndexToModel(row);
+            setHorizontalAlignment(getAlignment(actualCol));
+            setToolTipText(getTooltip(actualRow, actualCol));
+
+            return this;
+        }
+
+    }
+
+    private Person getLogisticsPerson() {
+        if (null == logisticsPerson) {
+            logisticsPerson = campaign.getLogisticsPerson();
+        }
+        return logisticsPerson;
+    }
+}

--- a/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ProcurementTableModel.java
@@ -33,6 +33,7 @@
 package mekhq.gui.model;
 
 import java.awt.Component;
+import java.text.DecimalFormat;
 import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.stream.IntStream;
@@ -52,6 +53,10 @@ import mekhq.campaign.work.IAcquisitionWork;
  * and so we have to be more careful in its design
  */
 public class ProcurementTableModel extends DataTableModel<IAcquisitionWork> {
+    private static final DecimalFormat FORMATTER = new DecimalFormat();
+    static {
+        FORMATTER.setMaximumFractionDigits(3);
+    }
     //region Variable Declarations
     private final Campaign campaign;
 
@@ -135,7 +140,7 @@ public class ProcurementTableModel extends DataTableModel<IAcquisitionWork> {
                 final int days = shoppingItem.getDaysToWait();
                 return String.format("%d %s", days, resources.getString((days == 1) ? "Day.text" : "Days.text"));
             case COL_QUEUE:
-                return shoppingItem.getQuantity();
+                return String.format("%s [+%s]", FORMATTER.format(shoppingItem.getQuantity()), FORMATTER.format(shoppingItem.getTotalQuantity()));
             default:
                 return "?";
 


### PR DESCRIPTION
Fixes #1418 #2948 
Fixes regression where `AmmoStorage.getNewPart` would round `getKgPerShot` incorrectly.
<img width="1715" height="770" alt="2025-08-05_14-59" src="https://github.com/user-attachments/assets/d58a86e2-593e-4101-8132-5af3a94d9781" />
<img width="926" height="587" alt="2025-08-05_15-00" src="https://github.com/user-attachments/assets/7ca58ae5-be32-458b-baf6-6a4b4d23e538" />
<img width="1389" height="990" alt="2025-08-05_15-00_1" src="https://github.com/user-attachments/assets/7933e11c-db2d-4be6-afe5-f073f3195856" />
