### PR TITLE
Improvement: Updated StratCon Scenario Generation Tempo; Introduced Morale-Based Crisis Scenarios

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -95,6 +95,7 @@ public class Scenario implements IPlayerSettings {
     private String desc;
     private String report;
     private ScenarioStatus status;
+    private boolean isCrisis;
     private LocalDate date;
     private List<Integer> subForceIds;
     private List<UUID> unitIds;
@@ -168,6 +169,7 @@ public class Scenario implements IPlayerSettings {
         desc = "";
         report = "";
         setStatus(ScenarioStatus.CURRENT);
+        isCrisis = false;
         date = null;
         subForceIds = new ArrayList<>();
         unitIds = new ArrayList<>();
@@ -258,6 +260,14 @@ public class Scenario implements IPlayerSettings {
 
     public void setStatus(final ScenarioStatus status) {
         this.status = status;
+    }
+
+    public boolean isCrisis() {
+        return isCrisis;
+    }
+
+    public void setIsCrisis(final boolean isCrisis) {
+        this.isCrisis = isCrisis;
     }
 
     public @Nullable LocalDate getDate() {
@@ -946,6 +956,7 @@ public class Scenario implements IPlayerSettings {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingAnySEx", startingAnySEx);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "startingAnySEy", startingAnySEy);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "status", getStatus().name());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "isCrisis", isCrisis);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "id", id);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "linkedScenarioID", linkedScenarioID);
         if (null != stub) {
@@ -1075,6 +1086,8 @@ public class Scenario implements IPlayerSettings {
                     retVal.setStratConScenarioType(ScenarioType.parseFromString(wn2.getTextContent()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("status")) {
                     retVal.setStatus(ScenarioStatus.parseFromString(wn2.getTextContent().trim()));
+                } else if (wn2.getNodeName().equalsIgnoreCase("isCrisis")) {
+                    retVal.setIsCrisis(Boolean.parseBoolean(wn2.getTextContent().trim()));
                 } else if (wn2.getNodeName().equalsIgnoreCase("id")) {
                     retVal.id = Integer.parseInt(wn2.getTextContent());
                 } else if (wn2.getNodeName().equalsIgnoreCase("desc")) {

--- a/MekHQ/src/mekhq/campaign/mission/enums/AtBMoraleLevel.java
+++ b/MekHQ/src/mekhq/campaign/mission/enums/AtBMoraleLevel.java
@@ -42,17 +42,18 @@ import mekhq.MekHQ;
  */
 public enum AtBMoraleLevel {
     // region Enum Declarations
-    ROUTED(-3, "AtBMoraleLevel.ROUTED.text", "AtBMoraleLevel.ROUTED.toolTipText"),
-    CRITICAL(-2, "AtBMoraleLevel.CRITICAL.text", "AtBMoraleLevel.CRITICAL.toolTipText"),
-    WEAKENED(-1, "AtBMoraleLevel.WEAKENED.text", "AtBMoraleLevel.WEAKENED.toolTipText"),
-    STALEMATE(0, "AtBMoraleLevel.STALEMATE.text", "AtBMoraleLevel.STALEMATE.toolTipText"),
-    ADVANCING(1, "AtBMoraleLevel.ADVANCING.text", "AtBMoraleLevel.ADVANCING.toolTipText"),
-    DOMINATING(2, "AtBMoraleLevel.DOMINATING.text", "AtBMoraleLevel.DOMINATING.toolTipText"),
-    OVERWHELMING(3, "AtBMoraleLevel.OVERWHELMING.text", "AtBMoraleLevel.OVERWHELMING.toolTipText");
+    ROUTED(-3, 7, "AtBMoraleLevel.ROUTED.text", "AtBMoraleLevel.ROUTED.toolTipText"),
+    CRITICAL(-2, 6, "AtBMoraleLevel.CRITICAL.text", "AtBMoraleLevel.CRITICAL.toolTipText"),
+    WEAKENED(-1, 5, "AtBMoraleLevel.WEAKENED.text", "AtBMoraleLevel.WEAKENED.toolTipText"),
+    STALEMATE(0, 4, "AtBMoraleLevel.STALEMATE.text", "AtBMoraleLevel.STALEMATE.toolTipText"),
+    ADVANCING(1, 3, "AtBMoraleLevel.ADVANCING.text", "AtBMoraleLevel.ADVANCING.toolTipText"),
+    DOMINATING(2, 2, "AtBMoraleLevel.DOMINATING.text", "AtBMoraleLevel.DOMINATING.toolTipText"),
+    OVERWHELMING(3, 1, "AtBMoraleLevel.OVERWHELMING.text", "AtBMoraleLevel.OVERWHELMING.toolTipText");
     // endregion Enum Declarations
 
     // region Variable Declarations
     private final int level;
+    private final int crisisDieSize;
     private final String name;
     private final String toolTipText;
     // endregion Variable Declarations
@@ -60,15 +61,18 @@ public enum AtBMoraleLevel {
     /**
      * Initializes a new {@link AtBMoraleLevel} object with the specified name and tooltip text.
      *
-     * @param level       the severity of the morale level
-     * @param name        the resource key for the name of the Morale Level
-     * @param toolTipText the resource key for the tooltip text of the Morale Level
+     * @param level         the severity of the morale level
+     * @param crisisDieSize the number of sides on the die rolled to determine if a scenario is classified as a
+     *                      'crisis'
+     * @param name          the resource key for the name of the Morale Level
+     * @param toolTipText   the resource key for the tooltip text of the Morale Level
      */
     // region Constructors
-    AtBMoraleLevel(final int level, final String name, final String toolTipText) {
+    AtBMoraleLevel(final int level, final int crisisDieSize, final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("mekhq.resources.Mission",
               MekHQ.getMHQOptions().getLocale());
         this.level = level;
+        this.crisisDieSize = crisisDieSize;
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }
@@ -76,6 +80,10 @@ public enum AtBMoraleLevel {
 
     public int getLevel() {
         return level;
+    }
+
+    public int getCrisisDieSize() {
+        return crisisDieSize;
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/OutstandingScenariosNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/OutstandingScenariosNagLogic.java
@@ -111,7 +111,8 @@ public class OutstandingScenariosNagLogic {
 
                         // Determine if the scenario is special or a turning point
                         boolean isCrisis = backingScenario != null &&
-                                                 backingScenario.getStratConScenarioType().isSpecial();
+                                                 (backingScenario.getStratConScenarioType().isSpecial() ||
+                                                        backingScenario.isCrisis());
                         boolean isTurningPoint = stratconScenario.isTurningPoint();
 
                         // Define the addendum text based on StratCon scenario type

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/UnresolvedStratConContactsNagLogic.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/nagLogic/UnresolvedStratConContactsNagLogic.java
@@ -104,7 +104,8 @@ public class UnresolvedStratConContactsNagLogic {
 
                         // Determine if the scenario is special or a turning point
                         boolean isCrisis = backingScenario != null &&
-                                                 backingScenario.getStratConScenarioType().isSpecial();
+                                                 (backingScenario.getStratConScenarioType().isSpecial() ||
+                                                        backingScenario.isCrisis());
                         boolean isTurningPoint = scenario.isTurningPoint();
 
                         // Define the addendum text based on StratCon scenario type

--- a/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/ScenarioTableModel.java
@@ -137,7 +137,7 @@ public class ScenarioTableModel extends DataTableModel<Scenario> {
                 if (stratconScenario != null) {
                     // Determine attributes of the scenario
                     boolean isTurningPoint = stratconScenario.isTurningPoint();
-                    boolean isCrisis = scenario.getStratConScenarioType().isSpecial();
+                    boolean isCrisis = scenario.isCrisis() || scenario.getStratConScenarioType().isSpecial();
 
                     // Set the opening span color based on scenario type (Crisis or Turning Point)
                     String openingSpan = "";


### PR DESCRIPTION
A few months ago we updated StratCon's scenario generation tempo. The intention was to create situations where the player was encouraged to deploy half-repaired forces. To create the kinds of desperation moments we read about in the novels.

It worked for a grand total of one release. Afterwhich it became business as usual.

Why did it only have such a short spanned effectiveness? Simple: more scenarios means more salvage. More salvage means bigger player campaigns. Bigger campaigns can more readily handle the increased tempo, leading to more victories, leading to more salvage.

Once the playerbase became used to the updated tempo it acted as a force multiplier to their campaign economics. Essentially worsening the march towards the 'post-scarcity' phase of a campaign. Literally the opposite of what we've been trying to do these part months.

This PR comes in an makes two changes:
- Morale no longer affects scenario spawn changes (except for failed reinforcement attempts). This takes scenario generation back to its' pre-tempo update state.
- Instead Morale now influences the chance a scenario will spawn as a 'Crisis'.

Crisis scenarios were introduced earlier this year. A Crisis scenario acts like a Turning Point, in that losing the scenario reduces victory points by 1. However, unlike a Turning Point, Crisis scenarios do not award a Victory Point on victory. Essentially, this creates scenarios the player _has_ to complete.

Overall this should address balance in a few ways. By reducing scenario tempo we reduce salvage on the field. By creating 'you must do this' scenarios we increase the likelihood the player will need to do a scenario they would have otherwise skipped. Such as no salvage scenarios, or scenarios where they are out-gunned. Finally, it reduces the issue of players destroying entire regiments of stuff every contract. Now, scenarios will be fewer (and due to changes in 50.07, smaller).