### PR TITLE
Fix: TO&E Catching Incorrect Error

### DIFF
--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -208,7 +208,7 @@ public final class TOETab extends CampaignGuiTab {
             try {
                 tabUnit.setSelectedIndex(tabUnitLastSelectedIndex);
                 tabUnit.addChangeListener(evt -> forceViewTabChange()); // added late so it won't overwrite
-            } catch (ArrayIndexOutOfBoundsException ignored) {}
+            } catch (IndexOutOfBoundsException ignored) {}
             // We can ignore here because if the selected index is out of bounds, we're just going
             // to not select the unit in the TO&E.
         } else if (node instanceof Force) {


### PR DESCRIPTION
We were incorrectly catching `ArrayIndexOutOfBoundsException` errors instead of `IndexOutOfBoundsException`