### PR TITLE
Fix #7673: Updated Out-of-Date Princess Behavior File

### DIFF
--- a/MekHQ/mmconf/princessBehaviors.xml
+++ b/MekHQ/mmconf/princessBehaviors.xml
@@ -1,8 +1,189 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <princessBehaviors>
   <behavior>
+    <name>Skirmisher (pPT)</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>4</fallShameIndex>
+    <hyperAggressionIndex>6</hyperAggressionIndex>
+    <selfPreservationIndex>4</selfPreservationIndex>
+    <herdMentalityIndex>4</herdMentalityIndex>
+    <braveryIndex>3</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>Sniper (pPT)</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>1</hyperAggressionIndex>
+    <selfPreservationIndex>6</selfPreservationIndex>
+    <herdMentalityIndex>2</herdMentalityIndex>
+    <braveryIndex>4</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>Scout (pPT)</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>4</fallShameIndex>
+    <hyperAggressionIndex>8</hyperAggressionIndex>
+    <selfPreservationIndex>6</selfPreservationIndex>
+    <herdMentalityIndex>3</herdMentalityIndex>
+    <braveryIndex>7</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>LRM Missile Boat (pPT)</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>1</hyperAggressionIndex>
+    <selfPreservationIndex>4</selfPreservationIndex>
+    <herdMentalityIndex>3</herdMentalityIndex>
+    <braveryIndex>6</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>SRM Missile Boat (pPT)</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>6</hyperAggressionIndex>
+    <selfPreservationIndex>6</selfPreservationIndex>
+    <herdMentalityIndex>7</herdMentalityIndex>
+    <braveryIndex>6</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>Striker (pPT)</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>9</hyperAggressionIndex>
+    <selfPreservationIndex>2</selfPreservationIndex>
+    <herdMentalityIndex>7</herdMentalityIndex>
+    <braveryIndex>5</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>Juggernaut (pPT)</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>9</hyperAggressionIndex>
+    <selfPreservationIndex>3</selfPreservationIndex>
+    <herdMentalityIndex>5</herdMentalityIndex>
+    <braveryIndex>5</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>BERSERK v2</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>false</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>10</hyperAggressionIndex>
+    <selfPreservationIndex>3</selfPreservationIndex>
+    <herdMentalityIndex>8</herdMentalityIndex>
+    <braveryIndex>2</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>Brawler (pPT)</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>4</hyperAggressionIndex>
+    <selfPreservationIndex>5</selfPreservationIndex>
+    <herdMentalityIndex>2</herdMentalityIndex>
+    <braveryIndex>8</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>ESCAPE</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>3</hyperAggressionIndex>
+    <selfPreservationIndex>10</selfPreservationIndex>
+    <herdMentalityIndex>4</herdMentalityIndex>
+    <braveryIndex>8</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>DEFAULT</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>true</forcedWithdrawal>
+    <goHome>true</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>5</hyperAggressionIndex>
+    <selfPreservationIndex>5</selfPreservationIndex>
+    <herdMentalityIndex>5</herdMentalityIndex>
+    <braveryIndex>5</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
+    <name>DEFAULT v2 BRAVER</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>false</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>5</fallShameIndex>
+    <hyperAggressionIndex>5</hyperAggressionIndex>
+    <selfPreservationIndex>3</selfPreservationIndex>
+    <herdMentalityIndex>8</herdMentalityIndex>
+    <braveryIndex>2</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
+  </behavior>
+  <behavior>
     <name>COWARDLY</name>
-    <homeEdge>0</homeEdge>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
     <forcedWithdrawal>true</forcedWithdrawal>
     <goHome>false</goHome>
     <autoFlee>false</autoFlee>
@@ -11,45 +192,22 @@
     <selfPreservationIndex>10</selfPreservationIndex>
     <herdMentalityIndex>8</herdMentalityIndex>
     <braveryIndex>2</braveryIndex>
-    <strategicTargets />
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
   </behavior>
   <behavior>
-    <name>BERSERK</name>
-    <homeEdge>0</homeEdge>
-    <forcedWithdrawal>false</forcedWithdrawal>
-    <goHome>false</goHome>
-    <autoFlee>false</autoFlee>
-    <fallShameIndex>2</fallShameIndex>
-    <hyperAggressionIndex>10</hyperAggressionIndex>
-    <selfPreservationIndex>2</selfPreservationIndex>
-    <herdMentalityIndex>5</herdMentalityIndex>
-    <braveryIndex>9</braveryIndex>
-    <strategicTargets />
-  </behavior>
-  <behavior>
-    <name>ESCAPE</name>
-    <homeEdge>0</homeEdge>
-    <forcedWithdrawal>true</forcedWithdrawal>
-    <goHome>true</goHome>
-    <autoFlee>true</autoFlee>
-    <fallShameIndex>7</fallShameIndex>
-    <hyperAggressionIndex>1</hyperAggressionIndex>
-    <selfPreservationIndex>10</selfPreservationIndex>
-    <herdMentalityIndex>5</herdMentalityIndex>
-    <braveryIndex>2</braveryIndex>
-    <strategicTargets />
-  </behavior>
-  <behavior>
-    <name>DEFAULT</name>
-    <homeEdge>0</homeEdge>
+    <name>Ambusher</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
     <forcedWithdrawal>true</forcedWithdrawal>
     <goHome>false</goHome>
     <autoFlee>false</autoFlee>
     <fallShameIndex>5</fallShameIndex>
-    <hyperAggressionIndex>5</hyperAggressionIndex>
-    <selfPreservationIndex>5</selfPreservationIndex>
-    <herdMentalityIndex>5</herdMentalityIndex>
-    <braveryIndex>5</braveryIndex>
-    <strategicTargets />
+    <hyperAggressionIndex>7</hyperAggressionIndex>
+    <selfPreservationIndex>6</selfPreservationIndex>
+    <herdMentalityIndex>4</herdMentalityIndex>
+    <braveryIndex>7</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets />
   </behavior>
 </princessBehaviors>


### PR DESCRIPTION
The Princess Behavior file exists in both mm and mhq, however mhq's version only included the default bot behaviors overwriting the mm version.

This updates the mhq version to match mm.

We probably want to move it into mm-data at some point so this doesn't happen again.