### PR TITLE
Fix: Corrected Vehicle Crew Compatibility Handler

### DIFF
--- a/MekHQ/resources/mekhq/resources/Personnel.properties
+++ b/MekHQ/resources/mekhq/resources/Personnel.properties
@@ -523,10 +523,11 @@ ineligibleForSecondaryRole=%s<b>WARNING:</b>%s %s was found to be ineligible for
 vehicleProfessionSkillChange=%s<b>WARNING:</b>%s starting in version 50.10, vehicle drivers are now required to have \
   the vehicle gunnery skill. %s did not already have this skill, so they were given it for free. The skill level of \
   their free gunnery skill matches whatever skill they had in driving.
-vehicleCrewProfessionSkillChange=%s<b>WARNING:</b>%s starting in version 50.10, vehicle crews have returned to just \
-  using the Tech/Mechanic skill. See the 'Vehicle & Vessel Crews' Glossary entry for more information.  %s did not \
-  already have Tech/Mechanic, so they were given it for free. The skill level of their free skill matches whatever \
-  their highest relevant skill level was before the change.
+vehicleCrewProfessionSkillChange=%s<b>WARNING:</b>%s starting in version 50.10, vehicle crews were rebranded as \
+  Combat Technicians. Combat Technicians use the Tech/Mechanic skill, however %s did not have that skill. They have \
+  been given the skill for free at level 3 (Regular). As a bonus, Combat Technicians function identically to \
+  Mechanics, so can be assigned to tasks and benefit from Administration (if the appropriate Campaign Option is \
+  enabled).
 # Gambling
 gambling.success=%s gambled their Wealth. Wealth has %s<b>Improved</b>%s by 1. They now have %s Wealth.
 gambling.neutral=%s gambled their Wealth. They %s<b>Broke Even</b>%s. They still have %s Wealth.

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -133,7 +133,6 @@ import mekhq.campaign.personnel.skills.Attributes;
 import mekhq.campaign.personnel.skills.Skill;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.personnel.skills.Skills;
-import mekhq.campaign.personnel.skills.VehicleCrewSkills;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 import mekhq.campaign.personnel.skills.enums.SkillSubType;
 import mekhq.campaign.randomEvents.personalities.PersonalityController;
@@ -4171,14 +4170,14 @@ public class Person {
      * Updates skills for personnel with the Vehicle Crew profession by ensuring they have the Mechanic skill.
      *
      * <p>This method is used during XML loading to migrate legacy data. If the person lacks the
-     * {@link SkillType#S_TECH_MECHANIC} skill, it will be added at a level equal to their highest existing vehicle
-     * crew-related skill (e.g., Tech Vee, Gunnery Vee, Piloting Vee, or Driving). This ensures backwards compatibility
-     * when loading older save files.</p>
+     * {@link SkillType#S_TECH_MECHANIC} skill, it will be added at level 4 with 0 experience. This ensures backwards
+     * compatibility when loading older save files.</p>
      *
      * @param person      the person whose skills should be updated
      * @param currentRole the role to check
      *
-     * @return {@code true} if the Mechanic skill was added, {@code false} otherwise
+     * @return {@code true} if the Mechanic skill was added, {@code false} if the person already had the skill or is not
+     *       in the Vehicle Crew role
      *
      * @author Illiani
      * @since 0.50.10
@@ -4189,22 +4188,8 @@ public class Person {
         }
 
         if (!person.hasSkill(S_TECH_MECHANIC)) {
-            int highestSkillLevel = EXP_NONE;
-            String highestSkill = null;
-            for (String skillName : VehicleCrewSkills.VEHICLE_CREW_SKILLS) {
-                if (person.hasSkill(skillName)) {
-                    int level = person.getSkill(skillName).getLevel();
-                    if (level > highestSkillLevel) {
-                        highestSkillLevel = level;
-                        highestSkill = skillName;
-                    }
-                }
-            }
-
-            if (highestSkill != null) {
-                person.addSkill(highestSkill, highestSkillLevel, 0);
-                return true;
-            }
+            person.addSkill(S_TECH_MECHANIC, 3, 0);
+            return true;
         }
 
         return false;


### PR DESCRIPTION
It wasn't correctly catching skills to use as the basis for the free Mechanic 'gift'. This PR corrects it to be simpler to ensure players do get their free skill, where eligible.