### PR TITLE
Improvement: Added Out-of-Character Notice to Disband Events

### DIFF
--- a/MekHQ/resources/mekhq/resources/FactionJudgmentSceneDialog.properties
+++ b/MekHQ/resources/mekhq/resources/FactionJudgmentSceneDialog.properties
@@ -159,6 +159,8 @@ FactionJudgmentSceneDialog.BARRED.MBA=<h2 style="text-align:center">Two Years La
 ## button
 FactionJudgmentSceneDialog.button.DISBAND=<html>{0}<b>Game Over</b>{1}</html>
 ## messages
+FactionJudgmentSceneDialog.DISBAND.ooc=Your campaign has reached a definitive conclusion. However, MekHQ does not \
+  enforce this campaign end. This is done so that you have the power to continue your narrative, should you wish.
 FactionJudgmentSceneDialog.DISBAND.innerSphere=<h2 style="text-align:center">Three Years Later...</h2>\
   <p>The coffee at the Veteran''s Club was always too weak and too hot. {23} drank it anyway.</p>\
   <p>The walls were covered in faded photos - old drop-zones, honor shots, reunion plaques that hadn''t been updated in \

--- a/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentSceneDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/factionStanding/factionJudgment/FactionJudgmentSceneDialog.java
@@ -100,13 +100,16 @@ public class FactionJudgmentSceneDialog {
         String inCharacterText = getInCharacterText(RESOURCE_BUNDLE, dialogKey, commander, secondCharacter,
               factionName, campaignName, locationName, 0, commanderAddress);
 
+        String outOfCharacterText = sceneType != FactionJudgmentSceneType.DISBAND ? null : getTextAt(RESOURCE_BUNDLE,
+              "FactionJudgmentSceneDialog.DISBAND.ooc");
+
         new ImmersiveDialogSimple(
               campaign,
               commander,
               secondCharacter,
               inCharacterText,
               getButtonLabels(sceneType),
-              null,
+              outOfCharacterText,
               null,
               false,
               ImmersiveDialogWidth.LARGE);


### PR DESCRIPTION
Player feedback was that it wasn't obvious why they could continue playing after a disband event occurred. This PR adds a notice explaining why.