### PR TITLE
Improvement: Removed Silent Nature of First Two Faction Standing Accolade Levels

### DIFF
--- a/MekHQ/resources/mekhq/resources/FactionJudgmentDialog.properties
+++ b/MekHQ/resources/mekhq/resources/FactionJudgmentDialog.properties
@@ -1475,6 +1475,10 @@ FactionJudgmentDialog.message.ACCOLADE.ADOPTION_OR_MEKS.meks.campaign=You may no
   <p>{1}<b>Warning:</b>{2} This benefit is temporarily <b>Lost</b> if you gain a <b>Censure</b> or negative \
   <b>Regard</b> with <b>{0}</b>. This ability is restored once the <b>Censure</b> has expired and <b>Regard</b> is \
   positive once more.</p>
+FactionJudgmentDialog.message.TAKING_NOTICE_0.message=A powerful political or military figure within <b>{0}</b> has \
+  taken an interest in you.
+FactionJudgmentDialog.message.TAKING_NOTICE_1.message=Another powerful political or military figure within <b>{0}</b> \
+  has taken an interest in you.
 #### IC
 ##### Adoption
 FactionJudgmentDialog.message.ACCOLADE.ADOPTION_OR_MEKS.adoption.innerSphere={22}, your reputation precedes you. In light of \

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionAccoladeEvent.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionAccoladeEvent.java
@@ -164,8 +164,6 @@ public class FactionAccoladeEvent {
 
             ImmersiveDialogWidth dialogWidth;
             if (accoladeLevel.is(APPEARING_IN_SEARCHES) ||
-                      accoladeLevel.is(TAKING_NOTICE_0) ||
-                      accoladeLevel.is(TAKING_NOTICE_1) ||
                       isCashReward) {
                 dialogWidth = ImmersiveDialogWidth.MEDIUM;
             } else {


### PR DESCRIPTION
Player feedback was that the system didn't feel like it was rewarding their victories enough. This is due to the first two levels of Accolades being silent. That results in the campaign going at least a year (after hitting the milestone needed for accolades) without any in game reaction.

This PR addresses that by triggering notifications at accolade levels `TAKING_NOTICE_0` and `TAKING_NOTICE_1`.