### PR TITLE
Improvement: Added Additional Toggle Buttons to the Abilities Tabs in Campaign Options

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -2224,8 +2224,8 @@ lblAntiMekChance.text=Anti-Mek Percent
 lblAntiMekChance.tooltip=The percentage chance a conventional infantry character has of being\
   \ created with the Anti-Mek skill.
 lblSecondarySkillChance.text=Secondary Skill Percent
-lblSecondarySkillChance.tooltip=The percentage chance a conventional infantry character has of being\
-  \ created with a random secondary skill.
+lblSecondarySkillChance.tooltip=The percentage chance a character has of being created with a random combat or support \
+  skill.
 lblSecondarySkillBonus.text=Modifier
 lblSecondarySkillBonus.tooltip=The skill level modifier applied to the skill (if present).
 ## Recruitment Bonuses Tab
@@ -2318,10 +2318,14 @@ lblCharacterCreationOnlyTab.text=Origin Options \u2318
 lblEdgeCostPanel.text=Edge Cost
 lblEdgeCost.text=Cost
 lblEdgeCost.tooltip=The cost per rank of Edge.
-lblAddAll.text=Enable All
-lblAddAll.tooltip=Enable all SPA.
-lblRemoveAll.text=Disable All
-lblRemoveAll.tooltip=Disable all SPA.
+lblAddAllCurrent.text=Enable All (Current Tab)
+lblAddAllCurrent.tooltip=Enable all SPAs across all SPA tabs.
+lblRemoveAllCurrent.text=Disable All (Current Tab)
+lblRemoveAllCurrent.tooltip=Disable all SPAs across all SPA tabs.
+lblAddAll.text=Enable All (Global)
+lblAddAll.tooltip=Enable all SPAs across all SPA tabs.
+lblRemoveAll.text=Disable All (Global)
+lblRemoveAll.tooltip=Disable all SPAs across all SPA tabs.
 abilityEnable.text=Enable Ability
 abilityCost.text=XP Cost: %s
 prerequisites.text=<b>Prerequisites</b><br>

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/AbilitiesTab.java
@@ -237,23 +237,17 @@ public class AbilitiesTab {
         };
 
         // Contents
-        RoundedJButton btnEnableAll = new CampaignOptionsButton("AddAll");
-        btnEnableAll.addActionListener(e -> {
-            for (CampaignOptionsAbilityInfo abilityInfo : allAbilityInfo.values()) {
-                abilityInfo.setEnabled(true);
-            }
+        RoundedJButton btnEnableCurrent = new CampaignOptionsButton("AddAllCurrent");
+        btnEnableCurrent.addActionListener(e -> toggleAbilitiesAction(abilityCategory, true));
 
-            refreshAll();
-        });
+        RoundedJButton btnRemoveCurrent = new CampaignOptionsButton("RemoveAllCurrent");
+        btnRemoveCurrent.addActionListener(e -> toggleAbilitiesAction(abilityCategory, false));
+
+        RoundedJButton btnEnableAll = new CampaignOptionsButton("AddAll");
+        btnEnableAll.addActionListener(e -> toggleAbilitiesAction(null, true));
 
         RoundedJButton btnRemoveAll = new CampaignOptionsButton("RemoveAll");
-        btnRemoveAll.addActionListener(e -> {
-            for (CampaignOptionsAbilityInfo abilityInfo : allAbilityInfo.values()) {
-                abilityInfo.setEnabled(false);
-            }
-
-            refreshAll();
-        });
+        btnRemoveAll.addActionListener(e -> toggleAbilitiesAction(null, false));
 
         // Layout the Panels
         final JPanel panel = new CampaignOptionsStandardPanel("AbilitiesGeneralTab", true);
@@ -265,6 +259,12 @@ public class AbilitiesTab {
         panel.add(headerPanel, layout);
 
         layout.gridwidth = 1;
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(btnEnableCurrent, layout);
+        layout.gridx++;
+        panel.add(btnRemoveCurrent, layout);
+
         layout.gridx = 0;
         layout.gridy++;
         panel.add(btnEnableAll, layout);
@@ -284,7 +284,7 @@ public class AbilitiesTab {
                 JPanel abilityPanel = createSPAPanel(abilityInfo);
 
                 layout.gridx = abilityCounter % 3;
-                layout.gridy = 2 + (abilityCounter / 3);
+                layout.gridy = 3 + (abilityCounter / 3);
                 abilityCounter++;
 
                 layout.gridwidth = 1;
@@ -317,6 +317,29 @@ public class AbilitiesTab {
                 yield characterCreationOnlyTab;
             }
         };
+    }
+
+    /**
+     * Enables or disables abilities in the specified category, or all abilities if the category is {@code null}.
+     *
+     * <p>Iterates through all abilities and applies the {@code enable} status as indicated, then refreshes all ability
+     * tabs to reflect the changes.</p>
+     *
+     * @param abilityCategory the {@link AbilityCategory} to filter abilities, or {@code null} to affect all categories
+     * @param enable          {@code true} to enable the abilities; {@code false} to disable them
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private void toggleAbilitiesAction(@Nullable AbilityCategory abilityCategory, boolean enable) {
+        boolean skipComparison = abilityCategory == null;
+        for (CampaignOptionsAbilityInfo abilityInfo : allAbilityInfo.values()) {
+            if (skipComparison || abilityInfo.getCategory() == abilityCategory) {
+                abilityInfo.setEnabled(enable);
+            }
+        }
+
+        refreshAll();
     }
 
     /**


### PR DESCRIPTION
Earlier in the week a player had an atrocious play experience. They didn't realize that the 'disable all' button in Campaign Options disabled all SPAs, not just those in the current tab. Once they clicked 'apply' this change became irrecoverable. All their custom SPA changes were lost. As they were unable to rollback - due to when they made this discovery - they lost hours of work.

This PR addresses the above issue by more clearly labeling the 'enable all' and 'disable all' buttons. It also adds another pair. This second pair only enables/disables the SPAs in the current tab.

This PR also fixes #7731.