### PR TITLE
Fix #7592: Corrected Sorting of Personality Quirks in Edit Person Dialog So That 'None' is Always First in the List

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/PersonalityQuirk.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/PersonalityQuirk.java
@@ -438,11 +438,17 @@ public enum PersonalityQuirk {
     /**
      * Returns a list of Personality Quirks sorted alphabetically by their label.
      *
+     * <p>{@link #NONE} is always the first element in the list.</p>
+     *
      * @return a sorted {@link List} of {@link PersonalityQuirk} objects by their label.
      */
     public static List<PersonalityQuirk> personalityQuirksSortedAlphabetically() {
         List<PersonalityQuirk> quirks = new ArrayList<>(List.of(PersonalityQuirk.values()));
         quirks.sort(Comparator.comparing(PersonalityQuirk::getLabel));
+
+        quirks.remove(PersonalityQuirk.NONE);
+        quirks.add(0, PersonalityQuirk.NONE);
+
         return quirks;
     }
     // endregion Getters

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/PersonalityQuirk.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/PersonalityQuirk.java
@@ -443,12 +443,14 @@ public enum PersonalityQuirk {
      * @return a sorted {@link List} of {@link PersonalityQuirk} objects by their label.
      */
     public static List<PersonalityQuirk> personalityQuirksSortedAlphabetically() {
-        List<PersonalityQuirk> quirks = new ArrayList<>(List.of(PersonalityQuirk.values()));
+        List<PersonalityQuirk> quirks = new ArrayList<>();
+        for (PersonalityQuirk quirk : PersonalityQuirk.values()) {
+            if (quirk != PersonalityQuirk.NONE) {
+                quirks.add(quirk);
+            }
+        }
         quirks.sort(Comparator.comparing(PersonalityQuirk::getLabel));
-
-        quirks.remove(PersonalityQuirk.NONE);
         quirks.add(0, PersonalityQuirk.NONE);
-
         return quirks;
     }
     // endregion Getters


### PR DESCRIPTION
Fix #7592

Previously personality quirks were sorted alphabetically. With this PR they still are, but 'None' is fixed in position 0.