### PR TITLE
Fix #7783: Corrected Large Vessel Ammo Reloading

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
+++ b/MekHQ/src/mekhq/campaign/parts/equipment/LargeCraftAmmoBin.java
@@ -167,7 +167,7 @@ public class LargeCraftAmmoBin extends AmmoBin {
      * Gets the unused capacity of the bay, in tons.
      */
     public double getUnusedCapacity() {
-        return getCapacity() - Math.ceil(getCurrentShots() * ammoTonnage / getType().getShots());
+        return getCapacity() - (getCurrentShots() * ammoTonnage / getType().getShots());
     }
 
     @Override


### PR DESCRIPTION
Fix #7783

We were incorrectly ceiling the return value. This created problems if the ammo used wasn't in increments of whole tons. As the bin would think it was full - as it would round up to the ton.