### PR TITLE
Improvement: Adjusted Date Range for Random Start Year Button to Remove Pre-Star League Bias

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -75,7 +75,7 @@ lblGeneralBody.text=<center><p>"War has been described as an art, as a science, 
 lblName.text=Unit Name
 lblName.tooltip=The most important decision you will ever make.
 lblRandomDate.text=<html>Randomize <span style="color:#7FCF43;">\u2606</span></html>
-lblRandomDate.tooltip=Pick a random date between 2850 & 3150
+lblRandomDate.tooltip=Pick a random date between 2775 & 3151
 lblNameGenerator.text=Randomize
 lblNameGenerator.tooltip=Generate a new random name.
 lblFaction.text=Unit Faction

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/GeneralTab.java
@@ -100,8 +100,8 @@ import mekhq.gui.displayWrappers.FactionDisplay;
  * This class extends the user interface features provided by {@link AbstractMHQTabbedPane}.
  */
 public class GeneralTab {
-    private static final LocalDate RANDOM_DATE_EARLIEST = LocalDate.of(2850, 1, 1);
-    private static final LocalDate RANDOM_DATE_LATEST = LocalDate.of(3150, 1, 1);
+    private static final LocalDate RANDOM_DATE_EARLIEST = LocalDate.of(2775, 1, 1);
+    private static final LocalDate RANDOM_DATE_LATEST = LocalDate.of(3151, 1, 1);
 
     private final JFrame frame;
     private final Campaign campaign;


### PR DESCRIPTION
Just narrowed the available years so that we don't have an extreme bias towards the Age of War.