### PR TITLE
Fix: Fixed CamOps Reputation Treating Empty Campaigns as Legendary

### DIFF
--- a/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
+++ b/MekHQ/src/mekhq/campaign/rating/CamOpsReputation/AverageExperienceRating.java
@@ -52,6 +52,8 @@ import mekhq.campaign.unit.Unit;
 public class AverageExperienceRating {
     private static final MMLogger LOGGER = MMLogger.create(AverageExperienceRating.class);
 
+    private static final int NO_CAMPAIGN_EXPERIENCE = 7;
+
     /**
      * Calculates the skill level based on the average experience rating of a campaign.
      *
@@ -65,10 +67,12 @@ public class AverageExperienceRating {
     protected static SkillLevel getSkillLevel(Campaign campaign, boolean log) {
         // values below 0 are treated as 'Legendary',
         // values above 7 are treated as 'wet behind the ears' which we call 'None'
-        int experienceScore = MathUtility.clamp(calculateAverageExperienceRating(campaign, log), 0, 7);
+        int experienceScore = MathUtility.clamp(calculateAverageExperienceRating(campaign, log),
+              0,
+              NO_CAMPAIGN_EXPERIENCE);
 
         return switch (experienceScore) {
-            case 7 -> SkillLevel.NONE;
+            case NO_CAMPAIGN_EXPERIENCE -> SkillLevel.NONE;
             case 6 -> SkillLevel.ULTRA_GREEN;
             case 5 -> SkillLevel.GREEN;
             case 4 -> SkillLevel.REGULAR;
@@ -118,7 +122,7 @@ public class AverageExperienceRating {
         ArrayList<CombatTeam> combatTeams = campaign.getCombatTeamsAsList();
 
         if (combatTeams.isEmpty()) {
-            return 7; // No campaign experience
+            return NO_CAMPAIGN_EXPERIENCE;
         }
 
         boolean hasAtLeastOneCrew = false;
@@ -160,7 +164,7 @@ public class AverageExperienceRating {
         }
 
         if (unitCount == 0 || !hasAtLeastOneCrew) { // this can equal false no matter what IDEA says
-            return 7; // No campaign experience
+            return NO_CAMPAIGN_EXPERIENCE;
         }
 
         // CamOps states that we need to divide the skill target numbers by twice the unit count.


### PR DESCRIPTION
Empty campaigns (and campaigns in transit) were returning 0 for Experience Rating in CamOps Reputation. That corresponds to 'Legendary' rating. This PR fixes it so that in those cases we correctly return 'no experience'.