### PR TITLE
Fix: Fixed 'Recoverable' Toggle Always Being Disabled on Exchange Contracts

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/ResolveScenarioWizardDialog.java
@@ -1782,7 +1782,7 @@ public class ResolveScenarioWizardDialog extends JDialog {
                 escaped.setSelected(false);
                 escaped.setEnabled(false);
             } else {
-                salvaged.setEnabled(!tracker.usesSalvageExchange());
+                salvaged.setEnabled(!tracker.usesSalvageExchange() || isUseCamOpsSalvage);
                 sold.setEnabled(!tracker.usesSalvageExchange() &&
                                       tracker.getCampaign().getCampaignOptions().isSellUnits());
                 escaped.setEnabled(true);


### PR DESCRIPTION
A simple fix for a simple problem. The player was unable to override whether a unit escaped or is recoverable if the contract was Exchange.