### PR TITLE
Improvement: Training Forces Always Deploy to StratCon 'Sticky' by Default

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1117,7 +1117,9 @@ public class StratConRulesManager {
             return;
         }
 
-        boolean isPatrol = combatTeam.getRole().isPatrol();
+        CombatRole combatRole = combatTeam.getRole();
+        boolean isPatrol = combatRole.isPatrol();
+        boolean isTraining = combatRole.isTraining();
 
         // the following things should happen:
         // 1. call to "process force deployment", which reveals fog of war in or around the coords,
@@ -1194,6 +1196,12 @@ public class StratConRulesManager {
             }
 
             finalizeBackingScenario(campaign, contract, track, autoAssignLances, scenario);
+            return;
+        }
+
+        // If we didn't trip a scenario or facility, Training forces should deploy 'sticky'
+        if (isTraining) {
+            track.addStickyForce(forceID);
         }
     }
 


### PR DESCRIPTION
Currently, if the player wants to gain the benefits of a Training force they need to deploy the force to StratCon. Then they need to manually mark the force as 'remain deployed'. Otherwise the next day the force will return.

This PR removes the manual element. Now, if you deploy a Training force to StratCon and that deployment doesn't trigger a scenario, or hostile facility, the force will automatically deploy with 'remain deployed' checked.