### PR TITLE
Fix #7897: Fixed Legendary MekWarriors Not Counting Towards CamOps Reputation

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
@@ -155,11 +155,8 @@ public class AverageExperienceRating {
             }
 
             // if both primary and secondary roles are support roles, skip this person as they are also not
-            // considered combat personnel. Combat Technicians need special handling as they're technically a Combat
-            // Role not Support
-            boolean isDedicatedCombatTechnician = person.getPrimaryRole().isCombatTechnician() &&
-                                                        person.getSecondaryRole().isCombatTechnician();
-            if (isDedicatedCombatTechnician || person.isSupport()) {
+            // considered combat personnel.
+            if (person.isSupport()) {
                 continue;
             }
 


### PR DESCRIPTION
Fix #7897

This came about from a very early misunderstanding of the rules when translating mhq to CamOps. The original interpretation was that we should be comparing total skill level. However, skill levels are an ATOW thing, not TW. CamOps expected us to be comparing skill _target numbers_.

Under the original interpretation a total skill level of `0` would mean the character had no skill whatsoever. As opposed to `0+` meaning the character is the most skilled thing ever.

As we were still checking if the experience score was `>0` any legendary characters were being incorrectly treated as if they were completely unskilled.

This only affected MekWarriors. Proof that 'Meks really aren't the 'kings of the battlefield.'

As a secondary fix I also made sure to include a special handler for Combat Technicians, as they were being incorrectly included in the calculations. It's possible they were being excluded elsewhere - and I think they were - but a little insurance never hurt and adding a single conditional clause isn't going to hurt anyone.