### PR TITLE
Fix: Fixed Campaign Upgrader Occasionally Hanging During Upgrade Process

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CampaignUpgradeDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignUpgradeDialog.java
@@ -180,36 +180,46 @@ public class CampaignUpgradeDialog {
      * @author Illiani
      * @since 0.50.07
      */
+    /**
+     * Triggers a loading dialog while upgrading campaign options. This method can be called from any thread and will
+     * ensure all Swing operations occur on the Event Dispatch Thread.
+     *
+     * @param campaign          the campaign to upgrade
+     * @param chosenPreset      the preset to apply
+     * @param onUpgradeComplete callback to run after upgrade completes
+     */
     private static void triggerLoadingDialog(Campaign campaign, CampaignPreset chosenPreset,
           Runnable onUpgradeComplete) {
-        JDialog loadingDialog = new JDialog((Frame) null, true);
-        loadingDialog.setUndecorated(true);
+        SwingUtilities.invokeLater(() -> {
+            JDialog loadingDialog = new JDialog((Frame) null, true);
+            loadingDialog.setUndecorated(true);
 
-        JLabel loadingLabel = new JLabel(getFormattedTextAt(RESOURCE_BUNDLE, "CampaignUpgradeDialog.upgrading",
-              MHQConstants.VERSION.toString()));
-        loadingLabel.setBorder(RoundedLineBorder.createRoundedLineBorder());
-        loadingDialog.add(loadingLabel);
-        loadingDialog.pack();
-        loadingDialog.setLocationRelativeTo(null);
+            JLabel loadingLabel = new JLabel(getFormattedTextAt(RESOURCE_BUNDLE, "CampaignUpgradeDialog.upgrading",
+                  MHQConstants.VERSION.toString()));
+            loadingLabel.setBorder(RoundedLineBorder.createRoundedLineBorder());
+            loadingDialog.add(loadingLabel);
+            loadingDialog.pack();
+            loadingDialog.setLocationRelativeTo(null);
 
-        SwingWorker<Void, Void> worker = new SwingWorker<>() {
-            @Override
-            protected Void doInBackground() {
-                CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(campaign, chosenPreset);
-                optionsDialog.processApplyAction();
-                return null;
-            }
+            SwingWorker<Void, Void> worker = new SwingWorker<>() {
+                @Override
+                protected Void doInBackground() {
+                    CampaignOptionsDialog optionsDialog = new CampaignOptionsDialog(campaign, chosenPreset);
+                    optionsDialog.processApplyAction();
+                    return null;
+                }
 
-            @Override
-            protected void done() {
-                loadingDialog.setVisible(false);
-                loadingDialog.dispose();
-                onUpgradeComplete.run();
-            }
-        };
+                @Override
+                protected void done() {
+                    loadingDialog.setVisible(false);
+                    loadingDialog.dispose();
+                    onUpgradeComplete.run();
+                }
+            };
 
-        worker.execute();
-        loadingDialog.setVisible(true);
+            worker.execute();
+            loadingDialog.setVisible(true); // Blocks EDT until worker.done() closes dialog
+        });
     }
 
     /**


### PR DESCRIPTION
So, this has been an issue for a while but I thought it was an IDE problem. Basically, sometimes the campaign upgrade process would get stuck. Restarting the app usually fixes the issue, and I never saw it happen in production, so just ignored the problem. I figured it was just due to running from the IDE, maybe a fight over access rights, you know: the usual nonsense.

However, we started to see user contact about this, recently. Investigating I found a really stupid interaction that never should have been a problem and I'm kinda salty it was.

When we're upgrading a campaign we show a little display saying that we're upgrading the campaign, what version we're upgrading to, and that it'll take a bit. That dialog is modal so that the user can't break things by clicking all over the place, or (on Mac) accidentally hide it behind the splash screen and mistakenly think the whole thing had hung.

However, setting that dialog to modal blocks the event thread. Meaning that in _some_ (but not all cases) we can end up in a situation where the upgrader notice doesn't complete cleanly, and then clogs up the whole process. Because upgrading can't finish until that dialog has released access. But access can't be released, because the upgrade dialog is still present.

As I say, a stupid situation and I'm very salty over it.,