### PR TITLE
Fix: Fixed Combat Technicians Not Counting Towards CamOps Rating

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -5756,7 +5756,7 @@ public class Person {
         } else if (entity instanceof BattleArmor) {
             return hasSkill(S_TECH_BA) && isTechBA();
         } else if (entity instanceof Tank) {
-            return hasSkill(S_TECH_MECHANIC) && (isTechMechanic() || isVehicleCrew());
+            return hasSkill(S_TECH_MECHANIC) && (isTechMechanic() || isCombatTechnician());
         } else {
             return false;
         }
@@ -6061,7 +6061,7 @@ public class Person {
     }
 
     public boolean isTech() {
-        return isTechMek() || isTechAero() || isTechMechanic() || isTechBA() || isVehicleCrew();
+        return isTechMek() || isTechAero() || isTechMechanic() || isTechBA() || isCombatTechnician();
     }
 
     /**
@@ -6070,7 +6070,12 @@ public class Person {
      * @return true if the person is a tech
      */
     public boolean isTechExpanded() {
-        return isTechMek() || isTechAero() || isTechMechanic() || isVehicleCrew() || isTechBA() || isTechLargeVessel();
+        return isTechMek() ||
+                     isTechAero() ||
+                     isTechMechanic() ||
+                     isCombatTechnician() ||
+                     isTechBA() ||
+                     isTechLargeVessel();
     }
 
     public boolean isTechLargeVessel() {
@@ -6098,7 +6103,7 @@ public class Person {
         return hasSkill && (getPrimaryRole().isBATech() || getSecondaryRole().isBATech());
     }
 
-    public boolean isVehicleCrew() {
+    public boolean isCombatTechnician() {
         boolean hasSkill = hasSkill(S_TECH_MECHANIC);
         return hasSkill && (getPrimaryRole().isCombatTechnician() || getSecondaryRole().isCombatTechnician());
     }

--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/SupportRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/SupportRating.java
@@ -300,6 +300,7 @@ public class SupportRating {
         for (Person person : campaign.getActivePersonnel(false, false)) {
             updateCount(person::isTechMek, "techMekCount", techCounts);
             updateCount(person::isTechMechanic, "techMechanicCount", techCounts);
+            updateCount(person::isCombatTechnician, "techMechanicCount", techCounts); // Counts as Mechanic
             updateCount(person::isTechAero, "techAeroCount", techCounts);
             updateCount(person::isTechBA, "techBattleArmorCount", techCounts);
         }

--- a/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelRoleTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/enums/PersonnelRoleTest.java
@@ -118,7 +118,7 @@ class PersonnelRoleTest {
     }
 
     @Test
-    void testIsVehicleCrewGround() {
+    void testIsCombatTechnicianGround() {
         for (final PersonnelRole personnelRole : roles) {
             if (personnelRole == PersonnelRole.VEHICLE_CREW_GROUND) {
                 assertTrue(personnelRole.isVehicleCrewGround());
@@ -140,7 +140,7 @@ class PersonnelRoleTest {
     }
 
     @Test
-    void testIsVehicleCrewVTOL() {
+    void testIsCombatTechnicianVTOL() {
         for (final PersonnelRole personnelRole : roles) {
             if (personnelRole == PersonnelRole.VEHICLE_CREW_VTOL) {
                 assertTrue(personnelRole.isVehicleCrewVTOL());
@@ -151,7 +151,7 @@ class PersonnelRoleTest {
     }
 
     @Test
-    void testIsVehicleCrew() {
+    void testIsCombatTechnician() {
         for (final PersonnelRole personnelRole : roles) {
             if (personnelRole == PersonnelRole.COMBAT_TECHNICIAN) {
                 assertTrue(personnelRole.isCombatTechnician());
@@ -477,7 +477,7 @@ class PersonnelRoleTest {
 
     @ParameterizedTest
     @EnumSource(PersonnelRole.class)
-    void testIsVehicleCrewMember(PersonnelRole personnelRole) {
+    void testIsCombatTechnicianMember(PersonnelRole personnelRole) {
         boolean expected = switch (personnelRole) {
             case VEHICLE_CREW_GROUND,
                  VEHICLE_CREW_NAVAL,

--- a/MekHQ/unittests/mekhq/gui/enums/PersonnelFilterTest.java
+++ b/MekHQ/unittests/mekhq/gui/enums/PersonnelFilterTest.java
@@ -138,7 +138,7 @@ class PersonnelFilterTest {
     }
 
     @Test
-    void testIsVehicleCrewMember() {
+    void testIsCombatTechnicianMember() {
         for (final PersonnelFilter personnelFilter : filters) {
             if (personnelFilter == PersonnelFilter.VEHICLE_CREWMEMBER) {
                 assertTrue(personnelFilter.isVehicleCrewMember());
@@ -182,7 +182,7 @@ class PersonnelFilterTest {
     }
 
     @Test
-    void testIsVehicleCrew() {
+    void testIsCombatTechnician() {
         for (final PersonnelFilter personnelFilter : filters) {
             if (personnelFilter == PersonnelFilter.COMBAT_TECHNICIANS) {
                 assertTrue(personnelFilter.isVehicleCrew());


### PR DESCRIPTION
We were only checking for Mechanics, now we check for Mechanics and Combat Technicians.

I also renamed `getVehicleCrew` as that was still referencing the now defunct Vehicle Crew profession.