### PR TITLE
Fix: Addressed Rank System Loading Failure

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/ranks/Ranks.java
+++ b/MekHQ/src/mekhq/campaign/personnel/ranks/Ranks.java
@@ -171,9 +171,17 @@ public class Ranks {
         }
 
         if (!getRankSystems().containsKey(DEFAULT_SYSTEM_CODE)) {
-            LOGGER.fatal("Ranks MUST load the " + DEFAULT_SYSTEM_CODE
-                               + " system. Initialization failure, shutting MekHQ down.");
-            java.lang.System.exit(-1);
+            LOGGER.fatalDialog(new NullPointerException(),
+                  """
+                        Error: Unable to Load the default rank system (SSLDF).\
+                        
+                        
+                        This is likely due to a missing ranks directory\
+                        
+                        
+                        Please report to the MegaMek Team""",
+                  "Unable to Load Rank Systems");
+            return;
         }
 
         LOGGER.info("Completed Rank System XML Load");


### PR DESCRIPTION
This PR addresses the issue of rank systems initialization resulting in an early exit of all processes should ranks fail to load. For example, if loading rank systems in the headless-dateless GitHub test environment.