### PR TITLE
Fix #7472: Fixed Execute Prisoners Message

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
@@ -615,7 +615,7 @@ public class PrisonerEventManager {
         }
 
         // Build the report
-        String key = getFormattedTextAt(RESOURCE_BUNDLE, hasBackfired ? "execute.backfired" : "execute.successful");
+        String key = hasBackfired ? "execute.backfired" : "execute.successful";
 
         String messageColor = hasBackfired ?
                                     spanOpeningWithCustomColor(ReportingUtilities.getNegativeColor()) :


### PR DESCRIPTION
Fix #7472 

This was caused by a whoopsie. We were mistakenly using the message as a resource key.