### PR TITLE
Fix #7920: Fixed Large Vessels Incorrectly Spawning with a Maintenance Multiplier Higher Than x1

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1854,7 +1854,9 @@ public class Campaign implements ITechManager {
         unit.getEntity().setOwner(player);
         unit.getEntity().setGame(game);
         unit.getEntity().setExternalIdAsString(unit.getId().toString());
-        unit.setMaintenanceMultiplier(getCampaignOptions().getDefaultMaintenanceTime());
+        if (!unit.isSelfCrewed()) {
+            unit.setMaintenanceMultiplier(getCampaignOptions().getDefaultMaintenanceTime());
+        }
 
         // now lets grab the parts from the test unit and set them up with this unit
         for (Part p : testUnit.getParts()) {
@@ -1905,7 +1907,9 @@ public class Campaign implements ITechManager {
      */
     public Unit addNewUnit(Entity en, boolean allowNewPilots, int days, PartQuality quality) {
         Unit unit = new Unit(en, this);
-        unit.setMaintenanceMultiplier(getCampaignOptions().getDefaultMaintenanceTime());
+        if (!unit.isSelfCrewed()) {
+            unit.setMaintenanceMultiplier(getCampaignOptions().getDefaultMaintenanceTime());
+        }
         getHangar().addUnit(unit);
 
         // reset the game object


### PR DESCRIPTION
Fix #7920

This adds additional safeguards to ensure that self-crewed units don't have a maintenance multiplier. If they do, they become unable to be maintained.

Logged as 'medium' as this is setup to self-correct on load.