### PR TITLE
Improvement: Added Sorting to Skills in Mass Training; Owned Skills in Edit Person Dialog Now Pinned to the Top

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -406,6 +406,57 @@ public class SkillType {
     }
 
     /**
+     * Returns a list of skill names sorted by category.
+     *
+     * <p>The sorting order is:</p>
+     * <ol>
+     *     <li>Combat skills</li>
+     *     <li>Support skills</li>
+     *     <li>Roleplay skills</li>
+     * </ol>
+     *
+     * <p>Skill names are categorized by querying their {@code SkillType}. Any unknown skill types are ignored and a
+     * warning is logged.</p>
+     *
+     * @return a {@code List} of skill names sorted by skill category
+     *
+     * @author Illiani
+     * @since 0.50.06
+     */
+    public static List<String> getSortedSkillNames() {
+        String[] unsortedSkillNames = SkillType.getSkillList();
+        List<String> sortedSkillNames = new ArrayList<>();
+        List<String> combatSkills = new ArrayList<>();
+        List<String> supportSkills = new ArrayList<>();
+        List<String> roleplaySkills = new ArrayList<>();
+        for (String skillName : unsortedSkillNames) {
+            SkillType skillType = SkillType.getType(skillName);
+
+            if (skillType == null) {
+                LOGGER.warn("Unknown skill type: {}", skillName);
+                continue;
+            }
+
+            if (skillType.isRoleplaySkill()) {
+                roleplaySkills.add(skillName);
+                continue;
+            }
+
+            if (skillType.isSupportSkill()) {
+                supportSkills.add(skillName);
+                continue;
+            }
+
+            combatSkills.add(skillName);
+        }
+
+        sortedSkillNames.addAll(combatSkills);
+        sortedSkillNames.addAll(supportSkills);
+        sortedSkillNames.addAll(roleplaySkills);
+        return sortedSkillNames;
+    }
+
+    /**
      * Default constructor for the {@code SkillType} class.
      *
      * <p>Initializes a default skill type with placeholder values, primarily for testing or fallback purposes.</p>
@@ -470,10 +521,10 @@ public class SkillType {
      *
      *                          <p>For example:</p>
      *                          <pre>
-     *                                                                                                                                                                                                           Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
-     *                                                                                                                                                                                                           SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
-     *                                                                                                                                                                                                           SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
-     *                                                                                                                                                                                                       </pre>
+     *                                                                                                                                                                                                                                    Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
+     *                                                                                                                                                                                                                                    SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
+     *                                                                                                                                                                                                                                    SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
+     *                                                                                                                                                                                                                                </pre>
      * @param skillLevelsMatter if {@code true}, the skill's level will be displayed in Person View in addition to the
      *                          skill's Target Number
      *

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -258,7 +258,7 @@ public final class BatchXPDialog extends JDialog {
         choiceSkill.setMaximumSize(new Dimension(Short.MAX_VALUE, (int) choiceSkill.getPreferredSize().getHeight()));
         DefaultComboBoxModel<String> personSkillModel = new DefaultComboBoxModel<>();
         personSkillModel.addElement(choiceNoSkill);
-        for (String skill : SkillType.getSkillList()) {
+        for (String skill : SkillType.getSortedSkillNames()) {
             personSkillModel.addElement(skill);
         }
         choiceSkill.setModel(personSkillModel);

--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -1227,7 +1227,7 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
         c.insets = new Insets(0, 10, 0, 0);
         c.gridx = 0;
 
-        List<String> sortedSkillNames = getSortedSkillNames();
+        List<String> sortedSkillNames = SkillType.getSortedSkillNames();
 
         SkillType skillType;
         for (int index = 0; index < sortedSkillNames.size(); index++) {
@@ -1303,57 +1303,6 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
             c.weightx = 1.0;
             panSkills.add(spnBonus, c);
         }
-    }
-
-    /**
-     * Returns a list of skill names sorted by category.
-     *
-     * <p>The sorting order is:</p>
-     * <ol>
-     *     <li>Combat skills</li>
-     *     <li>Support skills</li>
-     *     <li>Roleplay skills</li>
-     * </ol>
-     *
-     * <p>Skill names are categorized by querying their {@code SkillType}. Any unknown skill types are ignored and a
-     * warning is logged.</p>
-     *
-     * @return a {@code List} of skill names sorted by skill category
-     *
-     * @author Illiani
-     * @since 0.50.06
-     */
-    private static List<String> getSortedSkillNames() {
-        String[] unsortedSkillNames = SkillType.getSkillList();
-        List<String> sortedSkillNames = new ArrayList<>();
-        List<String> combatSkills = new ArrayList<>();
-        List<String> supportSkills = new ArrayList<>();
-        List<String> roleplaySkills = new ArrayList<>();
-        for (String skillName : unsortedSkillNames) {
-            SkillType skillType = SkillType.getType(skillName);
-
-            if (skillType == null) {
-                LOGGER.warn("Unknown skill type: {}", skillName);
-                continue;
-            }
-
-            if (skillType.isRoleplaySkill()) {
-                roleplaySkills.add(skillName);
-                continue;
-            }
-
-            if (skillType.isSupportSkill()) {
-                supportSkills.add(skillName);
-                continue;
-            }
-
-            combatSkills.add(skillName);
-        }
-
-        sortedSkillNames.addAll(combatSkills);
-        sortedSkillNames.addAll(supportSkills);
-        sortedSkillNames.addAll(roleplaySkills);
-        return sortedSkillNames;
     }
 
     private void setSkills() {

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1737,12 +1737,11 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
      */
     private List<String> getSortedSkills() {
         List<String> sortedSkillNames = SkillType.getSortedSkillNames();
+
         List<String> ownedSkills = person.getSkills().getSkills().stream()
                                          .map(Skill::getType)
                                          .filter(Objects::nonNull)
-                                         .map(SkillType::getName)
-                                         .sorted()
-                                         .toList();
+                                         .map(SkillType::getName).distinct().sorted().toList();
 
         List<String> remainingSkills = new ArrayList<>(sortedSkillNames);
         remainingSkills.removeAll(ownedSkills);


### PR DESCRIPTION
Since the RP Skills were added a couple of versions ago we've have semi-frequent feedback that they've made the Mass Training dialog a little hard to use. This is because those skills are sorted alphabetically.

This PR changes the sorting so that they're sorted Gunnery -> Piloting -> Support -> RP Only (and alphabetically within those categories).

It also updates the sorting in Edit Person so that skills the character owns are pinned to the top of the list. This means ~~I~~ I mean, _our players_, don't have to keep hunting for whatever skills the character has during testing.

<img width="2236" height="1180" alt="image" src="https://github.com/user-attachments/assets/82db84f9-a2b0-4571-9c64-e43f58ace6a6" />
