### PR TITLE
Fix: Fixed Hidden Scenarios Appearing in the TO&E Deployment Dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/TOETab.java
+++ b/MekHQ/src/mekhq/gui/TOETab.java
@@ -183,6 +183,8 @@ public final class TOETab extends CampaignGuiTab {
         }
 
         List<Scenario> sortedScenarios = new ArrayList<>(scenarioMissionMap.keySet());
+        // A scenario will have a null date if it hasn't been found in StratCon yet
+        sortedScenarios.removeIf(scenario -> scenario.getDate() == null);
         sortedScenarios.sort(Comparator.comparing(Scenario::getDate).reversed());
 
         // Show scenario picker


### PR DESCRIPTION
Scenarios will have a `null` due date if they haven't been found in the StratCon map. However, the deploy from TO&E button was still trying to process them, resulting in an NPE. This PR fixes that by properly excluding them.