### PR TITLE
Improvement: Reduced User Confusion by Removing Combat Teams Line from Contract Summary

### DIFF
--- a/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
+++ b/MekHQ/src/mekhq/gui/view/ContractSummaryPanel.java
@@ -558,16 +558,6 @@ public class ContractSummaryPanel extends JPanel {
         mainPanel.add(txtBattleLossComp, gridBagConstraintsText);
 
         if (contract instanceof AtBContract) {
-            JLabel lblRequiredLances = new JLabel(resourceMap.getString("lblRequiredLances.text"));
-            lblRequiredLances.setName("lblRequiredLances");
-            gridBagConstraintsLabels.gridy = ++y;
-            mainPanel.add(lblRequiredLances, gridBagConstraintsLabels);
-
-            JLabel txtRequiredLances = new JLabel(String.valueOf(((AtBContract) contract).getRequiredCombatTeams()));
-            txtRequiredLances.setName("txtRequiredLances");
-            gridBagConstraintsText.gridy = y;
-            mainPanel.add(txtRequiredLances, gridBagConstraintsText);
-
             JLabel lblRequiredCombatElements = new JLabel(resourceMap.getString("lblRequiredCombatElements.text"));
             lblRequiredCombatElements.setName("lblRequiredCombatElements");
             gridBagConstraintsLabels.gridy = ++y;


### PR DESCRIPTION
As Combat Teams is an internal value only relevant to StratCon and not something users generally need to worry about, I went ahead and removed it from the Contract Market summary panel. Now only elements is displayed.