### PR TITLE
Fix #8010: Fixed Salvaged Units Using Default Repair Site

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -1063,6 +1063,7 @@ public class CampaignNewDayManager {
         }
 
         // ok now we can check for other stuff we might need to do to units
+        int defaultRepairSite = AtBContract.getBestRepairLocation(campaign.getActiveAtBContracts());
         List<UUID> unitsToRemove = new ArrayList<>();
         for (Unit unit : hangar.getUnits()) {
             if (unit.isRefitting()) {
@@ -1080,6 +1081,7 @@ public class CampaignNewDayManager {
                           unit.getHyperlinkedName(),
                           spanOpeningWithCustomColor(MekHQ.getMHQOptions().getFontColorPositiveHexColor()),
                           CLOSING_SPAN_TAG));
+                    unit.setSite(defaultRepairSite);
                 }
             }
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -599,6 +599,34 @@ public class AtBContract extends Contract {
     }
 
     /**
+     * Determines the best available repair location from a list of active contracts.
+     *
+     * <p>This method evaluates all active contracts and returns the highest quality repair facility available.
+     * Repair locations are ranked numerically, with higher values representing better facilities. If no active
+     * contracts exist, a basic facility is assumed to be available.</p>
+     *
+     * @param activeContracts the list of active contracts to evaluate for repair facilities
+     *
+     * @return the numeric value of the best available repair location; returns {@link Unit#SITE_FACILITY_BASIC} if no
+     *       contracts are active
+     */
+    public static int getBestRepairLocation(List<AtBContract> activeContracts) {
+        if (activeContracts.isEmpty()) {
+            return Unit.SITE_FACILITY_BASIC;
+        }
+
+        int bestSite = Unit.SITE_IMPROVISED;
+        for (AtBContract contract : activeContracts) {
+            int repairLocation = contract.getRepairLocation();
+            if (repairLocation > bestSite) {
+                bestSite = repairLocation;
+            }
+        }
+
+        return bestSite;
+    }
+
+    /**
      * Calculates the overall contract score based on scenario outcomes and modifiers.
      *
      * <p>For StratCon campaigns, this returns the current victory points from the campaign state.</p>

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
@@ -190,7 +190,11 @@ public class CamOpsSalvageUtilities {
 
             campaign.clearGameData(salvageUnit.getEntity());
             campaign.addTestUnit(salvageUnit, deliveryTime);
-            salvageUnit.setSite(mission.getRepairLocation());
+            if (mission instanceof AtBContract atbContract) {
+                salvageUnit.setSite(atbContract.getRepairLocation());
+            } else {
+                salvageUnit.setSite(mission.getRepairLocation());
+            }
 
             // if this is a contract, add to the salvaged value
             if (isContract) {


### PR DESCRIPTION
Fix #8010

Updated site fetcher to correctly use AtBContract where relevant. Also fixed newly purchased units defaulting to the wrong site.