### PR TITLE
Task: Removed FM:MR Unit Reputation Campaign Option

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1474,16 +1474,12 @@ lblAllowMonthlyConnections.tooltip=Each month the campaign commander will use th
   \ generate money for the campaign. If the new Personnel Market is enabled, Connections will also be used to increase\
   \ the number of recruits each month. A check can result in the character temporarily losing their levels in \
   Connections. See the Glossary for more information.
-reputationTab.title=Reputation
-lblReputationTab.text=Reputation Options
+reputationTab.title=CamOps Force Reputation
+lblReputationTab.text=CamOps Force Reputation Options
 reputationTab.border="Reputation opens doors\u2014or gets them slammed in your face. In this business, it's as\
   \ valuable as armor and twice as hard to repair."\
   <br><i>Colonel Mira "Silverbrand" Tanaka\
   <br>Dustblade Mercenaries</i>
-lblReputation.text=Reputation \u2714
-lblReputation.tooltip=Which reputation method should your campaign be graded against?\
-  <br>\
-  <br><b>Recommended:</b> Campaign Operations
 lblManualUnitRatingModifier.text=Manual Modifier
 lblManualUnitRatingModifier.tooltip=This allows you to manually adjust your reputation rating.
 lblResetCriminalRecord.text=Reset Criminal Record \u26A0

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -1310,13 +1310,15 @@ public class CampaignOptions {
     /**
      * @return the method of unit rating to use
      */
+    @Deprecated(since = "0.50.10", forRemoval = false)
     public UnitRatingMethod getUnitRatingMethod() {
-        return unitRatingMethod;
+        return UnitRatingMethod.CAMPAIGN_OPS;
     }
 
     /**
      * @param unitRatingMethod the method of unit rating to use
      */
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public void setUnitRatingMethod(final UnitRatingMethod unitRatingMethod) {
         this.unitRatingMethod = unitRatingMethod;
     }

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -102,7 +102,6 @@ public class CampaignOptionsMarshaller {
         // endregion Repair and Maintenance Tab
 
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useFactionForNames", campaignOptions.isUseOriginFactionForNames());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "unitRatingMethod", campaignOptions.getUnitRatingMethod().name());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useEraMods", campaignOptions.isUseEraMods());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "assignedTechFirst", campaignOptions.isAssignedTechFirst());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "resetToFirstTech", campaignOptions.isResetToFirstTech());

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -55,7 +55,6 @@ import mekhq.campaign.market.enums.UnitMarketMethod;
 import mekhq.campaign.market.personnelMarket.enums.PersonnelMarketStyle;
 import mekhq.campaign.personnel.enums.*;
 import mekhq.campaign.randomEvents.prisoners.enums.PrisonerCaptureStyle;
-import mekhq.campaign.rating.UnitRatingMethod;
 import mekhq.campaign.universe.PlanetarySystem.PlanetaryRating;
 import mekhq.campaign.universe.PlanetarySystem.PlanetarySophistication;
 import mekhq.gui.campaignOptions.enums.ProcurementPersonnelPick;
@@ -257,9 +256,6 @@ public class CampaignOptionsUnmarshaller {
             case "variableTechLevel" -> campaignOptions.setVariableTechLevel(parseBoolean(nodeContents));
             case "factionIntroDate" -> campaignOptions.setIsUseFactionIntroDate(parseBoolean(nodeContents));
             case "techLevel" -> campaignOptions.setTechLevel(parseInt(nodeContents));
-            case "unitRatingMethod", "dragoonsRatingMethod" ->
-                  campaignOptions.setUnitRatingMethod(UnitRatingMethod.parseFromString(
-                        nodeContents));
             case "manualUnitRatingModifier" -> campaignOptions.setManualUnitRatingModifier(parseInt(nodeContents));
             case "clampReputationPayMultiplier" -> campaignOptions.setClampReputationPayMultiplier(parseBoolean(
                   nodeContents));

--- a/MekHQ/src/mekhq/campaign/rating/UnitRatingMethod.java
+++ b/MekHQ/src/mekhq/campaign/rating/UnitRatingMethod.java
@@ -43,8 +43,10 @@ import mekhq.MekHQ;
  */
 public enum UnitRatingMethod {
     //region Enum Declarations
+    @Deprecated(since = "0.50.10", forRemoval = true)
     NONE("UnitRatingMethod.NONE.text"),
     CAMPAIGN_OPS("UnitRatingMethod.CAMPAIGN_OPS.text"),
+    @Deprecated(since = "0.50.10", forRemoval = true)
     FLD_MAN_MERCS_REV("UnitRatingMethod.FLD_MAN_MERCS_REV.text");
     //endregion Enum Declarations
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SystemsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SystemsTab.java
@@ -34,9 +34,7 @@ package mekhq.gui.campaignOptions.contents;
 
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createParentPanel;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.createTipPanelUpdater;
-import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getCampaignOptionsResourceBundle;
 import static mekhq.gui.campaignOptions.CampaignOptionsUtilities.getImageDirectory;
-import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.GridBagConstraints;
 import javax.swing.JCheckBox;
@@ -44,12 +42,10 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
 
-import megamek.client.ui.comboBoxes.MMComboBox;
 import megamek.common.annotations.Nullable;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.personnel.skills.RandomSkillPreferences;
-import mekhq.campaign.rating.UnitRatingMethod;
 import mekhq.gui.campaignOptions.components.CampaignOptionsCheckBox;
 import mekhq.gui.campaignOptions.components.CampaignOptionsGridBagConstraints;
 import mekhq.gui.campaignOptions.components.CampaignOptionsHeaderPanel;
@@ -76,7 +72,6 @@ public class SystemsTab {
     // Reputation Tab
     private CampaignOptionsHeaderPanel reputationHeader;
 
-    private MMComboBox<UnitRatingMethod> unitRatingMethodCombo;
     private JCheckBox chkResetCriminalRecord;
 
     private JSpinner manualUnitRatingModifier;
@@ -174,13 +169,6 @@ public class SystemsTab {
      */
     private JPanel createReputationGeneralPanel() {
         // Contents
-        JLabel lblReputation = new CampaignOptionsLabel("Reputation");
-        lblReputation.addMouseListener(createTipPanelUpdater(reputationHeader, "Reputation"));
-        unitRatingMethodCombo = new MMComboBox<>("unitRatingMethodCombo", UnitRatingMethod.values());
-        unitRatingMethodCombo.setToolTipText(String.format("<html>%s</html>",
-              getTextAt(getCampaignOptionsResourceBundle(), "lblReputation.tooltip")));
-        unitRatingMethodCombo.addMouseListener(createTipPanelUpdater(reputationHeader, "Reputation"));
-
         JLabel lblManualUnitRatingModifier = new CampaignOptionsLabel("ManualUnitRatingModifier");
         lblManualUnitRatingModifier.addMouseListener(createTipPanelUpdater(reputationHeader,
               "ManualUnitRatingModifier"));
@@ -197,12 +185,6 @@ public class SystemsTab {
         layout.gridy = 0;
         layout.gridx = 0;
         layout.gridwidth = 1;
-        panel.add(lblReputation, layout);
-        layout.gridx++;
-        panel.add(unitRatingMethodCombo, layout);
-
-        layout.gridx = 0;
-        layout.gridy++;
         panel.add(lblManualUnitRatingModifier, layout);
         layout.gridx++;
         panel.add(manualUnitRatingModifier, layout);
@@ -521,7 +503,6 @@ public class SystemsTab {
         }
 
         // Reputation
-        unitRatingMethodCombo.setSelectedItem(options.getUnitRatingMethod());
         manualUnitRatingModifier.setValue(options.getManualUnitRatingModifier());
 
         chkClampReputationPayMultiplier.setSelected(options.isClampReputationPayMultiplier());
@@ -577,7 +558,6 @@ public class SystemsTab {
         }
 
         // Reputation
-        options.setUnitRatingMethod(unitRatingMethodCombo.getSelectedItem());
         options.setManualUnitRatingModifier((int) manualUnitRatingModifier.getValue());
 
         if (chkResetCriminalRecord.isSelected()) {


### PR DESCRIPTION
Field Manual: Mercenaries (revised) support has been deprecated since the end of the 49.x cycle. This PR is the first step in its removal.

This PR simply removes it from being accessed by players, the underlying code remains unchanged. Code changes will be made in a follow-up PR, aimed at 50.11.