### PR TITLE
Improvement: Improved 'Crew Needs' Display in Hangar In Attempt To Reduce Player Confusion

### DIFF
--- a/MekHQ/resources/mekhq/resources/UnitTableModel.properties
+++ b/MekHQ/resources/mekhq/resources/UnitTableModel.properties
@@ -29,6 +29,7 @@
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
 UnitTableModel.crewNeeds.unknown=Unknown
+UnitTableModel.crewNeeds.none=None
 UnitTableModel.crewNeeds.drivers=Drivers ({0})
 UnitTableModel.crewNeeds.gunners=Gunners ({0})
 UnitTableModel.crewNeeds.soldiers=Soldiers

--- a/MekHQ/resources/mekhq/resources/UnitTableModel.properties
+++ b/MekHQ/resources/mekhq/resources/UnitTableModel.properties
@@ -1,0 +1,36 @@
+# Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+UnitTableModel.crewNeeds.drivers=Drivers
+UnitTableModel.crewNeeds.gunners=Gunners
+UnitTableModel.crewNeeds.soldiers=Soldiers
+UnitTableModel.crewNeeds.other=Other (see Glossary)
+UnitTableModel.crewNeeds.crew=Vessel Crew
+UnitTableModel.crewNeeds.navigator=Navigator

--- a/MekHQ/resources/mekhq/resources/UnitTableModel.properties
+++ b/MekHQ/resources/mekhq/resources/UnitTableModel.properties
@@ -28,8 +28,9 @@
 # Microsoft's "Game Content Usage Rules"
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
-UnitTableModel.crewNeeds.drivers=Drivers
-UnitTableModel.crewNeeds.gunners=Gunners
+UnitTableModel.crewNeeds.unknown=Unknown
+UnitTableModel.crewNeeds.drivers=Drivers ({0})
+UnitTableModel.crewNeeds.gunners=Gunners ({0})
 UnitTableModel.crewNeeds.soldiers=Soldiers
 UnitTableModel.crewNeeds.other=Other (see Glossary)
 UnitTableModel.crewNeeds.crew=Vessel Crew

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -7367,11 +7367,11 @@ public class Unit implements ITechnology {
             return PersonnelRole.LAM_PILOT;
         } else if (entity.isMek()) {
             return PersonnelRole.MEKWARRIOR;
-        } else if (entity instanceof VTOL) {
-            return PersonnelRole.VEHICLE_CREW_VTOL;
         } else if (entity instanceof Tank) { // instanceof to include Gun Emplacements
             if (entity.getMovementMode().isMarine()) {
                 return PersonnelRole.VEHICLE_CREW_NAVAL;
+            } else if (entity.getMovementMode().isVTOL()) {
+                return PersonnelRole.VEHICLE_CREW_VTOL;
             } else {
                 return PersonnelRole.VEHICLE_CREW_GROUND;
             }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -5080,8 +5080,8 @@ public class Unit implements ITechnology {
      * @param isDrivers        {@code true} to return drivers, {@code false} to return gunners (ignored if
      *                         {@code isTankOrInfantry} is {@code true})
      *
-     * @return a list of personnel; for tanks or infantry returns the full crew, for other entities returns either drivers or a copy
-     *       of the gunners list
+     * @return a list of personnel; for tanks or infantry returns the full crew, for other entities returns either
+     *       drivers or a copy of the gunners list
      */
     private List<Person> getCompositeCrew(boolean isTankOrInfantry, boolean isDrivers) {
         if (isTankOrInfantry) {
@@ -7343,5 +7343,101 @@ public class Unit implements ITechnology {
         }
 
         return canSalvage && isFullyCrewed();
+    }
+
+    /**
+     * Determines the appropriate personnel role for the driver/pilot position of this unit's entity.
+     *
+     * <p>The role is determined based on the entity's type and movement characteristics. For example, 'Meks require
+     * MekWarriors, while tanks may require different crew types based on whether hey are ground, naval, or VTOL
+     * units.</p>
+     *
+     * @return the personnel role required to operate this entity as a driver/pilot, or {@code null} if the entity is
+     *       null or of an unknown type
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    public @Nullable PersonnelRole getDriverRole() {
+        if (entity == null) {
+            return null;
+        }
+
+        if (entity instanceof LandAirMek) {
+            return PersonnelRole.LAM_PILOT;
+        } else if (entity instanceof Mek) {
+            return PersonnelRole.MEKWARRIOR;
+        } else if (entity instanceof VTOL) {
+            return PersonnelRole.VEHICLE_CREW_VTOL;
+        } else if (entity instanceof Tank) {
+            if (entity.getMovementMode().isMarine()) {
+                return PersonnelRole.VEHICLE_CREW_NAVAL;
+            } else {
+                return PersonnelRole.VEHICLE_CREW_GROUND;
+            }
+        } else if (entity instanceof ConvFighter) {
+            return PersonnelRole.CONVENTIONAL_AIRCRAFT_PILOT;
+        } else if ((entity instanceof SmallCraft) || (entity instanceof Jumpship)) {
+            return PersonnelRole.VESSEL_PILOT;
+        } else if (entity instanceof Aero) {
+            return PersonnelRole.AEROSPACE_PILOT;
+        } else if (entity instanceof BattleArmor) {
+            return PersonnelRole.BATTLE_ARMOUR;
+        } else if (entity instanceof Infantry) {
+            return PersonnelRole.SOLDIER;
+        } else if (entity instanceof ProtoMek) {
+            return PersonnelRole.PROTOMEK_PILOT;
+        } else {
+            LOGGER.info("Unknown unit type parsed into getDriverRole(): {}", entity.getUnitType());
+            return null;
+        }
+    }
+
+    /**
+     * Determines the appropriate personnel role for the gunner position of this unit's entity.
+     *
+     * <p>The role is determined based on the entity's type and movement characteristics. For most single-crew units
+     * ('Meks, aerospace fighters, etc.), the gunner role is the same as the driver role. For multi-crew units like
+     * vessels, a separate gunner role exists.</p>
+     *
+     * @return the personnel role required to operate this entity as a gunner, or {@code null} if the entity is null or
+     *       of an unknown type
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    public @Nullable PersonnelRole getGunnerRole() {
+        if (entity == null) {
+            return null;
+        }
+
+        if (entity instanceof LandAirMek) {
+            return PersonnelRole.LAM_PILOT;
+        } else if (entity instanceof Mek) {
+            return PersonnelRole.MEKWARRIOR;
+        } else if (entity instanceof Tank) {
+            if (entity.getMovementMode().isMarine()) {
+                return PersonnelRole.VEHICLE_CREW_NAVAL;
+            } else if (entity.getMovementMode().isVTOL()) {
+                return PersonnelRole.VEHICLE_CREW_VTOL;
+            } else {
+                return PersonnelRole.VEHICLE_CREW_GROUND;
+            }
+        } else if (entity instanceof ConvFighter) {
+            return PersonnelRole.CONVENTIONAL_AIRCRAFT_PILOT;
+        } else if ((entity instanceof SmallCraft) || (entity instanceof Jumpship)) {
+            return PersonnelRole.VESSEL_GUNNER;
+        } else if (entity instanceof Aero) {
+            return PersonnelRole.AEROSPACE_PILOT;
+        } else if (entity instanceof BattleArmor) {
+            return PersonnelRole.BATTLE_ARMOUR;
+        } else if (entity instanceof Infantry) {
+            return PersonnelRole.SOLDIER;
+        } else if (entity instanceof ProtoMek) {
+            return PersonnelRole.PROTOMEK_PILOT;
+        } else {
+            LOGGER.info("Unknown unit type parsed into getGunnerRole(): {}", entity.getUnitType());
+            return null;
+        }
     }
 }

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -7349,7 +7349,7 @@ public class Unit implements ITechnology {
      * Determines the appropriate personnel role for the driver/pilot position of this unit's entity.
      *
      * <p>The role is determined based on the entity's type and movement characteristics. For example, 'Meks require
-     * MekWarriors, while tanks may require different crew types based on whether hey are ground, naval, or VTOL
+     * MekWarriors, while tanks may require different crew types based on whether they are ground, naval, or VTOL
      * units.</p>
      *
      * @return the personnel role required to operate this entity as a driver/pilot, or {@code null} if the entity is

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -7365,27 +7365,27 @@ public class Unit implements ITechnology {
 
         if (entity instanceof LandAirMek) {
             return PersonnelRole.LAM_PILOT;
-        } else if (entity instanceof Mek) {
+        } else if (entity.isMek()) {
             return PersonnelRole.MEKWARRIOR;
         } else if (entity instanceof VTOL) {
             return PersonnelRole.VEHICLE_CREW_VTOL;
-        } else if (entity instanceof Tank) {
+        } else if (entity instanceof Tank) { // instanceof to include Gun Emplacements
             if (entity.getMovementMode().isMarine()) {
                 return PersonnelRole.VEHICLE_CREW_NAVAL;
             } else {
                 return PersonnelRole.VEHICLE_CREW_GROUND;
             }
-        } else if (entity instanceof ConvFighter) {
+        } else if (entity.isConventionalFighter()) {
             return PersonnelRole.CONVENTIONAL_AIRCRAFT_PILOT;
-        } else if ((entity instanceof SmallCraft) || (entity instanceof Jumpship)) {
+        } else if (entity.isLargeCraft()) {
             return PersonnelRole.VESSEL_PILOT;
-        } else if (entity instanceof Aero) {
+        } else if (entity.isAerospace()) {
             return PersonnelRole.AEROSPACE_PILOT;
-        } else if (entity instanceof BattleArmor) {
+        } else if (entity.isBattleArmor()) {
             return PersonnelRole.BATTLE_ARMOUR;
-        } else if (entity instanceof Infantry) {
+        } else if (entity.isConventionalInfantry()) {
             return PersonnelRole.SOLDIER;
-        } else if (entity instanceof ProtoMek) {
+        } else if (entity.isProtoMek()) {
             return PersonnelRole.PROTOMEK_PILOT;
         } else {
             LOGGER.info("Unknown unit type parsed into getDriverRole(): {}", entity.getUnitType());
@@ -7413,9 +7413,9 @@ public class Unit implements ITechnology {
 
         if (entity instanceof LandAirMek) {
             return PersonnelRole.LAM_PILOT;
-        } else if (entity instanceof Mek) {
+        } else if (entity.isMek()) {
             return PersonnelRole.MEKWARRIOR;
-        } else if (entity instanceof Tank) {
+        } else if (entity instanceof Tank) { // instanceof to include Gun Emplacements
             if (entity.getMovementMode().isMarine()) {
                 return PersonnelRole.VEHICLE_CREW_NAVAL;
             } else if (entity.getMovementMode().isVTOL()) {
@@ -7423,17 +7423,17 @@ public class Unit implements ITechnology {
             } else {
                 return PersonnelRole.VEHICLE_CREW_GROUND;
             }
-        } else if (entity instanceof ConvFighter) {
+        } else if (entity.isConventionalInfantry()) {
             return PersonnelRole.CONVENTIONAL_AIRCRAFT_PILOT;
-        } else if ((entity instanceof SmallCraft) || (entity instanceof Jumpship)) {
+        } else if (entity.isSmallCraft() || entity.isLargeCraft()) {
             return PersonnelRole.VESSEL_GUNNER;
-        } else if (entity instanceof Aero) {
+        } else if (entity.isAerospace()) {
             return PersonnelRole.AEROSPACE_PILOT;
-        } else if (entity instanceof BattleArmor) {
+        } else if (entity.isBattleArmor()) {
             return PersonnelRole.BATTLE_ARMOUR;
-        } else if (entity instanceof Infantry) {
+        } else if (entity.isConventionalInfantry()) {
             return PersonnelRole.SOLDIER;
-        } else if (entity instanceof ProtoMek) {
+        } else if (entity.isProtoMek()) {
             return PersonnelRole.PROTOMEK_PILOT;
         } else {
             LOGGER.info("Unknown unit type parsed into getGunnerRole(): {}", entity.getUnitType());

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -32,6 +32,7 @@
  */
 package mekhq.gui.model;
 
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.Component;
@@ -53,6 +54,7 @@ import megamek.common.units.UnitType;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.PersonnelRole;
 import mekhq.campaign.unit.Unit;
 import mekhq.gui.BasicInfo;
 import mekhq.gui.utilities.MekHqTableCellRenderer;
@@ -206,15 +208,25 @@ public class UnitTableModel extends DataTableModel<Unit> {
         StringBuilder report = new StringBuilder("<html>");
 
 
+        Campaign campaign = unit.getCampaign();
+        boolean isClanCampaign = campaign != null && campaign.isClanCampaign();
         if (driversNeeded > 0 && soldiersNeeded == 0) {
-            appendReport(report, getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.drivers"), driversAssigned,
-                  driversNeeded);
+            PersonnelRole driverRole = unit.getDriverRole();
+            String driverDisplay = driverRole == null ? getTextAt(RESOURCE_BUNDLE,
+                  "UnitTableModel.crewNeeds.unknown") : driverRole.getLabel(isClanCampaign);
+            appendReport(report, getFormattedTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.drivers", driverDisplay),
+                  driversAssigned, driversNeeded);
         }
 
         if (gunnersNeeded > 0 && soldiersNeeded == 0) {
             report.append("<br>");
-            appendReport(report, getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.gunners"), gunnersAssigned,
-                  gunnersNeeded);
+
+            PersonnelRole gunnerRole = unit.getGunnerRole();
+            String gunnerDisplay = gunnerRole == null ? getTextAt(RESOURCE_BUNDLE,
+                  "UnitTableModel.crewNeeds.unknown") : gunnerRole.getLabel(isClanCampaign);
+
+            appendReport(report, getFormattedTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.gunners", gunnerDisplay),
+                  gunnersAssigned, gunnersNeeded);
         }
 
         if (soldiersNeeded > 0) {

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -38,6 +38,7 @@ import static mekhq.utilities.MHQInternationalization.getTextAt;
 import java.awt.Component;
 import java.awt.Image;
 import java.util.ArrayList;
+import java.util.List;
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -205,8 +206,7 @@ public class UnitTableModel extends DataTableModel<Unit> {
         int crewNeeded = unit.getTotalCrewNeeds();
         int crewAssigned = unit.getActiveCrew().size() - (gunnersAssigned + driversAssigned + navigatorsAssigned);
 
-        StringBuilder report = new StringBuilder("<html>");
-
+        List<String> reports = new ArrayList<>();
 
         Campaign campaign = unit.getCampaign();
         boolean isClanCampaign = campaign != null && campaign.isClanCampaign();
@@ -214,54 +214,52 @@ public class UnitTableModel extends DataTableModel<Unit> {
             PersonnelRole driverRole = unit.getDriverRole();
             String driverDisplay = driverRole == null ? getTextAt(RESOURCE_BUNDLE,
                   "UnitTableModel.crewNeeds.unknown") : driverRole.getLabel(isClanCampaign);
-            appendReport(report, getFormattedTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.drivers", driverDisplay),
-                  driversAssigned, driversNeeded);
+            appendReport(reports,
+                  getFormattedTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.drivers", driverDisplay),
+                  driversAssigned,
+                  driversNeeded);
         }
 
         if (gunnersNeeded > 0 && soldiersNeeded == 0) {
-            report.append("<br>");
-
             PersonnelRole gunnerRole = unit.getGunnerRole();
             String gunnerDisplay = gunnerRole == null ? getTextAt(RESOURCE_BUNDLE,
                   "UnitTableModel.crewNeeds.unknown") : gunnerRole.getLabel(isClanCampaign);
 
-            appendReport(report, getFormattedTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.gunners", gunnerDisplay),
-                  gunnersAssigned, gunnersNeeded);
+            appendReport(reports,
+                  getFormattedTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.gunners", gunnerDisplay),
+                  gunnersAssigned,
+                  gunnersNeeded);
         }
 
         if (soldiersNeeded > 0) {
-            report.append("<br>");
-            appendReport(report, getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.soldiers"), soldiersAssigned,
+            appendReport(reports, getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.soldiers"), soldiersAssigned,
                   soldiersNeeded);
         }
 
         if (crewNeeded > 0) {
-            report.append("<br>");
             String key = entity.isLargeCraft() ? "UnitTableModel.crewNeeds.crew" : "UnitTableModel.crewNeeds.other";
-            appendReport(report, getTextAt(RESOURCE_BUNDLE, key), crewAssigned, crewNeeded);
+            appendReport(reports, getTextAt(RESOURCE_BUNDLE, key), crewAssigned, crewNeeded);
         }
 
         if (navigatorsNeeded > 0) {
-            report.append("<br>");
-            appendReport(report, getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.navigator"), navigatorsAssigned,
+            appendReport(reports, getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.navigator"), navigatorsAssigned,
                   navigatorsNeeded);
         }
 
-        report.append("</html>");
-
-        return report.toString();
+        String finalReport = reports.isEmpty() ? "" : String.join("<br>", reports);
+        return "<html>" + finalReport + "</html>";
     }
 
     /**
      * Appends a crew report line to the provided StringBuilder.
      *
-     * @param report   the {@link StringBuilder} to append to
+     * @param report   the {@link List} to add to
      * @param title    the title of the crew role (e.g., "Driver", "Gunner")
      * @param assigned the number of crew members assigned to the role
      * @param needed   the number of crew members needed for the role
      */
-    private static void appendReport(StringBuilder report, String title, int assigned, int needed) {
-        report.append(String.format("<b>%s: </b>%d/%d", title, assigned, needed));
+    private static void appendReport(List<String> report, String title, int assigned, int needed) {
+        report.add(String.format("<b>%s: </b>%d/%d", title, assigned, needed));
     }
 
     @Override

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -32,6 +32,8 @@
  */
 package mekhq.gui.model;
 
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
 import java.awt.Component;
 import java.awt.Image;
 import java.util.ArrayList;
@@ -61,6 +63,8 @@ import mekhq.gui.utilities.MekHqTableCellRenderer;
  * @author Jay lawson
  */
 public class UnitTableModel extends DataTableModel<Unit> {
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.UnitTableModel";
+
     //region Variable Declarations
     public static final int COL_NAME = 0;
     public static final int COL_TYPE = 1;
@@ -203,27 +207,32 @@ public class UnitTableModel extends DataTableModel<Unit> {
 
 
         if (driversNeeded > 0 && soldiersNeeded == 0) {
-            appendReport(report, "Drivers", driversAssigned, driversNeeded);
+            appendReport(report, getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.drivers"), driversAssigned,
+                  driversNeeded);
         }
 
         if (gunnersNeeded > 0 && soldiersNeeded == 0) {
             report.append("<br>");
-            appendReport(report, "Gunners", gunnersAssigned, gunnersNeeded);
+            appendReport(report, getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.gunners"), gunnersAssigned,
+                  gunnersNeeded);
         }
 
         if (soldiersNeeded > 0) {
             report.append("<br>");
-            appendReport(report, "Soldiers", soldiersAssigned, soldiersNeeded);
+            appendReport(report, getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.soldiers"), soldiersAssigned,
+                  soldiersNeeded);
         }
 
         if (crewNeeded > 0) {
             report.append("<br>");
-            appendReport(report, "Crew", crewAssigned, crewNeeded);
+            String key = entity.isLargeCraft() ? "UnitTableModel.crewNeeds.crew" : "UnitTableModel.crewNeeds.other";
+            appendReport(report, getTextAt(RESOURCE_BUNDLE, key), crewAssigned, crewNeeded);
         }
 
         if (navigatorsNeeded > 0) {
             report.append("<br>");
-            appendReport(report, "Navigator", navigatorsAssigned, navigatorsNeeded);
+            appendReport(report, getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.navigator"), navigatorsAssigned,
+                  navigatorsNeeded);
         }
 
         report.append("</html>");

--- a/MekHQ/src/mekhq/gui/model/UnitTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/UnitTableModel.java
@@ -246,7 +246,9 @@ public class UnitTableModel extends DataTableModel<Unit> {
                   navigatorsNeeded);
         }
 
-        String finalReport = reports.isEmpty() ? "" : String.join("<br>", reports);
+        String finalReport = reports.isEmpty() ?
+                                   getTextAt(RESOURCE_BUNDLE, "UnitTableModel.crewNeeds.none") :
+                                   String.join("<br>", reports);
         return "<html>" + finalReport + "</html>";
     }
 

--- a/MekHQ/unittests/mekhq/gui/model/UnitTableModelTest.java
+++ b/MekHQ/unittests/mekhq/gui/model/UnitTableModelTest.java
@@ -116,7 +116,7 @@
                0, 0,
                0, 0,
                true, mock(SpaceStation.class),
-               "<html></html>");
+               "<html>None</html>");
      }
 
      @Test

--- a/MekHQ/unittests/mekhq/gui/model/UnitTableModelTest.java
+++ b/MekHQ/unittests/mekhq/gui/model/UnitTableModelTest.java
@@ -121,37 +121,53 @@
 
      @Test
      public void fullyCrewed() {
-         setCrew(1, 1,
-               2, 2,
-               3, 3,
-               true, mock(Jumpship.class),
-               "<html><b>Drivers: </b>1/1<br><b>Gunners: </b>2/2<br><b>Crew: </b>3/3<br><b>Navigator: </b>1/1</html>");
+         setCrew(1,
+               1,
+               2,
+               2,
+               3,
+               3,
+               true,
+               mock(Jumpship.class),
+               "<html><b>Drivers (Unknown): </b>1/1<br><b>Gunners (Unknown): </b>2/2<br><b>Other (see Glossary): </b>3/3<br><b>Navigator: </b>1/1</html>");
      }
 
      @Test
      public void partiallyCrewed() {
-         setCrew(0, 1,
-               1, 2,
-               2, 3,
-               false, mock(Jumpship.class),
-               "<html><b>Drivers: </b>0/1<br><b>Gunners: </b>1/2<br><b>Crew: </b>2/3<br><b>Navigator: </b>0/1</html>");
+         setCrew(0,
+               1,
+               1,
+               2,
+               2,
+               3,
+               false,
+               mock(Jumpship.class),
+               "<html><b>Drivers (Unknown): </b>0/1<br><b>Gunners (Unknown): </b>1/2<br><b>Other (see Glossary): </b>2/3<br><b>Navigator: </b>0/1</html>");
      }
 
      @Test
      public void excessCrew() {
-         setCrew(2, 1,
-               4, 2,
-               6, 5,
-               true, mock(SpaceStation.class),
-               "<html><b>Drivers: </b>2/1<br><b>Gunners: </b>4/2<br><b>Crew: </b>6/5</html>");
+         setCrew(2,
+               1,
+               4,
+               2,
+               6,
+               5,
+               true,
+               mock(SpaceStation.class),
+               "<html><b>Drivers (Unknown): </b>2/1<br><b>Gunners (Unknown): </b>4/2<br><b>Other (see Glossary): </b>6/5</html>");
      }
 
      @Test
      public void noAssignedCrew() {
-         setCrew(0, 1,
-               0, 1,
-               0, 1,
-               false, mock(Jumpship.class),
-               "<html><b>Drivers: </b>0/1<br><b>Gunners: </b>0/1<br><b>Crew: </b>0/1<br><b>Navigator: </b>0/1</html>");
+         setCrew(0,
+               1,
+               0,
+               1,
+               0,
+               1,
+               false,
+               mock(Jumpship.class),
+               "<html><b>Drivers (Unknown): </b>0/1<br><b>Gunners (Unknown): </b>0/1<br><b>Other (see Glossary): </b>0/1<br><b>Navigator: </b>0/1</html>");
      }
  }


### PR DESCRIPTION
The new 'crew needs' display in the hangar shows what crew are needed by the unit, however we're still seeing a lot of user contact about what roles are needed for what units.

This PR updates the crew display even further so that it explicitly states what professions are needed. I've included some examples below, as it's easier to see than describe.

<img width="438" height="220" alt="image" src="https://github.com/user-attachments/assets/59b7f8fd-446b-4d40-a90f-f27dd3f48e32" />

<img width="441" height="188" alt="image" src="https://github.com/user-attachments/assets/2ed055c7-5421-47d4-b391-5eef0a7362a4" />

<img width="448" height="205" alt="image" src="https://github.com/user-attachments/assets/79f17b27-46d6-4ce2-9320-ae5ae2ecbd83" />

<img width="440" height="186" alt="image" src="https://github.com/user-attachments/assets/99fc30c9-0900-4c07-996f-cb49cf61f4d5" />



