### PR TITLE
Improvement #4969: Added Tabbed Daily Report Functionality

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -86,6 +86,8 @@ Version.text=Version
 Year.text=Year
 Yes.text=Yes
 AreYouSure.text=Are you sure?
+tabLogs.general=<html><h2 style="text-align:center">\u2139</h2></html>
+tabLogs.skill=<html><h2 style="text-align:center">\u2694</h2></html>
 ##### Adapter
 #### PersonnelTableMouseAdapter Class - TODO : unfinished, with cleanup required
 improved.format=%s improved %s!

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -256,8 +256,14 @@ public class CampaignNewDayManager {
         campaign.getCurrentReport().clear();
         campaign.setCurrentReportHTML("");
         campaign.getNewReports().clear();
-        campaign.getPersonnelWhoAdvancedInXP().clear();
+
+        campaign.getSkillReport().clear();
+        campaign.setSkillReportHTML("");
+        campaign.getNewSkillReports().clear();
+
         campaign.beginReport("<b>" + MekHQ.getMHQOptions().getLongDisplayFormattedDate(today) + "</b>");
+
+        campaign.getPersonnelWhoAdvancedInXP().clear();
 
         // New Year Changes
         if (isNewYear) {

--- a/MekHQ/src/mekhq/campaign/enums/DailyReportType.java
+++ b/MekHQ/src/mekhq/campaign/enums/DailyReportType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.enums;
+
+public enum DailyReportType {
+    GENERAL,
+    SKILL
+}

--- a/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
+++ b/MekHQ/src/mekhq/campaign/io/CampaignXmlParser.java
@@ -859,6 +859,27 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
                             campaign.getCurrentReport().add(wn2.getTextContent());
                         }
                     }
+                } else if (nodeName.equalsIgnoreCase("skillReport")) {
+                    // First, get all the child nodes;
+                    NodeList nl2 = childNode.getChildNodes();
+
+                    // Then, make sure the report is empty. *just* in case.
+                    // ...That is, creating a new campaign throws in a date line
+                    // for us...
+                    // So make sure it's cleared out.
+                    campaign.getSkillReport().clear();
+
+                    for (int x2 = 0; x2 < nl2.getLength(); x2++) {
+                        Node wn2 = nl2.item(x2);
+
+                        if (wn2.getParentNode() != childNode) {
+                            continue;
+                        }
+
+                        if (wn2.getNodeName().equalsIgnoreCase("reportLine")) {
+                            campaign.getSkillReport().add(wn2.getTextContent());
+                        }
+                    }
                 } else if (nodeName.equalsIgnoreCase("faction")) {
                     Faction faction = Factions.getInstance().getFaction(childNode.getTextContent());
                     campaign.setFaction(faction);
@@ -937,21 +958,32 @@ public record CampaignXmlParser(InputStream is, MekHQ app) {
             }
         }
 
-        // TODO: this could probably be better
+        // Update daily reports
         campaign.setCurrentReportHTML(Utilities.combineString(campaign.getCurrentReport(), Campaign.REPORT_LINEBREAK));
-
-        // Everything's new
         List<String> newReports = new ArrayList<>(campaign.getCurrentReport().size() * 2);
-        boolean firstReport = true;
+        boolean firstGeneralReport = true;
         for (String report : campaign.getCurrentReport()) {
-            if (firstReport) {
-                firstReport = false;
+            if (firstGeneralReport) {
+                firstGeneralReport = false;
             } else {
                 newReports.add(Campaign.REPORT_LINEBREAK);
             }
             newReports.add(report);
         }
         campaign.setNewReports(newReports);
+
+        campaign.setSkillReportHTML(Utilities.combineString(campaign.getSkillReport(), Campaign.REPORT_LINEBREAK));
+        List<String> newSkillReports = new ArrayList<>(campaign.getSkillReport().size() * 2);
+        boolean firstSkillReport = true;
+        for (String report : campaign.getSkillReport()) {
+            if (firstSkillReport) {
+                firstSkillReport = false;
+            } else {
+                newSkillReports.add(Campaign.REPORT_LINEBREAK);
+            }
+            newSkillReports.add(report);
+        }
+        campaign.setNewSkillReports(newSkillReports);
     }
 
     private static void processCombatTeamNodes(Campaign campaign, Node workingNode) {

--- a/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
@@ -32,6 +32,8 @@
  */
 package mekhq.gui.dialog;
 
+import static mekhq.utilities.MHQInternationalization.getText;
+
 import java.awt.Container;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
@@ -54,6 +56,7 @@ import megamek.client.ui.buttons.MMButton;
 import megamek.client.ui.preferences.JIntNumberSpinnerPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.event.Subscribe;
+import megamek.common.ui.EnhancedTabbedPane;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.events.ReportEvent;
@@ -77,6 +80,7 @@ public class AdvanceDaysDialog extends AbstractMHQDialogBasic {
     private JButton btnNewYear;
     private JButton btnNewQuinquennial;
     private DailyReportLogPanel dailyLogPanel;
+    private DailyReportLogPanel skillLogPanel;
     // endregion Variable Declarations
 
     // region Constructors
@@ -171,6 +175,14 @@ public class AdvanceDaysDialog extends AbstractMHQDialogBasic {
     public void setDailyLogPanel(final DailyReportLogPanel dailyLogPanel) {
         this.dailyLogPanel = dailyLogPanel;
     }
+
+    public DailyReportLogPanel getSkillLogPanel() {
+        return skillLogPanel;
+    }
+
+    public void setSkillLogPanel(final DailyReportLogPanel skillLogPanel) {
+        this.skillLogPanel = skillLogPanel;
+    }
     // endregion Getters/Setters
 
     // region Initialization
@@ -180,7 +192,14 @@ public class AdvanceDaysDialog extends AbstractMHQDialogBasic {
         final JPanel advanceDaysDurationPanel = createDurationPanel();
 
         setDailyLogPanel(new DailyReportLogPanel(getGUI()));
-        getDailyLogPanel().refreshLog(gui.getCommandCenterTab().getPanLog().getLogText());
+        getDailyLogPanel().refreshLog(gui.getCommandCenterTab().getGeneralLog().getLogText());
+
+        setSkillLogPanel(new DailyReportLogPanel(getGUI()));
+        getSkillLogPanel().refreshLog(gui.getCommandCenterTab().getSkillLog().getLogText());
+
+        EnhancedTabbedPane dailyReportTab = new EnhancedTabbedPane();
+        dailyReportTab.addTab(getText("tabLogs.general"), getDailyLogPanel());
+        dailyReportTab.addTab(getText("tabLogs.skill"), getSkillLogPanel());
 
         // Layout the Panel
         final JPanel panel = new JPanel();
@@ -194,12 +213,12 @@ public class AdvanceDaysDialog extends AbstractMHQDialogBasic {
         layout.setVerticalGroup(
               layout.createSequentialGroup()
                     .addComponent(advanceDaysDurationPanel)
-                    .addComponent(getDailyLogPanel()));
+                    .addComponent(dailyReportTab));
 
         layout.setHorizontalGroup(
               layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                     .addComponent(advanceDaysDurationPanel)
-                    .addComponent(getDailyLogPanel()));
+                    .addComponent(dailyReportTab));
 
         return panel;
     }
@@ -317,22 +336,29 @@ public class AdvanceDaysDialog extends AbstractMHQDialogBasic {
 
         setRunning(true);
         boolean firstDay = true;
-        final List<String> reports = new ArrayList<>();
+        final List<String> generalReports = new ArrayList<>();
+        final List<String> skillReports = new ArrayList<>();
         for (; days > 0; days--) {
             try {
                 if (!getGUI().getCampaign().newDay()) {
                     break;
                 }
 
-                final String report = getGUI().getCampaign().getCurrentReportHTML();
+                final String generalReport = getGUI().getCampaign().getCurrentReportHTML();
+                final String skillReport = getGUI().getCampaign().getSkillReportHTML();
                 if (firstDay) {
-                    getDailyLogPanel().refreshLog(report);
+                    getDailyLogPanel().refreshLog(generalReport);
+                    getSkillLogPanel().refreshLog(skillReport);
                     firstDay = false;
                 } else {
-                    reports.add("<hr>");
-                    reports.add(report);
+                    generalReports.add("<hr>");
+                    generalReports.add(generalReport);
+
+                    skillReports.add("<hr>");
+                    skillReports.add(skillReport);
                 }
-                reports.addAll(getGUI().getCampaign().fetchAndClearNewReports());
+                generalReports.addAll(getGUI().getCampaign().fetchAndClearNewReports());
+                skillReports.addAll(getGUI().getCampaign().fetchAndClearNewReports());
             } catch (Exception ex) {
                 LOGGER.error("", ex);
                 break;
@@ -340,7 +366,8 @@ public class AdvanceDaysDialog extends AbstractMHQDialogBasic {
         }
 
         setRunning(false);
-        getDailyLogPanel().appendLog(reports);
+        getDailyLogPanel().appendLog(generalReports);
+        getSkillLogPanel().appendLog(skillReports);
 
         // We couldn't advance all days for some reason,
         // set the spinner to the number of remaining days
@@ -359,6 +386,7 @@ public class AdvanceDaysDialog extends AbstractMHQDialogBasic {
             evt.cancel();
         } else {
             getDailyLogPanel().refreshLog(getGUI().getCampaign().getCurrentReportHTML());
+            getSkillLogPanel().refreshLog(getGUI().getCampaign().getSkillReportHTML());
         }
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/AdvanceDaysDialog.java
@@ -358,7 +358,7 @@ public class AdvanceDaysDialog extends AbstractMHQDialogBasic {
                     skillReports.add(skillReport);
                 }
                 generalReports.addAll(getGUI().getCampaign().fetchAndClearNewReports());
-                skillReports.addAll(getGUI().getCampaign().fetchAndClearNewReports());
+                skillReports.addAll(getGUI().getCampaign().fetchAndClearNewSkillReports());
             } catch (Exception ex) {
                 LOGGER.error("", ex);
                 break;


### PR DESCRIPTION
Close #4969

This PR updates our daily log technology to allow for tabs. This allows developers to push daily report updates to specific tabs rather than all reports being piled into the one massive stream.

This achieves two goals:
- It becomes easier for players to spot important information when they don't need to sift through mountains of text.
- Load times will be reduced, as the size of each text block will be decreased by merit of splitting it up

I have pushed this update to both the command center tab and advance multiple days. I've tested advance day, loading, saving, and hyperlinks. All work without issue.

To keep things simple and easy to review I've not rolled the functionality, instead it's currently pushing all updates to the general tab - mirroring current behavior. Rolling this out to our 389 individual `Campaign#addReport()` calls will take some time and will be handled by a follow-up PR.