### PR TITLE
Fix: Fixed Free Field Kitchen Actually Trying (and Failing) to Gift the Player a Unit That Doesn't Exist

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/FatigueTrackingCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/FatigueTrackingCampaignOptionsChangedConfirmationDialog.java
@@ -191,9 +191,9 @@ public class FatigueTrackingCampaignOptionsChangedConfirmationDialog extends JDi
     }
 
     public static void processFreeUnit(Campaign campaign) {
-        MekSummary mekSummary = MekSummaryCache.getInstance().getMek("Flatbed Truck (Kitchen)");
+        MekSummary mekSummary = MekSummaryCache.getInstance().getMek("Sherpa Armored Truck (Mobile Canteen)");
         if (mekSummary == null) {
-            LOGGER.error("Cannot find entry for {}", "Flatbed Truck (Kitchen)");
+            LOGGER.error("Cannot find entry for {}", "Sherpa Armored Truck (Mobile Canteen)");
             return;
         }
 


### PR DESCRIPTION
I accidentally picked a player custom out of the bucket and not an official unit. Now we are giving the player a unit that exists.