### PR TITLE
Improvement #7449: Technology Cost Modifiers Applied to Unit Market

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/unitMarket/AbstractUnitMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/unitMarket/AbstractUnitMarket.java
@@ -228,7 +228,8 @@ public abstract class AbstractUnitMarket {
             }
         }
 
-        getOffers().add(new UnitMarketOffer(market, unitType, mekSummary, percent, generateTransitDuration(campaign)));
+        getOffers().add(new UnitMarketOffer(market, unitType, mekSummary, percent, generateTransitDuration(campaign),
+         campaign.getCampaignOptions()));
 
         return mekSummary.getName();
     }


### PR DESCRIPTION
Closes #7449

Multiplies the final unit price on unit market by the corresponding technology base's price coefficient from campaign settings, to be in line with non-market unit purchasing.