### PR TITLE
Fix: Fixed Edge Not Passing to MegaMek From MekHQ

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4839,7 +4839,7 @@ public class Unit implements ITechnology {
      * double-counting personnel who serve in multiple roles.</p>
      *
      * <p>Non-combat crew members (such as vessel crew and combat technicians) are excluded from this calculation as
-     * their Edge is handled separately through MekHQ's non-combat personnel system.<p>
+     * their Edge is handled separately through MekHQ's non-combat personnel system.</p>
      *
      * @param crewSize         the total size of the crew to use for calculating the average Edge value
      * @param isCommandersOnly {@code true} if the 'Commanders Only' option is enabled for this unit type


### PR DESCRIPTION
Prior to the Edge changes made in #7925 edge was stored in the SPA data.

For multi-crewed units we would fetch current edge and apply that to the unit's Entity data, prior to a scenario. For single crewed units we would just pass the Edge 'SPA' data directly.

However, now Edge data is stored in a character's ATOW Attributes information. Due to the above, Edge worked fine for multi-crewed units, but for single crew units an Edge value of 0 would always be passed - because Edge is no longer stored where MekHQ was looking.

This also revealed another bug. As we were previously fetching Edge count directly from the SPA data single crewed units would always be considered to have maximum Edge. Even if they had spent some in a prior scenario within the same Edge refresh cycle.

This PR updates how we store Edge in an Entity to fix both of the above bugs.