### PR TITLE
Fix #8200: Fixed Crew Tooltip for Fixed-Wing Support Vehicles

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -7380,7 +7380,7 @@ public class Unit implements ITechnology {
             } else {
                 return PersonnelRole.VEHICLE_CREW_GROUND;
             }
-        } else if (entity.isConventionalFighter()) {
+        } else if (entity instanceof ConvFighter) { // do not use entity.isConventionalFighter here
             return PersonnelRole.CONVENTIONAL_AIRCRAFT_PILOT;
         } else if (entity.isLargeCraft()) {
             return PersonnelRole.VESSEL_PILOT;
@@ -7428,7 +7428,7 @@ public class Unit implements ITechnology {
             } else {
                 return PersonnelRole.VEHICLE_CREW_GROUND;
             }
-        } else if (entity.isConventionalInfantry()) {
+        } else if (entity instanceof ConvFighter) { // do not use entity.isConventionalFighter here
             return PersonnelRole.CONVENTIONAL_AIRCRAFT_PILOT;
         } else if (entity.isSmallCraft() || entity.isLargeCraft()) {
             return PersonnelRole.VESSEL_GUNNER;


### PR DESCRIPTION
Fix #8200

The conditionals that handle ConvFighter crewing were using `Entity#isConventionalFighter`, however that only checks whether the entity is a ConvFighter and excludes anything that extends from ConvFighter (including Fixed-Wing Support Vehicles). This PR switches to using `instanceof` to avoid that issue.