### PR TITLE
Fix: Fixed Loading of CamOps Reputation When Campaign is Rated as Ultra-Green

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/ReputationController.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/ReputationController.java
@@ -607,7 +607,7 @@ public class ReputationController {
      */
     public void writeReputationToXML(final PrintWriter pw, int indent) {
         // average experience rating
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "averageSkillLevel", averageSkillLevel.toString());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "averageSkillLevel", averageSkillLevel.name());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "averageExperienceRating", averageExperienceRating);
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "atbModifier", atbModifier);
 


### PR DESCRIPTION
We were saving average experience using the enum's label (via an override toString) and not `name()`