### PR TITLE
Issue MML#2059

### DIFF
--- a/MekHQ/src/mekhq/gui/MekLabTab.java
+++ b/MekHQ/src/mekhq/gui/MekLabTab.java
@@ -1308,7 +1308,7 @@ public class MekLabTab extends CampaignGuiTab {
 
         @Override
         public void refreshPreview() {
-            structureTab.refresh();
+            structureTab.refreshPreview();
         }
 
         @Override


### PR DESCRIPTION
Fixes MegaMek/megameklab#2059

Prevents a loop when calling refreshPreview on BA. Other units have a separate preview tab and forward the refresh call only to that tab. I was unable to reproduce any problem in MML itself, only MHQ.