### PR TITLE
Fix: #7474 Fixed Tutorial Panel Scaling in the Briefing Room

### DIFF
--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -1128,7 +1128,7 @@ public class MissionViewPanel extends JScrollablePanel {
 
         String fontStyle = "font-family: Noto Sans;";
         editorPane.setText(String.format("<div style='width: %s; %s padding:%spx;'>%s</div>",
-              scaleForGUI(800),
+              scaleForGUI(590),
               fontStyle,
               scaleForGUI(5),
               resourceMap.getString("txtStratConTutorial.text")));
@@ -1144,7 +1144,8 @@ public class MissionViewPanel extends JScrollablePanel {
         pnlTutorial = new JPanel(new BorderLayout());
 
         pnlTutorial.setBorder(RoundedLineBorder.createRoundedLineBorder());
-        pnlTutorial.setPreferredSize(new Dimension(800, 0));
+        pnlTutorial.setPreferredSize(new Dimension(600, 0));
+        pnlTutorial.setMinimumSize(new Dimension(600, 0));
         pnlTutorial.add(scrollPane, BorderLayout.CENTER);
     }
 }


### PR DESCRIPTION
Fix #7474

This PR adjusts the scaling of the tutorial panel, in the Briefing Room, so it doesn't get squashed when the first contract is chosen.