### PR TITLE
Fix #7552: Fixed Contract Generation on New Campaign

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -289,11 +289,15 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                 int retries = MAXIMUM_GENERATION_RETRIES;
                 AtBContract contract = null;
                 while ((retries > 0) && (contract == null)) {
+                    Faction employer = RandomFactionGenerator.getInstance().getEmployerFaction();
+                    if (employer == null) {
+                        retries--;
+                        continue;
+                    }
+
+                    String employerCode = employer.getShortName();
                     // Send only 1 retry down because we're handling retries in our loop
-                    contract = generateAtBContract(campaign,
-                          RandomFactionGenerator.getInstance().getEmployerFaction().getShortName(),
-                          unitRatingMod,
-                          1);
+                    contract = generateAtBContract(campaign, employerCode, unitRatingMod, 1);
 
                     // This try-catch is specifically implemented to make testing easier. Otherwise, we would need to
                     // define the player's TO&E, their Ally's unit availability, and their Enemy's unit availability,


### PR DESCRIPTION
Fix #7552

During the recent refactor a change was made to an AtB Contract Generation method so that it accepted String (faction code) instead of the full Faction class. However, the source of the Faction (which we use to fetch the code) is Nullable. No null safety was included, resulting in an NPE and contract creation failure in the event RandomFactionGenerator returned a null value (returning a null value here is working as programmed).