### PR TITLE
Improvement: Enforced Official Rule That Edge Can Only Be Used on a Single Roll Once Per Roll

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/AtBScenarioModifierApplicator.java
@@ -192,7 +192,7 @@ public class AtBScenarioModifierApplicator {
                     int numClusters = Compute.randomInt(battleDamageIntensity);
 
                     for (int clusterCount = 0; clusterCount < numClusters; clusterCount++) {
-                        HitData hitData = en.rollHitLocation(ToHitData.HIT_NORMAL, Compute.randomInt(4));
+                        HitData hitData = en.rollHitLocation(ToHitData.HIT_NORMAL, Compute.randomInt(4), false);
                         int resultingArmor = Math.max(1, en.getArmor(hitData) - 5);
 
                         en.setArmor(resultingArmor, hitData);


### PR DESCRIPTION
# Requires [Fix #5477, #5478: Enforce Official Rule That Edge Can Only Be Used on a Single Roll Once Per Roll; Stopped Edge Being Used to Re-roll Crit Locations When Only 1 Viable Location Remains](https://github.com/MegaMek/megamek/pull/7585)

This is the MekHQ portion of the above cited PR.