### PR TITLE
Fix #7779: Removed Unnecessary Recommendation & Warning from Scenario XP Campaign Option

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1926,14 +1926,8 @@ lblMistakeXP.tooltip=How much experience should be awarded whenever an unsuccess
   <br><b>Recommended:</b> Keep this disabled.
 # createScenariosPanel
 lblScenariosPanel.text=Scenarios \u270E
-lblScenarioXP.text=XP per Scenario \u26A0 \u2714
-lblScenarioXP.tooltip=How much experience should be awarded per scenario?\
-  <br>\
-  <br><b>Warning:</b> This option creates a situation where higher skilled characters get more\
-  \ experience than lower skilled characters, as they are more likely to be dispatched to a\
-  \ scenario. It also disproportionately punishes support characters, who don't go on scenarios.\
-  <br>\
-  <br><b>Recommended:</b> If this is enabled, it should only aware one or two experience.
+lblScenarioXP.text=XP per Scenario
+lblScenarioXP.tooltip=How much experience should be awarded per scenario?
 lblKillXP.text=XP per
 lblKillXP.tooltip=How much experience should be awarded per kill?
 lblKills.text=Kills


### PR DESCRIPTION
Fix #7779

This warning is no longer necessary now that scenario xp is not deprecated.