### PR TITLE
Improvement #7941: Added Bonus to Reinforcement Speeds for LAM Units

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -4567,7 +4567,7 @@ public class AtBDynamicScenarioFactory {
 
         if (entity.getAnyTypeMaxJumpMP() > 0) {
             // If the entity has jump capability, adjust the speed
-            if (entity instanceof Infantry) {
+            if (entity.isInfantry()) {
                 // For infantry, use jump MP instead of walk MP
                 speed = entity.getJumpMP();
             } else {
@@ -4577,7 +4577,7 @@ public class AtBDynamicScenarioFactory {
         }
 
         // For aerospace units, multiply the walk MP
-        if (entity.isAerospace() && !entity.isSpheroid()) {
+        if (entity instanceof LandAirMek || entity.isAerospace() && !entity.isSpheroid()) {
             speed *= 2;
         }
 


### PR DESCRIPTION
Close #7941

Non-Speroid aerospace assets double their 'walk' speed, when calculating reinforcement times. This PR extends that to LAM units.

As the reinforcement speed calculation method is reused in Advanced Scouting, this bonus is extended to that mechanic also.