### PR TITLE
Issue #7751: Match Destroyed Ammo Bins

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/cleanup/ExactMatchStep.java
+++ b/MekHQ/src/mekhq/campaign/unit/cleanup/ExactMatchStep.java
@@ -32,8 +32,11 @@
  */
 package mekhq.campaign.unit.cleanup;
 
+import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.Mounted;
+import mekhq.campaign.parts.equipment.AmmoBin;
 import mekhq.campaign.parts.equipment.EquipmentPart;
+import mekhq.campaign.parts.equipment.MissingAmmoBin;
 import mekhq.campaign.parts.equipment.MissingEquipmentPart;
 
 public class ExactMatchStep extends UnscrambleStep {
@@ -48,8 +51,16 @@ public class ExactMatchStep extends UnscrambleStep {
     @Override
     public void visit(final EquipmentProposal proposal, final MissingEquipmentPart part) {
         final Mounted<?> mount = proposal.getEquipment(part.getEquipmentNum());
-        if ((mount != null) && part.getType().equals(mount.getType())) {
+        if (mount == null) {
+            return;
+        }
+        if (part.getType().equals(mount.getType())) {
             proposal.proposeMapping(part, part.getEquipmentNum());
+        }
+
+        if (part instanceof MissingAmmoBin missingAmmoBin &&
+                  ((AmmoBin) missingAmmoBin.getReplacementPart()).canChangeMunitions((AmmoType) mount.getType())) {
+            proposal.proposeMapping(missingAmmoBin, part.getEquipmentNum());
         }
     }
 }


### PR DESCRIPTION
Fixes #7751

Also fixes the issue described in this comment: https://github.com/MegaMek/mekhq/issues/7812#issuecomment-3439941630

The interesting twist is that the steps described in the comment on 7812 had a Mek that was still functional before being saved. But once saved and loaded, it was unable to associate the `MissingAmmoBin`s with the Entity's `AmmoMounted`.

I couldn't track down what initially caused this, which has me a little concerned. I couldn't find how the entity's ammo parts would be updated to reflect that the ammo type they had prior to their destruction. Anyway, tested and everything seems to be normal with the unit & entity after loading. 