### PR TITLE
Improvement: Adjusted Scenario Hex Bias

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
@@ -546,22 +546,22 @@ public class StratConContractInitializer {
     /**
      * Searches for a suitable, random unoccupied coordinate on the specified {@link StratConTrackState}.
      *
-     * <p>A coordinate is considered suitable based on the absence of any existing scenario, and depending
-     * on the input parameters, may also depend on the presence or absence of facilities, player forces, or an emphasis
-     * on strategic locations.</p>
+     * <p>A coordinate is considered suitable based on the absence of any existing scenario, and depending on the
+     * input parameters, may also depend on the presence or absence of facilities, player forces, or an emphasis on
+     * strategic locations.</p>
      *
      * <p>The method performs the following steps:</p>
      * <ol>
      *   <li>Iterates over all possible coordinates on the provided track.</li>
      *   <li>Filters the coordinates based on the following criteria:
      *     <ul>
-     *       <li>A coordinate is not occupied by a scenario.</li>
+     *       <li>A scenario does not occupy the coordinate.</li>
      *       <li>{@code allowPlayerFacilities = true}: Locations with facilities owned by the player
      *           are suitable and factored into the result.</li>
      *       <li>{@code allowPlayerForces = true}: Coordinates with forces assigned to them are also
      *           included in the result.</li>
      *       <li>{@code emphasizeStrategicTargets = true}: Strategic locations, such as those containing
-     *           facilities not owned by players, are given additional weight to increase their chance
+     *           facilities owned by players, are given additional weight to increase their chance
      *           of being selected.</li>
      *     </ul>
      *   </li>


### PR DESCRIPTION
A few months ago we added a bias to what hexes scenarios would spawn in, in StratCon. This PR does two things:

- Fix facility bias. We were biasing facilities _not_ allied to the player, when the intention was to bias towards _player_ facilities
- Adjusted the bias towards player forces. The original effect was too subtle.