### PR TITLE
Fix: Clan Forces Now Factor in Campaign Difficulty When Bidding Away Units

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1120,7 +1120,8 @@ public class AtBDynamicScenarioFactory {
                 int playerBattleValue = calculateEffectiveBV(scenario, campaign, true);
                 int playerUnitValue = calculateEffectiveUnitCount(scenario, campaign, true);
 
-                forceBVBudget = (int) (playerBattleValue * forceMultiplier);
+                double difficultyMultiplier = getDifficultyMultiplier(campaign);
+                forceBVBudget = (int) (playerBattleValue * forceMultiplier * difficultyMultiplier);
 
                 LOGGER.info("Base bidding budget is {} BV2. This is seed force multiplied by scenario force " +
                                   "multiplier", forceBVBudget);


### PR DESCRIPTION
Previously the campaign difficulty multiplier was not being factored into Clan bidding, it is now. This meant that Clan bids would be easier or harder than intended, based on campaign difficulty.