### PR TITLE
Fix #7973: Fixed Inability to Assign Personnel to Vehicle Extra Crew Seats

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -1318,11 +1318,10 @@ public enum PersonnelRole {
     }
 
     /**
-     * @return {@code true} if the character is assigned to the Ground Vehicle Crew, Naval Vehicle Crew, or the VTOL
-     *       Pilot role, {@code false} otherwise.
+     * @return {@code true} if the character is assigned to the Vehicle Crew/x or Combat Technician role
      */
     public boolean isVehicleCrewMember() {
-        return isGroundVehicleCrew() || isVehicleCrewNaval() || isVehicleCrewVTOL();
+        return isGroundVehicleCrew() || isNavalVehicleCrew() || isVTOLCrew();
     }
 
     /**

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToPersonMenu.java
@@ -201,12 +201,16 @@ public class AssignUnitToPersonMenu extends JScrollableMenu {
         } else if (isVTOL) {
             personnel = personnel.stream()
                               .filter(person -> person.getPrimaryRole().isVTOLCrew() ||
-                                                      person.getSecondaryRole().isVTOLCrew())
+                                                      person.getSecondaryRole().isVTOLCrew() ||
+                                                      person.getPrimaryRole().isVehicleCrewExtended() ||
+                                                      person.getSecondaryRole().isVehicleCrewExtended())
                               .collect(Collectors.toList());
         } else if (isTank) {
             personnel = personnel.stream()
                               .filter(person -> person.getPrimaryRole().isVehicleCrewMember() ||
-                                                      person.getSecondaryRole().isVehicleCrewMember())
+                                                      person.getSecondaryRole().isVehicleCrewMember() ||
+                                                      person.getPrimaryRole().isVehicleCrewExtended() ||
+                                                      person.getSecondaryRole().isVehicleCrewExtended())
                               .collect(Collectors.toList());
         } else if (isSmallCraftOrJumpShip) {
             personnel = personnel.stream()


### PR DESCRIPTION
Fix #7973

We were incorrectly failing to include the possible professions that can fill extra crew seats when filtering personnel.