### PR TITLE
Fix #8059: Fixed a Number of Instances Where Technician Skills Were Being Unintentionally Excluded; Fixed NPE When Applying Campaign Options

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -2948,7 +2948,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                                 case NONE -> currentMenu.add(menuItem);
                                 case COMBAT_GUNNERY -> combatGunnerySkillsCurrent.add(menuItem);
                                 case COMBAT_PILOTING -> combatPilotingSkillsCurrent.add(menuItem);
-                                case SUPPORT -> supportSkillsCurrent.add(menuItem);
+                                case SUPPORT, SUPPORT_TECHNICIAN -> supportSkillsCurrent.add(menuItem);
                                 case UTILITY, UTILITY_COMMAND -> utilitySkillsCurrent.add(menuItem);
                                 case ROLEPLAY_GENERAL -> roleplaySkillsCurrent.add(menuItem);
                                 case ROLEPLAY_ART -> roleplaySkillsArtCurrent.add(menuItem);

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/SkillsTab.java
@@ -204,7 +204,8 @@ public class SkillsTab {
             boolean isCorrectType = switch (category) {
                 case NONE, COMBAT_GUNNERY -> subType == COMBAT_GUNNERY;
                 case COMBAT_PILOTING -> subType == COMBAT_PILOTING;
-                case SUPPORT, SUPPORT_TECHNICIAN -> subType == SUPPORT;
+                case SUPPORT -> subType == SUPPORT ||
+                                      subType == SUPPORT_TECHNICIAN;
                 case UTILITY -> subType == UTILITY ||
                                       subType == UTILITY_COMMAND;
                 case ROLEPLAY_GENERAL -> subType == ROLEPLAY_GENERAL ||
@@ -213,6 +214,7 @@ public class SkillsTab {
                                                subType == ROLEPLAY_SCIENCE ||
                                                subType == ROLEPLAY_SECURITY;
                 // These next few cases shouldn't get hit, but we include them just in case
+                case SUPPORT_TECHNICIAN -> subType == SUPPORT_TECHNICIAN;
                 case UTILITY_COMMAND, SUPPORT_COMMAND -> subType == UTILITY_COMMAND;
                 case ROLEPLAY_ART -> subType == ROLEPLAY_ART;
                 case ROLEPLAY_INTEREST -> subType == ROLEPLAY_INTEREST;

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -226,7 +226,7 @@ public class PersonViewPanel extends JScrollablePanel {
         }
 
         List<String> relevantSkills = person.getKnownSkillsBySkillSubType(List.of(COMBAT_GUNNERY, COMBAT_PILOTING,
-              SUPPORT));
+              SUPPORT, SUPPORT_TECHNICIAN));
         if (!relevantSkills.isEmpty()) {
             JPanel pnlCombatSkills = fillSkills(relevantSkills, "pnlSkills.profession");
             gridBagConstraints = new GridBagConstraints();
@@ -1946,7 +1946,6 @@ public class PersonViewPanel extends JScrollablePanel {
               doctorsUseAdmin,
               techsUseAdmin,
               isUseArtillery));
-        secondaryProfessionSkills.removeAll(primaryProfessionSkills);
 
         // Calculate how many rows per column for even distribution
         double numColumns = 3.0;


### PR DESCRIPTION
Fix #8059

The introduction of the new 'Support Technician' subtype wasn't handled properly. This corrects any remaining oversights.