### PR TITLE
Removed logic to zero minutes out on techs assigned to vehicles deployed for salvage operations

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -5987,16 +5987,7 @@ public class Person {
      *                                 their available working time
      */
     public void resetMinutesLeft(boolean isTechsUseAdministration) {
-        // Units deployed to combat have no available time
-
-        // Commented out to allow crew assigned to Salvage vehicles to do salvage
-        // TODO: possibly revisit for exclusion only for techs crewing a vehicle which has mobile field base?
-        //       those are designed specifically for repair / refit / salvage per TO
-        // if (unit != null && (unit.isDeployed() || StratConRulesManager.isUnitDeployedToStratCon(unit))) {
-        //    this.minutesLeft = 0;
-        //    this.overtimeLeft = 0;
-        //    return;
-        // }
+        // Removed - Units deployed to combat have no available time
 
         // Personnel without tech or doctor roles have no available time
         if (!isTechExpanded() && !isDoctor()) {


### PR DESCRIPTION
This fixes the immediate issue of combat technicians or mechanics assigned to crew slots on salvage vehicles from having zero minutes available upon deployment to scenario, preventing them from being used for salvage operations. 

Ideally there would be a follow up to this to:

1. Only allow this exclusion if the unit in question has a "Mobile Field Base" part, as the crew slots those add are meant to be used by the technicians doing repairs or salvage operations on the vehicles. This would prevent someone from, say, sending field kitchen units with crew slots filled with techs out for salvage operations. :)

And/or 

2. Checking if the unit which is deployed to scenario is part of Salvage force in TOE, and not some other role (convoy, combat).

Additional follow-up task is needed on repair screen.