### PR TITLE
Fix: Removed Unit Coloring from Personnel & Hangar Context Menus

### DIFF
--- a/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignPersonToUnitMenu.java
@@ -289,8 +289,6 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                         if (valid) {
                             final JMenuItem miPilot = new JMenuItem(unit.getName());
                             miPilot.setName("miPilot");
-                            miPilot.setForeground(unit.determineForegroundColor("Menu"));
-                            miPilot.setBackground(unit.determineBackgroundColor("Menu"));
                             miPilot.addActionListener(evt -> {
                                 final Unit oldUnit = people[0].getUnit();
                                 boolean useTransfers = false;
@@ -316,8 +314,6 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     if (((entity instanceof SmallCraft) || (entity instanceof Jumpship)) && areAllVesselPilots) {
                         final JMenuItem miVesselPilot = new JMenuItem(unit.getName());
                         miVesselPilot.setName("miVesselPilot");
-                        miVesselPilot.setForeground(unit.determineForegroundColor("Menu"));
-                        miVesselPilot.setBackground(unit.determineBackgroundColor("Menu"));
                         miVesselPilot.addActionListener(evt -> {
                             for (final Person person : people) {
                                 if (!unit.canTakeMoreDrivers()) {
@@ -344,8 +340,6 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                                   areAllGroundVehicleCrew) {
                             final JMenuItem miDriver = new JMenuItem(unit.getName());
                             miDriver.setName("miDriver");
-                            miDriver.setForeground(unit.determineForegroundColor("Menu"));
-                            miDriver.setBackground(unit.determineBackgroundColor("Menu"));
                             miDriver.addActionListener(evt -> {
                                 final Unit oldUnit = people[0].getUnit();
                                 boolean useTransfers = false;
@@ -388,8 +382,6 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     if (valid) {
                         final JMenuItem miGunner = new JMenuItem(unit.getName());
                         miGunner.setName("miGunner");
-                        miGunner.setForeground(unit.determineForegroundColor("Menu"));
-                        miGunner.setBackground(unit.determineBackgroundColor("Menu"));
                         miGunner.addActionListener(evt -> {
                             for (final Person person : people) {
                                 if (!unit.canTakeMoreGunners()) {
@@ -425,8 +417,6 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     if (valid) {
                         final JMenuItem miCrewmember = new JMenuItem(unit.getName());
                         miCrewmember.setName("miCrewmember");
-                        miCrewmember.setForeground(unit.determineForegroundColor("Menu"));
-                        miCrewmember.setBackground(unit.determineBackgroundColor("Menu"));
                         miCrewmember.addActionListener(evt -> {
                             for (final Person person : people) {
                                 if (!unit.canTakeMoreVesselCrew()) {
@@ -460,8 +450,6 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                         if (people[0].canDrive(entity) || people[0].canGun(entity)) {
                             final JMenuItem miConsoleCommander = new JMenuItem(unit.getName());
                             miConsoleCommander.setName("miConsoleCommander");
-                            miConsoleCommander.setForeground(unit.determineForegroundColor("Menu"));
-                            miConsoleCommander.setBackground(unit.determineBackgroundColor("Menu"));
                             miConsoleCommander.addActionListener(evt -> {
                                 final Unit oldUnit = people[0].getUnit();
                                 boolean useTransfers = false;
@@ -479,8 +467,6 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     } else if (people[0].canDrive(entity) && people[0].canGun(entity)) {
                         final JMenuItem miTechOfficer = new JMenuItem(unit.getName());
                         miTechOfficer.setName("miTechOfficer");
-                        miTechOfficer.setForeground(unit.determineForegroundColor("Menu"));
-                        miTechOfficer.setBackground(unit.determineBackgroundColor("Menu"));
                         miTechOfficer.addActionListener(evt -> {
                             final Unit oldUnit = people[0].getUnit();
                             boolean useTransfers = false;
@@ -504,8 +490,6 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                     if (valid) {
                         final JMenuItem miSoldier = new JMenuItem(unit.getName());
                         miSoldier.setName("miSoldier");
-                        miSoldier.setForeground(unit.determineForegroundColor("Menu"));
-                        miSoldier.setBackground(unit.determineBackgroundColor("Menu"));
                         miSoldier.addActionListener(evt -> {
                             for (final Person person : people) {
                                 if (!unit.canTakeMoreGunners()) {
@@ -530,8 +514,6 @@ public class AssignPersonToUnitMenu extends JScrollableMenu {
                 if (singlePerson && unit.canTakeNavigator() && people[0].hasRole(PersonnelRole.VESSEL_NAVIGATOR)) {
                     final JMenuItem miNavigator = new JMenuItem(unit.getName());
                     miNavigator.setName("miNavigator");
-                    miNavigator.setForeground(unit.determineForegroundColor("Menu"));
-                    miNavigator.setBackground(unit.determineBackgroundColor("Menu"));
                     miNavigator.addActionListener(evt -> {
                         final Unit oldUnit = people[0].getUnit();
                         boolean useTransfers = false;

--- a/MekHQ/src/mekhq/gui/menus/AssignTechToUnitMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignTechToUnitMenu.java
@@ -120,8 +120,6 @@ public class AssignTechToUnitMenu extends JScrollableMenu {
 
             final JMenuItem miUnit = new JMenuItem(unit.getName());
             miUnit.setName("miUnit");
-            miUnit.setForeground(unit.determineForegroundColor("Menu"));
-            miUnit.setBackground(unit.determineBackgroundColor("Menu"));
             miUnit.addActionListener(evt -> unit.setTech(person));
             entityWeightClassMenu.add(miUnit);
         }


### PR DESCRIPTION
We were having an issue with some context menus having options using black text. Checking into it we were incorrectly using the unit color method (that determines what color a unit should be in the hangar table) to color text in the context menus. This was a non-issue when everyone was using Light themes, but makes the option very difficult to read in dark themes.

I went ahead and removed the coloring, this should also make it easier on the eyes for players with colorblindness.