### PR TITLE
Improvement: Restored Ability to Deploy from TO&E; Added Ability to Deploy to StratCon from Briefing Room

### DIFF
--- a/MekHQ/resources/mekhq/resources/MaplessStratConForcePicker.properties
+++ b/MekHQ/resources/mekhq/resources/MaplessStratConForcePicker.properties
@@ -1,0 +1,34 @@
+# Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+# suppress inspection "UnusedMessageFormatParameter" for whole file
+MaplessStratConForcePicker.inCharacterMessage.normal=Here are our options...
+MaplessStratConForcePicker.inCharacterMessage.noForces=Sorry, we don't have any Combat Teams ready right now.
+MaplessStratConForcePicker.combo.label=Select a Combat Team:

--- a/MekHQ/resources/mekhq/resources/MaplessStratConScenarioPicker.properties
+++ b/MekHQ/resources/mekhq/resources/MaplessStratConScenarioPicker.properties
@@ -1,0 +1,36 @@
+# Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+# suppress inspection "UnusedMessageFormatParameter" for the whole file
+MaplessStratConScenarioPicker.inCharacterMessage.normal=Understood, {0}.\
+  <p>Let me know who where we're deploying, and I'll issue the orders.</p>
+MaplessStratConScenarioPicker.inCharacterMessage.noScenarios=Sorry, {0}, we don't have any deployment opportunities. \
+  Rest assured, the OpFor will change that soon enough.
+MaplessStratConScenarioPicker.combo.label=Select a scenario:

--- a/MekHQ/src/mekhq/campaign/stratCon/MaplessStratCon.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/MaplessStratCon.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.stratCon;
+
+import static mekhq.campaign.stratCon.StratConScenario.ScenarioState.PRIMARY_FORCES_COMMITTED;
+import static mekhq.campaign.stratCon.StratConScenario.ScenarioState.UNRESOLVED;
+
+import java.util.Map;
+
+import megamek.common.annotations.Nullable;
+import megamek.logging.MMLogger;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.mission.Mission;
+import mekhq.campaign.mission.Scenario;
+import mekhq.gui.StratConPanel;
+import mekhq.gui.stratCon.StratConScenarioWizard;
+import mekhq.gui.stratCon.TrackForceAssignmentUI;
+
+
+/**
+ * Utility class for managing mapless StratCon scenario deployment operations.
+ *
+ * <p>This class provides functionality for deploying forces to StratCon scenarios without using the traditional
+ * map-based interface. It handles the workflow of locating scenarios within campaign tracks, presenting appropriate
+ * dialogs for force assignment, and managing the deployment state transitions.</p>
+ *
+ * @author Illiani
+ * @since 0.50.10
+ */
+public class MaplessStratCon {
+    private static final MMLogger LOGGER = MMLogger.create(MaplessStratCon.class);
+
+    /**
+     * Represents the complete context required for deploying forces to a StratCon scenario.
+     *
+     * <p>This record encapsulates all the state information needed to identify and interact with a specific scenario
+     * within the StratCon campaign structure.</p>
+     *
+     * @param campaignState    the overall state of the StratCon campaign
+     * @param trackState       the state of the specific track containing the scenario
+     * @param stratConScenario the StratCon scenario being deployed to
+     * @param scenarioCoords   the coordinates of the scenario within its track
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private record StratConDeploymentContext(StratConCampaignState campaignState, StratConTrackState trackState,
+          StratConScenario stratConScenario, StratConCoords scenarioCoords) {}
+
+    /**
+     * Initiates a mapless deployment workflow for the specified scenario.
+     *
+     * <p>This method serves as the main entry point for deploying forces to a StratCon scenario without using the
+     * map interface. It validates the scenario, retrieves the necessary context information, and triggers the
+     * appropriate assignment dialogs.</p>
+     *
+     * @param stratConPanel the UI panel managing StratCon operations
+     * @param campaign      the current campaign
+     * @param scenario      the scenario to deploy forces to
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    public static void deployWithoutMap(StratConPanel stratConPanel, Campaign campaign, Scenario scenario) {
+        StratConDeploymentContext deploymentContext = buildScenarioData(campaign, scenario);
+        if (deploymentContext == null) {
+            return;
+        }
+
+        triggerAssignmentDialog(stratConPanel, campaign, deploymentContext);
+    }
+
+
+    /**
+     * Builds the deployment context for a given scenario by locating it within the campaign structure.
+     *
+     * <p>This method validates that the scenario belongs to an AtB contract with an active StratCon campaign state,
+     * then searches through all tracks to find the scenario and construct the necessary context information.</p>
+     *
+     * @param campaign the current campaign
+     * @param scenario the scenario to build context for
+     *
+     * @return a {@link StratConDeploymentContext} containing all necessary scenario information, or {@code null} if the
+     *       scenario cannot be located or is invalid
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private static @Nullable StratConDeploymentContext buildScenarioData(Campaign campaign, Scenario scenario) {
+        Mission mission = campaign.getMission(scenario.getMissionId());
+        if (!(mission instanceof AtBContract atbContract)) {
+            // We should have obstructed the user before they get to this point
+            LOGGER.error("Mission is not an AtBContract: {}", mission);
+            return null;
+        }
+
+        StratConCampaignState campaignState = atbContract.getStratconCampaignState();
+        if (campaignState == null) {
+            LOGGER.warn("CampaignState is null for contract: {}", atbContract);
+            return null;
+        }
+
+        int scenarioId = scenario.getId();
+
+        for (StratConTrackState track : campaignState.getTracks()) {
+            for (Map.Entry<StratConCoords, StratConScenario> scenarioInTrack : track.getScenarios().entrySet()) {
+                if (scenarioInTrack.getValue().getBackingScenarioID() == scenarioId) {
+                    return new StratConDeploymentContext(campaignState, track, scenarioInTrack.getValue(),
+                          scenarioInTrack.getKey());
+                }
+            }
+        }
+
+        LOGGER.warn("Unable to find scenario {} in any tracks", scenarioId);
+        return null;
+    }
+
+    /**
+     * Triggers the appropriate force assignment dialog based on the scenario's current state.
+     *
+     * <p>This method manages the deployment workflow by:</p>
+     *
+     * <ul>
+     *   <li>Setting the active track and selected coordinates in the StratCon panel</li>
+     *   <li>Displaying the force assignment UI for unresolved scenarios (primary force deployment)</li>
+     *   <li>Displaying the scenario wizard for scenarios with committed primary forces (reinforcement deployment)</li>
+     *   <li>Handling cancellation and cleanup of the deployment process</li>
+     * </ul>
+     *
+     * @param stratConPanel     the UI panel managing StratCon operations
+     * @param campaign          the current campaign
+     * @param deploymentContext the context information for the scenario being deployed to
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private static void triggerAssignmentDialog(StratConPanel stratConPanel, Campaign campaign,
+          StratConDeploymentContext deploymentContext) {
+        if (deploymentContext == null) {
+            return;
+        }
+
+        // We're going to use these values a lot, so we're going to unpack them from the deploymentContext Record
+        StratConCampaignState campaignState = deploymentContext.campaignState;
+        StratConTrackState trackState = deploymentContext.trackState;
+        StratConScenario stratConScenario = deploymentContext.stratConScenario;
+        StratConCoords scenarioCoords = deploymentContext.scenarioCoords;
+
+        stratConPanel.setCurrentTrack(deploymentContext.trackState);
+        stratConPanel.setSelectedCoords(deploymentContext.scenarioCoords);
+
+        TrackForceAssignmentUI assignmentUI = stratConPanel.getAssignmentUI();
+        StratConScenarioWizard scenarioWizard = stratConPanel.getStratConScenarioWizard();
+
+        boolean isPrimaryForce = false;
+        StratConScenario.ScenarioState currentState = stratConScenario.getCurrentState();
+        if (currentState.equals(UNRESOLVED)) {
+            assignmentUI.display(campaign, campaignState, scenarioCoords);
+            assignmentUI.setVisible(true);
+            isPrimaryForce = true;
+        }
+
+        // Let's reload the scenario in case it updated
+        stratConScenario = trackState.getScenario(scenarioCoords);
+        if (stratConScenario == null) {
+            LOGGER.error("StratConScenario is null for scenarioCoords: {}", scenarioCoords);
+            return;
+        }
+
+
+        if (stratConScenario.getCurrentState() == PRIMARY_FORCES_COMMITTED) {
+            scenarioWizard.setCurrentScenario(stratConScenario,
+                  trackState,
+                  campaignState,
+                  isPrimaryForce);
+
+            scenarioWizard.toFront();
+            scenarioWizard.setVisible(true);
+        }
+
+        if (scenarioWizard.isWasCanceled()) {
+            stratConScenario.resetScenario(campaign);
+
+            // We currently retain the wizard in memory, so need to make sure we reset the canceled state
+            scenarioWizard.setWasCanceled(false);
+        }
+
+        stratConPanel.setCommitForces(false);
+        stratConPanel.repaint();
+    }
+}

--- a/MekHQ/src/mekhq/gui/StratConPanel.java
+++ b/MekHQ/src/mekhq/gui/StratConPanel.java
@@ -149,6 +149,14 @@ public class StratConPanel extends JPanel implements ActionListener {
 
     private boolean commitForces = false;
 
+    public StratConScenarioWizard getStratConScenarioWizard() {
+        return scenarioWizard;
+    }
+
+    public TrackForceAssignmentUI getAssignmentUI() {
+        return assignmentUI;
+    }
+
     /**
      * Constructs a StratConPanel instance, given a parent campaign GUI and a pointer to an info area.
      */
@@ -886,8 +894,16 @@ public class StratConPanel extends JPanel implements ActionListener {
         return currentTrack;
     }
 
+    public void setCurrentTrack(StratConTrackState track) {
+        currentTrack = track;
+    }
+
     public StratConCoords getSelectedCoords() {
         return boardState.getSelectedCoords();
+    }
+
+    public void setSelectedCoords(StratConCoords coords) {
+        boardState.setSelectedCoords(coords);
     }
 
     /**
@@ -988,6 +1004,11 @@ public class StratConPanel extends JPanel implements ActionListener {
             } else {
                 return new StratConCoords(selectedX, selectedY);
             }
+        }
+
+        public void setSelectedCoords(StratConCoords coords) {
+            selectedX = coords.getX();
+            selectedY = coords.getY();
         }
     }
 

--- a/MekHQ/src/mekhq/gui/StratConTab.java
+++ b/MekHQ/src/mekhq/gui/StratConTab.java
@@ -105,6 +105,10 @@ public class StratConTab extends CampaignGuiTab {
     }
     //endregion Constructors
 
+    public StratConPanel getStratconPanel() {
+        return stratconPanel;
+    }
+
     /**
      * Override of the base initTab method. Populates the tab.
      */

--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -36,17 +36,16 @@ import static megamek.client.ui.util.UIUtil.scaleForGUI;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import javax.swing.DropMode;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
-import javax.swing.JTabbedPane;
-import javax.swing.JTree;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingUtilities;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+import javax.swing.*;
 import javax.swing.tree.TreeSelectionModel;
 
 import megamek.common.event.Subscribe;
@@ -60,10 +59,19 @@ import mekhq.campaign.events.scenarios.ScenarioResolvedEvent;
 import mekhq.campaign.events.units.UnitChangedEvent;
 import mekhq.campaign.events.units.UnitRemovedEvent;
 import mekhq.campaign.force.Force;
+import mekhq.campaign.mission.AtBContract;
+import mekhq.campaign.mission.AtBDynamicScenario;
+import mekhq.campaign.mission.Mission;
+import mekhq.campaign.mission.Scenario;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.stratCon.MaplessStratCon;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.adapter.TOEMouseAdapter;
+import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
+import mekhq.gui.dialog.ForceTemplateAssignmentDialog;
+import mekhq.gui.dialog.MaplessStratConForcePicker;
+import mekhq.gui.dialog.MaplessStratConScenarioPicker;
 import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.handler.TOETransferHandler;
 import mekhq.gui.model.CrewListModel;
@@ -118,6 +126,13 @@ public final class TOETab extends CampaignGuiTab {
 
         JPanel leftPanel = new JPanel(new BorderLayout());
         leftPanel.setBorder(null);
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        JButton btnDeploy = new RoundedJButton("Deploy Directly to Scenario");
+        btnDeploy.addActionListener(evt -> deploymentButton());
+        buttonPanel.add(btnDeploy);
+        leftPanel.add(buttonPanel, BorderLayout.NORTH);
+
         JScrollPane orgScrollPane = new JScrollPane(orgTree);
         orgScrollPane.setBorder(null);
         leftPanel.add(orgScrollPane, BorderLayout.CENTER);
@@ -146,6 +161,113 @@ public final class TOETab extends CampaignGuiTab {
         add(splitOrg, gridBagConstraints);
 
         tabUnitLastSelectedIndex = 0;
+    }
+
+    /**
+     * Handles the deployment button action by allowing the player to select a scenario and deploy forces to it.
+     *
+     * <p>This method presents a dialog with all current scenarios from active missions, sorted by date (newest
+     * first). After the player selects a scenario, the method determines whether it's a StratCon scenario or a regular
+     * scenario and delegates to the appropriate deployment handler.</p>
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private void deploymentButton() {
+        // Build scenario list with mission mapping
+        Map<Scenario, Mission> scenarioMissionMap = new HashMap<>();
+        for (Mission mission : getCampaign().getActiveMissions(false)) {
+            for (Scenario scenario : mission.getCurrentScenarios()) {
+                scenarioMissionMap.put(scenario, mission);
+            }
+        }
+
+        List<Scenario> sortedScenarios = new ArrayList<>(scenarioMissionMap.keySet());
+        sortedScenarios.sort(Comparator.comparing(Scenario::getDate).reversed());
+
+        // Show scenario picker
+        MaplessStratConScenarioPicker scenarioPicker = new MaplessStratConScenarioPicker(getCampaign(),
+              sortedScenarios);
+        if (!scenarioPicker.wasConfirmed()) {
+            return;
+        }
+
+        Scenario selectedScenario = sortedScenarios.get(scenarioPicker.getComboBoxChoiceIndex());
+        Mission selectedMission = scenarioMissionMap.get(selectedScenario);
+
+        // Check if this is a StratCon scenario
+        boolean isStratConScenario = selectedScenario instanceof AtBDynamicScenario &&
+                                           selectedMission instanceof AtBContract atbContract &&
+                                           atbContract.getStratconCampaignState() != null;
+
+        if (isStratConScenario) {
+            deployToStratCon(selectedScenario);
+        } else {
+            deployToRegularScenario(selectedScenario);
+        }
+    }
+
+    /**
+     * Deploys forces to a StratCon scenario using the mapless StratCon deployment interface.
+     *
+     * <p>This method retrieves the StratCon tab and delegates to the mapless deployment system, which handles force
+     * assignment through the StratCon scenario wizard.</p>
+     *
+     * @param selectedScenario the StratCon scenario to deploy forces to
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private void deployToStratCon(Scenario selectedScenario) {
+        if (getCampaignGui().getTab(MHQTabType.STRAT_CON) instanceof StratConTab stratConTab) {
+            MaplessStratCon.deployWithoutMap(stratConTab.getStratconPanel(), getCampaign(), selectedScenario);
+        }
+    }
+
+    /**
+     * Deploys forces to a regular (non-StratCon) scenario.
+     *
+     * <p>This method presents a dialog allowing the player to select from available combat teams that are not
+     * currently deployed. For AtB dynamic scenarios, it opens the force template assignment dialog. For standard
+     * scenarios, it directly assigns the selected force to the scenario and triggers the appropriate deployment
+     * events.</p>
+     *
+     * @param selectedScenario the scenario to deploy forces to
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private void deployToRegularScenario(Scenario selectedScenario) {
+        // Get available forces
+        List<Force> forceOptions = getCampaign().getAllCombatTeams().stream()
+                                         .map(combatTeam -> getCampaign().getForce(combatTeam.getForceId()))
+                                         .filter(force -> force != null && !force.isDeployed())
+                                         .sorted(Comparator.comparing(Force::getFullName))
+                                         .toList();
+
+        // Show force picker
+        MaplessStratConForcePicker forcePicker = new MaplessStratConForcePicker(getCampaign(), forceOptions);
+        if (!forcePicker.wasConfirmed()) {
+            return;
+        }
+
+        Force selectedForce = forceOptions.get(forcePicker.getComboBoxChoiceIndex());
+
+        // Deploy force to scenario
+        if (selectedScenario instanceof AtBDynamicScenario dynamicScenario) {
+            new ForceTemplateAssignmentDialog(getCampaignGui(),
+                  new Vector<>(List.of(selectedForce)),
+                  null,
+                  dynamicScenario);
+        } else {
+            getCampaignGui().undeployForce(selectedForce);
+            selectedForce.clearScenarioIds(getCampaign(), true);
+            if (selectedScenario != null) {
+                selectedScenario.addForces(selectedForce.getId());
+                selectedForce.setScenarioId(selectedScenario.getId(), getCampaign());
+            }
+            MekHQ.triggerEvent(new DeploymentChangedEvent(selectedForce, selectedScenario));
+        }
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
@@ -41,10 +41,14 @@ import javax.swing.JTable;
 
 import mekhq.MekHQ;
 import mekhq.campaign.events.scenarios.ScenarioChangedEvent;
+import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.stratCon.MaplessStratCon;
 import mekhq.gui.CampaignGUI;
+import mekhq.gui.StratConTab;
 import mekhq.gui.dialog.CustomizeScenarioDialog;
+import mekhq.gui.enums.MHQTabType;
 import mekhq.gui.model.ScenarioTableModel;
 
 public class ScenarioTableMouseAdapter extends JPopupMenuAdapter {
@@ -79,6 +83,15 @@ public class ScenarioTableMouseAdapter extends JPopupMenuAdapter {
         JMenu menu;
 
         // let's fill the pop-up menu
+        if (gui.getTab(MHQTabType.STRAT_CON) instanceof StratConTab stratConTab
+                  && scenario instanceof AtBDynamicScenario) {
+            menuItem = new JMenuItem("Deploy...");
+            menuItem.addActionListener(evt -> MaplessStratCon.deployWithoutMap(stratConTab.getStratconPanel(),
+                  gui.getCampaign(),
+                  scenario));
+            popup.add(menuItem);
+        }
+
         menuItem = new JMenuItem("Edit...");
         menuItem.addActionListener(evt -> editScenario(scenario));
         popup.add(menuItem);

--- a/MekHQ/src/mekhq/gui/dialog/MaplessStratConForcePicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/MaplessStratConForcePicker.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.dialog;
+
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getText;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import megamek.client.ui.comboBoxes.MMComboBox;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.force.Force;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
+
+/**
+ * Dialog for selecting a force to deploy in a mapless StratCon scenario.
+ *
+ * <p>This immersive dialog presents the player with a list of available forces to choose from when deploying to a
+ * scenario without using the map interface. The dialog is presented in-character through the campaign's command liaison
+ * and includes proper handling for cases where no forces are available for deployment.</p>
+ *
+ * @author Illiani
+ * @since 0.50.10
+ */
+public class MaplessStratConForcePicker extends ImmersiveDialogCore {
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.MaplessStratConForcePicker";
+
+    public final int SELECTION_CANCELLED = 0;
+    public final int SELECTION_CONFIRMED = 1;
+
+    /**
+     * Checks whether the user confirmed their force selection.
+     *
+     * @return {@code true} if the user confirmed their selection, {@code false} if they canceled
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    public boolean wasConfirmed() {
+        return getDialogChoice() == SELECTION_CONFIRMED;
+    }
+
+    /**
+     * Creates a new force picker dialog for mapless StratCon deployment.
+     *
+     * <p>The dialog adapts its presentation based on whether forces are available:</p>
+     *
+     * <ul>
+     *   <li>If forces are available: Shows a dropdown to select from and a confirm button</li>
+     *   <li>If no forces are available: Shows an informational message with only a cancel button</li>
+     * </ul>
+     *
+     * @param campaign the current campaign
+     * @param forces   the list of available forces the player can choose from
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    public MaplessStratConForcePicker(Campaign campaign, List<Force> forces) {
+        super(campaign,
+              campaign.getSeniorAdminPerson(Campaign.AdministratorSpecialization.COMMAND),
+              null,
+              getInCharacterMessage(campaign.getCommanderAddress(), !forces.isEmpty()),
+              getButtons(!forces.isEmpty()),
+              null,
+              ImmersiveDialogWidth.SMALL.getWidth(),
+              false,
+              getSupplementalPanel(forces),
+              null,
+              true);
+    }
+
+    /**
+     * Generates the in-character message displayed in the dialog.
+     *
+     * <p>The message varies depending on whether forces are available for deployment.</p>
+     *
+     * @param commanderAddress the formal address/title of the campaign commander
+     * @param hasForces        {@code true} if forces are available, {@code false} otherwise
+     *
+     * @return the formatted in-character message string
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private static String getInCharacterMessage(String commanderAddress, boolean hasForces) {
+        String key = "MaplessStratConForcePicker.inCharacterMessage." + (hasForces ? "normal" : "noForces");
+        return getFormattedTextAt(RESOURCE_BUNDLE, key, commanderAddress);
+    }
+
+    /**
+     * Creates the list of buttons to display in the dialog.
+     *
+     * <p>Always includes a Cancel button. If forces are available, also includes a Confirm button.</p>
+     *
+     * @param hasForces {@code true} if forces are available for selection, {@code false} otherwise
+     *
+     * @return a list of button configurations for the dialog
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private static List<ButtonLabelTooltipPair> getButtons(boolean hasForces) {
+        List<ButtonLabelTooltipPair> buttons = new ArrayList<>();
+        buttons.add(new ButtonLabelTooltipPair(getText("Cancel.text"), null));
+
+        if (hasForces) {
+            buttons.add(new ButtonLabelTooltipPair(getText("Confirm.text"), null));
+        }
+
+        return buttons;
+    }
+
+    /**
+     * Creates the supplemental panel containing the force selection dropdown.
+     *
+     * <p>This panel is displayed below the main dialog message and contains a labeled combo box populated with the
+     * names of all available forces.</p>
+     *
+     * @param forces the list of forces to display in the dropdown
+     *
+     * @return a {@link JPanel} containing the force selection UI
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private static JPanel getSupplementalPanel(List<Force> forces) {
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.anchor = GridBagConstraints.WEST;
+
+        JLabel lblScenarios = new JLabel(getTextAt(RESOURCE_BUNDLE, "MaplessStratConForcePicker.combo.label"));
+        addComponent(panel, lblScenarios, constraints, 0, 1, GridBagConstraints.NONE);
+
+        MMComboBox<String> cboSkills = new MMComboBox<>("cboScenarios", getComboListItems(forces));
+        addComponent(panel, cboSkills, constraints, 1, 2, GridBagConstraints.HORIZONTAL);
+
+        return panel;
+    }
+
+    /**
+     * Utility method to add a component to a panel with specific grid bag constraints.
+     *
+     * @param panel       the panel to add the component to
+     * @param component   the component to add
+     * @param constraints the base constraints to use (will be modified)
+     * @param gridX       the grid x position
+     * @param gridWidth   the grid width to span
+     * @param fill        the fill constraint value
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private static void addComponent(JPanel panel, JComponent component, GridBagConstraints constraints, int gridX,
+          int gridWidth, int fill) {
+        constraints.gridx = gridX;
+        constraints.gridy = 0;
+        constraints.gridwidth = gridWidth;
+        constraints.fill = fill;
+        panel.add(component, constraints);
+    }
+
+    /**
+     * Converts the list of forces into an array of strings suitable for display in a combo box.
+     *
+     * <p>Each force is represented by its full hierarchical name in the force structure.</p>
+     *
+     * @param forces the list of forces to convert
+     *
+     * @return an array of force names as strings
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private static String[] getComboListItems(List<Force> forces) {
+        List<String> forceOptions = new ArrayList<>();
+
+        for (Force force : forces) {
+            String scenarioName = force.getFullName();
+            forceOptions.add(scenarioName);
+        }
+
+        return forceOptions.toArray(new String[0]);
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/MaplessStratConScenarioPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/MaplessStratConScenarioPicker.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.dialog;
+
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getText;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import megamek.client.ui.comboBoxes.MMComboBox;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.mission.Scenario;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
+
+public class MaplessStratConScenarioPicker extends ImmersiveDialogCore {
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.MaplessStratConScenarioPicker";
+
+    public final int SCENARIO_SELECTION_CANCELLED = 0;
+    public final int SCENARIO_SELECTION_CONFIRMED = 1;
+
+    public boolean wasConfirmed() {
+        return getDialogChoice() == SCENARIO_SELECTION_CONFIRMED;
+    }
+
+    public MaplessStratConScenarioPicker(Campaign campaign, List<Scenario> scenarios) {
+        super(campaign,
+              campaign.getSeniorAdminPerson(Campaign.AdministratorSpecialization.COMMAND),
+              null,
+              getInCharacterMessage(campaign.getCommanderAddress(), !scenarios.isEmpty()),
+              getButtons(!scenarios.isEmpty()),
+              null,
+              ImmersiveDialogWidth.SMALL.getWidth(),
+              false,
+              getSupplementalPanel(scenarios),
+              null,
+              true);
+    }
+
+    private static String getInCharacterMessage(String commanderAddress, boolean hasScenarios) {
+        String key = "MaplessStratConScenarioPicker.inCharacterMessage." + (hasScenarios ? "normal" : "noScenarios");
+        return getFormattedTextAt(RESOURCE_BUNDLE, key, commanderAddress);
+    }
+
+    private static List<ButtonLabelTooltipPair> getButtons(boolean hasScenarios) {
+        List<ButtonLabelTooltipPair> buttons = new ArrayList<>();
+        buttons.add(new ButtonLabelTooltipPair(getText("Cancel.text"), null));
+
+        if (hasScenarios) {
+            buttons.add(new ButtonLabelTooltipPair(getText("Confirm.text"), null));
+        }
+
+        return buttons;
+    }
+
+    private static JPanel getSupplementalPanel(List<Scenario> scenarios) {
+        JPanel panel = new JPanel(new GridBagLayout());
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.anchor = GridBagConstraints.WEST;
+
+        JLabel lblScenarios = new JLabel(getTextAt(RESOURCE_BUNDLE, "MaplessStratConScenarioPicker.combo.label"));
+        addComponent(panel, lblScenarios, constraints, 0, 1, GridBagConstraints.NONE);
+
+        MMComboBox<String> cboSkills = new MMComboBox<>("cboScenarios", getComboListItems(scenarios));
+        addComponent(panel, cboSkills, constraints, 1, 2, GridBagConstraints.HORIZONTAL);
+
+        return panel;
+    }
+
+    private static void addComponent(JPanel panel, JComponent component, GridBagConstraints constraints, int gridX,
+          int gridWidth, int fill) {
+        constraints.gridx = gridX;
+        constraints.gridy = 0;
+        constraints.gridwidth = gridWidth;
+        constraints.fill = fill;
+        panel.add(component, constraints);
+    }
+
+    private static String[] getComboListItems(List<Scenario> scenarios) {
+        List<String> scenarioOptions = new ArrayList<>();
+
+        for (Scenario scenario : scenarios) {
+            String scenarioName = scenario.getName();
+            LocalDate scenarioDueDate = scenario.getDate();
+
+            scenarioOptions.add(scenarioName + " (" + scenarioDueDate + ")");
+        }
+
+        return scenarioOptions.toArray(new String[0]);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to deploy to StratCon scenarios directly from the Briefing Room. Simply right-click on the scenario and off you go.

It also restores the ability to deploy from the TO&E via a handy button. The TO&E deployment button works for all scenario types, not just StratCon scenarios.