### PR TITLE
Fix #7896: Fixed Copy-Paste Error Breaking Artillery Skill Enabled Campaigns

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4800,7 +4800,7 @@ public class Person {
                                                        EXP_NONE :
                                                        gunnery.getExperienceLevel(skillModifierData);
                     Skill artillery = getSkill(S_ARTILLERY);
-                    int artilleryExperienceLevel = gunnery == null ?
+                    int artilleryExperienceLevel = artillery == null ?
                                                          EXP_NONE :
                                                          artillery.getExperienceLevel(skillModifierData);
 


### PR DESCRIPTION
Fix #7896 

This was caused by me incorrectly checking whether `gunnery` was `null`, when I should have been checking for the `null` state of `artillery`.