### PR TITLE
Fix: Added Missing Dialog Size Memory for Salvage Pickers

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/SalvageForcePicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/SalvageForcePicker.java
@@ -56,8 +56,11 @@ import javax.swing.JTextArea;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableRowSorter;
 
+import megamek.client.ui.preferences.JWindowPreference;
+import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import megamek.logging.MMLogger;
+import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.force.ForceType;
@@ -178,6 +181,7 @@ public class SalvageForcePicker extends JDialog {
 
         pack();
         setLocationRelativeTo(null);
+        setPreferences(); // Must be before setVisible
         setVisible(true);
     }
 
@@ -656,6 +660,19 @@ public class SalvageForcePicker extends JDialog {
             }
 
             return component;
+        }
+    }
+
+    /**
+     * This override forces the preferences for this class to be tracked in MekHQ instead of MegaMek.
+     */
+    private void setPreferences() {
+        try {
+            PreferencesNode preferences = MekHQ.getMHQPreferences().forClass(SalvageForcePicker.class);
+            setName("SalvageForcePicker");
+            preferences.manage(new JWindowPreference(this));
+        } catch (Exception ex) {
+            LOGGER.error("Failed to set user preferences", ex);
         }
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/SalvageTechPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/SalvageTechPicker.java
@@ -54,8 +54,11 @@ import javax.swing.JTextArea;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableRowSorter;
 
+import megamek.client.ui.preferences.JWindowPreference;
+import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.util.sorter.NaturalOrderComparator;
 import megamek.logging.MMLogger;
+import mekhq.MekHQ;
 import mekhq.campaign.mission.camOpsSalvage.SalvageTechData;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 
@@ -173,6 +176,7 @@ public class SalvageTechPicker extends JDialog {
 
         pack();
         setLocationRelativeTo(null);
+        setPreferences(); // Must be before setVisible
         setVisible(true);
     }
 
@@ -477,6 +481,19 @@ public class SalvageTechPicker extends JDialog {
          */
         public int getRankNumeric(int rowIndex) {
             return techs.get(rowIndex).rankNumeric();
+        }
+    }
+
+    /**
+     * This override forces the preferences for this class to be tracked in MekHQ instead of MegaMek.
+     */
+    private void setPreferences() {
+        try {
+            PreferencesNode preferences = MekHQ.getMHQPreferences().forClass(SalvageTechPicker.class);
+            setName("SalvageTechPicker");
+            preferences.manage(new JWindowPreference(this));
+        } catch (Exception ex) {
+            LOGGER.error("Failed to set user preferences", ex);
         }
     }
 }


### PR DESCRIPTION
The Salvage Force Picker and Salvage Tech Picker dialogs weren't remembering their last opened size, forcing the player to resize them each time they were opened. i.e. before _every_ scenario. This was an awful play-feel. These dialogs now correctly remember their last opened size.