### PR TITLE
Fix: Fixed Contracts Sending You Halfway Around the Inner Sphere Because Your Jump Captain is Scared of Empty Systems

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6252,7 +6252,9 @@ public class Campaign implements ITechManager {
                 String neighborId = neighborSystem.getId();
 
                 // Skip systems without population if avoiding empty systems
-                if (isAvoidingEmptySystems && neighborSystem.getPopulation(currentDay) == 0) {
+                if (!skipEmptySystemCheck
+                          && isAvoidingEmptySystems
+                          && neighborSystem.getPopulation(currentDay) == 0) {
                     return;
                 }
 

--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -473,7 +473,7 @@ public class Contract extends Mission {
         if ((getCachedJumpPath() == null) || getCachedJumpPath().isEmpty()
                   || !getCachedJumpPath().getFirstSystem().equals(c.getCurrentSystem())
                   || !getCachedJumpPath().getLastSystem().equals(getSystem())) {
-            setCachedJumpPath(c.calculateJumpPath(c.getCurrentSystem(), getSystem(), true, true));
+            setCachedJumpPath(c.calculateJumpPath(c.getCurrentSystem(), getSystem()));
         }
 
         return getCachedJumpPath();


### PR DESCRIPTION
This fixes an issue where we were calculating contract market Jump Paths with a mind towards avoiding systems the player is outlawed in and empty systems. This created some very inflated transport clauses in contracts. As well as being a bit odd.