### PR TITLE
Sentry: Fixed Error When Faction Standing Simulates a Mission with a Missing Start Date

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -628,8 +628,12 @@ public final class BriefingTab extends CampaignGuiTab {
         LocalDate startDate = mission instanceof Contract
                                     ? ((Contract) mission).getStartDate()
                                     : null;
+        LocalDate today = getCampaign().getLocalDate();
+        if (startDate == null) {
+            startDate = today;
+        }
 
-        if (startDate != null && startDate.equals(getCampaign().getLocalDate())) {
+        if (startDate.equals(today)) {
             for (Scenario scenario : mission.getScenarios()) {
                 LocalDate scenarioDate = scenario.getDate();
                 if (scenarioDate.isBefore(startDate)) {


### PR DESCRIPTION
[Sentry Report](https://sentry.tapenvy.us/organizations/tapenvyus/issues/7579/events/2953523012ea4aeb9bb2e586ab3ad0bb/)

This fixes an oversight where we could pass a `null` startDate into Faction Standing's mission simulation code.