### PR TITLE
Fix Mount<?> issues

### DIFF
--- a/MekHQ/unittests/mekhq/campaign/unit/cleanup/EquipmentProposalTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/cleanup/EquipmentProposalTest.java
@@ -96,7 +96,7 @@ class EquipmentProposalTest {
         assertEquals(mockMounted, proposal.getEquipment(equipmentNum));
         assertFalse(proposal.getEquipment().isEmpty());
 
-        for (Entry<Integer, Mounted> entry : proposal.getEquipment()) {
+        for (Entry<Integer, Mounted<?>> entry : proposal.getEquipment()) {
             assertEquals(equipmentNum, (int) entry.getKey());
             assertEquals(mockMounted, entry.getValue());
         }

--- a/MekHQ/unittests/mekhq/campaign/unit/cleanup/MovedAmmoBinTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/cleanup/MovedAmmoBinTest.java
@@ -34,6 +34,7 @@ package mekhq.campaign.unit.cleanup;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -80,7 +81,9 @@ class MovedAmmoBinTest {
         EquipmentProposal mockProposal = mock(EquipmentProposal.class);
         Mounted mockMount = mock(Mounted.class);
         when(mockMount.isDestroyed()).thenReturn(true);
-        when(mockProposal.getEquipment()).thenReturn(Collections.singletonMap(0, mockMount).entrySet());
+        doAnswer(ans -> {
+            return Collections.singletonMap(0, mockMount).entrySet();
+        }).when(mockProposal).getEquipment();
         AmmoBin mockPart = mock(AmmoBin.class);
 
         MovedAmmoBinStep step = new MovedAmmoBinStep();
@@ -95,7 +98,9 @@ class MovedAmmoBinTest {
         EquipmentProposal mockProposal = mock(EquipmentProposal.class);
         Mounted mockMount = mock(Mounted.class);
         when(mockMount.getType()).thenReturn(mock(EquipmentType.class));
-        when(mockProposal.getEquipment()).thenReturn(Collections.singletonMap(0, mockMount).entrySet());
+        doAnswer(ans -> {
+            return Collections.singletonMap(0, mockMount).entrySet();
+        }).when(mockProposal).getEquipment();
         AmmoBin mockPart = mock(AmmoBin.class);
         when(mockPart.getType()).thenReturn(mock(AmmoType.class));
 
@@ -111,7 +116,9 @@ class MovedAmmoBinTest {
         EquipmentProposal mockProposal = mock(EquipmentProposal.class);
         Mounted mockMount = mock(Mounted.class);
         when(mockMount.getType()).thenReturn(mock(AmmoType.class));
-        when(mockProposal.getEquipment()).thenReturn(Collections.singletonMap(0, mockMount).entrySet());
+        doAnswer(ans -> {
+            return Collections.singletonMap(0, mockMount).entrySet();
+        }).when(mockProposal).getEquipment();
         AmmoBin mockPart = mock(AmmoBin.class);
         when(mockPart.getType()).thenReturn(mock(AmmoType.class));
 
@@ -128,7 +135,9 @@ class MovedAmmoBinTest {
         AmmoType mockType = mock(AmmoType.class);
         Mounted mockMount = mock(Mounted.class);
         when(mockMount.getType()).thenReturn(mockType);
-        when(mockProposal.getEquipment()).thenReturn(Collections.singletonMap(1, mockMount).entrySet());
+        doAnswer(ans -> {
+            return Collections.singletonMap(0, mockMount).entrySet();
+        }).when(mockProposal).getEquipment();
         AmmoBin mockPart = mock(AmmoBin.class);
         when(mockPart.getType()).thenReturn(mock(AmmoType.class));
         doReturn(true).when(mockPart).canChangeMunitions(mockType);

--- a/MekHQ/unittests/mekhq/campaign/unit/cleanup/MovedEquipmentStepTest.java
+++ b/MekHQ/unittests/mekhq/campaign/unit/cleanup/MovedEquipmentStepTest.java
@@ -35,18 +35,27 @@ package mekhq.campaign.unit.cleanup;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+
+import mekhq.campaign.parts.Part;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.Mounted;
 import mekhq.campaign.parts.equipment.EquipmentPart;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
 
 public class MovedEquipmentStepTest {
     @Test
@@ -78,9 +87,13 @@ public class MovedEquipmentStepTest {
     @Test
     public void doesNotMatchDestroyedEquipmentTest() {
         EquipmentProposal mockProposal = mock(EquipmentProposal.class);
-        Mounted mockMount = mock(Mounted.class);
+        Mounted<EquipmentType> mockMount = (Mounted<EquipmentType>) mock(Mounted.class);
         when(mockMount.isDestroyed()).thenReturn(true);
-        when(mockProposal.getEquipment()).thenReturn(Collections.singletonMap(0, mockMount).entrySet());
+
+        doAnswer(ans -> {
+            return Collections.singletonMap(0, mockMount).entrySet();
+        }).when(mockProposal).getEquipment();
+
         EquipmentPart mockPart = mock(EquipmentPart.class);
 
         MovedEquipmentStep step = new MovedEquipmentStep();
@@ -95,7 +108,9 @@ public class MovedEquipmentStepTest {
         EquipmentProposal mockProposal = mock(EquipmentProposal.class);
         Mounted mockMount = mock(Mounted.class);
         when(mockMount.isDestroyed()).thenReturn(true);
-        when(mockProposal.getEquipment()).thenReturn(Collections.singletonMap(0, mockMount).entrySet());
+        doAnswer(ans -> {
+            return Collections.singletonMap(0, mockMount).entrySet();
+        }).when(mockProposal).getEquipment();
         MissingEquipmentPart mockMissingPart = mock(MissingEquipmentPart.class);
 
         MovedEquipmentStep step = new MovedEquipmentStep();
@@ -110,7 +125,9 @@ public class MovedEquipmentStepTest {
         EquipmentProposal mockProposal = mock(EquipmentProposal.class);
         Mounted mockMount = mock(Mounted.class);
         when(mockMount.getType()).thenReturn(mock(EquipmentType.class));
-        when(mockProposal.getEquipment()).thenReturn(Collections.singletonMap(0, mockMount).entrySet());
+        doAnswer(ans -> {
+            return Collections.singletonMap(0, mockMount).entrySet();
+        }).when(mockProposal).getEquipment();
         EquipmentPart mockPart = mock(EquipmentPart.class);
         when(mockPart.getType()).thenReturn(mock(EquipmentType.class));
 
@@ -126,7 +143,9 @@ public class MovedEquipmentStepTest {
         EquipmentProposal mockProposal = mock(EquipmentProposal.class);
         Mounted mockMount = mock(Mounted.class);
         when(mockMount.getType()).thenReturn(mock(EquipmentType.class));
-        when(mockProposal.getEquipment()).thenReturn(Collections.singletonMap(0, mockMount).entrySet());
+        doAnswer(ans -> {
+            return Collections.singletonMap(0, mockMount).entrySet();
+        }).when(mockProposal).getEquipment();
         MissingEquipmentPart mockMissingPart = mock(MissingEquipmentPart.class);
         when(mockMissingPart.getType()).thenReturn(mock(EquipmentType.class));
 
@@ -143,7 +162,9 @@ public class MovedEquipmentStepTest {
         EquipmentType mockType = mock(EquipmentType.class);
         Mounted mockMount = mock(Mounted.class);
         when(mockMount.getType()).thenReturn(mockType);
-        when(mockProposal.getEquipment()).thenReturn(Collections.singletonMap(1, mockMount).entrySet());
+        doAnswer(ans -> {
+            return Collections.singletonMap(0, mockMount).entrySet();
+        }).when(mockProposal).getEquipment();
         EquipmentPart mockPart = mock(EquipmentPart.class);
         when(mockPart.getType()).thenReturn(mockType);
 
@@ -160,7 +181,9 @@ public class MovedEquipmentStepTest {
         EquipmentType mockType = mock(EquipmentType.class);
         Mounted mockMount = mock(Mounted.class);
         when(mockMount.getType()).thenReturn(mockType);
-        when(mockProposal.getEquipment()).thenReturn(Collections.singletonMap(1, mockMount).entrySet());
+        doAnswer(ans -> {
+            return Collections.singletonMap(0, mockMount).entrySet();
+        }).when(mockProposal).getEquipment();
         MissingEquipmentPart mockMissingPart = mock(MissingEquipmentPart.class);
         when(mockMissingPart.getType()).thenReturn(mockType);
 


### PR DESCRIPTION
This fixes the issue with Mounted<?> generic class return values and Mockito mocking.
We can bypass Mockito's best-guess mocking and instruct the _when_ clause to return exactly what we want with `doAnswer()`.
I stole this fix from some of Watford's older tests.

## NOTE

This only fixes building and running tests; I still show 600+ tests failing.