### PR TITLE
Improvement: Added Ability to Deploy Multiple Forces as Reinforcements at Same Time

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBStratCon.properties
+++ b/MekHQ/resources/mekhq/resources/AtBStratCon.properties
@@ -46,7 +46,9 @@ leadershipCommit.text=Commit
 leadershipCancel.text=Cancel
 selectReinforcementsForTemplate.Text=<html><b>Select reinforcements from the list below.</b>\
   <br>\
-  <br>Each attempt will cost Support Points and may be unsuccessful.</html>
+  <br>Each attempt will cost Support Points and may be unsuccessful.\
+  <br>\
+  <br>You can select multiple forces, though each is counted as a separate reinforcement attempt.</html>
 selectReinforcementsForTemplateNoSupportPoints.Text=<html><b>No Support Points available.</b> Only\
   \ GM Reinforcement available.</html>
 reinforcementsAttempt.text=Attempting to reinforce scenario %s, roll <b>%s%s</b> vs. <b>%s</b>:

--- a/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
@@ -37,7 +37,7 @@ StratConReinforcementsConfirmationDialog.button.reinforce.gm=Reinforce (GM)
 StratConReinforcementsConfirmationDialog.button.reinforce.gm.instantly=Reinforce Instantly (GM)
 # Text
 StratConReinforcementsConfirmationDialog.inCharacter.cannotReinforce=Sorry {0}. We simply do not have the resources \
-  or allied support to arrange a secondary drop. We''re on our own.</p>
+  or allied support to arrange a secondary drop. We''re on our own.
 StratConReinforcementsConfirmationDialog.inCharacter.transport={0}, I''ve had the computer break down our likelihood \
   of success.\
   <p>We really should hire a specialist for this kind of thing...</p>

--- a/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/StratConReinforcementsConfirmationDialog.properties
@@ -28,6 +28,7 @@
 # Microsoft's "Game Content Usage Rules"
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
+# suppress inspection "UnusedProperty" for the whole file
 # Buttons
 StratConReinforcementsConfirmationDialog.button.cancel=Cancel Attempt
 StratConReinforcementsConfirmationDialog.button.reinforce=Reinforce
@@ -35,35 +36,38 @@ StratConReinforcementsConfirmationDialog.button.reinforce.instantly=Reinforce In
 StratConReinforcementsConfirmationDialog.button.reinforce.gm=Reinforce (GM)
 StratConReinforcementsConfirmationDialog.button.reinforce.gm.instantly=Reinforce Instantly (GM)
 # Text
+StratConReinforcementsConfirmationDialog.inCharacter.cannotReinforce=Sorry {0}. We simply do not have the resources \
+  or allied support to arrange a secondary drop. We''re on our own.</p>
 StratConReinforcementsConfirmationDialog.inCharacter.transport={0}, I''ve had the computer break down our likelihood \
   of success.\
   <p>We really should hire a specialist for this kind of thing...</p>
 StratConReinforcementsConfirmationDialog.inCharacter.tactical={0}, I''ve run the numbers. If we reinforce now, here''s \
   our likelihood of success:
-StratConReinforcementsConfirmationDialog.inCharacter.supportPoints=Support Points:
+StratConReinforcementsConfirmationDialog.inCharacter.supportPoints=Additional Support Points:
 StratConReinforcementsConfirmationDialog.inCharacter.total=<br><br><b>Target Number:</b> {0}
 StratConReinforcementsConfirmationDialog.outOfCharacter.transport=Having an <b>Intelligence Analyst</b>, <b>Military \
   Analyst</b>, <b>Military Theorist</b>, or <b>Tactical Analyst</b> employed by the unit will give more reliable \
   results (this is an RP effect only).\
-  <p>Reinforcing costs 1 <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and a check using the above <b>Target \
-  Number</b>. If the check is failed your reinforcements may be <b>Intercepted</b>! If an Interception attempt is \
-  made, the commander of your reinforcements will need to make a <b>Tactics</b> skill check to evade the \
-  interception.</p>\
+  <p>Reinforcing costs 1 <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> per reinforcing <a \
+  href='GLOSSARY:COMBAT_TEAMS'>Combat Team</a> and a check using the above <b>Target Number</b>. If the check is \
+  failed, your reinforcements may be <b>Intercepted</b>! If an Interception attempt is made, the commander of your \
+  reinforcements will need to make a <b>Tactics</b> skill check to evade the interception.</p>\
   <p>You can improve the chances your attempt succeeds by changing the reinforcing unit to the Auxiliary or Maneuver \
   <a href='GLOSSARY:COMBAT_ROLES'>Combat Roles</a>. Or by paying additional <b>Support Points</b>. Each additional \
-  Support Point spent reduces the Target Number by 2.</p>\
+  batch of Support Points reduces the Target Number by 2.</p>\
   <p>If the situation is truly dire, you can choose to <b>Reinforce Instantly</b>. This doubles all <b>Support \
   Points</b> paid and may take you into negative Support Points.</p>\
-  <p>If reinforcing using an option marked '(GM)' the reinforcement attempt is both free and automatically \
+  <p>If reinforcing using an option marked '(GM)', the reinforcement attempt is both free and automatically \
   succeeds.</p>
 StratConReinforcementsConfirmationDialog.outOfCharacter.tactical=Reinforcing costs 1 \
-  <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> and a check using the above <b>Target Number</b>. If the check is\
-  \ failed your reinforcements may be <b>Intercepted</b>! If an Interception attempt is made, the commander of your \
-  reinforcements will need to make a <b>Tactics</b> skill check to evade the interception.\
+  <a href='GLOSSARY:SUPPORT_POINTS'>Support Point</a> per reinforcing <a href='GLOSSARY:COMBAT_TEAMS'>Combat Team</a>\
+  \ and a check using the above <b>Target Number</b>. If the check is failed, your reinforcements may be \
+  <b>Intercepted</b>! If an Interception attempt is made, the commander of your reinforcements will need to make a \
+  <b>Tactics</b> skill check to evade the interception.\
   <p>You can improve the chances your attempt succeeds by changing the reinforcing unit to the Auxiliary or Maneuver \
   <a href='GLOSSARY:COMBAT_ROLES'>Combat Roles</a>. Or by paying additional <b>Support Points</b>. Each additional \
-  Support Point spent reduces the Target Number by 2.</p>\
+  batch of Support Points reduces the Target Number by 2.</p>\
   <p>If the situation is truly dire, you can choose to <b>Reinforce Instantly</b>. This doubles all <b>Support \
   Points</b> paid and may take you into negative Support Points.</p>\
-  <p>If reinforcing using an option marked '(GM)' the reinforcement attempt is both free and automatically \
+  <p>If reinforcing using an option marked '(GM)', the reinforcement attempt is both free and automatically \
   succeeds.</p>

--- a/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
@@ -362,7 +362,7 @@ public class StratConReinforcementsConfirmationDialog {
             breakdown.append("<br><b>").append(modifier.getDesc()).append(":</b> ").append(modifier.value());
         }
 
-        int modifier = supportPoints / costMultiplier * SUPPORT_POINTS_MODIFIER;
+        int modifier = (supportPoints * SUPPORT_POINTS_MODIFIER) / costMultiplier;
 
         breakdown.append("<br><b>")
               .append(getTextAt(RESOURCE_BUNDLE,

--- a/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
@@ -149,7 +149,7 @@ public class StratConReinforcementsConfirmationDialog {
         ImmersiveDialogCore dialog = new ImmersiveDialogCore(campaign,
               getSpeaker(campaign),
               null,
-              getInCharacterMessage(commanderAddress),
+              getInCharacterMessage(commanderAddress, canReinforce),
               getButtons(campaign.isGM(), canReinforce, canInstantReinforce),
               getOutOfCharacterMessage(),
               null,

--- a/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
@@ -312,7 +312,7 @@ public class StratConReinforcementsConfirmationDialog {
      */
     private JPanel getSpinnerPanel(double maximumSupportPoints, TargetRoll targetNumber, int costMultiplier) {
         final int PADDING = scaleForGUI(10);
-        int maximum = (int) floor(maximumSupportPoints / costMultiplier);
+        int maximum = (int) floor((maximumSupportPoints - costMultiplier) / costMultiplier);
 
         lblBreakdown = new JLabel("<html>" + getTargetNumberBreakdown(targetNumber, costMultiplier) + "</html>");
 

--- a/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
@@ -833,7 +833,7 @@ public class StratConScenarioWizard extends JDialog {
             }
             case REINFORCE_INSTANTLY -> {
                 // The costMultiplier addition here is to cover the base cost. Instant reinforcing doubles the cost.
-                int supportPointsSpent = dialog.getSupportPoints() + (costMultiplier * 2);
+                int supportPointsSpent = (dialog.getSupportPoints() + costMultiplier) * 2;
                 int supportPointModifier = supportPointsSpent / costMultiplier * SUPPORT_POINTS_MODIFIER;
                 int finalTargetNumber = targetNumber.getValue() + supportPointModifier;
                 currentCampaignState.changeSupportPoints(-supportPointsSpent);

--- a/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
@@ -823,7 +823,7 @@ public class StratConScenarioWizard extends JDialog {
             case REINFORCE -> {
                 // The costMultiplier addition here is to cover the base cost
                 int supportPointsSpent = dialog.getSupportPoints() + costMultiplier;
-                int supportPointModifier = supportPointsSpent / costMultiplier * SUPPORT_POINTS_MODIFIER;
+                int supportPointModifier = (supportPointsSpent / costMultiplier) * SUPPORT_POINTS_MODIFIER;
                 int finalTargetNumber = targetNumber.getValue() + supportPointModifier;
                 currentCampaignState.changeSupportPoints(-supportPointsSpent);
                 btnCommitClicked(finalTargetNumber, false, false);
@@ -834,7 +834,7 @@ public class StratConScenarioWizard extends JDialog {
             case REINFORCE_INSTANTLY -> {
                 // The costMultiplier addition here is to cover the base cost. Instant reinforcing doubles the cost.
                 int supportPointsSpent = (dialog.getSupportPoints() + costMultiplier) * 2;
-                int supportPointModifier = supportPointsSpent / costMultiplier * SUPPORT_POINTS_MODIFIER;
+                int supportPointModifier = (supportPointsSpent / costMultiplier) * SUPPORT_POINTS_MODIFIER;
                 int finalTargetNumber = targetNumber.getValue() + supportPointModifier;
                 currentCampaignState.changeSupportPoints(-supportPointsSpent);
                 btnCommitClicked(finalTargetNumber, false, true);

--- a/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
@@ -400,7 +400,7 @@ public class StratConScenarioWizard extends JDialog {
                 localGbc.gridy = 1;
                 JLabel selectedForceInfo = new JLabel();
                 JList<Force> availableForceList = addAvailableForceList(forcePanel, localGbc, forceTemplate);
-                availableForceList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+                availableForceList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
                 // Add a listener to handle changes to the selected force
                 availableForceList.addListSelectionListener(e -> {
                     availableForceSelectorChanged(e, selectedForceInfo, false);
@@ -792,8 +792,7 @@ public class StratConScenarioWizard extends JDialog {
         Person commandLiaison = campaign.getSeniorAdminPerson(AdministratorSpecialization.COMMAND);
         TargetRoll targetNumber = calculateReinforcementTargetNumber(commandLiaison,
               currentCampaignState.getContract());
-        // The -1 is due to the default cost for reinforcing
-        int availableSupportPoints = currentCampaignState.getSupportPoints() - 1;
+        int availableSupportPoints = currentCampaignState.getSupportPoints();
 
         AtBContract contract = currentScenario.getBackingContract(campaign);
         Faction enemy = contract.getEnemy();
@@ -810,27 +809,34 @@ public class StratConScenarioWizard extends JDialog {
             brokeBatchallTerms = true;
         }
 
+        int costMultiplier = 0;
+        for (String templateID : availableForceLists.keySet()) {
+            costMultiplier += availableForceLists.get(templateID).getSelectedValuesList().size();
+        }
+
         StratConReinforcementsConfirmationDialog dialog = new StratConReinforcementsConfirmationDialog(campaign,
-              targetNumber, availableSupportPoints);
+              targetNumber, availableSupportPoints, costMultiplier);
         StratConReinforcementsConfirmationDialog.ReinforcementDialogResponseType responseType =
               dialog.getResponseType();
         switch (responseType) {
             case CANCEL -> setVisible(true);
             case REINFORCE -> {
-                int supportPointsSpent = dialog.getSupportPoints();
-                int supportPointModifier = supportPointsSpent * SUPPORT_POINTS_MODIFIER;
+                // The costMultiplier addition here is to cover the base cost
+                int supportPointsSpent = dialog.getSupportPoints() + costMultiplier;
+                int supportPointModifier = supportPointsSpent / costMultiplier * SUPPORT_POINTS_MODIFIER;
                 int finalTargetNumber = targetNumber.getValue() + supportPointModifier;
-                currentCampaignState.changeSupportPoints(-(supportPointsSpent + 1));
+                currentCampaignState.changeSupportPoints(-supportPointsSpent);
                 btnCommitClicked(finalTargetNumber, false, false);
                 if (brokeBatchallTerms) {
                     processBatchallBreach(contract, enemy.getShortName());
                 }
             }
             case REINFORCE_INSTANTLY -> {
-                int supportPointsSpent = dialog.getSupportPoints();
-                int supportPointModifier = supportPointsSpent * SUPPORT_POINTS_MODIFIER;
+                // The costMultiplier addition here is to cover the base cost. Instant reinforcing doubles the cost.
+                int supportPointsSpent = dialog.getSupportPoints() + (costMultiplier * 2);
+                int supportPointModifier = supportPointsSpent / costMultiplier * SUPPORT_POINTS_MODIFIER;
                 int finalTargetNumber = targetNumber.getValue() + supportPointModifier;
-                currentCampaignState.changeSupportPoints(-(supportPointsSpent + 1) * 2);
+                currentCampaignState.changeSupportPoints(-supportPointsSpent);
                 btnCommitClicked(finalTargetNumber, false, true);
                 if (brokeBatchallTerms) {
                     processBatchallBreach(contract, enemy.getShortName());


### PR DESCRIPTION
This is a bit of QOL that allows players to deploy all desired reinforcements at the same time, without needing to handle them one-by-one. Reinforcement costs do factor in the number of forces being deployed, so if the player is deploying two forces of reinforcements all costs will be doubled, for example.

I also added a dialog unique to when the player does not have sufficient SP to pay for the reinforcement attempt.

Tested using all three methods of deployment: TO&E, Briefing Room, and AO.