### PR TITLE
Improvement #7658: Added MekHQ Option to Hide Unit Fluff Images from Hangar (So That Only Unit Sprites Are Used)

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -651,6 +651,9 @@ displayTab.title=Display Options
 labelDisplayDateFormat.text=Display Date Format
 labelLongDisplayDateFormat.text=Long Display Date Format
 invalidDateFormat.error=Invalid Date Format
+optionHideUnitFluff.text=Only Use Unit Sprites in Hangar
+optionHideUnitFluff.toolTipText=Some units have images assigned, usually of their models. This option hides these \
+  images while in the hangar. Units will always display their sprite instead.
 optionHistoricalDailyLog.text=Temporarily Retain Daily Log History
 optionHistoricalDailyLog.toolTipText=Keeps a limited historical daily report in-memory during the gaming session. This may result in increased memory usage.
 chkCompanyGeneratorStartup.text=Quick Start Company Generator Startup outside AtB (Unimplemented)

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -69,6 +69,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String DISPLAY_NODE = "mekhq/prefs/display";
     public static final String DISPLAY_DATE_FORMAT = "displayDateFormat";
     public static final String LONG_DISPLAY_DATE_FORMAT = "longDisplayDateFormat";
+    public static final String HIDE_UNIT_FLUFF = "hideUnitFluff";
     public static final String HISTORICAL_DAILY_LOG = "historicalDailyLog";
     public static final int MAX_HISTORICAL_LOG_DAYS = 120; // max number of days that will be stored in the history,
     // also used as a limit in the UI

--- a/MekHQ/src/mekhq/MHQOptions.java
+++ b/MekHQ/src/mekhq/MHQOptions.java
@@ -78,6 +78,14 @@ public final class MHQOptions extends SuiteOptions {
         userPreferences.node(MHQConstants.DISPLAY_NODE).put(MHQConstants.LONG_DISPLAY_DATE_FORMAT, value);
     }
 
+    public boolean getHideUnitFluff() {
+        return userPreferences.node(MHQConstants.DISPLAY_NODE).getBoolean(MHQConstants.HIDE_UNIT_FLUFF, false);
+    }
+
+    public void setHideUnitFluff(boolean value) {
+        userPreferences.node(MHQConstants.DISPLAY_NODE).putBoolean(MHQConstants.HIDE_UNIT_FLUFF, value);
+    }
+
     public boolean getHistoricalDailyLog() {
         return userPreferences.node(MHQConstants.DISPLAY_NODE).getBoolean(MHQConstants.HISTORICAL_DAILY_LOG, false);
     }

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -87,6 +87,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     private JTextField optionDisplayDateFormat;
     private JTextField optionLongDisplayDateFormat;
     private final JSlider guiScale = new JSlider();
+    private JCheckBox optionHideUnitFluff;
     private JCheckBox optionHistoricalDailyLog;
     private JCheckBox chkCompanyGeneratorStartup;
     private JCheckBox chkShowCompanyGenerator;
@@ -305,6 +306,9 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                         .withLocale(MekHQ.getMHQOptions().getDateLocale())) :
                     resources.getString("invalidDateFormat.error")));
 
+        optionHideUnitFluff = new JCheckBox(resources.getString("optionHideUnitFluff.text"));
+        optionHideUnitFluff.setToolTipText(resources.getString("optionHideUnitFluff.toolTipText"));
+
         optionHistoricalDailyLog = new JCheckBox(resources.getString("optionHistoricalDailyLog.text"));
         optionHistoricalDailyLog.setToolTipText(resources.getString("optionHistoricalDailyLog.toolTipText"));
 
@@ -462,6 +466,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                                       .addComponent(labelLongDisplayDateFormatExample,
                                                             Alignment.TRAILING))
                                       .addComponent(scaleLine)
+                                      .addComponent(optionHideUnitFluff)
                                       .addComponent(optionHistoricalDailyLog)
                                       .addComponent(chkCompanyGeneratorStartup)
                                       .addComponent(chkShowCompanyGenerator)
@@ -504,6 +509,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                                         .addComponent(optionLongDisplayDateFormat)
                                                         .addComponent(labelLongDisplayDateFormatExample))
                                         .addComponent(scaleLine)
+                                        .addComponent(optionHideUnitFluff)
                                         .addComponent(optionHistoricalDailyLog)
                                         .addComponent(chkCompanyGeneratorStartup)
                                         .addComponent(chkShowCompanyGenerator)
@@ -1351,6 +1357,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         if (validateDateFormat(optionLongDisplayDateFormat.getText())) {
             MekHQ.getMHQOptions().setLongDisplayDateFormat(optionLongDisplayDateFormat.getText());
         }
+        MekHQ.getMHQOptions().setHideUnitFluff(optionHideUnitFluff.isSelected());
         MekHQ.getMHQOptions().setHistoricalDailyLog(optionHistoricalDailyLog.isSelected());
         MekHQ.getMHQOptions().setCompanyGeneratorStartup(chkCompanyGeneratorStartup.isSelected());
         MekHQ.getMHQOptions().setShowCompanyGenerator(chkShowCompanyGenerator.isSelected());
@@ -1508,6 +1515,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         guiScale.setValue((int) (GUIPreferences.getInstance().getGUIScale() * 10));
         optionDisplayDateFormat.setText(MekHQ.getMHQOptions().getDisplayDateFormat());
         optionLongDisplayDateFormat.setText(MekHQ.getMHQOptions().getLongDisplayDateFormat());
+        optionHideUnitFluff.setSelected(MekHQ.getMHQOptions().getHideUnitFluff());
         optionHistoricalDailyLog.setSelected(MekHQ.getMHQOptions().getHistoricalDailyLog());
         chkCompanyGeneratorStartup.setSelected(MekHQ.getMHQOptions().getCompanyGeneratorStartup());
         chkShowCompanyGenerator.setSelected(MekHQ.getMHQOptions().getShowCompanyGenerator());

--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -90,8 +90,9 @@ public class UnitViewPanel extends JScrollablePanel {
 
         setLayout(new GridBagLayout());
 
+        boolean isHideUnitFluff = MekHQ.getMHQOptions().getHideUnitFluff();
         int compWidth = 1;
-        Image image = FluffImageHelper.getFluffImage(entity);
+        Image image = isHideUnitFluff ? null : FluffImageHelper.getFluffImage(entity);
         JLabel lblImage;
         if (null != image) {
             // fluff image exists so use custom ImgLabel to get full mek porn


### PR DESCRIPTION
Close MegaMek/megamek#7521

As per title. However, it is worth noting that this only affects the MekHQ Hangar, as all other code lives in MegaMek and MegaMekLab and therefore beyond the reach of a MekHQ option. We may add options for use there, too, but that's a task for another day as it remains to be seen as to whether there is enough interest.