### PR TITLE
Fix #7946: Fixed 'Fleet in Being' Status Not Correctly Applying to Scenarios

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -191,7 +191,6 @@ public class CampaignNewDayManager {
     private final Finances finances;
     private LocalDate today;
     private CurrentLocation updatedLocation;
-    private final Set<Integer> scenariosWithDeployedForces = new HashSet<>();
 
     public CampaignNewDayManager(Campaign campaign) {
         this.campaign = campaign;


### PR DESCRIPTION
Fix #7946

The original Fleet in Being code was written prior to the new day code being migrated out of Campaign. It seems it somehow got missed in the shuffle. This PR restores it.