### PR TITLE
Fix #7930: Removed Several (Mostly Legacy) Unit Type Allowance Options Affecting Non-Legacy Campaigns

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1810,11 +1810,6 @@ lblOpForLanceTypeVehicle.tooltip=What ratio of enemy forces should be vehicle fo
 lblUseDropShips.text=Use Player DropShips
 lblUseDropShips.tooltip=Some scenarios may require the player to deploy with a combat drop. If the\
   \ player doesn't have a DropShip, the employer will provide one.
-lblOpForUsesVTOLs.text=Enable OpFor VTOLs
-lblOpForUsesVTOLs.tooltip=The Princess may use VTOLS in its vehicle forces.
-lblClanVehicles.text=Enable Clan Vehicles
-lblClanVehicles.tooltip=Clan opposing forces have a small chance of fielding vehicle Stars. The\
-  \ lower the unit rating, the higher the chance of encountering vehicles.
 lblRegionalMekVariations.text=Faction Influences Mek Weights
 lblRegionalMekVariations.tooltip=Use alternate weight class distributions for some factions.
 lblAttachedPlayerCamouflage.text=Attached Units use Campaign Camouflage
@@ -1936,24 +1931,6 @@ lblMoraleDecisiveDefeat.text=Decisive Defeat Modifier <span style="color:#C344C3
 lblMoraleDecisiveDefeat.tooltip=If, at the end of a month, your defeats double (or greater) the number of victories, \
   you are considered to have suffered a Decisive Defeat. This option determines what penalty is applied to the morale\
   \ check. This can be increased or decreased to influence contract difficulty. See the Glossary for more information.
-# createLegacyOpForGenerationPanel
-lblLegacyOpForGenerationPanel.text=Force Generation
-lblUseVehicles.text=Enable NPC Vehicles
-lblUseVehicles.tooltip=Enemy forces can include vehicles.
-lblDoubleVehicles.text=Double NPC Vehicles
-lblDoubleVehicles.tooltip=Clan opposing forces have a small chance of fielding vehicle Stars. The\
-  \ lower the unit rating, the higher the chance of encountering vehicles.
-lblOpForUsesAero.text=Enable NPC Aerospace Fighters
-lblOpForUsesAero.tooltip=The bot may reinforce its units with aircraft.
-lblOpForAeroChance.text=Aerospace Chance
-lblOpForAeroChance.tooltip=The chance of an OpFor being reinforced with aircraft, determined with a\
-  \ 1d6 roll.
-lblOpForUsesLocalForces.text=Enable NPC Infantry & Turrets
-lblOpForUsesLocalForces.tooltip=The bot may introduce turrets, infantry, and battle armor in\
-  \ defensive scenarios with appropriate terrain.
-lblAdjustPlayerVehicles.text=Treat Player Vehicles as Half Weight
-lblAdjustPlayerVehicles.tooltip=Vehicles deployed by the player only count half their weight to the\
-  \ lance weight class to compensate for enemy force generation designed to oppose player Meks.
 # createLegacyScenarioGenerationPanel
 lblLegacyScenarioGenerationPanel.text=Scenario Generation
 lblGenerateChases.text=Generate Chase Scenarios

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -624,11 +624,6 @@ public class CampaignOptions {
     private boolean useAdvancedScouting;
     private SkillLevel skillLevel;
 
-    // Unit Administration
-    private boolean useAero;
-    private boolean useVehicles;
-    private boolean clanVehicles;
-
     // Contract Operations
     private int moraleVictoryEffect;
     private int moraleDecisiveVictoryEffect;
@@ -642,16 +637,9 @@ public class CampaignOptions {
     // Scenarios
     private boolean useGenericBattleValue;
     private boolean useVerboseBidding;
-    private boolean doubleVehicles;
     private int opForLanceTypeMeks;
     private int opForLanceTypeMixed;
     private int opForLanceTypeVehicles;
-    private boolean opForUsesVTOLs;
-    private boolean allowOpForAerospace;
-    private int opForAeroChance;
-    private boolean allowOpForLocalUnits;
-    private int opForLocalUnitChance;
-    private boolean adjustPlayerVehicles;
     private boolean regionalMekVariations;
     private boolean attachedPlayerCamouflage;
     private boolean playerControlsAttachedUnits;
@@ -1291,10 +1279,6 @@ public class CampaignOptions {
         autoResolveNumberOfScenarios = 100;
         autoResolveExperimentalPacarGuiEnabled = false;
         strategicViewMinimapTheme = "gbc green.theme";
-        // Unit Administration
-        useAero = false;
-        useVehicles = true;
-        clanVehicles = false;
 
         // Morale
         moraleDecisiveVictoryEffect = 2;
@@ -1316,18 +1300,11 @@ public class CampaignOptions {
         // Scenarios
         useGenericBattleValue = true;
         useVerboseBidding = false;
-        doubleVehicles = false;
         setOpForLanceTypeMeks(1);
         setOpForLanceTypeMixed(2);
         setOpForLanceTypeVehicles(3);
-        setOpForUsesVTOLs(true);
-        setAllowOpForAerospace(false);
-        setOpForAeroChance(5);
-        setAllowOpForLocalUnits(false);
-        setOpForLocalUnitChance(5);
         setFixedMapChance(25);
         setSpaUpgradeIntensity(0);
-        adjustPlayerVehicles = false;
         regionalMekVariations = false;
         attachedPlayerCamouflage = true;
         playerControlsAttachedUnits = false;
@@ -4814,30 +4791,6 @@ public class CampaignOptions {
         this.useAdvancedScouting = useAdvancedScouting;
     }
 
-    public boolean isUseAero() {
-        return useAero;
-    }
-
-    public void setUseAero(final boolean useAero) {
-        this.useAero = useAero;
-    }
-
-    public boolean isUseVehicles() {
-        return useVehicles;
-    }
-
-    public void setUseVehicles(final boolean useVehicles) {
-        this.useVehicles = useVehicles;
-    }
-
-    public boolean isClanVehicles() {
-        return clanVehicles;
-    }
-
-    public void setClanVehicles(final boolean clanVehicles) {
-        this.clanVehicles = clanVehicles;
-    }
-
     /**
      * Returns whether Generic BV is being used.
      *
@@ -4874,22 +4827,6 @@ public class CampaignOptions {
         this.useVerboseBidding = useVerboseBidding;
     }
 
-    public boolean isDoubleVehicles() {
-        return doubleVehicles;
-    }
-
-    public void setDoubleVehicles(final boolean doubleVehicles) {
-        this.doubleVehicles = doubleVehicles;
-    }
-
-    public boolean isAdjustPlayerVehicles() {
-        return adjustPlayerVehicles;
-    }
-
-    public void setAdjustPlayerVehicles(final boolean adjustPlayerVehicles) {
-        this.adjustPlayerVehicles = adjustPlayerVehicles;
-    }
-
     public int getOpForLanceTypeMeks() {
         return opForLanceTypeMeks;
     }
@@ -4912,14 +4849,6 @@ public class CampaignOptions {
 
     public void setOpForLanceTypeVehicles(final int opForLanceTypeVehicles) {
         this.opForLanceTypeVehicles = opForLanceTypeVehicles;
-    }
-
-    public boolean isOpForUsesVTOLs() {
-        return opForUsesVTOLs;
-    }
-
-    public void setOpForUsesVTOLs(final boolean opForUsesVTOLs) {
-        this.opForUsesVTOLs = opForUsesVTOLs;
     }
 
     public boolean isUseDropShips() {
@@ -5199,38 +5128,6 @@ public class CampaignOptions {
      */
     @Deprecated(since = "0.50.06", forRemoval = true)
     public void setLimitLanceNumUnits(final boolean limitLanceNumUnits) {
-    }
-
-    public boolean isAllowOpForAerospace() {
-        return allowOpForAerospace;
-    }
-
-    public void setAllowOpForAerospace(final boolean allowOpForAerospace) {
-        this.allowOpForAerospace = allowOpForAerospace;
-    }
-
-    public boolean isAllowOpForLocalUnits() {
-        return allowOpForLocalUnits;
-    }
-
-    public void setAllowOpForLocalUnits(final boolean allowOpForLocalUnits) {
-        this.allowOpForLocalUnits = allowOpForLocalUnits;
-    }
-
-    public int getOpForAeroChance() {
-        return opForAeroChance;
-    }
-
-    public void setOpForAeroChance(final int opForAeroChance) {
-        this.opForAeroChance = opForAeroChance;
-    }
-
-    public int getOpForLocalUnitChance() {
-        return opForLocalUnitChance;
-    }
-
-    public void setOpForLocalUnitChance(final int opForLocalUnitChance) {
-        this.opForLocalUnitChance = opForLocalUnitChance;
     }
 
     public int getFixedMapChance() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -1064,20 +1064,14 @@ public class CampaignOptionsMarshaller {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useStratCon", campaignOptions.isUseStratCon());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useMaplessStratCon", campaignOptions.isUseStratConMaplessMode());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useAdvancedScouting", campaignOptions.isUseAdvancedScouting());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useAero", campaignOptions.isUseAero());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useVehicles", campaignOptions.isUseVehicles());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "clanVehicles", campaignOptions.isClanVehicles());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useGenericBattleValue", campaignOptions.isUseGenericBattleValue());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useVerboseBidding", campaignOptions.isUseVerboseBidding());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "doubleVehicles", campaignOptions.isDoubleVehicles());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "adjustPlayerVehicles", campaignOptions.isAdjustPlayerVehicles());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "opForLanceTypeMeks", campaignOptions.getOpForLanceTypeMeks());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "opForLanceTypeMixed", campaignOptions.getOpForLanceTypeMixed());
         MHQXMLUtility.writeSimpleXMLTag(pw,
               indent,
               "opForLanceTypeVehicles",
               campaignOptions.getOpForLanceTypeVehicles());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "opForUsesVTOLs", campaignOptions.isOpForUsesVTOLs());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useDropShips", campaignOptions.isUseDropShips());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "mercSizeLimited", campaignOptions.isMercSizeLimited());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "moraleVictoryEffect", campaignOptions.getMoraleVictoryEffect());
@@ -1107,10 +1101,6 @@ public class CampaignOptionsMarshaller {
               campaignOptions.isAssignPortraitOnRoleChange());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "allowDuplicatePortraits",
               campaignOptions.isAllowDuplicatePortraits());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "allowOpForAeros", campaignOptions.isAllowOpForAerospace());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "allowOpForLocalUnits", campaignOptions.isAllowOpForLocalUnits());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "opForAeroChance", campaignOptions.getOpForAeroChance());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "opForLocalUnitChance", campaignOptions.getOpForLocalUnitChance());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "fixedMapChance", campaignOptions.getFixedMapChance());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "spaUpgradeIntensity", campaignOptions.getSpaUpgradeIntensity());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "scenarioModMax", campaignOptions.getScenarioModMax());

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -825,17 +825,11 @@ public class CampaignOptionsUnmarshaller {
             case "useStratCon" -> campaignOptions.setUseStratCon(parseBoolean(nodeContents));
             case "useMaplessStratCon" -> campaignOptions.setUseStratConMaplessMode(parseBoolean(nodeContents));
             case "useAdvancedScouting" -> campaignOptions.setUseAdvancedScouting(parseBoolean(nodeContents));
-            case "useAero" -> campaignOptions.setUseAero(parseBoolean(nodeContents));
-            case "useVehicles" -> campaignOptions.setUseVehicles(parseBoolean(nodeContents));
-            case "clanVehicles" -> campaignOptions.setClanVehicles(parseBoolean(nodeContents));
             case "useGenericBattleValue" -> campaignOptions.setUseGenericBattleValue(parseBoolean(nodeContents));
             case "useVerboseBidding" -> campaignOptions.setUseVerboseBidding(parseBoolean(nodeContents));
-            case "doubleVehicles" -> campaignOptions.setDoubleVehicles(parseBoolean(nodeContents));
-            case "adjustPlayerVehicles" -> campaignOptions.setAdjustPlayerVehicles(parseBoolean(nodeContents));
             case "opForLanceTypeMeks" -> campaignOptions.setOpForLanceTypeMeks(parseInt(nodeContents));
             case "opForLanceTypeMixed" -> campaignOptions.setOpForLanceTypeMixed(parseInt(nodeContents));
             case "opForLanceTypeVehicles" -> campaignOptions.setOpForLanceTypeVehicles(parseInt(nodeContents));
-            case "opForUsesVTOLs" -> campaignOptions.setOpForUsesVTOLs(parseBoolean(nodeContents));
             case "useDropShips" -> campaignOptions.setUseDropShips(parseBoolean(nodeContents));
             case "mercSizeLimited" -> campaignOptions.setMercSizeLimited(parseBoolean(nodeContents));
             case "moraleVictoryEffect" -> campaignOptions.setMoraleVictoryEffect(parseInt(nodeContents));
@@ -865,10 +859,6 @@ public class CampaignOptionsUnmarshaller {
             case "useLightConditions" -> campaignOptions.setUseLightConditions(parseBoolean(nodeContents));
             case "usePlanetaryConditions" -> campaignOptions.setUsePlanetaryConditions(parseBoolean(nodeContents));
             case "restrictPartsByMission" -> campaignOptions.setRestrictPartsByMission(parseBoolean(nodeContents));
-            case "allowOpForLocalUnits" -> campaignOptions.setAllowOpForLocalUnits(parseBoolean(nodeContents));
-            case "allowOpForAeros" -> campaignOptions.setAllowOpForAerospace(parseBoolean(nodeContents));
-            case "opForAeroChance" -> campaignOptions.setOpForAeroChance(parseInt(nodeContents));
-            case "opForLocalUnitChance" -> campaignOptions.setOpForLocalUnitChance(parseInt(nodeContents));
             case "fixedMapChance" -> campaignOptions.setFixedMapChance(parseInt(nodeContents));
             case "spaUpgradeIntensity" -> campaignOptions.setSpaUpgradeIntensity(parseInt(nodeContents));
             case "scenarioModMax" -> campaignOptions.setScenarioModMax(parseInt(nodeContents));

--- a/MekHQ/src/mekhq/campaign/force/CombatTeam.java
+++ b/MekHQ/src/mekhq/campaign/force/CombatTeam.java
@@ -767,7 +767,7 @@ public class CombatTeam {
                 CampaignOptions campaignOptions = campaign.getCampaignOptions();
                 if (campaignOptions.isUseAtB() && !campaignOptions.isUseStratCon()) {
                     if (entityType == ETYPE_TANK) {
-                        if (isClan || campaignOptions.isAdjustPlayerVehicles()) {
+                        if (isClan) {
                             weight += entity.getWeight() * 0.5;
                         } else {
                             weight += entity.getWeight();

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -2077,15 +2077,7 @@ public class AtBDynamicScenarioFactory {
         // return getEntityByName("Heavy Tracked APC", params.getFaction(), skill, campaign);
         // return getEntityByName("Badger (C) Tracked Transport B", params.getFaction(), skill, campaign);
 
-        if (campaign.getCampaignOptions().isOpForUsesVTOLs()) {
-            params.getMovementModes().addAll(IUnitGenerator.MIXED_TANK_VTOL);
-        } else {
-            if (filterOutClanTech(campaign, isFactionClan(params.getFaction()))) {
-                params.setFilter(mekSummary -> !mekSummary.isClan() && !mekSummary.getUnitType().equals("VTOL"));
-            } else {
-                params.setFilter(mekSummary -> !mekSummary.getUnitType().equals("VTOL"));
-            }
-        }
+        params.getMovementModes().addAll(IUnitGenerator.MIXED_TANK_VTOL);
 
         MekSummary unitData = campaign.getUnitGenerator().generate(params);
 
@@ -3080,9 +3072,7 @@ public class AtBDynamicScenarioFactory {
 
             // If ground vehicles are permitted in general and by environmental conditions,
             // and for Clans if this is a Clan faction, then use them. Otherwise, only use Meks.
-            if (campaign.getCampaignOptions().isUseVehicles() &&
-                      allowTanks &&
-                      (!faction.isClan() || (faction.isClan() && campaign.getCampaignOptions().isClanVehicles()))) {
+            if (allowTanks) {
 
                 // some specialized logic for clan op fors
                 // if we're in the late republic or dark ages, clans no longer have the luxury
@@ -3250,7 +3240,7 @@ public class AtBDynamicScenarioFactory {
 
         // Random determination of Mek or ground vehicle
         int roll = d6(2);
-        int unitType = campaign.getCampaignOptions().isClanVehicles() && (roll <= vehicleTarget) ? TANK : MEK;
+        int unitType = roll <= vehicleTarget ? TANK : MEK;
 
         if ((campaign.getGameYear() >= 3057) && (randomInt(100) < 6)) {
             unitType = PROTOMEK;

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -847,17 +847,14 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             final int enemyDir = enemyHome;
             reinforcements.stream().filter(Objects::nonNull).forEach(en -> en.setStartingPos(enemyDir));
 
-            if (campaign.getCampaignOptions().isAllowOpForLocalUnits()) {
-                reinforcements.addAll(AtBDynamicScenarioFactory.fillTransports(this,
-                      reinforcements,
-                      getContract(campaign).getEnemyCode(),
-                      getContract(campaign).getEnemySkill(),
-                      getContract(campaign).getEnemyQuality(),
-                      null,
-                      true,
-                      campaign));
-
-            }
+            reinforcements.addAll(AtBDynamicScenarioFactory.fillTransports(this,
+                  reinforcements,
+                  getContract(campaign).getEnemyCode(),
+                  getContract(campaign).getEnemySkill(),
+                  getContract(campaign).getEnemyQuality(),
+                  null,
+                  true,
+                  campaign));
 
             BotForce bf = getEnemyBotForce(getContract(campaign), enemyHome, enemyHome, reinforcements);
             bf.setName(bf.getName() + " (Reinforcements)");
@@ -1162,16 +1159,14 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             addEnemyLance(list, AtBConfiguration.decodeWeightStr(lances, i) + weightMod, maxWeight, campaign);
         }
 
-        if (campaign.getCampaignOptions().isAllowOpForLocalUnits()) {
-            list.addAll(AtBDynamicScenarioFactory.fillTransports(this,
-                  list,
-                  getContract(campaign).getEnemyCode(),
-                  getContract(campaign).getEnemySkill(),
-                  getContract(campaign).getEnemyQuality(),
-                  null,
-                  true,
-                  campaign));
-        }
+        list.addAll(AtBDynamicScenarioFactory.fillTransports(this,
+              list,
+              getContract(campaign).getEnemyCode(),
+              getContract(campaign).getEnemySkill(),
+              getContract(campaign).getEnemyQuality(),
+              null,
+              true,
+              campaign));
     }
 
     /**
@@ -1309,19 +1304,17 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         weights = adjustForMaxWeight(weights, maxWeight);
 
         int forceType = FORCE_MEK;
-        if (campaign.getCampaignOptions().isUseVehicles()) {
-            int totalWeight = campaign.getCampaignOptions().getOpForLanceTypeMeks() +
-                                    campaign.getCampaignOptions().getOpForLanceTypeMixed() +
-                                    campaign.getCampaignOptions().getOpForLanceTypeVehicles();
-            if (totalWeight > 0) {
-                int roll = Compute.randomInt(totalWeight);
-                if (roll < campaign.getCampaignOptions().getOpForLanceTypeVehicles()) {
-                    forceType = FORCE_VEHICLE;
-                } else if (roll <
-                                 campaign.getCampaignOptions().getOpForLanceTypeVehicles() +
-                                       campaign.getCampaignOptions().getOpForLanceTypeMixed()) {
-                    forceType = FORCE_MIXED;
-                }
+        int totalWeight = campaign.getCampaignOptions().getOpForLanceTypeMeks() +
+                                campaign.getCampaignOptions().getOpForLanceTypeMixed() +
+                                campaign.getCampaignOptions().getOpForLanceTypeVehicles();
+        if (totalWeight > 0) {
+            int roll = Compute.randomInt(totalWeight);
+            if (roll < campaign.getCampaignOptions().getOpForLanceTypeVehicles()) {
+                forceType = FORCE_VEHICLE;
+            } else if (roll <
+                             campaign.getCampaignOptions().getOpForLanceTypeVehicles() +
+                                   campaign.getCampaignOptions().getOpForLanceTypeMixed()) {
+                forceType = FORCE_MIXED;
             }
         }
         if (forceType == FORCE_MEK && campaign.getCampaignOptions().isRegionalMekVariations()) {
@@ -1354,19 +1347,6 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             if (en != null) {
                 en.setDeployRound(arrivalTurn);
                 list.add(en);
-            }
-
-            if ((unitTypes[i] == UnitType.TANK) && campaign.getCampaignOptions().isDoubleVehicles()) {
-                en = getEntity(faction,
-                      skill,
-                      quality,
-                      unitTypes[i],
-                      AtBConfiguration.decodeWeightStr(weights, i),
-                      campaign);
-                if (en != null) {
-                    en.setDeployRound(arrivalTurn);
-                    list.add(en);
-                }
             }
         }
     }
@@ -1404,7 +1384,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
         if (roll >= novaTarget) {
             forceType = FORCE_NOVA;
-        } else if (campaign.getCampaignOptions().isClanVehicles() && roll <= vehicleTarget) {
+        } else if (roll <= vehicleTarget) {
             forceType = FORCE_VEHICLE;
         }
 
@@ -1524,7 +1504,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
                 list.add(en);
             }
 
-            if (unitTypes[i] == UnitType.TANK && campaign.getCampaignOptions().isDoubleVehicles()) {
+            if (unitTypes[i] == UnitType.TANK) {
                 en = getEntity(faction,
                       skill,
                       quality,
@@ -1580,7 +1560,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         // one per "pip" of difficulty.
         // if generating aerospace (crude approximation), we have a 1/2 chance of a light,
         // 1/3 chance of medium and 1/6 chance of heavy
-        if (!(campaign.getCampaignOptions().isAllowOpForAerospace() && (isStandardScenario() || isBigBattle()))) {
+        if (!(isStandardScenario() || isBigBattle())) {
             return;
         }
 
@@ -1592,14 +1572,13 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
         boolean spawnConventional = opForOwnsPlanet &&
                                           Compute.d6() >=
-                                                MHQConstants.MAXIMUM_D6_VALUE -
-                                                      campaign.getCampaignOptions().getOpForAeroChance();
+                                                MHQConstants.MAXIMUM_D6_VALUE - 5;
 
         // aero techs are rarer, so spawn them less often
         boolean spawnAeroTech = !opForOwnsPlanet &&
                                       Compute.d6() >
                                             MHQConstants.MAXIMUM_D6_VALUE -
-                                                  campaign.getCampaignOptions().getOpForAeroChance() / 2;
+                                                  5 / 2;
 
         ArrayList<Entity> aircraft = new ArrayList<>();
         Entity aero;
@@ -1679,9 +1658,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         // of seeing 1-5 hostile conventional infantry, one per "pip".
         // if the op for does not own the planet, we have a 1/6 chance of seeing 1-5
         // hostile battle armor, one per "pip" of difficulty.
-        if (!(campaign.getCampaignOptions().isAllowOpForLocalUnits() &&
-                    isAttacker() &&
-                    (isStandardScenario() || isBigBattle()))) {
+        if (!(isAttacker() && (isStandardScenario() || isBigBattle()))) {
             return;
         }
 
@@ -1693,17 +1670,17 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         boolean spawnTurrets = opForOwnsPlanet &&
                                      Compute.d6() >=
                                            MHQConstants.MAXIMUM_D6_VALUE -
-                                                 campaign.getCampaignOptions().getOpForLocalUnitChance();
+                                                 5;
         boolean spawnConventionalInfantry = opForOwnsPlanet &&
                                                   Compute.d6() >=
                                                         MHQConstants.MAXIMUM_D6_VALUE -
-                                                              campaign.getCampaignOptions().getOpForLocalUnitChance();
+                                                              5;
 
         // battle armor is rarer
         boolean spawnBattleArmor = !opForOwnsPlanet &&
                                          Compute.d6() >=
                                                MHQConstants.MAXIMUM_D6_VALUE -
-                                                     campaign.getCampaignOptions().getOpForLocalUnitChance() / 2;
+                                                     5 / 2;
 
         boolean isTurretAppropriateTerrain = (getTerrainType().toUpperCase().contains("URBAN") ||
                                                     getTerrainType().toUpperCase().contains("FACILITY"));

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsTab.java
@@ -106,9 +106,7 @@ public class RulesetsTab {
     private MMComboBox<SkillLevel> comboMinimumCallsignSkillLevel;
 
     private JCheckBox chkUseDropShips;
-    private JCheckBox chkOpForUsesVTOLs;
 
-    private JCheckBox chkClanVehicles;
     private JCheckBox chkRegionalMekVariations;
 
     private JCheckBox chkAttachedPlayerCamouflage;
@@ -159,15 +157,6 @@ public class RulesetsTab {
     //start Legacy AtB
     private CampaignOptionsHeaderPanel legacyHeader;
     private JCheckBox chkUseAtB;
-
-    private JPanel pnlLegacyOpForGenerationPanel;
-    private JCheckBox chkUseVehicles;
-    private JCheckBox chkDoubleVehicles;
-    private JCheckBox chkOpForUsesAero;
-    private JLabel lblOpForAeroChance;
-    private JSpinner spnOpForAeroChance;
-    private JCheckBox chkOpForUsesLocalForces;
-    private JCheckBox chkAdjustPlayerVehicles;
 
     private JPanel pnlLegacyScenarioGenerationPanel;
     private JLabel lblIntensity;
@@ -243,8 +232,6 @@ public class RulesetsTab {
         spnOpForLanceTypeVehicles = new JSpinner();
 
         chkUseDropShips = new JCheckBox();
-        chkOpForUsesVTOLs = new JCheckBox();
-        chkClanVehicles = new JCheckBox();
         chkRegionalMekVariations = new JCheckBox();
 
         chkAttachedPlayerCamouflage = new JCheckBox();
@@ -321,8 +308,6 @@ public class RulesetsTab {
         pnlUnitRatioPanel = createUniversalUnitRatioPanel();
 
         chkUseDropShips = new CampaignOptionsCheckBox("UseDropShips");
-        chkOpForUsesVTOLs = new CampaignOptionsCheckBox("OpForUsesVTOLs");
-        chkClanVehicles = new CampaignOptionsCheckBox("ClanVehicles");
         chkRegionalMekVariations = new CampaignOptionsCheckBox("RegionalMekVariations");
 
         chkAttachedPlayerCamouflage = new CampaignOptionsCheckBox("AttachedPlayerCamouflage");
@@ -384,12 +369,6 @@ public class RulesetsTab {
         layout.gridy++;
         layout.gridwidth = 2;
         panel.add(chkUseDropShips, layout);
-
-        layout.gridy++;
-        panel.add(chkOpForUsesVTOLs, layout);
-
-        layout.gridy++;
-        panel.add(chkClanVehicles, layout);
 
         layout.gridy++;
         panel.add(chkRegionalMekVariations, layout);
@@ -802,8 +781,6 @@ public class RulesetsTab {
         comboMinimumCallsignSkillLevel.addMouseListener(createTipPanelUpdater(stratConHeader,
               "MinimumCallsignSkillLevel"));
         chkUseDropShips.addMouseListener(createTipPanelUpdater(stratConHeader, "UseDropShips"));
-        chkOpForUsesVTOLs.addMouseListener(createTipPanelUpdater(stratConHeader, "OpForUsesVTOLs"));
-        chkClanVehicles.addMouseListener(createTipPanelUpdater(stratConHeader, "ClanVehicles"));
         chkRegionalMekVariations.addMouseListener(createTipPanelUpdater(stratConHeader, "RegionalMekVariations"));
         chkAttachedPlayerCamouflage.addMouseListener(createTipPanelUpdater(stratConHeader, "AttachedPlayerCamouflage"));
         chkPlayerControlsAttachedUnits.addMouseListener(createTipPanelUpdater(stratConHeader,
@@ -883,16 +860,6 @@ public class RulesetsTab {
         // General
         chkUseAtB = new JCheckBox();
 
-        // OpFor Generation
-        pnlLegacyOpForGenerationPanel = new JPanel();
-        chkUseVehicles = new JCheckBox();
-        chkDoubleVehicles = new JCheckBox();
-        chkOpForUsesAero = new JCheckBox();
-        lblOpForAeroChance = new JLabel();
-        spnOpForAeroChance = new JSpinner();
-        chkOpForUsesLocalForces = new JCheckBox();
-        chkAdjustPlayerVehicles = new JCheckBox();
-
         // Scenarios
         pnlLegacyScenarioGenerationPanel = new JPanel();
         chkGenerateChases = new JCheckBox();
@@ -924,7 +891,6 @@ public class RulesetsTab {
 
         chkUseAtB = new CampaignOptionsCheckBox("UseAtB");
         chkUseAtB.addMouseListener(createTipPanelUpdater(legacyHeader, "UseAtB"));
-        pnlLegacyOpForGenerationPanel = createLegacyOpForGenerationPanel();
         pnlLegacyScenarioGenerationPanel = createLegacyScenarioGenerationPanel();
 
         // Layout the Panel
@@ -941,73 +907,10 @@ public class RulesetsTab {
         panel.add(chkUseAtB, layout);
 
         layout.gridy++;
-        panel.add(pnlLegacyOpForGenerationPanel, layout);
-        layout.gridx++;
         panel.add(pnlLegacyScenarioGenerationPanel, layout);
 
         // Create panel and return
         return createParentPanel(panel, "LegacyTab");
-    }
-
-    /**
-     * Creates the UI panel for configuring the Legacy AtB opponent force (OpFor) generation settings.
-     * <p>
-     * Options include enabling vehicle support, aero unit chances, local forces, and player vehicle adjustments. The
-     * panel provides various checkboxes and spinners for user interaction.
-     * </p>
-     *
-     * @return a {@link JPanel} containing controls to configure AtB opponent force generation options
-     */
-    private JPanel createLegacyOpForGenerationPanel() {
-        // Content
-        chkUseVehicles = new CampaignOptionsCheckBox("UseVehicles");
-        chkUseVehicles.addMouseListener(createTipPanelUpdater(legacyHeader, "UseVehicles"));
-        chkDoubleVehicles = new CampaignOptionsCheckBox("DoubleVehicles");
-        chkDoubleVehicles.addMouseListener(createTipPanelUpdater(legacyHeader, "DoubleVehicles"));
-        chkOpForUsesAero = new CampaignOptionsCheckBox("OpForUsesAero");
-        chkOpForUsesAero.addMouseListener(createTipPanelUpdater(legacyHeader, "OpForUsesAero"));
-        lblOpForAeroChance = new CampaignOptionsLabel("OpForAeroChance");
-        lblOpForAeroChance.addMouseListener(createTipPanelUpdater(legacyHeader, "OpForAeroChance"));
-        spnOpForAeroChance = new CampaignOptionsSpinner("OpForAeroChance",
-              0, 0, 6, 1);
-        spnOpForAeroChance.addMouseListener(createTipPanelUpdater(legacyHeader, "OpForAeroChance"));
-        chkOpForUsesLocalForces = new CampaignOptionsCheckBox("OpForUsesLocalForces");
-        chkOpForUsesLocalForces.addMouseListener(createTipPanelUpdater(legacyHeader, "OpForUsesLocalForces"));
-        chkAdjustPlayerVehicles = new CampaignOptionsCheckBox("AdjustPlayerVehicles");
-        chkAdjustPlayerVehicles.addMouseListener(createTipPanelUpdater(legacyHeader, "AdjustPlayerVehicles"));
-
-        // Layout the Panel
-        final JPanel panel = new CampaignOptionsStandardPanel("LegacyOpForGenerationPanel", true,
-              "LegacyOpForGenerationPanel");
-        final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
-
-        layout.gridx = 0;
-        layout.gridy = 0;
-        layout.gridwidth = 2;
-        panel.add(chkUseVehicles, layout);
-
-        layout.gridy++;
-        panel.add(chkDoubleVehicles, layout);
-
-        layout.gridy++;
-        panel.add(chkOpForUsesAero, layout);
-
-        layout.gridx = 0;
-        layout.gridy++;
-        layout.gridwidth = 1;
-        panel.add(lblOpForAeroChance, layout);
-        layout.gridx++;
-        panel.add(spnOpForAeroChance, layout);
-
-        layout.gridx = 0;
-        layout.gridy++;
-        layout.gridwidth = 2;
-        panel.add(chkOpForUsesLocalForces, layout);
-
-        layout.gridy++;
-        panel.add(chkAdjustPlayerVehicles, layout);
-
-        return panel;
     }
 
     /**
@@ -1215,8 +1118,6 @@ public class RulesetsTab {
         options.setAutoGenerateOpForCallSigns(chkAutoGenerateOpForCallSigns.isSelected());
         options.setMinimumCallsignSkillLevel(comboMinimumCallsignSkillLevel.getSelectedItem());
         options.setUseDropShips(chkUseDropShips.isSelected());
-        options.setOpForUsesVTOLs(chkOpForUsesVTOLs.isSelected());
-        options.setClanVehicles(chkClanVehicles.isSelected());
         options.setRegionalMekVariations(chkRegionalMekVariations.isSelected());
         options.setAttachedPlayerCamouflage(chkAttachedPlayerCamouflage.isSelected());
         options.setPlayerControlsAttachedUnits(chkPlayerControlsAttachedUnits.isSelected());
@@ -1249,12 +1150,6 @@ public class RulesetsTab {
 
         // Legacy
         options.setUseAtB(chkUseAtB.isSelected() && !chkUseStratCon.isSelected());
-        options.setUseVehicles(chkUseVehicles.isSelected());
-        options.setDoubleVehicles(chkDoubleVehicles.isSelected());
-        options.setUseAero(chkOpForUsesAero.isSelected());
-        options.setOpForAeroChance((int) spnOpForAeroChance.getValue());
-        options.setAllowOpForLocalUnits(chkOpForUsesLocalForces.isSelected());
-        options.setAdjustPlayerVehicles(chkAdjustPlayerVehicles.isSelected());
         options.setGenerateChases(chkGenerateChases.isSelected());
 
         for (int i = 0; i < spnAtBBattleChance.length; i++) {
@@ -1293,8 +1188,6 @@ public class RulesetsTab {
         chkAutoGenerateOpForCallSigns.setSelected(options.isAutoGenerateOpForCallSigns());
         comboMinimumCallsignSkillLevel.setSelectedItem(options.getMinimumCallsignSkillLevel());
         chkUseDropShips.setSelected(options.isUseDropShips());
-        chkOpForUsesVTOLs.setSelected(options.isOpForUsesVTOLs());
-        chkClanVehicles.setSelected(options.isClanVehicles());
         chkRegionalMekVariations.setSelected(options.isRegionalMekVariations());
         chkAttachedPlayerCamouflage.setSelected(options.isAttachedPlayerCamouflage());
         chkPlayerControlsAttachedUnits.setSelected(options.isPlayerControlsAttachedUnits());
@@ -1327,12 +1220,6 @@ public class RulesetsTab {
 
         // Legacy
         chkUseAtB.setSelected(options.isUseAtB() && !options.isUseStratCon());
-        chkUseVehicles.setSelected(options.isUseVehicles());
-        chkDoubleVehicles.setSelected(options.isDoubleVehicles());
-        chkOpForUsesAero.setSelected(options.isUseAero());
-        spnOpForAeroChance.setValue(options.getOpForAeroChance());
-        chkOpForUsesLocalForces.setSelected(options.isAllowOpForLocalUnits());
-        chkAdjustPlayerVehicles.setSelected(options.isAdjustPlayerVehicles());
         chkGenerateChases.setSelected(options.isGenerateChases());
         for (CombatRole role : CombatRole.values()) {
             if (role.ordinal() <= CombatRole.CADRE.ordinal()) {

--- a/MekHQ/src/mekhq/module/atb/PersonnelMarketAtB.java
+++ b/MekHQ/src/mekhq/module/atb/PersonnelMarketAtB.java
@@ -81,27 +81,15 @@ public class PersonnelMarketAtB implements PersonnelMarketMethod {
                     recruit = campaign.newPerson(PersonnelRole.BA_TECH);
                 } else if (secondaryRoll < 4) {
                     recruit = campaign.newPerson(PersonnelRole.MECHANIC);
-                } else if (secondaryRoll == 4 && campaign.getCampaignOptions().isUseAero()) {
+                } else if (secondaryRoll == 4) {
                     recruit = campaign.newPerson(PersonnelRole.AERO_TEK);
                 } else {
                     recruit = campaign.newPerson(PersonnelRole.MEK_TECH);
                 }
             } else if (roll == 4 || roll == 10) {
                 recruit = campaign.newPerson(PersonnelRole.MEKWARRIOR);
-            } else if (roll == 5 && campaign.getCampaignOptions().isUseAero()) {
-                recruit = campaign.newPerson(PersonnelRole.AEROSPACE_PILOT);
-            } else if (roll == 5 && campaign.getFaction().isClan()) {
-                recruit = campaign.newPerson(PersonnelRole.MEKWARRIOR);
             } else if (roll == 5) {
-                int secondaryRoll = Compute.d6(2);
-                if (secondaryRoll == 2) {
-                    recruit = campaign.newPerson(PersonnelRole.VEHICLE_CREW_VTOL);
-                    // Frequency based on frequency of VTOLs in Xotl 3028 Merc/General
-                } else if (secondaryRoll <= 5) {
-                    recruit = campaign.newPerson(PersonnelRole.VEHICLE_CREW_GROUND);
-                } else {
-                    recruit = campaign.newPerson(PersonnelRole.VEHICLE_CREW_GROUND);
-                }
+                recruit = campaign.newPerson(PersonnelRole.AEROSPACE_PILOT);
             } else if (roll == 6 || roll == 8) {
                 if (campaign.getFaction().isClan() && (campaign.getGameYear() > 2870) && (Compute.d6(2) > 3)) {
                     recruit = campaign.newPerson(PersonnelRole.BATTLE_ARMOUR);


### PR DESCRIPTION
Fix #7930

As per title, this PR removes a number of campaign options related to allowed unit types. For the most part these were legacy options from AtB that should not have been affecting non-AtB campaigns but were.

Two non-legacy options were also removed:

- Allow VTOLs: this option was back from the old TestBot days, where having VTOLs in the OpFor _significantly_ increased the amount of time it took for TestBot to plot a route. With Princess and the numerous improvements she's seen over the years, this is no longer an issue.
- Allow Clan Vehicles: I'm not wholly sure why this is an option. I don't see a reason to exclude vehicles from Clan OpFors, especially not when we already have special handlers to adjust Clan vehicle usage based on Clan. This feels superfluous in modern MekHQ.