### PR TITLE
Fix: Default Rank File Now Correctly Resaves with Legal Statement

### DIFF
--- a/MekHQ/resources/mekhq/resources/Ranks.properties
+++ b/MekHQ/resources/mekhq/resources/Ranks.properties
@@ -1,0 +1,18 @@
+Ranks.legalStatement=<!--\n\
+  # MegaMek Data (C) {0} by The MegaMek Team is licensed under CC BY-NC-SA 4.0.\n\
+  # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/\n\
+  #\n\
+  # NOTICE: The MegaMek organization is a non-profit group of volunteers\n\
+  # creating free software for the BattleTech community.\n\
+  #\n\
+  # MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks\n\
+  # of The Topps Company, Inc. All Rights Reserved.\n\
+  #\n\
+  # Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of\n\
+  # InMediaRes Productions, LLC.\n\
+  #\n\
+  # MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under\n\
+  # Microsoft''s "Game Content Usage Rules"\n\
+  # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or\n\
+  # affiliated with Microsoft.\n\
+  -->

--- a/MekHQ/src/mekhq/campaign/personnel/ranks/Ranks.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/Ranks.java
@@ -33,6 +33,8 @@
  */
 package mekhq.campaign.personnel.ranks;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -42,6 +44,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -66,6 +69,7 @@ import org.w3c.dom.NodeList;
  * custom one there.
  */
 public class Ranks {
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.Ranks";
     private static final MMLogger LOGGER = MMLogger.create(Ranks.class);
 
     // region Variable Declarations
@@ -119,17 +123,22 @@ public class Ranks {
             file = new File(path);
         }
         int indent = 0;
-        try (OutputStream fos = new FileOutputStream(file);
-              OutputStream bos = new BufferedOutputStream(fos);
-              OutputStreamWriter osw = new OutputStreamWriter(bos, StandardCharsets.UTF_8);
-              PrintWriter pw = new PrintWriter(osw)) {
+        try (OutputStream fileOutputStream = new FileOutputStream(file);
+              OutputStream outputStream = new BufferedOutputStream(fileOutputStream);
+              OutputStreamWriter osw = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+              PrintWriter writer = new PrintWriter(osw)) {
             // Then save it out to that file.
-            pw.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-            MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "rankSystems", "version", MHQConstants.VERSION);
+            writer.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+
+            String year = String.valueOf(LocalDate.now().getYear()).replace(",", "");
+            String legalStatement = getFormattedTextAt(RESOURCE_BUNDLE, "Ranks.legalStatement", year);
+            writer.println(legalStatement.trim());
+
+            MHQXMLUtility.writeSimpleXMLOpenTag(writer, indent++, "rankSystems", "version", MHQConstants.VERSION);
             for (final RankSystem rankSystem : rankSystems) {
-                rankSystem.writeToXML(pw, indent, true);
+                rankSystem.writeToXML(writer, indent, true);
             }
-            MHQXMLUtility.writeSimpleXMLCloseTag(pw, --indent, "rankSystems");
+            MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "rankSystems");
         } catch (Exception ex) {
             LOGGER.error("", ex);
         }


### PR DESCRIPTION
The default ranks file is resaved whenever mhq launches into a campaign. However, the file was resaving without the new legal statement forcing developers to manually add it each time.

This PR corrects that.