### PR TITLE
Improvement: Allowed AsTechs to Be Visible In Personnel Table when Filtering for Techs

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -5634,6 +5634,11 @@ public class Person {
         return hasSkill && (getPrimaryRole().isBATech() || getSecondaryRole().isBATech());
     }
 
+    public boolean isAsTech() {
+        boolean hasSkill = hasSkill(S_ASTECH);
+        return hasSkill && (getPrimaryRole().isAstech() || getSecondaryRole().isAstech());
+    }
+
     /**
      * Checks whether this character satisfies the requirements for a given personnel role.
      *

--- a/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelFilter.java
@@ -469,7 +469,8 @@ public enum PersonnelFilter {
                                                       person.getPrimaryRole().isVesselNavigator() :
                                                       person.hasRole(PersonnelRole.VESSEL_NAVIGATOR));
             case TECH -> active && (MekHQ.getMHQOptions().getPersonnelFilterOnPrimaryRole() ?
-                                          person.getPrimaryRole().isTech() : person.isTech());
+                                          (person.getPrimaryRole().isTech() || person.getPrimaryRole().isAstech()) :
+                                          (person.isTech() || person.isAsTech()));
             case MEK_TECH -> active && (MekHQ.getMHQOptions().getPersonnelFilterOnPrimaryRole() ?
                                               person.getPrimaryRole().isMekTech() :
                                               person.hasRole(PersonnelRole.MEK_TECH));


### PR DESCRIPTION
With this PR, when the player filters the Personnel Table to show techs, permanent AsTechs also appear. Otherwise these characters are only visible when viewing All Personnel (or All Active Personnel).

Medics work already so no change necessary there.