### PR TITLE
Fix #7720: Ensured Low Reputation (or Pirate) Campaigns Can Access New Recruits

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -177,15 +177,11 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
             }
         }
 
-        if (mercenaryFaction != null &&
-                  !interestedFactions.isEmpty() &&
-                  !interestedFactions.contains(mercenaryFaction)) {
+        if (mercenaryFaction != null && !interestedFactions.contains(mercenaryFaction)) {
             interestedFactions.add(mercenaryFaction);
         }
 
-        if (pirateFaction != null &&
-                  !interestedFactions.isEmpty() &&
-                  !interestedFactions.contains(pirateFaction)) {
+        if (pirateFaction != null && !interestedFactions.contains(pirateFaction)) {
             interestedFactions.add(pirateFaction);
         }
 


### PR DESCRIPTION
Fix #7720

This was caused by a pair of checks that were incorrectly checking whether the market was empty. This technically triggers for any campaign that has reason to filter out normal personnel factions, but is most apparent with Pirates.