### PR TITLE
Fix #8117: Fixed Order of Operations Creating Weird TO&E Skill Levels

### DIFF
--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -457,9 +457,6 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
             unit.setCampaign(campaign);
             unit.fixReferences(campaign);
 
-            // reset the pilot and entity, to reflect newly assigned personnel
-            unit.resetPilotAndEntity();
-
             if (null != unit.getRefit()) {
                 unit.getRefit().fixReferences(campaign);
 
@@ -562,6 +559,9 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                 unit.getEntity().setC3UUID();
                 unit.getEntity().setC3NetIdSelf();
             }
+
+            // This needs to be down here so that it can factor in any changes made to personnel prior to this point.
+            unit.resetPilotAndEntity();
         });
         campaign.refreshNetworks();
 


### PR DESCRIPTION
Fix #8117

This was a weird order of operations issue. I'm sure _why_ it was showing the values it was, but now it isn't and that's progress.

I checked that this does not break C3 Networks.