### PR TITLE
Improvement: Added GUI Indicator of Skill Experience Level

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Skill.java
@@ -808,11 +808,13 @@ public class Skill {
 
         int baseSkillLevel = level;
         int totalSkillLevel = getTotalSkillLevel(skillModifierData);
+        SkillLevel skillLevel = getSkillLevel(skillModifierData);
+        String skillLevelLabel = skillLevel.getShortName();
         if (baseSkillLevel != totalSkillLevel) {
-            display += String.format(" (<s><font color='gray'>%d</font></s>, %d)",
-                  baseSkillLevel, totalSkillLevel);
+            display += String.format(" (<s><font color='gray'>%d</font></s> %d%s)",
+                  baseSkillLevel, totalSkillLevel, skillLevelLabel);
         } else {
-            display += String.format(" (%d)", baseSkillLevel);
+            display += String.format(" (%d%s)", baseSkillLevel, skillLevelLabel);
         }
 
         return display;


### PR DESCRIPTION
While working on #8203 I realized that nowhere, outside of Campaign Options, do we actually show the user what experience level any of their skills are considered. So now we do.