### PR TITLE
Fix: Corrected Iconography for Functional Appraisal in Campaign Options

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -215,7 +215,7 @@ lblAcquisitionTab.text=Acquisition & Delivery Options
 lblAcquisitionPanel.text=Acquisitions
 lblChoiceAcquireSkill.text=Acquisitions Skill
 lblChoiceAcquireSkill.tooltip=What skill should be used when performing acquisition checks?
-lblUseFunctionalAppraisal.text=Use Functional Appraisal \u270E <span style="color:#7FCF43;">\u2606</span>
+lblUseFunctionalAppraisal.text=Use Functional Appraisal \u270E <span style="color:#C344C3;">\u2606</span>
 lblUseFunctionalAppraisal.tooltip=If enabled, a character's Appraisal skill will be used to influence the cost of \
   purchasing parts, refit kits, and units (acquired outside the unit market).
 lblProcurementPersonnelPick.text=Acquisitions Personnel


### PR DESCRIPTION
Functional Appraisal was using the 'added since last milestone' iconography when it should have been using 'added since last development'