### PR TITLE
Improvement: Added the Ability to Change Combat Roles in the TO&E; Forces Will Now Remember Their Last Assigned Combat Role; Contract Finances Updated to Better Account for Combat Roles

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -133,7 +133,10 @@ public class CombatTeam {
 
     public CombatTeam(int forceId, Campaign campaign) {
         this.forceId = forceId;
-        role = CombatRole.RESERVE;
+
+        Force force = campaign.getForce(forceId);
+        role = force != null ? force.getCombatRoleInMemory() : CombatRole.FRONTLINE;
+
         missionId = -1;
         for (AtBContract contract : campaign.getActiveAtBContracts()) {
             missionId = ((contract.getParentContract() == null) ? contract : contract.getParentContract()).getId();

--- a/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/TOEMouseAdapter.java
@@ -66,6 +66,7 @@ import mekhq.campaign.events.DeploymentChangedEvent;
 import mekhq.campaign.events.NetworkChangedEvent;
 import mekhq.campaign.events.OrganizationChangedEvent;
 import mekhq.campaign.events.units.UnitChangedEvent;
+import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.force.ForceType;
 import mekhq.campaign.force.FormationLevel;
@@ -73,6 +74,7 @@ import mekhq.campaign.log.AssignmentLogger;
 import mekhq.campaign.mission.AtBDynamicScenario;
 import mekhq.campaign.mission.Mission;
 import mekhq.campaign.mission.Scenario;
+import mekhq.campaign.mission.enums.CombatRole;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.HangarSorter;
@@ -173,6 +175,7 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
     private static final String COMMAND_REMOVE_STRATEGIC_FORCE_OVERRIDE = "REMOVE_STRATEGIC_FORCE_OVERRIDE|FORCE|empty|";
 
     private static final String COMMAND_OVERRIDE_FORCE_FORMATION_LEVEL = "OVERRIDE_FORMATION_LEVEL|FORCE|FORMATION_LEVEL|";
+    private static final String COMMAND_CHANGE_ROLE_PREFERENCE = "CHANGE_ROLE_PREFERENCE|FORCE|COMBAT_ROLE|";
 
     // C3 Network-related
     private static final String C3I = "C3I";
@@ -448,6 +451,18 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
             singleForce.setOverrideFormationLevel(formationLevel);
 
             Force.populateFormationLevelsFromOrigin(gui.getCampaign());
+        } else if (action.getActionCommand().startsWith(COMMAND_CHANGE_ROLE_PREFERENCE)) {
+            if (singleForce == null) {
+                return;
+            }
+
+            CombatRole combatRole = CombatRole.parseFromString(st.nextToken());
+            singleForce.setCombatRoleInMemory(combatRole);
+            CombatTeam team = gui.getCampaign().getCombatTeamsTable().get(singleForce.getId());
+            if (team != null) {
+                team.setRole(combatRole);
+                gui.refreshAllTabs();
+            }
         } else if (command.contains(TOEMouseAdapter.CHANGE_DESC)) {
             if (null != singleForce) {
                 MarkdownEditorDialog tad = new MarkdownEditorDialog(gui.getFrame(),
@@ -787,6 +802,29 @@ public class TOEMouseAdapter extends JPopupMenuAdapter {
                             menu.add(menuItem);
                         }
                     }
+                }
+
+                menu = new JMenu("Change Role");
+                menu.setActionCommand(TOEMouseAdapter.COMMAND_CHANGE_ROLE_PREFERENCE + forceIds);
+                menu.addActionListener(this);
+                menu.setEnabled(true);
+                popup.add(menu);
+
+                for (CombatRole combatRole : CombatRole.values()) {
+                    String displayText = combatRole.toString();
+                    if (combatRole == force.getCombatRoleInMemory()) {
+                        displayText = "✓ " + displayText;
+                    }
+
+                    menuItem = new JMenuItem(displayText);
+                    menuItem.setToolTipText(combatRole.getToolTipText());
+                    menuItem.setActionCommand(TOEMouseAdapter.COMMAND_CHANGE_ROLE_PREFERENCE +
+                                                    force.getId() +
+                                                    '|' +
+                                                    combatRole.name());
+                    menuItem.addActionListener(this);
+                    menuItem.setEnabled(true);
+                    menu.add(menuItem);
                 }
 
                 menuItem = new JMenuItem("Change Name...");

--- a/MekHQ/src/mekhq/gui/view/LanceAssignmentTableModel.java
+++ b/MekHQ/src/mekhq/gui/view/LanceAssignmentTableModel.java
@@ -117,6 +117,11 @@ class LanceAssignmentTableModel extends DataTableModel<CombatTeam> {
         } else if (col == COL_ROLE) {
             if (value instanceof CombatRole) {
                 data.get(row).setRole((CombatRole) value);
+                Force chosenForce = (Force) getValueAt(row, COL_FORCE);
+                chosenForce.setCombatRoleInMemory((CombatRole) value);
+                for (Force force : chosenForce.getSubForces()) {
+                    force.setCombatRoleInMemory((CombatRole) value);
+                }
             }
         }
         fireTableDataChanged();


### PR DESCRIPTION
This PR does the following:
- Combat Teams (and Forces) will remember their last assigned Combat Role.
- Combat Teams can have their Combat Role assigned in the TO&E
- When arriving at a contract all Combat Teams will be automatically assigned to their last Combat Role.
- Contract pay excludes Combat Teams assigned to non-combat roles. Your employer is paying for your combat forces, not your training battalion*. This is a double-down on the combat forces only considerations made earlier in the year.

*Cadre Duty is going to be updated in a follow-up PR.