### PR TITLE
Fix: Fixed Quick Train Failing on Unknown Skills

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/QuickTrain.java
@@ -193,7 +193,7 @@ public class QuickTrain {
                     continue;
                 }
 
-                person.spendXP(improvementCost);
+                person.spendXPOnSkills(campaign, improvementCost);
 
                 PerformanceLogger.improvedSkill(
                       isLogSkillGain, person, today, skillName, skill.getLevel());


### PR DESCRIPTION
This fixes a bug with the new Quick Train mechanic where the system will break when trying to train an unknown skill.