### PR TITLE
Fix: Fixed Salvage Operations Being Successful if Exactly 0 Minutes Available

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/SalvagePostScenarioPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/SalvagePostScenarioPicker.java
@@ -773,11 +773,12 @@ public class SalvagePostScenarioPicker {
 
         // Time budget check (disable and, ideally, color the time label in updateSalvageAllocation)
         if (usedSalvageTime > maximumSalvageTime) {
+            disableConfirmAndColorName(confirmButton, salvageTimeLabel);
+            shouldEnable = false;
+        } else {
             if (salvageTimeLabel != null) {
                 salvageTimeLabel.setForeground(null);
             }
-            disableConfirmAndColorName(confirmButton, salvageTimeLabel);
-            shouldEnable = false;
         }
 
         // All checks passed


### PR DESCRIPTION
Due to the way our checks were set up, if a player had exactly 0 minutes available to salvage they were able to complete salvage operations.