### PR TITLE
Sentry: Fixed Out of Index Error in MRMS

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/MRMSDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MRMSDialog.java
@@ -866,7 +866,7 @@ public class MRMSDialog extends JDialog {
 
     private void btnUnitsSelectNoneActionPerformed(ActionEvent evt) {
         int removalRowCount = unitTable.getRowCount() - 1;
-        if (removalRowCount > 0) {
+        if (removalRowCount >= 0) {
             unitTable.removeRowSelectionInterval(0, unitTable.getRowCount() - 1);
         }
     }


### PR DESCRIPTION
[Sentry Report](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8019/events/55c570c90c514c89984251cbcda62449/)

If we attempt to deselect all units in MRMS and there are no units selected we will throw an error as we attempt to deselect an array from 0 to -1. This fixes that.