### PR TITLE
Fix: Stopped Claiming Bounties on Prisoners of War Negatively Affecting Personnel Loyalty

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1278,7 +1278,9 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                           person.getFullName());
                     getCampaign().getFinances().credit(TransactionType.RANSOM, today, bounty, bountyReport);
                     person.changeStatus(getCampaign(), today, PersonnelStatus.HOMICIDE);
-                    validBounty = true;
+                    if (person.getPrisonerStatus().isFree()) { // Deliberately excluding Bondsmen from this check
+                        validBounty = true;
+                    }
                 }
 
                 if (validBounty) {


### PR DESCRIPTION
Now claiming bounties on prisoners is free real estate. Morally, maybe not, but they did something to deserve that bounty... probably...