### PR TITLE
Fix #8150: Fixed Edit Person & Create Person Panels Incorrectly Using Wrong Method to Fetch Skill Target Number; Fixed the Same Panels Also Presenting Incorrect Skill Information Once Skill Level is Edited

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CreateCharacterDialog.java
@@ -32,12 +32,12 @@
  */
 package mekhq.gui.dialog;
 
-import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static megamek.codeUtilities.MathUtility.clamp;
 import static mekhq.campaign.personnel.Person.*;
+import static mekhq.campaign.personnel.skills.Aging.getAgeModifier;
+import static mekhq.campaign.personnel.skills.Aging.getMilestone;
 import static mekhq.campaign.personnel.skills.Aging.updateAllSkillAgeModifiers;
-import static mekhq.campaign.personnel.skills.Skill.getCountDownMaxValue;
 import static mekhq.campaign.personnel.skills.Skill.getCountUpMaxValue;
 import static mekhq.campaign.randomEvents.personalities.PersonalityController.writeInterviewersNotes;
 import static mekhq.campaign.randomEvents.personalities.PersonalityController.writePersonalityDescription;
@@ -1273,8 +1273,7 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
             lblName = new JLabel(type);
             lblValue = new JLabel();
             if (person.hasSkill(type)) {
-                lblValue.setText(person.getSkill(type)
-                                       .toString(skillModifierData));
+                lblValue.setText(person.getSkill(type).getFinalSkillValue(skillModifierData) + "+");
             } else {
                 lblValue.setText("-");
             }
@@ -1554,18 +1553,31 @@ public class CreateCharacterDialog extends JDialog implements DialogOptionListen
             skillLvls.get(type).getModel().setValue(0);
             return;
         }
+
+        boolean isClanCampaign = campaign.isClanCampaign();
+        boolean isUseAgeEffects = campaign.getCampaignOptions().isUseAgeEffects();
+        LocalDate today = campaign.getLocalDate();
+
         SkillType skillType = SkillType.getType(type);
 
         int level = (Integer) skillLvls.get(type).getModel().getValue();
         int bonus = (Integer) skillBonus.get(type).getModel().getValue();
 
-        if (skillType.isCountUp()) {
-            int target = min(getCountUpMaxValue(), skillType.getTarget() + level + bonus);
-            skillValues.get(type).setText("+" + target);
-        } else {
-            int target = max(getCountDownMaxValue(), skillType.getTarget() - level - bonus);
-            skillValues.get(type).setText(target + "+");
+        int ageModifier = 0;
+        if (isUseAgeEffects) {
+            ageModifier = getAgeModifier(getMilestone(person.getAge(today)),
+                  skillType.getFirstAttribute(), skillType.getSecondAttribute());
         }
+
+        Skill skill = new Skill(type);
+        skill.setLevel(level);
+        skill.setBonus(bonus);
+        skill.setAgingModifier(ageModifier);
+
+        SkillModifierData skillModifierData = person.getSkillModifierData(isUseAgeEffects, isClanCampaign, today, true);
+
+        int target = min(getCountUpMaxValue(), skill.getFinalSkillValue(skillModifierData));
+        skillValues.get(type).setText(target + "+");
     }
 
     private void changeValueEnabled(String type) {


### PR DESCRIPTION
Fix #8150

And the award for the longest PR title goes to...

But yeah, there were two issues here. The first is that we were calling toString() instead of fetching the calculated skill target number. That meant we saw the GUI display version of the skill, which includes a bunch of html elements. Not something we want in Edit person.

The second issue that when the skill was edited suddenly the values displayed would be completely different. The reason for this is that we're manually constructing the skill target number. This is done because we can't fetch the skill data from the character as they might not _have_ the skill being adjusted.

To get around that limitation, while still showing correct information, we create a dummy skill.