### PR TITLE
Improvement #7639: Deescalated Unexpected Options from Error to Warn

### DIFF
--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -862,7 +862,7 @@ public class CampaignOptionsUnmarshaller {
                   nodeContents));
             case "factionStandingGainMultiplier" -> campaignOptions.setRegardMultiplier(parseDouble(
                   nodeContents, 1.0));
-            default -> throw new IllegalStateException("Potentially unexpected entry in campaign options: " + nodeName);
+            default -> LOGGER.warn("Potentially unexpected entry in campaign options: {}", nodeName);
         }
     }
 }


### PR DESCRIPTION
Fix #7639

I recently updated how campaign options presets load from xml, how I was a tad overzealous with how unexpected values should be treated. This de-escalates them from error to a humble warn.