### PR TITLE
Fix #7853: Fixed Diplomacy Report Triggering Daily

### DIFF
--- a/MekHQ/resources/mekhq/resources/WarAndPeaceProcessor.properties
+++ b/MekHQ/resources/mekhq/resources/WarAndPeaceProcessor.properties
@@ -33,26 +33,26 @@ WarAndPeaceProcessor.warStartFactions=<h1 style="text-align:center">WAR HAS BEEN
   Diplomacy has failed. Now guns will speak.\
   <p>Your faction is in a state of open war with:</p>
 WarAndPeaceProcessor.warEndFactions=<h1 style="text-align:center">CEASEFIRE DECLARED</h1>\
-  This isn''t peace. It''s a pause.\
+  This isn't peace. It's a pause.\
   <p>Your faction is no longer at war with:</p>
 WarAndPeaceProcessor.rivalryStartFactions=<h1 style="text-align:center">RIVALRY INITIATED</h1>\
   This is how wars begin.\
   <p>A formal rivalry has been declared between your faction and:</p>
 WarAndPeaceProcessor.rivalryEndFactions=<h1 style="text-align:center">RIVALRY RESOLVED</h1>\
   Stay vigilant. Old fires reignite fast.\
-  <p>Your faction''s rivalry with the following has been officially de-escalated:</p>
+  <p>Your faction's rivalry with the following has been officially de-escalated:</p>
 WarAndPeaceProcessor.neutralStartFactions=<h1 style="text-align:center">NEUTRALITY PACT FORGED</h1>\
   Peace is always temporary.\
   <p>Your faction has entered into a neutrality pact with::</p>
 WarAndPeaceProcessor.neutralEndFactions=<h1 style="text-align:center">NEUTRALITY PACT DISSOLVED</h1>\
   The agreement is void.\
-  <p>Your faction''s neutrality pact with the following has been dissolved:</p>
+  <p>Your faction's neutrality pact with the following has been dissolved:</p>
 WarAndPeaceProcessor.allianceStartFactions=<h1 style="text-align:center">ALLIANCE FORGED</h1>\
   New allies. New agendas.\
   <p>Your faction has entered into a formal alliance with:</p>
 WarAndPeaceProcessor.allianceEndFactions=<h1 style="text-align:center">RIVALRY RESOLVED</h1>\
-  The pact is broken. We''re on our own.\
-  <p>Your faction''s alliance with the following has been officially terminated:</p>
+  The pact is broken. We're on our own.\
+  <p>Your faction's alliance with the following has been officially terminated:</p>
 WarAndPeaceProcessor.ooc=Wars, alliances, and rivalries are used by MekHQ to influence contract generation. If you \
   have Faction Standings enabled, these events will also affect how the relevant factions view your campaign.
 WarAndPeaceProcessor.button=Understood

--- a/MekHQ/src/mekhq/campaign/universe/factionHints/FactionHint.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionHints/FactionHint.java
@@ -50,16 +50,46 @@ public class FactionHint {
         this.end = end;
     }
 
+    /**
+     * Checks if a given date falls within this object's date range.
+     *
+     * <p>The date is considered in range if:</p>
+     *
+     * <ul>
+     *   <li>It is on or after the start date (or start is null)</li>
+     *   <li>AND it is on or before the end date (or end is null)</li>
+     * </ul>
+     *
+     * <p>A {@code null} start or end date means that bound is unbounded (open-ended).</p>
+     *
+     * @param date the date to check
+     *
+     * @return {@code true} if the date is within the range (inclusive)
+     */
     public boolean isInDateRange(final LocalDate date) {
         return ((start == null) || !date.isBefore(start)) && ((end == null) || !date.isAfter(end));
     }
 
+    /**
+     * Checks if this object's start date is today.
+     *
+     * @param today the current date to check against
+     *
+     * @return {@code true} if the start date is defined and equals today
+     */
     public boolean hintStartsToday(final LocalDate today) {
-        return (start == null) || start.isEqual(today);
+        return (start != null) && start.isEqual(today);
     }
 
+    /**
+     * Checks if this object's end date is today.
+     *
+     * @param today the current date to check against
+     *
+     * @return {@code true} if the end date is defined and equals today
+     */
     public boolean hintEndsToday(final LocalDate today) {
-        return (end == null) || end.isEqual(today);
+        return (end != null) && end.isEqual(today);
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/universe/factionHints/WarAndPeaceProcessor.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionHints/WarAndPeaceProcessor.java
@@ -223,7 +223,7 @@ public class WarAndPeaceProcessor {
         for (Faction faction : activeFactions) {
             List<FactionHint> hints = factionHints.getOrDefault(faction, List.of());
             for (FactionHint hint : hints) {
-                if (hint.hintStartsToday(today)) {
+                if (!activeOnly && hint.hintStartsToday(today)) {
                     startFactions.add(faction);
                 } else if (activeOnly && hint.isInDateRange(today)) {
                     startFactions.add(faction);


### PR DESCRIPTION
Fix #7853

This was caused by invalid start/end criteria for open ended faction hints. I updated the methods and added javadocs so this won't happen again. The diplomacy reports were the only places those methods were used.

I also fixed a minor text error.