### PR TITLE
Improvement #8137: Updated Illiterate State Removal Based on Player Expectations; Updated Skill Display to More Clearly Display Base & Modified Skill Level

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -590,6 +590,8 @@ public class CampaignNewDayManager {
 
             processAnniversaries(person);
 
+            person.checkForIlliterateRemoval();
+
             // Weekly events
             if (today.getDayOfWeek() == DayOfWeek.MONDAY) {
                 if (!campaign.getRandomDeath().processNewWeek(campaign, today, person)) {

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -8391,29 +8391,32 @@ public class Person {
     }
 
     /**
-     * Determines whether the character is considered illiterate.
+     * Checks whether the character should lose the Illiterate flaw.
      *
-     * <p>A person is regarded as illiterate if they possess the {@link PersonnelOptions#FLAW_ILLITERATE} flaw, and
-     * their base level in the {@link SkillType#S_LANGUAGES} skill is below
-     * {@link PersonnelOptions#ILLITERACY_LANGUAGES_THRESHOLD}.</p>
+     * <p>If the Illiterate flaw is not currently active, this method returns immediately. Otherwise, it inspects the
+     * character's Languages skill. If the character has no Languages skill, the flaw remains.</p>
      *
-     * @return {@code true} if the person is considered illiterate; {@code false} otherwise.
+     * <p>If the character's base Languages skill level is greater than or equal to
+     * {@code ILLITERACY_LANGUAGES_THRESHOLD}, the Illiterate flaw is removed by setting its option value to
+     * {@code false}.</p>
      *
      * @author Illiani
-     * @since 0.50.07
+     * @since 0.50.10
      */
-    public boolean isIlliterate() {
+    public void checkForIlliterateRemoval() {
         if (!options.booleanOption(FLAW_ILLITERATE)) {
-            return false;
+            return;
         }
 
         Skill languages = skills.getSkill(S_LANGUAGES);
         if (languages == null) {
-            return true;
+            return;
         }
 
-        int level = languages.getLevel();
-        return level < ILLITERACY_LANGUAGES_THRESHOLD;
+        int baseLevel = languages.getLevel();
+        if (baseLevel >= ILLITERACY_LANGUAGES_THRESHOLD) {
+            options.getOption(FLAW_ILLITERATE).setValue(false);
+        }
     }
 
     /**
@@ -8458,7 +8461,7 @@ public class Person {
         List<InjuryEffect> injuryEffects = excludeInjuryEffects ? new ArrayList<>() :
                                                  AdvancedMedicalAlternate.getAllActiveInjuryEffects(isAmbidextrous,
                                                        injuries);
-        return new SkillModifierData(options, atowAttributes, 0, isIlliterate(), injuryEffects);
+        return new SkillModifierData(options, atowAttributes, 0, injuryEffects);
     }
 
     /**
@@ -8513,6 +8516,6 @@ public class Person {
                                                  AdvancedMedicalAlternate.getAllActiveInjuryEffects(isAmbidextrous,
                                                        injuries);
 
-        return new SkillModifierData(options, atowAttributes, adjustedReputation, isIlliterate(), injuryEffects);
+        return new SkillModifierData(options, atowAttributes, adjustedReputation, injuryEffects);
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -38,7 +38,6 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static megamek.common.options.OptionsConstants.UNOFFICIAL_SENSOR_GEEK;
 import static mekhq.campaign.personnel.PersonnelOptions.*;
-import static mekhq.campaign.personnel.skills.SkillCheckUtility.UNTRAINED_SKILL_MODIFIER;
 import static mekhq.campaign.personnel.skills.SkillType.*;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.CHARISMA;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.INTELLIGENCE;
@@ -279,6 +278,8 @@ public class Skill {
     /**
      * Calculates the skill modifiers for the current skill type based on the character's SPAs.
      *
+     * <p><b>Usage:</b> Positive modifiers make the skill check easier, negative make it harder.</p>
+     *
      * @param characterOptions The {@link PersonnelOptions} with the character's attributes and options.
      * @param reputation       The character's reputation
      *
@@ -370,12 +371,15 @@ public class Skill {
                 modifier -= 1;
             }
 
-            if (hasReligiousFanaticism) {
-                modifier -= 1;
-            }
-
             if (characterOptions.booleanOption(ATOW_ATTRACTIVE)) {
                 modifier += 2;
+            }
+        }
+
+        // Illiterate
+        if (type.hasAttribute(INTELLIGENCE)) {
+            if (characterOptions.booleanOption(FLAW_ILLITERATE)) {
+                modifier -= 4;
             }
         }
 
@@ -608,7 +612,6 @@ public class Skill {
             skillModifierData = new SkillModifierData(new PersonnelOptions(),
                   new Attributes(),
                   0,
-                  false,
                   new ArrayList<>());
         }
 
@@ -638,12 +641,7 @@ public class Skill {
         int attributeModifiers = getTotalAttributeModifier(new TargetRoll(), skillModifierData.attributes(), type);
         int totalInjuryModifier = getTotalInjuryModifier(skillModifierData, type);
 
-        boolean isIntelligenceBased = INTELLIGENCE.equals(type.getFirstAttribute())
-                                            || INTELLIGENCE.equals(type.getSecondAttribute());
-        int literacyModifier = isIntelligenceBased && skillModifierData.isIlliterate()
-                                     ? UNTRAINED_SKILL_MODIFIER : 0;
-
-        return spaModifiers + attributeModifiers + literacyModifier + totalInjuryModifier;
+        return spaModifiers + attributeModifiers + totalInjuryModifier;
     }
 
     public static int getTotalInjuryModifier(SkillModifierData skillModifierData, SkillType type) {
@@ -760,7 +758,7 @@ public class Skill {
     @Override
     public String toString() {
         SkillModifierData skillModifierData = new SkillModifierData(new PersonnelOptions(), new Attributes(),
-              0, false, new ArrayList<>());
+              0, new ArrayList<>());
         return toString(skillModifierData);
     }
 
@@ -791,9 +789,13 @@ public class Skill {
             display = getFinalSkillValue(skillModifierData) + "+";
         }
 
-        if (type.isSkillLevelsMatter()) {
-            int totalSkillLevel = getTotalSkillLevel(skillModifierData);
-            display += String.format(" (%d)", totalSkillLevel);
+        int baseSkillLevel = level;
+        int totalSkillLevel = getTotalSkillLevel(skillModifierData);
+        if (baseSkillLevel != totalSkillLevel) {
+            display += String.format(" (<s><font color='gray'>%d</font></s>, %d)",
+                  baseSkillLevel, totalSkillLevel);
+        } else {
+            display += String.format(" (%d)", baseSkillLevel);
         }
 
         return display;

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillModifierData.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillModifierData.java
@@ -49,12 +49,11 @@ import mekhq.campaign.personnel.medical.advancedMedicalAlternate.InjuryEffect;
  * @param characterOptions   the person's options and special traits
  * @param attributes         the person's physical and mental attributes
  * @param adjustedReputation the calculated reputation modifier (0 if not applicable)
- * @param isIlliterate       whether the person is illiterate
  * @param injuryEffects      a list of injury effects currently affecting the character
  *
  * @author Illiani
  * @since 0.50.11
  */
 public record SkillModifierData(PersonnelOptions characterOptions, Attributes attributes, int adjustedReputation,
-      boolean isIlliterate, List<InjuryEffect> injuryEffects) {
+      List<InjuryEffect> injuryEffects) {
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/SkillType.java
@@ -268,7 +268,6 @@ public class SkillType {
     private int heroicLvl;
     private int legendaryLvl;
     private Integer[] costs;
-    private boolean skillLevelsMatter;
 
     /**
      * @param level skill level integer to get name for
@@ -477,7 +476,6 @@ public class SkillType {
         this.legendaryLvl = 7;
         this.costs = new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
                                      DISABLED_SKILL_LEVEL };
-        this.skillLevelsMatter = false;
     }
 
     /**
@@ -491,40 +489,31 @@ public class SkillType {
      * array has more than 11 entries, it will be trimmed to size. Additionally, the input array is copied to prevent
      * accidental external changes to the internal state of the instance.</p>
      *
-     * @param name              The name of the skill type. <b>Cannot</b> be {@code null}.
-     * @param target            The target value representing a threshold or goal for the skill. If {@code null}, the
-     *                          default value is {@code 7}.
-     * @param isCountUp         {@code true} if the skill counts up toward a goal, {@code false} otherwise. If
-     *                          {@code null}, the default value is {@code false}.
-     * @param subType           The {@link SkillSubType} category of the skill. This indicates the broader
-     *                          classification of the skill (e.g., combat-related, role-playing).
-     *                          <b>Cannot</b> be {@code null}.
-     * @param firstAttribute    The primary {@link SkillAttribute} associated with the skill, influencing its
-     *                          calculation or behavior. <b>Cannot</b> be {@code null}.
-     * @param secondAttribute   The secondary {@link SkillAttribute} associated with the skill. If {@code null}, the
-     *                          default value is {@link SkillAttribute#NONE}.
-     * @param greenLvl          The value representing the skill's "Green" proficiency level. If {@code null}, the
-     *                          default value is {@code 1}.
-     * @param regLvl            The value representing the skill's "Regular" proficiency level. If {@code null}, the
-     *                          default value is {@code 3}.
-     * @param vetLvl            The value representing the skill's "Veteran" proficiency level. If {@code null}, the
-     *                          default value is {@code 4}.
-     * @param eliteLvl          The value representing the skill's "Elite" proficiency level. If {@code null}, the
-     *                          default value is {@code 5}.
-     * @param costs             An {@code Integer[]} array representing the skill's progression costs for each level
-     *                          from 0 to 10 inclusive. If the array is {@code null} or its length is not exactly 11, a
-     *                          new array is created with default values. Missing entries are filled with
-     *                          {@link #DISABLED_SKILL_LEVEL}, and extra entries beyond the 11th are ignored. A clean
-     *                          copy of the array is always used to ensure the integrity of the internal state.
-     *
-     *                          <p>For example:</p>
-     *                          <pre>
-     *                                                                                                                                                                                                                                                                                                                                                                                                                                            Integer[] costs = new Integer[] {8, 4, 4, 4, 4, 4, 4, 4, 4, -1, -1};
-     *                                                                                                                                                                                                                                                                                                                                                                                                                                            SkillType skillType = new SkillType("Example Skill", 7, false, SkillSubType.COMBAT,
-     *                                                                                                                                                                                                                                                                                                                                                                                                                                            SkillAttribute.DEXTERITY, SkillAttribute.INTELLIGENCE, 1, 3, 4, 5, costs);
-     *                                                                                                                                                                                                                                                                                                                                                                                                                                        </pre>
-     * @param skillLevelsMatter if {@code true}, the skill's level will be displayed in Person View in addition to the
-     *                          skill's Target Number
+     * @param name            The name of the skill type. <b>Cannot</b> be {@code null}.
+     * @param target          The target value representing a threshold or goal for the skill. If {@code null}, the
+     *                        default value is {@code 7}.
+     * @param isCountUp       {@code true} if the skill counts up toward a goal, {@code false} otherwise. If
+     *                        {@code null}, the default value is {@code false}.
+     * @param subType         The {@link SkillSubType} category of the skill. This indicates the broader classification
+     *                        of the skill (e.g., combat-related, role-playing).
+     *                        <b>Cannot</b> be {@code null}.
+     * @param firstAttribute  The primary {@link SkillAttribute} associated with the skill, influencing its calculation
+     *                        or behavior. <b>Cannot</b> be {@code null}.
+     * @param secondAttribute The secondary {@link SkillAttribute} associated with the skill. If {@code null}, the
+     *                        default value is {@link SkillAttribute#NONE}.
+     * @param greenLvl        The value representing the skill's "Green" proficiency level. If {@code null}, the default
+     *                        value is {@code 1}.
+     * @param regLvl          The value representing the skill's "Regular" proficiency level. If {@code null}, the
+     *                        default value is {@code 3}.
+     * @param vetLvl          The value representing the skill's "Veteran" proficiency level. If {@code null}, the
+     *                        default value is {@code 4}.
+     * @param eliteLvl        The value representing the skill's "Elite" proficiency level. If {@code null}, the default
+     *                        value is {@code 5}.
+     * @param costs           An {@code Integer[]} array representing the skill's progression costs for each level from
+     *                        0 to 10 inclusive. If the array is {@code null} or its length is not exactly 11, a new
+     *                        array is created with default values. Missing entries are filled with
+     *                        {@link #DISABLED_SKILL_LEVEL}, and extra entries beyond the 11th are ignored. A clean copy
+     *                        of the array is always used to ensure the integrity of the internal state.
      *
      * @author Illiani
      * @since 0.50.05
@@ -532,7 +521,7 @@ public class SkillType {
     public SkillType(String name, @Nullable Integer target, @Nullable Boolean isCountUp, SkillSubType subType,
           SkillAttribute firstAttribute, @Nullable SkillAttribute secondAttribute, @Nullable Integer greenLvl,
           @Nullable Integer regLvl, @Nullable Integer vetLvl, @Nullable Integer eliteLvl, @Nullable Integer heroicLvl,
-          @Nullable Integer legendaryLvl, Integer[] costs, boolean skillLevelsMatter) {
+          @Nullable Integer legendaryLvl, Integer[] costs) {
         this.name = name;
         this.target = target == null ? 7 : target;
         this.countUp = isCountUp != null && isCountUp;
@@ -545,7 +534,6 @@ public class SkillType {
         this.eliteLvl = eliteLvl == null ? 5 : eliteLvl;
         this.heroicLvl = heroicLvl == null ? 6 : heroicLvl;
         this.legendaryLvl = legendaryLvl == null ? 7 : legendaryLvl;
-        this.skillLevelsMatter = skillLevelsMatter;
 
         // This validates the length of costs to ensure that valid entries exist for all possible skill levels (0-10,
         // inclusive)
@@ -863,10 +851,6 @@ public class SkillType {
 
     public void setLegendaryLevel(int level) {
         legendaryLvl = level;
-    }
-
-    public boolean isSkillLevelsMatter() {
-        return skillLevelsMatter;
     }
 
     /**
@@ -1343,8 +1327,6 @@ public class SkillType {
                     for (int i = 0; i < values.length; i++) {
                         skillType.costs[i] = MathUtility.parseInt(values[i], skillType.costs[i]);
                     }
-                } else if (wn2.getNodeName().equalsIgnoreCase("skillLevelsMatter")) {
-                    skillType.skillLevelsMatter = Boolean.parseBoolean(wn2.getTextContent().trim());
                 }
             }
 
@@ -1557,7 +1539,6 @@ public class SkillType {
         skillType.firstAttribute = temporarySkillType.getFirstAttribute();
         skillType.secondAttribute = temporarySkillType.getSecondAttribute();
         skillType.countUp = temporarySkillType.isCountUp();
-        skillType.skillLevelsMatter = temporarySkillType.isSkillLevelsMatter();
 
         if (skillType.subType == SUPPORT_COMMAND) {
             skillType.target = temporarySkillType.getTarget();
@@ -1578,8 +1559,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createGunneryMek() {
@@ -1596,8 +1577,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createPilotingAero() {
@@ -1613,8 +1594,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createGunneryAero() {
@@ -1631,8 +1612,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createPilotingJet() {
@@ -1648,8 +1629,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createGunneryJet() {
@@ -1666,8 +1647,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createPilotingSpace() {
@@ -1683,8 +1664,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createGunnerySpace() {
@@ -1701,8 +1682,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createPilotingGroundVee() {
@@ -1718,8 +1699,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createPilotingNavalVee() {
@@ -1735,8 +1716,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createPilotingVTOL() {
@@ -1752,8 +1733,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createGunneryVehicle() {
@@ -1770,8 +1751,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createArtillery() {
@@ -1788,8 +1769,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createGunneryBA() {
@@ -1806,8 +1787,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createGunneryProto() {
@@ -1824,8 +1805,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 8, 8, 8, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createSmallArms() {
@@ -1841,8 +1822,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createAntiMek() {
@@ -1859,8 +1840,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createTechMek() {
@@ -1878,8 +1859,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createTechMechanic() {
@@ -1897,8 +1878,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createTechAero() {
@@ -1916,8 +1897,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createTechBA() {
@@ -1935,8 +1916,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createTechVessel() {
@@ -1954,8 +1935,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 12, 6, 0, 6, 6, 6, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createAstech() {
@@ -1974,8 +1955,8 @@ public class SkillType {
               null,
               new Integer[] { 12, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
                               DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              true);
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createSurgery() {
@@ -1993,8 +1974,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 16, 8, 0, 8, 8, 8, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              true);
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createMedTech() {
@@ -2012,8 +1993,8 @@ public class SkillType {
               null,
               new Integer[] { 16, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
                               DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              true);
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createNavigation() {
@@ -2030,8 +2011,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              false);
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createTactics() {
@@ -2047,8 +2028,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 },
-              true);
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 }
+        );
     }
 
     public static SkillType createStrategy() {
@@ -2064,8 +2045,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 },
-              true);
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 }
+        );
     }
 
     public static SkillType createAdmin() {
@@ -2082,8 +2063,8 @@ public class SkillType {
               null,
               null,
               new Integer[] { 8, 4, 0, 4, 4, 4, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL,
-                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL },
-              true);
+                              DISABLED_SKILL_LEVEL, DISABLED_SKILL_LEVEL }
+        );
     }
 
     public static SkillType createLeadership() {
@@ -2099,8 +2080,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 },
-              true);
+              new Integer[] { 12, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 }
+        );
     }
 
     public static SkillType createNegotiation() {
@@ -2116,8 +2097,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 },
-              false);
+              new Integer[] { 8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 }
+        );
     }
 
     public static SkillType createAcrobatics() {
@@ -2133,8 +2114,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createActing() {
@@ -2150,8 +2131,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createAnimalHandling() {
@@ -2167,8 +2148,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createAppraisal() {
@@ -2184,8 +2165,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createArchery() {
@@ -2201,8 +2182,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createArtDancing() {
@@ -2218,8 +2199,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createArtDrawing() {
@@ -2235,8 +2216,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createArtPainting() {
@@ -2252,8 +2233,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createArtWriting() {
@@ -2269,8 +2250,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createArtPoetry() {
@@ -2286,8 +2267,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
 
@@ -2304,8 +2285,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
 
@@ -2322,8 +2303,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createArtCooking() {
@@ -2339,8 +2320,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createArtSinging() {
@@ -2356,8 +2337,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createArtOther() {
@@ -2373,8 +2354,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createCommunications() {
@@ -2390,8 +2371,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createComputers() {
@@ -2407,8 +2388,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createCryptography() {
@@ -2424,8 +2405,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createDemolitions() {
@@ -2441,8 +2422,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createDisguise() {
@@ -2458,8 +2439,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createEscapeArtist() {
@@ -2475,8 +2456,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createForgery() {
@@ -2492,8 +2473,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestHistory() {
@@ -2509,8 +2490,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestLiterature() {
@@ -2526,8 +2507,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestHoloGames() {
@@ -2543,8 +2524,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestSports() {
@@ -2560,8 +2541,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestFashion() {
@@ -2577,8 +2558,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestMusic() {
@@ -2594,8 +2575,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestMilitary() {
@@ -2611,8 +2592,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestAntiques() {
@@ -2628,8 +2609,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestTheology() {
@@ -2645,8 +2626,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestGambling() {
@@ -2662,8 +2643,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestPolitics() {
@@ -2679,8 +2660,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestPhilosophy() {
@@ -2696,8 +2677,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestEconomics() {
@@ -2713,8 +2694,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestPopCulture() {
@@ -2730,8 +2711,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestAstrology() {
@@ -2747,8 +2728,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestFishing() {
@@ -2764,8 +2745,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestMythology() {
@@ -2781,8 +2762,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestCartography() {
@@ -2798,8 +2779,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestArcheology() {
@@ -2815,8 +2796,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestHoloCinema() {
@@ -2832,8 +2813,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestExoticAnimals() {
@@ -2849,8 +2830,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestLaw() {
@@ -2866,8 +2847,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterestOther() {
@@ -2883,8 +2864,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInterrogation() {
@@ -2900,8 +2881,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createInvestigation() {
@@ -2917,8 +2898,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createLanguage() {
@@ -2934,8 +2915,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createMartialArts() {
@@ -2951,8 +2932,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createPerception() {
@@ -2968,8 +2949,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createSleightOfHand() {
@@ -2987,8 +2968,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createProtocols() {
@@ -3004,8 +2985,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createScienceBiology() {
@@ -3021,8 +3002,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createScienceChemistry() {
@@ -3038,8 +3019,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createScienceMathematics() {
@@ -3055,8 +3036,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createSciencePhysics() {
@@ -3072,8 +3053,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createScienceMilitary() {
@@ -3089,8 +3070,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createScienceGeology() {
@@ -3106,8 +3087,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createScienceXenobiology() {
@@ -3123,8 +3104,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createSciencePharmacology() {
@@ -3140,8 +3121,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createScienceGenetics() {
@@ -3157,8 +3138,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createSciencePsychology() {
@@ -3174,8 +3155,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createScienceOther() {
@@ -3191,8 +3172,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createSecuritySystemsElectronic() {
@@ -3208,8 +3189,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createSecuritySystemsMechanical() {
@@ -3225,8 +3206,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createSensorOperations() {
@@ -3242,8 +3223,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createStealth() {
@@ -3259,8 +3240,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createStreetwise() {
@@ -3276,8 +3257,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createSurvival() {
@@ -3293,8 +3274,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createTracking() {
@@ -3310,8 +3291,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createTraining() {
@@ -3327,8 +3308,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createCareer() {
@@ -3344,8 +3325,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createZeroGOperations() {
@@ -3361,8 +3342,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              true);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createMeleeWeapons() {
@@ -3378,8 +3359,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createThrownWeapons() {
@@ -3395,8 +3376,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createSupportWeapons() {
@@ -3412,8 +3393,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createSwimming() {
@@ -3429,8 +3410,8 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 
     public static SkillType createRunning() {
@@ -3446,7 +3427,7 @@ public class SkillType {
               null,
               null,
               null,
-              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 },
-              false);
+              new Integer[] { 20, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 }
+        );
     }
 }

--- a/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/PersonViewPanel.java
@@ -1972,12 +1972,11 @@ public class PersonViewPanel extends JScrollablePanel {
                 label = formattedSkillName;
             }
             JLabel lblName = new JLabel(label);
-            boolean isIlliterate = person.isIlliterate();
             boolean isAmbidextrous = person.getOptions().booleanOption(PersonnelOptions.ATOW_AMBIDEXTROUS);
             List<InjuryEffect> injuryEffects = AdvancedMedicalAlternate.getAllActiveInjuryEffects(isAmbidextrous,
                   person.getInjuries());
             SkillModifierData skillModifierData = new SkillModifierData(options, attributes, adjustedReputation,
-                  isIlliterate, injuryEffects);
+                  injuryEffects);
             int attributeModifier = getTotalAttributeModifier(new TargetRoll(), attributes, skill.getType());
             int spaModifier = skill.getSPAModifiers(options, adjustedReputation);
             int injuryModifier = Skill.getTotalInjuryModifier(skillModifierData, skill.getType());

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/TestSkillModifierData.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/TestSkillModifierData.java
@@ -43,6 +43,6 @@ public class TestSkillModifierData {
      * <p><b>Warning:</b> this is intended for use in Unit Tests only.</p>
      */
     public static SkillModifierData createDefault() {
-        return new SkillModifierData(new PersonnelOptions(), new Attributes(), 0, false, new ArrayList<>());
+        return new SkillModifierData(new PersonnelOptions(), new Attributes(), 0, new ArrayList<>());
     }
 }


### PR DESCRIPTION
Close #8137

This PR updates how the Illiterate Flaw is handled. Previously, if the Flaw was present, its' penalties would be removed if the character obtained level 4 in the Language/Any skill. However, as it was only the penalty being removed the Flaw remained. This created a conflict with player expectations. Now, once level 4 has been obtained, the Flaw itself is removed.

Furthermore, I realized that it was difficult for players to see their base and modified skill levels (as opposed to their skill target numbers). The more ATOW-like systems we integrate the more important skill levels are becoming. This PR also removes the 'skillLevelsMatter` boolean from SkillType effectively switching it to always enabled. It then updates the display so that both base skill level and modified are on display.

Finally, this PR fixes two bugs:
- Religious Fanaticism was applying its' Charisma penalty twice
- The penalty from Illiterate was actually being applied as a bonus