### PR TITLE
Fix #6312, #7952: Added 'Point of No Return' to StratCon Deployment Dialogs

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -43,10 +43,6 @@ lblLeadershipTransportInstructions.text=<html><b>Transport Type:</b></html>
 lblLeadershipCommitForces.text=Commit {0} and any selected auxiliary units?
 lblLeadershipCommitForces.fallback.text=Commit force?
 leadershipCommit.text=Commit
-leadershipCancel.text=Cancel
-selectForceForTemplate.Text=<html><b>Select a force from the list below.</b>\
-  <br>\
-  <br>If multiple forces are selected, only the first will be deployed.</html>
 selectReinforcementsForTemplate.Text=<html><b>Select reinforcements from the list below.</b>\
   <br>\
   <br>Each attempt will cost Support Points and may be unsuccessful.</html>

--- a/MekHQ/src/mekhq/campaign/stratCon/MaplessStratCon.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/MaplessStratCon.java
@@ -209,13 +209,6 @@ public class MaplessStratCon {
             scenarioWizard.setVisible(true);
         }
 
-        if (scenarioWizard.isWasCanceled()) {
-            stratConScenario.resetScenario(campaign);
-
-            // We currently retain the wizard in memory, so need to make sure we reset the canceled state
-            scenarioWizard.setWasCanceled(false);
-        }
-
         stratConPanel.setCommitForces(false);
         stratConPanel.repaint();
     }

--- a/MekHQ/src/mekhq/gui/StratConPanel.java
+++ b/MekHQ/src/mekhq/gui/StratConPanel.java
@@ -1099,13 +1099,6 @@ public class StratConPanel extends JPanel implements ActionListener {
                     scenarioWizard.toFront();
                     scenarioWizard.setVisible(true);
                 }
-                if (selectedScenario != null && scenarioWizard.isWasCanceled()) {
-                    logger.info("Scenario wizard was cancelled. Resetting scenario to default state.");
-                    selectedScenario.resetScenario(campaign);
-
-                    // We currently retain the wizard in memory, so need to make sure we reset the canceled state
-                    scenarioWizard.setWasCanceled(false);
-                }
 
                 setCommitForces(false);
                 break;

--- a/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
@@ -64,6 +64,7 @@ import javax.swing.event.ListSelectionListener;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.Minefield;
 import megamek.common.rolls.TargetRoll;
+import megamek.common.ui.FastJScrollPane;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
@@ -86,7 +87,6 @@ import mekhq.gui.StratConPanel;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogConfirmation;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 import mekhq.gui.dialog.StratConReinforcementsConfirmationDialog;
-import mekhq.gui.utilities.JScrollPaneWithSpeed;
 import mekhq.utilities.MHQInternationalization;
 import mekhq.utilities.ReportingUtilities;
 import org.apache.commons.lang3.ArrayUtils;
@@ -115,8 +115,6 @@ public class StratConScenarioWizard extends JDialog {
     private CampaignTransportType selectedCampaignTransportType = null;
 
     private JComboBox<String> cboTransportType = new JComboBox<>();
-
-    private boolean wasCanceled;
 
     private JPanel contentPanel;
     private JButton btnCommit;
@@ -163,14 +161,6 @@ public class StratConScenarioWizard extends JDialog {
         setUI(isPrimaryForce);
     }
 
-    public boolean isWasCanceled() {
-        return wasCanceled;
-    }
-
-    public void setWasCanceled(boolean wasCancelled) {
-        this.wasCanceled = wasCancelled;
-    }
-
     /**
      * Configures and initializes the user interface for the scenario setup wizard. This method dynamically assembles
      * various UI components based on the scenario's state and whether the primary force is being assigned.
@@ -207,6 +197,7 @@ public class StratConScenarioWizard extends JDialog {
     private void setUI(boolean isPrimaryForce) {
         setTitle(resources.getString("scenarioSetupWizard.title"));
         getContentPane().removeAll();
+        setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
 
         // Create a new panel to hold all components
         contentPanel = new JPanel(new CardLayout());
@@ -497,7 +488,7 @@ public class StratConScenarioWizard extends JDialog {
      */
     private JList<Force> addAvailableForceList(JPanel parent, GridBagConstraints gbc,
           ScenarioForceTemplate forceTemplate) {
-        JScrollPane forceListContainer = new JScrollPaneWithSpeed();
+        JScrollPane forceListContainer = new FastJScrollPane();
 
         ScenarioWizardLanceModel lanceModel = new ScenarioWizardLanceModel(campaign,
               StratConRulesManager.getAvailableForceIDsForManualDeployment(forceTemplate.getAllowedUnitType(),
@@ -711,14 +702,6 @@ public class StratConScenarioWizard extends JDialog {
             btnCommit.addActionListener(evt -> reinforcementConfirmDialog());
         }
 
-        JButton btnCancel = new JButton(MHQInternationalization.getTextAt(resourcePath, "leadershipCancel.text"));
-        btnCancel.setActionCommand("CANCEL_CLICK");
-        btnCancel.addActionListener(evt -> {
-            wasCanceled = true;
-            closeWizard();
-        });
-        btnCancel.setEnabled(true);
-
         // Configure layout constraints for the buttons
         constraints.gridwidth = GridBagConstraints.REMAINDER;
         constraints.anchor = GridBagConstraints.CENTER;
@@ -747,8 +730,6 @@ public class StratConScenarioWizard extends JDialog {
         // Align and add cancel button to the content panel
         constraints.gridy++;
         constraints.gridheight = GridBagConstraints.REMAINDER;
-        constraints.anchor = GridBagConstraints.WEST;
-        contentPanel.add(btnCancel, constraints);
         constraints.anchor = GridBagConstraints.CENTER;
 
         // Add the commit button to the content panel

--- a/MekHQ/src/mekhq/gui/stratCon/TrackForceAssignmentUI.java
+++ b/MekHQ/src/mekhq/gui/stratCon/TrackForceAssignmentUI.java
@@ -51,6 +51,7 @@ import mekhq.campaign.stratCon.StratConCampaignState;
 import mekhq.campaign.stratCon.StratConCoords;
 import mekhq.campaign.stratCon.StratConRulesManager;
 import mekhq.gui.StratConPanel;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogConfirmation;
 import mekhq.gui.utilities.JScrollPaneWithSpeed;
 
 /**
@@ -105,6 +106,11 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
         availableForceList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         availableForceList.setModel(lanceModel);
         availableForceList.setCellRenderer(new ScenarioWizardLanceRenderer(campaign));
+        availableForceList.addListSelectionListener(e -> {
+            if (!e.getValueIsAdjusting()) {
+                btnConfirm.setEnabled(!availableForceList.isSelectionEmpty());
+            }
+        });
 
         forceListContainer.setViewportView(availableForceList);
 
@@ -113,7 +119,7 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
         gbc.gridy++;
 
         getContentPane().add(btnConfirm, gbc);
-        btnConfirm.setEnabled(true);
+        btnConfirm.setEnabled(false);
 
         pack();
         repaint();
@@ -139,6 +145,15 @@ public class TrackForceAssignmentUI extends JDialog implements ActionListener {
             // sometimes the scenario templates take a little while to load, we don't want the user
             // clicking the button fifty times and getting a bunch of scenarios.
             btnConfirm.setEnabled(false);
+
+            // This dialog marks a point of no return, so we ask the player to confirm their decision before moving
+            // forward
+            ImmersiveDialogConfirmation dialog = new ImmersiveDialogConfirmation(campaign);
+            if (!dialog.wasConfirmed()) {
+                btnConfirm.setEnabled(true);
+                return;
+            }
+
             for (Force force : availableForceList.getSelectedValuesList()) {
                 StratConRulesManager.deployForceToCoords(ownerPanel.getSelectedCoords(),
                       force.getId(), campaign, currentCampaignState.getContract(), ownerPanel.getCurrentTrack(), false);


### PR DESCRIPTION
Fix #6312
Fix #7952

We've had an issue for a while where players could back out of deployment at certain points in the process. However, MekHQ would continue processing a few steps - as if the player _had_ deployed. This introduces a few bugs.

The classic example is that MekHQ would generate the scenario with a BV Budget of 0, because no force was deployed so there were no player units to count.

More recently it caused scenarios to wholly reset when the player deploys from the TO&E or Briefing Room.

Finally, as outlined by #6312 (and also in the comments in #7952), it allows players to avoid 'ambush' scenarios. I.e. if the player deploys to StratCon 'blind' (to an unexplored hex) and that hex contains a scenario the player can back out. And then follow-up by deploying the forces they _do_ want to deploy.

This PR resolves the issue by adding a point of no return in the deployment process. When the player is asked to select a force, they can cancel out at any time. However, if they continue they will be prompted with a confirmation dialog. Confirming the deployment locks the player in, they can select Leadership units, but have no capacity to withdraw from the deployment.

Finally, the player cannot 'commit' to the drop unless they have a force selected in the force picker - this is another cause of the 0 BV budget bug.