### PR TITLE
Fix #8056: Fixed Inability to Conclude Salvage Operations When No Techs Assigned

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/SalvagePostScenarioPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/SalvagePostScenarioPicker.java
@@ -720,7 +720,7 @@ public class SalvagePostScenarioPicker {
      * <ul>
      *   <li>Any salvage assignment has invalid validation (insufficient capacity, missing naval tug)</li>
      *   <li>For contracts: the player's salvage percentage exceeds the contract limit</li>
-     *   <li>The available remaining minutes is less than or equal to zero</li>
+     *   <li>The used minutes exceed the available minutes</li>
      * </ul>
      *
      * <p>When the salvage percentage is exceeded, the unit salvage label is also colored red.</p>


### PR DESCRIPTION
Fix #8056

This fixes a flaw in our logic that was causing the confirm button, in salvage operations, to only be enabled if there were more than 0 available minutes. Now it correctly is enabled by default, but will disable if used time is greater than available time.