### PR TITLE
Improvement: Removed Scenario Odds Reduction when Alt-Advanced Medical is Enabled

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -443,8 +443,7 @@ public class AtBContract extends Contract {
 
                     if (contractDefinition != null) {
                         for (StratConTrackState trackState : stratconCampaignState.getTracks()) {
-                            int scenarioOdds = StratConContractInitializer.getScenarioOdds(
-                                  campaign.getCampaignOptions().isUseAlternativeAdvancedMedical(), contractDefinition);
+                            int scenarioOdds = StratConContractInitializer.getScenarioOdds(contractDefinition);
 
                             trackState.setScenarioOdds(scenarioOdds);
                         }

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
@@ -303,7 +303,7 @@ public class StratConContractInitializer {
      * @author Illiani
      * @since 0.50.05
      */
-    private static int getScenarioOdds(StratConContractDefinition contractDefinition) {
+    public static int getScenarioOdds(StratConContractDefinition contractDefinition) {
         return contractDefinition.getScenarioOdds().get(Compute.randomInt(contractDefinition.getScenarioOdds().size()));
     }
 


### PR DESCRIPTION
Previously we reduced scenario odds by 33% when Alt-AM was enabled. This PR removes that based on player feedback following the earlier reduction of AAM healing times.