### PR TITLE
Fix: Fixed Atmosphere Loading for Custom Planetary Systems

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -591,12 +591,12 @@ public class AtBDynamicScenarioFactory {
                                                                                .getAtmosphere(currentDate);
 
                 switch (specific_atmosphere) {
-                    case TOXIC_POISON, TOXIC_CAUSTIC -> {
+                    case TOXIC_POISON, TOXICPOISON, TOXIC_CAUSTIC, TOXICCAUSTIC -> {
                         LOGGER.info("Atmosphere is {}, disallowing Tanks and Infantry", specific_atmosphere);
                         allowsConvInfantry = false;
                         allowsTanks = false;
                     }
-                    case TAINTED_POISON, TAINTED_CAUSTIC -> {
+                    case TAINTED_POISON, TAINTEDPOISON, TAINTED_CAUSTIC, TAINTEDCAUSTIC -> {
                         LOGGER.info("Atmosphere is {}, setting tainted flag", specific_atmosphere);
                         isTainted = true;
                     }

--- a/MekHQ/src/mekhq/campaign/universe/Atmosphere.java
+++ b/MekHQ/src/mekhq/campaign/universe/Atmosphere.java
@@ -40,7 +40,14 @@ public enum Atmosphere {
     TOXIC_POISON("Toxic (Poisonous)"),
     TOXIC_CAUSTIC("Toxic (Caustic)"),
     TOXIC_FLAME("Toxic (Flammable)"),
-    BREATHABLE("Breathable");
+    BREATHABLE("Breathable"),
+    // Pre <50.07 enums. Removing these will break player customized systems
+    TAINTEDPOISON("Tainted (Poisonous)"),
+    TAINTEDCAUSTIC("Tainted (Caustic)"),
+    TAINTEDFLAME("Tainted (Flammable)"),
+    TOXICPOISON("Toxic (Poisonous)"),
+    TOXICCAUSTIC("Toxic (Caustic)"),
+    TOXICFLAME("Toxic (Flammable)");
 
     public final String name;
 
@@ -56,27 +63,27 @@ public enum Atmosphere {
     }
 
     public boolean isTaintedPoison() {
-        return this == TAINTED_POISON;
+        return this == TAINTED_POISON || this == TAINTEDPOISON;
     }
 
     public boolean isTaintedCaustic() {
-        return this == TAINTED_CAUSTIC;
+        return this == TAINTED_CAUSTIC || this == TAINTEDCAUSTIC;
     }
 
     public boolean isTaintedFlame() {
-        return this == TAINTED_FLAME;
+        return this == TAINTED_FLAME || this == TAINTEDFLAME;
     }
 
     public boolean isToxicPoison() {
-        return this == TOXIC_POISON;
+        return this == TOXIC_POISON || this == TOXICPOISON;
     }
 
     public boolean isToxicCaustic() {
-        return this == TOXIC_CAUSTIC;
+        return this == TOXIC_CAUSTIC || this == TOXICCAUSTIC;
     }
 
     public boolean isToxicFlame() {
-        return this == TOXIC_FLAME;
+        return this == TOXIC_FLAME || this == TOXICFLAME;
     }
 
     public boolean isBreathable() {

--- a/MekHQ/src/mekhq/campaign/universe/Atmosphere.java
+++ b/MekHQ/src/mekhq/campaign/universe/Atmosphere.java
@@ -42,11 +42,17 @@ public enum Atmosphere {
     TOXIC_FLAME("Toxic (Flammable)"),
     BREATHABLE("Breathable"),
     // Pre <50.07 enums. Removing these will break player customized systems
+    @Deprecated(since = "50.07", forRemoval = false)
     TAINTEDPOISON("Tainted (Poisonous)"),
+    @Deprecated(since = "50.07", forRemoval = false)
     TAINTEDCAUSTIC("Tainted (Caustic)"),
+    @Deprecated(since = "50.07", forRemoval = false)
     TAINTEDFLAME("Tainted (Flammable)"),
+    @Deprecated(since = "50.07", forRemoval = false)
     TOXICPOISON("Toxic (Poisonous)"),
+    @Deprecated(since = "50.07", forRemoval = false)
     TOXICCAUSTIC("Toxic (Caustic)"),
+    @Deprecated(since = "50.07", forRemoval = false)
     TOXICFLAME("Toxic (Flammable)");
 
     public final String name;


### PR DESCRIPTION
This PR adds back enums that were renamed during the data overhaul. Due to the way planetary data is loaded in this renaming broke all player AUs, if the player were previously using the old format.

Unlike things like saves, where it's reasonably easy to walk through versions AUs can be _huge_ endeavors. Where possible we should try and support them into perpetuity. Barring _major_ data changes, such as those made by the move to YML.