### PR TITLE
Fix: Fixed MASH & Field Kitchen Capacity Still Not Being Bypassed While in Transit

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -2171,7 +2171,7 @@ public class Campaign implements ITechManager {
     }
 
     public boolean getMashTheatresWithinCapacity() {
-        return mashTheatreCapacity >= getPatientsAssignedToDoctors().size();
+        return isOnContractAndPlanetside() || mashTheatreCapacity >= getPatientsAssignedToDoctors().size();
     }
 
     public int getMashTheatreCapacity() {

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -466,8 +466,9 @@ public class CampaignNewDayManager {
                         false), campaignOptions.getFieldKitchenCapacity());
             int fieldKitchenUsage = checkFieldKitchenUsage(campaign.getActivePersonnel(false, false),
                   campaignOptions.isUseFieldKitchenIgnoreNonCombatants());
-            campaign.setFieldKitchenWithinCapacity(areFieldKitchensWithinCapacity(fieldKitchenCapacity,
-                  fieldKitchenUsage));
+            boolean withinCapacity = campaign.isOnContractAndPlanetside() ||
+                                           areFieldKitchensWithinCapacity(fieldKitchenCapacity, fieldKitchenUsage);
+            campaign.setFieldKitchenWithinCapacity(withinCapacity);
         } else {
             campaign.setFieldKitchenWithinCapacity(false);
         }

--- a/MekHQ/src/mekhq/campaign/OptimizeInfirmaryAssignments.java
+++ b/MekHQ/src/mekhq/campaign/OptimizeInfirmaryAssignments.java
@@ -142,7 +142,7 @@ public class OptimizeInfirmaryAssignments {
                 continue;
             }
 
-            if (isOnContractAndPlanetside && useMASHTheatres && totalPatientCounter >= mashTheatreCapacity) {
+            if (campaign.getMashTheatresWithinCapacity() && totalPatientCounter >= mashTheatreCapacity) {
                 // Similar to the above, we're just unassigning doctors for any remaining patients.
                 continue;
             }

--- a/MekHQ/src/mekhq/gui/InfirmaryTab.java
+++ b/MekHQ/src/mekhq/gui/InfirmaryTab.java
@@ -431,14 +431,7 @@ public final class InfirmaryTab extends CampaignGuiTab {
         boolean useMASHTheatres = campaignOptions.isUseMASHTheatres();
         boolean isWithinTheatreCapacity = !useMASHTheatres;
         if (useMASHTheatres) {
-            final int mashTheatreCapacity = getCampaign().getMashTheatreCapacity();
-            final int patientsAssignedToDoctors = getCampaign().getPatientsAssignedToDoctors().size();
-
-            if (getCampaign().isOnContractAndPlanetside()) {
-                isWithinTheatreCapacity = mashTheatreCapacity > patientsAssignedToDoctors;
-            } else {
-                isWithinTheatreCapacity = true;
-            }
+            isWithinTheatreCapacity = getCampaign().getMashTheatresWithinCapacity();
         }
 
         return isWithinDoctorCapacity && isWithinTheatreCapacity;


### PR DESCRIPTION
This updates the checks to be more robust, for MASH Kitchens, and to exclude a missed setter for Field Kitchens.