### PR TITLE
Fix #7743: Fixed Parts in Use Order Display Error

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3253,10 +3253,13 @@ public class Campaign implements ITechManager {
         for (IAcquisitionWork maybePart : shoppingList.getPartList()) {
             PartInUse newPartInUse = getPartInUse((Part) maybePart);
             if (partInUse.equals(newPartInUse)) {
-                Part newPart = (maybePart instanceof MissingPart) ?
-                                     (((MissingPart) maybePart).getNewPart())
+                Part newPart = (maybePart instanceof MissingPart)
+                                     ? ((MissingPart) maybePart).getNewPart()
                                      : (Part) maybePart;
-                partInUse.setPlannedCount(partInUse.getPlannedCount() + newPart.getTotalQuantity());
+                partInUse.setPlannedCount(
+                      partInUse.getPlannedCount() +
+                            getQuantity(newPart) * maybePart.getQuantity()
+                );
             }
         }
     }
@@ -3350,10 +3353,14 @@ public class Campaign implements ITechManager {
                 }
                 inUse.put(partInUse, partInUse);
             }
-            Part newPart = (maybePart instanceof MissingPart) ?
-                                 (((MissingPart) maybePart).getNewPart())
+
+            Part newPart = (maybePart instanceof MissingPart)
+                                 ? ((MissingPart) maybePart).getNewPart()
                                  : (Part) maybePart;
-            partInUse.setPlannedCount(partInUse.getPlannedCount() + newPart.getTotalQuantity());
+            partInUse.setPlannedCount(
+                  partInUse.getPlannedCount() +
+                        getQuantity(newPart) * maybePart.getQuantity()
+            );
         }
         return inUse.keySet()
                      .stream()


### PR DESCRIPTION
Fix #7743

This fixes a pair of logic errors that were causing the parts in use table to incorrectly so `1` instead of `n`, where `n` is the number of items on order.

This was a visual error only.