### PR TITLE
Fix #8075: Fixed Personnel Tab Context Menu Showing Wrong XP Cost for Attribute Score (inc. Edge) Purchases

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -3212,7 +3212,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                       attribute.getLabel(),
                       current,
                       target,
-                      traitCost));
+                      attributeCost));
                 menuItem.setToolTipText(wordWrap(String.format(resources.getString("spendOnAttributes.tooltip"))));
                 menuItem.setActionCommand(makeCommand(CMD_CHANGE_ATTRIBUTE,
                       String.valueOf(attribute),


### PR DESCRIPTION
Fix #8075

We were using the Trait cost not Attribute/Edge. This previously wasn't an issue because they had an identical cost of 100 xp.

This was a visual bug only.