### PR TITLE
Fix #7865: Fixed Unit History Appearing Over Other Panels in Unit View

### DIFF
--- a/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/UnitViewPanel.java
@@ -145,6 +145,7 @@ public class UnitViewPanel extends JScrollablePanel {
         gridBagConstraints.fill = GridBagConstraints.BOTH;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
         add(pnlStats, gridBagConstraints);
+        y++;
 
         pnlCrew.setName("pnlCrew");
         pnlCrew.setLayout(new BorderLayout());


### PR DESCRIPTION
Fix #7865 

just duplicated `y` axis arrangement to blame. While I was at it I also moved Unit History slightly so that it's more prominent. I figured players who were using Unit History probably don't want it buried beneath everything else.