### PR TITLE
Fix: Fixed Display of Required Combat Elements in Briefing Room

### DIFF
--- a/MekHQ/src/mekhq/gui/view/RequiredLancesTableModel.java
+++ b/MekHQ/src/mekhq/gui/view/RequiredLancesTableModel.java
@@ -129,12 +129,22 @@ class RequiredLancesTableModel extends DataTableModel<AtBContract> {
                 return t + "/" + contract.getRequiredCombatElements();
             }
             return Integer.toString(contract.getRequiredCombatElements());
-        } else if (contract.getContractType().getRequiredCombatRole().ordinal() == column - 2) {
+        }
+
+        CombatRole requiredRole = contract.getContractType().getRequiredCombatRole();
+        CombatRole columnRole = switch (column) {
+            case COL_FIGHT -> MANEUVER;
+            case COL_DEFEND -> FRONTLINE;
+            case COL_SCOUT -> PATROL;
+            case COL_TRAINING -> CADRE;
+            default -> null;
+        };
+
+        if (columnRole != null && requiredRole == columnRole) {
             int t = 0;
             for (CombatTeam combatTeam : campaign.getCombatTeamsAsList()) {
                 if (data.get(row).equals(combatTeam.getContract(campaign)) &&
-                          (combatTeam.getRole() ==
-                                 combatTeam.getContract(campaign).getContractType().getRequiredCombatRole()) &&
+                          (combatTeam.getRole() == requiredRole) &&
                           combatTeam.isEligible(campaign)) {
                     t += combatTeam.getSize(campaign);
                 }


### PR DESCRIPTION
This PR fixes an issue in how we display required combat elements in the Briefing Room GUI. Basically a legacy decision was made to map the columns to ordinals and use those ordinals to reference what combat role is necessary. However, that broke immediately once we introduced new combat roles (Cadre, in this instance).

This PR changes the gui to use directly mapped references (strong) instead of using ordinals (fragile).