### PR TITLE
Fix: Restored Performance Log Entry Adding

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -3881,6 +3881,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             menu.add(menuItem);
 
             menuItem = new JMenuItem(resources.getString("editPerformanceLog.text"));
+            menuItem.setActionCommand(CMD_ADD_PERFORMANCE_LOG_ENTRY);
+            menuItem.addActionListener(this);
+            menu.add(menuItem);
         } else {
             menuItem = new JMenuItem(resources.getString("addSingleLogEntry.text"));
             menuItem.setActionCommand(CMD_ADD_LOG_ENTRY);


### PR DESCRIPTION
During the data overhaul the ability to manually add new performance log entries was incorrectly removed. This PR restores it.