### PR TITLE
Improvement: Added More Robust Notifications for When Contracts Can Be Ended Early

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBContract.properties
+++ b/MekHQ/resources/mekhq/resources/AtBContract.properties
@@ -42,3 +42,7 @@ responseBringItOn.text=Bring It On
 responseBringItOn.tooltip=You will face the full strength of the Clans during this contract.
 refusalConfirmation.text=Are you sure? %s will not forget this betrayal.
 refusalReport.text=<center><b>YOU DARE TO REFUSE MY BATCHALL!?!</b></center>
+stratCon.earlyContractEnd.objectives=You have completely broken the OpFor in <b>%s</b>. Allied command will resolve \
+  any remaining objectives at their leisure. Though failed objectives will still count against you.\
+  <p>The contract will end tomorrow. If the contract was successful, any outstanding payments will be rendered once \
+  the contract has concluded.</b>

--- a/MekHQ/resources/mekhq/resources/Campaign.properties
+++ b/MekHQ/resources/mekhq/resources/Campaign.properties
@@ -164,3 +164,7 @@ unableToEnterSystem.outlawed.ic=%s, I regret to inform you that we're unable to 
   travel somewhere else?
 unableToEnterSystem.outlawed.ooc=Outlawing can occur as the result of supremely low Faction Standing, or accepting a \
   contract from an enemy of the system owners.
+# StratCon
+stratCon.earlyContractEnd.objectives=You have resolved all outstanding objectives for <b>%s</b>.\
+  <p>The contract will end tomorrow. If the contract was successful, any outstanding payments will be rendered once \
+  the contract has concluded.</b>

--- a/MekHQ/resources/mekhq/resources/Mission.properties
+++ b/MekHQ/resources/mekhq/resources/Mission.properties
@@ -116,8 +116,7 @@ ContractCommandRights.INTEGRATED.toolTipText=Integrated command rights, standard
   \ without inter-service rivalry or confusion over command authority.\
   <br>- Keep your Campaign Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
   <br>- Allies will join you in all scenarios.\
-  <br>- Most scenarios are considered Turning Points.\
-  <br>- You must complete the full contract duration, even if all objectives are completed.
+  <br>- Most scenarios are considered Turning Points.
 ContractCommandRights.INTEGRATED.stratConText=Complete <b>Turning Point</b> scenarios to fulfill contract conditions.
 ContractCommandRights.HOUSE.text=House
 ContractCommandRights.HOUSE.toolTipText=House command rights empower noble scions and military leaders with autonomy over\
@@ -125,8 +124,7 @@ ContractCommandRights.HOUSE.toolTipText=House command rights empower noble scion
   \ and House interests.\
   <br>- Keep your Campaign Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
   <br>- Allies will join you in scenarios around a third of the time.\
-  <br>- Roughly a third of scenarios are considered Turning Points.\
-  <br>- You must complete the full contract duration, even if all objectives are completed.
+  <br>- Roughly a third of scenarios are considered Turning Points.
 ContractCommandRights.HOUSE.stratConText=Complete Turning Point scenarios to fulfill contract conditions.
 ContractCommandRights.LIAISON.text=Liaison
 ContractCommandRights.LIAISON.toolTipText=Liaison command rights empower trusted officers to coordinate cooperation\
@@ -135,9 +133,7 @@ ContractCommandRights.LIAISON.toolTipText=Liaison command rights empower trusted
   <br>- Keep your Campaign Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
   <br>- Complete any additional objectives listed in the Area of Operations tab.\
   <br>- Allies will join you in scenarios around a third of the time.\
-  <br>- Roughly a third of scenarios are considered Turning Points.\
-  <br>- You may end the contract the moment all objectives are complete, so long as you are not on a Garrison Duty, Cadre\
-  \ Duty, Relief Duty, or Riot-Duty contract
+  <br>- Roughly a third of scenarios are considered Turning Points.
 ContractCommandRights.LIAISON.stratConText=Complete Turning Point scenarios and strategic objectives to fulfill contract\
   \ conditions.
 ContractCommandRights.INDEPENDENT.text=Independent
@@ -147,9 +143,7 @@ ContractCommandRights.INDEPENDENT.toolTipText=Independent command rights afford 
   <br>- Keep your Campaign Victory Points (CVP) positive by completing Turning Point and Crisis scenarios.\
   <br>- Complete any additional objectives listed in the Area of Operations tab.\
   <br>- Allies will only rarely join you on scenarios.\
-  <br>- Roughly a third of scenarios are considered Turning Points.\
-  <br>- You may end the contract the moment all objectives are complete, so long as you are not on a Garrison Duty, Cadre\
-  \ Duty, Relief Duty, or Riot-Duty contract
+  <br>- Roughly a third of scenarios are considered Turning Points.
 ContractCommandRights.INDEPENDENT.stratConText=Complete strategic objectives to fulfill contract conditions.
 # MissionStatus Enum
 MissionStatus.ACTIVE.text=Active

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -300,6 +300,7 @@ import mekhq.campaign.universe.selectors.planetSelectors.RangedPlanetSelector;
 import mekhq.campaign.utilities.AutomatedPersonnelCleanUp;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.campaign.work.IPartWork;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNotification;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
 import mekhq.gui.campaignOptions.enums.ProcurementPersonnelPick;
@@ -5353,7 +5354,9 @@ public class Campaign implements ITechManager {
 
         processNewDayATBScenarios();
 
+        // Daily events
         for (AtBContract contract : getActiveAtBContracts()) {
+            // Batchalls
             if (campaignOptions.isUseGenericBattleValue() &&
                       !contract.getContractType().isGarrisonType() &&
                       contract.getStartDate().equals(currentDay)) {
@@ -5382,6 +5385,23 @@ public class Campaign implements ITechManager {
                             addReport(report);
                         }
                     }
+                }
+            }
+
+            // Early Contract End (StratCon Only)
+            StratConCampaignState campaignState = contract.getStratconCampaignState();
+            if (campaignState != null && !contract.getEndingDate().equals(currentDay)) {
+                if (campaignState.canEndContractEarly()) {
+                    new ImmersiveDialogNotification(this,
+                          String.format(resources.getString("stratCon.earlyContractEnd.objectives"),
+                                contract.getHyperlinkedName()), true);
+
+                    // This ensures any outstanding payout is paid out before the contract ends
+                    LocalDate adjustedDate = currentDay.plusDays(1);
+                    int remainingMonths = contract.getMonthsLeft(adjustedDate);
+                    Money finalPayout = contract.getMonthlyPayOut().multipliedBy(remainingMonths);
+                    contract.setRoutedPayout(finalPayout);
+                    contract.setEndDate(adjustedDate);
                 }
             }
         }

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -149,6 +149,7 @@ import mekhq.campaign.universe.factionStanding.BatchallFactions;
 import mekhq.campaign.universe.factionStanding.FactionStandingUtilities;
 import mekhq.campaign.universe.factionStanding.FactionStandings;
 import mekhq.campaign.universe.factionStanding.PerformBatchall;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNotification;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -527,8 +528,8 @@ public class AtBContract extends Contract {
 
                 campaign.setTemporaryPrisonerCapacity(DEFAULT_TEMPORARY_CAPACITY);
             } else {
-                campaign.addReport("With the enemy routed, any remaining objectives have been" +
-                                         " successfully completed. The contract will conclude tomorrow.");
+                new ImmersiveDialogNotification(campaign,
+                      String.format(resources.getString("stratCon.earlyContractEnd.objectives"), getName()), true);
                 int remainingMonths = getMonthsLeft(campaign.getLocalDate().plusDays(1));
                 routedPayout = getMonthlyPayOut().multipliedBy(remainingMonths);
                 setEndDate(today.plusDays(1));
@@ -1290,6 +1291,11 @@ public class AtBContract extends Contract {
                     stratconCampaignState = StratConCampaignState.Deserialize(item);
                     stratconCampaignState.setContract(this);
                     this.setStratConCampaignState(stratconCampaignState);
+
+                    // <50.10 compatibility handler
+                    if (!(getContractType().isGarrisonType() || getContractType().isReliefDuty())) {
+                        stratconCampaignState.setAllowEarlyVictory(true);
+                    }
                 } else if (item.getNodeName().equalsIgnoreCase("parentContractId")) {
                     parentContract = new AtBContractRef(Integer.parseInt(item.getTextContent()));
                 } else if (item.getNodeName().equalsIgnoreCase("employerLiaison")) {
@@ -2506,6 +2512,10 @@ public class AtBContract extends Contract {
      */
     public void setTransportRoll(int roll) {
         transportRoll = roll;
+    }
+
+    public @Nullable Money setRoutedPayout(Money routedPayout) {
+        return routedPayout;
     }
 
     public @Nullable Money getRoutedPayout() {

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -2514,8 +2514,8 @@ public class AtBContract extends Contract {
         transportRoll = roll;
     }
 
-    public @Nullable Money setRoutedPayout(Money routedPayout) {
-        return routedPayout;
+    public void setRoutedPayout(@Nullable Money routedPayout) {
+        this.routedPayout = routedPayout;
     }
 
     public @Nullable Money getRoutedPayout() {

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConCampaignState.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConCampaignState.java
@@ -312,7 +312,6 @@ public class StratConCampaignState {
         for (StratConTrackState track : tracks) {
             List<StratConStrategicObjective> objectives = track.getStrategicObjectives();
             for (StratConStrategicObjective objective : objectives) {
-                LOGGER.warn("Checking objective: {}", objective.toString());
 
                 hasObjectives = true;
                 if (!objective.isObjectiveResolved(track)) {

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConCampaignState.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConCampaignState.java
@@ -74,6 +74,7 @@ public class StratConCampaignState {
     private int supportPoints;
     private int victoryPoints;
     private String briefingText;
+    @XmlElement(required = true, defaultValue = "false")
     private boolean allowEarlyVictory;
 
     // these are applied to any scenario generated in the campaign; use sparingly
@@ -285,6 +286,42 @@ public class StratConCampaignState {
         }
 
         return null;
+    }
+
+    /**
+     * Determines whether the contract can be ended early based on strategic objective completion.
+     *
+     * <p>A contract can be ended early only if:</p>
+     * <ul>
+     *   <li>The base contract allows early termination</li>
+     *   <li>There is at least one strategic objective defined</li>
+     *   <li>All strategic objectives across all tracks have been resolved (completed or failed)</li>
+     * </ul>
+     *
+     * @return {@code true} if the contract can be ended early, {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    public boolean canEndContractEarly() {
+        if (!allowEarlyVictory()) {
+            return false;
+        }
+
+        boolean hasObjectives = false;
+        for (StratConTrackState track : tracks) {
+            List<StratConStrategicObjective> objectives = track.getStrategicObjectives();
+            for (StratConStrategicObjective objective : objectives) {
+                LOGGER.warn("Checking objective: {}", objective.toString());
+
+                hasObjectives = true;
+                if (!objective.isObjectiveResolved(track)) {
+                    return false;
+                }
+            }
+        }
+
+        return hasObjectives;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConStrategicObjective.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConStrategicObjective.java
@@ -126,4 +126,21 @@ public class StratConStrategicObjective {
                   false;
         };
     }
+
+    /**
+     * Determines whether a StratCon objective has been resolved (either completed or failed).
+     *
+     * <p>An objective is considered resolved if it has reached a terminal state, meaning it is no longer active and
+     * requires no further player action.</p>
+     *
+     * @param trackState the current state of the StratCon track containing the objective
+     *
+     * @return {@code true} if the objective is completed or failed, {@code false} if it is still active
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    public boolean isObjectiveResolved(StratConTrackState trackState) {
+        return isObjectiveCompleted(trackState) || isObjectiveFailed(trackState);
+    }
 }


### PR DESCRIPTION
# Requires [Fix: Corrected Contract Definitions' Early End State ](https://github.com/MegaMek/mm-data/pull/122)

We were getting a lot of user contact and confusion related to this. Especially given the 'rules' have changed a few times over the years. This PR causes a notification to appear whenever a campaign has met the requirements for an early contract end.

Contracts end under the following circumstances:
- The enemy is routed
- All objectives have been resolved (completed or failed).
- Contracts ending in 'duty', _except_ Relief Duty never end early.
- Relief Duty contracts will end early _only_ if the enemy is routed.

Early end conditions based on command rights have been removed as these were only causing confusion.