### PR TITLE
Improvement: Updated Alternative Advanced Medical Based on Player Feedback

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -646,7 +646,7 @@ lblUseAlternativeAdvancedMedical.tooltip=Advanced Medical will use injuries base
   \ have no effect if they are disabled.
 lblUseKinderAlternativeAdvancedMedical.text=Use Easy Alternative Mode \u270E \u26A0 \
   <span style="color:#C344C3;">\u2605</span>
-lblUseKinderAlternativeAdvancedMedical.tooltip=Halves all recovery times whole 'Alt Mode' is enabled.
+lblUseKinderAlternativeAdvancedMedical.tooltip=Halves all recovery times while 'Alt Mode' is enabled.
 lblMaximumPatients.text=Base Beds per Doctor
 lblMaximumPatients.tooltip=This is the base number of patients that can be treated per doctor. This can be modified by\
   \ Administration.

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -641,8 +641,12 @@ lblUseTougherHealing.text=Use Tougher Healing \u270E
 lblUseTougherHealing.tooltip=The healing check will be penalized for every additional hit above 2.
 lblUseAlternativeAdvancedMedical.text=Use Alternative Mode \u270E \u26A0 <span style="color:#C344C3;">\u2605</span>
 lblUseAlternativeAdvancedMedical.tooltip=Advanced Medical will use injuries based on the Advanced Hit Locations \
-  tables in ATOW:Companion. Healing times are based on real-world values. Injury penalties affect ATOW Attribute \
-  scores, so will have no effect if they are disabled.
+  tables in ATOW:Companion. Healing times are based on real-world values, you are expected to cycle out injured \
+  characters and maintain a roster of 'second-line' personnel. Injury penalties affect ATOW Attribute scores, so will\
+  \ have no effect if they are disabled.
+lblUseKinderAlternativeAdvancedMedical.text=Use Easy Alternative Mode \u270E \u26A0 \
+  <span style="color:#C344C3;">\u2605</span>
+lblUseKinderAlternativeAdvancedMedical.tooltip=Halves all recovery times whole 'Alt Mode' is enabled.
 lblMaximumPatients.text=Base Beds per Doctor
 lblMaximumPatients.tooltip=This is the base number of patients that can be treated per doctor. This can be modified by\
   \ Administration.

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -268,6 +268,7 @@ public class CampaignOptions {
     private boolean useRandomHitsForVehicles;
     private boolean tougherHealing;
     private boolean useAlternativeAdvancedMedical;
+    private boolean useKinderAlternativeAdvancedMedical;
     private int maximumPatients;
     private boolean doctorsUseAdministration;
     private boolean useUsefulMedics;
@@ -862,6 +863,7 @@ public class CampaignOptions {
         setUseRandomHitsForVehicles(false);
         setTougherHealing(false);
         useAlternativeAdvancedMedical = false;
+        useKinderAlternativeAdvancedMedical = false;
         setMaximumPatients(25);
         setDoctorsUseAdministration(false);
         useUsefulMedics = false;
@@ -2007,7 +2009,32 @@ public class CampaignOptions {
     // endregion Expanded Personnel Information
 
     // region Medical
+
+    /**
+     * Checks if any form of advanced medical system is enabled.
+     *
+     * <p>This method returns {@code true} if either the standard advanced medical system or the alternative advanced
+     * medical system is enabled.</p>
+     *
+     * @return {@code true} if either advanced medical system is in use, {@code false} otherwise
+     *
+     * @see #isUseAdvancedMedicalDirect()
+     */
     public boolean isUseAdvancedMedical() {
+        return useAdvancedMedical || useAlternativeAdvancedMedical;
+    }
+
+    /**
+     * Checks if the standard advanced medical system is enabled.
+     *
+     * <p>This method specifically checks only the standard advanced medical system, ignoring the alternative
+     * advanced medical system setting.</p>
+     *
+     * @return {@code true} if the standard advanced medical system is enabled, {@code false} otherwise
+     *
+     * @see #isUseAdvancedMedical()
+     */
+    public boolean isUseAdvancedMedicalDirect() {
         return useAdvancedMedical;
     }
 
@@ -2061,6 +2088,14 @@ public class CampaignOptions {
 
     public void setUseAlternativeAdvancedMedical(final boolean useAlternativeAdvancedMedical) {
         this.useAlternativeAdvancedMedical = useAlternativeAdvancedMedical;
+    }
+
+    public boolean isUseKinderAlternativeAdvancedMedical() {
+        return useKinderAlternativeAdvancedMedical;
+    }
+
+    public void setUseKinderAlternativeAdvancedMedical(final boolean useKinderAlternativeAdvancedMedical) {
+        this.useKinderAlternativeAdvancedMedical = useKinderAlternativeAdvancedMedical;
     }
 
     public int getMaximumPatients() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -337,7 +337,9 @@ public class CampaignOptionsMarshaller {
         // endregion Admin
 
         // region Medical
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useAdvancedMedical", campaignOptions.isUseAdvancedMedical());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useAdvancedMedical", campaignOptions.isUseAdvancedMedicalDirect());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useKinderAlternativeAdvancedMedical",
+              campaignOptions.isUseKinderAlternativeAdvancedMedical());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "healWaitingPeriod", campaignOptions.getHealingWaitingPeriod());
         MHQXMLUtility.writeSimpleXMLTag(pw,
               indent,

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -359,6 +359,8 @@ public class CampaignOptionsUnmarshaller {
             case "tougherHealing" -> campaignOptions.setTougherHealing(parseBoolean(nodeContents));
             case "useAlternativeAdvancedMedical" ->
                   campaignOptions.setUseAlternativeAdvancedMedical(parseBoolean(nodeContents));
+            case "useKinderAlternativeAdvancedMedical" ->
+                  campaignOptions.setUseKinderAlternativeAdvancedMedical(parseBoolean(nodeContents));
             case "maximumPatients" -> campaignOptions.setMaximumPatients(parseInt(nodeContents));
             case "doctorsUseAdministration" -> campaignOptions.setDoctorsUseAdministration(parseBoolean(
                   nodeContents));

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
@@ -49,7 +49,6 @@ import megamek.common.compute.Compute;
 import megamek.common.units.Aero;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
-import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.GameEffect;
 import mekhq.campaign.log.MedicalLogger;
@@ -175,11 +174,8 @@ public final class InjuryUtil {
         Collection<Injury> newInjuries = AdvancedMedicalAlternate.generateInjuriesFromHits(campaign, person, hits);
         for (Injury injury : newInjuries) {
             if (isUseKinderMode) {
-                MMLogger LOGGER = MMLogger.create(InjuryUtil.class);
                 int originalRecoveryTime = injury.getOriginalTime();
-                LOGGER.info("originalRecoveryTime: " + originalRecoveryTime);
                 int newRecoveryTime = (int) ceil(originalRecoveryTime / 2.0);
-                LOGGER.info("newRecoveryTime: " + newRecoveryTime);
                 injury.setOriginalTime(newRecoveryTime);
                 injury.setTime(newRecoveryTime);
             }

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryUtil.java
@@ -32,6 +32,8 @@
  */
 package mekhq.campaign.personnel.medical.advancedMedical;
 
+import static java.lang.Math.ceil;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -47,6 +49,7 @@ import megamek.common.compute.Compute;
 import megamek.common.units.Aero;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
+import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.GameEffect;
 import mekhq.campaign.log.MedicalLogger;
@@ -121,7 +124,8 @@ public final class InjuryUtil {
      */
     public static void resolveCombatDamage(Campaign campaign, Person person, int hits) {
         if (campaign.getCampaignOptions().isUseAlternativeAdvancedMedical()) {
-            resolveCombatDamageUsingAlternateModel(campaign, person, hits);
+            resolveCombatDamageUsingAlternateModel(campaign, person, hits,
+                  campaign.getCampaignOptions().isUseKinderAlternativeAdvancedMedical());
         } else {
             resolveCombatDamageUsingStandardModel(campaign, person, hits);
         }
@@ -158,16 +162,30 @@ public final class InjuryUtil {
      * <p>Injuries may be automatically removed during processing if the body location they affect has been severed
      * by another injury.</p>
      *
-     * @param campaign the current campaign
-     * @param person   the person who suffered combat damage
-     * @param hits     the number of TW-scale Hits taken
+     * @param campaign        the current campaign
+     * @param person          the person who suffered combat damage
+     * @param hits            the number of TW-scale Hits taken
+     * @param isUseKinderMode {@code true} to halve all recovery times
      *
      * @author Illiani
      * @since 0.50.10
      */
-    private static void resolveCombatDamageUsingAlternateModel(Campaign campaign, Person person, int hits) {
+    private static void resolveCombatDamageUsingAlternateModel(Campaign campaign, Person person, int hits,
+          boolean isUseKinderMode) {
         Collection<Injury> newInjuries = AdvancedMedicalAlternate.generateInjuriesFromHits(campaign, person, hits);
-        newInjuries.forEach(person::addInjury);
+        for (Injury injury : newInjuries) {
+            if (isUseKinderMode) {
+                MMLogger LOGGER = MMLogger.create(InjuryUtil.class);
+                int originalRecoveryTime = injury.getOriginalTime();
+                LOGGER.info("originalRecoveryTime: " + originalRecoveryTime);
+                int newRecoveryTime = (int) ceil(originalRecoveryTime / 2.0);
+                LOGGER.info("newRecoveryTime: " + newRecoveryTime);
+                injury.setOriginalTime(newRecoveryTime);
+                injury.setTime(newRecoveryTime);
+            }
+
+            person.addInjury(injury);
+        }
 
         // Remove injuries from limbs that have been severed
         AdvancedMedicalAlternate.purgeIllogicalInjuries(person);
@@ -427,7 +445,7 @@ public final class InjuryUtil {
                           GenderDescriptors.HIS_HER_THEIR.getDescriptor(p.getGender()),
                           i.getName()), rnd -> {
                         int time = i.getTime();
-                        i.setTime((int) Math.max(Math.ceil(time * 1.2), time + 5));
+                        i.setTime((int) Math.max(ceil(time * 1.2), time + 5));
                         MedicalLogger.docMadeAMistake(doc, p, i, c.getLocalDate());
 
                         // TODO: Add in special handling of the critical

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
@@ -54,19 +54,19 @@ import mekhq.campaign.personnel.medical.BodyLocation;
 public class AlternateInjuries {
     private static final String RESOURCE_BUNDLE = "mekhq.resources.AlternateInjuries";
 
-    private static final int BURN_HEALING_DAYS = 7; // Internet says 1-3 weeks
-    private static final int DEAFNESS_HEALING_DAYS = 7; // Internet says around a week
-    private static final int BLINDNESS_HEALING_DAYS = 7; // Internet says this varies a lot, we went with a week
-    private static final int FRACTURE_HEALING_DAYS = 42; // Internet says 6-8 weeks
-    private static final int COMPOUND_FRACTURE_HEALING_DAYS = 42; // Internet says 6-12 weeks
-    private static final int SMOKE_INHALATION_HEALING_DAYS = 2; // Internet says 2-3 days
-    private static final int PUNCTURED_LUNG_HEALING_DAYS = 42; // Internet says 6-8 weeks
-    private static final int HEART_TRAUMA_HEALING_DAYS = 28; // Internet says 4-12 weeks
-    private static final int ORGAN_BRUISE_HEALING_DAYS = 28; // Internet says 4-6 weeks
-    private static final int ORGAN_TRAUMA_HEALING_DAYS = 42; // Internet says 6-8 weeks
-    private static final int DISEMBOWELED_HEALING_DAYS = 42; // Internet says 6-8 weeks
-    private static final int BONE_BRUISE_HEALING_DAYS = 42; // Internet says 6 weeks
-    private static final int BLOOD_LOSS_HEALING_DAYS = 28; // Internet says 4-6 weeks
+    private static final int BURN_HEALING_DAYS = 4; // Internet says 1-3 weeks
+    private static final int DEAFNESS_HEALING_DAYS = 4; // Internet says around a week
+    private static final int BLINDNESS_HEALING_DAYS = 4; // Internet says this varies a lot, we went with a week
+    private static final int FRACTURE_HEALING_DAYS = 21; // Internet says 6-8 weeks
+    private static final int COMPOUND_FRACTURE_HEALING_DAYS = 21; // Internet says 6-12 weeks
+    private static final int SMOKE_INHALATION_HEALING_DAYS = 1; // Internet says 2-3 days
+    private static final int PUNCTURED_LUNG_HEALING_DAYS = 21; // Internet says 6-8 weeks
+    private static final int HEART_TRAUMA_HEALING_DAYS = 14; // Internet says 4-12 weeks
+    private static final int ORGAN_BRUISE_HEALING_DAYS = 14; // Internet says 4-6 weeks
+    private static final int ORGAN_TRAUMA_HEALING_DAYS = 21; // Internet says 6-8 weeks
+    private static final int DISEMBOWELED_HEALING_DAYS = 21; // Internet says 6-8 weeks
+    private static final int BONE_BRUISE_HEALING_DAYS = 21; // Internet says 6 weeks
+    private static final int BLOOD_LOSS_HEALING_DAYS = 14; // Internet says 4-6 weeks
     private static final int SEVER_HEALING_DAYS = 180; // We need to have something here for Advanced Medical
 
     private static final InjuryLevel SEVERE_INJURY_LEVEL = InjuryLevel.CHRONIC;

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/PersonnelTab.java
@@ -187,6 +187,7 @@ public class PersonnelTab {
     private JCheckBox chkUseRandomHitsForVehicles;
     private JCheckBox chkUseTougherHealing;
     private JCheckBox chkUseAlternativeAdvancedMedical;
+    private JCheckBox chkUseKinderAlternativeAdvancedMedical;
     private JLabel lblMaximumPatients;
     private JSpinner spnMaximumPatients;
     private JCheckBox chkDoctorsUseAdministration;
@@ -277,6 +278,7 @@ public class PersonnelTab {
         chkUseRandomHitsForVehicles = new JCheckBox();
         chkUseTougherHealing = new JCheckBox();
         chkUseAlternativeAdvancedMedical = new JCheckBox();
+        chkUseKinderAlternativeAdvancedMedical = new JCheckBox();
 
         lblMaximumPatients = new JLabel();
         spnMaximumPatients = new JSpinner();
@@ -848,6 +850,10 @@ public class PersonnelTab {
         chkUseAlternativeAdvancedMedical.addMouseListener(createTipPanelUpdater(medicalHeader,
               "UseAlternativeAdvancedMedical"));
 
+        chkUseKinderAlternativeAdvancedMedical = new CampaignOptionsCheckBox("UseKinderAlternativeAdvancedMedical");
+        chkUseKinderAlternativeAdvancedMedical.addMouseListener(createTipPanelUpdater(medicalHeader,
+              "UseKinderAlternativeAdvancedMedical"));
+
         lblMaximumPatients = new CampaignOptionsLabel("MaximumPatients");
         lblMaximumPatients.addMouseListener(createTipPanelUpdater(medicalHeader, "MaximumPatients"));
         spnMaximumPatients = new CampaignOptionsSpinner("MaximumPatients", 25, 1, 100, 1);
@@ -930,6 +936,8 @@ public class PersonnelTab {
         panelRight.add(chkUseTougherHealing, layoutRight);
         layoutRight.gridy++;
         panelRight.add(chkUseAlternativeAdvancedMedical, layoutRight);
+        layoutRight.gridy++;
+        panelRight.add(chkUseKinderAlternativeAdvancedMedical, layoutRight);
 
         // Layout the Panels
         final JPanel panelParent = new CampaignOptionsStandardPanel("MedicalTab", true);
@@ -1388,13 +1396,14 @@ public class PersonnelTab {
         txtAwardSetFilterList.setText(options.getAwardSetFilterList());
 
         // Medical
-        chkUseAdvancedMedical.setSelected(options.isUseAdvancedMedical());
+        chkUseAdvancedMedical.setSelected(options.isUseAdvancedMedicalDirect());
         spnHealWaitingPeriod.setValue(options.getHealingWaitingPeriod());
         spnNaturalHealWaitingPeriod.setValue(options.getNaturalHealingWaitingPeriod());
         spnMinimumHitsForVehicles.setValue(options.getMinimumHitsForVehicles());
         chkUseRandomHitsForVehicles.setSelected(options.isUseRandomHitsForVehicles());
         chkUseTougherHealing.setSelected(options.isTougherHealing());
         chkUseAlternativeAdvancedMedical.setSelected(options.isUseAlternativeAdvancedMedical());
+        chkUseKinderAlternativeAdvancedMedical.setSelected(options.isUseKinderAlternativeAdvancedMedical());
         spnMaximumPatients.setValue(options.getMaximumPatients());
         chkDoctorsUseAdministration.setSelected(options.isDoctorsUseAdministration());
         chkUseUsefulMedics.setSelected(options.isUseUsefulMedics());
@@ -1495,6 +1504,7 @@ public class PersonnelTab {
         options.setUseRandomHitsForVehicles(chkUseRandomHitsForVehicles.isSelected());
         options.setTougherHealing(chkUseTougherHealing.isSelected());
         options.setUseAlternativeAdvancedMedical(chkUseAlternativeAdvancedMedical.isSelected());
+        options.setUseKinderAlternativeAdvancedMedical(chkUseKinderAlternativeAdvancedMedical.isSelected());
         options.setMaximumPatients((int) spnMaximumPatients.getValue());
         options.setDoctorsUseAdministration(chkDoctorsUseAdministration.isSelected());
         options.setIsUseUsefulMedics(chkUseUsefulMedics.isSelected());


### PR DESCRIPTION
AAM was a tad overtuned. While the healing times _were_ real world accurate, it turns out that doesn't make a great play experience.

This PR does the following:
- Removes the need to have both AM and AAM enabled for AM to function
- Halved all healing times
- Adds an 'easy mode' campaign option that halves all healing times again.

It's my hope that this will make AAM more accessible, and improve user uptake.