### PR TITLE
Fix #7856: Fixed New Day Error; Renamed Methods to Reduce Room for Confusion

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -804,7 +804,7 @@ public class Campaign implements ITechManager {
      *
      * @return the sanitized {@link Hashtable} of {@link CombatTeam} objects stored in the current campaign.
      */
-    public Hashtable<Integer, CombatTeam> getCombatTeamsTable() {
+    public Hashtable<Integer, CombatTeam> getCombatTeamsAsMap() {
         // Here we sanitize the list, ensuring ineligible formations have been removed
         // before
         // returning the hashtable. In theory, this shouldn't be necessary, however,
@@ -842,11 +842,10 @@ public class Campaign implements ITechManager {
      *
      * @return an {@link ArrayList} of all the {@link CombatTeam} objects in the {@code combatTeams} {@link Hashtable}
      */
-    public ArrayList<CombatTeam> getAllCombatTeams() {
-        // This call allows us to utilize the self-sanitizing feature of
-        // getCombatTeamsTable(),
-        // without needing to directly include the code here, too.
-        combatTeams = getCombatTeamsTable();
+    public ArrayList<CombatTeam> getCombatTeamsAsList() {
+        // This call allows us to utilize the self-sanitizing feature of getCombatTeamsTable(), without needing to
+        // directly include the code here, too.
+        combatTeams = getCombatTeamsAsMap();
 
         return combatTeams.values()
                      .stream()

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1708,7 +1708,7 @@ public class CampaignNewDayManager {
             for (final AtBScenario atBScenario : contract.getCurrentAtBScenarios()) {
                 if ((atBScenario.getDate() != null) && atBScenario.getDate().equals(today)) {
                     int forceId = atBScenario.getCombatTeamId();
-                    if ((campaign.getAllCombatTeams().get(forceId) != null) &&
+                    if ((campaign.getCombatTeamsAsMap().get(forceId) != null) &&
                               !campaign.getForceIds().get(forceId).isDeployed()) {
                         // If any unit in the force is under repair, don't deploy the force
                         // Merely removing the unit from deployment would break with user expectation

--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -795,7 +795,7 @@ public class CombatTeam {
      * @param campaign the current campaign.
      */
     public static void recalculateCombatTeams(Campaign campaign) {
-        Hashtable<Integer, CombatTeam> combatTeamsTable = campaign.getCombatTeamsTable();
+        Hashtable<Integer, CombatTeam> combatTeamsTable = campaign.getCombatTeamsAsMap();
         CombatTeam combatTeam = combatTeamsTable.get(0); // This is the origin node
         Force force = campaign.getForce(0);
 
@@ -822,7 +822,7 @@ public class CombatTeam {
 
         // Update the TO&E and then begin recursively walking it
         MekHQ.triggerEvent(new OrganizationChangedEvent(force));
-        recalculateSubForceStrategicStatus(campaign, campaign.getCombatTeamsTable(), force);
+        recalculateSubForceStrategicStatus(campaign, campaign.getCombatTeamsAsMap(), force);
     }
 
     /**
@@ -865,7 +865,7 @@ public class CombatTeam {
 
             // Update the TO&E and then continue recursively walking it
             MekHQ.triggerEvent(new OrganizationChangedEvent(force));
-            recalculateSubForceStrategicStatus(campaign, campaign.getCombatTeamsTable(), force);
+            recalculateSubForceStrategicStatus(campaign, campaign.getCombatTeamsAsMap(), force);
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -42,7 +42,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import megamek.Version;
-import megamek.codeUtilities.MathUtility;
 import megamek.common.annotations.Nullable;
 import megamek.common.icons.Camouflage;
 import megamek.common.units.Entity;
@@ -694,7 +693,7 @@ public class Force {
 
     private void updateCombatTeamCommanderIfCombatTeam(Campaign campaign) {
         if (isCombatTeam()) {
-            CombatTeam combatTeam = campaign.getCombatTeamsTable().getOrDefault(getId(), null);
+            CombatTeam combatTeam = campaign.getCombatTeamsAsMap().getOrDefault(getId(), null);
             if (combatTeam != null) {
                 combatTeam.setCommander(getForceCommanderID());
             }
@@ -1040,9 +1039,10 @@ public class Force {
      * Finds the distance (depth) from the origin force
      *
      * @param force the force to get depth for
+     *
      * @deprecated
      */
-    @Deprecated (since = "0.50.10", forRemoval = true)
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public static int getDepth(Force force) {
         int depth = 0;
 
@@ -1062,9 +1062,10 @@ public class Force {
      *
      * @param force the current force. Should always equal campaign.getForce(0), if called remotely
      * @param depth the current recursive depth.
+     *
      * @deprecated
      */
-    @Deprecated (since = "0.50.10", forRemoval = true)
+    @Deprecated(since = "0.50.10", forRemoval = true)
     public static int getMaximumDepth(Force force, Integer depth) {
         int maximumDepth = depth;
 
@@ -1082,6 +1083,7 @@ public class Force {
     /**
      * Populates the formation levels of a force hierarchy starting from the origin force. For all subforces, it will
      * determine the smallest formations - Teams/Lances - and then parent formations will be one formation higher.
+     *
      * @param campaign campaign that the force belongs to
      */
     public static void populateFormationLevelsFromOrigin(Campaign campaign) {
@@ -1101,6 +1103,7 @@ public class Force {
 
     /**
      * Based on a force's subforces and units, set this unit's formation to the default.
+     *
      * @param campaign campaign that the force belongs to
      */
     public void defaultFormationLevelForForce(Campaign campaign) {
@@ -1108,7 +1111,7 @@ public class Force {
               getAllSubForces().stream().max(Comparator.comparing(f -> f.getFormationLevel().getDepth())).orElse(null);
         if (largestSubForce == null) {
             int depth = 1;
-            setFormationLevel(FormationLevel.parseFromDepth(campaign,depth + getOddFormationSizeModifier(campaign,
+            setFormationLevel(FormationLevel.parseFromDepth(campaign, depth + getOddFormationSizeModifier(campaign,
                   depth)));
         } else {
             int depth = largestSubForce.getFormationLevel().getDepth();
@@ -1135,9 +1138,10 @@ public class Force {
      * @param force                 the force whose formation level is to be changed
      * @param currentFormationLevel the current formation level of the force
      * @param lowerBoundary         the lower boundary for the formation level
+     *
      * @deprecated See {@link Force#recursivelyUpdateFormationLevel}
      */
-    @Deprecated (since = "0.50.10", forRemoval = true)
+    @Deprecated(since = "0.50.10", forRemoval = true)
     private static void changeFormationLevel(Force force, int currentFormationLevel, int lowerBoundary) {
         for (Force subforce : force.getSubForces()) {
             if (currentFormationLevel - 1 < lowerBoundary) {
@@ -1160,9 +1164,10 @@ public class Force {
      * @param campaign the campaign object to retrieve the lower boundary for
      *
      * @return the lower boundary value as an integer
+     *
      * @deprecated
      */
-    @Deprecated (since = "0.50.10", forRemoval = true)
+    @Deprecated(since = "0.50.10", forRemoval = true)
     private static int getLowerBoundary(Campaign campaign) {
         int lowerBoundary = FormationLevel.values().length;
 
@@ -1196,9 +1201,10 @@ public class Force {
      * @param origin   the origin node
      *
      * @return the parsed integer value of the origin node's formation level
+     *
      * @deprecated See {@link Force#recursivelyUpdateFormationLevel}
      */
-    @Deprecated (since = "0.50.10", forRemoval = true)
+    @Deprecated(since = "0.50.10", forRemoval = true)
     private static int populateOriginNode(Campaign campaign, Force origin) {
         FormationLevel overrideFormationLevel = origin.getOverrideFormationLevel();
         int maximumDepth = getMaximumDepth(origin, 0);

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -420,7 +420,7 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
 
         // determine if we've missed any lances and add those back into the campaign
         if (options.isUseAtB()) {
-            Hashtable<Integer, CombatTeam> lances = campaign.getCombatTeamsTable();
+            Hashtable<Integer, CombatTeam> lances = campaign.getCombatTeamsAsMap();
             for (Force f : campaign.getAllForces()) {
                 if (!f.getUnits().isEmpty() && (null == lances.get(f.getId()))) {
                     lances.put(f.getId(), new CombatTeam(f.getId(), campaign));

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenario.java
@@ -422,7 +422,7 @@ public class AtBDynamicScenario extends AtBScenario {
             return null; // if we don't have forces, just a bunch of units, then get the highest-ranked?
         }
 
-        CombatTeam combatTeam = campaign.getCombatTeamsTable().get(getForceIDs().get(0));
+        CombatTeam combatTeam = campaign.getCombatTeamsAsMap().get(getForceIDs().get(0));
 
         if (combatTeam != null) {
             combatTeam.refreshCommander(campaign);

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -2204,7 +2204,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             return null;
         }
 
-        return campaign.getCombatTeamsTable().get(combatTeamId);
+        return campaign.getCombatTeamsAsMap().get(combatTeamId);
     }
 
     public void setCombatTeam(CombatTeam combatTeam) {

--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioFactory.java
@@ -146,7 +146,7 @@ public class AtBScenarioFactory {
         }
 
         // If we have an active contract, then we can progress with generation
-        Hashtable<Integer, CombatTeam> combatTeamsTable = campaign.getCombatTeamsTable();
+        Hashtable<Integer, CombatTeam> combatTeamsTable = campaign.getCombatTeamsAsMap();
 
         List<AtBScenario> scenarios;
         List<Integer> assignedLances = new ArrayList<>();

--- a/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
+++ b/MekHQ/src/mekhq/campaign/mission/resupplyAndCaches/Resupply.java
@@ -407,7 +407,7 @@ public class Resupply {
         // First, calculate the total tonnage across all combat units in the campaign.
         // We define a 'combat unit' as any unit not flagged as non-combat who is both in a Combat
         // Team and not in a Force flagged as non-combat
-        for (CombatTeam formation : campaign.getCombatTeamsTable().values()) {
+        for (CombatTeam formation : campaign.getCombatTeamsAsMap().values()) {
             Force force = campaign.getForce(formation.getForceId());
 
             if (force == null) {

--- a/MekHQ/src/mekhq/campaign/mission/utilities/ContractUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/utilities/ContractUtilities.java
@@ -52,7 +52,7 @@ public class ContractUtilities {
     public static int calculateBaseNumberOfRequiredLances(Campaign campaign) {
 
         int combatForceCount = 0;
-        for (CombatTeam combatTeam : campaign.getAllCombatTeams()) {
+        for (CombatTeam combatTeam : campaign.getCombatTeamsAsList()) {
             if (0 >= combatTeam.getSize(campaign)) { // Don't count empty combat teams (or warship-only)
                 continue;
             }
@@ -100,7 +100,7 @@ public class ContractUtilities {
      */
     public static int getEffectiveNumUnits(Campaign campaign) {
         double numUnits = 0;
-        for (CombatTeam combatTeam : campaign.getAllCombatTeams()) {
+        for (CombatTeam combatTeam : campaign.getCombatTeamsAsList()) {
             Force force = combatTeam.getForce(campaign);
 
             if (force == null) {

--- a/MekHQ/src/mekhq/campaign/personnel/autoAwards/MiscAwards.java
+++ b/MekHQ/src/mekhq/campaign/personnel/autoAwards/MiscAwards.java
@@ -288,7 +288,7 @@ public class MiscAwards {
      */
     private static boolean drillInstructor(Campaign campaign, Award award, UUID person) {
         if (award.canBeAwarded(campaign.getPerson(person)) && campaign.hasActiveAtBContract()) {
-            return campaign.getAllCombatTeams().stream()
+            return campaign.getCombatTeamsAsList().stream()
                          .anyMatch(lance -> (lance.getRole().isTraining()) && (lance.getCommanderId().equals(person)));
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -109,7 +109,7 @@ public class TrainingCombatTeams {
      */
     public static void processTrainingCombatTeams(final Campaign campaign) {
         final LocalDate today = campaign.getLocalDate();
-        final List<CombatTeam> combatTeams = campaign.getAllCombatTeams();
+        final List<CombatTeam> combatTeams = campaign.getCombatTeamsAsList();
 
         for (CombatTeam combatTeam : combatTeams) {
             if (!combatTeam.getRole().isTraining()) {

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
@@ -242,7 +242,7 @@ public class Fatigue {
 
         int leaveThreshold = campaignOptions.getFatigueUndeploymentThreshold();
 
-        for (CombatTeam combatTeam : campaign.getAllCombatTeams()) {
+        for (CombatTeam combatTeam : campaign.getCombatTeamsAsList()) {
             Force force = combatTeam.getForce(campaign);
             if (force == null || force.isDeployed()) {
                 // 'isDeployed' will only return true if the force is deployed to a scenario. In which cases we don't

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1084,7 +1084,7 @@ public class StratConRulesManager {
      */
     public static void deployForceToCoords(StratConCoords coords, int forceID, Campaign campaign, AtBContract contract,
           StratConTrackState track, boolean sticky) {
-        CombatTeam combatTeam = campaign.getCombatTeamsTable().get(forceID);
+        CombatTeam combatTeam = campaign.getCombatTeamsAsMap().get(forceID);
 
         // This shouldn't be possible, but never hurts to have a little insurance
         if (combatTeam == null) {
@@ -1153,7 +1153,7 @@ public class StratConRulesManager {
                 // If the player doesn't have any available forces, we grab a force at random to
                 // seed the scenario
                 if (availableForceIDs.isEmpty()) {
-                    ArrayList<CombatTeam> combatTeams = campaign.getAllCombatTeams();
+                    ArrayList<CombatTeam> combatTeams = campaign.getCombatTeamsAsList();
                     if (!combatTeams.isEmpty()) {
                         combatTeam = getRandomItem(combatTeams);
 
@@ -1419,7 +1419,7 @@ public class StratConRulesManager {
 
         // Determine scan range
         int scanRangeIncrease = track.getScanRangeIncrease();
-        CombatTeam combatTeam = campaign.getCombatTeamsTable().get(forceID);
+        CombatTeam combatTeam = campaign.getCombatTeamsAsMap().get(forceID);
         if (combatTeam != null && combatTeam.getRole().isPatrol()) {
             scanRangeIncrease++;
         }
@@ -2111,7 +2111,7 @@ public class StratConRulesManager {
         if (lanceCommander != null) {
             Unit commanderUnit = lanceCommander.getUnit();
             if (commanderUnit != null) {
-                CombatTeam lance = campaign.getCombatTeamsTable().get(commanderUnit.getForceId());
+                CombatTeam lance = campaign.getCombatTeamsAsMap().get(commanderUnit.getForceId());
 
                 return (lance != null) && lance.getRole().isFrontline();
             }
@@ -2484,7 +2484,7 @@ public class StratConRulesManager {
     public static List<Integer> getAvailableForceIDs(Campaign campaign, AtBContract contract,
           boolean bypassRoleRestrictions) {
         // First, build a list of all combat teams in the campaign
-        ArrayList<CombatTeam> combatTeams = campaign.getAllCombatTeams();
+        ArrayList<CombatTeam> combatTeams = campaign.getCombatTeamsAsList();
 
         if (combatTeams.isEmpty()) {
             // If we don't have any combat teams, there is no point in continuing, so we exit early
@@ -2585,7 +2585,7 @@ public class StratConRulesManager {
             forcesInTracks.addAll(currentScenario.getFailedReinforcements());
         }
 
-        for (CombatTeam formation : campaign.getCombatTeamsTable().values()) {
+        for (CombatTeam formation : campaign.getCombatTeamsAsMap().values()) {
             Force force = campaign.getForce(formation.getForceId());
 
             if (force == null) {
@@ -2738,7 +2738,7 @@ public class StratConRulesManager {
         }
 
         // Check the associated combat team and its role
-        CombatTeam combatTeam = force.isCombatTeam() ? campaign.getCombatTeamsTable().get(forceId) : null;
+        CombatTeam combatTeam = force.isCombatTeam() ? campaign.getCombatTeamsAsMap().get(forceId) : null;
 
         if (combatTeam == null) {
             return false;
@@ -2931,8 +2931,8 @@ public class StratConRulesManager {
         // it can deploy "for free" (ReinforcementEligibilityType.ChainedScenario)
 
         // if the force is in 'fight' stance, it'll be able to deploy using 'fight lance' rules
-        if (campaign.getCombatTeamsTable().containsKey(forceID)) {
-            Hashtable<Integer, CombatTeam> combatTeamsTable = campaign.getCombatTeamsTable();
+        if (campaign.getCombatTeamsAsMap().containsKey(forceID)) {
+            Hashtable<Integer, CombatTeam> combatTeamsTable = campaign.getCombatTeamsAsMap();
             CombatTeam formation = combatTeamsTable.get(forceID);
 
             if (formation == null) {

--- a/MekHQ/src/mekhq/gui/stratCon/ScenarioWizardLanceRenderer.java
+++ b/MekHQ/src/mekhq/gui/stratCon/ScenarioWizardLanceRenderer.java
@@ -97,7 +97,7 @@ public class ScenarioWizardLanceRenderer extends JLabel implements ListCellRende
         String statusCloseFormat = operationalStatus == NOT_OPERATIONAL ? "</s>" : CLOSING_SPAN_TAG;
 
         // Get combat role
-        CombatTeam combatTeam = campaign.getCombatTeamsTable().get(force.getId());
+        CombatTeam combatTeam = campaign.getCombatTeamsAsMap().get(force.getId());
         String roleString = "";
         if (combatTeam != null) {
             roleString = combatTeam.getRole().toString() + ", ";

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentView.java
@@ -232,7 +232,7 @@ public class LanceAssignmentView extends JPanel {
             cbContract.addItem(contract);
         }
         AtBContract defaultContract = activeContracts.isEmpty() ? null : activeContracts.get(0);
-        for (CombatTeam combatTeam : campaign.getCombatTeamsTable().values()) {
+        for (CombatTeam combatTeam : campaign.getCombatTeamsAsMap().values()) {
             if ((combatTeam.getContract(campaign) == null) ||
                       !combatTeam.getContract(campaign).isActiveOn(campaign.getLocalDate(), true)) {
                 combatTeam.setContract(defaultContract);
@@ -240,7 +240,7 @@ public class LanceAssignmentView extends JPanel {
         }
 
         ((DataTableModel<AtBContract>) tblRequiredLances.getModel()).setData(activeContracts);
-        ((DataTableModel<CombatTeam>) tblAssignments.getModel()).setData(campaign.getAllCombatTeams());
+        ((DataTableModel<CombatTeam>) tblAssignments.getModel()).setData(campaign.getCombatTeamsAsList());
         panRequiredLances.setVisible(tblRequiredLances.getRowCount() > 0);
     }
 

--- a/MekHQ/src/mekhq/gui/view/RequiredLancesTableModel.java
+++ b/MekHQ/src/mekhq/gui/view/RequiredLancesTableModel.java
@@ -114,7 +114,7 @@ class RequiredLancesTableModel extends DataTableModel<AtBContract> {
 
         if (column == COL_TOTAL) {
             int t = 0;
-            for (CombatTeam combatTeam : campaign.getAllCombatTeams()) {
+            for (CombatTeam combatTeam : campaign.getCombatTeamsAsList()) {
                 AtBContract assignedContract = combatTeam.getContract(campaign);
                 boolean isCadreDuty = assignedContract.getContractType().isCadreDuty();
                 CombatRole role = combatTeam.getRole();
@@ -131,7 +131,7 @@ class RequiredLancesTableModel extends DataTableModel<AtBContract> {
             return Integer.toString(contract.getRequiredCombatElements());
         } else if (contract.getContractType().getRequiredCombatRole().ordinal() == column - 2) {
             int t = 0;
-            for (CombatTeam combatTeam : campaign.getAllCombatTeams()) {
+            for (CombatTeam combatTeam : campaign.getCombatTeamsAsList()) {
                 if (data.get(row).equals(combatTeam.getContract(campaign)) &&
                           (combatTeam.getRole() ==
                                  combatTeam.getContract(campaign).getContractType().getRequiredCombatRole()) &&

--- a/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
+++ b/MekHQ/unittests/mekhq/campaign/mission/AtBContractTest.java
@@ -345,7 +345,7 @@ public class AtBContractTest {
             // Arrange
             ArrayList<CombatTeam> mockedCombatTeams = new ArrayList<>();
 
-            when(mockCampaign.getAllCombatTeams()).thenReturn(mockedCombatTeams);
+            when(mockCampaign.getCombatTeamsAsList()).thenReturn(mockedCombatTeams);
 
             // Act
             int teams = ContractUtilities.calculateBaseNumberOfRequiredLances(mockCampaign);
@@ -362,7 +362,7 @@ public class AtBContractTest {
             ArrayList<CombatTeam> mockedCombatTeams = new ArrayList<>();
             mockedCombatTeams.add(getMockLanceCombatTeam(formationSize));
 
-            when(mockCampaign.getAllCombatTeams()).thenReturn(mockedCombatTeams);
+            when(mockCampaign.getCombatTeamsAsList()).thenReturn(mockedCombatTeams);
 
             // Act
             int teams = ContractUtilities.calculateBaseNumberOfRequiredLances(mockCampaign);
@@ -381,7 +381,7 @@ public class AtBContractTest {
                 mockedCombatTeams.add(getMockLanceCombatTeam(formationSize));
             }
 
-            when(mockCampaign.getAllCombatTeams()).thenReturn(mockedCombatTeams);
+            when(mockCampaign.getCombatTeamsAsList()).thenReturn(mockedCombatTeams);
 
             // Act
             int teams = ContractUtilities.calculateBaseNumberOfRequiredLances(mockCampaign);
@@ -400,7 +400,7 @@ public class AtBContractTest {
                 mockedCombatTeams.add(getMockLanceCombatTeam(formationSize));
             }
 
-            when(mockCampaign.getAllCombatTeams()).thenReturn(mockedCombatTeams);
+            when(mockCampaign.getCombatTeamsAsList()).thenReturn(mockedCombatTeams);
 
             // Act
             int teams = ContractUtilities.calculateBaseNumberOfRequiredLances(mockCampaign);
@@ -417,7 +417,7 @@ public class AtBContractTest {
             ArrayList<CombatTeam> mockedCombatTeams = new ArrayList<>();
             mockedCombatTeams.add(getMockCompanyCombatTeam(formationSize));
 
-            when(mockCampaign.getAllCombatTeams()).thenReturn(mockedCombatTeams);
+            when(mockCampaign.getCombatTeamsAsList()).thenReturn(mockedCombatTeams);
 
             // Act
             int teams = ContractUtilities.calculateBaseNumberOfRequiredLances(mockCampaign);
@@ -436,7 +436,7 @@ public class AtBContractTest {
                 mockedCombatTeams.add(getMockCompanyCombatTeam(formationSize));
             }
 
-            when(mockCampaign.getAllCombatTeams()).thenReturn(mockedCombatTeams);
+            when(mockCampaign.getCombatTeamsAsList()).thenReturn(mockedCombatTeams);
 
             // Act
             int teams = ContractUtilities.calculateBaseNumberOfRequiredLances(mockCampaign);
@@ -455,7 +455,7 @@ public class AtBContractTest {
                 mockedCombatTeams.add(getMockCompanyCombatTeam(formationSize));
             }
 
-            when(mockCampaign.getAllCombatTeams()).thenReturn(mockedCombatTeams);
+            when(mockCampaign.getCombatTeamsAsList()).thenReturn(mockedCombatTeams);
 
             // Act
             int teams = ContractUtilities.calculateBaseNumberOfRequiredLances(mockCampaign);
@@ -473,7 +473,7 @@ public class AtBContractTest {
             mockedCombatTeams.add(getMockLanceCombatTeam(formationSize));
             mockedCombatTeams.add(getMockCompanyCombatTeam(formationSize));
 
-            when(mockCampaign.getAllCombatTeams()).thenReturn(mockedCombatTeams);
+            when(mockCampaign.getCombatTeamsAsList()).thenReturn(mockedCombatTeams);
 
             // Act
             int teams = ContractUtilities.calculateBaseNumberOfRequiredLances(mockCampaign);
@@ -493,7 +493,7 @@ public class AtBContractTest {
             }
             mockedCombatTeams.add(getMockCompanyCombatTeam(formationSize));
 
-            when(mockCampaign.getAllCombatTeams()).thenReturn(mockedCombatTeams);
+            when(mockCampaign.getCombatTeamsAsList()).thenReturn(mockedCombatTeams);
 
             // Act
             int teams = ContractUtilities.calculateBaseNumberOfRequiredLances(mockCampaign);
@@ -568,7 +568,7 @@ public class AtBContractTest {
             ArrayList<CombatTeam> mockedCombatTeams = new ArrayList<>();
             mockedCombatTeams.add(mockLanceCombatTeam);
 
-            when(mockCampaign.getAllCombatTeams()).thenReturn(mockedCombatTeams);
+            when(mockCampaign.getCombatTeamsAsList()).thenReturn(mockedCombatTeams);
 
             // Act
             int teams = ContractUtilities.calculateBaseNumberOfRequiredLances(mockCampaign);


### PR DESCRIPTION
This was caused by us incorrectly accessing a List as if it were a Map.

We have two very similarly named methods, to reduce room for confusion, moving forward I went ahead and renamed them.

Marking as 'high' as the trigger conditions are very common.