### PR TITLE
Improvement: Increased Recruitment Opportunities for Campaigns with Alternate Advanced Medical Enabled

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/PersonnelMarketMekHQ.java
@@ -91,6 +91,8 @@ import mekhq.campaign.universe.factionStanding.FactionStandings;
  * @since 0.50.06
  */
 public class PersonnelMarketMekHQ extends NewPersonnelMarket {
+    public static final int ALTERNATE_ADVANCED_MEDICAL_RECRUITMENT_MULTIPLIER = 2;
+
     /**
      * Constructs a personnel market using the MekHQ classic ruleset.
      *
@@ -334,6 +336,13 @@ public class PersonnelMarketMekHQ extends NewPersonnelMarket {
         getLogger().debug("Base rolls: {}", lengthOfMonth);
 
         int rolls = lengthOfMonth * getSystemStatusRecruitmentMultiplier();
+        if (getCampaign().getCampaignOptions().isUseAlternativeAdvancedMedical()) {
+            // Alt Advanced Medical increases the impact of injuries. Therefore, players need to maintain a larger
+            // roster of combat personnel. This multiplier doubles the number of recruits in the pool to account for
+            // this.
+            rolls *= ALTERNATE_ADVANCED_MEDICAL_RECRUITMENT_MULTIPLIER;
+        }
+
         getLogger().debug("Rolls modified for location: {}", rolls);
 
         rolls = clamp((int) round(rolls * getSystemPopulationRecruitmentMultiplier()), 1, rolls);

--- a/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/markets/personnelMarket/PersonnelMarketDialog.java
@@ -38,6 +38,7 @@ import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.finances.enums.TransactionType.RECRUITMENT;
 import static mekhq.campaign.market.personnelMarket.enums.PersonnelMarketStyle.MEKHQ;
 import static mekhq.campaign.market.personnelMarket.enums.PersonnelMarketStyle.PERSONNEL_MARKET_DISABLED;
+import static mekhq.campaign.market.personnelMarket.markets.PersonnelMarketMekHQ.ALTERNATE_ADVANCED_MEDICAL_RECRUITMENT_MULTIPLIER;
 import static mekhq.gui.enums.PersonnelFilter.ACTIVE;
 import static mekhq.gui.enums.PersonnelFilter.ALL;
 import static mekhq.gui.enums.PersonnelFilter.getStandardPersonnelFilters;
@@ -310,6 +311,10 @@ public class PersonnelMarketDialog extends JDialog {
         int recruitmentSliderMaximum = campaignOptions.getPersonnelMarketStyle() != PERSONNEL_MARKET_DISABLED ?
                                              MAXIMUM_DAYS_IN_MONTH * MAXIMUM_NUMBER_OF_SYSTEM_ROLLS :
                                              MAXIMUM_DAYS_IN_MONTH;
+        if (campaignOptions.isUseAlternativeAdvancedMedical()) {
+            recruitmentSliderMaximum *= ALTERNATE_ADVANCED_MEDICAL_RECRUITMENT_MULTIPLIER;
+        }
+
         int recruitmentSliderCurrent = min(market.getRecruitmentRolls(), recruitmentSliderMaximum);
         JSlider personnelAvailabilitySlider = new JSlider(0, recruitmentSliderMaximum, recruitmentSliderCurrent);
         personnelAvailabilitySlider.setEnabled(false);


### PR DESCRIPTION
Alt Advanced Medical is built around the idea that players will need to maintain a roster of 'spares', rather than just having their A-Team. When a character is injured they are usually out of action for a realistic, but extended period of time.

Player feedback for AAM has been overall positive, however one friction point is recruitment. Recruitment wasn't factoring in the increased need for bodies.

This PR doubles the number of applicants in the pool each month, if AAM is enabled. This should make it much easier for players to maintain their rosters. This may need further adjustment based on additional feedback, but should be a good starting point.