### PR TITLE
Fix: Updated Glossary Entries to No Longer Claim Attribute Score Effects Are Coming in 50.07... 'Cause They're Already Here!

### DIFF
--- a/MekHQ/resources/mekhq/resources/Glossary.properties
+++ b/MekHQ/resources/mekhq/resources/Glossary.properties
@@ -76,10 +76,8 @@ ATTRIBUTE_SCORES.definition=In <i>A Time of War</i> There are seven Attribute Sc
  \ Reflexes (RFL), Dexterity (DEX), Intelligence (INT), Willpower (WIL), and Edge (EDG). Each skill is assigned 1-2 of\
  \ these Attributes as its <a href='GLOSSARY:LINKED_ATTRIBUTES'>Linked Attributes</a>, which influence the skill''s final\
  \ Target Number.\
- <p><a href='GLOSSARY:EDGE'>Edge</a> is handled differently in MekHQ and has its own Glossary entry.\
- <p><b>Important:</b> Attribute Scores don''t currently influence skill Target Numbers. This functionality is going to be\
- \ coming in 0.50.07.\
- <p>A character''s starting Attribute Scores are dependent on their starting Profession. For more details on starting\
+ <p><a href='GLOSSARY:EDGE'>Edge</a> is handled differently in MekHQ and has its own Glossary entry.
+<p>A character''s starting Attribute Scores are dependent on their starting Profession. For more details on starting\
   \ attribute scores, refer to the documentation in\
  <br><i>MekHQ/docs/Personnel Modules/Starting Attribute Scores.pdf</i></p>
 AUTOINFIRMARY.title=AutoInfirmary
@@ -445,9 +443,7 @@ LEADERSHIP_UNITS.definition=When <a href='GLOSSARY:HOW_TO_DEPLOY'>deploying</a> 
  \ pilot skills.</p>
 LINKED_ATTRIBUTES.title=Linked Attributes
 LINKED_ATTRIBUTES.definition=In <i>A Time of War</i> each skill is assigned 1-2 ''Linked Attributes.'' These influence the\
- \ final Target Number of the skill.\
- <p><b>Important:</b> <a href='GLOSSARY:ATTRIBUTE_SCORES'>Attribute Scores</a> don''t currently influence skill Target\
- \ Numbers. This functionality is going to be coming in 0.50.07.
+ \ final Target Number of the skill.
 LOYALTY.title=Loyalty
 LOYALTY.definition=Loyalty measures how committed a character is to your cause. Characters with higher loyalty are less\
   \ likely to resign. Loyalty can fluctuate over time because of your decisions  and personal life events, like marriage\

--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -94,10 +94,8 @@ ATTRIBUTE_SCORES.definition=In <i>A Time of War</i> There are seven Attribute Sc
  \ Reflexes (RFL), Dexterity (DEX), Intelligence (INT), Willpower (WIL), and Edge (EDG). Each skill is assigned 1-2 of\
  \ these Attributes as its <a href='GLOSSARY:LINKED_ATTRIBUTES'>Linked Attributes</a>, which influence the skill's final\
  \ Target Number.\
- <p><a href='GLOSSARY:EDGE'>Edge</a> is handled differently in MekHQ and has its own Glossary entry.\
- <p><b>Important:</b> Attribute Scores don't currently influence skill Target Numbers. This functionality is going to be\
- \ coming in 0.50.07.\
- <p>A character's starting Attribute Scores are dependent on their starting Profession. For more details on starting\
+ <p><a href='GLOSSARY:EDGE'>Edge</a> is handled differently in MekHQ and has its own Glossary entry.
+<p>A character's starting Attribute Scores are dependent on their starting Profession. For more details on starting\
   \ attribute scores, refer to the documentation in\
  <br><i>MekHQ/docs/Personnel Modules/Starting Attribute Scores.pdf</i></p>
 AUTOINFIRMARY.title=AutoInfirmary
@@ -501,9 +499,7 @@ LEADERSHIP_UNITS.definition=When <a href='GLOSSARY:HOW_TO_DEPLOY'>deploying</a> 
  \ pilot skills.</p>
 LINKED_ATTRIBUTES.title=Linked Attributes
 LINKED_ATTRIBUTES.definition=In <i>A Time of War</i> each skill is assigned 1-2 'Linked Attributes.' These influence the\
- \ final Target Number of the skill.\
- <p><b>Important:</b> <a href='GLOSSARY:ATTRIBUTE_SCORES'>Attribute Scores</a> don't currently influence skill Target\
- \ Numbers. This functionality is going to be coming in 0.50.07.
+ \ final Target Number of the skill.
 LOYALTY.title=Loyalty
 LOYALTY.definition=Loyalty measures how committed a character is to your cause. Characters with higher loyalty are less\
   \ likely to resign. Loyalty can fluctuate over time because of your decisions  and personal life events, like marriage\


### PR DESCRIPTION
Removed Glossary Entry references to Attribute score effects not coming until 50.07, on account of this being 50.07 and they're already implemented.