### PR TITLE
Fix 7634: Add backwards-compatibility class name handler for BaArmor -> BAArmor

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -692,6 +692,7 @@ public abstract class Part implements IPartWork, ITechnology {
             case "VeeStabiliser" -> VeeStabilizer.class.getSimpleName();
             case "MissingVeeStabiliser" -> MissingVeeStabilizer.class.getSimpleName();
             // <50.07 compatibility handlers
+            case "mekhq.campaign.parts.BaArmor" -> "mekhq.campaign.parts.BAArmor";
             case "mekhq.campaign.parts.MekLocation" -> "mekhq.campaign.parts.meks.MekLocation";
             case "mekhq.campaign.parts.MekGyro" -> "mekhq.campaign.parts.meks.MekGyro";
             case "mekhq.campaign.parts.MekLifeSupport" -> "mekhq.campaign.parts.meks.MekLifeSupport";


### PR DESCRIPTION
Adds a case-sensitive backwards compatibility handler to the Campaign Parts loading code to handle BaArmor -> BAArmor.

Close #7634 

Testing:
- Loaded OP's test campaign and confirmed no issues with the BAArmor part in their inventory, and no NPE/Exception in log.
- Ran all 3 projects' unit tests.