### PR TITLE
Improvement #7694: Escalated Conflict Between WoB & Other Factions During Jihad

### DIFF
--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -353,5 +353,14 @@ public final class MHQConstants extends SuiteConstants {
     // startregion Important Dates
     public static final LocalDate CLAN_INVASION_FIRST_WAVE_BEGINS = LocalDate.of(3050, 3, 7);
     public static final LocalDate BATTLE_OF_TUKAYYID = LocalDate.of(3052, 5, 21);
+    /**
+     * The invasion of Luthien kicks off the Jihad
+     */
+    public static final LocalDate JIHAD_START = LocalDate.of(3068, 1, 1);
+    /**
+     * The last WoB resistance on Terra is broken, and despite not being the formal end of the Jihad, heralds the end of
+     * the worst fighting.
+     */
+    public static final LocalDate NOMINAL_JIHAD_END = LocalDate.of(3079, 2, 1);
     // endregion Important Dates
 }

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -61,8 +61,8 @@ import mekhq.campaign.Campaign;
  *       <p>
  *       Uses Factions and Planets to weighted lists of potential employers and enemies for contract generation. Also
  *       finds a suitable planet for the action.
- *                                                                         TODO : Account for the de facto alliance of the invading Clans and the
- *                                                                         TODO : Fortress Republic in a way that doesn't involve hard-coding them here.
+ *                                                                               TODO : Account for the de facto alliance of the invading Clans and the
+ *                                                                               TODO : Fortress Republic in a way that doesn't involve hard-coding them here.
  */
 public class RandomFactionGenerator {
     private static final MMLogger LOGGER = MMLogger.create(RandomFactionGenerator.class);
@@ -491,6 +491,10 @@ public class RandomFactionGenerator {
         boolean isDuringClanInvasionHeight = isBeforeTukayyid && isAfterFirstWaveBegins;
         List<String> innerSphereClanWarCombatants = List.of("FC", "FRR", "DC");
 
+        boolean isAfterJihadBegins = date.isAfter(MHQConstants.JIHAD_START);
+        boolean isBeforeJihadEnds = date.isBefore(MHQConstants.NOMINAL_JIHAD_END);
+        boolean isDuringJihad = isAfterJihadBegins && isBeforeJihadEnds;
+
         if (factionHints.isNeutral(employer, enemy, getCurrentDate()) ||
                   factionHints.isNeutral(enemy, employer, getCurrentDate())) {
             return 0;
@@ -514,6 +518,9 @@ public class RandomFactionGenerator {
         if (innerSphereClanWarCombatants.contains(employer.getShortName()) &&
                   enemy.isClan() &&
                   isDuringClanInvasionHeight) {
+            count *= 2.0;
+        }
+        if (isDuringJihad && enemy.isWoB()) {
             count *= 2.0;
         }
         /*
@@ -589,12 +596,12 @@ public class RandomFactionGenerator {
     public List<PlanetarySystem> getMissionTargetList(Faction attacker, Faction defender) {
         boolean attackerIsPirate = attacker.isPirate();
         boolean attackerIsMerc = attacker.isMercenary();
-        boolean attackerIsComStar = attacker.isComStar();
+        boolean attackerIsComStar = attacker.isComStarOrWoB();
         boolean attackerHasNoPlanets = !borderTracker.getFactionsInRegion().contains(attacker);
 
         boolean defenderIsPirate = defender.isPirate();
         boolean defenderIsMerc = defender.isMercenary();
-        boolean defenderIsComStar = defender.isComStar();
+        boolean defenderIsComStar = defender.isComStarOrWoB();
         boolean defenderHasNoPlanets = !borderTracker.getFactionsInRegion().contains(defender);
 
         // Faction host logic


### PR DESCRIPTION
Close #7694

Similarly to how we handle the height of the Clan Invasion, this PR pumps up the frequency of contracts against the Word of Blake during the height of the Jihad. Furthermore, it also significantly increases the likelihood of seeing contracts from the Word (which also ignore borders, meaning the Word can strike anywhere).

This helps add flavor during this critical period of the setting's history.