### PR TITLE
Fix: Camp Followers Announcing Unemployment Upon Arrival

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2385,7 +2385,7 @@ public class Campaign implements ITechManager {
                 asTechPoolOvertime += Person.SECONDARY_ROLE_OVERTIME_SUPPORT_TIME;
             }
         } else {
-            person.changeStatus(this, currentDay, PersonnelStatus.CAMP_FOLLOWER);
+            person.setStatus(PersonnelStatus.CAMP_FOLLOWER);
         }
 
         person.setPrisonerStatus(this, prisonerStatus, log);


### PR DESCRIPTION
This PR stops Camp Followers from declaring that they are now unemployed whenever they join the campaign.