### PR TITLE
Improvement #7924: MASH Theater & Field Kitchen Capacities Are Now Bypassed if Campaign is Not Planetside While On Contract

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1726,6 +1726,12 @@ public class Campaign implements ITechManager {
         return location;
     }
 
+    public boolean isOnContractAndPlanetside() {
+        boolean isOnContract = !getActiveMissions(false).isEmpty();
+        boolean isPlanetside = location.isOnPlanet();
+        return isPlanetside && isOnContract;
+    }
+
     public List<String> getTurnoverRetirementInformation() {
         return turnoverRetirementInformation;
     }

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -564,7 +564,11 @@ public class CampaignNewDayManager {
                 person.resetCurrentEdge();
 
                 if (!person.getStatus().isMIA()) {
-                    processFatigueRecovery(campaign, person, campaign.getFieldKitchenWithinCapacity());
+                    boolean isOnContract = !campaign.getActiveMissions(false).isEmpty();
+                    boolean isPlanetside = campaign.getLocation().isOnPlanet();
+                    boolean isOnContractAndPlanetside = isPlanetside && isOnContract;
+                    boolean isWithinCapacity = !isOnContractAndPlanetside || campaign.getFieldKitchenWithinCapacity();
+                    processFatigueRecovery(campaign, person, isWithinCapacity);
                 }
 
                 processCompulsionsAndMadness(person, personnelOptions, isUseAdvancedMedical, isUseFatigue);
@@ -925,7 +929,7 @@ public class CampaignNewDayManager {
         if (MekHQ.getMHQOptions().getSelfCorrectMaintenance()) {
             Maintenance.checkAndCorrectMaintenanceSchedule(campaign);
         }
-        
+
         // need to loop through units twice, the first time to do all maintenance and
         // the second time to do whatever else. Otherwise, maintenance minutes might
         // get sucked up by other stuff. campaign is also a good place to ensure that a

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -564,10 +564,8 @@ public class CampaignNewDayManager {
                 person.resetCurrentEdge();
 
                 if (!person.getStatus().isMIA()) {
-                    boolean isOnContract = !campaign.getActiveMissions(false).isEmpty();
-                    boolean isPlanetside = campaign.getLocation().isOnPlanet();
-                    boolean isOnContractAndPlanetside = isPlanetside && isOnContract;
-                    boolean isWithinCapacity = !isOnContractAndPlanetside || campaign.getFieldKitchenWithinCapacity();
+                    boolean isWithinCapacity = !campaign.isOnContractAndPlanetside() ||
+                                                     campaign.getFieldKitchenWithinCapacity();
                     processFatigueRecovery(campaign, person, isWithinCapacity);
                 }
 

--- a/MekHQ/src/mekhq/campaign/OptimizeInfirmaryAssignments.java
+++ b/MekHQ/src/mekhq/campaign/OptimizeInfirmaryAssignments.java
@@ -94,7 +94,15 @@ public class OptimizeInfirmaryAssignments {
         organizePatients();
 
         // Assign doctors to patients
-        assignDoctors(isDoctorsUseAdministration, maximumPatients, healingWaitingPeriod, patients, doctors);
+        boolean isOnContract = !campaign.getActiveMissions(false).isEmpty();
+        boolean isPlanetside = campaign.getLocation().isOnPlanet();
+        boolean isOnContractAndPlanetside = isPlanetside && isOnContract;
+        assignDoctors(isDoctorsUseAdministration,
+              maximumPatients,
+              healingWaitingPeriod,
+              patients,
+              doctors,
+              isOnContractAndPlanetside);
     }
 
     /**
@@ -116,9 +124,12 @@ public class OptimizeInfirmaryAssignments {
      *                                   cannot be assigned due to insufficient doctor capacity remain unassigned.
      * @param doctors                    The list of available doctors, ordered by priority (e.g., experience level or
      *                                   suitability). Doctors higher on the list are assigned first.
+     * @param isOnContractAndPlanetside  {@code true} if the campaign has an active mission and is planetside (i.e., not
+     *                                   in transit).
      */
     private void assignDoctors(final boolean isDoctorsUseAdministration, final int maximumPatients,
-          final int healingWaitingPeriod, final List<Person> patients, List<Person> doctors) {
+          final int healingWaitingPeriod, final List<Person> patients, List<Person> doctors,
+          final boolean isOnContractAndPlanetside) {
         boolean useMASHTheatres = campaign.getCampaignOptions().isUseMASHTheatres();
         int mashTheatreCapacity = useMASHTheatres ? campaign.getMashTheatreCapacity() : Integer.MAX_VALUE;
 
@@ -134,7 +145,7 @@ public class OptimizeInfirmaryAssignments {
                 continue;
             }
 
-            if (useMASHTheatres && totalPatientCounter >= mashTheatreCapacity) {
+            if (isOnContractAndPlanetside && useMASHTheatres && totalPatientCounter >= mashTheatreCapacity) {
                 // Similar to the above, we're just unassigning doctors for any remaining patients.
                 continue;
             }

--- a/MekHQ/src/mekhq/campaign/OptimizeInfirmaryAssignments.java
+++ b/MekHQ/src/mekhq/campaign/OptimizeInfirmaryAssignments.java
@@ -94,15 +94,12 @@ public class OptimizeInfirmaryAssignments {
         organizePatients();
 
         // Assign doctors to patients
-        boolean isOnContract = !campaign.getActiveMissions(false).isEmpty();
-        boolean isPlanetside = campaign.getLocation().isOnPlanet();
-        boolean isOnContractAndPlanetside = isPlanetside && isOnContract;
         assignDoctors(isDoctorsUseAdministration,
               maximumPatients,
               healingWaitingPeriod,
               patients,
               doctors,
-              isOnContractAndPlanetside);
+              campaign.isOnContractAndPlanetside());
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/InfirmaryTab.java
+++ b/MekHQ/src/mekhq/gui/InfirmaryTab.java
@@ -434,10 +434,7 @@ public final class InfirmaryTab extends CampaignGuiTab {
             final int mashTheatreCapacity = getCampaign().getMashTheatreCapacity();
             final int patientsAssignedToDoctors = getCampaign().getPatientsAssignedToDoctors().size();
 
-            boolean isOnContract = !getCampaign().getActiveMissions(false).isEmpty();
-            boolean isPlanetside = getCampaign().getLocation().isOnPlanet();
-            boolean isOnContractAndPlanetside = isPlanetside && isOnContract;
-            if (isOnContractAndPlanetside) {
+            if (getCampaign().isOnContractAndPlanetside()) {
                 isWithinTheatreCapacity = mashTheatreCapacity > patientsAssignedToDoctors;
             } else {
                 isWithinTheatreCapacity = true;

--- a/MekHQ/src/mekhq/gui/InfirmaryTab.java
+++ b/MekHQ/src/mekhq/gui/InfirmaryTab.java
@@ -433,7 +433,15 @@ public final class InfirmaryTab extends CampaignGuiTab {
         if (useMASHTheatres) {
             final int mashTheatreCapacity = getCampaign().getMashTheatreCapacity();
             final int patientsAssignedToDoctors = getCampaign().getPatientsAssignedToDoctors().size();
-            isWithinTheatreCapacity = mashTheatreCapacity > patientsAssignedToDoctors;
+
+            boolean isOnContract = !getCampaign().getActiveMissions(false).isEmpty();
+            boolean isPlanetside = getCampaign().getLocation().isOnPlanet();
+            boolean isOnContractAndPlanetside = isPlanetside && isOnContract;
+            if (isOnContractAndPlanetside) {
+                isWithinTheatreCapacity = mashTheatreCapacity > patientsAssignedToDoctors;
+            } else {
+                isWithinTheatreCapacity = true;
+            }
         }
 
         return isWithinDoctorCapacity && isWithinTheatreCapacity;

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -113,10 +113,7 @@ public class NagController {
 
         // Untreated personnel
         boolean isUseMASHTheatres = campaignOptions.isUseMASHTheatres();
-        boolean isOnContract = !campaign.getActiveMissions(false).isEmpty();
-        boolean isPlanetside = campaign.getLocation().isOnPlanet();
-        boolean isOnContractAndPlanetside = isPlanetside && isOnContract;
-        int mashTheatreCapacity = isUseMASHTheatres && isOnContractAndPlanetside ?
+        int mashTheatreCapacity = isUseMASHTheatres && campaign.isOnContractAndPlanetside() ?
                                         campaign.getMashTheatreCapacity() :
                                         Integer.MAX_VALUE;
         if (UntreatedPersonnelNagDialog.checkNag(activePersonnel,

--- a/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
+++ b/MekHQ/src/mekhq/gui/dialog/nagDialogs/NagController.java
@@ -113,7 +113,12 @@ public class NagController {
 
         // Untreated personnel
         boolean isUseMASHTheatres = campaignOptions.isUseMASHTheatres();
-        int mashTheatreCapacity = isUseMASHTheatres ? campaign.getMashTheatreCapacity() : Integer.MAX_VALUE;
+        boolean isOnContract = !campaign.getActiveMissions(false).isEmpty();
+        boolean isPlanetside = campaign.getLocation().isOnPlanet();
+        boolean isOnContractAndPlanetside = isPlanetside && isOnContract;
+        int mashTheatreCapacity = isUseMASHTheatres && isOnContractAndPlanetside ?
+                                        campaign.getMashTheatreCapacity() :
+                                        Integer.MAX_VALUE;
         if (UntreatedPersonnelNagDialog.checkNag(activePersonnel,
               doctorCapacity,
               isDoctorsUseAdministration,


### PR DESCRIPTION
Close #7924

While the campaign is off-contract, or in transit, Field Kitchen and MASH Theater capacities are ignored. That is to say the campaign is considered to be fully catered for by either their barrack housing or shipboard facilities.

This avoids a frustrating experience where players using the automothballing feature (when accepting a contract) find themselves unable to heal personnel mid-transit.