### PR TITLE
Improvement #7460: Improved Display of Possible Hires to Display Civilians Separately to Other Applicants

### DIFF
--- a/MekHQ/resources/mekhq/resources/PersonnelMarket.properties
+++ b/MekHQ/resources/mekhq/resources/PersonnelMarket.properties
@@ -66,5 +66,6 @@ hint.personnelMarket.onContract=<html>{0}<b>Unable to Recruit{1}:</b> On Militar
 hyperlink.personnelMarket.report=<a href='PERSONNEL_MARKET'>Personnel Market Updated</a>
 hyperlink.personnelMarket.report.experienceLevel=<b>{0}</b> {1}<b>{2}</b>{3} {4, choice, 0#applicant|1#applicants} \
   available
+hyperlink.personnelMarket.report.civilians=Civilian
 connections.recruits={0} was able to leverage their <b>Connections</b> to link up with {1} {2}<b>Additional \
   Recruits</b>{3}.

--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
@@ -1091,6 +1091,8 @@ public class NewPersonnelMarket {
     private String generatePersonnelReport(Campaign campaign) {
         StringBuilder report = new StringBuilder(getTextAt(RESOURCE_BUNDLE, "hyperlink.personnelMarket.report"));
 
+        int civilians = 0;
+
         // Define the experience levels and tie them to their respective constants.
         final int[] expLevels = {
               EXP_ULTRA_GREEN, EXP_GREEN, EXP_REGULAR,
@@ -1109,6 +1111,11 @@ public class NewPersonnelMarket {
 
         // Tally applicants per experience level
         for (Person applicant : currentApplicants) {
+            if (applicant.isCivilian()) {
+                civilians++;
+                continue;
+            }
+
             int experienceLevel = applicant.getExperienceLevel(campaign, false);
             for (int i = 0; i < expLevels.length; i++) {
                 if (experienceLevel == expLevels[i]) {
@@ -1126,6 +1133,14 @@ public class NewPersonnelMarket {
                       .append(getFormattedTextAt(RESOURCE_BUNDLE, "hyperlink.personnelMarket.report.experienceLevel",
                             applicantCounts[i], colors[i], names[i], CLOSING_SPAN_TAG, pluralizer));
             }
+        }
+
+        if (civilians > 0) {
+            int pluralizer = civilians > 1 ? 1 : 0;
+            report.append("<br>")
+                  .append(getFormattedTextAt(RESOURCE_BUNDLE, "hyperlink.personnelMarket.report.experienceLevel",
+                        civilians, "", getTextAt(RESOURCE_BUNDLE, "hyperlink.personnelMarket.report.civilians"), "",
+                        pluralizer));
         }
 
         return report.toString();


### PR DESCRIPTION
Close #7460

This PR just changes up the new applicants report so that Civilians are not lumped in with other professions.