### PR TITLE
Improvement: Decreased Odds a Veterancy Award Will Be Negative, From 12.5% to 2%.

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -2084,7 +2084,7 @@ lblComingOfAgePanel.text=Coming of Age & Veterancy
 lblVeterancySPAs.text=Award Veterancy Awards \u2714 <span style="color:#C344C3;">\u2605</span>
 lblVeterancySPAs.tooltip=If checked, a character will receive an SPA or Flaw upon reaching Veteran in their \
   primary profession. These rewards ignore skill requirements, allowing characters to get SPAs they might otherwise be\
-  \ ineligible for. Characters are three times more likely to receive an SPA than a Flaw.\
+  \ ineligible for. Characters have a 1-in-40 chance of getting a Flaw instead of an SPA. Some Flaws can be career ending.\
   <br>\
   <br><b>Recommendation:</b> This was balanced around the inclusion of Flaws and ATOW SPAs. If you are working with a \
   smaller SPA pool due to disabling those SPAs or have Flaws disabled, you might want to leave this off.

--- a/MekHQ/resources/mekhq/resources/VeterancyAwardsCampaignOptionsChangedConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/VeterancyAwardsCampaignOptionsChangedConfirmationDialog.properties
@@ -5,6 +5,6 @@ VeterancyAwards.description=You have just enabled <b>Veterancy Awards</b> in a c
   Normally characters recruited at Veteran rank, or better, are ineligible for veterancy awards. This restriction \
   will be waived in this instance.</p>\
   <p>{0}<b>Warning</b>{1}: This process {0}<b>cannot be reversed</b>{1}. Not all Veterancy Awards are positive. Each \
-  character has a <b>1-in-40</b> chance of getting a Flaw, instead of an SPA. Some Flaws are <b>career ending</b>
+  character has a <b>1-in-40</b> chance of getting a Flaw, instead of an SPA. Some Flaws are <b>career ending</b>.
 VeterancyAwards.button.confirm=Confirm
 VeterancyAwards.button.cancel=Cancel

--- a/MekHQ/resources/mekhq/resources/VeterancyAwardsCampaignOptionsChangedConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/VeterancyAwardsCampaignOptionsChangedConfirmationDialog.properties
@@ -4,7 +4,7 @@ VeterancyAwards.description=You have just enabled <b>Veterancy Awards</b> in a c
   <p>If you confirm this action, any character who has a Veteran rank (or better) will be granted a Veterancy Award. \
   Normally characters recruited at Veteran rank, or better, are ineligible for veterancy awards. This restriction \
   will be waived in this instance.</p>\
-  <p>{0}<b>Warning</b>{1}: This process {0}<b>cannot be reversed</b>{1}. Not all Veterancy Awards are positive, and it \
-  is possible one or more of your characters may find themselves with a new Flaw, instead of an SPA.</p>
+  <p>{0}<b>Warning</b>{1}: This process {0}<b>cannot be reversed</b>{1}. Not all Veterancy Awards are positive. Each \
+  character has a <b>1-in-40</b> chance of getting a Flaw, instead of an SPA. Some Flaws are <b>career ending</b>
 VeterancyAwards.button.confirm=Confirm
 VeterancyAwards.button.cancel=Cancel

--- a/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
@@ -97,7 +97,7 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
               useAlternativeWeighting,
               ignoreEligibility,
               isVeterancyAward);
-        if (abilityList == null) {
+        if (abilityList.isEmpty()) {
             return null;
         }
 
@@ -189,12 +189,12 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
      * @param isVeterancyAward        if {@code true}, some SPAs may be excluded based on veterancy award eligibility
      *                                status
      *
-     * @return a list of available special abilities based on the criteria, or {@code null} if none are found
+     * @return a list of available special abilities based on the criteria, or an empty list is none are found
      *
      * @author Illiani
      * @since 0.50.10
      */
-    private @Nullable List<SpecialAbility> getSpecialAbilities(Person person, boolean useAlternativeWeighting,
+    private List<SpecialAbility> getSpecialAbilities(Person person, boolean useAlternativeWeighting,
           boolean ignoreEligibility, boolean isVeterancyAward) {
         final PersonnelOptions options = person.getOptions();
         List<SpecialAbility> abilityList = new ArrayList<>();
@@ -228,10 +228,6 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
             }
         } else {
             abilityList = getEligibleSPAs(person, isVeterancyAward);
-        }
-
-        if (abilityList.isEmpty()) {
-            return null;
         }
 
         // Alternative weighting will pre-determine whether the SPA is positive or negative.

--- a/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
@@ -236,11 +236,17 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
 
         // Alternative weighting will pre-determine whether the SPA is positive or negative.
         if (useAlternativeWeighting) {
-            int roll = Compute.randomInt(40);
-            if (roll == 0) {
-                abilityList.addAll(negativeAbilities);
+            if (negativeAbilities.isEmpty()) {
+                return positiveAbilities;
+            } else if (positiveAbilities.isEmpty()) {
+                return negativeAbilities;
             } else {
-                abilityList.addAll(positiveAbilities);
+                int roll = Compute.randomInt(40);
+                if (roll == 0) {
+                    abilityList.addAll(negativeAbilities);
+                } else {
+                    abilityList.addAll(positiveAbilities);
+                }
             }
         } else {
             abilityList = SpecialAbility.getWeightedSpecialAbilities(abilityList);

--- a/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
@@ -43,7 +43,6 @@ import megamek.common.compute.Compute;
 import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.units.Crew;
-import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
@@ -234,8 +233,6 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
         if (abilityList.isEmpty()) {
             return null;
         }
-
-        MMLogger LOGGER = MMLogger.create(SingleSpecialAbilityGenerator.class);
 
         // Alternative weighting will pre-determine whether the SPA is positive or negative.
         if (useAlternativeWeighting) {

--- a/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/SingleSpecialAbilityGenerator.java
@@ -43,6 +43,7 @@ import megamek.common.compute.Compute;
 import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.units.Crew;
+import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.PersonnelOptions;
@@ -197,11 +198,11 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
     private @Nullable List<SpecialAbility> getSpecialAbilities(Person person, boolean useAlternativeWeighting,
           boolean ignoreEligibility, boolean isVeterancyAward) {
         final PersonnelOptions options = person.getOptions();
-        List<SpecialAbility> abilityList;
+        List<SpecialAbility> abilityList = new ArrayList<>();
         final List<SpecialAbility> positiveAbilities = new ArrayList<>();
+        final List<SpecialAbility> negativeAbilities = new ArrayList<>();
 
         if (ignoreEligibility) {
-            abilityList = new ArrayList<>();
             for (SpecialAbility ability : SpecialAbility.getSpecialAbilities().values()) {
                 if (isVeterancyAward && ability.getOriginOnly()) {
                     continue;
@@ -221,6 +222,8 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
                     abilityList.add(ability);
                     if (ability.getCost() >= 0) {
                         positiveAbilities.add(ability);
+                    } else {
+                        negativeAbilities.add(ability);
                     }
                 }
             }
@@ -232,10 +235,14 @@ public class SingleSpecialAbilityGenerator extends AbstractSpecialAbilityGenerat
             return null;
         }
 
+        MMLogger LOGGER = MMLogger.create(SingleSpecialAbilityGenerator.class);
+
+        // Alternative weighting will pre-determine whether the SPA is positive or negative.
         if (useAlternativeWeighting) {
-            // Duplicate positiveAbilities three times for alternative weighting. This allows us to reduce the chance
-            // of a character getting a Flaw
-            for (int i = 0; i < 3; i++) {
+            int roll = Compute.randomInt(40);
+            if (roll == 0) {
+                abilityList.addAll(negativeAbilities);
+            } else {
                 abilityList.addAll(positiveAbilities);
             }
         } else {


### PR DESCRIPTION
While some Veterancy Awards being negative is by design, player feedback was that Flaws were too common. This PR reduces them to be once in a while things, rather than every 10 characters.

I also further reinforced the nature of Flaws in campaign options explanation texts.