### PR TITLE
Fix #8036: Stopped Transportation Cost Calculator Trying to Put Handheld Weapons, Space Stations, JumpShips, and WarShips into Transport Bays

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
+++ b/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
@@ -734,7 +734,7 @@ public class TransportCostCalculations {
                     battleArmorCount++;
                 } else if (entity.isInfantry()) {
                     infantryCount++;
-                } else if (!(entity instanceof Jumpship)) { // Includes WarShips
+                } else if (!(entity instanceof Jumpship) && !entity.isHandheldWeapon()) { // Includes WarShips
                     otherUnitCount++;
                 }
             }


### PR DESCRIPTION
Fix #8036