### PR TITLE
Fix #7864: Fixed Scenario Resolution Error

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -913,17 +913,19 @@ public class ResolveScenarioWizardDialog extends JDialog {
                 continue;
             }
             for (Unit unit : tracker.getUnits()) {
-                index++;
                 if (unit.getEntity() instanceof GunEmplacement) {
+                    index++;
                     assignModel.addElement("AutoTurret, " + unit.getName());
+                    if (unit.getId().toString().equals(tracker.getKillCredits().get(killName))) {
+                        selected = index;
+                    }
                 } else if (unit.hasCommander()) {
-                    // If there's no commander we don't need to show anything because we only credit
-                    // kills to personnel.
+                    // If there's no commander we don't need to show anything because we only credit kills to personnel.
+                    index++;
                     assignModel.addElement(unit.getCommander().getFullTitle() + ", " + unit.getName());
-                }
-
-                if (unit.getId().toString().equals(tracker.getKillCredits().get(killName))) {
-                    selected = index;
+                    if (unit.getId().toString().equals(tracker.getKillCredits().get(killName))) {
+                        selected = index;
+                    }
                 }
             }
             comboAssign = new JComboBox<>(assignModel);


### PR DESCRIPTION
Fix #7864 

This should fix some desyncing in kill credits if a kill would be assigned to a unit that has no crew. This was occurring in ACAR because ACAR loves to kill pilots. :D