### PR TITLE
Fix: Fixed CamOps Reputation Including Bay Personnel in Passenger Capacity

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/TransportationRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/TransportationRating.java
@@ -37,16 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import megamek.common.bays.SuperHeavyVehicleBay;
-import megamek.common.bays.ASFBay;
-import megamek.common.bays.BattleArmorBay;
-import megamek.common.bays.Bay;
-import megamek.common.bays.HeavyVehicleBay;
-import megamek.common.bays.InfantryBay;
-import megamek.common.bays.LightVehicleBay;
-import megamek.common.bays.MekBay;
-import megamek.common.bays.ProtoMekBay;
-import megamek.common.bays.SmallCraftBay;
+import megamek.common.bays.*;
 import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
@@ -328,7 +319,7 @@ public class TransportationRating {
                 passengerCapacity += bay.getPersonnel(entity.isClan());
             }
 
-            passengerCapacity += entity.getNPassenger();
+            passengerCapacity += entity.getPassengerCapacityWithoutBayCrew();
         }
 
         // Map the capacity of each bay type


### PR DESCRIPTION
# Requires [Task: Added Utility Method to Entity to Fetch Passenger Capacity Without Bay Personnel Count](https://github.com/MegaMek/megamek/pull/7580)

CamOps Reputation's Transportation Rating was incorrectly including Bay Personnel capacity when calculating the total Passenger Capacity of all large vessels in the players' campaign.