### PR TITLE
Fix #6995: Fixed Parts Costs Being Reduced by Around 50%

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -223,7 +223,7 @@ public abstract class Part implements IPartWork, ITechnology {
         this.usedForRefitPlanning = false;
         this.daysToArrival = 0;
         this.campaign = c;
-        this.brandNew = false;
+        this.brandNew = true;
         this.quantity = 1;
         this.quality = PartQuality.QUALITY_D;
         this.childParts = new ArrayList<>();


### PR DESCRIPTION
Fix #6995

Parts were defaulting on creation to 'used', this PR flips them to 'brand new'. I checked and all instances where we would want the item to be substantiated as used we already have explicit calls doing so.