### PR TITLE
Fix #7529: Fixed Education Sorting in Personnel Tab to Order Based on Education Level and Not Alphabetically.

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/education/EducationLevel.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/education/EducationLevel.java
@@ -40,30 +40,36 @@ import mekhq.MekHQ;
 
 public enum EducationLevel {
     // region Enum Declarations
-    EARLY_CHILDHOOD("EducationLevel.EARLY_CHILDHOOD.text", "EducationLevel.EARLY_CHILDHOOD.toolTipText"),
-    HIGH_SCHOOL("EducationLevel.HIGH_SCHOOL.text", "EducationLevel.HIGH_SCHOOL.toolTipText"),
-    COLLEGE("EducationLevel.COLLEGE.text", "EducationLevel.COLLEGE.toolTipText"),
-    POST_GRADUATE("EducationLevel.POST_GRADUATE.text", "EducationLevel.POST_GRADUATE.toolTipText"),
-    DOCTORATE("EducationLevel.DOCTORATE.text", "EducationLevel.DOCTORATE.toolTipText");
+    EARLY_CHILDHOOD("EducationLevel.EARLY_CHILDHOOD.text", "EducationLevel.EARLY_CHILDHOOD.toolTipText", 0),
+    HIGH_SCHOOL("EducationLevel.HIGH_SCHOOL.text", "EducationLevel.HIGH_SCHOOL.toolTipText", 1),
+    COLLEGE("EducationLevel.COLLEGE.text", "EducationLevel.COLLEGE.toolTipText", 2),
+    POST_GRADUATE("EducationLevel.POST_GRADUATE.text", "EducationLevel.POST_GRADUATE.toolTipText", 3),
+    DOCTORATE("EducationLevel.DOCTORATE.text", "EducationLevel.DOCTORATE.toolTipText", 4);
     // endregion Enum Declarations
 
     // region Variable Declarations
     private final String name;
     private final String toolTipText;
+    private final int order;
     // endregion Variable Declarations
 
     // region Constructors
-    EducationLevel(final String name, final String toolTipText) {
+    EducationLevel(final String name, final String toolTipText, final int order) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Personnel",
               MekHQ.getMHQOptions().getLocale());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
+        this.order = order;
     }
     // endregion Constructors
 
     // region Getters
     public String getToolTipText() {
         return toolTipText;
+    }
+
+    public int getOrder() {
+        return order;
     }
     // endregion Getters
 

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -44,11 +44,11 @@ import javax.swing.SwingConstants;
 
 import megamek.client.ui.util.UIUtil;
 import megamek.codeUtilities.StringUtility;
+import megamek.common.annotations.Nullable;
 import megamek.common.units.Entity;
 import megamek.common.units.Jumpship;
 import megamek.common.units.SmallCraft;
 import megamek.common.units.Tank;
-import megamek.common.annotations.Nullable;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -70,6 +70,7 @@ import mekhq.campaign.universe.Planet;
 import mekhq.gui.sorter.AttributeScoreSorter;
 import mekhq.gui.sorter.BonusSorter;
 import mekhq.gui.sorter.DateStringComparator;
+import mekhq.gui.sorter.EducationLevelSorter;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.IntegerStringSorter;
 import mekhq.gui.sorter.LevelSorter;
@@ -1195,8 +1196,7 @@ public enum PersonnelTableModelColumn {
             };
             case PERSONALITY -> switch (this) {
                 case RANK, FIRST_NAME, LAST_NAME -> true;
-                case AGGRESSION, AMBITION, GREED, SOCIAL ->
-                      campaign.getCampaignOptions().isUseRandomPersonalities();
+                case AGGRESSION, AMBITION, GREED, SOCIAL -> campaign.getCampaignOptions().isUseRandomPersonalities();
                 default -> false;
             };
             case TRAITS -> switch (this) {
@@ -1233,6 +1233,7 @@ public enum PersonnelTableModelColumn {
     public Comparator<?> getComparator(final Campaign campaign) {
         return switch (this) {
             case RANK -> new PersonRankStringSorter(campaign);
+            case EDUCATION -> new EducationLevelSorter();
             case AGE, BIRTHDAY, RECRUITMENT_DATE, LAST_RANK_CHANGE_DATE, DUE_DATE, RETIREMENT_DATE, DEATH_DATE ->
                   new DateStringComparator();
             case SKILL_LEVEL -> new LevelSorter();

--- a/MekHQ/src/mekhq/gui/sorter/EducationLevelSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/EducationLevelSorter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.sorter;
+
+import java.util.Comparator;
+
+import megamek.logging.MMLogger;
+import mekhq.campaign.personnel.enums.education.EducationLevel;
+
+/**
+ * A comparator for sorting Education Level {@link String} values.
+ *
+ * <p>This comparator relies on the {@link EducationLevel#fromString(String)} method to convert string
+ * representations into {@link EducationLevel} objects, and then orders them based on their
+ * {@link EducationLevel#getOrder()} value.</p>
+ *
+ * <p>If either string cannot be parsed into a valid {@code EducationLevel}, an error will be logged and the
+ * malformed string will be placed after valid entries.</p>
+ *
+ * @author Illiani
+ * @since 0.50.07
+ */
+public class EducationLevelSorter implements Comparator<String> {
+    private static final MMLogger LOGGER = MMLogger.create(EducationLevelSorter.class);
+
+    @Override
+    public int compare(String firstString, String secondString) {
+        try {
+            int firstOrder = EducationLevel.fromString(firstString).getOrder();
+            int secondOrder = EducationLevel.fromString(secondString).getOrder();
+            return Integer.compare(firstOrder, secondOrder);
+        } catch (Exception e) {
+            LOGGER.error("Error comparing education levels: {} or {}", firstString, secondString, e);
+            // malformed/non-matching strings go last
+            return 1;
+        }
+    }
+}

--- a/MekHQ/src/mekhq/gui/sorter/EducationLevelSorter.java
+++ b/MekHQ/src/mekhq/gui/sorter/EducationLevelSorter.java
@@ -55,14 +55,20 @@ public class EducationLevelSorter implements Comparator<String> {
 
     @Override
     public int compare(String firstString, String secondString) {
+        int firstOrder;
+        int secondOrder;
         try {
-            int firstOrder = EducationLevel.fromString(firstString).getOrder();
-            int secondOrder = EducationLevel.fromString(secondString).getOrder();
-            return Integer.compare(firstOrder, secondOrder);
+            firstOrder = EducationLevel.fromString(firstString).getOrder();
         } catch (Exception e) {
-            LOGGER.error("Error comparing education levels: {} or {}", firstString, secondString, e);
-            // malformed/non-matching strings go last
-            return 1;
+            LOGGER.error("Error parsing education level: {}", firstString, e);
+            firstOrder = Integer.MAX_VALUE;
         }
+        try {
+            secondOrder = EducationLevel.fromString(secondString).getOrder();
+        } catch (Exception e) {
+            LOGGER.error("Error parsing education level: {}", secondString, e);
+            secondOrder = Integer.MAX_VALUE;
+        }
+        return Integer.compare(firstOrder, secondOrder);
     }
 }

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelTableModelColumnTest.java
@@ -49,6 +49,7 @@ import mekhq.campaign.Campaign;
 import mekhq.gui.sorter.AttributeScoreSorter;
 import mekhq.gui.sorter.BonusSorter;
 import mekhq.gui.sorter.DateStringComparator;
+import mekhq.gui.sorter.EducationLevelSorter;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.IntegerStringSorter;
 import mekhq.gui.sorter.LevelSorter;
@@ -821,6 +822,8 @@ public class PersonnelTableModelColumnTest {
         for (final PersonnelTableModelColumn personnelTableModelColumn : columns) {
             switch (personnelTableModelColumn) {
                 case RANK -> assertInstanceOf(PersonRankStringSorter.class,
+                      personnelTableModelColumn.getComparator(mockCampaign));
+                case EDUCATION -> assertInstanceOf(EducationLevelSorter.class,
                       personnelTableModelColumn.getComparator(mockCampaign));
                 case AGE, BIRTHDAY, RECRUITMENT_DATE, LAST_RANK_CHANGE_DATE, DUE_DATE, RETIREMENT_DATE, DEATH_DATE ->
                       assertInstanceOf(DateStringComparator.class,


### PR DESCRIPTION
Fix #7529

Now when the Education column is sorted it will sort Early Childhood -> High School -> College -> Post Graduate -> Doctorate