### PR TITLE
Improvement: Added 'Bolster Contract Skill' Option to Optionally Increase OpFor & Ally Skills

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1748,6 +1748,11 @@ lblUseDynamicDifficulty.text=Dynamically Adjust Contract Difficulty
 lblUseDynamicDifficulty.tooltip=The difficulty of random contracts is adjusted based on the average skill level of combat\
   \ personnel in your campaign. The higher skilled you are, the more challenging - and potentially rewarding - contracts\
   \ will be.
+lblUseBolsterContractSkill.text=Bolster Contract Skill \u270E <span style="color:#C344C3;">\u2605</span>
+lblUseBolsterContractSkill.tooltip=The average skill level of allies and enemy forces will be increased by one level \
+  higher than listed in the random experience level table (TW pg 273). This option was added as players found the \
+  official rules created unsatisfying challenges. This is due to how skilled MekHQ characters can get, when compared \
+  to their TW compatriots.
 lblContractMarketReportRefresh.text=Post Report on Market Refresh
 lblContractMarketReportRefresh.tooltip=Adds a report to the daily log when the contract market\
   \ refreshes.

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -612,6 +612,7 @@ public class CampaignOptions {
     private int contractSearchRadius;
     private boolean variableContractLength;
     private boolean useDynamicDifficulty;
+    private boolean useBolsterContractSkill;
     private boolean contractMarketReportRefresh;
     private int contractMaxSalvagePercentage;
     private int dropShipBonusPercentage;
@@ -1266,6 +1267,7 @@ public class CampaignOptions {
         setContractSearchRadius(800);
         setVariableContractLength(true);
         setUseDynamicDifficulty(false);
+        useBolsterContractSkill = false;
         setContractMarketReportRefresh(true);
         setContractMaxSalvagePercentage(100);
         setDropShipBonusPercentage(0);
@@ -3984,6 +3986,14 @@ public class CampaignOptions {
 
     public void setUseDynamicDifficulty(final boolean useDynamicDifficulty) {
         this.useDynamicDifficulty = useDynamicDifficulty;
+    }
+
+    public boolean isUseBolsterContractSkill() {
+        return useBolsterContractSkill;
+    }
+
+    public void setUseBolsterContractSkill(final boolean useBolsterContractSkill) {
+        this.useBolsterContractSkill = useBolsterContractSkill;
     }
 
     public boolean isContractMarketReportRefresh() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -1017,6 +1017,10 @@ public class CampaignOptionsMarshaller {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useDynamicDifficulty", campaignOptions.isUseDynamicDifficulty());
         MHQXMLUtility.writeSimpleXMLTag(pw,
               indent,
+              "useBolsterContractSkill",
+              campaignOptions.isUseBolsterContractSkill());
+        MHQXMLUtility.writeSimpleXMLTag(pw,
+              indent,
               "contractMarketReportRefresh",
               campaignOptions.isContractMarketReportRefresh());
         MHQXMLUtility.writeSimpleXMLTag(pw,

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -801,6 +801,7 @@ public class CampaignOptionsUnmarshaller {
             case "contractSearchRadius" -> campaignOptions.setContractSearchRadius(parseInt(nodeContents));
             case "variableContractLength" -> campaignOptions.setVariableContractLength(parseBoolean(nodeContents));
             case "useDynamicDifficulty" -> campaignOptions.setUseDynamicDifficulty(parseBoolean(nodeContents));
+            case "useBolsterContractSkill" -> campaignOptions.setUseBolsterContractSkill(parseBoolean(nodeContents));
             case "contractMarketReportRefresh" -> campaignOptions.setContractMarketReportRefresh(parseBoolean(
                   nodeContents));
             case "contractMaxSalvagePercentage" -> campaignOptions.setContractMaxSalvagePercentage(parseInt(

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AbstractContractMarket.java
@@ -684,7 +684,7 @@ public abstract class AbstractContractMarket {
      * @param year                      the year of the contract, used for applying historical context modifiers.
      * @param averageSkillLevel         the average skill level of the player, used to adjust the enemy contract
      *                                  difficulty.
-     * @param isUseBolsterContractSkill {@code true} to increase ally skill
+     * @param isUseBolsterContractSkill {@code true} to increase enemy skill
      */
     protected void setEnemyRating(AtBContract contract, int year, SkillLevel averageSkillLevel,
           boolean isUseBolsterContractSkill) {

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -469,11 +469,18 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         final ReputationController reputation = campaign.getReputation();
         final SkillLevel campaignSkillLevel = reputation == null ? REGULAR : reputation.getAverageSkillLevel();
         final boolean useDynamicDifficulty = campaign.getCampaignOptions().isUseDynamicDifficulty();
-        setAllyRating(contract, campaign.getGameYear(), useDynamicDifficulty ? campaignSkillLevel : REGULAR);
-        setEnemyRating(contract, campaign.getGameYear(), useDynamicDifficulty ? campaignSkillLevel : REGULAR);
+        final boolean useBolsterContractSkill = campaign.getCampaignOptions().isUseBolsterContractSkill();
+        setAllyRating(contract,
+              campaign.getGameYear(),
+              useDynamicDifficulty ? campaignSkillLevel : REGULAR,
+              useBolsterContractSkill);
+        setEnemyRating(contract,
+              campaign.getGameYear(),
+              useDynamicDifficulty ? campaignSkillLevel : REGULAR,
+              useBolsterContractSkill);
 
         if (contract.getContractType().isCadreDuty()) {
-            contract.setAllySkill(GREEN);
+            contract.setAllySkill(campaign.getCampaignOptions().isUseBolsterContractSkill() ? REGULAR : GREEN);
             contract.setAllyQuality(IUnitRating.DRAGOON_F);
         }
 
@@ -558,11 +565,18 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
 
         setAttacker(contract);
         contract.setSystemId(parent.getSystemId());
-        setAllyRating(contract, campaign.getGameYear(), campaign.getReputation().getAverageSkillLevel());
-        setEnemyRating(contract, campaign.getGameYear(), campaign.getReputation().getAverageSkillLevel());
+        final boolean useBolsterContractSkill = campaign.getCampaignOptions().isUseBolsterContractSkill();
+        setAllyRating(contract,
+              campaign.getGameYear(),
+              campaign.getReputation().getAverageSkillLevel(),
+              useBolsterContractSkill);
+        setEnemyRating(contract,
+              campaign.getGameYear(),
+              campaign.getReputation().getAverageSkillLevel(),
+              useBolsterContractSkill);
 
         if (contract.getContractType().isCadreDuty()) {
-            contract.setAllySkill(GREEN);
+            contract.setAllySkill(campaign.getCampaignOptions().isUseBolsterContractSkill() ? REGULAR : GREEN);
             contract.setAllyQuality(IUnitRating.DRAGOON_F);
         }
         contract.calculateLength(campaign.getCampaignOptions().isVariableContractLength());

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/CamOpsContractMarket.java
@@ -33,6 +33,7 @@
 package mekhq.campaign.market.contractMarket;
 
 import static megamek.common.compute.Compute.d6;
+import static megamek.common.enums.SkillLevel.GREEN;
 import static megamek.common.enums.SkillLevel.REGULAR;
 import static mekhq.campaign.Campaign.AdministratorSpecialization.COMMAND;
 import static mekhq.campaign.personnel.PersonnelOptions.ADMIN_NETWORKER;
@@ -270,10 +271,17 @@ public class CamOpsContractMarket extends AbstractContractMarket {
         // Step 4: Populate some information about enemies and allies
         final SkillLevel campaignSkillLevel = reputation.getAverageSkillLevel();
         final boolean useDynamicDifficulty = campaign.getCampaignOptions().isUseDynamicDifficulty();
-        setAllyRating(contract, campaign.getGameYear(), useDynamicDifficulty ? campaignSkillLevel : REGULAR);
-        setEnemyRating(contract, campaign.getGameYear(), useDynamicDifficulty ? campaignSkillLevel : REGULAR);
+        final boolean useBolsterContractSkill = campaign.getCampaignOptions().isUseBolsterContractSkill();
+        setAllyRating(contract,
+              campaign.getGameYear(),
+              useDynamicDifficulty ? campaignSkillLevel : REGULAR,
+              useBolsterContractSkill);
+        setEnemyRating(contract,
+              campaign.getGameYear(),
+              useDynamicDifficulty ? campaignSkillLevel : REGULAR,
+              useBolsterContractSkill);
         if (contract.getContractType().isCadreDuty()) {
-            contract.setAllySkill(SkillLevel.GREEN);
+            contract.setAllySkill(campaign.getCampaignOptions().isUseBolsterContractSkill() ? REGULAR : GREEN);
             contract.setAllyQuality(IUnitRating.DRAGOON_F);
         }
         // Step 5: Determine the contract length (Not CamOps RAW)

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
@@ -146,6 +146,7 @@ public class MarketsTab {
     private JCheckBox chkUseCamOpsSalvage;
     private JCheckBox chkUseRiskySalvage;
     private JCheckBox chkUseDynamicDifficulty;
+    private JCheckBox chkUseBolsterContractSkill;
     private JCheckBox chkContractMarketReportRefresh;
     private JLabel lblContractMaxSalvagePercentage;
     private JSpinner spnContractMaxSalvagePercentage;
@@ -546,6 +547,7 @@ public class MarketsTab {
         chkUseCamOpsSalvage = new JCheckBox();
         chkUseRiskySalvage = new JCheckBox();
         chkUseDynamicDifficulty = new JCheckBox();
+        chkUseBolsterContractSkill = new JCheckBox();
         chkContractMarketReportRefresh = new JCheckBox();
         lblContractMaxSalvagePercentage = new JLabel();
         spnContractMaxSalvagePercentage = new JSpinner();
@@ -646,6 +648,10 @@ public class MarketsTab {
         chkUseDynamicDifficulty = new CampaignOptionsCheckBox("UseDynamicDifficulty");
         chkUseDynamicDifficulty.addMouseListener(createTipPanelUpdater(contractMarketHeader, "UseDynamicDifficulty"));
 
+        chkUseBolsterContractSkill = new CampaignOptionsCheckBox("UseBolsterContractSkill");
+        chkUseBolsterContractSkill.addMouseListener(createTipPanelUpdater(contractMarketHeader,
+              "UseBolsterContractSkill"));
+
         chkContractMarketReportRefresh = new CampaignOptionsCheckBox("ContractMarketReportRefresh");
         chkContractMarketReportRefresh.addMouseListener(createTipPanelUpdater(contractMarketHeader,
               "ContractMarketReportRefresh"));
@@ -697,6 +703,9 @@ public class MarketsTab {
 
         layout.gridy++;
         panel.add(chkUseDynamicDifficulty, layout);
+
+        layout.gridy++;
+        panel.add(chkUseBolsterContractSkill, layout);
 
         layout.gridy++;
         panel.add(chkContractMarketReportRefresh, layout);
@@ -912,6 +921,7 @@ public class MarketsTab {
         chkUseCamOpsSalvage.setSelected(options.isUseCamOpsSalvage());
         chkUseRiskySalvage.setSelected(options.isUseRiskySalvage());
         chkUseDynamicDifficulty.setSelected(options.isUseDynamicDifficulty());
+        chkUseBolsterContractSkill.setSelected(options.isUseBolsterContractSkill());
         chkContractMarketReportRefresh.setSelected(options.isContractMarketReportRefresh());
         spnContractMaxSalvagePercentage.setValue(options.getContractMaxSalvagePercentage());
         spnDropShipBonusPercentage.setValue(options.getDropShipBonusPercentage());
@@ -982,6 +992,7 @@ public class MarketsTab {
         options.setUseCamOpsSalvage(chkUseCamOpsSalvage.isSelected());
         options.setUseRiskySalvage(chkUseRiskySalvage.isSelected());
         options.setUseDynamicDifficulty(chkUseDynamicDifficulty.isSelected());
+        options.setUseBolsterContractSkill(chkUseBolsterContractSkill.isSelected());
         options.setContractMarketReportRefresh(chkContractMarketReportRefresh.isSelected());
         options.setContractMaxSalvagePercentage((int) spnContractMaxSalvagePercentage.getValue());
         options.setDropShipBonusPercentage((int) spnDropShipBonusPercentage.getValue());


### PR DESCRIPTION
I've been keeping an eye on player chatter over the past couple of versions and a theme that I've seen come up a lot is that green allies are not fun to fight alongside. Similarly, neither are green enemies fun to fight against.

With that in mind I've gone ahead and added a campaign option that will increase the experience level of allies and enemies by one level. If previously they would have been green, they are now regular, and so on. This is extended to Cadre Duty.

This will have a few knock-on effects:

- Contract scenarios will, overall, be slightly more challenging on average.
- Prisoners will, on average, be slightly more skilled.
- Clan OpFors will, on average, be slightly smaller (if the Batchall is accepted).
- Allies & OpFors can now be rated as 'Heroic', rather than capping out at Elite. This will allow them to challenge players for longer.

At lot of the points above are marked as 'on average.' This is due to the 'randomize skills' campaign option which can generate crews one experience level above, below, or at the requested skill level. That means 'regular' could generate green, regular, or veteran crews. While 'heroic' could see elite, heroic, or legendary crews.