### PR TITLE
Fix #8122: Fixed MASH Theater Capacity Using MASH Equipment Count Instead of MASH Theater Count

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/medical/MASHCapacity.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/MASHCapacity.java
@@ -68,7 +68,7 @@ public class MASHCapacity {
 
             for (MiscMounted item : unit.getEntity().getMisc()) {
                 if (item.getType().hasFlag(MiscType.F_MASH)) {
-                    mashTheatreCount++;
+                    mashTheatreCount += (int) Math.floor(item.getSize());
                 }
             }
         }


### PR DESCRIPTION
Fix #8122

Previously we were counting the number of MASH Theater _equipment_ and _not_ how many individual theaters are in each equipment instance. Which is why during testing we were seeing the correct values. The units tested had multiple 'MASH Theater' equipment instances.