### PR TITLE
Fix #7944: Fixed Replacement Limb Surgeon Picker Using Incorrect Method to Determine In-House Surgeon Eligibility

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1867,7 +1867,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 Skill skill = person.getSkill(S_SURGERY);
 
                 if (skill != null &&
-                          skill.getFinalSkillValue(skillModifierData) >=
+                          skill.getTotalSkillLevel(skillModifierData) >=
                                 REPLACEMENT_LIMB_MINIMUM_SKILL_REQUIRED_TYPES_3_4_5) {
                     suitableDoctors.add(person);
                 }


### PR DESCRIPTION
Fix #7944

`skill.getFinalSkillValue()` returns the target number and _not_ the total skill level.