### PR TITLE
Improvement: Improved Compatibility Handling of Vehicle Crewmember -> Combat Technician Role Change to Reduce Player Confusion

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignXmlParser.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignXmlParser.properties
@@ -31,3 +31,7 @@
 CampaignXmlParser.compatibility.edge={0}<b>WARNING:</b>{1} In an attempt to bring our current implementation \
   closer to the official rules a cap has been placed on <b>Edge</b>. {2} had {3} more Edge than possible, they have \
   received an XP Rebate for a total of {4} additional XP.
+vehicleCrewProfessionSkillChange={0}<b>WARNING:</b>{1} starting in version 50.10, vehicle crews were changed to Combat \
+  Technicians. Combat Technicians use the Tech/Mechanic skill. However, {2} did not have that skill. They have \
+  been given the skill for free at level 3 (Regular). Combat Technicians are functionally identical to Mechanics. The\
+  \ distinction between Combat Technician and Mechanic exists for roleplay and Bloodname purposes only.

--- a/MekHQ/resources/mekhq/resources/Personnel.properties
+++ b/MekHQ/resources/mekhq/resources/Personnel.properties
@@ -558,11 +558,6 @@ vehicleProfessionSkillChange={0}<b>WARNING:</b>{1} starting in version 50.10, th
   were giving gunnery for free. The level will match their piloting skill. If the character was missing piloting, they \
   were giving piloting for free. The level will match their gunnery skill. If the character was missing both, they were \
   given both for free at level 3.
-vehicleCrewProfessionSkillChange={0}<b>WARNING:</b>{1} starting in version 50.10, vehicle crews were changed to Combat \
-  Technicians. Combat Technicians use the Tech/Mechanic skill. However, {2} did not have that skill. They have \
-  been given the skill for free at level 3 (Regular). As a bonus, Combat Technicians function identically to \
-  Mechanics, so can be assigned to tasks and benefit from Administration (if the appropriate Campaign Option is \
-  enabled).
 # Gambling
 gambling.success=%s gambled their Wealth. Wealth has %s<b>Improved</b>%s by 1. They now have %s Wealth.
 gambling.neutral=%s gambled their Wealth. They %s<b>Broke Even</b>%s. They still have %s Wealth.

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -541,6 +541,15 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                       person.getHyperlinkedFullTitle());
                 campaign.addReport(report);
             }
+
+            if (Person.updateSkillsForVehicleCrewProfession(today, person, person.getPrimaryRole(), true) ||
+                      Person.updateSkillsForVehicleCrewProfession(today, person, person.getSecondaryRole(), false)) {
+                String report = getFormattedTextAt(RESOURCE_BUNDLE, "vehicleCrewProfessionSkillChange",
+                      spanOpeningWithCustomColor(getWarningColor()),
+                      CLOSING_SPAN_TAG,
+                      person.getHyperlinkedFullTitle());
+                campaign.addReport(report);
+            }
         }
 
         campaign.getHangar().forEachUnit(unit -> {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4276,9 +4276,8 @@ public class Person {
      * Updates skills for personnel with the Vehicle Crew profession by ensuring they have the Mechanic skill.
      *
      * <p>This method is used during XML loading to migrate legacy data. If the person lacks the
-     * {@link SkillType#S_TECH_MECHANIC} skill, it will be added at a level equal to their highest existing vehicle
-     * crew-related skill (e.g., Tech Vee, Gunnery Vee, Piloting Vee, or Driving). This ensures backwards compatibility
-     * when loading older save files.</p>
+     * {@link SkillType#S_TECH_MECHANIC} skill, it will be added at a level 3. This ensures backwards compatibility when
+     * loading older save files.</p>
      *
      * @param today       the current date
      * @param person      the person whose skills should be updated
@@ -4299,7 +4298,6 @@ public class Person {
 
         if (!person.hasSkill(S_TECH_MECHANIC)) {
             person.addSkill(S_TECH_MECHANIC, 3, 0);
-            return true;
         }
 
         if (isPrimary) {
@@ -4308,7 +4306,7 @@ public class Person {
             person.setSecondaryRole(PersonnelRole.COMBAT_TECHNICIAN);
         }
 
-        return false;
+        return true;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -4204,10 +4204,6 @@ public class Person {
      */
     public static boolean updateSkillsForVehicleProfessions(LocalDate today, Person person, PersonnelRole role,
           boolean isPrimary) {
-        if (role == PersonnelRole.VEHICLE_CREW) { // The old vehicle crew profession is handled differently
-            return updateSkillsForVehicleCrewProfession(today, person, role, isPrimary);
-        }
-
         PersonnelRole newProfession = null;
         String drivingSkillType = null;
         String gunnerySkillType = S_GUN_VEE;
@@ -4294,7 +4290,7 @@ public class Person {
      * @author Illiani
      * @since 0.50.10
      */
-    private static boolean updateSkillsForVehicleCrewProfession(LocalDate today, Person person,
+    public static boolean updateSkillsForVehicleCrewProfession(LocalDate today, Person person,
           PersonnelRole currentRole,
           boolean isPrimary) {
         if (currentRole != PersonnelRole.VEHICLE_CREW) {


### PR DESCRIPTION
When a character with the deprecated 'Vehicle Crewmember' profession is loaded in 50.10 they are automatically converted to Combat Technician. However we accidentally swallowed the message informing the player of the change and telling them about Combat Technicians.

This PR restores the message and also cleans up the language based on areas that have been confusing players.