### PR TITLE
Fix #7974: Fixed Vessel Crewmembers Being Generated For Non-Support Vehicles With Extra Crew Needs

### DIFF
--- a/MekHQ/src/mekhq/Utilities.java
+++ b/MekHQ/src/mekhq/Utilities.java
@@ -722,9 +722,9 @@ public class Utilities {
             }
 
             for (int slot = 0; slot < u.getTotalCrewNeeds(); slot++) {
-                Person p = c.newPerson(u.getEntity().isSupportVehicle() ?
-                                             PersonnelRole.COMBAT_TECHNICIAN :
-                                             PersonnelRole.VESSEL_CREW,
+                Person p = c.newPerson(u.getEntity().isLargeCraft() ?
+                                             PersonnelRole.VESSEL_CREW :
+                                             PersonnelRole.COMBAT_TECHNICIAN,
                       factionCode,
                       oldCrew.getGender(numberPeopleGenerated));
 


### PR DESCRIPTION
Fix #7974

When `genRandomCrewWithCombinedSkill` was created the only units with additional crew needs (beyond gunners and drivers) were Support Vehicles. Therefore a boolean that checked whether a unit was a Support Vehicle was sufficient. Nowadays we now support extra crew needs from equipment for combat vehicles (as per RAW). That caused combat vehicles to be crewed by Vessel Crewmembers - as they weren't Support Vehicles.

This PR changes the conditional to check whether the unit is a large vessel. If so, crew it with vessel crew members, elsewise Combat Technicians.