### PR TITLE
Improvement: Changed 'Combat Technician' Profession to 'Support'

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -87,7 +87,7 @@ public enum PersonnelRole {
 
     // ATOW: Battlefield Tech Archetype (but with the reduced Dexterity removed, as that's a Linked Attribute for the
     // Technician skill)
-    COMBAT_TECHNICIAN(PersonnelRoleSubType.COMBAT, KeyEvent.VK_UNDEFINED, 5, 4, 5, 3, 5, 4, 3),
+    COMBAT_TECHNICIAN(PersonnelRoleSubType.SUPPORT, KeyEvent.VK_UNDEFINED, 5, 4, 5, 3, 5, 4, 3),
 
     // ATOW: Tanker Archetype
     VEHICLE_CREW_GROUND(PersonnelRoleSubType.COMBAT, KeyEvent.VK_UNDEFINED, 5, 4, 5, 3, 5, 4, 3),


### PR DESCRIPTION
Previously we were classifying 'Combat Technicians' as a 'Combat' profession. This makes sense, given the title of the profession. However, while resolving #7898 I have swiftly come to the conclusion that having what is a special case support profession is going to cause us a lot of pain in the long run. Essentially, any time we'd want to check whether a character was support or combat we'd have to add a special clause to check whether they're actually a Combat Technician.

For the sake of our future sanities, this PR makes it so that Combat Technicians are a support role, like all the other technical professions.