### PR TITLE
Improvement #7622: Added Skill Improvement Log Entries For Training Combat Teams & Education

### DIFF
--- a/MekHQ/src/mekhq/campaign/log/PerformanceLogger.java
+++ b/MekHQ/src/mekhq/campaign/log/PerformanceLogger.java
@@ -60,9 +60,31 @@ public class PerformanceLogger {
               MessageFormat.format(message, patient, injuries, xp)));
     }
 
+    /**
+     * @deprecated use {@link #improvedSkill(boolean, Person, LocalDate, String, int)} instead
+     */
+    @Deprecated(since = "0.50.07", forRemoval = true)
     public static void improvedSkill(final Campaign campaign, final Person person, final LocalDate date,
           final String skill, final String value) {
         if (campaign.getCampaignOptions().isPersonnelLogSkillGain()) {
+            person.addPerformanceLogEntry(new PerformanceLogEntry(date,
+                  MessageFormat.format(resources.getString("improvedSkill.text"), skill, value)));
+        }
+    }
+
+    /**
+     * Logs a skill improvement event for a specified person if skill gain logging  is enabled. This method records the
+     * event details including the skill improved, its value, and the date of the improvement.
+     *
+     * @param isLogSkillGain a boolean indicating whether skill gain logging is enabled
+     * @param person         the {@link Person} object representing the individual gaining the skill
+     * @param date           the {@link LocalDate} of the skill improvement
+     * @param skill          a {@link String} representing the name of the skill that was improved
+     * @param value          an {@code int} representing the value of the improvement to the skill
+     */
+    public static void improvedSkill(final boolean isLogSkillGain, final Person person, final LocalDate date,
+          final String skill, final int value) {
+        if (isLogSkillGain) {
             person.addPerformanceLogEntry(new PerformanceLogEntry(date,
                   MessageFormat.format(resources.getString("improvedSkill.text"), skill, value)));
         }

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -57,6 +57,7 @@ import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.persons.PersonChangedEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
+import mekhq.campaign.log.PerformanceLogger;
 import mekhq.campaign.log.ServiceLogger;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
@@ -1595,15 +1596,19 @@ public class EducationController {
             }
         }
 
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        Integer curriculumXpRate = campaignOptions.getCurriculumXpRate();
+        boolean isLogSkillGain = campaignOptions.isPersonnelLogSkillGain();
         for (String skill : curriculum) {
             if (skill.equalsIgnoreCase("none")) {
                 return;
             }
 
             if (skill.equalsIgnoreCase("xp")) {
-                person.awardXP(campaign, campaign.getCampaignOptions().getCurriculumXpRate());
+                person.awardXP(campaign, curriculumXpRate);
             } else {
                 updateSkill(person, educationLevel, skill);
+                PerformanceLogger.improvedSkill(isLogSkillGain, person, campaign.getLocalDate(), skill, educationLevel);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -1608,7 +1608,14 @@ public class EducationController {
                 person.awardXP(campaign, curriculumXpRate);
             } else {
                 updateSkill(person, educationLevel, skill);
-                PerformanceLogger.improvedSkill(isLogSkillGain, person, campaign.getLocalDate(), skill, educationLevel);
+
+                String skillParsed = Academy.skillParser(skill);
+                int actualSkillLevel = person.hasSkill(skillParsed) ? person.getSkill(skillParsed).getLevel() : 0;
+                PerformanceLogger.improvedSkill(isLogSkillGain,
+                      person,
+                      campaign.getLocalDate(),
+                      skill,
+                      actualSkillLevel);
             }
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -84,7 +84,7 @@ import mekhq.utilities.ReportingUtilities;
  *     combat team.</li>
  *     <li>{@link #performTraining(Campaign, Force, Person, Map, int)}: Handles training for individual
  *     trainees in a force.</li>
- *     <li>{@link #processEducationTime(Person, Person, List, int, double)} Updates a trainee's education progression
+ *     <li>{@link #processEducationTime(Person, Person, List, int, double, boolean, LocalDate)}  Updates a trainee's education progression
  *     and improves skills.</li>
  *     <li>{@link #createSkillsList(Campaign, Set)}: Collects the skill levels of educators to
  *     determine skills eligible for training.</li>

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -642,18 +642,11 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 Skill skill = selectedPerson.getSkill(type);
                 SkillType skillType = skill.getType();
 
-                int adjustedReputation = selectedPerson.getAdjustedReputation(getCampaignOptions().isUseAgeEffects(),
-                      getCampaign().isClanCampaign(),
-                      getCampaign().getLocalDate(),
-                      selectedPerson.getRankNumeric());
-
-                PerformanceLogger.improvedSkill(getCampaign(),
+                PerformanceLogger.improvedSkill(getCampaignOptions().isPersonnelLogSkillGain(),
                       selectedPerson,
                       getCampaign().getLocalDate(),
                       skillType.getName(),
-                      skill.toString(selectedPerson.getOptions(),
-                            selectedPerson.getATOWAttributes(),
-                            adjustedReputation));
+                      skill.getLevel());
                 getCampaign().addReport(String.format(resources.getString("improved.format"),
                       selectedPerson.getHyperlinkedName(),
                       type));

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -390,17 +390,12 @@ public final class BatchXPDialog extends JDialog {
                 person.improveSkill(skillName);
                 person.spendXP(cost);
 
-                int adjustedReputation = person.getAdjustedReputation(campaignOptions.isUseAgeEffects(),
-                      campaign.isClanCampaign(),
-                      campaign.getLocalDate(),
-                      person.getRankNumeric());
-
-                PerformanceLogger.improvedSkill(campaign,
+                Skill skill = person.getSkill(skillName);
+                PerformanceLogger.improvedSkill(campaignOptions.isPersonnelLogSkillGain(),
                       person,
                       campaign.getLocalDate(),
-                      person.getSkill(skillName).getType().getName(),
-                      person.getSkill(skillName)
-                            .toString(person.getOptions(), person.getATOWAttributes(), adjustedReputation));
+                      skill.getType().getName(),
+                      skill.getLevel());
                 campaign.personUpdated(person);
             }
 


### PR DESCRIPTION
Close #7622 

This PR cleans up the skill improvement portion of the performance logger so that it no longer requires `campaign` to be passed in.

It also adds log triggers for when characters improve skills via Education and Training. Both only if skill logging is enabled in campaign options.