### PR TITLE
Improvement #7536: Added Option to Hide Monthly Climate Regard Report; Obfuscated Certain Factions from Faction Standing Report Prior to Clan Invasion

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1503,6 +1503,9 @@ lblTrackFactionStanding.text=Enable Faction Standing \u270E \u2318 <span style="
 lblTrackFactionStanding.tooltip=This option enables the tracking of Faction Standing. Faction Standing represents how\
   \ liked you are across the Inner Sphere. Actions such as taking contracts can increase or deminish your Standing. Full\
   \ documentation can be found in the docs folder.
+lblTrackClimateRegardChanges.text=Enable Verbose Climate Regard <span style="color:#C344C3;">\u2605</span>
+lblTrackClimateRegardChanges.tooltip=When enabled, the Climate Regard of each faction will be logged in the daily log\
+  \ on the 1st of each month.
 lblRegardMultiplier.text=Regard Gain Multiplier <span style="color:#C344C3;">\u2605</span>
 lblRegardMultiplier.tooltip=Faction Standing is balanced for a slow burn over multiple years. If you \
   find Regard gains to be too slow (or fast) this option applies a multiplier to all gains and losses. For example, \

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -351,6 +351,7 @@ public final class MHQConstants extends SuiteConstants {
     // endregion File Paths
 
     // startregion Important Dates
+    public static final LocalDate CLAN_INVASION_FIRST_WAVE_BEGINS = LocalDate.of(3050, 3, 7);
     public static final LocalDate BATTLE_OF_TUKAYYID = LocalDate.of(3052, 5, 21);
     // endregion Important Dates
 }

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -496,37 +496,37 @@ public class Campaign implements ITechManager {
 
     public Campaign(CampaignConfiguration campConf) {
         this(
-            campConf.getGame(),
-            campConf.getPlayer(),
-            campConf.getName(),
-            campConf.getDate(),
-            campConf.getCampaignOpts(),
-            campConf.getGameOptions(),
-            campConf.getPartsStore(),
-            campConf.getNewPersonnelMarket(),
-            campConf.getRandomDeath(),
-            campConf.getCampaignSummary(),
-            campConf.getfaction(),
-            campConf.getTechFaction(),
-            campConf.getCurrencyManager(),
-            campConf.getSystemsInstance(),
-            campConf.getLocation(),
-            campConf.getReputationController(),
-            campConf.getFactionStandings(),
-            campConf.getRankSystem(),
-            campConf.getforce(),
-            campConf.getfinances(),
-            campConf.getRandomEvents(),
-            campConf.getUltimatums(),
-            campConf.getRetDefTracker(),
-            campConf.getAutosave(),
-            campConf.getBehaviorSettings(),
-            campConf.getPersonnelMarket(),
-            campConf.getAtBMonthlyContractMarket(),
-            campConf.getUnitMarket(),
-            campConf.getDivorce(),
-            campConf.getMarriage(),
-            campConf.getProcreation()
+              campConf.getGame(),
+              campConf.getPlayer(),
+              campConf.getName(),
+              campConf.getDate(),
+              campConf.getCampaignOpts(),
+              campConf.getGameOptions(),
+              campConf.getPartsStore(),
+              campConf.getNewPersonnelMarket(),
+              campConf.getRandomDeath(),
+              campConf.getCampaignSummary(),
+              campConf.getfaction(),
+              campConf.getTechFaction(),
+              campConf.getCurrencyManager(),
+              campConf.getSystemsInstance(),
+              campConf.getLocation(),
+              campConf.getReputationController(),
+              campConf.getFactionStandings(),
+              campConf.getRankSystem(),
+              campConf.getforce(),
+              campConf.getfinances(),
+              campConf.getRandomEvents(),
+              campConf.getUltimatums(),
+              campConf.getRetDefTracker(),
+              campConf.getAutosave(),
+              campConf.getBehaviorSettings(),
+              campConf.getPersonnelMarket(),
+              campConf.getAtBMonthlyContractMarket(),
+              campConf.getUnitMarket(),
+              campConf.getDivorce(),
+              campConf.getMarriage(),
+              campConf.getProcreation()
         );
     }
 
@@ -3211,8 +3211,8 @@ public class Campaign implements ITechManager {
             PartInUse newPartInUse = getPartInUse((Part) maybePart);
             if (partInUse.equals(newPartInUse)) {
                 Part newPart = (maybePart instanceof MissingPart) ?
-                                        (((MissingPart) maybePart).getNewPart())
-                                        : (Part) maybePart;
+                                     (((MissingPart) maybePart).getNewPart())
+                                     : (Part) maybePart;
                 partInUse.setPlannedCount(partInUse.getPlannedCount() + newPart.getTotalQuantity());
             }
         }
@@ -3308,8 +3308,8 @@ public class Campaign implements ITechManager {
                 inUse.put(partInUse, partInUse);
             }
             Part newPart = (maybePart instanceof MissingPart) ?
-                    (((MissingPart) maybePart).getNewPart())
-                    : (Part) maybePart;
+                                 (((MissingPart) maybePart).getNewPart())
+                                 : (Part) maybePart;
             partInUse.setPlannedCount(partInUse.getPlannedCount() + newPart.getTotalQuantity());
         }
         return inUse.keySet()
@@ -6282,7 +6282,8 @@ public class Campaign implements ITechManager {
         if (isFirstOfMonth) {
             String report = factionStandings.updateClimateRegard(faction,
                   currentDay,
-                  campaignOptions.getRegardMultiplier());
+                  campaignOptions.getRegardMultiplier(),
+                  campaignOptions.isTrackClimateRegardChanges());
             addReport(report);
         }
 
@@ -10870,6 +10871,7 @@ public class Campaign implements ITechManager {
 
     /**
      * Now that systemsInstance is injectable and non-final, we may wish to update it on the fly.
+     *
      * @return systemsInstance Systems instance used when instantiating this Campaign instance.
      */
     public Systems getSystemsInstance() {
@@ -10877,8 +10879,9 @@ public class Campaign implements ITechManager {
     }
 
     /**
-     * Set the systemsInstance to a new instance.  Useful for testing, or updating the set of systems
-     * within a running Campaign.
+     * Set the systemsInstance to a new instance.  Useful for testing, or updating the set of systems within a running
+     * Campaign.
+     *
      * @param systemsInstance new Systems instance that this campaign should use.
      */
     public void setSystemsInstance(Systems systemsInstance) {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -643,6 +643,7 @@ public class CampaignOptions {
 
     // start region Faction Standing
     private boolean trackFactionStanding;
+    private boolean trackClimateRegardChanges;
     private boolean useFactionStandingNegotiation;
     private boolean useFactionStandingResupply;
     private boolean useFactionStandingCommandCircuit;
@@ -5359,6 +5360,14 @@ public class CampaignOptions {
 
     public void setTrackFactionStanding(boolean trackFactionStanding) {
         this.trackFactionStanding = trackFactionStanding;
+    }
+
+    public boolean isTrackClimateRegardChanges() {
+        return trackClimateRegardChanges;
+    }
+
+    public void setTrackClimateRegardChanges(boolean trackClimateRegardChanges) {
+        this.trackClimateRegardChanges = trackClimateRegardChanges;
     }
 
     public double getRegardMultiplier() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -1068,6 +1068,10 @@ public class CampaignOptionsMarshaller {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "trackFactionStanding", campaignOptions.isTrackFactionStanding());
         MHQXMLUtility.writeSimpleXMLTag(pw,
               indent,
+              "trackClimateRegardChanges",
+              campaignOptions.isTrackClimateRegardChanges());
+        MHQXMLUtility.writeSimpleXMLTag(pw,
+              indent,
               "useFactionStandingNegotiation",
               campaignOptions.isUseFactionStandingNegotiation());
         MHQXMLUtility.writeSimpleXMLTag(pw,

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -839,6 +839,8 @@ public class CampaignOptionsUnmarshaller {
             case "minimumCallsignSkillLevel" -> campaignOptions.setMinimumCallsignSkillLevel(SkillLevel.parseFromString(
                   nodeContents));
             case "trackFactionStanding" -> campaignOptions.setTrackFactionStanding(parseBoolean(nodeContents));
+            case "trackClimateRegardChanges" ->
+                  campaignOptions.setTrackClimateRegardChanges(parseBoolean(nodeContents));
             case "useFactionStandingNegotiation" -> campaignOptions.setUseFactionStandingNegotiation(parseBoolean(
                   nodeContents));
             case "useFactionStandingResupply" -> campaignOptions.setUseFactionStandingResupply(parseBoolean(

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
@@ -288,7 +288,7 @@ public class FactionStandings {
      * separately.</p>
      *
      * <p>If we're starting a new campaign, we should follow up object construction with a call to
-     * {@link #updateClimateRegard(Faction, LocalDate, double)}</p>
+     * {@link #updateClimateRegard(Faction, LocalDate, double, boolean)}</p>
      *
      * @author Illiani
      * @since 0.50.07
@@ -805,10 +805,10 @@ public class FactionStandings {
         return null;
     }
 
-    /** Use {@link #updateClimateRegard(Faction, LocalDate, double)} instead */
+    /** Use {@link #updateClimateRegard(Faction, LocalDate, double, boolean)} instead */
     @Deprecated(since = "0.50.07", forRemoval = true)
     public String updateClimateRegard(final Faction campaignFaction, final LocalDate today) {
-        return updateClimateRegard(campaignFaction, today, 1.0);
+        return updateClimateRegard(campaignFaction, today, 1.0, false);
     }
 
     /**
@@ -823,9 +823,11 @@ public class FactionStandings {
      * <p>After updating, this method generates and returns an HTML-formatted report summarizing the new climate
      * regard standings for all relevant factions.</p>
      *
-     * @param campaignFaction  the {@link Faction} representing the campaign's primary faction
-     * @param today            the {@link LocalDate} to use for validating factions and determining relationships
-     * @param regardMultiplier the regard multiplier set in campaign options
+     * @param campaignFaction            the {@link Faction} representing the campaign's primary faction
+     * @param today                      the {@link LocalDate} to use for validating factions and determining
+     *                                   relationships
+     * @param regardMultiplier           the regard multiplier set in campaign options
+     * @param enableVerboseClimateRegard {@code true} if the verbose climate regard campaign option is enabled
      *
      * @return an HTML-formatted {@link String} report of faction climate regard changes
      *
@@ -833,8 +835,8 @@ public class FactionStandings {
      * @since 0.50.07
      */
     public String updateClimateRegard(final Faction campaignFaction, final LocalDate today,
-          final double regardMultiplier) {
-        return updateClimateRegard(campaignFaction, today, regardMultiplier, false);
+          final double regardMultiplier, final boolean enableVerboseClimateRegard) {
+        return updateClimateRegard(campaignFaction, today, regardMultiplier, enableVerboseClimateRegard, false);
     }
 
     /**
@@ -849,10 +851,12 @@ public class FactionStandings {
      * <p>After updating, this method generates and returns an HTML-formatted report summarizing the new climate
      * regard standings for all relevant factions.</p>
      *
-     * @param campaignFaction  the {@link Faction} representing the campaign's primary faction
-     * @param today            the {@link LocalDate} to use for validating factions and determining relationships
-     * @param regardMultiplier the regard multiplier set in campaign options
-     * @param useTestDirectory {@code true} if called from within a Unit Test
+     * @param campaignFaction            the {@link Faction} representing the campaign's primary faction
+     * @param today                      the {@link LocalDate} to use for validating factions and determining
+     *                                   relationships
+     * @param regardMultiplier           the regard multiplier set in campaign options
+     * @param enableVerboseClimateRegard {@code true} if the verbose climate regard campaign option is enabled
+     * @param useTestDirectory           {@code true} if called from within a Unit Test
      *
      * @return an HTML-formatted {@link String} report of faction climate regard changes
      *
@@ -860,7 +864,7 @@ public class FactionStandings {
      * @since 0.50.07
      */
     public String updateClimateRegard(final Faction campaignFaction, final LocalDate today,
-          final double regardMultiplier, boolean useTestDirectory) {
+          final double regardMultiplier, boolean enableVerboseClimateRegard, boolean useTestDirectory) {
         Collection<Faction> allFactions = Factions.getInstance().getActiveFactions(today);
         FactionHints factionHints = FactionHints.defaultFactionHints(useTestDirectory);
         boolean isPirate = campaignFaction.isPirate();
@@ -926,7 +930,7 @@ public class FactionStandings {
         }
 
         // If we're not handling any climate modifiers, return an empty string
-        if (climateRegard.isEmpty()) {
+        if (climateRegard.isEmpty() || !enableVerboseClimateRegard) {
             return "";
         }
 

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
@@ -65,6 +65,7 @@ import javax.swing.ImageIcon;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
+import mekhq.MHQConstants;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.Contract;
 import mekhq.campaign.mission.Mission;
@@ -929,7 +930,7 @@ public class FactionStandings {
             return "";
         }
 
-        return buildClimateReport(campaignFaction.isPirate(), today).toString();
+        return buildClimateReport(campaignFaction.isPirate(), campaignFaction.isClan(), today).toString();
     }
 
     /**
@@ -941,7 +942,8 @@ public class FactionStandings {
      *
      * <p>If any entries exist, an introductory line is inserted at the beginning.</p>
      *
-     * @param campaignIsPirate whether the faction is a pirate faction
+     * @param campaignIsPirate whether the campaign faction is a pirate faction
+     * @param campaignIsClan   whether the campaign faction is a Clan faction
      * @param today            the {@link LocalDate} used for retrieving year-specific faction names
      *
      * @return a {@link StringBuilder} containing the formatted climate regard report
@@ -949,7 +951,10 @@ public class FactionStandings {
      * @author Illiani
      * @since 0.50.07
      */
-    private StringBuilder buildClimateReport(boolean campaignIsPirate, LocalDate today) {
+    private StringBuilder buildClimateReport(boolean campaignIsPirate, boolean campaignIsClan, LocalDate today) {
+        // We minus a day as otherwise this will return false if today is the first day of the First Wave
+        boolean clanInvasionHasBegun = MHQConstants.CLAN_INVASION_FIRST_WAVE_BEGINS.minusDays(1).isBefore(today);
+
         StringBuilder report = new StringBuilder();
         String factionName;
         double regard;
@@ -970,6 +975,11 @@ public class FactionStandings {
             if (faction == null) {
                 LOGGER.warn("Faction {} is missing from the Factions collection. Skipping.",
                       climateRegard.get(factionCode));
+                continue;
+            }
+
+            // If the Clan Invasion First Wave hasn't occurred
+            if (!clanInvasionHasBegun && (campaignIsClan != faction.isClan())) {
                 continue;
             }
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SystemsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SystemsTab.java
@@ -87,6 +87,7 @@ public class SystemsTab {
     // Faction Standing Tab
     private CampaignOptionsHeaderPanel factionStandingHeader;
     private JCheckBox chkTrackFactionStanding;
+    private JCheckBox chkTrackClimateRegardChanges;
     private JSpinner spnRegardMultiplier;
 
     private JCheckBox chkUseFactionStandingNegotiation;
@@ -272,6 +273,10 @@ public class SystemsTab {
         chkTrackFactionStanding = new CampaignOptionsCheckBox("TrackFactionStanding");
         chkTrackFactionStanding.addMouseListener(createTipPanelUpdater(factionStandingHeader, "TrackFactionStanding"));
 
+        chkTrackClimateRegardChanges = new CampaignOptionsCheckBox("TrackClimateRegardChanges");
+        chkTrackClimateRegardChanges.addMouseListener(createTipPanelUpdater(factionStandingHeader,
+              "TrackClimateRegardChanges"));
+
         JLabel lblRegardMultiplier = new CampaignOptionsLabel("RegardMultiplier");
         lblRegardMultiplier.addMouseListener(createTipPanelUpdater(factionStandingHeader, "RegardMultiplier"));
         spnRegardMultiplier = new CampaignOptionsSpinner("RegardMultiplier", 1.0, 0.1, 3.0, 0.1);
@@ -291,7 +296,10 @@ public class SystemsTab {
         layoutParent.gridy++;
         layoutParent.gridwidth = 1;
         panel.add(chkTrackFactionStanding, layoutParent);
+        layoutParent.gridx++;
+        panel.add(chkTrackClimateRegardChanges, layoutParent);
 
+        layoutParent.gridx = 0;
         layoutParent.gridy++;
         panel.add(lblRegardMultiplier, layoutParent);
         layoutParent.gridx++;
@@ -517,6 +525,7 @@ public class SystemsTab {
 
         // Faction Standing
         chkTrackFactionStanding.setSelected(options.isTrackFactionStanding());
+        chkTrackClimateRegardChanges.setSelected(options.isTrackClimateRegardChanges());
         spnRegardMultiplier.setValue(options.getRegardMultiplier());
         chkUseFactionStandingNegotiation.setSelected(options.isUseFactionStandingNegotiation());
         chkUseFactionStandingResupply.setSelected(options.isUseFactionStandingResupply());
@@ -577,6 +586,7 @@ public class SystemsTab {
 
         // Faction Standing
         options.setTrackFactionStanding(chkTrackFactionStanding.isSelected());
+        options.setTrackClimateRegardChanges(chkTrackClimateRegardChanges.isSelected());
         options.setRegardMultiplier((double) spnRegardMultiplier.getValue());
         options.setUseFactionStandingNegotiation(chkUseFactionStandingNegotiation.isSelected());
         options.setUseFactionStandingResupply(chkUseFactionStandingResupply.isSelected());

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -70,6 +70,7 @@ import mekhq.MekHQ;
 import mekhq.NullEntityException;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignFactory;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.OptionsChangedEvent;
 import mekhq.campaign.finances.CurrencyManager;
 import mekhq.campaign.finances.financialInstitutions.FinancialInstitutions;
@@ -374,10 +375,12 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 campaign.setReputation(reputationController);
 
                 // initialize starting faction standings
-                if (campaign.getCampaignOptions().isTrackFactionStanding()) {
+                CampaignOptions campaignOptions = campaign.getCampaignOptions();
+                if (campaignOptions.isTrackFactionStanding()) {
                     FactionStandings factionStandings = campaign.getFactionStandings();
                     String report = factionStandings.updateClimateRegard(campaign.getFaction(),
-                          campaign.getLocalDate(), campaign.getCampaignOptions().getRegardMultiplier());
+                          campaign.getLocalDate(), campaignOptions.getRegardMultiplier(),
+                          campaignOptions.isTrackClimateRegardChanges());
                     campaign.addReport(report);
                 }
                 // endregion Progress 6
@@ -389,25 +392,25 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                                            "</b>");
 
                 // Setup Personnel Modules
-                campaign.setMarriage(campaign.getCampaignOptions()
+                campaign.setMarriage(campaignOptions
                                            .getRandomMarriageMethod()
-                                           .getMethod(campaign.getCampaignOptions()));
-                campaign.setDivorce(campaign.getCampaignOptions()
+                                           .getMethod(campaignOptions));
+                campaign.setDivorce(campaignOptions
                                           .getRandomDivorceMethod()
-                                          .getMethod(campaign.getCampaignOptions()));
-                campaign.setProcreation(campaign.getCampaignOptions()
+                                          .getMethod(campaignOptions));
+                campaign.setProcreation(campaignOptions
                                               .getRandomProcreationMethod()
-                                              .getMethod(campaign.getCampaignOptions()));
+                                              .getMethod(campaignOptions));
 
                 // Setup Markets
                 campaign.refreshPersonnelMarkets(true);
-                ContractMarketMethod contractMarketMethod = campaign.getCampaignOptions().getContractMarketMethod();
+                ContractMarketMethod contractMarketMethod = campaignOptions.getContractMarketMethod();
                 campaign.setContractMarket(contractMarketMethod.getContractMarket());
                 if (!contractMarketMethod.isNone()) {
                     campaign.getContractMarket().generateContractOffers(campaign, true);
                 }
-                if (!campaign.getCampaignOptions().getUnitMarketMethod().isNone()) {
-                    campaign.setUnitMarket(campaign.getCampaignOptions().getUnitMarketMethod().getUnitMarket());
+                if (!campaignOptions.getUnitMarketMethod().isNone()) {
+                    campaign.setUnitMarket(campaignOptions.getUnitMarketMethod().getUnitMarket());
                     campaign.getUnitMarket().generateUnitOffers(campaign);
                 }
 
@@ -419,7 +422,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                 campaign.setGMMode((preset == null) || preset.isGM());
 
                 // AtB
-                if (campaign.getCampaignOptions().isUseAtB()) {
+                if (campaignOptions.isUseAtB()) {
                     campaign.initAtB(true);
                 }
 

--- a/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/DataLoadingDialog.java
@@ -380,7 +380,7 @@ public class DataLoadingDialog extends AbstractMHQDialogBasic implements Propert
                     FactionStandings factionStandings = campaign.getFactionStandings();
                     String report = factionStandings.updateClimateRegard(campaign.getFaction(),
                           campaign.getLocalDate(), campaignOptions.getRegardMultiplier(),
-                          campaignOptions.isTrackClimateRegardChanges());
+                          true);
                     campaign.addReport(report);
                 }
                 // endregion Progress 6

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/CampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/CampaignOptionsChangedConfirmationDialog.java
@@ -287,7 +287,7 @@ public class CampaignOptionsChangedConfirmationDialog extends JDialog {
             if (isFactionStandingEnabled) {
                 reports.add(getTextAt(RESOURCE_BUNDLE, "gmTools.ZERO_ALL_REGARD.report"));
                 factionStandings.resetAllFactionStandings();
-                factionStandings.updateClimateRegard(campaignFaction, today, regardMultiplier);
+                factionStandings.updateClimateRegard(campaignFaction, today, regardMultiplier, true);
                 reports.addAll(factionStandings.updateCampaignForPastMissions(missions,
                       campaignIcon,
                       campaignFaction,

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/FactionStandingReport.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/FactionStandingReport.java
@@ -66,6 +66,7 @@ import megamek.client.ui.util.UIUtil;
 import megamek.common.ui.FastJScrollPane;
 import megamek.logging.MMLogger;
 import megamek.utilities.ImageUtilities;
+import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
@@ -126,6 +127,9 @@ public class FactionStandingReport extends JDialog {
     private final boolean isFactionStandingEnabled;
     private final CampaignOptions campaignOptions;
 
+    private final boolean hideClanFactions;
+    private final boolean hideNonClanFactions;
+
     private final List<String> innerSphereFactions = new ArrayList<>();
     private final List<String> innerSphereMinorFactions = new ArrayList<>();
     private final List<String> clanFactions = new ArrayList<>();
@@ -156,6 +160,12 @@ public class FactionStandingReport extends JDialog {
         factions = Factions.getInstance();
         this.campaignOptions = campaign.getCampaignOptions();
         this.isFactionStandingEnabled = campaignOptions.isTrackFactionStanding();
+
+        // We minus a day as otherwise this will return false if today is the first day of the First Wave
+        boolean clanInvasionHasBegun = MHQConstants.CLAN_INVASION_FIRST_WAVE_BEGINS.minusDays(1).isBefore(today);
+        boolean campaignIsClan = campaignFaction.isClan();
+        hideClanFactions = !clanInvasionHasBegun && !campaignIsClan;
+        hideNonClanFactions = !clanInvasionHasBegun && campaignIsClan;
 
         sortFactions();
         createReportPanel();
@@ -227,11 +237,16 @@ public class FactionStandingReport extends JDialog {
                 continue;
             }
 
+            boolean factionIsClan = faction.isClan();
+            if ((factionIsClan && hideClanFactions) || (!factionIsClan && hideNonClanFactions)) {
+                continue;
+            }
+
             if (!faction.validIn(gameYear)) {
                 deadFactions.add(factionCode);
             } else if (faction.isMercenaryOrganization() || factionCode.equals(PIRACY_SUCCESS_INDEX_FACTION_CODE)) {
                 specialFactions.add(factionCode);
-            } else if (faction.isClan()) {
+            } else if (factionIsClan) {
                 clanFactions.add(factionCode);
             } else if (faction.isDeepPeriphery()) {
                 deepPeripheryFactions.add(factionCode);
@@ -273,13 +288,24 @@ public class FactionStandingReport extends JDialog {
         JTabbedPane tabbedPane = new JTabbedPane();
         tabbedPane.setName("tabbedPane");
         if (isFactionStandingEnabled) {
-            tabbedPane.addTab(innerSphereTabTitle, createReportPanelForFactionGroup(innerSphereFactions));
-            tabbedPane.addTab(innerSphereMinorTabTitle, createReportPanelForFactionGroup(innerSphereMinorFactions));
-            tabbedPane.addTab(clanTabTitle, createReportPanelForFactionGroup(clanFactions));
-            tabbedPane.addTab(peripheryTabTitle, createReportPanelForFactionGroup(peripheryFactions));
-            tabbedPane.addTab(deepPeripheryTabTitle, createReportPanelForFactionGroup(deepPeripheryFactions));
-            tabbedPane.addTab(specialTabTitle, createReportPanelForFactionGroup(specialFactions));
-            tabbedPane.addTab(deadTabTitle, createReportPanelForFactionGroup(deadFactions));
+            Object[][] tabs = {
+                  { innerSphereTabTitle, innerSphereFactions },
+                  { innerSphereMinorTabTitle, innerSphereMinorFactions },
+                  { clanTabTitle, clanFactions },
+                  { peripheryTabTitle, peripheryFactions },
+                  { deepPeripheryTabTitle, deepPeripheryFactions },
+                  { specialTabTitle, specialFactions },
+                  { deadTabTitle, deadFactions }
+            };
+
+            for (Object[] tab : tabs) {
+                String title = (String) tab[0];
+                @SuppressWarnings("unchecked")
+                List<String> factions = (List<String>) tab[1];
+                if (!factions.isEmpty()) {
+                    tabbedPane.addTab(title, createReportPanelForFactionGroup(factions));
+                }
+            }
         } else {
             tabbedPane.addTab(disabledTitle, createFactionStandingDisabledTab());
         }

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/gmToolsDialog/GMTools.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/gmToolsDialog/GMTools.java
@@ -379,7 +379,7 @@ public class GMTools extends JDialog {
                 case RESET_ALL_REGARD, ZERO_ALL_REGARD -> {
                     reports.add(getTextAt(RESOURCE_BUNDLE, "gmTools.ZERO_ALL_REGARD.report"));
                     factionStandings.resetAllFactionStandings();
-                    factionStandings.updateClimateRegard(campaignFaction, today, regardMultiplier);
+                    factionStandings.updateClimateRegard(campaignFaction, today, regardMultiplier, false);
                 }
                 case SET_SPECIFIC_REGARD -> {
                     Faction selectedFaction = factionSelectionDialog.getSelectedFaction();
@@ -395,7 +395,7 @@ public class GMTools extends JDialog {
                 case UPDATE_HISTORIC_CONTRACTS -> {
                     reports.add(getTextAt(RESOURCE_BUNDLE, "gmTools.ZERO_ALL_REGARD.report"));
                     factionStandings.resetAllFactionStandings();
-                    factionStandings.updateClimateRegard(campaignFaction, today, regardMultiplier);
+                    factionStandings.updateClimateRegard(campaignFaction, today, regardMultiplier, false);
                     reports.addAll(factionStandings.updateCampaignForPastMissions(missions,
                           campaignIcon,
                           campaignFaction,

--- a/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionStandingsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionStandingsTest.java
@@ -93,7 +93,7 @@ class FactionStandingsTest {
         LocalDate today = LocalDate.of(3028, 8, 20); // Start of the 4th Succession War
 
         FactionStandings factionStandings = new FactionStandings();
-        factionStandings.updateClimateRegard(campaignFaction, today, 1.0, true);
+        factionStandings.updateClimateRegard(campaignFaction, today, 1.0, true, true);
 
         // Act
         double actualRegard = factionStandings.getRegardForFaction(targetFaction, true);


### PR DESCRIPTION
Close #7536

First this PR adds a faction standings verbose mode option to campaign options. If enabled the monthly climate report will post the values of change from political climate. If this option is disabled the player must rely on the Faction Standing report.

Speaking of the Faction Standing report, it no longer shows empty tabs.

Finally, prior to the start of the Clan Invasion's First Wave all Non-Clan Faction Standings will be hidden from Clan campaigns; while Clan standings will be hidden from non-clan campaigns.