### PR TITLE
Fix #8125: Fixed Campaign Options Tooltip for Commanders Only Vehicle Edition

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -420,7 +420,7 @@ lblUseAbilities.text=Use Special Pilot Abilities (SPAs)
 lblUseAbilities.tooltip=Characters can purchase and benefit from SPAs.
 lblOnlyCommandersMatterVehicles.text=Only Commanders Matter - Vehicles <span style="color:#C344C3;">\u2605</span>
 lblOnlyCommandersMatterVehicles.tooltip=For all vehicles, including support vehicles and conventional aircraft, only the \
-  unit commander's SPAs and skills are used. This is always the unit's driver.
+  unit commander's SPAs and skills are used. Only drivers and gunners can be vehicle commanders.
 lblOnlyCommandersMatterInfantry.text=Only Commanders Matter - Infantry <span style="color:#C344C3;">\u2605</span>
 lblOnlyCommandersMatterInfantry.tooltip=For all conventional infantry units, only the unit commander's SPAs and skills \
   are used.


### PR DESCRIPTION
Fix #8125

`This is always the unit's driver` -> `Only drivers and gunners can be vehicle commanders.`