### PR TITLE
Task: Removed Excess Skill Clause in Academy Skill Parser

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
+++ b/MekHQ/src/mekhq/campaign/personnel/education/Academy.java
@@ -1019,7 +1019,6 @@ public class Academy implements Comparable<Academy> {
             case "interest/other" -> SkillType.S_INTEREST_OTHER;
             case "interrogation" -> SkillType.S_INTERROGATION;
             case "investigation" -> SkillType.S_INVESTIGATION;
-            //skill string is stored both plural and not plural in some cases
             case "language/any" -> SkillType.S_LANGUAGES;
             case "protocols/any" -> SkillType.S_PROTOCOLS;
             case "science/biology" -> SkillType.S_SCIENCE_BIOLOGY;


### PR DESCRIPTION
There were some additional changes that needed to be made to #8116, however if it wasn't merged before the nightly built the nightly would have been very broken.

This PR makes the minor changes I requested in my review of #8116. #8116 was fine already, these were just polish changes and so I asked Hammer to merge the original PR with a mind towards me making the changes myself. This PR can then live in the queue without any urgency tied to it.