### PR TITLE
Fix #8041: Fixed Missing Belligerents in Edit Mission Dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CustomizeAtBContractDialog.java
@@ -153,7 +153,7 @@ public class CustomizeAtBContractDialog extends JDialog {
         add(buttonPanel, BorderLayout.SOUTH);
 
         currentFactions = RandomFactionGenerator.getInstance().getCurrentFactions();
-        currentFactions.add(contract.getEmployer());
+        currentFactions.add(contract.getEmployerCode());
         currentFactions.add(contract.getEnemyCode());
 
         GridBagConstraints gbc;


### PR DESCRIPTION
Fix #8041

This bug is due to a legacy decision in how the edit mission dialog was set up. One of the things it does is filter available factions based on who is local. However, that potentially could mean a faction already involved in the mission is excluded, if that faction does not own any local planets. Such as for the mercenary faction.

This PR addresses this by adding the current contract factions to the dropdown after all other factions are gathered. As this list is a Set duplicated entries is not a concern.