### PR TITLE
Fix #7977: Stopped All Followup Contracts Being Identically Named

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -625,7 +625,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
         // The order in this method needs to match generateAtBContract
 
-        AtBContract followup = new AtBContract(contract.getContractType().toString() + " (followup)");
+        AtBContract followup = new AtBContract("Unnamed Contract");
         lastId++;
         followup.setId(lastId);
         contractIds.put(lastId, followup);
@@ -666,6 +666,13 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         followup.calculateContract(campaign);
 
         contract.clanTechSalvageOverride();
+
+        contract.setName(String.format("%s - %s - %s %s (Followup)",
+              contract.getStartDate()
+                    .format(DateTimeFormatter.ofPattern("yyyy").withLocale(MekHQ.getMHQOptions().getDateLocale())),
+              contract.getEmployer(),
+              contract.getSystem().getName(contract.getStartDate()),
+              contract.getContractType()));
 
         contracts.add(followup);
         followupContracts.put(followup.getId(), contract.getId());

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -667,12 +667,12 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
         contract.clanTechSalvageOverride();
 
-        contract.setName(String.format("(Followup) %s - %s - %s %s",
-              contract.getStartDate()
+        followup.setName(String.format("(Followup) %s - %s - %s %s",
+              followup.getStartDate()
                     .format(DateTimeFormatter.ofPattern("yyyy").withLocale(MekHQ.getMHQOptions().getDateLocale())),
-              contract.getEmployer(),
-              contract.getSystem().getName(contract.getStartDate()),
-              contract.getContractType()));
+              followup.getEmployer(),
+              followup.getSystem().getName(followup.getStartDate()),
+              followup.getContractType()));
 
         contracts.add(followup);
         followupContracts.put(followup.getId(), contract.getId());

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -667,7 +667,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
         contract.clanTechSalvageOverride();
 
-        contract.setName(String.format("%s - %s - %s %s (Followup)",
+        contract.setName(String.format("(Followup) %s - %s - %s %s",
               contract.getStartDate()
                     .format(DateTimeFormatter.ofPattern("yyyy").withLocale(MekHQ.getMHQOptions().getDateLocale())),
               contract.getEmployer(),

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -625,7 +625,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
         // The order in this method needs to match generateAtBContract
 
-        AtBContract followup = new AtBContract("Followup Contract");
+        AtBContract followup = new AtBContract(contract.getContractType().toString() + " (followup)");
         lastId++;
         followup.setId(lastId);
         contractIds.put(lastId, followup);


### PR DESCRIPTION
Fix #7977

Now followup contracts follow the same naming schema as all other contract types. Followup contracts can be spotted as their name will be preceded by "followup"