### PR TITLE
Fix #7811: Fixed null GUI Being Passed Into Custom Scenario Loot Picker

### DIFF
--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -743,7 +743,7 @@ public final class BriefingTab extends CampaignGuiTab {
             return;
         }
 
-        CustomizeScenarioDialog csd = new CustomizeScenarioDialog(getFrame(), true, null, mission, getCampaign());
+        CustomizeScenarioDialog csd = new CustomizeScenarioDialog(getFrame(), true, null, mission, getCampaignGui());
         csd.setVisible(true);
         // need to update the scenario table and refresh the scroll view
         refreshScenarioTableData();

--- a/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/ScenarioTableMouseAdapter.java
@@ -116,7 +116,7 @@ public class ScenarioTableMouseAdapter extends JPopupMenuAdapter {
         Mission mission = gui.getCampaign().getMission(scenario.getMissionId());
         if (mission != null) {
             CustomizeScenarioDialog csd = new CustomizeScenarioDialog(gui.getFrame(), true,
-                  scenario, mission, gui.getCampaign());
+                  scenario, mission, gui);
             csd.setVisible(true);
             MekHQ.triggerEvent(new ScenarioChangedEvent(scenario));
         }

--- a/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeScenarioDialog.java
@@ -66,6 +66,7 @@ import mekhq.campaign.mission.*;
 import mekhq.campaign.mission.atb.AtBScenarioModifier;
 import mekhq.campaign.mission.atb.AtBScenarioModifier.EventTiming;
 import mekhq.campaign.mission.enums.ScenarioStatus;
+import mekhq.gui.CampaignGUI;
 import mekhq.gui.FileDialogs;
 import mekhq.gui.model.BotForceTableModel;
 import mekhq.gui.model.LootTableModel;
@@ -161,7 +162,7 @@ public class CustomizeScenarioDialog extends JDialog {
     private MarkdownEditorPanel txtReport;
     // endregion Variable declarations
 
-    public CustomizeScenarioDialog(JFrame parent, boolean modal, Scenario s, Mission m, Campaign c) {
+    public CustomizeScenarioDialog(JFrame parent, boolean modal, Scenario s, Mission m, CampaignGUI gui) {
         super(parent, modal);
         this.frame = parent;
         this.mission = m;
@@ -172,7 +173,7 @@ public class CustomizeScenarioDialog extends JDialog {
             scenario = s;
             newScenario = false;
         }
-        campaign = c;
+        campaign = gui.getCampaign();
         if (scenario.getDate() == null) {
             scenario.setDate(campaign.getLocalDate());
         }
@@ -210,13 +211,13 @@ public class CustomizeScenarioDialog extends JDialog {
         usingFixedMap = scenario.isUsingFixedMap();
         boardType = scenario.getBoardType();
 
-        initComponents();
+        initComponents(gui);
         setLocationRelativeTo(parent);
         setUserPreferences();
         pack();
     }
 
-    private void initComponents() {
+    private void initComponents(CampaignGUI gui) {
         getContentPane().setLayout(new BorderLayout());
         final ResourceBundle resourceMap = ResourceBundle.getBundle("mekhq.resources.CustomizeScenarioDialog",
               MekHQ.getMHQOptions().getLocale());
@@ -350,7 +351,7 @@ public class CustomizeScenarioDialog extends JDialog {
         panObjectives.setBorder(BorderFactory.createCompoundBorder(BorderFactory.createTitledBorder(resourceMap.getString(
               "panObjectives.title")), BorderFactory.createEmptyBorder(5, 5, 5, 5)));
 
-        initLootPanel(resourceMap);
+        initLootPanel(resourceMap, gui);
         panLoot.setPreferredSize(new Dimension(400, 150));
         panLoot.setMinimumSize(new Dimension(400, 150));
         panLoot.setBorder(BorderFactory.createCompoundBorder(BorderFactory.createTitledBorder(resourceMap.getString(
@@ -997,18 +998,18 @@ public class CustomizeScenarioDialog extends JDialog {
         }
     }
 
-    private void initLootPanel(ResourceBundle resourceMap) {
+    private void initLootPanel(ResourceBundle resourceMap, CampaignGUI gui) {
         panLoot = new JPanel(new BorderLayout());
 
         JPanel panButtons = new JPanel(new GridLayout(1, 0));
         JButton btnAddLoot = new JButton(resourceMap.getString("btnAddLoot.text"));
-        btnAddLoot.addActionListener(evt -> addLoot());
+        btnAddLoot.addActionListener(evt -> addLoot(gui));
         btnAddLoot.setEnabled(scenario.getStatus().isCurrent());
         panButtons.add(btnAddLoot);
 
         btnEditLoot = new JButton(resourceMap.getString("btnEditLoot.text"));
         btnEditLoot.setEnabled(false);
-        btnEditLoot.addActionListener(evt -> editLoot());
+        btnEditLoot.addActionListener(evt -> editLoot(gui));
         panButtons.add(btnEditLoot);
 
         btnDeleteLoot = new JButton(resourceMap.getString("btnDeleteLoot.text"));
@@ -1038,8 +1039,8 @@ public class CustomizeScenarioDialog extends JDialog {
         btnEditLoot.setEnabled(row != -1);
     }
 
-    private void addLoot() {
-        LootDialog lootDialog = new LootDialog(frame, true, new Loot(), campaign);
+    private void addLoot(CampaignGUI gui) {
+        LootDialog lootDialog = new LootDialog(frame, true, new Loot(), gui);
         lootDialog.setVisible(true);
         if (null != lootDialog.getLoot()) {
             lootModel.addLoot(lootDialog.getLoot());
@@ -1047,10 +1048,10 @@ public class CustomizeScenarioDialog extends JDialog {
         refreshLootTable();
     }
 
-    private void editLoot() {
+    private void editLoot(CampaignGUI gui) {
         Loot loot = lootModel.getLootAt(lootTable.getSelectedRow());
         if (null != loot) {
-            LootDialog lootDialog = new LootDialog(frame, true, loot, campaign);
+            LootDialog lootDialog = new LootDialog(frame, true, loot, gui);
             lootDialog.setVisible(true);
             refreshLootTable();
         }

--- a/MekHQ/src/mekhq/gui/dialog/LootDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/LootDialog.java
@@ -52,6 +52,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.mission.Loot;
 import mekhq.campaign.parts.Part;
+import mekhq.gui.CampaignGUI;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
 
 /**
@@ -77,23 +78,22 @@ public class LootDialog extends JDialog {
     private JScrollPane scrParts;
 
     /** Creates new LootDialog form */
-    public LootDialog(JFrame parent, boolean modal, Loot l, Campaign c) {
+    public LootDialog(JFrame parent, boolean modal, Loot l, CampaignGUI gui) {
         super(parent, modal);
         this.frame = parent;
         this.loot = l;
-        this.campaign = c;
+        this.campaign = gui.getCampaign();
         cancelled = true;
         units = new ArrayList<>();
         parts = new ArrayList<>();
         units.addAll(l.getUnits());
         parts.addAll(l.getParts());
-        initComponents();
+        initComponents(gui);
         setLocationRelativeTo(parent);
         setUserPreferences();
     }
 
-    private void initComponents() {
-
+    private void initComponents(CampaignGUI gui) {
         txtName = new JTextField();
         JButton btnOK = new JButton("Done");
         JButton btnCancel = new JButton("Cancel");
@@ -205,7 +205,7 @@ public class LootDialog extends JDialog {
         gridBagConstraints.insets = new Insets(5, 5, 5, 5);
         getContentPane().add(new JLabel("Parts"), gridBagConstraints);
 
-        btnAddPart.addActionListener(evt -> addPart());
+        btnAddPart.addActionListener(evt -> addPart(gui));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 4;
@@ -302,8 +302,8 @@ public class LootDialog extends JDialog {
         refreshUnitList();
     }
 
-    private void addPart() {
-        PartsStoreDialog psd = new PartsStoreDialog(frame, true, null, campaign, false);
+    private void addPart(CampaignGUI gui) {
+        PartsStoreDialog psd = new PartsStoreDialog(frame, true, gui, campaign, false);
         psd.setVisible(true);
         Part p = psd.getPart();
         if (null != p) {

--- a/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsStoreDialog.java
@@ -53,6 +53,7 @@ import megamek.common.enums.TechBase;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.WeaponType;
 import megamek.common.rolls.TargetRoll;
+import megamek.common.ui.FastJScrollPane;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -74,7 +75,6 @@ import mekhq.gui.CampaignGUI;
 import mekhq.gui.model.PartsStoreModel;
 import mekhq.gui.model.PartsStoreModel.PartProxy;
 import mekhq.gui.sorter.PartsDetailSorter;
-import mekhq.gui.utilities.JScrollPaneWithSpeed;
 
 /**
  * @author Taharqa
@@ -155,7 +155,7 @@ public class PartsStoreDialog extends JDialog {
         }
         partsTable.setIntercellSpacing(new Dimension(0, 0));
         partsTable.setShowGrid(false);
-        JScrollPane scrollPartsTable = new JScrollPaneWithSpeed();
+        JScrollPane scrollPartsTable = new FastJScrollPane();
         scrollPartsTable.setName("scrollPartsTable");
         scrollPartsTable.setViewportView(partsTable);
         getContentPane().add(scrollPartsTable, BorderLayout.CENTER);


### PR DESCRIPTION
Fix #7811

This was being caused by us passing in a `null` value somewhere we really shouldn't have.