### PR TITLE
Fix #8179: Reduced Impact of Contract Breaches on Faction Standing; Added Falloff to Regard Changes from Contract Length

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandings.java
@@ -32,7 +32,6 @@
  */
 package mekhq.campaign.universe.factionStanding;
 
-import static java.lang.Math.max;
 import static megamek.codeUtilities.MathUtility.clamp;
 import static mekhq.campaign.universe.Faction.MERCENARY_FACTION_CODE;
 import static mekhq.campaign.universe.Faction.PIRATE_FACTION_CODE;
@@ -199,7 +198,7 @@ public class FactionStandings {
     /**
      * Regard penalty for breaching a contract (employer).
      */
-    static final double REGARD_DELTA_CONTRACT_BREACH_EMPLOYER = -(REGARD_DELTA_CONTRACT_SUCCESS_EMPLOYER * 3);
+    static final double REGARD_DELTA_CONTRACT_BREACH_EMPLOYER = -(REGARD_DELTA_CONTRACT_SUCCESS_EMPLOYER * 2.75);
 
     /**
      * Regard penalty for breaching a contract (employer's allies).
@@ -251,7 +250,7 @@ public class FactionStandings {
     /**
      * How much we should divide contract duration by when determining Duration Multiplier
      */
-    static final int CONTRACT_DURATION_LENGTH_DIVISOR = 6;
+    static final double CONTRACT_DURATION_LENGTH_DIVISOR = 6.0;
 
     /**
      * A mapping of faction names to their respective standing levels.
@@ -1241,7 +1240,8 @@ public class FactionStandings {
             regardDelta = REGARD_DELTA_CONTRACT_ACCEPT_ENEMY_NORMAL;
         }
 
-        double durationMultiplier = max((double) contractDuration / CONTRACT_DURATION_LENGTH_DIVISOR, 1.0);
+        double modifiedContractDuration = contractDuration / CONTRACT_DURATION_LENGTH_DIVISOR;
+        double durationMultiplier = 1.0 + Math.log1p(Math.sqrt(modifiedContractDuration));
         regardDelta *= durationMultiplier;
 
         return changeRegardForFaction(campaignFactionCode, enemyFaction.getShortName(), regardDelta, gameYear,
@@ -1338,7 +1338,8 @@ public class FactionStandings {
             default -> throw new IllegalStateException("Unexpected value: " + missionStatus);
         };
 
-        double durationMultiplier = max(contractDuration / CONTRACT_DURATION_LENGTH_DIVISOR, 1.0);
+        double modifiedContractDuration = contractDuration / CONTRACT_DURATION_LENGTH_DIVISOR;
+        double durationMultiplier = 1.0 + Math.log1p(Math.sqrt(modifiedContractDuration));
         regardDeltaEmployer *= durationMultiplier;
         return regardDeltaEmployer;
     }

--- a/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionStandingsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionStandingsTest.java
@@ -41,8 +41,6 @@ import static mekhq.campaign.universe.factionStanding.FactionStandings.CLIMATE_R
 import static mekhq.campaign.universe.factionStanding.FactionStandings.CLIMATE_REGARD_SAME_FACTION;
 import static mekhq.campaign.universe.factionStanding.FactionStandings.DEFAULT_REGARD;
 import static mekhq.campaign.universe.factionStanding.FactionStandings.DEFAULT_REGARD_DEGRADATION;
-import static mekhq.campaign.universe.factionStanding.FactionStandings.REGARD_DELTA_CONTRACT_ACCEPT_ENEMY_CLAN;
-import static mekhq.campaign.universe.factionStanding.FactionStandings.REGARD_DELTA_CONTRACT_ACCEPT_ENEMY_NORMAL;
 import static mekhq.campaign.universe.factionStanding.FactionStandings.REGARD_DELTA_EXECUTING_PRISONER;
 import static mekhq.campaign.universe.factionStanding.FactionStandings.REGARD_DELTA_REFUSE_BATCHALL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -134,43 +132,6 @@ class FactionStandingsTest {
         // Assert
         double actualRegard = factionStandings.getRegardForFaction("FS", false);
         assertEquals(expectedRegard, actualRegard, "Expected regard of " + expectedRegard + " but got " + actualRegard);
-    }
-
-    private static Stream<Arguments> provideContractAcceptCases() {
-        return Stream.of(Arguments.of("FS Enemy",
-                    "FS",
-                    10.0, REGARD_DELTA_CONTRACT_ACCEPT_ENEMY_NORMAL),
-              Arguments.of("CDS Enemy",
-                    "CDS",
-                    10.0, REGARD_DELTA_CONTRACT_ACCEPT_ENEMY_CLAN),
-              Arguments.of("CS Enemy",
-                    "CS",
-                    10.0,
-                    REGARD_DELTA_CONTRACT_ACCEPT_ENEMY_NORMAL),
-              Arguments.of("CSJ Enemy",
-                    "CSJ",
-                    10.0,
-                    REGARD_DELTA_CONTRACT_ACCEPT_ENEMY_CLAN));
-    }
-
-    @ParameterizedTest(name = "{0}")
-    @MethodSource(value = "provideContractAcceptCases")
-    void test_processAcceptContract_various(String testName, String primaryFaction, double primaryStart,
-          double expectedPrimaryDelta) {
-        // Setup
-        FactionStandings factionStandings = new FactionStandings();
-        factionStandings.setRegardForFaction(null, primaryFaction, primaryStart, 3050, false);
-
-        Faction enemyFaction = factions.getFaction(primaryFaction);
-        LocalDate today = LocalDate.of(3050, 1, 1);
-
-        // Act
-        factionStandings.processContractAccept("FS", enemyFaction, today, 1.0, 1);
-
-        // Assert
-        assertEquals(primaryStart + expectedPrimaryDelta,
-              factionStandings.getRegardForFaction(primaryFaction, false),
-              "Incorrect regard for " + primaryFaction);
     }
 
     @Test

--- a/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionStandingsTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/factionStanding/FactionStandingsTest.java
@@ -36,7 +36,15 @@ import static mekhq.campaign.universe.factionStanding.FactionStandingLevel.STAND
 import static mekhq.campaign.universe.factionStanding.FactionStandingLevel.STANDING_LEVEL_4;
 import static mekhq.campaign.universe.factionStanding.FactionStandingLevel.STANDING_LEVEL_5;
 import static mekhq.campaign.universe.factionStanding.FactionStandingUtilities.calculateFactionStandingLevel;
-import static mekhq.campaign.universe.factionStanding.FactionStandings.*;
+import static mekhq.campaign.universe.factionStanding.FactionStandings.CLIMATE_REGARD_ALLIED_FACTION;
+import static mekhq.campaign.universe.factionStanding.FactionStandings.CLIMATE_REGARD_ENEMY_FACTION_AT_WAR;
+import static mekhq.campaign.universe.factionStanding.FactionStandings.CLIMATE_REGARD_SAME_FACTION;
+import static mekhq.campaign.universe.factionStanding.FactionStandings.DEFAULT_REGARD;
+import static mekhq.campaign.universe.factionStanding.FactionStandings.DEFAULT_REGARD_DEGRADATION;
+import static mekhq.campaign.universe.factionStanding.FactionStandings.REGARD_DELTA_CONTRACT_ACCEPT_ENEMY_CLAN;
+import static mekhq.campaign.universe.factionStanding.FactionStandings.REGARD_DELTA_CONTRACT_ACCEPT_ENEMY_NORMAL;
+import static mekhq.campaign.universe.factionStanding.FactionStandings.REGARD_DELTA_EXECUTING_PRISONER;
+import static mekhq.campaign.universe.factionStanding.FactionStandings.REGARD_DELTA_REFUSE_BATCHALL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
@@ -47,7 +55,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import mekhq.campaign.Campaign;
-import mekhq.campaign.mission.enums.MissionStatus;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.Factions;
@@ -164,47 +171,6 @@ class FactionStandingsTest {
         assertEquals(primaryStart + expectedPrimaryDelta,
               factionStandings.getRegardForFaction(primaryFaction, false),
               "Incorrect regard for " + primaryFaction);
-    }
-
-    private static Stream<Arguments> provideContractStatuses() {
-        return Stream.of( // Mission status, startingFSRegard, startingLARegard, expectedFSRegard, expectedLARegard
-              Arguments.of("Mission Success",
-                    MissionStatus.SUCCESS,
-                    10.0,
-                    REGARD_DELTA_CONTRACT_SUCCESS_EMPLOYER),
-              Arguments.of("Mission Partial Success",
-                    MissionStatus.PARTIAL,
-                    10.0,
-                    REGARD_DELTA_CONTRACT_PARTIAL_EMPLOYER),
-              Arguments.of("Mission Failed",
-                    MissionStatus.FAILED,
-                    10.0,
-                    REGARD_DELTA_CONTRACT_FAILURE_EMPLOYER),
-              Arguments.of("Mission Contract Breached",
-                    MissionStatus.BREACH,
-                    10.0,
-                    REGARD_DELTA_CONTRACT_BREACH_EMPLOYER));
-    }
-
-    @ParameterizedTest(name = "{0}")
-    @MethodSource(value = "provideContractStatuses")
-    void test_processContractCompletion_variousOutcomes(String testName, MissionStatus status, double startingFsRegard,
-          double expectedFsDelta) {
-        // Setup
-        FactionStandings factionStandings = new FactionStandings();
-        factionStandings.setRegardForFaction(null, "FS", startingFsRegard, 3028, false);
-
-        Faction employerFaction = factions.getFaction("FS");
-        LocalDate today = LocalDate.of(3028, 8, 20);
-
-        // Act
-        factionStandings.processContractCompletion(factions.getDefaultFaction(), employerFaction, today, status, 1.0,
-              1);
-
-        // Assert
-        assertEquals(startingFsRegard + expectedFsDelta,
-              factionStandings.getRegardForFaction("FS", false),
-              "Incorrect regard for FS (" + status + ")");
     }
 
     @Test


### PR DESCRIPTION
Fix #8179

Contract Breach penalties were a little _too_ harsh, so they've been reduced.

The effects of contract length on regard delta were also not in the best of positions. These two could combine to create a really bad play experience if the player breached a very long contract (24 months, in the attached case). The effect of length now works logarithmically to effect a falloff, rather than being linear.