### PR TITLE
Improvement: Disabled & Deprecated AtB Ship Search

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -7621,10 +7621,6 @@ public class Campaign implements ITechManager {
                 }
                 MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "combatTeams");
             }
-            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "shipSearchStart", getShipSearchStart());
-            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "shipSearchType", shipSearchType);
-            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "shipSearchResult", shipSearchResult);
-            MHQXMLUtility.writeSimpleXMLTag(writer, indent, "shipSearchExpiration", getShipSearchExpiration());
             MHQXMLUtility.writeSimpleXMLTag(writer,
                   indent,
                   "autoResolveBehaviorSettings",

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1018,6 +1018,7 @@ public class Campaign implements ITechManager {
     /**
      * Sets the date a ship search was started, or null if no search is in progress.
      */
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public void setShipSearchStart(@Nullable LocalDate shipSearchStart) {
         this.shipSearchStart = shipSearchStart;
     }
@@ -1025,6 +1026,7 @@ public class Campaign implements ITechManager {
     /**
      * @return The date a ship search was started, or null if none is in progress.
      */
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public LocalDate getShipSearchStart() {
         return shipSearchStart;
     }
@@ -1032,6 +1034,7 @@ public class Campaign implements ITechManager {
     /**
      * Sets the lookup name of the available ship, or null if none were found.
      */
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public void setShipSearchResult(@Nullable String result) {
         shipSearchResult = result;
     }
@@ -1039,6 +1042,7 @@ public class Campaign implements ITechManager {
     /**
      * @return The lookup name of the available ship, or null if none is available
      */
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public String getShipSearchResult() {
         return shipSearchResult;
     }
@@ -1046,10 +1050,12 @@ public class Campaign implements ITechManager {
     /**
      * @return The date the ship is no longer available, if there is one.
      */
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public LocalDate getShipSearchExpiration() {
         return shipSearchExpiration;
     }
 
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public void setShipSearchExpiration(LocalDate shipSearchExpiration) {
         this.shipSearchExpiration = shipSearchExpiration;
     }
@@ -1057,15 +1063,18 @@ public class Campaign implements ITechManager {
     /**
      * Sets the unit type to search for.
      */
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public void setShipSearchType(int unitType) {
         shipSearchType = unitType;
     }
 
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public void startShipSearch(int unitType) {
         setShipSearchStart(getLocalDate());
         setShipSearchType(unitType);
     }
 
+    @Deprecated(since = "0.50.10", forRemoval = true)
     private void processShipSearch() {
         if (getShipSearchStart() == null) {
             return;
@@ -1126,6 +1135,7 @@ public class Campaign implements ITechManager {
         addReport(report.toString());
     }
 
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public void purchaseShipSearchResult() {
         MekSummary ms = MekSummaryCache.getInstance().getMek(getShipSearchResult());
         if (ms == null) {

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -32,7 +32,6 @@
  */
 package mekhq.campaign.io;
 
-import static megamek.common.units.UnitType.DROPSHIP;
 import static mekhq.campaign.force.CombatTeam.recalculateCombatTeams;
 import static mekhq.campaign.force.Force.FORCE_NONE;
 import static mekhq.campaign.market.personnelMarket.markets.NewPersonnelMarket.generatePersonnelMarketDataFromXML;
@@ -360,14 +359,6 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                     campaign.setPersonnelWhoAdvancedInXP(processPersonnelWhoAdvancedInXP(workingNode, campaign));
                 } else if (nodeName.equalsIgnoreCase("automatedMothballUnits")) {
                     campaign.setAutomatedMothballUnits(processAutomatedMothballNodes(workingNode));
-                } else if (nodeName.equalsIgnoreCase("shipSearchStart")) {
-                    campaign.setShipSearchStart(MHQXMLUtility.parseDate(workingNode.getTextContent().trim()));
-                } else if (nodeName.equalsIgnoreCase("shipSearchType")) {
-                    campaign.setShipSearchType(MathUtility.parseInt(workingNode.getTextContent(), DROPSHIP));
-                } else if (nodeName.equalsIgnoreCase("shipSearchResult")) {
-                    campaign.setShipSearchResult(workingNode.getTextContent());
-                } else if (nodeName.equalsIgnoreCase("shipSearchExpiration")) {
-                    campaign.setShipSearchExpiration(MHQXMLUtility.parseDate(workingNode.getTextContent().trim()));
                 } else if (nodeName.equalsIgnoreCase("autoResolveBehaviorSettings")) {
                     campaign.setAutoResolveBehaviorSettings(firstNonNull(BehaviorSettingsFactory.getInstance()
                                                                                .getBehavior(workingNode.getTextContent()),

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -747,13 +747,6 @@ public class CampaignGUI extends JPanel {
         miUnitMarket.setVisible(!getCampaign().getUnitMarket().getMethod().isNone());
         menuMarket.add(miUnitMarket);
 
-        miShipSearch = new JMenuItem(resourceMap.getString("miShipSearch.text"));
-        miShipSearch.setMnemonic(KeyEvent.VK_S);
-        miShipSearch.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK));
-        miShipSearch.addActionListener(evt -> new ShipSearchDialog(getFrame(), this).setVisible(true));
-        miShipSearch.setVisible(getCampaign().getCampaignOptions().isUseAtB());
-        menuMarket.add(miShipSearch);
-
         JMenuItem miPurchaseUnit = new JMenuItem(resourceMap.getString("miPurchaseUnit.text"));
         miPurchaseUnit.setMnemonic(KeyEvent.VK_N);
         miPurchaseUnit.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.ALT_DOWN_MASK));

--- a/MekHQ/src/mekhq/gui/dialog/ShipSearchDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ShipSearchDialog.java
@@ -64,6 +64,7 @@ import mekhq.gui.CampaignGUI;
  *
  * @author Neoancient
  */
+@Deprecated(since = "0.50.10", forRemoval = true)
 public class ShipSearchDialog extends JDialog {
     private static final MMLogger LOGGER = MMLogger.create(ShipSearchDialog.class);
 


### PR DESCRIPTION
Close #3369 (no longer relevant)

Ship Search has long been a source of user confusion and a system that frequently players voice a desire for replacing. With the arrival of #7734 the AtB Ship Search no longer has a place.

This PR disables Ship Search access, removes the parsing of ship search settings, and deprecates all ship search settings.