### PR TITLE
Fix: Fixed Estimated Arrival Time Displaying 1 Day Short

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -500,7 +500,7 @@ public class Contract extends Mission {
             double days = Math.round(jumpPath.getTotalTime(campaign.getLocalDate(),
                   campaign.getLocation().getTransitTime(), isUseCommandCircuit) * 100.0)
                                 / 100.0;
-            return (int) Math.round(days);
+            return (int) Math.ceil(days);
         }
         return 0;
     }


### PR DESCRIPTION
When a player accepts a contract their arrival time is posted to the daily report, however this always seemed 1 day short. Checking the code it was due to us using `round` instead of `ceil`. As partial days aren't factored into this system ceil is the better option.