### PR TITLE
Improvement #8089: Improved Visibility of Burned Connections

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/personnelMarket/markets/NewPersonnelMarket.java
@@ -296,7 +296,7 @@ public class NewPersonnelMarket {
             return 0;
         }
 
-        int adjustedConnections = commander.getAdjustedConnections();
+        int adjustedConnections = commander.getAdjustedConnections(false);
         ConnectionsLevel connectionsLevel = ConnectionsLevel.parseConnectionsLevelFromInt(adjustedConnections);
 
         if (!ConnectionsLevel.CONNECTIONS_ZERO.equals(connectionsLevel)) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -6432,18 +6432,23 @@ public class Person {
      *
      * <p>The Connections value is clamped within the allowed minimum and maximum range before being returned.</p>
      *
+     * @param excludeTemporaryAdjustments if {@code true} temporary adjustments, such as from paranoia or connections
+     *                                    burning, are excluded from the returned value
+     *
      * @return the character's Connections value, clamped within the minimum and maximum limits
      *
      * @author Illiani
      * @since 0.50.07
      */
-    public int getAdjustedConnections() {
-        if (burnedConnectionsEndDate != null) {
-            return 0;
-        }
+    public int getAdjustedConnections(boolean excludeTemporaryAdjustments) {
+        if (!excludeTemporaryAdjustments) {
+            if (burnedConnectionsEndDate != null) {
+                return 0;
+            }
 
-        if (sufferingFromClinicalParanoia) {
-            return 0;
+            if (sufferingFromClinicalParanoia) {
+                return 0;
+            }
         }
 
         boolean hasXenophobia = options.booleanOption(COMPULSION_XENOPHOBIA);
@@ -8287,7 +8292,7 @@ public class Person {
             return "";
         }
 
-        int adjustedConnections = getAdjustedConnections();
+        int adjustedConnections = getAdjustedConnections(false);
         ConnectionsLevel connectionsLevel = ConnectionsLevel.parseConnectionsLevelFromInt(adjustedConnections);
 
         if (!ConnectionsLevel.CONNECTIONS_ZERO.equals(connectionsLevel)) {
@@ -8325,7 +8330,7 @@ public class Person {
      * @since 0.50.07
      */
     public String checkForBurnedContacts(LocalDate today) {
-        int adjustedConnections = getAdjustedConnections();
+        int adjustedConnections = getAdjustedConnections(false);
         ConnectionsLevel connectionsLevel = ConnectionsLevel.parseConnectionsLevelFromInt(adjustedConnections);
 
         if (!ConnectionsLevel.CONNECTIONS_ZERO.equals(connectionsLevel)) {

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/CommandRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/CommandRating.java
@@ -136,7 +136,7 @@ public class CommandRating {
         PersonnelOptions options = commander.getOptions();
 
         // Connections
-        traitScore += commander.getAdjustedConnections();
+        traitScore += commander.getAdjustedConnections(false);
 
         // Wealth
         traitScore += commander.getWealth() >= 7 ? 1 : 0;

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -1037,7 +1037,7 @@ public enum PersonnelTableModelColumn {
                 if (person.getBurnedConnectionsEndDate() != null) {
                     return "<html><b><font color='gray'>" +
                                  person.getAdjustedConnections(true) +
-                                 "</font></s></b></html>";
+                                 "</font></b></html>";
                 } else {
                     return Integer.toString(person.getAdjustedConnections(true));
                 }

--- a/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
+++ b/MekHQ/src/mekhq/gui/enums/PersonnelTableModelColumn.java
@@ -1034,7 +1034,13 @@ public enum PersonnelTableModelColumn {
             case TOUGHNESS:
                 return Integer.toString(person.getToughness());
             case CONNECTIONS:
-                return Integer.toString(person.getAdjustedConnections());
+                if (person.getBurnedConnectionsEndDate() != null) {
+                    return "<html><b><font color='gray'>" +
+                                 person.getAdjustedConnections(true) +
+                                 "</font></s></b></html>";
+                } else {
+                    return Integer.toString(person.getAdjustedConnections(true));
+                }
             case WEALTH:
                 return Integer.toString(person.getWealth());
             case EXTRA_INCOME:

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -2285,11 +2285,16 @@ public class PersonViewPanel extends JScrollablePanel {
         pnlOther.setBorder(RoundedLineBorder.createRoundedLineBorder(resourceMap.getString("pnlSkills.traits")));
 
         JLabel lblConnections = null;
-        int connections = person.getAdjustedConnections();
+        int connections = person.getAdjustedConnections(true);
         if (connections != 0) {
+            String connectionsDisplayValue = Integer.toString(connections);
+            if (person.getBurnedConnectionsEndDate() != null) {
+                connectionsDisplayValue = "<html><b><font color='gray'>" + connections + "</font></b></html>";
+            }
+
             String connectionsLabel = String.format(resourceMap.getString("format.traitValue"),
                   resourceMap.getString("lblConnections.text"),
-                  connections,
+                  connectionsDisplayValue,
                   "");
             lblConnections = new JLabel(connectionsLabel);
             lblConnections.setToolTipText(wordWrap(resourceMap.getString("lblConnections.tooltip")));


### PR DESCRIPTION
Close #8089

Connections will now appear faded if it has been temporarily removed due to being 'burned' or paranoia.