### PR TITLE
Improvement: Adjusted Deployment Date to Equal Battle Date to Improve User Experience

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -2472,13 +2472,13 @@ public class StratConRulesManager {
      * Worker function that sets scenario deploy/battle/return dates based on the track's properties and current
      * campaign date. Takes a fixed deployment day of X days from campaign's today date.
      */
-    private static void setScenarioDates(int deploymentDay, StratConTrackState track, Campaign campaign,
+    private static void setScenarioDates(int deploymentDelay, StratConTrackState track, Campaign campaign,
           StratConScenario scenario) {
         // set up deployment day, battle day, return day here
         // safety code to prevent attempts to generate random int with upper bound of 0
         // which is apparently illegal
-        int battleDay = deploymentDay + (track.getDeploymentTime() > 0 ? randomInt(track.getDeploymentTime()) : 0);
-        int returnDay = deploymentDay + track.getDeploymentTime();
+        int battleDay = deploymentDelay + (track.getDeploymentTime() > 0 ? randomInt(track.getDeploymentTime()) : 0);
+        int returnDay = deploymentDelay + track.getDeploymentTime();
 
         LocalDate battleDate = campaign.getLocalDate().plusDays(battleDay);
         LocalDate returnDate = campaign.getLocalDate().plusDays(returnDay);

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -2480,11 +2480,10 @@ public class StratConRulesManager {
         int battleDay = deploymentDay + (track.getDeploymentTime() > 0 ? randomInt(track.getDeploymentTime()) : 0);
         int returnDay = deploymentDay + track.getDeploymentTime();
 
-        LocalDate deploymentDate = campaign.getLocalDate().plusDays(deploymentDay);
         LocalDate battleDate = campaign.getLocalDate().plusDays(battleDay);
         LocalDate returnDate = campaign.getLocalDate().plusDays(returnDay);
 
-        scenario.setDeploymentDate(deploymentDate);
+        scenario.setDeploymentDate(battleDate);
         scenario.setActionDate(battleDate);
         scenario.setReturnDate(returnDate);
     }


### PR DESCRIPTION
StratCon has a mechanic where the date a scenario takes place and the date a player needs to assign forces _to_ that scenario do not always match.

This is largely to represent the time it takes for a players' forces to get into position. However, this is not an intuitive system and we see semi-frequent user contact about it.

This PR adjusts things so that deployment day - by default - will be identical to battle day. I kept the variables separate to allow for developers to overwrite this when creating special scenarios and the like.