### PR TITLE
Fix #7723: Stopped POWs Appearing as Camp Followers

### DIFF
--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/CapturePrisoners.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/CapturePrisoners.java
@@ -536,7 +536,7 @@ public class CapturePrisoners {
 
         // 'Recruit' prisoner
         PrisonerStatus prisonerStatus = prisoner.getPrisonerStatus();
-        campaign.recruitPerson(prisoner, prisonerStatus, false, true, false);
+        campaign.recruitPerson(prisoner, prisonerStatus, false, true, true);
 
         if (prisonerStatus.isPrisonerDefector()) {
             campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE, "defection.report", prisoner.getHyperlinkedName()));


### PR DESCRIPTION
Fix #7723

Flipped a boolean that was causing POWs captured by the player to appear as Camp Followers