### PR TITLE
Fix #7590: Corrected Errant 'XP' Label in Education Academy Curriculum Tooltips

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -801,7 +801,7 @@ public class Academy implements Comparable<Academy> {
                     tooltip.append(skillName).append("<br>");
                     continue;
                 } else if (skillName.equalsIgnoreCase("xp")) {
-                    tooltip.append(skillName).append("XP (");
+                    tooltip.append(skillName).append(" (");
                 } else {
                     skillParsed = skillParser(skillName);
                     tooltip.append(skillParsed).append(" (");


### PR DESCRIPTION
Fix #7590

Removes unnecessary hardcoded 'XP' String that got left in at some point in ancient history.