### PR TITLE
Issue #7754: If a part's location is -1, display that as the reason instead of throwing an exception

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/MissingAmmoBin.java
@@ -40,6 +40,7 @@ import megamek.common.annotations.Nullable;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.Mounted;
 import megamek.common.units.Aero;
+import megamek.common.units.Entity;
 import megamek.common.units.Jumpship;
 import megamek.common.units.SmallCraft;
 import mekhq.campaign.Campaign;
@@ -186,11 +187,16 @@ public class MissingAmmoBin extends MissingEquipmentPart {
     @Override
     public @Nullable String checkFixable() {
         final Mounted<?> m = getMounted();
-        if (m.getLocation() < 0) {
-            if ((m.getLinkedBy() != null) && !(m.getLinkedBy().isDestroyed())) {
-                return null;
+        if (m != null) {
+            final int location = m.getLocation();
+            if (location == Entity.LOC_NONE) {
+                if ((m.getLinkedBy() != null) && !(m.getLinkedBy().isDestroyed())) { //OS Ammo Bins, for example
+                    return null;
+                }
+                return "No location to install part.";
+            } else if (location == Entity.LOC_DESTROYED) {
+                return "Location is destroyed.";
             }
-            return "No location to install part.";
         }
         return super.checkFixable();
     }


### PR DESCRIPTION
Fixes #7754 

<img width="1286" height="446" alt="image" src="https://github.com/user-attachments/assets/74cbac42-8e68-490e-9925-b1e3ef6470e8" />

Ammo Bins (or at least one-shot ammo bins) have a location of -1. When checking if that's fixable, it was immediately trying to use that location, which threw the OOB error. This will report that there's no location instead of throwing errors.