### PR TITLE
Fix #7942: Fixed Inability to Assign Vehicle Gunners from Personnel Tab

### DIFF
--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -154,6 +154,8 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                                                                   .isAerospaceGrouping() ||
                                                                                   person.getSecondaryRole()
                                                                                         .isAerospaceGrouping());
+            final boolean areAllGroundCrew = Stream.of(people)
+                                                   .allMatch(person -> person.hasRole(PersonnelRole.VEHICLE_CREW_GROUND));
             final boolean areAllVTOLCrew = Stream.of(people)
                                                  .allMatch(person -> person.hasRole(PersonnelRole.VEHICLE_CREW_VTOL));
             final boolean areAllVesselPilots = Stream.of(people)
@@ -371,7 +373,7 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                         } else if (entity.getMovementMode().isMarine()) {
                             valid = areAllNavalVehicleCrew;
                         } else {
-                            valid = areAllVehicleCrew;
+                            valid = areAllGroundCrew;
                         }
                     } else if (entity instanceof ConvFighter) {
                         valid = areAllConventionalAircraftPilots;


### PR DESCRIPTION
Fix #7942

We were incorrectly checking all personnel were support vehicle crew, and not Vehicle Crew/Ground