### PR TITLE
Fix #7678: Fixed Inability to Order Certain Gyro Weights When Multiple Units Have Same Gyro Type But Different Weight

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -34,6 +34,7 @@
 package mekhq.campaign.parts;
 
 import java.io.PrintWriter;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -103,6 +104,8 @@ import org.w3c.dom.NodeList;
  */
 public abstract class Part implements IPartWork, ITechnology {
     private static final MMLogger LOGGER = MMLogger.create(Part.class);
+
+    private static final DecimalFormat TONNAGE_FORMATTER = new DecimalFormat("0.#");
 
     protected static final TechAdvancement TA_POD = Entity.getOmniAdvancement();
     // Generic TechAdvancement for a number of basic components.
@@ -439,7 +442,7 @@ public abstract class Part implements IPartWork, ITechnology {
 
         if (this instanceof MekGyro gyro) {
             // We only want to display the decimal point if it's not zero
-            String tonnage = String.valueOf(gyro.getTonnage()).replace(".0", "");
+            String tonnage = TONNAGE_FORMATTER.format(gyro.getTonnage());
             toReturn.append(tonnage).append(" ton");
         }
 
@@ -1209,7 +1212,7 @@ public abstract class Part implements IPartWork, ITechnology {
 
         if (this instanceof MekGyro gyro) {
             // We only want to display the decimal point if it's not zero
-            String tonnage = String.valueOf(gyro.getTonnage()).replace(".0", "");
+            String tonnage = TONNAGE_FORMATTER.format(gyro.getTonnage());
             details.add(tonnage + " ton");
         }
 


### PR DESCRIPTION
Fix #7678

If a campaign has multiple Meks who all use the same type of gyro, but require different weights of gyro mhq would get confused. Any time replacement gyros were ordered (whether that be through the repair bay, auto logistics, or resupply) it would order the first weight of gyro it found. This meant that unless you were trying to repair a unit with that gyro weight you'd be unable to fix damage.

This PR addresses that by implementing a special handler for gyros. We are unable to utilize the existing 'unit tonnage matters' boolean, as gyros aren't bound by the unit weight exclusively. Instead there are weight boundaries, with units of differing weights using the same gyro weight so long as their weight falls within that gyro's boundary.

I've tested this with a battery of units with identical gyros with differing weights for all gyro types (that I know of). I've also confirmed that existing player warehouse contents will not be harmed with this change.

I've marked this issue as 'critical' as affected players are unable to repair their units without using GM Restore.