### PR TITLE
Fix for uncrewed field kitchens counting towards capacity

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/Fatigue.java
@@ -90,7 +90,6 @@ public class Fatigue {
             if ((unit.getCrewState().isFullyCrewed())) {
                 for (MiscMounted item : unit.getEntity().getMisc()) {
                     if (item.getType().hasFlag(MiscType.F_FIELD_KITCHEN)) {
-                        //final int crewAssignmentState = unit.getCrewState();
                         fieldKitchenCount++;
                     }
                 }


### PR DESCRIPTION
In the previous code several checks were made for uncrewed, partially crewed, etc. However, if a unit has all personnel stripped it returns Crewstate = unsupported, as technician is checked first, branching out to return unsupported (no tech + no crew) or unmaintained (some or full crew + no tech).

This change simply forces the issue; a full crew complement (including assigned tech) is required for the field kitchen to be fully functional for the unit.
