### PR TITLE
Fix #7697: Fixed New Day Advance when Character is Illiterate But Has No Languages/Any Skill

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7838,6 +7838,10 @@ public class Person {
         }
 
         Skill languages = skills.getSkill(S_LANGUAGES);
+        if (languages == null) {
+            return true;
+        }
+
         int level = languages.getLevel();
         return level < ILLITERACY_LANGUAGES_THRESHOLD;
     }


### PR DESCRIPTION
Fix #7697

This PR fixes an Advance Day error caused when a character is both Illiterate but also has no Languages/Any skill.

Giving the character Languages/Any (even at level 0) will work around this issue.