### PR TITLE
Fix #7535: Fixed Scenario Resolution Unit Tracking Causing Scenario Resolution Dialog to Not Trigger

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -244,6 +244,8 @@ public class ResolveScenarioTracker {
         int playerId = client.getLocalPlayer().getId();
         int team = client.getLocalPlayer().getTeam();
 
+        sanitizeAllEntityExternalIds();
+
         for (Enumeration<Entity> entityIterator = victoryEvent.getEntities(); entityIterator.hasMoreElements(); ) {
             Entity entity = entityIterator.nextElement();
             if (!entity.getSubEntities().isEmpty()) {
@@ -481,6 +483,42 @@ public class ResolveScenarioTracker {
             }
         }
         checkStatusOfPersonnel();
+    }
+
+    /**
+     * Ensures that every entity in all relevant victory event collections has a proper unique external ID assigned. If
+     * a UUID is missing ("-1"), a new one is generated and set.
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private void sanitizeAllEntityExternalIds() {
+        sanitizeEntityEnumeration(victoryEvent.getEntities());
+        sanitizeEntityEnumeration(victoryEvent.getGraveyardEntities());
+        sanitizeEntityEnumeration(victoryEvent.getWreckedEntities());
+        sanitizeEntityEnumeration(victoryEvent.getRetreatedEntities());
+        sanitizeEntityEnumeration(victoryEvent.getDevastatedEntities());
+    }
+
+    /**
+     * Ensures each entity in the given enumeration has a UUID assigned. If not set, a new UUID is created and
+     * assigned.
+     *
+     * @param entities Enumeration of entities to sanitize
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    private void sanitizeEntityEnumeration(Enumeration<Entity> entities) {
+        String UNSET_UUID = "-1";
+
+        while (entities.hasMoreElements()) {
+            Entity entity = entities.nextElement();
+            if (UNSET_UUID.equals(entity.getExternalIdAsString())) {
+                String uuid = UUID.randomUUID().toString();
+                entity.setExternalIdAsString(uuid);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Fix #7535

For years we have had reports from users of the scenario resolution dialog missing units or simply not triggering, after the player has dictated field control.

Thanks to #7535 I was able to identify what I believe to be the root cause. Under certain circumstances an entity can generate with an eternal ID of `-1` (no ID). Most of the scenario resolution code has explicit checks (around 60-ish) that confirm the id isn't `-1` before proceeding.

Most, not all. The author of #7535 ran into a circumstance where they had a unit with a `-1` ID as the only unit in the OpFor. This meant that scenario resolution completely failed, but was helpful enough to throw-up an error in the log. This error is silent. That is to say a player receiving the error would never notice, unless they happened to check the logs. Insofar as the player is concerned the scenario resolution dialog just never opened. In fact, it did open, but died so fast the player had no chance to notice.

What this PR does is go through every Entity in the scenario resolution tracker, prior to any processing occurring. If it finds an Entity with a missing ID it gives it a shiny new ID. At that point the unit is handled like any other and mhq never knows how close it came to calamity.