### PR TITLE
Fix #7740: Fixed Sale of Items Increasing Warehouse Item Count

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PartsTableMouseAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -88,28 +88,21 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
             parts[i] = partsModel.getPartAt(partsTable.convertRowIndexToModel(rows[i]));
         }
         if (command.equalsIgnoreCase("SELL")) {
-            for (Part part : parts) {
-                if (null != part) {
-                    gui.getCampaign().getQuartermaster().sellPart(part, 1);
+            for (Part p : parts) {
+                if (null != p) {
+                    gui.getCampaign().getQuartermaster().sellPart(p, 1);
                 }
             }
         } else if (command.equalsIgnoreCase("SELL_ALL")) {
-            for (Part part : parts) {
-                if (null != part) {
-                    gui.getCampaign().getQuartermaster().sellPart(part);
+            for (Part p : parts) {
+                if (null != p) {
+                    gui.getCampaign().getQuartermaster().sellPart(p);
                 }
             }
         } else if (command.equalsIgnoreCase("SELL_N")) {
             if (null != selectedPart) {
-                int n = selectedPart.getQuantity();
-                if (selectedPart instanceof AmmoStorage) {
-                    n = ((AmmoStorage) selectedPart).getShots();
-                }
-                if (selectedPart instanceof Armor) {
-                    n = ((Armor) selectedPart).getAmount();
-                }
                 PopupValueChoiceDialog popupValueChoiceDialog = getPopupValueChoiceDialog(selectedPart,
-                      "Sell How Many " + selectedPart.getName() + "s?");
+                      "Sell How Many ");
                 if (popupValueChoiceDialog.getValue() < 0) {
                     return;
                 }
@@ -148,15 +141,7 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
             }
         } else if (command.equalsIgnoreCase("REMOVE_N")) {
             if (null != selectedPart) {
-                int n = selectedPart.getQuantity();
-                if (selectedPart instanceof AmmoStorage) {
-                    n = ((AmmoStorage) selectedPart).getShots();
-                }
-                if (selectedPart instanceof Armor) {
-                    n = ((Armor) selectedPart).getAmount();
-                }
-                PopupValueChoiceDialog dialog = getPopupValueChoiceDialog(selectedPart,
-                      "Remove How Many " + selectedPart.getName() + "s?");
+                PopupValueChoiceDialog dialog = getPopupValueChoiceDialog(selectedPart, "Remove How Many ");
                 if (dialog.getValue() < 0) {
                     return;
                 }
@@ -165,8 +150,13 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
             }
         } else if (command.equalsIgnoreCase("ADD_N")) {
             if (null != selectedPart) {
-                PopupValueChoiceDialog dialog = getPopupValueChoiceDialog(selectedPart,
-                      "Add How Many " + selectedPart.getName() + "s?");
+                PopupValueChoiceDialog dialog = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      "Add How Many " + selectedPart.getName() + "s?",
+                      0,
+                      0,
+                      9999999);
+                dialog.setVisible(true);
                 if (dialog.getValue() < 0) {
                     return;
                 }
@@ -240,8 +230,13 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
         } else if (command.equalsIgnoreCase("DEPOD_N")) {
             if (null != selectedPart) {
                 int n = selectedPart.getQuantity();
-                PopupValueChoiceDialog popupValueChoiceDialog = getPopupValueChoiceDialog(selectedPart,
-                      "Remove How Many Pods" + selectedPart.getName() + "s?");
+                PopupValueChoiceDialog popupValueChoiceDialog = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      "Remove How Many Pods" + selectedPart.getName() + "s?",
+                      1,
+                      1,
+                      n);
+                popupValueChoiceDialog.setVisible(true);
                 if (popupValueChoiceDialog.getValue() < 0) {
                     return;
                 }
@@ -256,8 +251,12 @@ public class PartsTableMouseAdapter extends JPopupMenuAdapter {
             }
         } else if (command.equalsIgnoreCase("BUY_N")) {
             if (null != selectedPart) {
-                PopupValueChoiceDialog popupValueChoiceDialog = getPopupValueChoiceDialog(selectedPart,
-                      "Buy How Much " + selectedPart.getName());
+                PopupValueChoiceDialog popupValueChoiceDialog = new PopupValueChoiceDialog(gui.getFrame(),
+                      true,
+                      "Buy How Much " + selectedPart.getName(),
+                      1,
+                      1);
+                popupValueChoiceDialog.setVisible(true);
                 if (popupValueChoiceDialog.getValue() < 1) {
                     return;
                 }


### PR DESCRIPTION
Fix #7740

This was a bug introduced by the data overhaul, where a deprecated method was replaced with a modern version. However a missing `-` caused items to be added to the warehouse and not removed.

This appears to be the only place where this mistake was made.