### PR TITLE
Fix #8149: Fixed Stacking Modifiers Causing Personnel to Generate 1-2 Experience Levels Higher Than Intended

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -83,7 +83,7 @@ public enum PersonnelRole {
     ADMINISTRATOR_HR(PersonnelRoleSubType.SUPPORT, KeyEvent.VK_H, 3, 4, 4, 4, 5, 5, 5),
 
     // If we're generating a character without a Profession, we're just going to leave them with middle of the road
-    // Attribute scores (5 in everything)
+    // Attribute scores (4 in everything)
     NONE(PersonnelRoleSubType.CIVILIAN, false, KeyEvent.VK_UNDEFINED, 4, 4, 4, 4, 4, 4, 4),
 
     // No archetype, but ATOW pg 35 states that the Attribute scores for an average person are 4. We've gone with 5


### PR DESCRIPTION
Fix #8149

When Attribute modifiers were added a decision was made to treat the average character as having 5 in all attribute scores. The reason was that 5 was middle of the road, whereas 4 (the default according to ATOW) was only 1 step above a penalty, but 3 steps below a bonus.

However, due to the updated starting attributes we were suddenly seeing characters generate 2 experience levels higher than intended. What should be Ultra-Green would be Regular, while Elite would be Legendary.

This PR reduces starting attributes by 1 per attribute.