### PR TITLE
Fix #8038: Fixed Dark Secret Inexplicably Applying a -1 Penalty Even When Not Revealed

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -8249,7 +8249,7 @@ public class Person {
      * @since 0.50.07
      */
     public int getDarkSecretModifier(final boolean isReputation) {
-        // If the dark secret is not revealed or the character does not have a dark secret, return 0
+        // Only apply modifiers if the character has a dark secret AND it is revealed; otherwise, return 0
         if (!darkSecretRevealed || !hasDarkSecret()) {
             return 0;
         }


### PR DESCRIPTION
Fix #8038

Why did I introduce a -1 penalty if the Dark Secret wasn't revealed? I have no idea. It's complete nonsense.

Why did I introduce two booleans just to check whether the character had a dark secret that had been revealed? Not a clue. It probably made sense at the time, but it sure doesn't now.

This PR fixes everything.