### PR TITLE
Fix #7702: Fixed Personnel Being Incorrectly Marked as Camp Followers If Edited in Hire (GM) Dialog Prior to Hiring

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1367,7 +1367,7 @@ public class Person {
         }
 
         switch (status) {
-            case ACTIVE:
+            case ACTIVE -> {
                 if (getStatus().isMIA()) {
                     campaign.addReport(String.format(resources.getString("recoveredMIA.report"),
                           getHyperlinkedFullTitle()));
@@ -1397,60 +1397,56 @@ public class Person {
                     ServiceLogger.rehired(this, today);
                 }
                 setRetirement(null);
-                break;
-            case RETIRED:
+            }
+            case RETIRED -> {
                 campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
                 ServiceLogger.retired(this, today);
 
                 setRetirement(today);
-
-                break;
-            case RESIGNED:
+            }
+            case RESIGNED -> {
                 campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
                 ServiceLogger.resigned(this, today);
 
                 setRetirement(today);
-
-                break;
-            case DESERTED:
+            }
+            case DESERTED -> {
                 campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
                 ServiceLogger.deserted(this, today);
 
                 setRetirement(today);
-
-                break;
-            case DEFECTED:
+            }
+            case DEFECTED -> {
                 campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
                 ServiceLogger.defected(this, today);
 
                 setRetirement(today);
-
-                break;
-            case SACKED:
+            }
+            case CAMP_FOLLOWER, SACKED -> {
                 campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
                 ServiceLogger.sacked(this, today);
 
                 setRetirement(today);
-
-                break;
-            case LEFT:
+            }
+            case LEFT -> {
                 campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
                 ServiceLogger.left(this, today);
 
                 setRetirement(today);
-
-                break;
-            case STUDENT:
+            }
+            case STUDENT -> {
                 // log entries and reports are handled by the education package
                 // (mekhq/campaign/personnel/education)
-                break;
-            case PREGNANCY_COMPLICATIONS:
+            }
+            case PREGNANCY_COMPLICATIONS -> {
                 campaign.getProcreation().processPregnancyComplications(campaign, campaign.getLocalDate(), this);
-                // purposeful fall through
-            default:
                 campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
                 ServiceLogger.changedStatus(this, campaign.getLocalDate(), status);
-                break;
+            }
+            default -> {
+                campaign.addReport(String.format(status.getReportText(), getHyperlinkedFullTitle()));
+                ServiceLogger.changedStatus(this, campaign.getLocalDate(), status);
+            }
         }
 
         setStatus(status);

--- a/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizePersonDialog.java
@@ -1471,17 +1471,6 @@ public class CustomizePersonDialog extends JDialog implements DialogOptionListen
         if (campaign.getCampaignOptions().isUseAgeEffects()) {
             updateAllSkillAgeModifiers(campaign.getLocalDate(), person);
         }
-        if (person.isEmployed()) {
-            LocalDate joinedDate = person.getJoinedCampaign();
-
-            if (recruitment != null) {
-                if (joinedDate == null || recruitment.isBefore(joinedDate)) {
-                    person.setJoinedCampaign(recruitment);
-                }
-            } else {
-                person.setRecruitment(null);
-            }
-        }
         person.setLastRankChangeDate(lastRankChangeDate);
         person.setRetirement(retirement);
         person.setOriginFaction((Faction) choiceFaction.getSelectedItem());


### PR DESCRIPTION
Fix #7702

This fixes some minor logic errors and cleans up the switch used to handle status change.