### PR TITLE
Task: Removed Campaign Archive from Build

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -232,7 +232,7 @@ tasks.register('stageFiles', Copy) {
     dependsOn copyLicenseFiles
 
     from projectDir
-    include "campaigns/"
+    include "campaigns/The Learning Ropes.cpnx.gz"
     include "data/**"
     include "docs/**"
     include "mmconf/**"


### PR DESCRIPTION
`campaigns/**` includes an archive of very old (circa 47.15) campaign files. These campaigns were prebuilt using FASA scenario packs. They were meant to show off mhq's capacity to manage campaigns.

Over the years support for these campaigns waned as mhq increasingly became a vehicle for single player campaigns. The campaigns themselves stopped being updated and became very buggy as a result.

Earlier in the year we made the decision (with Hammer's blessing) to archive those campaigns. The idea was to preserve them for legacy's sake. However, we are finding that players are still trying to run campaigns using these files. Those players are then running into issues - some obvious, some _really_ odd - and looking for support.

As these campaigns are no longer supported this PR blocks them from being included in builds of MekHQ moving forward. They will still be retained in the repo.