### PR TITLE
Fix #7456: Corrected Math for Free Prisoners Option

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/PrisonerEventManager.java
@@ -265,7 +265,7 @@ public class PrisonerEventManager {
     List<Boolean> checkForPrisonerEvents(boolean isHeadless, int totalPrisoners, int prisonerCapacityUsage,
           int prisonerCapacity) {
         // Calculate overflow as the percentage over prisonerCapacity
-        double overflowPercentage = ((double) (prisonerCapacityUsage - prisonerCapacity) / prisonerCapacity) * 100;
+        double overflowPercentage = (double) (prisonerCapacityUsage - prisonerCapacity) / prisonerCapacity;
 
         // If no overflow and total prisoners are below the minimum count, no risk of event
         if (overflowPercentage <= 0 && totalPrisoners < MINIMUM_PRISONER_COUNT) {


### PR DESCRIPTION
Fix #7456

This addresses a minor math error that resulted in players being prompted to free all prisoners when faced with overflow, rather than just a percentage.