### PR TITLE
Fix #7842: Corrected Advanced Scouting Not Correctly Excluding Already Revealed Hexes

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1488,7 +1488,9 @@ public class StratConRulesManager {
                         StratConCoords checkCoords = currentCoords.translate(direction);
 
                         // Skip already visited coordinates (refer to per-scout AND global)
-                        if (scoutVisited.contains(checkCoords) || visited.contains(checkCoords)) {
+                        if (scoutVisited.contains(checkCoords) ||
+                                  visited.contains(checkCoords) ||
+                                  track.getRevealedCoords().contains(checkCoords)) {
                             continue;
                         }
 


### PR DESCRIPTION
Close [#7842](https://github.com/MegaMek/mekhq/issues/7842)

When using advanced scouting, ensures successful scout attempts ignore already-revealed hexes. Previously the check only looked within this batch of scouting.

Partially addresses https://github.com/MegaMek/mekhq/issues/7767