### PR TITLE
Fix: Fixed Broken 'Reset all Faction Standings' Option

### DIFF
--- a/MekHQ/resources/mekhq/resources/FactionStandingJudgments.properties
+++ b/MekHQ/resources/mekhq/resources/FactionStandingJudgments.properties
@@ -39,6 +39,7 @@ FactionAccoladeDialog.confirmation.outOfCharacter=<b>WARNING:</b> each faction w
 FactionAccoladeDialog.confirmation.button.confirm=(Confirm) Continue as ordered.
 FactionAccoladeDialog.confirmation.button.cancel=(Cancel) Let me reconsider.
 # General
+FactionStandingUtilities.faction=Faction Not Found
 FactionStandingUtilities.clan=Clan
 FactionStandingUtilities.the=The
 FactionCensureDialog.button.cancel=Cancel

--- a/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandingUtilities.java
+++ b/MekHQ/src/mekhq/campaign/universe/factionStanding/FactionStandingUtilities.java
@@ -623,6 +623,10 @@ public class FactionStandingUtilities {
      * @since 0.50.07
      */
     public static String getFactionName(Faction faction, int gameYear) {
+        if (faction == null) {
+            return getTextAt(RESOURCE_BUNDLE, "FactionStandingUtilities.faction");
+        }
+
         final String CLAN = getTextAt(RESOURCE_BUNDLE, "FactionStandingUtilities.clan");
         final String THE = getTextAt(RESOURCE_BUNDLE, "FactionStandingUtilities.the");
 


### PR DESCRIPTION
The 'reset all' option in faction standings apparently broke at some point in development and it went unnoticed until now. We've not even seen anything in Sentry!