### PR TITLE
Fix: Fixed Order of Operations Causing All Female Personnel to Generate with a Same-Sex Preference

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
+++ b/MekHQ/src/mekhq/campaign/personnel/generator/DefaultPersonnelGenerator.java
@@ -134,15 +134,15 @@ public class DefaultPersonnelGenerator extends AbstractPersonnelGenerator {
             specialAbilityGenerator.generateSpecialAbilities(campaign, person, expLvl);
         }
 
+        // Do naming at the end, to ensure the keys are set
+        generateNameAndGender(campaign, person, gender);
+
         // Set relationship flags
         determineOrientation(person, campaignOptions.getNoInterestInRelationshipsDiceSize(),
               campaignOptions.getInterestedInSameSexDiceSize(), campaignOptions.getInterestedInBothSexesDiceSize());
 
         int interestInChildren = campaignOptions.getNoInterestInChildrenDiceSize();
         person.setTryingToConceive(((interestInChildren != 0) && (randomInt(interestInChildren)) != 0));
-
-        // Do naming at the end, to ensure the keys are set
-        generateNameAndGender(campaign, person, gender);
 
         //check for Bloodname
         campaign.checkBloodnameAdd(person, false);


### PR DESCRIPTION
We were setting sexuality before gender, causing all personnel to be treated as if they were male.

Marking as 'critical' as this would bypass player campaign options over whether they want same-sex relationships in their campaign.