### PR TITLE
Fix #7907: Fixed Race Condition When Loading Campaign

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -466,20 +466,11 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
         LOGGER.info("[Campaign Load] Rank references fixed in {}ms", System.currentTimeMillis() - timestamp);
         timestamp = System.currentTimeMillis();
 
-        // First we need to set the campaign reference in all units
+        // Okay, Units, need their pilot references fixed.
         campaign.getHangar().forEachUnit(unit -> {
+            // Also, the unit should have its campaign set.
             unit.setCampaign(campaign);
             unit.fixReferences(campaign);
-        });
-
-        // Then we need to parse everything to fix references and make sure the unit is validated.
-        // The double-parsing of hangar contents is essential to avoid a race condition where we start validating
-        // units before the campaign and personnel references have finished being set.
-        campaign.getHangar().forEachUnit(unit -> {
-            List<String> reports = unit.checkForOverCrewing();
-            for (String report : reports) {
-                campaign.addReport(report);
-            }
 
             // reset the pilot and entity, to reflect newly assigned personnel
             unit.resetPilotAndEntity();
@@ -569,6 +560,11 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 } else {
                     unit.setSalvage(true);
                 }
+            }
+
+            List<String> reports = unit.checkForOverCrewing();
+            for (String report : reports) {
+                campaign.addReport(report);
             }
         });
 


### PR DESCRIPTION
Fix #7907

We were running into issues when checking for overcrewing, because we were trying to validate crew before all references had be finished being assigned.