### PR TITLE
Fix #8148: Fixed Duplicate Selections in Salvage Resolution Screen; Fixed Prior Selected Salvage Forces & Techs Not Appearing Pre-selected in Salvage Force & Salvage Tech Picker

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Scenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/Scenario.java
@@ -650,7 +650,9 @@ public class Scenario implements IPlayerSettings {
     }
 
     public void addSalvageForce(int forceId) {
-        salvageForces.add(forceId);
+        if (!salvageForces.contains(forceId)) {
+            salvageForces.add(forceId);
+        }
     }
 
     public void clearSalvageForces() {
@@ -662,7 +664,9 @@ public class Scenario implements IPlayerSettings {
     }
 
     public void addSalvageTech(UUID personId) {
-        salvageTechs.add(personId);
+        if (!salvageTechs.contains(personId)) {
+            salvageTechs.add(personId);
+        }
     }
 
     public void clearSalvageTechs() {
@@ -1180,7 +1184,8 @@ public class Scenario implements IPlayerSettings {
                             LOGGER.error("Unknown node type loaded in salvageForces nodes: {}", wn3.getNodeName());
                             continue;
                         }
-                        retVal.salvageForces.add(MathUtility.parseInt(wn3.getTextContent().trim(), FORCE_NONE));
+                        // We need to use this method, as it includes additional safeties
+                        retVal.addSalvageForce(MathUtility.parseInt(wn3.getTextContent().trim(), FORCE_NONE));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase("salvageTechs")) {
                     NodeList nl2 = wn2.getChildNodes();
@@ -1196,7 +1201,8 @@ public class Scenario implements IPlayerSettings {
                             LOGGER.error("Unknown node type loaded in salvageTechs nodes: {}", wn3.getNodeName());
                             continue;
                         }
-                        retVal.salvageTechs.add(UUID.fromString(wn3.getTextContent().trim()));
+                        // We need to use this method, as it includes additional safeties
+                        retVal.addSalvageTech(UUID.fromString(wn3.getTextContent().trim()));
                     }
                 } else if (wn2.getNodeName().equalsIgnoreCase(ScenarioObjective.ROOT_XML_ELEMENT_NAME)) {
                     retVal.getScenarioObjectives().add(ScenarioObjective.Deserialize(wn2));

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -926,9 +926,11 @@ public final class BriefingTab extends CampaignGuiTab {
         boolean isSpace = scenario.getBoardType() == AtBScenario.T_SPACE;
         List<SalvageForceData> salvageForceOptions = getSalvageForces(getCampaign(), isSpace);
 
-        SalvageForcePicker forcePicker = new SalvageForcePicker(getCampaign(), salvageForceOptions, isSpace);
+        SalvageForcePicker forcePicker = new SalvageForcePicker(getCampaign(), salvageForceOptions, isSpace,
+              scenario.getSalvageForces());
         boolean wasConfirmed = forcePicker.wasConfirmed();
         if (wasConfirmed) {
+            scenario.clearSalvageForces();
             Hangar hangar = getCampaign().getHangar();
             List<Force> selectedForces = forcePicker.getSelectedForces();
             for (Force force : selectedForces) {
@@ -1012,10 +1014,18 @@ public final class BriefingTab extends CampaignGuiTab {
             techData.add(data);
         }
 
+        // Add any other techs that were previously selected
+        for (UUID techID : scenario.getSalvageTechs()) {
+            if (!priorSelectedTechs.contains(techID)) {
+                priorSelectedTechs.add(techID);
+            }
+        }
+
         SalvageTechPicker techPicker = new SalvageTechPicker(techData, priorSelectedTechs,
               getCampaign().isClanCampaign());
         boolean wasConfirmed = techPicker.wasConfirmed();
         if (wasConfirmed) {
+            scenario.clearSalvageTechs();
             List<UUID> selectedTechs = techPicker.getSelectedTechs();
             for (UUID techId : selectedTechs) {
                 scenario.addSalvageTech(techId);


### PR DESCRIPTION
Fix #8148

This adds additional safeties to prevent a force or tech being added to the salvage force/tech lists multiple times. It also ensures that previously selected techs and forces are selected when the dialog is re-opened, if it is re-opened for the same scenario.

The duplication reported in the associated case was due to the scenario being rerun multiple times. Each time the player would select their salvage setup and each time we'd add a duplicate entry in the tech and force lists stored in the scenario.