### PR TITLE
Fix #7571: Corrected Return Value of pickRandomCamouflage to Account for Missing Data

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -340,7 +340,7 @@ public class AtBContract extends Contract {
         } else {
             // Log if no files were found in the directory
             logger.warn("No files in directory {} - using default camouflage", camouflageDirectory);
-            return null;
+            return new Camouflage(); // return no camouflage
         }
     }
 


### PR DESCRIPTION
Fix #7571

This PR updates `pickRandomCamouflage()` to return a blank camo in the event the data directory returns empty (such as when running tests in a dataless environment, i.e. the GitHub test environ). Previously the method returned an undocumented `null`.