### PR TITLE
Fix: Fixed Personnel Generation Failing to Properly Reconsider the Experience Level of Young Personnel

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
@@ -36,6 +36,7 @@ import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.personnel.education.EducationController.setInitialEducationLevel;
 import static mekhq.campaign.personnel.skills.Aging.updateAllSkillAgeModifiers;
 import static mekhq.campaign.personnel.skills.SkillType.EXP_NONE;
+import static mekhq.campaign.personnel.skills.SkillType.EXP_ULTRA_GREEN;
 
 import java.util.Objects;
 
@@ -121,9 +122,12 @@ public class DefaultPersonnelGenerator extends AbstractPersonnelGenerator {
             person.removeAllSkills();
             expLvl = EXP_NONE;
             person.setPrimaryRole(campaign.getLocalDate(), PersonnelRole.DEPENDENT);
-        } else if (age < 18) {
-            person.limitSkills(1);
-            // regenerate expLvl to factor in skill changes from age
+        } else {
+            if (age < 18) {
+                person.limitSkills(1);
+            }
+            // regenerate expLvl to factor in skill additions (as this can modify character experience level beyond
+            // the requested level)
             expLvl = person.getExperienceLevel(campaign, false);
         }
 


### PR DESCRIPTION
For young personnel we were regenerating their experience level after we adjust their skills based on their age. However we should have, instead, been assessing their current experience level. This fixes that.