### PR TITLE
Fix #7652: Updated Camp Follower Mechanic for More Consistent Functionality

### DIFF
--- a/MekHQ/resources/mekhq/resources/PersonnelReport.properties
+++ b/MekHQ/resources/mekhq/resources/PersonnelReport.properties
@@ -51,6 +51,7 @@ support.KIA.text=KIA Support Personnel
 support.retired.text=Retired Support Personnel
 support.dead.text=Dead Support Personnel
 support.student.text=Student Support Personnel
+support.campFollowers.text=Camp Followers
 support.salary.text=Monthly Salary For Support Personnel
 support.dependant.text=You have {0} adult civilian of which {1} are students
 support.dependants.text=You have {0} adult civilian of which {1} are students

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -496,37 +496,37 @@ public class Campaign implements ITechManager {
 
     public Campaign(CampaignConfiguration campConf) {
         this(
-            campConf.getGame(),
-            campConf.getPlayer(),
-            campConf.getName(),
-            campConf.getDate(),
-            campConf.getCampaignOpts(),
-            campConf.getGameOptions(),
-            campConf.getPartsStore(),
-            campConf.getNewPersonnelMarket(),
-            campConf.getRandomDeath(),
-            campConf.getCampaignSummary(),
-            campConf.getfaction(),
-            campConf.getTechFaction(),
-            campConf.getCurrencyManager(),
-            campConf.getSystemsInstance(),
-            campConf.getLocation(),
-            campConf.getReputationController(),
-            campConf.getFactionStandings(),
-            campConf.getRankSystem(),
-            campConf.getforce(),
-            campConf.getfinances(),
-            campConf.getRandomEvents(),
-            campConf.getUltimatums(),
-            campConf.getRetDefTracker(),
-            campConf.getAutosave(),
-            campConf.getBehaviorSettings(),
-            campConf.getPersonnelMarket(),
-            campConf.getAtBMonthlyContractMarket(),
-            campConf.getUnitMarket(),
-            campConf.getDivorce(),
-            campConf.getMarriage(),
-            campConf.getProcreation()
+              campConf.getGame(),
+              campConf.getPlayer(),
+              campConf.getName(),
+              campConf.getDate(),
+              campConf.getCampaignOpts(),
+              campConf.getGameOptions(),
+              campConf.getPartsStore(),
+              campConf.getNewPersonnelMarket(),
+              campConf.getRandomDeath(),
+              campConf.getCampaignSummary(),
+              campConf.getfaction(),
+              campConf.getTechFaction(),
+              campConf.getCurrencyManager(),
+              campConf.getSystemsInstance(),
+              campConf.getLocation(),
+              campConf.getReputationController(),
+              campConf.getFactionStandings(),
+              campConf.getRankSystem(),
+              campConf.getforce(),
+              campConf.getfinances(),
+              campConf.getRandomEvents(),
+              campConf.getUltimatums(),
+              campConf.getRetDefTracker(),
+              campConf.getAutosave(),
+              campConf.getBehaviorSettings(),
+              campConf.getPersonnelMarket(),
+              campConf.getAtBMonthlyContractMarket(),
+              campConf.getUnitMarket(),
+              campConf.getDivorce(),
+              campConf.getMarriage(),
+              campConf.getProcreation()
         );
     }
 
@@ -2806,38 +2806,61 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Retrieves a list of active personnel in the campaign, optionally including prisoners.
+     * @deprecated use {@link #getActivePersonnel(boolean, boolean)} instead.
+     */
+    @Deprecated(since = "0.50.07", forRemoval = true)
+    public List<Person> getActivePersonnel(boolean includePrisoners) {
+        return getActivePersonnel(includePrisoners, false);
+    }
+
+    /**
+     * Returns a list of personnel who are considered "active" according to various status filters.
      *
-     * <p>
-     * This method iterates through all personnel and filters out inactive members. It then further filters prisoners
-     * based on the provided parameter:
-     * </p>
+     * <p>This method iterates through all personnel and includes those whose status is considered "active," then
+     * optionally excludes personnel based on the provided flags for prisoners and camp followers.</p>
+     *
      * <ul>
-     * <li>If {@code includePrisoners} is {@code true}, all active personnel,
-     * including prisoners,
-     * are included in the result.</li>
-     * <li>If {@code includePrisoners} is {@code false}, only active personnel who
-     * are either
-     * free or classified as bondsmen are included.</li>
+     *   <li>If {@code includePrisoners} is {@code false}, any personnel who are currently prisoners (not free or
+     *   bondsmen) will be excluded from the result.</li>
+     *   <li>If {@code includeCampFollowers} is {@code false}, (non-prisoner) camp followers will be excluded from the
+     *   result.</li>
+     *   <li>All included personnel are guaranteed to have a status of {@link PersonnelStatus#ACTIVE} or
+     *   {@link PersonnelStatus#CAMP_FOLLOWER} (if appropriate).</li>
      * </ul>
      *
-     * @param includePrisoners {@code true} to include all active prisoners in the result, {@code false} to exclude them
-     *                         unless they are free or bondsmen.
+     * <p><b>Notes:</b> It might be tempting to overload this method with a version that skips one of the boolean
+     * params. I strongly recommend against this. By forcing developers to explicitly dictate prisoner and follower
+     * inclusion we reduce the risk of either demographic being included/excluded by accident. As happened
+     * frequently prior to these booleans being added. - Illiani, 5th Oct 2025</p>
      *
-     * @return A {@link List} of {@link Person} objects representing the filtered active personnel.
+     * @param includePrisoners     {@code true} to include prisoners
+     * @param includeCampFollowers {@code true} to include <b>non-prisoner</b> camp followers
+     *
+     * @return a {@link List} of {@link Person} objects matching the criteria
      */
-    public List<Person> getActivePersonnel(boolean includePrisoners) {
+    public List<Person> getActivePersonnel(boolean includePrisoners, boolean includeCampFollowers) {
         List<Person> activePersonnel = new ArrayList<>();
 
         for (Person person : getPersonnel()) {
-            if (!person.getStatus().isActive()) {
+            PersonnelStatus status = person.getStatus();
+            PrisonerStatus prisonerStatus = person.getPrisonerStatus();
+            boolean isActive = status.isActiveFlexible();
+            boolean isCampFollower = prisonerStatus.isFreeOrBondsman() && status.isCampFollower();
+            boolean isActivePrisoner = person.getPrisonerStatus().isCurrentPrisoner() && isActive;
+
+            if (!isActive) {
                 continue;
             }
 
-            PrisonerStatus prisonerStatus = person.getPrisonerStatus();
-            if (includePrisoners || prisonerStatus.isFreeOrBondsman()) {
-                activePersonnel.add(person);
+            if (!includeCampFollowers && isCampFollower) {
+                continue;
             }
+
+            if (!includePrisoners && isActivePrisoner) {
+                continue;
+            }
+
+            activePersonnel.add(person);
         }
 
         return activePersonnel;
@@ -2850,7 +2873,7 @@ public class Campaign implements ITechManager {
      * @since 0.50.06
      */
     public List<Person> getSalaryEligiblePersonnel() {
-        return getActivePersonnel(false).stream()
+        return getActivePersonnel(false, false).stream()
                      .filter(person -> person.getStatus().isSalaryEligible())
                      .collect(Collectors.toList());
     }
@@ -2865,20 +2888,20 @@ public class Campaign implements ITechManager {
      * @return a {@link List} of {@link Person} objects representing combat-capable personnel
      */
     public List<Person> getActiveCombatPersonnel() {
-        return getActivePersonnel(true).stream()
+        return getActivePersonnel(false, false).stream()
                      .filter(p -> p.getPrimaryRole().isCombat() || p.getSecondaryRole().isCombat())
                      .collect(Collectors.toList());
     }
 
     /**
-     * Provides a filtered list of personnel including only active Dependents.
+     * Provides a filtered list of personnel including only active Dependents (including camp followers).
      *
      * @return a {@link Person} <code>List</code> containing all active personnel
      */
     public List<Person> getActiveDependents() {
         return getPersonnel().stream()
                      .filter(person -> person.getPrimaryRole().isDependent())
-                     .filter(person -> person.getStatus().isActive())
+                     .filter(person -> person.getStatus().isActiveFlexible())
                      .collect(Collectors.toList());
     }
 
@@ -2888,7 +2911,7 @@ public class Campaign implements ITechManager {
      * @return a {@link Person} <code>List</code> containing all active personnel
      */
     public List<Person> getCurrentPrisoners() {
-        return getActivePersonnel(true).stream()
+        return getActivePersonnel(true, false).stream()
                      .filter(person -> person.getPrisonerStatus().isCurrentPrisoner())
                      .collect(Collectors.toList());
     }
@@ -2899,7 +2922,7 @@ public class Campaign implements ITechManager {
      * @return a {@link Person} <code>List</code> containing all active personnel
      */
     public List<Person> getPrisonerDefectors() {
-        return getActivePersonnel(false).stream()
+        return getActivePersonnel(true, false).stream()
                      .filter(person -> person.getPrisonerStatus().isPrisonerDefector())
                      .collect(Collectors.toList());
     }
@@ -2989,7 +3012,7 @@ public class Campaign implements ITechManager {
             if (person.needsFixing() ||
                       (getCampaignOptions().isUseAdvancedMedical() &&
                              person.hasInjuries(true) &&
-                             person.getStatus().isActive())) {
+                             person.getStatus().isActiveFlexible())) {
                 patients.add(person);
             }
         }
@@ -3211,8 +3234,8 @@ public class Campaign implements ITechManager {
             PartInUse newPartInUse = getPartInUse((Part) maybePart);
             if (partInUse.equals(newPartInUse)) {
                 Part newPart = (maybePart instanceof MissingPart) ?
-                                        (((MissingPart) maybePart).getNewPart())
-                                        : (Part) maybePart;
+                                     (((MissingPart) maybePart).getNewPart())
+                                     : (Part) maybePart;
                 partInUse.setPlannedCount(partInUse.getPlannedCount() + newPart.getTotalQuantity());
             }
         }
@@ -3308,8 +3331,8 @@ public class Campaign implements ITechManager {
                 inUse.put(partInUse, partInUse);
             }
             Part newPart = (maybePart instanceof MissingPart) ?
-                    (((MissingPart) maybePart).getNewPart())
-                    : (Part) maybePart;
+                                 (((MissingPart) maybePart).getNewPart())
+                                 : (Part) maybePart;
             partInUse.setPlannedCount(partInUse.getPlannedCount() + newPart.getTotalQuantity());
         }
         return inUse.keySet()
@@ -3368,7 +3391,7 @@ public class Campaign implements ITechManager {
         boolean isUseAgingEffects = campaignOptions.isUseAgeEffects();
         boolean isClanCampaign = isClanCampaign();
 
-        for (Person person : getActivePersonnel(false)) {
+        for (Person person : getActivePersonnel(false, false)) {
             int adjustedReputation = person.getAdjustedReputation(isUseAgingEffects,
                   isClanCampaign,
                   currentDay,
@@ -3438,7 +3461,7 @@ public class Campaign implements ITechManager {
     public @Nullable Person findBestAtSkill(String skillName) {
         Person bestAtSkill = null;
         int highest = 0;
-        for (Person person : getActivePersonnel(false)) {
+        for (Person person : getActivePersonnel(false, false)) {
             int adjustedReputation = person.getAdjustedReputation(campaignOptions.isUseAgeEffects(),
                   isClanCampaign(),
                   currentDay,
@@ -3511,7 +3534,7 @@ public class Campaign implements ITechManager {
      *       skill, available time, and rank as specified by the input parameters.
      */
     public List<Person> getTechsExpanded(final boolean noZeroMinute, final boolean eliteFirst, final boolean expanded) {
-        final List<Person> techs = getActivePersonnel(true).stream()
+        final List<Person> techs = getActivePersonnel(false, false).stream()
                                          .filter(person -> (expanded ? person.isTechExpanded() : person.isTech()) &&
                                                                  (!noZeroMinute || (person.getMinutesLeft() > 0)))
                                          .collect(Collectors.toList());
@@ -3550,7 +3573,7 @@ public class Campaign implements ITechManager {
 
     public List<Person> getAdmins() {
         List<Person> admins = new ArrayList<>();
-        for (Person person : getActivePersonnel(true)) {
+        for (Person person : getActivePersonnel(false, false)) {
             if (person.isAdministrator()) {
                 admins.add(person);
             }
@@ -3567,7 +3590,7 @@ public class Campaign implements ITechManager {
 
     public List<Person> getDoctors() {
         List<Person> docs = new ArrayList<>();
-        for (Person person : getActivePersonnel(true)) {
+        for (Person person : getActivePersonnel(false, false)) {
             if (person.isDoctor()) {
                 docs.add(person);
             }
@@ -3577,7 +3600,7 @@ public class Campaign implements ITechManager {
 
     public int getPatientsFor(Person doctor) {
         int patients = 0;
-        for (Person person : getActivePersonnel(true)) {
+        for (Person person : getActivePersonnel(true, true)) {
             if ((null != person.getDoctorId()) && person.getDoctorId().equals(doctor.getId())) {
                 patients++;
             }
@@ -3618,8 +3641,7 @@ public class Campaign implements ITechManager {
         if (skillName.equals(S_AUTO)) {
             return null;
         } else if (skillName.equals(S_TECH)) {
-            for (Person person : getActivePersonnel(false)) {
-
+            for (Person person : getActivePersonnel(false, false)) {
                 if (isIneligibleToPerformProcurement(person, acquisitionCategory)) {
                     continue;
                 }
@@ -3647,8 +3669,7 @@ public class Campaign implements ITechManager {
                 }
             }
         } else {
-            for (Person person : getActivePersonnel(false)) {
-
+            for (Person person : getActivePersonnel(false, false)) {
                 if (isIneligibleToPerformProcurement(person, acquisitionCategory)) {
                     continue;
                 }
@@ -3805,7 +3826,7 @@ public class Campaign implements ITechManager {
         Person commander = flaggedCommander;
         Person secondInCommand = null;
 
-        for (Person person : getActivePersonnel(false)) {
+        for (Person person : getActivePersonnel(false, false)) {
             // If we have a flagged commander, skip them
             if (flaggedCommander != null) {
                 if (person.equals(flaggedCommander)) {
@@ -3871,7 +3892,7 @@ public class Campaign implements ITechManager {
             final ProcurementPersonnelPick acquisitionCategory = campaignOptions.getAcquisitionPersonnelCategory();
             List<Person> logisticsPersonnel = new ArrayList<>();
 
-            for (Person person : getActivePersonnel(true)) {
+            for (Person person : getActivePersonnel(false, false)) {
                 if (isIneligibleToPerformProcurement(person, acquisitionCategory)) {
                     continue;
                 }
@@ -6523,7 +6544,7 @@ public class Campaign implements ITechManager {
         if (campaignOptions.isUseFatigue()) {
             int fieldKitchenCapacity = checkFieldKitchenCapacity(getForce(FORCE_ORIGIN).getAllUnitsAsUnits(units,
                   false), campaignOptions.getFieldKitchenCapacity());
-            int fieldKitchenUsage = checkFieldKitchenUsage(getActivePersonnel(false),
+            int fieldKitchenUsage = checkFieldKitchenUsage(getActivePersonnel(false, false),
                   campaignOptions.isUseFieldKitchenIgnoreNonCombatants());
             fieldKitchenWithinCapacity = areFieldKitchensWithinCapacity(fieldKitchenCapacity, fieldKitchenUsage);
         } else {
@@ -6654,7 +6675,7 @@ public class Campaign implements ITechManager {
     @Deprecated(since = "0.50.07", forRemoval = true)
     public Person getSeniorCommander() {
         Person commander = null;
-        for (Person person : getActivePersonnel(true)) {
+        for (Person person : getActivePersonnel(false, false)) {
             if (person.isCommander()) {
                 return person;
             }
@@ -8689,7 +8710,7 @@ public class Campaign implements ITechManager {
     }
 
     public int getAsTechNeed() {
-        return (Math.toIntExact(getActivePersonnel(true).stream().filter(Person::isTech).count()) *
+        return (Math.toIntExact(getActivePersonnel(false, false).stream().filter(Person::isTech).count()) *
                       MHQConstants.AS_TECH_TEAM_SIZE) -
                      getNumberAsTechs();
     }
@@ -8731,7 +8752,7 @@ public class Campaign implements ITechManager {
      */
     public int getNumberPrimaryAsTechs() {
         int asTechs = getAsTechPool();
-        for (Person person : getActivePersonnel(false)) {
+        for (Person person : getActivePersonnel(false, false)) {
             if (person.getPrimaryRole().isAstech() && !person.isDeployed()) {
                 asTechs++;
             }
@@ -8750,7 +8771,7 @@ public class Campaign implements ITechManager {
      */
     public int getNumberSecondaryAsTechs() {
         int asTechs = 0;
-        for (Person person : getActivePersonnel(false)) {
+        for (Person person : getActivePersonnel(false, false)) {
             if (person.getSecondaryRole().isAstech() && !person.isDeployed()) {
                 asTechs++;
             }
@@ -8832,7 +8853,7 @@ public class Campaign implements ITechManager {
      */
     public int getNumberMedics() {
         int count = 0;
-        for (Person person : getActivePersonnel(false)) {
+        for (Person person : getActivePersonnel(false, false)) {
             if ((person.getPrimaryRole().isMedic() || person.getSecondaryRole().isMedic()) &&
                       !person.isDeployed() &&
                       person.isEmployed()) {
@@ -10870,6 +10891,7 @@ public class Campaign implements ITechManager {
 
     /**
      * Now that systemsInstance is injectable and non-final, we may wish to update it on the fly.
+     *
      * @return systemsInstance Systems instance used when instantiating this Campaign instance.
      */
     public Systems getSystemsInstance() {
@@ -10877,8 +10899,9 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Set the systemsInstance to a new instance.  Useful for testing, or updating the set of systems
-     * within a running Campaign.
+     * Set the systemsInstance to a new instance.  Useful for testing, or updating the set of systems within a running
+     * Campaign.
+     *
      * @param systemsInstance new Systems instance that this campaign should use.
      */
     public void setSystemsInstance(Systems systemsInstance) {

--- a/MekHQ/src/mekhq/campaign/CampaignSummary.java
+++ b/MekHQ/src/mekhq/campaign/CampaignSummary.java
@@ -110,6 +110,7 @@ public class CampaignSummary {
 
     /**
      * Link this CampaignSummary to a Campaign instance and update state with information from it.
+     *
      * @param campaign Campaign to link
      */
     public void setCampaign(Campaign campaign) {
@@ -126,10 +127,10 @@ public class CampaignSummary {
         totalCombatPersonnel = 0;
         totalSupportPersonnel = 0;
         totalInjuries = 0;
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             if (person.getPrimaryRole().isCombat()) {
                 totalCombatPersonnel++;
-            } else {
+            } else if (!person.isDependent()) {
                 totalSupportPersonnel++;
             }
 
@@ -200,7 +201,7 @@ public class CampaignSummary {
         cargoCapacity = cargoStats.getTotalCombinedCargoCapacity();
 
         double tetrisMasterMultiplier = 1.0;
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             PersonnelOptions options = person.getOptions();
             if (options.booleanOption(ADMIN_TETRIS_MASTER)) {
                 tetrisMasterMultiplier += 0.05;
@@ -428,7 +429,7 @@ public class CampaignSummary {
             List<Unit> unitsInToe = campaign.getForce(FORCE_ORIGIN).getAllUnitsAsUnits(campaign.getHangar(), false);
 
             int fieldKitchenCapacity = checkFieldKitchenCapacity(unitsInToe, campaignOptions.getFieldKitchenCapacity());
-            int fieldKitchenUsage = checkFieldKitchenUsage(campaign.getActivePersonnel(false),
+            int fieldKitchenUsage = checkFieldKitchenUsage(campaign.getActivePersonnel(false, true),
                   campaignOptions.isUseFieldKitchenIgnoreNonCombatants());
             boolean isWithinCapacity = areFieldKitchensWithinCapacity(fieldKitchenCapacity, fieldKitchenUsage);
 
@@ -460,7 +461,7 @@ public class CampaignSummary {
             final boolean isDoctorsUseAdministration = campaignOptions.isDoctorsUseAdministration();
             final int maximumPatients = campaignOptions.getMaximumPatients();
             int doctorCapacity = 0;
-            for (Person person : campaign.getActivePersonnel(false)) {
+            for (Person person : campaign.getActivePersonnel(false, false)) {
                 doctorCapacity += person.getDoctorMedicalCapacity(isDoctorsUseAdministration, maximumPatients);
             }
 

--- a/MekHQ/src/mekhq/campaign/finances/Finances.java
+++ b/MekHQ/src/mekhq/campaign/finances/Finances.java
@@ -586,14 +586,14 @@ public class Finances {
         if (campaign.getCampaignOptions().isTrackTotalEarnings()) {
             boolean sharesForAll = campaign.getCampaignOptions().isSharesForAll();
 
-            int numberOfShares = campaign.getActivePersonnel(true)
+            int numberOfShares = campaign.getActivePersonnel(false, true)
                                        .stream()
                                        .mapToInt(person -> person.getNumShares(campaign, sharesForAll))
                                        .sum();
 
             Money singleShare = shares.dividedBy(numberOfShares);
 
-            for (Person person : campaign.getActivePersonnel(true)) {
+            for (Person person : campaign.getActivePersonnel(false, true)) {
                 person.payPersonShares(campaign, singleShare, sharesForAll);
             }
         }

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -61,6 +61,7 @@ import static mekhq.campaign.mission.enums.AtBMoraleLevel.DOMINATING;
 import static mekhq.campaign.mission.enums.AtBMoraleLevel.OVERWHELMING;
 import static mekhq.campaign.mission.enums.AtBMoraleLevel.STALEMATE;
 import static mekhq.campaign.randomEvents.prisoners.PrisonerEventManager.DEFAULT_TEMPORARY_CAPACITY;
+import static mekhq.campaign.randomEvents.prisoners.enums.PrisonerStatus.FREE;
 import static mekhq.campaign.rating.IUnitRating.DRAGOON_A;
 import static mekhq.campaign.rating.IUnitRating.DRAGOON_ASTAR;
 import static mekhq.campaign.rating.IUnitRating.DRAGOON_B;
@@ -786,7 +787,7 @@ public class AtBContract extends Contract {
 
                     for (int i = 0; i < number; i++) {
                         Person person = campaign.newDependent(Gender.RANDOMIZE);
-                        campaign.recruitPerson(person);
+                        campaign.recruitPerson(person, FREE, true, false, false);
                     }
                 } else {
                     campaign.addReport("Bonus: Ronin");

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1481,7 +1481,7 @@ public class Person {
             }
         }
 
-        if (status.isActive()) {
+        if (status.isActiveFlexible()) {
             // Check Pregnancy
             if (isPregnant() && getDueDate().isBefore(today)) {
                 campaign.getProcreation().birth(campaign, getDueDate(), this);
@@ -4898,7 +4898,7 @@ public class Person {
     }
 
     public boolean needsFixing() {
-        return ((hits > 0) || needsAMFixing()) && getStatus().isActive();
+        return ((hits > 0) || needsAMFixing()) && getStatus().isActiveFlexible();
     }
 
     /**
@@ -7290,7 +7290,7 @@ public class Person {
 
         if (hasBerserker && failedWillpowerCheck) {
             Set<Person> victims = new HashSet<>();
-            List<Person> allActivePersonnel = campaign.getActivePersonnel(false);
+            List<Person> allActivePersonnel = campaign.getActivePersonnel(true, true);
             if (isDeployed() && unit != null) {
                 getLocalVictims(allActivePersonnel, victims);
             } else {

--- a/MekHQ/src/mekhq/campaign/personnel/RandomDependents.java
+++ b/MekHQ/src/mekhq/campaign/personnel/RandomDependents.java
@@ -150,7 +150,7 @@ public class RandomDependents {
     int prepareData() {
         int activeNonDependents = 0;
 
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             if (!person.isEmployed()) {
                 activeDependents.add(person);
                 continue;

--- a/MekHQ/src/mekhq/campaign/personnel/death/RandomDeath.java
+++ b/MekHQ/src/mekhq/campaign/personnel/death/RandomDeath.java
@@ -699,7 +699,7 @@ public class RandomDeath {
             return PersonnelStatus.KIA;
         } else if (person.hasInjuries(false)) {
             final PersonnelStatus status = determineIfInjuriesCausedTheDeath(person);
-            if (!status.isActive()) {
+            if (status.isCauseOfDeath()) {
                 return status;
             }
         }

--- a/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/EducationController.java
@@ -313,17 +313,17 @@ public class EducationController {
 
         boolean hasActiveParent = false;
         if (spouse != null) {
-            if (spouse.getStatus().isActive() && (spouse.isDependent() || !spouse.isEmployed())) {
+            if (spouse.getStatus().isActiveFlexible() && (spouse.isDependent() || !spouse.isEmployed())) {
                 person.addEduTagAlong(spouse.getId());
                 spouse.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ON_LEAVE);
             }
 
-            hasActiveParent = spouse.getStatus().isActive();
+            hasActiveParent = spouse.getStatus().isActiveFlexible();
         }
 
         if (!hasActiveParent) {
             for (Person child : children) {
-                if (child.getStatus().isActive()) {
+                if (child.getStatus().isActiveFlexible()) {
                     if (child.isChild(campaign.getLocalDate())) {
                         person.addEduTagAlong(child.getId());
                         child.changeStatus(campaign, campaign.getLocalDate(), PersonnelStatus.ON_LEAVE);

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
@@ -255,7 +255,20 @@ public enum PersonnelStatus {
     // region Boolean Comparison Methods
 
     /**
+     * Checks if the character has either the {@link #ACTIVE} or {@link #CAMP_FOLLOWER} personnel status.
+     *
+     * @return {@code true} if the character has the {@link #ACTIVE} personnel status {@code false} otherwise.
+     */
+    public boolean isActiveFlexible() {
+        return this == ACTIVE || this == CAMP_FOLLOWER;
+    }
+
+    /**
      * Checks if the character has the {@link #ACTIVE} personnel status.
+     *
+     * <p><b>Usage:</b> In most cases we likely want to use {@link #isActiveFlexible()} as this will also return
+     * {@code true} for 'camp follower' characters. Those characters are also 'active', just not active employees of the
+     * player's campaign.</p>
      *
      * @return {@code true} if the character has the {@link #ACTIVE} personnel status {@code false} otherwise.
      */

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/BirthAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/BirthAnnouncement.java
@@ -208,7 +208,7 @@ public class BirthAnnouncement {
      *       found.
      */
     private @Nullable Person getSpeaker(Campaign campaign) {
-        List<Person> potentialSpeakers = campaign.getActivePersonnel(false);
+        List<Person> potentialSpeakers = campaign.getActivePersonnel(false, false);
 
         if (potentialSpeakers.isEmpty()) {
             return getFallbackSpeaker(campaign);

--- a/MekHQ/src/mekhq/campaign/personnel/lifeEvents/NewYearsDayAnnouncement.java
+++ b/MekHQ/src/mekhq/campaign/personnel/lifeEvents/NewYearsDayAnnouncement.java
@@ -114,7 +114,7 @@ public record NewYearsDayAnnouncement(Campaign campaign) {
      * @return the selected {@link Person}, or {@code null} if no suitable speaker is found
      */
     private @Nullable Person getSpeaker() {
-        List<Person> activePersonnel = campaign.getActivePersonnel(false);
+        List<Person> activePersonnel = campaign.getActivePersonnel(false, false);
 
         Person commander = campaign.getCommander();
         if (commander != null) {

--- a/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
+++ b/MekHQ/src/mekhq/campaign/personnel/marriage/AbstractMarriage.java
@@ -134,7 +134,7 @@ public abstract class AbstractMarriage {
             return resources.getString("cannotMarry.AlreadyMarried.text");
         }
 
-        if (!person.getStatus().isActive()) {
+        if (!person.getStatus().isActiveFlexible()) {
             return resources.getString("cannotMarry.Inactive.text");
         }
 
@@ -387,7 +387,7 @@ public abstract class AbstractMarriage {
         Person spouse = null;
 
         if (isInterUnit) {
-            List<Person> activePersonnel = campaign.getActivePersonnel(false);
+            List<Person> activePersonnel = campaign.getActivePersonnel(true, true);
             potentialSpouses = new ArrayList<>();
 
             for (Person potentialSpouse : activePersonnel) {

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -237,7 +237,7 @@ public abstract class AbstractProcreation {
             return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.AlreadyPregnant.text");
         }
 
-        if (!person.getStatus().isActive()) {
+        if (!person.getStatus().isActiveFlexible()) {
             return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.Inactive.text");
         }
 
@@ -284,7 +284,7 @@ public abstract class AbstractProcreation {
                     return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.SpouseNotTryingForABaby.text");
                 }
 
-                if (!person.getGenealogy().getSpouse().getStatus().isActive()) {
+                if (!person.getGenealogy().getSpouse().getStatus().isActiveFlexible()) {
                     return getFormattedTextAt(RESOURCE_BUNDLE, "cannotProcreate.InactiveSpouse.text");
                 }
 

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
@@ -38,10 +38,10 @@ import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
 import java.util.List;
 
-import megamek.common.units.Entity;
-import megamek.common.equipment.MiscType;
 import megamek.common.enums.SkillLevel;
 import megamek.common.equipment.MiscMounted;
+import megamek.common.equipment.MiscType;
+import megamek.common.units.Entity;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelStatus;
@@ -112,7 +112,7 @@ public class Fatigue {
         int fieldKitchenUsage = 0;
 
         for (Person person : activePersonnel) {
-            if (person.isSupport() && isUseFieldKitchenIgnoreNonCombatants) {
+            if (!person.isCombat() && isUseFieldKitchenIgnoreNonCombatants) {
                 continue;
             }
 
@@ -158,9 +158,9 @@ public class Fatigue {
      * Processes fatigue-related actions for a given person in the campaign.
      *
      * <p>This method calculates the effective fatigue of the person, determines their fatigue
-     * state (e.g., tired, fatigued, exhausted, critical), generates reports based on their fatigue level, and
-     * updates their recovery status. If the fatigue exceeds the campaign's leave threshold, the person's status is
-     * updated to {@link PersonnelStatus#ON_LEAVE}.</p>
+     * state (e.g., tired, fatigued, exhausted, critical), generates reports based on their fatigue level, and updates
+     * their recovery status. If the fatigue exceeds the campaign's leave threshold, the person's status is updated to
+     * {@link PersonnelStatus#ON_LEAVE}.</p>
      *
      * @param campaign the campaign context in which the person operates.
      * @param person   the person whose fatigue actions are being processed.
@@ -226,9 +226,10 @@ public class Fatigue {
      *     <li>Whether field kitchens are operating within their required capacity.</li>
      * </ul>
      *
-     * @param fatigue                        the base fatigue level of the person.
-     * @param isClan                         flag indicating whether the person is Clan personnel.
-     * @param skillLevel                     the person's skill level.
+     * @param fatigue    the base fatigue level of the person.
+     * @param isClan     flag indicating whether the person is Clan personnel.
+     * @param skillLevel the person's skill level.
+     *
      * @return the calculated effective fatigue value.
      */
     public static int getEffectiveFatigue(int fatigue, boolean isClan, SkillLevel skillLevel) {
@@ -260,8 +261,8 @@ public class Fatigue {
      * zero or less, the person's recovery state is cleared, and their status may be updated to {@code ACTIVE} if they
      * were previously on leave.</p>
      *
-     * @param campaign the campaign context in which the fatigue recovery occurs.
-     * @param person   the person whose fatigue recovery is being handled.
+     * @param campaign                       the campaign context in which the fatigue recovery occurs.
+     * @param person                         the person whose fatigue recovery is being handled.
      * @param fieldKitchensAreWithinCapacity flag indicating if field kitchens are within capacity.
      */
     public static void processFatigueRecovery(Campaign campaign, Person person,

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -138,9 +138,8 @@ public class RetirementDefectionTracker {
             getManagementSkillValues(campaign);
         }
 
-        for (Person person : campaign.getActivePersonnel(true)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             if ((person.getPrimaryRole().isCivilian()) ||
-                      (!person.getPrisonerStatus().isFree()) ||
                       (person.isDeployed())) {
                 continue;
             }
@@ -511,10 +510,8 @@ public class RetirementDefectionTracker {
      * @param campaign The Campaign object for which to calculate the management skill values.
      */
     private void getManagementSkillValues(Campaign campaign) {
-        for (Person person : campaign.getActivePersonnel(true)) {
-            if ((person.getPrimaryRole().isCivilian()) ||
-                      (person.getPrisonerStatus().isPrisoner()) ||
-                      (person.getPrisonerStatus().isPrisonerDefector())) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
+            if (person.getPrimaryRole().isCivilian()) {
                 continue;
             }
 
@@ -682,12 +679,12 @@ public class RetirementDefectionTracker {
     public static int getHRStrain(Campaign campaign) {
         double personnel = 0;
 
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             PersonnelRole primaryRole = person.getPrimaryRole();
-            if (primaryRole.isAssistant() && person.getSecondaryRole().isNone()) {
-            } else if (primaryRole.isCivilian()) {
+
+            if (primaryRole.isCivilian()) {
                 personnel += 0.1;
-            } else {
+            } else if (!(primaryRole.isAssistant() && person.getSecondaryRole().isNone())) {
                 personnel++;
             }
         }
@@ -709,7 +706,7 @@ public class RetirementDefectionTracker {
         boolean isClanCampaign = campaign.isClanCampaign();
         LocalDate today = campaign.getLocalDate();
 
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             boolean isAdmin = person.getPrimaryRole().isAdministratorHR() ||
                                     person.getSecondaryRole().isAdministratorHR();
             if (!isAdmin) {
@@ -794,7 +791,7 @@ public class RetirementDefectionTracker {
 
         Money profits = campaign.getFinances().getProfits();
 
-        int totalShares = campaign.getActivePersonnel(true)
+        int totalShares = campaign.getActivePersonnel(false, true)
                                 .stream()
                                 .mapToInt(p -> p.getNumShares(campaign, campaign.getCampaignOptions().isSharesForAll()))
                                 .sum();

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/EventEffectsManager.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/EventEffectsManager.java
@@ -1088,7 +1088,7 @@ public class EventEffectsManager {
 
         final int magnitude = result.magnitude();
 
-        List<Person> potentialTargets = campaign.getActivePersonnel(false);
+        List<Person> potentialTargets = campaign.getActivePersonnel(false, true);
 
         if (potentialTargets.isEmpty()) {
             return "";

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
@@ -118,7 +118,7 @@ public class AverageExperienceRating {
         int personnelCount = 0;
         double totalExperience = 0.0;
 
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             Unit unit = person.getUnit();
 
             // if the person does not belong to a unit, then skip this person

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/SupportRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/SupportRating.java
@@ -112,7 +112,7 @@ public class SupportRating {
         LocalDate today = campaign.getLocalDate();
 
         int administratorCount = 0;
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             boolean isAdult = !person.isChild(today);
 
             if (isAdult &&
@@ -297,7 +297,7 @@ public class SupportRating {
         techCounts.put("techAeroCount", 0);
         techCounts.put("techBattleArmorCount", 0);
 
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             updateCount(person::isTechMek, "techMekCount", techCounts);
             updateCount(person::isTechMechanic, "techMechanicCount", techCounts);
             updateCount(person::isTechAero, "techAeroCount", techCounts);

--- a/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/FieldManualMercRevDragoonsRating.java
@@ -131,7 +131,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
     }
 
     void updateAvailableSupport() {
-        for (Person p : getCampaign().getActivePersonnel(true)) {
+        for (Person p : getCampaign().getActivePersonnel(false, false)) {
             if (p.isTech()) {
                 updateTechSupportHours(p);
             } else if (p.isDoctor()) {
@@ -267,7 +267,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
     // 3 + (4/5) = 3 + 0.8 = 3.8 = 4 hours.
     // total = 16 hours.
     private void calcMedicalSupportHoursNeeded() {
-        int activePersonnelCount = getCampaign().getActivePersonnel(true).size();
+        int activePersonnelCount = getCampaign().getActivePersonnel(false, false).size();
 
         // Calculated based on 7-person squads
         int numSquads = activePersonnelCount / 7; // integer division intended
@@ -285,7 +285,7 @@ public class FieldManualMercRevDragoonsRating extends AbstractUnitRating {
     }
 
     private void calcAdminSupportHoursNeeded() {
-        int personnelCount = (int) getCampaign().getActivePersonnel(true)
+        int personnelCount = (int) getCampaign().getActivePersonnel(false, false)
                                          .stream()
                                          .filter(p -> !p.isAdministrator())
                                          .count();

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -152,7 +152,7 @@ public class PersonnelReport extends AbstractReport {
         LocalDate today = getCampaign().getLocalDate();
 
         for (Person person : getCampaign().getPersonnel()) {
-            if (person.getStatus().isCampFollower() && person.getPrisonerStatus().isFree()) {
+            if (person.getStatus().isCampFollower() && !person.getPrisonerStatus().isCurrentPrisoner()) {
                 campFollowers++;
                 continue;
             }

--- a/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
+++ b/MekHQ/src/mekhq/campaign/report/PersonnelReport.java
@@ -101,7 +101,6 @@ public class PersonnelReport extends AbstractReport {
             } else if (p.getStatus().isStudent()) {
                 countStudents++;
             }
-
         }
 
         StringBuilder sb = new StringBuilder(resources.getString("combat.personnel.header.text") + "\n\n");
@@ -146,12 +145,18 @@ public class PersonnelReport extends AbstractReport {
         int bondsmen = 0;
         int dependents = 0;
         int dependentStudents = 0;
+        int campFollowers = 0;
         int children = 0;
         int childrenStudents = 0;
         Money civilianSalaries = Money.zero();
         LocalDate today = getCampaign().getLocalDate();
 
         for (Person person : getCampaign().getPersonnel()) {
+            if (person.getStatus().isCampFollower() && person.getPrisonerStatus().isFree()) {
+                campFollowers++;
+                continue;
+            }
+
             // Add them to the total count
             final boolean primarySupport = person.getPrimaryRole().isSupport(true);
 
@@ -234,8 +239,12 @@ public class PersonnelReport extends AbstractReport {
               .append(String.format("%-30s           %4s\n", resources.getString("support.KIA.text"), countKIA))
               .append(String.format("%-30s           %4s\n", resources.getString("support.retired.text"), countRetired))
               .append(String.format("%-30s           %4s\n", resources.getString("support.dead.text"), countDead))
-              .append(String.format("%-30s           %4s\n", resources.getString("support.student.text"),
+              .append(String.format("%-30s           %4s\n",
+                    resources.getString("support.student.text"),
                     countStudents))
+              .append(String.format("%-30s           %4s\n",
+                    resources.getString("support.campFollowers.text"),
+                    campFollowers))
               .append("\n").append(resources.getString("support.salary.text")).append(": ")
               .append(salary.toAmountAndSymbolString())
               .append((dependents == 1) ?

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -465,16 +465,12 @@ public final class BriefingTab extends CampaignGuiTab {
 
         LocalDate today = getCampaign().getLocalDate();
         if (xpAward > 0) {
-            for (Person person : getCampaign().getActivePersonnel(false)) {
+            for (Person person : getCampaign().getActivePersonnel(false, false)) {
                 if (person.isChild(today)) {
                     continue;
                 }
 
                 if (person.isDependent()) {
-                    continue;
-                }
-
-                if (!person.isEmployed()) {
                     continue;
                 }
 

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -1978,7 +1978,7 @@ public class CampaignGUI extends JPanel {
                 return;
             }
             r.setTech(engineer);
-        } else if (getCampaign().getActivePersonnel(true).stream().anyMatch(Person::isTech)) {
+        } else if (getCampaign().getActivePersonnel(false, false).stream().anyMatch(Person::isTech)) {
             String name;
             Map<String, Person> techHash = new HashMap<>();
             List<String> techList = new ArrayList<>();
@@ -2417,7 +2417,7 @@ public class CampaignGUI extends JPanel {
             // Fix Spouse Id Information - This is required to fix spouse NPEs where one doesn't export both members
             // of the couple
             // TODO : make it so that exports will automatically include both spouses
-            for (Person p : getCampaign().getActivePersonnel(true)) {
+            for (Person p : getCampaign().getActivePersonnel(true, true)) {
                 if (p.getGenealogy().hasSpouse() &&
                           !getCampaign().getPersonnel().contains(p.getGenealogy().getSpouse())) {
                     // If this happens, we need to clear the spouse

--- a/MekHQ/src/mekhq/gui/InfirmaryTab.java
+++ b/MekHQ/src/mekhq/gui/InfirmaryTab.java
@@ -485,7 +485,7 @@ public final class InfirmaryTab extends CampaignGuiTab {
             // Knock out inactive doctors
             if ((patient.getDoctorId() != null) &&
                       (getCampaign().getPerson(patient.getDoctorId()) != null) &&
-                      !getCampaign().getPerson(patient.getDoctorId()).getStatus().isActive()) {
+                      !getCampaign().getPerson(patient.getDoctorId()).getStatus().isActiveFlexible()) {
                 patient.setDoctorId(null, getCampaign().getCampaignOptions().getNaturalHealingWaitingPeriod());
             }
             if (patient.getDoctorId() == null) {

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1776,7 +1776,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
     private void replaceLimb(String selectedInjury, Person selectedPerson, Campaign campaign) {
         List<Person> suitableDoctors = new ArrayList<>();
 
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             if (person.isDoctor()) {
                 Skill skill = person.getSkill(S_SURGERY);
 
@@ -2144,7 +2144,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         }
 
         if ((oneSelected) && (!person.isChild(getCampaign().getLocalDate()))) {
-            List<Person> orphans = getCampaign().getActivePersonnel(true)
+            List<Person> orphans = getCampaign().getActivePersonnel(true, true)
                                          .stream()
                                          .filter(child -> (child.isChild(getCampaign().getLocalDate())) &&
                                                                 (!child.getGenealogy().hasLivingParents()))
@@ -2271,7 +2271,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         }
 
         // give C-Bill payment
-        if (oneSelected && person.getStatus().isActive()) {
+        if (oneSelected && person.getStatus().isActiveFlexible()) {
             menuItem = new JMenuItem(resources.getString("givePayment.text"));
             menuItem.setActionCommand(CMD_GIVE_PAYMENT);
             menuItem.addActionListener(this);
@@ -2305,7 +2305,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
 
         JMenuHelpers.addMenuIfNonEmpty(popup, new AssignPersonToUnitMenu(getCampaign(), selected));
 
-        if (oneSelected && person.getStatus().isActive()) {
+        if (oneSelected && person.getStatus().isActiveFlexible()) {
             if (getCampaignOptions().isUseManualMarriages() &&
                       (getCampaign().getMarriage().canMarry(getCampaign().getLocalDate(), person, false) == null)) {
                 menu = new JMenu(resources.getString("chooseSpouse.text"));
@@ -2515,7 +2515,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             // it every time
             Campaign campaign = getCampaign();
 
-            if (StaticChecks.areAllActive(selected)) {
+            if (StaticChecks.areAllActiveFlexible(selected)) {
                 if (Arrays.stream(selected).noneMatch(prospectiveStudent -> person.needsFixing())) {
                     // this next block preps variables for use by the menu & tooltip
                     List<String> academySetNames = AcademyFactory.getInstance().getAllSetNames();
@@ -2703,7 +2703,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
         // endregion Education Menu
 
         // region Spend XP Menu
-        if (oneSelected && person.getStatus().isActive()) {
+        if (oneSelected && person.getStatus().isActiveFlexible()) {
             final double xpCostMultiplier = getCampaignOptions().getXpCostMultiplier();
 
             menu = new JMenu(resources.getString("spendXP.text"));
@@ -3644,7 +3644,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             // endregion Edge Triggers
 
             popup.add(menu);
-        } else if (StaticChecks.areAllActive(selected)) {
+        } else if (StaticChecks.areAllActiveFlexible(selected)) {
             if (getCampaignOptions().isUseEdge()) {
                 menu = new JMenu(resources.getString("setEdgeTriggers.text"));
                 submenu = new JMenu(resources.getString("On.text"));

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -429,7 +429,7 @@ public final class BatchXPDialog extends JDialog {
         @Override
         public boolean include(Entry<? extends PersonnelTableModel, ? extends Integer> entry) {
             Person person = entry.getModel().getPerson(entry.getIdentifier().intValue());
-            if (!person.getStatus().isActive()) {
+            if (!person.getStatus().isActiveFlexible()) {
                 return false;
             } else if (!prisoners && !person.getPrisonerStatus().isFree()) {
                 return false;

--- a/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignExportWizard.java
@@ -279,7 +279,7 @@ public class CampaignExportWizard extends JDialog {
     private void setupPersonList() {
         personList = new JList<>();
         DefaultListModel<Person> personListModel = new DefaultListModel<>();
-        List<Person> people = sourceCampaign.getActivePersonnel(true);
+        List<Person> people = sourceCampaign.getActivePersonnel(true, true);
         people.sort(Comparator.comparing(Person::getPrimaryRole));
         for (Person person : people) {
             personListModel.addElement(person);

--- a/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/NewContractDialog.java
@@ -340,7 +340,7 @@ public class NewContractDialog extends JDialog {
 
         cboNegotiator.setName("cboNegotiator");
         // Add negotiators
-        for (Person p : campaign.getActivePersonnel(true)) {
+        for (Person p : campaign.getActivePersonnel(false, false)) {
             if (p.hasSkill(SkillType.S_NEGOTIATION)) {
                 cboNegotiator.addItem(p);
             }

--- a/MekHQ/src/mekhq/gui/dialog/ReplacementLimbDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ReplacementLimbDialog.java
@@ -180,7 +180,7 @@ public class ReplacementLimbDialog {
     private Person getSpeaker() {
         Person seniorDoctor = null;
 
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             if (person.isDoctor()) {
                 if (person.outRanksUsingSkillTiebreaker(campaign, seniorDoctor)) {
                     seniorDoctor = person;

--- a/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
@@ -181,7 +181,7 @@ public class StratConReinforcementsConfirmationDialog {
         final List<PersonnelRole> TACTICAL_PROFESSIONS = List.of(MILITARY_ANALYST, MILITARY_THEORIST,
               TACTICAL_ANALYST, INTELLIGENCE_ANALYST);
         Person speaker = null;
-        for (Person potentialSpeaker : campaign.getActivePersonnel(false)) {
+        for (Person potentialSpeaker : campaign.getActivePersonnel(false, false)) {
             if (!potentialSpeaker.isEmployed()) {
                 continue;
             }

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/FactionStandingUltimatumDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/FactionStandingUltimatumDialog.java
@@ -229,7 +229,7 @@ public class FactionStandingUltimatumDialog {
      * @param secondInCommand     the second-in-command {@link Person}, may be {@code null}
      * @param thirdInCommand      the third-in-command {@link Person}, may be {@code null}
      * @param isMercenary         {@code true} if the campaign is changing to the mercenary faction; {@code false} if
-     *                                       the campaign is changing to the pirate faction
+     *                            the campaign is changing to the pirate faction
      *
      * @author Illiani
      * @since 0.50.07
@@ -324,7 +324,7 @@ public class FactionStandingUltimatumDialog {
     public @Nullable Person getThirdInCommand(Person commander, Person secondInCommand) {
         Person thirdInCommand = null;
 
-        for (Person person : campaign.getActivePersonnel(false)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             if (person.equals(commander) || person.equals(secondInCommand)) {
                 continue;
             }

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAsTechsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAsTechsNagDialog.java
@@ -92,7 +92,7 @@ public class InsufficientAsTechsNagDialog extends ImmersiveDialogNag {
      */
     @Override
     protected @Nullable Person getSpeaker(Campaign campaign, @Nullable AdministratorSpecialization specialization) {
-        List<Person> potentialSpeakers = campaign.getActivePersonnel(false);
+        List<Person> potentialSpeakers = campaign.getActivePersonnel(false, false);
 
         if (potentialSpeakers.isEmpty()) {
             return getFallbackSpeaker(campaign);

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechTimeNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientAstechTimeNagDialog.java
@@ -100,7 +100,7 @@ public class InsufficientAstechTimeNagDialog extends ImmersiveDialogNag {
             return null;
         }
 
-        List<Person> potentialSpeakers = campaign.getActivePersonnel(false);
+        List<Person> potentialSpeakers = campaign.getActivePersonnel(false, false);
 
         if (potentialSpeakers.isEmpty()) {
             return getFallbackSpeaker(campaign);

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientMedicsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/InsufficientMedicsNagDialog.java
@@ -96,7 +96,7 @@ public class InsufficientMedicsNagDialog extends ImmersiveDialogNag {
             return null;
         }
 
-        List<Person> potentialSpeakers = campaign.getActivePersonnel(false);
+        List<Person> potentialSpeakers = campaign.getActivePersonnel(false, false);
 
         if (potentialSpeakers.isEmpty()) {
             return getFallbackSpeaker(campaign);

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -103,7 +103,7 @@ public class NagController {
             }
         }
 
-        final List<Person> activePersonnel = campaign.getActivePersonnel(false);
+        final List<Person> activePersonnel = campaign.getActivePersonnel(false, false);
         final CampaignOptions campaignOptions = campaign.getCampaignOptions();
         final int doctorCapacity = campaignOptions.getMaximumPatients();
         final boolean isDoctorsUseAdministration = campaignOptions.isDoctorsUseAdministration();

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UnmaintainedUnitsNagDialog.java
@@ -96,7 +96,7 @@ public class UnmaintainedUnitsNagDialog extends ImmersiveDialogNag {
             return null;
         }
 
-        List<Person> potentialSpeakers = campaign.getActivePersonnel(false);
+        List<Person> potentialSpeakers = campaign.getActivePersonnel(false, false);
 
         if (potentialSpeakers.isEmpty()) {
             return getFallbackSpeaker(campaign);

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/UntreatedPersonnelNagDialog.java
@@ -77,7 +77,7 @@ public class UntreatedPersonnelNagDialog extends ImmersiveDialogNag {
             return null;
         }
 
-        List<Person> potentialSpeakers = campaign.getActivePersonnel(false);
+        List<Person> potentialSpeakers = campaign.getActivePersonnel(false, false);
 
         if (potentialSpeakers.isEmpty()) {
             return getFallbackSpeaker(campaign);

--- a/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogItinerary.java
+++ b/MekHQ/src/mekhq/gui/dialog/resupplyAndCaches/DialogItinerary.java
@@ -285,7 +285,7 @@ public class DialogItinerary {
         int rationPacks = 0;
         int medicalSupplies = 0;
 
-        for (Person person : campaign.getActivePersonnel(true)) {
+        for (Person person : campaign.getActivePersonnel(false, false)) {
             PersonnelRole primaryRole = person.getPrimaryRole();
             PersonnelRole secondaryRole = person.getSecondaryRole();
 

--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
@@ -396,7 +396,7 @@ public enum PersonnelFilter {
     }
 
     public boolean getFilteredInformation(final Person person, LocalDate currentDate) {
-        final boolean active = person.getStatus().isActive() && !person.getPrisonerStatus().isCurrentPrisoner();
+        final boolean active = person.getStatus().isActiveFlexible() && !person.getPrisonerStatus().isCurrentPrisoner();
         final boolean dead = person.getStatus().isDead();
 
         PersonnelStatus status = person.getStatus();
@@ -515,7 +515,7 @@ public enum PersonnelFilter {
             case PRISONER -> ((!dead) &&
                                     ((person.getPrisonerStatus().isCurrentPrisoner()) ||
                                            (person.getPrisonerStatus().isBondsman())));
-            case INACTIVE -> ((!dead) && (!status.isActive()));
+            case INACTIVE -> ((!dead) && (!status.isActiveFlexible()));
             case ON_LEAVE -> status.isOnLeave() || status.isOnMaternityLeave();
             case MIA -> status.isMIA() || status.isPoW();
             case RETIRED -> status.isRetired();

--- a/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
+++ b/MekHQ/src/mekhq/gui/utilities/StaticChecks.java
@@ -353,6 +353,10 @@ public class StaticChecks {
         return Arrays.stream(people).allMatch(p -> p.getStatus().isActive());
     }
 
+    public static boolean areAllActiveFlexible(Person... people) {
+        return Arrays.stream(people).allMatch(p -> p.getStatus().isActiveFlexible());
+    }
+
     public static boolean areAnyActive(Person... people) {
         return Stream.of(people).anyMatch(p -> p.getStatus().isActive());
     }

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -65,7 +65,6 @@ import megamek.common.units.Entity;
 import megamek.common.units.Mek;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.CampaignTransportType;
-import mekhq.campaign.universe.TestSystems;
 import mekhq.campaign.parts.AmmoStorage;
 import mekhq.campaign.parts.Armor;
 import mekhq.campaign.parts.Cubicle;
@@ -87,6 +86,7 @@ import mekhq.campaign.personnel.enums.PersonnelStatus;
 import mekhq.campaign.personnel.ranks.Ranks;
 import mekhq.campaign.unit.AbstractTransportedUnitsSummary;
 import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.TestSystems;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -205,7 +205,7 @@ public class CampaignTest {
 
         Campaign testCampaign = mock(Campaign.class);
         when(testCampaign.getPersonnel()).thenReturn(testPersonList);
-        when(testCampaign.getActivePersonnel(true)).thenReturn(testActivePersonList);
+        when(testCampaign.getActivePersonnel(false, false)).thenReturn(testActivePersonList);
         when(testCampaign.getTechs()).thenCallRealMethod();
         when(testCampaign.getTechs(anyBoolean())).thenCallRealMethod();
         when(testCampaign.getTechs(anyBoolean(), anyBoolean())).thenCallRealMethod();

--- a/MekHQ/unittests/mekhq/campaign/personnel/RandomDependentsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/RandomDependentsTest.java
@@ -94,7 +94,7 @@ class RandomDependentsTest {
             activeNonDependent.add(nonDependent);
         }
         activeNonDependent.addAll(activeDependents);
-        when(mockCampaign.getActivePersonnel(false)).thenReturn(activeNonDependent);
+        when(mockCampaign.getActivePersonnel(false, false)).thenReturn(activeNonDependent);
 
         // Act
         RandomDependents randomDependents = new RandomDependents(mockCampaign);
@@ -129,7 +129,7 @@ class RandomDependentsTest {
 
             activeNonDependent.add(nonDependent);
         }
-        when(mockCampaign.getActivePersonnel(true)).thenReturn(activeNonDependent);
+        when(mockCampaign.getActivePersonnel(true, true)).thenReturn(activeNonDependent);
 
         // Act
         RandomDependents randomDependents = new RandomDependents(mockCampaign);

--- a/MekHQ/unittests/mekhq/campaign/personnel/marriage/AbstractMarriageTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/marriage/AbstractMarriageTest.java
@@ -516,7 +516,7 @@ public class AbstractMarriageTest {
         final List<Person> mockPersonnel = new ArrayList<>();
         mockPersonnel.add(mockMale);
         mockPersonnel.add(mockFemale);
-        when(mockCampaign.getActivePersonnel(false)).thenReturn(mockPersonnel);
+        when(mockCampaign.getActivePersonnel(true, true)).thenReturn(mockPersonnel);
 
         final Person mockPerson = mock(Person.class);
         when(mockPerson.getGender()).thenReturn(Gender.FEMALE);

--- a/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/randomEvents/prisoners/EventEffectsManagerTest.java
@@ -790,7 +790,7 @@ class EventEffectsManagerTest {
         Person soldier1 = new Person(mockCampaign);
         Person soldier2 = new Person(mockCampaign);
         List<Person> potentialTargets = List.of(soldier0, soldier1, soldier2);
-        when(mockCampaign.getActivePersonnel(false)).thenReturn(new ArrayList<>(potentialTargets));
+        when(mockCampaign.getActivePersonnel(false, true)).thenReturn(new ArrayList<>(potentialTargets));
 
         // Act
         new EventEffectsManager(mockCampaign, eventData, 0, true);

--- a/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
@@ -161,7 +161,6 @@ public class FieldManualMercRevDragoonsRatingTest {
 
         when(mockCampaign.getPersonnel()).thenReturn(mockPersonnelList);
         when(mockCampaign.getActivePersonnel(false, false)).thenReturn(mockActivePersonnelList);
-        when(mockCampaign.getActivePersonnel(false, false)).thenReturn(mockActivePersonnelList);
         when(mockCampaign.getNumberMedics()).thenCallRealMethod();
         when(mockCampaign.getNumberAsTechs()).thenCallRealMethod();
         when(mockCampaign.getNumberPrimaryAsTechs()).thenCallRealMethod();

--- a/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
+++ b/MekHQ/unittests/mekhq/campaign/rating/FieldManualMercRevDragoonsRatingTest.java
@@ -160,8 +160,8 @@ public class FieldManualMercRevDragoonsRatingTest {
         mockActivePersonnelList.add(mockTech);
 
         when(mockCampaign.getPersonnel()).thenReturn(mockPersonnelList);
-        when(mockCampaign.getActivePersonnel(true)).thenReturn(mockActivePersonnelList);
-        when(mockCampaign.getActivePersonnel(false)).thenReturn(mockActivePersonnelList);
+        when(mockCampaign.getActivePersonnel(false, false)).thenReturn(mockActivePersonnelList);
+        when(mockCampaign.getActivePersonnel(false, false)).thenReturn(mockActivePersonnelList);
         when(mockCampaign.getNumberMedics()).thenCallRealMethod();
         when(mockCampaign.getNumberAsTechs()).thenCallRealMethod();
         when(mockCampaign.getNumberPrimaryAsTechs()).thenCallRealMethod();


### PR DESCRIPTION
Fix #7652

This PR does a couple of things:
- Fixes `getActivePersonnel` to explicitly include or exclude Camp Followers, this fixes a bug where prisoners are not treated as prisoners for capacity purposes
- Updated the same method to improve code flow, nothing too exciting
- Propagates the updated getActivePersonnel across our codebase, fixing a number of bugs in the process. Namely there were a _lot_ of instances when we were including prisoners when we shouldn't have. This looks like it was introduced when an even older version of `getActivePersonnel` was removed. Luckily, most of these bugs would only cause issues in very rare circumstances.
- Fixed random dependents from AtB events not spawning as camp followers.

Marked as 'high' as the first point above completely breaks the Prisoners module.