### PR TITLE
Fix #8046: Fixed Error When Ordering from Parts in Use Dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -402,7 +402,7 @@ public class PartsReportDialog extends JDialog {
 
     private void refreshOverviewSpecificPart(int row, PartInUse partInUse, IAcquisitionWork newPart) {
         storePartInUseRequestedStock(partInUse);
-        if (partInUse.equals(new PartInUse((Part) newPart))) {
+        if (partInUse.equals(new PartInUse(newPart.getAcquisitionPart()))) {
             // Simple update
             partsInUseManager.updatePartInUse(partInUse, ignoreMothballedCheck.isSelected(),
                   getMinimumQuality((String) ignoreSparesUnderQualityCB.getSelectedItem()));


### PR DESCRIPTION
Fix #8046

This error was caused by some weird casting we were doing converting `IAcquisitionWork` into `Part`. I might be misunderstanding how the two classes interact, but I don't see how we could cast one into the other. Evidently we couldn't, which is why we hit the bug.