### PR TITLE
Fix #7551: Restored Ability to Advance Campaign Day

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignController.java
+++ b/MekHQ/src/mekhq/campaign/CampaignController.java
@@ -92,5 +92,6 @@ public class CampaignController {
      * Advances the local {@link Campaign} to the next day.
      */
     public void advanceDay() {
+        getLocalCampaign().newDay();
     }
 }


### PR DESCRIPTION
Fix #7551

During the recent refactor the newDay call in CampaignController was deleted. This PR restores it, as its' absence was preventing campaigns from advancing day.