### PR TITLE
Fix #8014: Fixed Error When Sorting Certain Columns in Personnel Market

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonTableModel.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonTableModel.java
@@ -196,7 +196,7 @@ public class PersonTableModel extends AbstractTableModel {
         ApplicantTableColumns column = ApplicantTableColumns.values()[columnIndex];
         return switch (column) {
             case AGE, HIRING_COST -> new IntegerStringSorter();
-            case POSITIVE_ABILITIES, NEGATIVE_ABILITIES, PERFORMANCE_EXAM -> new IntegerStringSorter();
+            case POSITIVE_ABILITIES, NEGATIVE_ABILITIES, PERFORMANCE_EXAM -> Comparator.naturalOrder();
             case EXPERIENCE -> new LevelSorter();
             default -> new NaturalOrderComparator();
         };


### PR DESCRIPTION
Fix #8014

We were using IntegerStringSorter instead of NaturalOrder