### PR TITLE
Fix #8119: Fixed Reference Entry for Maximum Patients Campaign Option

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -655,7 +655,7 @@ lblUseRandomDiseases.text=Use Random Diseases \u270E \u26A0 <span style="color:#
 lblUseRandomDiseases.tooltip=Characters can catch random diseases. See the Glossary for more information.\
   <br>\
   <br><b>Requirement:</b> Requires 'Use Alternative Mode.'
-MaximumPatients.text=Base Beds per Doctor
+lblMaximumPatients.text=Base Beds per Doctor
 lblMaximumPatients.tooltip=This is the base number of patients that can be treated per doctor. This can be modified by\
   \ Administration.
 lblDoctorsUseAdministration.text=Doctors Need Administration \u270E


### PR DESCRIPTION
Fix #8119

`MaximumPatients` -> `lblMaximumPatients`