### PR TITLE
Fix: Allowed Training Forces to Function When Using Mapless Mode

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/TrainingCombatTeams.java
@@ -129,8 +129,10 @@ public class TrainingCombatTeams {
             StratConCampaignState campaignState = contract.getStratconCampaignState();
             boolean isForceDeployed = campaignState != null &&
                                             campaignState.isForceDeployedHere(combatTeam.getForceId());
-            if (!isUsingStratCon || (!isUsingMaplessMode && !isForceDeployed)) {
-                continue;
+            if (isUsingStratCon) {
+                if (!isUsingMaplessMode && !isForceDeployed) {
+                    continue;
+                }
             }
 
             Force force = combatTeam.getForce(campaign);


### PR DESCRIPTION
Training Forces were not awarding Training progression while using Mapless mode. This PR fixes that.