### PR TITLE
Fix #8118: Stopped Passengers Rudely Backseat Driving Tanks

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -4517,8 +4517,13 @@ public class Unit implements ITechnology {
             return null;
         }
 
+        List<Person> validCrew = new ArrayList<>(drivers);
+        if (!entity.isInfantry() && !usesSoldiers()) { // No need to add gunners for these units
+            validCrew.addAll(gunners);
+        }
+
         Person commander = null;
-        for (Person potentialCommander : getCrew()) {
+        for (Person potentialCommander : validCrew) {
             if (commander == null) {
                 commander = potentialCommander;
                 continue;
@@ -7440,4 +7445,6 @@ public class Unit implements ITechnology {
             return null;
         }
     }
+
+
 }


### PR DESCRIPTION
Fix #8118

Commanders now can only be pulled from gunners or drivers, not passengers.