### PR TITLE
Improvement: Displayed Total Skill Level For Those Skills Where Skill Level is Important

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -792,8 +792,8 @@ public class Skill {
      *   <li>Otherwise, the final skill value is suffixed with a plus sign (<code>+</code>).</li>
      * </ul>
      *
-     * @param options    The {@link PersonnelOptions} to use for calculating the final skill value.
-     * @param reputation The reputation value used in the calculation.
+     * @param options            The {@link PersonnelOptions} to use for calculating the final skill value.
+     * @param adjustedReputation The reputation value used in the calculation.
      *
      * @return A string representation of the calculated final skill value, formatted depending on the state of
      *       {@link #isCountUp()}.
@@ -801,12 +801,21 @@ public class Skill {
      * @see #isCountUp()
      * @see #getFinalSkillValue(PersonnelOptions, Attributes, int)
      */
-    public String toString(PersonnelOptions options, Attributes attributes, int reputation) {
+    public String toString(PersonnelOptions options, Attributes attributes, int adjustedReputation) {
+        String display;
+
         if (isCountUp()) {
-            return "+" + getFinalSkillValue(options, attributes, reputation);
+            display = "+" + getFinalSkillValue(options, attributes, adjustedReputation);
         } else {
-            return getFinalSkillValue(options, attributes, reputation) + "+";
+            display = getFinalSkillValue(options, attributes, adjustedReputation) + "+";
         }
+
+        if (type.isSkillLevelsMatter()) {
+            int totalSkillLevel = getTotalSkillLevel(options, attributes, adjustedReputation);
+            display += String.format(" (%d)", totalSkillLevel);
+        }
+
+        return display;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -276,6 +276,7 @@ public class SkillType {
     private int heroicLvl;
     private int legendaryLvl;
     private Integer[] costs;
+    private boolean skillLevelsMatter;
 
     /**
      * @param level skill level integer to get name for
@@ -427,6 +428,7 @@ public class SkillType {
         this.legendaryLvl = 7;
         this.costs = new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
                                      DISABLED_SKILL_LEVEL };
+        this.skillLevelsMatter = false;
     }
 
     /**
@@ -440,38 +442,40 @@ public class SkillType {
      * array has more than 11 entries, it will be trimmed to size. Additionally, the input array is copied to prevent
      * accidental external changes to the internal state of the instance.</p>
      *
-     * @param name            The name of the skill type. <b>Cannot</b> be {@code null}.
-     * @param target          The target value representing a threshold or goal for the skill. If {@code null}, the
-     *                        default value is {@code 7}.
-     * @param isCountUp       {@code true} if the skill counts up toward a goal, {@code false} otherwise. If
-     *                        {@code null}, the default value is {@code false}.
-     * @param subType         The {@link SkillSubType} category of the skill. This indicates the broader classification
-     *                        of the skill (e.g., combat-related, role-playing).
-     *                        <b>Cannot</b> be {@code null}.
-     * @param firstAttribute  The primary {@link SkillAttribute} associated with the skill, influencing its calculation
-     *                        or behavior. <b>Cannot</b> be {@code null}.
-     * @param secondAttribute The secondary {@link SkillAttribute} associated with the skill. If {@code null}, the
-     *                        default value is {@link SkillAttribute#NONE}.
-     * @param greenLvl        The value representing the skill's "Green" proficiency level. If {@code null}, the default
-     *                        value is {@code 1}.
-     * @param regLvl          The value representing the skill's "Regular" proficiency level. If {@code null}, the
-     *                        default value is {@code 3}.
-     * @param vetLvl          The value representing the skill's "Veteran" proficiency level. If {@code null}, the
-     *                        default value is {@code 4}.
-     * @param eliteLvl        The value representing the skill's "Elite" proficiency level. If {@code null}, the default
-     *                        value is {@code 5}.
-     * @param costs           An {@code Integer[]} array representing the skill's progression costs for each level from
-     *                        0 to 10 inclusive. If the array is {@code null} or its length is not exactly 11, a new
-     *                        array is created with default values. Missing entries are filled with
-     *                        {@link #DISABLED_SKILL_LEVEL}, and extra entries beyond the 11th are ignored. A clean copy
-     *                        of the array is always used to ensure the integrity of the internal state.
+     * @param name              The name of the skill type. <b>Cannot</b> be {@code null}.
+     * @param target            The target value representing a threshold or goal for the skill. If {@code null}, the
+     *                          default value is {@code 7}.
+     * @param isCountUp         {@code true} if the skill counts up toward a goal, {@code false} otherwise. If
+     *                          {@code null}, the default value is {@code false}.
+     * @param subType           The {@link SkillSubType} category of the skill. This indicates the broader
+     *                          classification of the skill (e.g., combat-related, role-playing).
+     *                          <b>Cannot</b> be {@code null}.
+     * @param firstAttribute    The primary {@link SkillAttribute} associated with the skill, influencing its
+     *                          calculation or behavior. <b>Cannot</b> be {@code null}.
+     * @param secondAttribute   The secondary {@link SkillAttribute} associated with the skill. If {@code null}, the
+     *                          default value is {@link SkillAttribute#NONE}.
+     * @param greenLvl          The value representing the skill's "Green" proficiency level. If {@code null}, the
+     *                          default value is {@code 1}.
+     * @param regLvl            The value representing the skill's "Regular" proficiency level. If {@code null}, the
+     *                          default value is {@code 3}.
+     * @param vetLvl            The value representing the skill's "Veteran" proficiency level. If {@code null}, the
+     *                          default value is {@code 4}.
+     * @param eliteLvl          The value representing the skill's "Elite" proficiency level. If {@code null}, the
+     *                          default value is {@code 5}.
+     * @param costs             An {@code Integer[]} array representing the skill's progression costs for each level
+     *                          from 0 to 10 inclusive. If the array is {@code null} or its length is not exactly 11, a
+     *                          new array is created with default values. Missing entries are filled with
+     *                          {@link #DISABLED_SKILL_LEVEL}, and extra entries beyond the 11th are ignored. A clean
+     *                          copy of the array is always used to ensure the integrity of the internal state.
      *
-     *                        <p>For example:</p>
-     *                        <pre>
-     *                        Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
-     *                        SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
-     *                        SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
-     *                                               </pre>
+     *                          <p>For example:</p>
+     *                          <pre>
+     *                                                                                                       Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
+     *                                                                                                       SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
+     *                                                                                                       SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
+     *                                                                                                   </pre>
+     * @param skillLevelsMatter if {@code true}, the skill's level will be displayed in Person View in addition to the
+     *                          skill's Target Number
      *
      * @author Illiani
      * @since 0.50.05
@@ -479,7 +483,7 @@ public class SkillType {
     public SkillType(String name, @Nullable Integer target, @Nullable Boolean isCountUp, SkillSubType subType,
           SkillAttribute firstAttribute, @Nullable SkillAttribute secondAttribute, @Nullable Integer greenLvl,
           @Nullable Integer regLvl, @Nullable Integer vetLvl, @Nullable Integer eliteLvl, @Nullable Integer heroicLvl,
-          @Nullable Integer legendaryLvl, Integer[] costs) {
+          @Nullable Integer legendaryLvl, Integer[] costs, boolean skillLevelsMatter) {
         this.name = name;
         this.target = target == null ? 7 : target;
         this.countUp = isCountUp != null && isCountUp;
@@ -492,6 +496,7 @@ public class SkillType {
         this.eliteLvl = eliteLvl == null ? 5 : eliteLvl;
         this.heroicLvl = heroicLvl == null ? 6 : heroicLvl;
         this.legendaryLvl = legendaryLvl == null ? 7 : legendaryLvl;
+        this.skillLevelsMatter = skillLevelsMatter;
 
         // This validates the length of costs to ensure that valid entries exist for all possible skill levels (0-10,
         // inclusive)
@@ -783,6 +788,10 @@ public class SkillType {
 
     public void setLegendaryLevel(int level) {
         legendaryLvl = level;
+    }
+
+    public boolean isSkillLevelsMatter() {
+        return skillLevelsMatter;
     }
 
     /**
@@ -1226,12 +1235,14 @@ public class SkillType {
                     for (int i = 0; i < values.length; i++) {
                         skillType.costs[i] = MathUtility.parseInt(values[i], skillType.costs[i]);
                     }
+                } else if (wn2.getNodeName().equalsIgnoreCase("skillLevelsMatter")) {
+                    skillType.skillLevelsMatter = Boolean.parseBoolean(wn2.getTextContent().trim());
                 }
             }
 
             // Skill settings from prior to this are incompatible and cannot be used, so we use the default values instead.
-            boolean preDatesSkillChanges = version.isLowerThan(new Version("0.50.08"));
-            if (preDatesSkillChanges) {
+            boolean preDatesLastSkillChanges = version.isLowerThan(new Version("0.50.08"));
+            if (preDatesLastSkillChanges) {
                 compatibilityHandler(skillType);
             }
 
@@ -1433,10 +1444,12 @@ public class SkillType {
             return;
         }
 
+        // <50.07 compatibility handlers.
         skillType.subType = temporarySkillType.getSubType();
         skillType.firstAttribute = temporarySkillType.getFirstAttribute();
         skillType.secondAttribute = temporarySkillType.getSecondAttribute();
         skillType.countUp = temporarySkillType.isCountUp();
+        skillType.skillLevelsMatter = temporarySkillType.isSkillLevelsMatter();
 
         if (skillType.subType == SUPPORT_COMMAND) {
             skillType.target = temporarySkillType.getTarget();
@@ -1457,7 +1470,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createGunneryMek() {
@@ -1474,7 +1488,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createPilotingAero() {
@@ -1490,7 +1505,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createGunneryAero() {
@@ -1507,7 +1523,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createPilotingJet() {
@@ -1523,7 +1540,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createGunneryJet() {
@@ -1540,7 +1558,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createPilotingSpace() {
@@ -1556,7 +1575,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createGunnerySpace() {
@@ -1573,7 +1593,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createPilotingGroundVee() {
@@ -1589,7 +1610,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createPilotingNavalVee() {
@@ -1605,7 +1627,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createPilotingVTOL() {
@@ -1621,7 +1644,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createGunneryVehicle() {
@@ -1638,7 +1662,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createArtillery() {
@@ -1655,7 +1680,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createGunneryBA() {
@@ -1672,7 +1698,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createGunneryProto() {
@@ -1689,7 +1716,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createSmallArms() {
@@ -1705,7 +1733,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createAntiMek() {
@@ -1722,7 +1751,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createTechMek() {
@@ -1740,7 +1770,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createTechMechanic() {
@@ -1758,7 +1789,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createTechAero() {
@@ -1776,7 +1808,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createTechBA() {
@@ -1794,7 +1827,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createTechVessel() {
@@ -1812,7 +1846,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createAstech() {
@@ -1831,7 +1866,8 @@ public class SkillType {
               null,
               new Integer[] { 12, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
                               DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              true);
     }
 
     public static SkillType createSurgery() {
@@ -1849,7 +1885,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 0, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createMedTech() {
@@ -1867,7 +1904,8 @@ public class SkillType {
               null,
               new Integer[] { 16, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
                               DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              true);
     }
 
     public static SkillType createNavigation() {
@@ -1884,7 +1922,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              false);
     }
 
     public static SkillType createTactics() {
@@ -1900,7 +1939,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 });
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 },
+              true);
     }
 
     public static SkillType createStrategy() {
@@ -1916,7 +1956,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 });
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 },
+              true);
     }
 
     public static SkillType createAdmin() {
@@ -1933,7 +1974,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 8, 4, 0, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL });
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
+              true);
     }
 
     public static SkillType createLeadership() {
@@ -1949,7 +1991,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 });
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 },
+              true);
     }
 
     public static SkillType createNegotiation() {
@@ -1965,7 +2008,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 });
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 },
+              false);
     }
 
     public static SkillType createAcrobatics() {
@@ -1981,7 +2025,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createActing() {
@@ -1997,7 +2042,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createAnimalHandling() {
@@ -2013,7 +2059,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createAppraisal() {
@@ -2029,7 +2076,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createArchery() {
@@ -2045,7 +2093,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createArtDancing() {
@@ -2061,7 +2110,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createArtDrawing() {
@@ -2077,7 +2127,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createArtPainting() {
@@ -2093,7 +2144,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createArtWriting() {
@@ -2109,7 +2161,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createArtPoetry() {
@@ -2125,7 +2178,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
 
@@ -2142,7 +2196,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
 
@@ -2159,7 +2214,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createArtCooking() {
@@ -2175,7 +2231,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createArtSinging() {
@@ -2191,7 +2248,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createArtOther() {
@@ -2207,7 +2265,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createCommunications() {
@@ -2223,7 +2282,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createComputers() {
@@ -2239,7 +2299,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createCryptography() {
@@ -2255,7 +2316,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createDemolitions() {
@@ -2271,7 +2333,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createDisguise() {
@@ -2287,7 +2350,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createEscapeArtist() {
@@ -2303,7 +2367,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createForgery() {
@@ -2319,7 +2384,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestHistory() {
@@ -2335,7 +2401,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestLiterature() {
@@ -2351,7 +2418,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestHoloGames() {
@@ -2367,7 +2435,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestSports() {
@@ -2383,7 +2452,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestFashion() {
@@ -2399,7 +2469,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestMusic() {
@@ -2415,7 +2486,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestMilitary() {
@@ -2431,7 +2503,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestAntiques() {
@@ -2447,7 +2520,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestTheology() {
@@ -2463,7 +2537,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestGambling() {
@@ -2479,7 +2554,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestPolitics() {
@@ -2495,7 +2571,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestPhilosophy() {
@@ -2511,7 +2588,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestEconomics() {
@@ -2527,7 +2605,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestPopCulture() {
@@ -2543,7 +2622,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestAstrology() {
@@ -2559,7 +2639,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestFishing() {
@@ -2575,7 +2656,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestMythology() {
@@ -2591,7 +2673,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestCartography() {
@@ -2607,7 +2690,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestArcheology() {
@@ -2623,7 +2707,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestHoloCinema() {
@@ -2639,7 +2724,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestExoticAnimals() {
@@ -2655,7 +2741,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestLaw() {
@@ -2671,7 +2758,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterestOther() {
@@ -2687,7 +2775,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInterrogation() {
@@ -2703,7 +2792,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createInvestigation() {
@@ -2719,7 +2809,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createLanguage() {
@@ -2735,7 +2826,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createMartialArts() {
@@ -2751,7 +2843,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createPerception() {
@@ -2767,7 +2860,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createSleightOfHand() {
@@ -2785,7 +2879,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createProtocols() {
@@ -2801,7 +2896,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createScienceBiology() {
@@ -2817,7 +2913,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createScienceChemistry() {
@@ -2833,7 +2930,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createScienceMathematics() {
@@ -2849,7 +2947,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createSciencePhysics() {
@@ -2865,7 +2964,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createScienceMilitary() {
@@ -2881,7 +2981,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createScienceGeology() {
@@ -2897,7 +2998,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createScienceXenobiology() {
@@ -2913,7 +3015,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createSciencePharmacology() {
@@ -2929,7 +3032,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createScienceGenetics() {
@@ -2945,7 +3049,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createSciencePsychology() {
@@ -2961,7 +3066,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createScienceOther() {
@@ -2977,7 +3083,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createSecuritySystemsElectronic() {
@@ -2993,7 +3100,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createSecuritySystemsMechanical() {
@@ -3009,7 +3117,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createSensorOperations() {
@@ -3025,7 +3134,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createStealth() {
@@ -3041,7 +3151,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createStreetwise() {
@@ -3057,7 +3168,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createSurvival() {
@@ -3073,7 +3185,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createTracking() {
@@ -3089,7 +3202,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createTraining() {
@@ -3105,7 +3219,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createCareer() {
@@ -3121,7 +3236,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createZeroGOperations() {
@@ -3137,7 +3253,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createMeleeWeapons() {
@@ -3153,7 +3270,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createThrownWeapons() {
@@ -3169,7 +3287,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createSupportWeapons() {
@@ -3185,7 +3304,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createSwimming() {
@@ -3201,7 +3321,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 
     public static SkillType createRunning() {
@@ -3217,6 +3338,7 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 });
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
+              false);
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -470,10 +470,10 @@ public class SkillType {
      *
      *                          <p>For example:</p>
      *                          <pre>
-     *                                                                                                       Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
-     *                                                                                                       SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
-     *                                                                                                       SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
-     *                                                                                                   </pre>
+     *                                                                                                                                Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
+     *                                                                                                                                SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
+     *                                                                                                                                SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
+     *                                                                                                                            </pre>
      * @param skillLevelsMatter if {@code true}, the skill's level will be displayed in Person View in addition to the
      *                          skill's Target Number
      *
@@ -1886,7 +1886,7 @@ public class SkillType {
               null,
               new Integer[] { 16, 8, 0, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
                               DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              true);
     }
 
     public static SkillType createMedTech() {
@@ -3254,7 +3254,7 @@ public class SkillType {
               null,
               null,
               new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              true);
     }
 
     public static SkillType createMeleeWeapons() {


### PR DESCRIPTION
It was raised on the Discord a little while ago that for some skills (command skills, mainly) you want to be able to skill how many levels a character has in that skill, not just the skill's target number.

This PR updates SkillTypes so that some skills (where appropriate) will now display both the TN and Level of the skill in the character sheet.

<img width="689" height="108" alt="image" src="https://github.com/user-attachments/assets/1f9ecc0e-733a-41fd-9215-cdf28c91f0b4" />
