### PR TITLE
Fix: Fixed Hammer Traveling Back in Time to Release MegaMek Before MegaMek Was Invented, Thus Creating an Time Paradox That Breaches the Temporal Prime Directive

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -10,6 +10,11 @@ plugins {
     id 'checkstyle'
 }
 
+tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = true
+    reproducibleFileOrder = true
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)


### PR DESCRIPTION
This PR updates our gradle build so that file and folder metadata is preserved when the files are packaged inside an archive.

I have no idea why this broke, but this fixes it.