### PR TITLE
Improvement: Added Free MASH Truck Option for Existing Campaigns Enabling MASH Tracking for The First Time

### DIFF
--- a/MekHQ/resources/mekhq/resources/MASHTheatreTrackingCampaignOptionsChangedConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/MASHTheatreTrackingCampaignOptionsChangedConfirmationDialog.properties
@@ -1,0 +1,37 @@
+# Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+MASHTheatreTrackingCampaignOptionsChangedConfirmationDialog.description=You have just enabled the tracking of MASH \
+  Theater capacity in a campaign that previously had it disabled.\
+  <p>Would you like a complementary MASH Theater-enabled unit? This unit will be fully crewed. However, if your \
+  campaign is particularly large, this may not be sufficient to cover all your needs.</p>\
+  <p>Additional MASH Theater-equipped units can be purchased from the Unit Market, or <b>Purchase Unit</b> dialog.</p>
+MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.cancel=Decline
+MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.confirm=Accept

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -73,6 +73,7 @@ import mekhq.gui.CampaignGUI;
 import mekhq.gui.baseComponents.AbstractMHQTabbedPane;
 import mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode;
 import mekhq.gui.campaignOptions.contents.*;
+import mekhq.gui.campaignOptions.optionChangeDialogs.MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog;
 import mekhq.gui.dialog.factionStanding.FactionStandingCampaignOptionsChangedConfirmationDialog;
 import mekhq.gui.dialog.factionStanding.VeterancyAwardsCampaignOptionsChangedConfirmationDialog;
 
@@ -505,6 +506,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             presetSkills = preset.getSkills();
         }
 
+        // Store old values for use if we want to trigger certain dialogs
+        boolean oldAwardVeterancySPAs = options.isAwardVeterancySPAs();
+        boolean oldIsTrackFactionStanding = options.isTrackFactionStanding();
+        boolean oldIsUseMASHTheatres = options.isUseMASHTheatres();
+
         // Everything assumes general tab will be the first applied.
         // While this shouldn't break anything, it's not worth moving around.
         // For all other tabs, it makes sense to apply them in the order they
@@ -513,7 +519,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         // Human Resources
         personnelTab.applyCampaignOptionsToCampaign(campaign, options);
-        boolean oldAwardVeterancySPAs = options.isAwardVeterancySPAs();
         biographyTab.applyCampaignOptionsToCampaign(options);
         relationshipsTab.applyCampaignOptionsToCampaign(options);
         salariesTab.applyCampaignOptionsToCampaign(options);
@@ -532,8 +537,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         financesTab.applyCampaignOptionsToCampaign(options);
         marketsTab.applyCampaignOptionsToCampaign(options);
         rulesetsTab.applyCampaignOptionsToCampaign(options);
-
-        boolean oldIsTrackFactionStanding = options.isTrackFactionStanding();
         systemsTab.applyCampaignOptionsToCampaign(options, presetRandomSkillPreferences);
 
         // Tidy up
@@ -568,6 +571,11 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
         boolean newIsAwardVeterancySPAs = options.isAwardVeterancySPAs();
         if (!isStartUp && newIsAwardVeterancySPAs && !oldAwardVeterancySPAs) { // Has tracking changed?
             new VeterancyAwardsCampaignOptionsChangedConfirmationDialog(campaign);
+        }
+
+        boolean newIsUseMASHTheatres = options.isUseMASHTheatres();
+        if (!isStartUp && newIsUseMASHTheatres && !oldIsUseMASHTheatres) { // Has tracking changed?
+            new MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
         campaign.resetRandomDeath();

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -73,9 +73,9 @@ import mekhq.gui.CampaignGUI;
 import mekhq.gui.baseComponents.AbstractMHQTabbedPane;
 import mekhq.gui.campaignOptions.CampaignOptionsDialog.CampaignOptionsDialogMode;
 import mekhq.gui.campaignOptions.contents.*;
+import mekhq.gui.campaignOptions.optionChangeDialogs.FactionStandingCampaignOptionsChangedConfirmationDialog;
 import mekhq.gui.campaignOptions.optionChangeDialogs.MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog;
-import mekhq.gui.dialog.factionStanding.FactionStandingCampaignOptionsChangedConfirmationDialog;
-import mekhq.gui.dialog.factionStanding.VeterancyAwardsCampaignOptionsChangedConfirmationDialog;
+import mekhq.gui.campaignOptions.optionChangeDialogs.VeterancyAwardsCampaignOptionsChangedConfirmationDialog;
 
 /**
  * The {@code CampaignOptionsPane} class represents a tabbed pane used for displaying and managing various campaign

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.campaignOptions.optionChangeDialogs;
+
+import static java.lang.Integer.MAX_VALUE;
+import static megamek.client.ui.util.FlatLafStyleBuilder.setFontScaling;
+import static megamek.client.ui.util.UIUtil.scaleForGUI;
+import static megamek.utilities.ImageUtilities.scaleImageIcon;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getText;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
+import static mekhq.utilities.ReportingUtilities.getWarningColor;
+import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ImageIcon;
+import javax.swing.JDialog;
+import javax.swing.JEditorPane;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+
+import megamek.common.loaders.MekSummary;
+import megamek.common.loaders.MekSummaryCache;
+import megamek.logging.MMLogger;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.parts.enums.PartQuality;
+import mekhq.campaign.unit.UnitOrder;
+import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
+import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
+
+public class MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog extends JDialog {
+    final MMLogger LOGGER = MMLogger.create(MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.class);
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.MASHTheatreTrackingCampaignOptionsChangedConfirmationDialog";
+
+    private final int PADDING = scaleForGUI(10);
+    protected static final int IMAGE_WIDTH = scaleForGUI(200);
+    protected static final int CENTER_WIDTH = scaleForGUI(450);
+
+    private ImageIcon campaignIcon;
+    private final Campaign campaign;
+
+    public MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog(Campaign campaign) {
+        this.campaignIcon = campaign.getCampaignFactionIcon();
+        this.campaign = campaign;
+
+        populateDialog();
+        initializeDialog();
+    }
+
+    void initializeDialog() {
+        setTitle(getText("accessingTerminal.title"));
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        setResizable(false);
+        pack();
+        setLocationRelativeTo(null);
+        setModal(true);
+        setAlwaysOnTop(true);
+        setVisible(true);
+    }
+
+    void populateDialog() {
+        JPanel mainPanel = new JPanel(new GridBagLayout());
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.insets = new Insets(PADDING, PADDING, PADDING, PADDING);
+        constraints.fill = GridBagConstraints.BOTH;
+        constraints.weighty = 1;
+
+        int gridx = 0;
+
+        // Left box for campaign icon
+        JPanel pnlLeft = buildLeftPanel();
+        pnlLeft.setBorder(new EmptyBorder(PADDING, PADDING, PADDING, PADDING));
+        constraints.gridx = gridx;
+        constraints.gridy = 0;
+        constraints.weightx = 1;
+        mainPanel.add(pnlLeft, constraints);
+        gridx++;
+
+        // Center box for the message
+        JPanel pnlCenter = populateCenterPanel();
+        constraints.gridx = gridx;
+        constraints.gridy = 0;
+        constraints.weightx = 2;
+        constraints.weighty = 2;
+        mainPanel.add(pnlCenter, constraints);
+
+        add(mainPanel, BorderLayout.CENTER);
+    }
+
+    private JPanel buildLeftPanel() {
+        JPanel pnlCampaign = new JPanel();
+        pnlCampaign.setLayout(new BoxLayout(pnlCampaign, BoxLayout.Y_AXIS));
+        pnlCampaign.setAlignmentX(Component.CENTER_ALIGNMENT);
+        pnlCampaign.setMaximumSize(new Dimension(IMAGE_WIDTH, scaleForGUI(MAX_VALUE)));
+
+        campaignIcon = scaleImageIcon(campaignIcon, IMAGE_WIDTH, true);
+        JLabel imageLabel = new JLabel();
+        imageLabel.setIcon(campaignIcon);
+        imageLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        pnlCampaign.add(imageLabel);
+
+        return pnlCampaign;
+    }
+
+    private JPanel populateCenterPanel() {
+        JPanel pnlCenter = new JPanel();
+        pnlCenter.setLayout(new BoxLayout(pnlCenter, BoxLayout.Y_AXIS));
+
+        JEditorPane editorPane = new JEditorPane();
+        editorPane.setBorder(RoundedLineBorder.createRoundedLineBorder());
+        editorPane.setContentType("text/html");
+        editorPane.setEditable(false);
+        editorPane.setFocusable(false);
+
+        String description = getFormattedTextAt(RESOURCE_BUNDLE,
+              "MASHTheatreTrackingCampaignOptionsChangedConfirmationDialog.description",
+              spanOpeningWithCustomColor(getWarningColor()),
+              CLOSING_SPAN_TAG);
+        String fontStyle = "font-family: Noto Sans;";
+        editorPane.setText(String.format("<div style='width: %s; %s'>%s</div>", CENTER_WIDTH, fontStyle, description));
+        setFontScaling(editorPane, false, 1.1);
+        pnlCenter.add(editorPane);
+
+        pnlCenter.add(Box.createVerticalStrut(PADDING));
+        pnlCenter.add(createButtonPanel());
+
+        return pnlCenter;
+    }
+
+    private JPanel createButtonPanel() {
+        JPanel pnlButtons = new JPanel();
+        pnlButtons.setLayout(new BoxLayout(pnlButtons, BoxLayout.X_AXIS));
+        pnlButtons.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        RoundedJButton btnCancel = new RoundedJButton(getTextAt(RESOURCE_BUNDLE,
+              "MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.cancel"));
+        btnCancel.addActionListener(evt -> dispose());
+
+        RoundedJButton btnConfirm = new RoundedJButton(getTextAt(RESOURCE_BUNDLE,
+              "MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.confirm"));
+        btnConfirm.addActionListener(evt -> {
+            processFreeUnit();
+            dispose();
+        });
+
+        pnlButtons.add(btnCancel);
+        pnlButtons.add(Box.createRigidArea(new Dimension(PADDING, 0)));
+        pnlButtons.add(btnConfirm);
+
+        return pnlButtons;
+    }
+
+    private void processFreeUnit() {
+        MekSummary mekSummary = MekSummaryCache.getInstance().getMek("MASH Truck (Small)");
+        if (mekSummary == null) {
+            LOGGER.error("Cannot find entry for {}", "MASH Truck (Small)");
+            return;
+        }
+
+        try {
+            PartQuality quality = PartQuality.QUALITY_D;
+            if (campaign.getCampaignOptions().isUseRandomUnitQualities()) {
+                quality = UnitOrder.getRandomUnitQuality(0);
+            }
+            campaign.addNewUnit(mekSummary.loadEntity(), true, 0, quality);
+        } catch (Exception e) {
+            LOGGER.error(e, "Unable to load entity: {}: {}. Returning none.",
+                  mekSummary.getSourceFile(),
+                  mekSummary.getEntryName());
+        }
+    }
+}

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.java
@@ -68,7 +68,7 @@ import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 
 public class MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog extends JDialog {
-    final MMLogger LOGGER = MMLogger.create(MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.class);
+    private static final MMLogger LOGGER = MMLogger.create(MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog.class);
     private static final String RESOURCE_BUNDLE = "mekhq.resources.MASHTheatreTrackingCampaignOptionsChangedConfirmationDialog";
 
     private final int PADDING = scaleForGUI(10);


### PR DESCRIPTION
It's important that we don't leave campaigns unable to heal if they enable this option mid-run. Therefore I opted to create a dialog that gifts them a free single theater MASH Truck. For larger campaigns this won't solve their issues, but larger campaigns have sufficient funds to not need freebies.