### PR TITLE
Fix #8002, #8020: Fixed Crew Fetching for Non-Tanks With Composite Crews

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -5050,7 +5050,7 @@ public class Unit implements ITechnology {
      * @param isDrivers        {@code true} to return drivers, {@code false} to return gunners (ignored if
      *                         {@code isTankOrInfantry} is {@code true})
      *
-     * @return a list of personnel; for tanks returns the full crew, for other entities returns either drivers or a copy
+     * @return a list of personnel; for tanks or infantry returns the full crew, for other entities returns either drivers or a copy
      *       of the gunners list
      */
     private List<Person> getCompositeCrew(boolean isTankOrInfantry, boolean isDrivers) {


### PR DESCRIPTION
Fix #8002
Fix #8020

This fixes the crew fetcher method to properly return the relevant crew for the unit type.