### PR TITLE
Improvement: Added ATOW Mechanical Effects to Zero-G Operations Skill

### DIFF
--- a/MekHQ/resources/mekhq/resources/SkillType.properties
+++ b/MekHQ/resources/mekhq/resources/SkillType.properties
@@ -142,7 +142,7 @@ Training.flavorText=No mechanical effects.
 CareerAny.flavorText=No mechanical effects.
 Running.flavorText=No mechanical effects.
 Swimming.flavorText=No mechanical effects.
-ZeroGOperations.flavorText=No mechanical effects.
+ZeroGOperations.flavorText=Each level in Zero-G Operations reduces non-combat gravity penalties by 1.
 Archery.flavorText=No mechanical effects.\
   <br>\
   <br>MegaMek handles combat at the Total Warfare scale where Small Arms largely handles weapon skills. However, we have\

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -69,6 +69,7 @@ import static mekhq.campaign.personnel.skills.Aging.updateAllSkillAgeModifiers;
 import static mekhq.campaign.personnel.skills.AttributeCheckUtility.performQuickAttributeCheck;
 import static mekhq.campaign.personnel.skills.SkillType.EXP_NONE;
 import static mekhq.campaign.personnel.skills.SkillType.S_STRATEGY;
+import static mekhq.campaign.personnel.skills.SkillType.S_ZERO_G_OPERATIONS;
 import static mekhq.campaign.personnel.skills.SkillType.getType;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.areFieldKitchensWithinCapacity;
 import static mekhq.campaign.personnel.turnoverAndRetention.Fatigue.checkFieldKitchenCapacity;
@@ -496,37 +497,37 @@ public class Campaign implements ITechManager {
 
     public Campaign(CampaignConfiguration campConf) {
         this(
-            campConf.getGame(),
-            campConf.getPlayer(),
-            campConf.getName(),
-            campConf.getDate(),
-            campConf.getCampaignOpts(),
-            campConf.getGameOptions(),
-            campConf.getPartsStore(),
-            campConf.getNewPersonnelMarket(),
-            campConf.getRandomDeath(),
-            campConf.getCampaignSummary(),
-            campConf.getfaction(),
-            campConf.getTechFaction(),
-            campConf.getCurrencyManager(),
-            campConf.getSystemsInstance(),
-            campConf.getLocation(),
-            campConf.getReputationController(),
-            campConf.getFactionStandings(),
-            campConf.getRankSystem(),
-            campConf.getforce(),
-            campConf.getfinances(),
-            campConf.getRandomEvents(),
-            campConf.getUltimatums(),
-            campConf.getRetDefTracker(),
-            campConf.getAutosave(),
-            campConf.getBehaviorSettings(),
-            campConf.getPersonnelMarket(),
-            campConf.getAtBMonthlyContractMarket(),
-            campConf.getUnitMarket(),
-            campConf.getDivorce(),
-            campConf.getMarriage(),
-            campConf.getProcreation()
+              campConf.getGame(),
+              campConf.getPlayer(),
+              campConf.getName(),
+              campConf.getDate(),
+              campConf.getCampaignOpts(),
+              campConf.getGameOptions(),
+              campConf.getPartsStore(),
+              campConf.getNewPersonnelMarket(),
+              campConf.getRandomDeath(),
+              campConf.getCampaignSummary(),
+              campConf.getfaction(),
+              campConf.getTechFaction(),
+              campConf.getCurrencyManager(),
+              campConf.getSystemsInstance(),
+              campConf.getLocation(),
+              campConf.getReputationController(),
+              campConf.getFactionStandings(),
+              campConf.getRankSystem(),
+              campConf.getforce(),
+              campConf.getfinances(),
+              campConf.getRandomEvents(),
+              campConf.getUltimatums(),
+              campConf.getRetDefTracker(),
+              campConf.getAutosave(),
+              campConf.getBehaviorSettings(),
+              campConf.getPersonnelMarket(),
+              campConf.getAtBMonthlyContractMarket(),
+              campConf.getUnitMarket(),
+              campConf.getDivorce(),
+              campConf.getMarriage(),
+              campConf.getProcreation()
         );
     }
 
@@ -3211,8 +3212,8 @@ public class Campaign implements ITechManager {
             PartInUse newPartInUse = getPartInUse((Part) maybePart);
             if (partInUse.equals(newPartInUse)) {
                 Part newPart = (maybePart instanceof MissingPart) ?
-                                        (((MissingPart) maybePart).getNewPart())
-                                        : (Part) maybePart;
+                                     (((MissingPart) maybePart).getNewPart())
+                                     : (Part) maybePart;
                 partInUse.setPlannedCount(partInUse.getPlannedCount() + newPart.getTotalQuantity());
             }
         }
@@ -3308,8 +3309,8 @@ public class Campaign implements ITechManager {
                 inUse.put(partInUse, partInUse);
             }
             Part newPart = (maybePart instanceof MissingPart) ?
-                    (((MissingPart) maybePart).getNewPart())
-                    : (Part) maybePart;
+                                 (((MissingPart) maybePart).getNewPart())
+                                 : (Part) maybePart;
             partInUse.setPlannedCount(partInUse.getPlannedCount() + newPart.getTotalQuantity());
         }
         return inUse.keySet()
@@ -8426,11 +8427,13 @@ public class Campaign implements ITechManager {
     public TargetRoll getTargetForMaintenance(IPartWork partWork, Person tech, int asTechsUsed) {
         int value = 10;
         String skillLevel = "Unmaintained";
+        PersonnelOptions options = tech.getOptions();
+        Attributes attributes = tech.getATOWAttributes();
         if (null != tech) {
             Skill skill = tech.getSkillForWorkingOn(partWork);
             if (null != skill) {
-                value = skill.getFinalSkillValue(tech.getOptions(), tech.getATOWAttributes());
-                skillLevel = skill.getSkillLevel(tech.getOptions(), tech.getATOWAttributes()).toString();
+                value = skill.getFinalSkillValue(options, attributes);
+                skillLevel = skill.getSkillLevel(options, attributes).toString();
             }
         }
 
@@ -8452,12 +8455,24 @@ public class Campaign implements ITechManager {
                 megamek.common.planetaryConditions.Atmosphere planetaryConditions = planet.getPressure(getLocalDate());
                 int temperature = planet.getTemperature(getLocalDate());
 
+                Skill zeroGSkill = tech.getSkill(S_ZERO_G_OPERATIONS);
+                int zeroGSkillLevel = 0;
+                if (zeroGSkill != null) {
+                    zeroGSkillLevel = zeroGSkill.getTotalSkillLevel(options, attributes);
+                }
+
                 if (planet.getGravity() < 0.8) {
-                    target.addModifier(2, "Low Gravity");
+                    int modifier = 2;
+                    target.addModifier(modifier, "Low Gravity");
+                    addZeroGOperationsModifier(zeroGSkillLevel, modifier, target);
                 } else if (planet.getGravity() >= 2.0) {
-                    target.addModifier(4, "Very High Gravity");
+                    int modifier = 4;
+                    target.addModifier(modifier, "Very High Gravity");
+                    addZeroGOperationsModifier(zeroGSkillLevel, modifier, target);
                 } else if (planet.getGravity() > 1.2) {
-                    target.addModifier(1, "High Gravity");
+                    int modifier = 1;
+                    target.addModifier(modifier, "High Gravity");
+                    addZeroGOperationsModifier(zeroGSkillLevel, modifier, target);
                 }
 
                 if (atmosphere.isTainted() || atmosphere.isToxic()) {
@@ -8502,6 +8517,30 @@ public class Campaign implements ITechManager {
         }
 
         return target;
+    }
+
+    /**
+     * Applies a Zero-G Operations skill gravityModifier to the specified {@link TargetRoll}, offsetting a penalty
+     * gravityModifier.
+     *
+     * <ul>
+     *   <li>If {@code zeroGSkillLevel} >= {@code gravityModifier}, does nothing.</li>
+     *   <li>If {@code zeroGSkillLevel} < {@code gravityModifier}, applies {@code -zeroGSkillLevel}.</li>
+     * </ul>
+     *
+     * @param zeroGSkillLevel the Zero-G Operations skill level, which negates up to that much penalty from the
+     *                        gravityModifier
+     * @param gravityModifier the penalty gravityModifier to offset
+     * @param target          the {@link TargetRoll} instance to modify
+     */
+    private static void addZeroGOperationsModifier(int zeroGSkillLevel, int gravityModifier, TargetRoll target) {
+        if (zeroGSkillLevel > 0) {
+            int effectiveModifier = zeroGSkillLevel >= gravityModifier ? 0 : -zeroGSkillLevel;
+
+            if (effectiveModifier < 0) {
+                target.addModifier(effectiveModifier, "Zero-G Operations");
+            }
+        }
     }
 
     public TargetRoll getTargetForAcquisition(final IAcquisitionWork acquisition) {
@@ -10870,6 +10909,7 @@ public class Campaign implements ITechManager {
 
     /**
      * Now that systemsInstance is injectable and non-final, we may wish to update it on the fly.
+     *
      * @return systemsInstance Systems instance used when instantiating this Campaign instance.
      */
     public Systems getSystemsInstance() {
@@ -10877,8 +10917,9 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Set the systemsInstance to a new instance.  Useful for testing, or updating the set of systems
-     * within a running Campaign.
+     * Set the systemsInstance to a new instance.  Useful for testing, or updating the set of systems within a running
+     * Campaign.
+     *
      * @param systemsInstance new Systems instance that this campaign should use.
      */
     public void setSystemsInstance(Systems systemsInstance) {

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -136,6 +136,7 @@ public class SkillType {
     public static final String S_STRATEGY = "Strategy";
     public static final String S_TACTICS = "Tactics/Any";
     public static final String S_TRAINING = "Training";
+    public static final String S_ZERO_G_OPERATIONS = "Zero-G Operations";
 
     // roleplay skills
     public static final String S_ACROBATICS = "Acrobatics" + RP_ONLY_TAG;
@@ -211,7 +212,6 @@ public class SkillType {
     public static final String S_CAREER_ANY = "Career/Any" + RP_ONLY_TAG;
     public static final String S_RUNNING = "Running" + RP_ONLY_TAG;
     public static final String S_SWIMMING = "Swimming" + RP_ONLY_TAG;
-    public static final String S_ZERO_G_OPERATIONS = "Zero-G Operations" + RP_ONLY_TAG;
     public static final String S_MELEE_WEAPONS = "Melee Weapons" + RP_ONLY_TAG;
     public static final String S_THROWN_WEAPONS = "Thrown Weapons" + RP_ONLY_TAG;
     public static final String S_SUPPORT_WEAPONS = "Support Weapons" + RP_ONLY_TAG;
@@ -468,10 +468,10 @@ public class SkillType {
      *
      *                        <p>For example:</p>
      *                        <pre>
-     *                        Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
-     *                        SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
-     *                        SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
-     *                                               </pre>
+     *                                                                                             Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
+     *                                                                                             SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
+     *                                                                                             SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
+     *                                                                                                                    </pre>
      *
      * @author Illiani
      * @since 0.50.05
@@ -1051,6 +1051,7 @@ public class SkillType {
             case "tactics" -> "Tactics/Any"; // <50.07
             case "tracking (rp only)" -> "Tracking/Any" + RP_ONLY_TAG; // <50.07
             case "training (rp only)" -> "Training"; // <50.07
+            case "zero-g operations (rp only)" -> "Zero-G Operations"; // <50.07
             default -> skillName;
         };
         return skillName;
@@ -1418,7 +1419,7 @@ public class SkillType {
             case S_TRAINING, "Training (RP Only)" -> createTraining();
             case S_CAREER_ANY -> createCareer();
             case S_SWIMMING -> createSwimming();
-            case S_ZERO_G_OPERATIONS -> createZeroGOperations();
+            case S_ZERO_G_OPERATIONS, "Zero-G Operations (RP Only)" -> createZeroGOperations();
             case S_MELEE_WEAPONS -> createMeleeWeapons();
             case S_THROWN_WEAPONS -> createThrownWeapons();
             case S_SUPPORT_WEAPONS -> createSupportWeapons();
@@ -3128,7 +3129,7 @@ public class SkillType {
         return new SkillType(S_ZERO_G_OPERATIONS,
               7,
               false,
-              ROLEPLAY_GENERAL,
+              SUPPORT,
               REFLEXES,
               NONE,
               null,


### PR DESCRIPTION
As per ATOW each level in the Zero-G Operations skill reduces gravity penalties by 1. This mechanic is now implemented into mhq for non-combat modifiers only. This is largely irrelevant for non-techs, but will be useful for techs operating on planets with non-standard gravities.