### PR TITLE
Improvement: Updated Tech Assignment Menus to Include Display of Maintenance Time Available & Required to Reduce Manual Menu Cross-Referencing

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -1157,6 +1157,7 @@ asSoldierMenu.text=As Soldier
 asNavigatorMenu.text=As Navigator
 #### AssignTechToUnitMenu Class
 AssignTechToUnitMenu.title=As Tech
+AssignTechToUnitMenu.display=<html>{0}<br>Requires {1}/{2} maintenance minutes per cycle</html>
 #### AssignUnitToPersonMenu Class
 AssignUnitToPersonMenu.title=Assign Person
 pilotMenu.text=Pilot
@@ -1170,7 +1171,6 @@ navigatorMenu.text=Navigator
 miUnassignCrew.text=Unassign Crew
 #### AssignUnitToTechMenu Class
 AssignUnitToTechMenu.title=Tech
-miAssignTech.text=%s (%s available minutes)
 miUnassignTech.text=Unassign Tech
 #### ExportUnitSpriteMenu Class
 ExportUnitSpriteMenu.title=Export Unit Sprite

--- a/MekHQ/src/mekhq/gui/menus/AssignTechToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignTechToUnitMenu.java
@@ -32,6 +32,8 @@
  */
 package mekhq.gui.menus;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedText;
+
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JMenuItem;
@@ -66,6 +68,7 @@ public class AssignTechToUnitMenu extends JScrollableMenu {
                   || person.isDeployed() || !person.isTech()) {
             return;
         }
+        boolean techsUseAdmin = campaign.getCampaignOptions().isTechsUseAdministration();
 
         // Initialize Menu
         setText(resources.getString("AssignTechToUnitMenu.title"));
@@ -118,7 +121,9 @@ public class AssignTechToUnitMenu extends JScrollableMenu {
                       EntityWeightClass.getClassName(weightClass, unit.getEntity()));
             }
 
-            final JMenuItem miUnit = new JMenuItem(unit.getName());
+            String display = getFormattedText("AssignTechToUnitMenu.display", unit.getName(),
+                  unit.getMaintenanceTime(), person.getDailyAvailableTechTime(techsUseAdmin));
+            final JMenuItem miUnit = new JMenuItem(display);
             miUnit.setName("miUnit");
             miUnit.setForeground(unit.determineForegroundColor("Menu"));
             miUnit.setBackground(unit.determineBackgroundColor("Menu"));

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToTechMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToTechMenu.java
@@ -32,6 +32,8 @@
  */
 package mekhq.gui.menus;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedText;
+
 import java.util.stream.Stream;
 import javax.swing.JMenuItem;
 
@@ -68,6 +70,8 @@ public class AssignUnitToTechMenu extends JScrollableMenu {
         if ((units.length == 0) || Stream.of(units).anyMatch(Unit::isSelfCrewed)) {
             return;
         }
+
+        boolean techsUseAdmin = campaign.getCampaignOptions().isTechsUseAdministration();
 
         // Initialize Menu
         setText(resources.getString("AssignUnitToTechMenu.title"));
@@ -122,13 +126,9 @@ public class AssignUnitToTechMenu extends JScrollableMenu {
                     };
 
                     if (subMenu != null) {
-                        int dailyTime = tech.getDailyAvailableTechTime(campaign.getCampaignOptions()
-                                                                             .isTechsUseAdministration());
-                        int dailyTimeUsing = tech.getMaintenanceTimeUsing();
-                        int available = dailyTime - dailyTimeUsing;
-
-                        final JMenuItem miAssignTech = new JMenuItem(String.format(resources.getString(
-                              "miAssignTech.text"), tech.getFullTitle(), available));
+                        String display = getFormattedText("AssignTechToUnitMenu.display", tech.getFullTitle(),
+                              maintenanceTime, tech.getDailyAvailableTechTime(techsUseAdmin));
+                        final JMenuItem miAssignTech = new JMenuItem(display);
                         miAssignTech.setName("miAssignTech");
                         miAssignTech.addActionListener(evt -> {
                             for (final Unit unit : units) {


### PR DESCRIPTION
When a player wants to assign a tech to a unit they need the following information:

- Maintenance time required by unit
- Maintenance time available to tech

Both of these items are available in the gui, but in separate locations and rather hidden behind filters. This PR changes things so that when a player is assigning a tech to a unit this information will be immediately visible in the context menu.