### PR TITLE
`TaskTableModel` optimizations

### DIFF
--- a/MekHQ/src/mekhq/gui/ITechWorkPanel.java
+++ b/MekHQ/src/mekhq/gui/ITechWorkPanel.java
@@ -46,4 +46,8 @@ public interface ITechWorkPanel {
     IPartWork getSelectedTask();
 
     Person getSelectedTech();
+
+    Person getTempTech();
+
+    void setTempTech(Person tempTech);
 }

--- a/MekHQ/src/mekhq/gui/RepairTab.java
+++ b/MekHQ/src/mekhq/gui/RepairTab.java
@@ -138,6 +138,7 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
     private int selectedLocation = -1;
     private Unit selectedUnit = null;
     private Person selectedTech = getSelectedTech();
+    private Person tempTech = getTempTech();
     private boolean ignoreUnitTable = false; // Used to disable selection listener while data is updated.
 
     // region Constructors
@@ -597,6 +598,16 @@ public final class RepairTab extends CampaignGuiTab implements ITechWorkPanel {
         }
 
         return techsModel.getTechAt(techTable.convertRowIndexToModel(row));
+    }
+
+    @Override
+    public Person getTempTech() {
+        return tempTech;
+    }
+
+    @Override
+    public void setTempTech(Person tempTech) {
+        this.tempTech = tempTech;
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/WarehouseTab.java
+++ b/MekHQ/src/mekhq/gui/WarehouseTab.java
@@ -149,6 +149,7 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
     private int selectedRow = -1;
     private int partId = -1;
     private Person selectedTech;
+    private Person tempTech;
 
     // region Constructors
     public WarehouseTab(CampaignGUI gui, String name) {
@@ -690,6 +691,16 @@ public final class WarehouseTab extends CampaignGuiTab implements ITechWorkPanel
             return null;
         }
         return techsModel.getTechAt(techTable.convertRowIndexToModel(row));
+    }
+
+    @Override
+    public Person getTempTech() {
+        return tempTech;
+    }
+
+    @Override
+    public void setTempTech(Person tempTech) {
+        this.tempTech = tempTech;
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/model/TaskTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TaskTableModel.java
@@ -113,7 +113,10 @@ public class TaskTableModel extends DataTableModel<IPartWork> {
         public Component getTableCellRendererComponent(JTable table, Object value,
               boolean isSelected, boolean hasFocus,
               int row, int column) {
-            table.setRowHeight(UIUtil.scaleForGUI(100));
+            int newRowHeight = UIUtil.scaleForGUI(100);
+            if (table.getRowHeight(row) != newRowHeight) {
+                table.setRowHeight(newRowHeight);
+            }
             Component c = this;
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
@@ -167,6 +170,9 @@ public class TaskTableModel extends DataTableModel<IPartWork> {
                 if (availableLevel == REPAIR_STATE.AVAILABLE) {
                     Person tech = panel.getSelectedTech();
 
+                    if (tech == null) {
+                        tech = panel.getTempTech();
+                    }
                     if (null == tech) {
                         //Find a valid tech that we can copy their skill from
                         List<Person> techs = gui.getCampaign().getTechs();
@@ -180,6 +186,7 @@ public class TaskTableModel extends DataTableModel<IPartWork> {
 
                             if (techTemp.canTech(part.getUnit().getEntity())) {
                                 tech = techTemp;
+                                panel.setTempTech(techTemp);
                                 break;
                             }
                         }


### PR DESCRIPTION
Flame graph before changes: 
<img width="1813" height="188" alt="image" src="https://github.com/user-attachments/assets/9264aa89-e8ba-4083-8035-ad3498f402c3" />


Flame graph after changes:
<img width="1851" height="362" alt="image" src="https://github.com/user-attachments/assets/c6665261-e9bf-449f-bcea-1793ee16f9ca" />

When changes happen to the table, and the user hasn't selected a Tech, it will now store a "temp tech" for that panel so it doesn't need to repeatedly get the entire list of techs and filter it down for a temp tech. 

Also stops row height from repeatedly adjusting itself.