### PR TITLE
Improvement: Added a Campaign Option to Obstruct Delivery of Parts and Units While in Transit

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -274,6 +274,10 @@ lblDeliveryPanel.text=Deliveries
 lblTransitTimeUnits.text=Delivery Scale
 lblTransitTimeUnits.tooltip=Should deliveries be scaled using days, weeks, or months? Campaign\
   \ Operations uses months.
+lblNoDeliveriesInTransit.text=No Deliveries in Transit
+lblNoDeliveriesInTransit.tooltip=When this campaign option is enabled, parts and units will not be delivered unless \
+  the campaign is planetside. Delivery time will still go down, while in transit, but will stop at 1 day. This means \
+  delivery will occur the day after you arrive at your destination.
 transitUnitNamesDays.text=Days
 transitUnitNamesWeeks.text=Weeks
 transitUnitNamesMonths.text=Months

--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -274,7 +274,7 @@ lblDeliveryPanel.text=Deliveries
 lblTransitTimeUnits.text=Delivery Scale
 lblTransitTimeUnits.tooltip=Should deliveries be scaled using days, weeks, or months? Campaign\
   \ Operations uses months.
-lblNoDeliveriesInTransit.text=No Deliveries in Transit
+lblNoDeliveriesInTransit.text=No Deliveries in Transit <span style="color:#C344C3;">\u2605</span>
 lblNoDeliveriesInTransit.tooltip=When this campaign option is enabled, parts and units will not be delivered unless \
   the campaign is planetside. Delivery time will still go down, while in transit, but will stop at 1 day. This means \
   delivery will occur the day after you arrive at your destination.

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1003,6 +1003,16 @@ public class CampaignNewDayManager {
             // If the part is currently in-transit...
             if (!part.isPresent()) {
                 // ... decrement the number of days until it arrives...
+                int newDaysToArrival = part.getDaysToArrival() - 1;
+
+                // If we're in transit and we don't allow deliveries while in transit the part will remain fixed with
+                // a delivery time of 1 day until we arrive at our destination.
+                if (campaignOptions.isNoDeliveriesInTransit() &&
+                          !campaign.getLocation().isOnPlanet() &&
+                          newDaysToArrival <= 0) {
+                    return;
+                }
+
                 part.setDaysToArrival(part.getDaysToArrival() - 1);
 
                 if (part.isPresent()) {
@@ -1072,7 +1082,7 @@ public class CampaignNewDayManager {
                 campaign.workOnMothballingOrActivation(unit);
             }
             if (!unit.isPresent()) {
-                unit.checkArrival();
+                unit.checkArrival(!campaign.getLocation().isOnPlanet() && campaignOptions.isNoDeliveriesInTransit());
 
                 // Has unit just been delivered?
                 if (unit.isPresent()) {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -188,6 +188,7 @@ public class CampaignOptions {
 
     // Delivery
     private int unitTransitTime;
+    private boolean noDeliveriesInTransit;
 
     // Planetary Acquisition
     private boolean usePlanetaryAcquisition;
@@ -770,6 +771,7 @@ public class CampaignOptions {
 
         // Delivery
         unitTransitTime = TRANSIT_UNIT_MONTH;
+        noDeliveriesInTransit = false;
 
         // Planetary Acquisition
         usePlanetaryAcquisition = false;
@@ -4480,6 +4482,14 @@ public class CampaignOptions {
 
     public void setUnitTransitTime(final int unitTransitTime) {
         this.unitTransitTime = unitTransitTime;
+    }
+
+    public boolean isNoDeliveriesInTransit() {
+        return noDeliveriesInTransit;
+    }
+
+    public void setNoDeliveriesInTransit(final boolean noDeliveriesInTransit) {
+        this.noDeliveriesInTransit = noDeliveriesInTransit;
     }
 
     public boolean isUsePlanetaryAcquisition() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -156,6 +156,7 @@ public class CampaignOptionsMarshaller {
               campaignOptions.getAcquisitionPersonnelCategory().name());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "techLevel", campaignOptions.getTechLevel());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "unitTransitTime", campaignOptions.getUnitTransitTime());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "noDeliveriesInTransit", campaignOptions.isNoDeliveriesInTransit());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "usePlanetaryAcquisition",
               campaignOptions.isUsePlanetaryAcquisition());
         MHQXMLUtility.writeSimpleXMLTag(pw,

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -156,6 +156,7 @@ public class CampaignOptionsUnmarshaller {
             case "acquisitionSkill" -> campaignOptions.setAcquisitionSkill(nodeContents);
             case "useFunctionalAppraisal" -> campaignOptions.setUseFunctionalAppraisal(parseBoolean(nodeContents));
             case "unitTransitTime" -> campaignOptions.setUnitTransitTime(parseInt(nodeContents));
+            case "noDeliveriesInTransit" -> campaignOptions.setNoDeliveriesInTransit(parseBoolean(nodeContents));
             case "clanAcquisitionPenalty" -> campaignOptions.setClanAcquisitionPenalty(parseInt(nodeContents));
             case "isAcquisitionPenalty" -> campaignOptions.setIsAcquisitionPenalty(parseInt(nodeContents));
             case "usePlanetaryAcquisition" -> campaignOptions.setPlanetaryAcquisition(parseBoolean(nodeContents));

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -6173,12 +6173,32 @@ public class Unit implements ITechnology {
         return daysToArrival;
     }
 
-    public boolean checkArrival() {
+    /**
+     * Checks and updates the arrival countdown for this unit.
+     *
+     * <p>This method decrements the days to arrival counter and determines whether the unit has arrived. If delivery
+     * is obstructed when the unit would arrive, the arrival is delayed by maintaining the counter at 1 day
+     * remaining.</p>
+     *
+     * <p>When a unit successfully arrives (countdown reaches 0 and delivery is not obstructed), a UnitArrivedEvent
+     * is triggered.</p>
+     *
+     * @param obstructDelivery if {@code true}, delays arrival by one day when the unit would otherwise arrive; if
+     *                         {@code false}, allows normal arrival
+     *
+     * @return {@code true} if the unit has arrived this check
+     */
+    public boolean checkArrival(boolean obstructDelivery) {
         if (daysToArrival > 0) {
             daysToArrival--;
-            if (daysToArrival == 0) {
-                MekHQ.triggerEvent(new UnitArrivedEvent(this));
-                return true;
+            if (daysToArrival <= 0) {
+                if (obstructDelivery) {
+                    daysToArrival = 1;
+                    return false;
+                } else {
+                    MekHQ.triggerEvent(new UnitArrivedEvent(this));
+                    return true;
+                }
             }
         }
         return false;

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
@@ -134,6 +134,7 @@ public class EquipmentAndSuppliesTab {
     private static final int TRANSIT_UNIT_WEEK = 1;
     private static final int TRANSIT_UNIT_MONTH = 2;
     private static final int TRANSIT_UNIT_NUM = 3;
+    private JCheckBox chkNoDeliveriesInTransit;
     //end Delivery Tab
 
     //start Planetary Acquisition Tab
@@ -252,6 +253,7 @@ public class EquipmentAndSuppliesTab {
     private void initializeDelivery() {
         lblTransitTimeUnits = new JLabel();
         choiceTransitTimeUnits = new MMComboBox<>("choiceTransitTimeUnits", getTransitUnitOptions());
+        chkNoDeliveriesInTransit = new JCheckBox();
     }
 
     /**
@@ -411,6 +413,9 @@ public class EquipmentAndSuppliesTab {
         lblTransitTimeUnits.addMouseListener(createTipPanelUpdater(acquisitionHeader, "TransitTimeUnits"));
         choiceTransitTimeUnits.addMouseListener(createTipPanelUpdater(acquisitionHeader, "TransitTimeUnits"));
 
+        chkNoDeliveriesInTransit = new CampaignOptionsCheckBox("NoDeliveriesInTransit");
+        chkNoDeliveriesInTransit.addMouseListener(createTipPanelUpdater(acquisitionHeader, "NoDeliveriesInTransit"));
+
         // Layout the Panel
         final JPanel panel = new CampaignOptionsStandardPanel("AcquisitionPanel", true, "AcquisitionPanel");
         final GridBagConstraints layout = new CampaignOptionsGridBagConstraints(panel);
@@ -462,6 +467,10 @@ public class EquipmentAndSuppliesTab {
         panel.add(lblTransitTimeUnits, layout);
         layout.gridx++;
         panel.add(choiceTransitTimeUnits, layout);
+
+        layout.gridx = 0;
+        layout.gridy++;
+        panel.add(chkNoDeliveriesInTransit, layout);
 
         return panel;
     }
@@ -1136,6 +1145,7 @@ public class EquipmentAndSuppliesTab {
 
         // Delivery
         options.setUnitTransitTime(choiceTransitTimeUnits.getSelectedIndex());
+        options.setNoDeliveriesInTransit(chkNoDeliveriesInTransit.isSelected());
 
         // Planetary Acquisitions
         options.setPlanetaryAcquisition(usePlanetaryAcquisitions.isSelected());
@@ -1218,6 +1228,7 @@ public class EquipmentAndSuppliesTab {
 
         // Delivery
         choiceTransitTimeUnits.setSelectedIndex(options.getUnitTransitTime());
+        chkNoDeliveriesInTransit.setSelected(options.isNoDeliveriesInTransit());
 
         // Planetary Acquisitions
         usePlanetaryAcquisitions.setSelected(options.isUsePlanetaryAcquisition());


### PR DESCRIPTION
This PR addresses a minor simulation issue: space amazon flying out to meet you mid-jump, even when in unoccupied systems.

When this campaign option is enabled, parts and units will not be delivered unless the campaign is planetside. Delivery time will still go down, while in transit, but will stop at 1 day. This is a gameplay concession, it can be logic'd as the players' Admin/Logistics arranging for the part/unit to be delivered to the destination.