### PR TITLE
Fix: Fixed Employment of Camp Followers

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1883,7 +1883,6 @@ public class Person {
     }
 
     public @Nullable LocalDate getRecruitment() {
-
         return recruitment;
     }
 

--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -1217,7 +1217,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
             }
             case CMD_EMPLOY: {
                 for (Person person : people) {
-                    getCampaign().recruitPerson(person);
+                    getCampaign().employCampFollower(person);
                 }
 
                 break;


### PR DESCRIPTION
When players opt to employ their camp followers we were using an invalid method to handle the process. This PR corrects that with a purpose-built method.