### PR TITLE
Fix: Refactored Post-Scenario Unit Resetting Potentially Fixing the Infamous 'Ghost Meks' Bug

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -100,6 +100,7 @@ import mekhq.MHQStaticDirectoryManager;
 import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.events.persons.PersonCrewAssignmentEvent;
 import mekhq.campaign.events.persons.PersonTechAssignmentEvent;
@@ -4416,7 +4417,31 @@ public class Unit implements ITechnology {
     }
 
     public void resetPilotAndEntity() {
+        final CampaignOptions campaignOptions = getCampaign().getCampaignOptions();
+
+        // Reset transient data
+        getCampaign().clearGameData(entity);
+        entity.setCommander(false);
         entity.getCrew().resetGameState();
+        entity.getCrew().setCommandBonus(0);
+
+        // Update crew data
+        updateCrew();
+
+        // commander can be null at this point, but that's ok because both of the following calls include null
+        // handling built into their methods.
+        Person commander = getCommander();
+
+        if (campaignOptions.isUseInitiativeBonus()) {
+            setCommandBonus(commander);
+        }
+
+        if (campaignOptions.isUseAbilities() || campaignOptions.isUseEdge() || campaignOptions.isUseImplants()) {
+            processUnitSPAs(commander);
+        }
+    }
+
+    private void updateCrew() {
         if (entity.getCrew().getSlotCount() > 1) {
             final String driveType = SkillType.getDrivingSkillFor(entity);
             final String gunType = SkillType.getGunnerySkillFor(entity);
@@ -4493,208 +4518,191 @@ public class Unit implements ITechnology {
             }
             entity.getCrew().setMissing(false, 0);
         }
+    }
 
-        // Clear any stale game data that may somehow have gotten set incorrectly
-        getCampaign().clearGameData(entity);
+    private void setCommandBonus(@Nullable Person commander) {
+        // Tactics command bonus. This should actually reflect the unit's commander
+        if (null != commander && commander.hasSkill(SkillType.S_TACTICS)) {
+            entity.getCrew()
+                  .setCommandBonus(commander.getSkill(SkillType.S_TACTICS)
+                                         .getTotalSkillLevel(commander.getOptions(),
+                                               commander.getATOWAttributes(),
+                                               0));
+        }
+    }
 
-        // Set up SPAs, Implants, Edge, etc.
-        // Find the unit commander
-        Person commander = getCommander();
+    private void processUnitSPAs(@Nullable Person commander) {
+        if (null == commander) {
+            // This is a legacy decision. Previously we early exited, but that caused a heap of problems. So instead
+            // we now create a temporary fake 'commander' with no PilotOptions. This allows all the code here to
+            // process, without us needing to worry about nulls or rewriting this rather large and complex piece of
+            // code. - Illiani 5th October 2025
+            commander = new Person(getCampaign());
+        }
 
-        // Set Tactics-based Commander's Initiative Bonus, if applicable
-        entity.getCrew().setCommandBonus(0);
-        if (getCampaign().getCampaignOptions().isUseTactics() ||
-                  getCampaign().getCampaignOptions().isUseInitiativeBonus()) {
-            // Tactics command bonus. This should actually reflect the unit's commander
-            if (null != commander && commander.hasSkill(SkillType.S_TACTICS)) {
-                entity.getCrew()
-                      .setCommandBonus(commander.getSkill(SkillType.S_TACTICS)
-                                             .getTotalSkillLevel(commander.getOptions(),
-                                                   commander.getATOWAttributes(),
-                                                   0));
+        PilotOptions options = new PilotOptions(); // MegaMek-style as it is sent to MegaMek
+        // This double enumeration is annoying to work with for crew-served units.
+        // Get the option names while we enumerate so they can be used later
+        List<String> optionNames = new ArrayList<>();
+        Set<String> cyberOptionNames = new HashSet<>();
+        for (Enumeration<IOptionGroup> i = options.getGroups(); i.hasMoreElements(); ) {
+            IOptionGroup group = i.nextElement();
+            for (Enumeration<IOption> j = group.getOptions(); j.hasMoreElements(); ) {
+                IOption option = j.nextElement();
+                if (getCampaign().getCampaignOptions().isUseImplants() &&
+                          group.getKey().equals(PersonnelOptions.MD_ADVANTAGES)) {
+                    cyberOptionNames.add(option.getName());
+                } else if (getCampaign().getCampaignOptions().isUseEdge() &&
+                                 group.getKey().equals(PersonnelOptions.EDGE_ADVANTAGES)) {
+                    optionNames.add(option.getName());
+                } else if (getCampaign().getCampaignOptions().isUseAbilities() &&
+                                 !group.getKey().equals(PersonnelOptions.EDGE_ADVANTAGES)) {
+                    optionNames.add(option.getName());
+                }
             }
         }
 
-        // Reset commander status
-        entity.setCommander(false);
+        boolean commanderOnly = campaign.getCampaignOptions().isUseCommanderAbilitiesOnly();
 
-        if (getCampaign().getCampaignOptions().isUseAbilities() ||
-                  getCampaign().getCampaignOptions().isUseEdge() ||
-                  getCampaign().getCampaignOptions().isUseImplants()) {
-            PilotOptions options = new PilotOptions(); // MegaMek-style as it is sent to MegaMek
-            // This double enumeration is annoying to work with for crew-served units.
-            // Get the option names while we enumerate so they can be used later
-            List<String> optionNames = new ArrayList<>();
-            Set<String> cyberOptionNames = new HashSet<>();
-            for (Enumeration<IOptionGroup> i = options.getGroups(); i.hasMoreElements(); ) {
-                IOptionGroup group = i.nextElement();
-                for (Enumeration<IOption> j = group.getOptions(); j.hasMoreElements(); ) {
-                    IOption option = j.nextElement();
-                    if (getCampaign().getCampaignOptions().isUseImplants() &&
-                              group.getKey().equals(PersonnelOptions.MD_ADVANTAGES)) {
-                        cyberOptionNames.add(option.getName());
-                    } else if (getCampaign().getCampaignOptions().isUseEdge() &&
-                                     group.getKey().equals(PersonnelOptions.EDGE_ADVANTAGES)) {
-                        optionNames.add(option.getName());
-                    } else if (getCampaign().getCampaignOptions().isUseAbilities() &&
-                                     !group.getKey().equals(PersonnelOptions.EDGE_ADVANTAGES)) {
-                        optionNames.add(option.getName());
-                    }
+        // For crew-served units, let's look at the abilities of the group. If more than half the crew (gunners
+        // and pilots only, for spacecraft) have an ability, grant the benefit to the unit
+        // TODO : Mobile structures, large naval support vehicles
+        if (!commanderOnly &&
+                  (entity.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT) ||
+                         entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP) ||
+                         entity.hasETypeFlag(Entity.ETYPE_TANK) ||
+                         entity.hasETypeFlag(Entity.ETYPE_INFANTRY) ||
+                         entity.hasETypeFlag(Entity.ETYPE_TRIPOD_MEK))) {
+            // Combine drivers and gunners into a single list
+
+            List<Person> crew = new ArrayList<>(drivers);
+
+            // Infantry and BA troops count as both drivers and gunners
+            // only count them once.
+            if (!entity.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
+                crew.addAll(gunners);
+            }
+            double crewSize = crew.size();
+
+            // This does the following:
+            // 1. For each crew member, get all of their PersonnelOptions by name
+            // 2. Flatten the crew member options into one stream
+            // 3. Group these options by their name
+            // 4. For each group, group by the object value and get the counts for each
+            // value
+            // 5. Take each group which has more than crewSize/2 values, and find the
+            // maximum value
+            Map<String, Optional<Object>> bestOptions = crew.stream()
+                                                              .flatMap(p -> optionNames.stream()
+                                                                                  .map(n -> p.getOptions()
+                                                                                                  .getOption(n)))
+                                                              .collect(Collectors.groupingBy(IOption::getName,
+                                                                    Collectors.collectingAndThen(Collectors.groupingBy(
+                                                                                IOption::getValue,
+                                                                                Collectors.counting()),
+                                                                          m -> m.entrySet()
+                                                                                     .stream()
+                                                                                     .filter(e -> (cyberOptionNames.contains(
+                                                                                           e.getKey()) ?
+                                                                                                         e.getValue() >=
+                                                                                                               crewSize :
+                                                                                                         e.getValue() >
+                                                                                                               crewSize /
+                                                                                                                     2))
+                                                                                     .max(Entry.comparingByValue())
+                                                                                     .map(Entry::getKey))));
+
+            // Go through all the options and start with the commander's value,
+            // then add any values which more than half our crew had
+            for (String optionName : optionNames) {
+                IOption option = commander.getOptions().getOption(optionName);
+                if (null != option) {
+                    options.getOption(optionName).setValue(option.getValue());
+                }
+
+                if (bestOptions.containsKey(optionName)) {
+                    Optional<Object> crewOption = bestOptions.get(optionName);
+                    crewOption.ifPresent(o -> options.getOption(optionName).setValue(o));
                 }
             }
 
-            boolean commanderOnly = campaign.getCampaignOptions().isUseCommanderAbilitiesOnly();
-
-            // For crew-served units, let's look at the abilities of the group. If more than half the crew (gunners
-            // and pilots only, for spacecraft) have an ability, grant the benefit to the unit
-            // TODO : Mobile structures, large naval support vehicles
-            if (!commanderOnly &&
-                      (entity.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT) ||
-                             entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP) ||
-                             entity.hasETypeFlag(Entity.ETYPE_TANK) ||
-                             entity.hasETypeFlag(Entity.ETYPE_INFANTRY) ||
-                             entity.hasETypeFlag(Entity.ETYPE_TRIPOD_MEK))) {
-                // If there is no crew, there's nothing left to do here.
-                if (null == commander) {
-                    return;
+            // Yuck. Most cybernetic implants require all members of a unit's crew to have
+            // the implant rather than half.
+            // A few just require 1/4 the crew, there's at least one commander only, some
+            // just add an effect for every
+            // trooper who has the implant...you get the idea.
+            // TODO : Revisit this once all implants are fully implemented.
+            for (String implantName : cyberOptionNames) {
+                IOption option = commander.getOptions().getOption(implantName);
+                if (null != option) {
+                    options.getOption(implantName).setValue(option.getValue());
                 }
-                // Combine drivers and gunners into a single list
 
-                List<Person> crew = new ArrayList<>(drivers);
+                if (bestOptions.containsKey(implantName)) {
+                    Optional<Object> crewOption = bestOptions.get(implantName);
+                    crewOption.ifPresent(o -> options.getOption(implantName).setValue(o));
+                }
+            }
 
-                // Infantry and BA troops count as both drivers and gunners
-                // only count them once.
+            // Assign the options to our unit
+            entity.getCrew().setOptions(options);
+
+            // Assign edge points to spacecraft and vehicle crews and infantry units
+            // This overwrites the Edge value assigned above.
+            if (getCampaign().getCampaignOptions().isUseEdge()) {
+                double sumEdge = 0;
+                for (Person p : drivers) {
+                    sumEdge += p.getCurrentEdge();
+                }
+                // Again, don't count infantrymen twice
                 if (!entity.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
-                    crew.addAll(gunners);
-                }
-                double crewSize = crew.size();
-
-                // This does the following:
-                // 1. For each crew member, get all of their PersonnelOptions by name
-                // 2. Flatten the crew member options into one stream
-                // 3. Group these options by their name
-                // 4. For each group, group by the object value and get the counts for each
-                // value
-                // 5. Take each group which has more than crewSize/2 values, and find the
-                // maximum value
-                Map<String, Optional<Object>> bestOptions = crew.stream()
-                                                                  .flatMap(p -> optionNames.stream()
-                                                                                      .map(n -> p.getOptions()
-                                                                                                      .getOption(n)))
-                                                                  .collect(Collectors.groupingBy(IOption::getName,
-                                                                        Collectors.collectingAndThen(Collectors.groupingBy(
-                                                                                    IOption::getValue,
-                                                                                    Collectors.counting()),
-                                                                              m -> m.entrySet()
-                                                                                         .stream()
-                                                                                         .filter(e -> (cyberOptionNames.contains(
-                                                                                               e.getKey()) ?
-                                                                                                             e.getValue() >=
-                                                                                                                   crewSize :
-                                                                                                             e.getValue() >
-                                                                                                                   crewSize /
-                                                                                                                         2))
-                                                                                         .max(Entry.comparingByValue())
-                                                                                         .map(Entry::getKey))));
-
-                // Go through all the options and start with the commander's value,
-                // then add any values which more than half our crew had
-                for (String optionName : optionNames) {
-                    IOption option = commander.getOptions().getOption(optionName);
-                    if (null != option) {
-                        options.getOption(optionName).setValue(option.getValue());
-                    }
-
-                    if (bestOptions.containsKey(optionName)) {
-                        Optional<Object> crewOption = bestOptions.get(optionName);
-                        crewOption.ifPresent(o -> options.getOption(optionName).setValue(o));
-                    }
-                }
-
-                // Yuck. Most cybernetic implants require all members of a unit's crew to have
-                // the implant rather than half.
-                // A few just require 1/4 the crew, there's at least one commander only, some
-                // just add an effect for every
-                // trooper who has the implant...you get the idea.
-                // TODO : Revisit this once all implants are fully implemented.
-                for (String implantName : cyberOptionNames) {
-                    IOption option = commander.getOptions().getOption(implantName);
-                    if (null != option) {
-                        options.getOption(implantName).setValue(option.getValue());
-                    }
-
-                    if (bestOptions.containsKey(implantName)) {
-                        Optional<Object> crewOption = bestOptions.get(implantName);
-                        crewOption.ifPresent(o -> options.getOption(implantName).setValue(o));
-                    }
-                }
-
-                // Assign the options to our unit
-                entity.getCrew().setOptions(options);
-
-                // Assign edge points to spacecraft and vehicle crews and infantry units
-                // This overwrites the Edge value assigned above.
-                if (getCampaign().getCampaignOptions().isUseEdge()) {
-                    double sumEdge = 0;
-                    for (Person p : drivers) {
+                    for (Person p : gunners) {
                         sumEdge += p.getCurrentEdge();
                     }
-                    // Again, don't count infantrymen twice
-                    if (!entity.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
-                        for (Person p : gunners) {
-                            sumEdge += p.getCurrentEdge();
-                        }
-                    }
-                    // Average the edge values of pilots and gunners. The Spacecraft Engineer
-                    // (vessel crewmembers)
-                    // handle edge solely through MHQ as noncombat personnel, so aren't considered
-                    // here
-                    int edge = (int) Math.round(sumEdge / crewSize);
-                    IOption edgeOption = entity.getCrew().getOptions().getOption(OptionsConstants.EDGE);
-                    edgeOption.setValue((Integer) edge);
                 }
+                // Average the edge values of pilots and gunners. The Spacecraft Engineer
+                // (vessel crewmembers)
+                // handle edge solely through MHQ as noncombat personnel, so aren't considered
+                // here
+                int edge = (int) Math.round(sumEdge / crewSize);
+                IOption edgeOption = entity.getCrew().getOptions().getOption(OptionsConstants.EDGE);
+                edgeOption.setValue((Integer) edge);
+            }
 
-                // Reset the composite technician used by spacecraft and infantry
-                // Important if you just changed technician edge options for members of either
-                // unit type
-                resetEngineer();
+            // Reset the composite technician used by spacecraft and infantry
+            // Important if you just changed technician edge options for members of either
+            // unit type
+            resetEngineer();
 
-                // TODO : Set up crew hits. This might only apply to spacecraft, and should
-                // reflect
-                // the unit's current crew size vs its required crew size. There's also the
-                // question
-                // of what to do with extra crew quarters and crewmember assignments beyond the
-                // minimum.
-            } else {
-                // For other unit types, just use the unit commander's abilities.
-                PilotOptions cdrOptions = new PilotOptions(); // MegaMek-style as it is sent to MegaMek
-                if (null != commander) {
-                    for (String optionName : optionNames) {
-                        IOption option = commander.getOptions().getOption(optionName);
-                        if (null != option) {
-                            cdrOptions.getOption(optionName).setValue(option.getValue());
-                        }
-                    }
-                    for (String implantName : cyberOptionNames) {
-                        IOption option = commander.getOptions().getOption(implantName);
-                        if (null != option) {
-                            cdrOptions.getOption(implantName).setValue(option.getValue());
-                        }
-                    }
-                    entity.getCrew().setOptions(cdrOptions);
-
-                    if (usesSoloPilot()) {
-                        if (!commander.getStatus().isActive()) {
-                            entity.getCrew().setMissing(true, 0);
-                            return;
-                        }
-                        entity.getCrew().setHits(commander.getHits(), 0);
-                    }
+            // TODO : Set up crew hits. This might only apply to spacecraft, and should
+            // reflect
+            // the unit's current crew size vs its required crew size. There's also the
+            // question
+            // of what to do with extra crew quarters and crewmember assignments beyond the
+            // minimum.
+        } else {
+            // For other unit types, just use the unit commander's abilities.
+            PilotOptions cdrOptions = new PilotOptions(); // MegaMek-style as it is sent to MegaMek
+            for (String optionName : optionNames) {
+                IOption option = commander.getOptions().getOption(optionName);
+                if (null != option) {
+                    cdrOptions.getOption(optionName).setValue(option.getValue());
                 }
+            }
+            for (String implantName : cyberOptionNames) {
+                IOption option = commander.getOptions().getOption(implantName);
+                if (null != option) {
+                    cdrOptions.getOption(implantName).setValue(option.getValue());
+                }
+            }
+            entity.getCrew().setOptions(cdrOptions);
 
-                // There was a resetEngineer() here. We shouldn't need it as spacecraft and
-                // infantry are handled
-                // by the preceding block
+            if (usesSoloPilot()) {
+                if (!commander.getStatus().isActive()) {
+                    entity.getCrew().setMissing(true, 0);
+                    return;
+                }
+                entity.getCrew().setHits(commander.getHits(), 0);
             }
         }
     }


### PR DESCRIPTION
There’s a long-standing and infamous bug in MHQ, often called the “ghost 'Mek” or “haunted 'Mek” bug. If you’ve played MHQ for any length of time, you’ve probably run into it: you deploy your forces to a scenario, and one unit ends up placed far away from the rest—seemingly at random. This happens because the unit is retaining deployment data from a previous scenario.

It was dubbed the “ghost 'Mek” bug because it usually affected 'Meks that had been destroyed via cockpit destruction—almost as if they were haunted by the memories of past violence.

Thanks to some solid teamwork, we think we’ve finally identified and resolved the root cause—hopefully for good.

Here’s what was happening:

MHQ has a method that resets crew and unit data. It’s called in various situations, but most importantly, it runs at the end of a scenario. Its job is to clean up scenario-specific information and update crew status, including fatalities and other changes.

Over time, like many old methods, this one accumulated extra responsibilities. One of those was updating a unit’s SPAs during the reset. However, a conditional check was added: if a unit had no commander (i.e., no crew), the method would exit early and skip the rest of the reset process.

And that’s the problem. If a unit wasn’t crewed, MHQ would skip the part that clears scenario data. As a result, the unit could retain information from a previous scenario—like deployment zones—until it was explicitly refreshed. That might not happen until after the unit is already sent into a new scenario, carrying its old baggage with it.

Veteran players will know that restarting MHQ fixes this bug. That’s because the corrupted scenario data isn’t saved in the campaign file. On reload, MHQ generates that data, without the old info.