### PR TITLE
Fix #7650: Restored Ability to View Permanent Injuries in Personnel Tab Character Sheet; Improved Visual Clarity of Injuries

### DIFF
--- a/MekHQ/resources/mekhq/resources/PersonViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/PersonViewPanel.properties
@@ -125,4 +125,4 @@ format.kills=Kills: %d
 format.killDetail=%s with %s
 format.scenarios=Scenarios: %d
 format.italic=<html><i>%s</i></html>
-format.injuryTime=%d days
+format.injuryLabel=<html>%s (%s days)</html>

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -6479,6 +6479,22 @@ public class Person {
               isPiloting ? ModifierValue.PILOTING : ModifierValue.GUNNERY);
     }
 
+    /**
+     * Determines whether the person has any injuries, possibly filtering by permanence.
+     *
+     * <ul>
+     *     <li>If {@code permanentCheck} is {@code false}, this method returns {@code true} if the person has any
+     *     recorded injuries.</li>
+     *     <li>If {@code permanentCheck} is {@code true}, it will return {@code true} only if the person has at least
+     *     one injury that is either non-permanent or has a remaining recovery time greater than zero. Otherwise, it
+     *     returns {@code false}.</li>
+     * </ul>
+     *
+     * @param permanentCheck if {@code true}, only injuries that are not permanent or have time remaining are
+     *                       considered; if {@code false}, any injury will be counted
+     *
+     * @return {@code true} if the person has injuries matching the specified criteria; {@code false} otherwise
+     */
     public boolean hasInjuries(final boolean permanentCheck) {
         return !injuries.isEmpty() &&
                      (!permanentCheck ||

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -57,6 +57,8 @@ import static mekhq.campaign.personnel.skills.enums.SkillSubType.SUPPORT_COMMAND
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.getEffectiveFatigue;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.getNegativeColor;
+import static mekhq.utilities.ReportingUtilities.getWarningColor;
+import static mekhq.utilities.ReportingUtilities.messageSurroundedBySpanWithColor;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 import static org.jfree.chart.ChartColor.DARK_BLUE;
 import static org.jfree.chart.ChartColor.DARK_RED;
@@ -2437,6 +2439,8 @@ public class PersonViewPanel extends JScrollablePanel {
     }
 
     private JPanel fillInjuries() {
+        final String WARNING_ICON = "\u26A0";
+
         JPanel pnlInjuries = new JPanel(new BorderLayout());
         pnlInjuries.setBorder(RoundedLineBorder.createRoundedLineBorder(resourceMap.getString("pnlInjuries.title")));
 
@@ -2452,19 +2456,19 @@ public class PersonViewPanel extends JScrollablePanel {
         GridBagConstraints gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
+        gridBagConstraints.weightx = 1.0;
         gridBagConstraints.fill = GridBagConstraints.NONE;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         pnlInjuryDetails.add(lblAdvancedMedical1, gridBagConstraints);
 
         double vWeight = 1.0;
-        if (person.hasInjuries(false)) {
+        if (person.hasInjuries(true)) {
             vWeight = 0.0;
         }
 
         lblAdvancedMedical2.setName("lblAdvancedMedical2");
         lblAdvancedMedical2.setText(getAdvancedMedalEffectString(person));
         lblAdvancedMedical1.setLabelFor(lblAdvancedMedical2);
-        gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 0;
         gridBagConstraints.weightx = 1.0;
@@ -2474,38 +2478,42 @@ public class PersonViewPanel extends JScrollablePanel {
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         pnlInjuryDetails.add(lblAdvancedMedical2, gridBagConstraints);
 
+        // This adds a dummy/invisible label to column 2, row 0 to prevent column 3 from being pushed away
+        JLabel dummy = new JLabel();
+        dummy.setPreferredSize(new Dimension(0, 0));
+        gridBagConstraints.gridx = 2;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.weightx = 1.0;
+        gridBagConstraints.weighty = 0.0;
+        gridBagConstraints.insets = new Insets(0, 0, 0, 0);
+        gridBagConstraints.fill = GridBagConstraints.NONE;
+        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+        pnlInjuryDetails.add(dummy, gridBagConstraints);
+
         JLabel lblInjury;
-        JLabel txtInjury;
-        int row = 1;
         List<Injury> injuries = person.getInjuries();
-        for (Injury injury : injuries) {
-            lblInjury = new JLabel(injury.getFluff());
-            gridBagConstraints = new GridBagConstraints();
-            gridBagConstraints.gridx = 0;
-            gridBagConstraints.gridy = row;
+        int columns = 3;
+        int rowsPerColumn = (int) Math.ceil((double) injuries.size() / columns);
+
+        for (int i = 0; i < injuries.size(); ++i) {
+            Injury injury = injuries.get(i);
+
+            int col = i / rowsPerColumn;
+            int displayRow = (i % rowsPerColumn) + 1; // Start rows at 1 as we have a header
+
+            String durationValue = injury.isPermanent() ? WARNING_ICON : String.valueOf(injury.getTime());
+            String durationColor = injury.isPermanent() ? getNegativeColor() : getWarningColor();
+            String durationText = messageSurroundedBySpanWithColor(durationColor, durationValue);
+            String label = String.format(resourceMap.getString("format.injuryLabel"), injury.getName(), durationText);
+
+            lblInjury = new JLabel(label);
+            gridBagConstraints.gridx = col;
+            gridBagConstraints.gridy = displayRow;
             gridBagConstraints.weightx = 0.0;
             gridBagConstraints.insets = new Insets(0, 10, 0, 0);
             gridBagConstraints.fill = GridBagConstraints.NONE;
             gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
             pnlInjuryDetails.add(lblInjury, gridBagConstraints);
-
-            String text = (injury.isPermanent() && injury.getTime() < 1) ?
-                                resourceMap.getString("lblPermanentInjury.text") :
-                                String.format(resourceMap.getString("format.injuryTime"), injury.getTime());
-            txtInjury = new JLabel("<html>" + text + "</html>");
-            lblInjury.setLabelFor(txtInjury);
-            gridBagConstraints = new GridBagConstraints();
-            gridBagConstraints.gridx = 1;
-            gridBagConstraints.gridy = row;
-            gridBagConstraints.weightx = 1.0;
-            if (row == (injuries.size() - 1)) {
-                gridBagConstraints.weighty = 1.0;
-            }
-            gridBagConstraints.insets = new Insets(0, 20, 0, 0);
-            gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-            pnlInjuryDetails.add(txtInjury, gridBagConstraints);
-            row++;
         }
 
         pnlInjuries.add(pnlInjuryDetails, BorderLayout.CENTER);
@@ -2519,25 +2527,33 @@ public class PersonViewPanel extends JScrollablePanel {
      * @return an HTML encoded string of effects
      */
     private String getAdvancedMedalEffectString(Person person) {
-        StringBuilder medicalEffects = new StringBuilder("<html>");
+        StringBuilder medicalEffects = new StringBuilder();
         final int pilotingMod = person.getInjuryModifiers(true);
         final int gunneryMod = person.getInjuryModifiers(false);
+        boolean hadEffect = false;
+
         if ((pilotingMod != 0) && (pilotingMod < Integer.MAX_VALUE)) {
-            medicalEffects.append(String.format("  Piloting %+d <br>", pilotingMod));
+            medicalEffects.append(String.format("Piloting %+d", pilotingMod));
+            hadEffect = true;
         } else if (pilotingMod == Integer.MAX_VALUE) {
-            medicalEffects.append("  Piloting: <i>Impossible</i>  <br>");
+            medicalEffects.append("Piloting: Impossible");
+            hadEffect = true;
         }
 
         if ((gunneryMod != 0) && (gunneryMod < Integer.MAX_VALUE)) {
-            medicalEffects.append(String.format("  Gunnery: %+d <br>", gunneryMod));
+            if (hadEffect) {medicalEffects.append(", ");}
+            medicalEffects.append(String.format("Gunnery %+d", gunneryMod));
+            hadEffect = true;
         } else if (gunneryMod == Integer.MAX_VALUE) {
-            medicalEffects.append("  Gunnery: <i>Impossible</i>  <br>");
+            if (hadEffect) {medicalEffects.append(", ");}
+            medicalEffects.append("Gunnery: Impossible");
+            hadEffect = true;
         }
 
-        if ((gunneryMod == 0) && (pilotingMod == 0)) {
+        if (!hadEffect) {
             medicalEffects.append("None");
         }
-        return medicalEffects.append("</html>").toString();
+        return medicalEffects.toString();
     }
 
     private JPanel fillKillRecord() {


### PR DESCRIPTION
Fix #7650

Permanent injuries were not visible due to an incorrectly falsified boolean param. Once restored I realized that the injury panel hadn't received the same love and care that the rest of Person View had received during the recent rework. So I went ahead and updated it visually:

## Old
<img width="685" height="155" alt="image" src="https://github.com/user-attachments/assets/cbc1a232-93de-4efc-9fa8-0f11c153e2c7" />

## New
<img width="687" height="87" alt="image" src="https://github.com/user-attachments/assets/0b31e4c4-4e40-4a47-bdbd-98ffe424c33c" />
