### PR TITLE
Improvement: Optimized Name Fetching

### DIFF
--- a/MekHQ/src/mekhq/campaign/force/ForceType.java
+++ b/MekHQ/src/mekhq/campaign/force/ForceType.java
@@ -32,7 +32,7 @@
  */
 package mekhq.campaign.force;
 
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.logging.MMLogger;
 
@@ -70,6 +70,8 @@ public enum ForceType {
     SALVAGE(4, true, true);
 
     // region Fields
+    private final String displayName;
+    private final String symbol;
     private final int key;
     private final boolean standardizeParents;
     private final boolean childrenInherit;
@@ -86,12 +88,21 @@ public enum ForceType {
      *                           ForceType.
      */
     ForceType(final int key, boolean standardizeParents, boolean childrenInherit) {
+        this.displayName = generateDisplayName();
+        this.symbol = generateSymbol();
         this.key = key;
         this.standardizeParents = standardizeParents;
         this.childrenInherit = childrenInherit;
     }
     // endregion Constructor
 
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
 
     // region Getters
 
@@ -105,11 +116,11 @@ public enum ForceType {
      *
      * @return The localized display name for the current instance.
      */
-    public String getDisplayName() {
+    private String generateDisplayName() {
         final String RESOURCE_BUNDLE = "mekhq.resources.ForceType";
         final String RESOURCE_KEY = name() + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**
@@ -124,7 +135,7 @@ public enum ForceType {
      * @return The localized symbol associated with the current instance, or an empty string if the instance is
      *       {@code STANDARD}.
      */
-    public String getSymbol() {
+    private String generateSymbol() {
         if (this == STANDARD) {
             return "";
         }
@@ -132,7 +143,7 @@ public enum ForceType {
         final String RESOURCE_BUNDLE = "mekhq.resources.ForceType";
         final String RESOURCE_KEY = name() + ".symbol";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/enums/BloodGroup.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/BloodGroup.java
@@ -33,7 +33,7 @@
 package mekhq.campaign.personnel.enums;
 
 import static megamek.common.compute.Compute.randomInt;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.util.List;
 
@@ -66,6 +66,7 @@ public enum BloodGroup {
     OO_POSITIVE(37, true, Allele.O, Allele.O),
     OO_NEGATIVE(6, false, Allele.O, Allele.O);
 
+    private final String label;
     private final int chance;  // Represents the probability of occurrence for the blood group.
     private final boolean hasPositiveRhFactor;  // Indicates if the blood group has a positive Rh factor.
     private final List<Allele> alleles;  // Genetic composition of the blood group.
@@ -78,6 +79,7 @@ public enum BloodGroup {
      * @param alleles             the alleles that define the genetic composition of the blood group.
      */
     BloodGroup(int chance, boolean hasPositiveRhFactor, Allele... alleles) {
+        this.label = generateLabel();
         this.chance = chance;
         this.hasPositiveRhFactor = hasPositiveRhFactor;
         this.alleles = List.of(alleles);  // Store alleles as an immutable list.
@@ -85,6 +87,9 @@ public enum BloodGroup {
 
     final private String RESOURCE_BUNDLE = "mekhq.resources." + getClass().getSimpleName();
 
+    public String getLabel() {
+        return label;
+    }
 
     /**
      * Gets the chance value for this blood group.
@@ -136,10 +141,10 @@ public enum BloodGroup {
      *
      * @return the localized name of the blood group.
      */
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = name() + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelRole.java
@@ -33,7 +33,6 @@
 package mekhq.campaign.personnel.enums;
 
 import static mekhq.campaign.personnel.skills.InfantryGunnerySkills.INFANTRY_GUNNERY_SKILLS;
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.event.KeyEvent;
@@ -424,7 +423,7 @@ public enum PersonnelRole {
      */
     public String getLabel(final boolean isClan) {
         final boolean useClan = isClan && hasClanName;
-        return getFormattedTextAt(RESOURCE_BUNDLE, name() + ".label" + (useClan ? ".clan" : ""));
+        return getTextAt(RESOURCE_BUNDLE, name() + ".label" + (useClan ? ".clan" : ""));
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/PersonnelStatus.java
@@ -33,6 +33,7 @@
 package mekhq.campaign.personnel.enums;
 
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 import static mekhq.utilities.ReportingUtilities.CLOSING_SPAN_TAG;
 import static mekhq.utilities.ReportingUtilities.spanOpeningWithCustomColor;
 
@@ -131,6 +132,9 @@ public enum PersonnelStatus {
     final private String RESOURCE_BUNDLE = "mekhq.resources." + getClass().getSimpleName();
 
     // region Variable Declarations
+    private final String label;
+    private final String tooltip;
+    private final String logText;
     private final NotificationSeverity severity;
     private final boolean isPrisonerSuitableStatus;
     private final boolean isCauseOfDeath;
@@ -150,11 +154,26 @@ public enum PersonnelStatus {
      */
     PersonnelStatus(final NotificationSeverity severity, final boolean isPrisonerSuitableStatus,
           final boolean isCauseOfDeath) {
+        this.label = generateLabel();
+        this.tooltip = generateTooltip();
+        this.logText = generateLogText();
         this.severity = severity;
         this.isPrisonerSuitableStatus = isPrisonerSuitableStatus;
         this.isCauseOfDeath = isCauseOfDeath;
     }
     // endregion Constructors
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getToolTipText() {
+        return tooltip;
+    }
+
+    public String getLogText() {
+        return logText;
+    }
 
     /**
      * Retrieves the severity level of this status.
@@ -195,10 +214,10 @@ public enum PersonnelStatus {
      *
      * @return the localized label text
      */
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = name() + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**
@@ -209,10 +228,10 @@ public enum PersonnelStatus {
      *
      * @return the localized tooltip text
      */
-    public String getToolTipText() {
+    private String generateTooltip() {
         final String RESOURCE_KEY = name() + ".tooltip";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**
@@ -246,10 +265,10 @@ public enum PersonnelStatus {
      *
      * @return the localized log text
      */
-    public String getLogText() {
+    private String generateLogText() {
         final String RESOURCE_KEY = name() + ".log";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
     // endregion Getters
 

--- a/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
@@ -32,7 +32,7 @@
  */
 package mekhq.campaign.personnel.enums;
 
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -76,6 +76,9 @@ public enum Phenotype {
     private static final MMLogger logger = MMLogger.create(Phenotype.class);
     private static final String RESOURCE_BUNDLE = "mekhq.resources.Phenotype";
 
+    private final String shortName;
+    private final String label;
+    private final String tooltip;
     private final boolean isTrueborn;
     private final boolean external;
     private final int strength;
@@ -93,6 +96,9 @@ public enum Phenotype {
 
     Phenotype(final boolean isTrueborn, final boolean external, final int strength, final int body, final int reflexes,
           final int dexterity, final Attributes attributeCaps, final List<String> bonusTraits) {
+        this.shortName = generateShortName();
+        this.label = generateLabel();
+        this.tooltip = generateTooltip();
         this.isTrueborn = isTrueborn;
         this.external = external;
         this.strength = strength;
@@ -105,6 +111,18 @@ public enum Phenotype {
     // endregion Constructors
 
     // region Getters
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
 
     /**
      * Retrieves the cap (maximum allowable score) for a specified {@link SkillAttribute}.
@@ -194,10 +212,10 @@ public enum Phenotype {
      * @author Illiani
      * @since 0.50.05
      */
-    public String getShortName() {
+    private String generateShortName() {
         String key = "shortName." + (isTrueborn ? "trueborn" : "freeborn");
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, key);
+        return getTextAt(RESOURCE_BUNDLE, key);
     }
 
     /**
@@ -213,8 +231,8 @@ public enum Phenotype {
      * @author Illiani
      * @since 0.50.05
      */
-    public String getLabel() {
-        return getFormattedTextAt(RESOURCE_BUNDLE, name() + ".label");
+    private String generateLabel() {
+        return getTextAt(RESOURCE_BUNDLE, name() + ".label");
     }
 
     /**
@@ -230,8 +248,8 @@ public enum Phenotype {
      * @author Illiani
      * @since 0.50.05
      */
-    public String getTooltip() {
-        return getFormattedTextAt(RESOURCE_BUNDLE, name() + ".tooltip");
+    private String generateTooltip() {
+        return getTextAt(RESOURCE_BUNDLE, name() + ".tooltip");
     }
     // endregion Getters
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/enums/MarginOfSuccess.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/enums/MarginOfSuccess.java
@@ -32,7 +32,7 @@
  */
 package mekhq.campaign.personnel.skills.enums;
 
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.logging.MMLogger;
 import mekhq.utilities.ReportingUtilities;
@@ -69,9 +69,10 @@ public enum MarginOfSuccess {
     TERRIBLE(-6, -5, -3, ReportingUtilities.getNegativeColor()),
     DISASTROUS(Integer.MIN_VALUE, -7, -4, ReportingUtilities.getNegativeColor());
 
-    private static final MMLogger logger = MMLogger.create(MarginOfSuccess.class);
+    private static final MMLogger LOGGER = MMLogger.create(MarginOfSuccess.class);
     private static final String RESOURCE_BUNDLE = "mekhq.resources.MarginOfSuccess";
 
+    private final String label;
     private final int lowerBound;
     private final int upperBound;
     private final int margin;
@@ -89,6 +90,7 @@ public enum MarginOfSuccess {
      * @since 0.50.05
      */
     MarginOfSuccess(int lowerBound, int upperBound, int margin, String color) {
+        this.label = generateMarginOfSuccessString();
         this.lowerBound = lowerBound;
         this.upperBound = upperBound;
         this.margin = margin;
@@ -171,7 +173,7 @@ public enum MarginOfSuccess {
                 return margin;
             }
         }
-        logger.error("No valid MarginOfSuccess found for roll: {}. Returning DISASTROUS",
+        LOGGER.error("No valid MarginOfSuccess found for roll: {}. Returning DISASTROUS",
               differenceBetweenRollAndTarget);
         return DISASTROUS;
     }
@@ -200,7 +202,7 @@ public enum MarginOfSuccess {
             }
         }
 
-        logger.error("No valid MarginOfSuccess found for marginValue: {}. Returning DISASTROUS", marginValue);
+        LOGGER.error("No valid MarginOfSuccess found for marginValue: {}. Returning DISASTROUS", marginValue);
         return DISASTROUS;
     }
 
@@ -218,6 +220,10 @@ public enum MarginOfSuccess {
      * @since 0.50.05
      */
     public static String getMarginOfSuccessString(MarginOfSuccess marginOfSuccess) {
-        return getFormattedTextAt(RESOURCE_BUNDLE, marginOfSuccess + ".label");
+        return marginOfSuccess.label;
+    }
+
+    private String generateMarginOfSuccessString() {
+        return getTextAt(RESOURCE_BUNDLE, margin + ".label");
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/enums/SkillAttribute.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/enums/SkillAttribute.java
@@ -32,7 +32,7 @@
  */
 package mekhq.campaign.personnel.skills.enums;
 
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.codeUtilities.MathUtility;
 import megamek.logging.MMLogger;
@@ -68,6 +68,9 @@ public enum SkillAttribute {
     final private static String RESOURCE_BUNDLE = "mekhq.resources.SkillAttribute";
 
     private final String lookupName;
+    private final String label;
+    private final String shortName;
+    private final String description;
 
     /**
      * Constructs a {@link SkillAttribute} with the specified lookup name.
@@ -76,6 +79,9 @@ public enum SkillAttribute {
      */
     SkillAttribute(String lookupName) {
         this.lookupName = lookupName;
+        this.label = generateLabel();
+        this.shortName = generateShortName();
+        this.description = generateDescription();
     }
 
     /**
@@ -85,6 +91,18 @@ public enum SkillAttribute {
      */
     public String getLookupName() {
         return lookupName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public String getDescription() {
+        return description;
     }
 
     /**
@@ -104,32 +122,12 @@ public enum SkillAttribute {
      *
      * @return The localized label for this {@link SkillAttribute}.
      *
-     * @see #getLabel(SkillAttribute)
      * @since 0.50.05
      */
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = lookupName + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
-    }
-
-    /**
-     * Retrieves the label associated with the given {@link SkillAttribute}.
-     *
-     * <p>The label is determined by looking up a resource bundle key associated with the attribute's name in the
-     * format <code>{name}.label</code>.</p>
-     *
-     * @param attribute The {@link SkillAttribute} whose label is to be retrieved.
-     *
-     * @return The localized label for the provided {@link SkillAttribute}.
-     *
-     * @see #getLabel()
-     * @since 0.50.05
-     */
-    public static String getLabel(SkillAttribute attribute) {
-        final String RESOURCE_KEY = attribute.lookupName + ".label";
-
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**
@@ -140,32 +138,12 @@ public enum SkillAttribute {
      *
      * @return The localized short name for this {@link SkillAttribute}.
      *
-     * @see #getShortName(SkillAttribute)
      * @since 0.50.05
      */
-    public String getShortName() {
+    private String generateShortName() {
         final String RESOURCE_KEY = lookupName + ".shortName";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
-    }
-
-    /**
-     * Retrieves the short name associated with the given {@link SkillAttribute}.
-     *
-     * <p>The short name is determined by looking up a resource bundle key associated with the attribute's name in
-     * the format <code>{name}.shortName</code>.</p>
-     *
-     * @param attribute The {@link SkillAttribute} whose short name is to be retrieved.
-     *
-     * @return The localized short name for the provided {@link SkillAttribute}.
-     *
-     * @see #getShortName()
-     * @since 0.50.05
-     */
-    public static String getShortName(SkillAttribute attribute) {
-        final String RESOURCE_KEY = attribute.lookupName + ".shortName";
-
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**
@@ -176,32 +154,12 @@ public enum SkillAttribute {
      *
      * @return The localized description for this {@link SkillAttribute}.
      *
-     * @see #getDescription(SkillAttribute)
      * @since 0.50.05
      */
-    public String getDescription() {
+    private String generateDescription() {
         final String RESOURCE_KEY = lookupName + ".description";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
-    }
-
-    /**
-     * Retrieves the description associated with the given {@link SkillAttribute}.
-     *
-     * <p>The description is determined by looking up a resource bundle key associated with the attribute's name in
-     * the format <code>{name}.description</code>.</p>
-     *
-     * @param attribute The {@link SkillAttribute} whose description is to be retrieved.
-     *
-     * @return The localized description for the provided {@link SkillAttribute}.
-     *
-     * @see #getDescription()
-     * @since 0.50.05
-     */
-    public static String getDescription(SkillAttribute attribute) {
-        final String RESOURCE_KEY = attribute.lookupName + ".description";
-
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Aggression.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Aggression.java
@@ -35,6 +35,7 @@ package mekhq.campaign.randomEvents.personalities.enums;
 import static megamek.codeUtilities.MathUtility.clamp;
 import static mekhq.campaign.randomEvents.personalities.enums.PersonalityTraitType.AGGRESSION;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.common.enums.Gender;
 import megamek.logging.MMLogger;
@@ -88,12 +89,14 @@ public enum Aggression {
     // endregion Enum Declarations
 
     // region Variable Declarations
+    private final String label;
     private final boolean isPositive;
     private final boolean isMajor;
     // endregion Variable Declarations
 
     // region Constructors
     Aggression(boolean isPositive, boolean isMajor) {
+        this.label = this.generateLabel();
         this.isPositive = isPositive;
         this.isMajor = isMajor;
     }
@@ -131,6 +134,12 @@ public enum Aggression {
         return getPersonalityTraitType().getLabel();
     }
 
+    public String getLabel() {
+        return label;
+    }
+
+    // region Getters
+
     /**
      * Retrieves the label associated with the current enumeration value.
      *
@@ -139,11 +148,10 @@ public enum Aggression {
      *
      * @return the localized label string corresponding to the enumeration value.
      */
-    // region Getters
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = name() + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Ambition.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Ambition.java
@@ -35,6 +35,7 @@ package mekhq.campaign.randomEvents.personalities.enums;
 import static megamek.codeUtilities.MathUtility.clamp;
 import static mekhq.campaign.randomEvents.personalities.enums.PersonalityTraitType.AMBITION;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.common.enums.Gender;
 import megamek.logging.MMLogger;
@@ -87,12 +88,14 @@ public enum Ambition {
     // endregion Enum Declarations
 
     // region Variable Declarations
+    private final String label;
     private final boolean isPositive;
     private final boolean isMajor;
     // endregion Variable Declarations
 
     // region Constructors
     Ambition(boolean isPositive, boolean isMajor) {
+        this.label = this.generateLabel();
         this.isPositive = isPositive;
         this.isMajor = isMajor;
     }
@@ -132,6 +135,10 @@ public enum Ambition {
         return getPersonalityTraitType().getLabel();
     }
 
+    public String getLabel() {
+        return label;
+    }
+
     /**
      * Retrieves the label associated with the current enumeration value.
      *
@@ -140,10 +147,10 @@ public enum Ambition {
      *
      * @return the localized label string corresponding to the enumeration value.
      */
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = name() + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Greed.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Greed.java
@@ -35,6 +35,7 @@ package mekhq.campaign.randomEvents.personalities.enums;
 import static megamek.codeUtilities.MathUtility.clamp;
 import static mekhq.campaign.randomEvents.personalities.enums.PersonalityTraitType.GREED;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.common.enums.Gender;
 import megamek.logging.MMLogger;
@@ -87,12 +88,14 @@ public enum Greed {
     // endregion Enum Declarations
 
     // region Variable Declarations
+    private final String label;
     private final boolean isPositive;
     private final boolean isMajor;
     // endregion Variable Declarations
 
     // region Constructors
     Greed(boolean isPositive, boolean isMajor) {
+        this.label = generateLabel();
         this.isPositive = isPositive;
         this.isMajor = isMajor;
     }
@@ -109,6 +112,10 @@ public enum Greed {
      * The index at which major traits begin within the enumeration.
      */
     public final static int MAJOR_TRAITS_START_INDEX = 25;
+
+    public String getLabel() {
+        return label;
+    }
 
     /**
      * @return the {@link PersonalityTraitType} representing greed
@@ -139,10 +146,10 @@ public enum Greed {
      * @return the localized label string corresponding to the enumeration value.
      */
     // region Getters
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = name() + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/PersonalityQuirk.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/PersonalityQuirk.java
@@ -37,6 +37,7 @@ import static mekhq.campaign.personnel.enums.PersonnelRole.BATTLE_ARMOUR;
 import static mekhq.campaign.personnel.enums.PersonnelRole.SOLDIER;
 import static mekhq.campaign.randomEvents.personalities.enums.PersonalityTraitType.PERSONALITY_QUIRK;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -315,6 +316,16 @@ public enum PersonalityQuirk {
 
     final private String RESOURCE_BUNDLE = "mekhq.resources." + getClass().getSimpleName();
 
+    private final String label;
+
+    PersonalityQuirk() {
+        this.label = this.generateLabel();
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
     /**
      * Defines the number of individual description variants available for each trait.
      *
@@ -353,10 +364,10 @@ public enum PersonalityQuirk {
      * @return the localized label string corresponding to the enumeration value.
      */
     // region Getters
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = name() + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Reasoning.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Reasoning.java
@@ -37,6 +37,7 @@ import static megamek.codeUtilities.MathUtility.clamp;
 import static megamek.common.compute.Compute.randomInt;
 import static mekhq.campaign.randomEvents.personalities.enums.PersonalityTraitType.REASONING;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.codeUtilities.MathUtility;
 import megamek.common.enums.Gender;
@@ -109,6 +110,7 @@ public enum Reasoning {
 
     final private String RESOURCE_BUNDLE = "mekhq.resources." + getClass().getSimpleName();
 
+    private final String label;
     private final ReasoningComparison comparison;
     private final int level;
 
@@ -125,8 +127,13 @@ public enum Reasoning {
      * @param level      The integer score associated with this {@link Reasoning} enum value
      */
     Reasoning(ReasoningComparison comparison, int level) {
+        this.label = generateLabel();
         this.comparison = comparison;
         this.level = level;
+    }
+
+    public String getLabel() {
+        return label;
     }
 
     /**
@@ -152,9 +159,9 @@ public enum Reasoning {
      * @return the localized label string corresponding to the enumeration value.
      */
     // region Getters
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = name() + ".label";
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY) + " (" + level + ")";
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY) + " (" + level + ")";
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Social.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/personalities/enums/Social.java
@@ -35,6 +35,7 @@ package mekhq.campaign.randomEvents.personalities.enums;
 import static megamek.codeUtilities.MathUtility.clamp;
 import static mekhq.campaign.randomEvents.personalities.enums.PersonalityTraitType.SOCIAL;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.common.enums.Gender;
 import megamek.logging.MMLogger;
@@ -87,12 +88,14 @@ public enum Social {
     // endregion Enum Declarations
 
     // region Variable Declarations
+    private final String label;
     private final boolean isPositive;
     private final boolean isMajor;
     // endregion Variable Declarations
 
     // region Constructors
     Social(boolean isPositive, boolean isMajor) {
+        this.label = generateLabel();
         this.isPositive = isPositive;
         this.isMajor = isMajor;
     }
@@ -109,6 +112,10 @@ public enum Social {
      * The index at which major traits begin within the enumeration.
      */
     public final static int MAJOR_TRAITS_START_INDEX = 25;
+
+    public String getLabel() {
+        return label;
+    }
 
     /**
      * @return the {@link PersonalityTraitType} representing social aptitude
@@ -139,10 +146,10 @@ public enum Social {
      * @return the localized label string corresponding to the enumeration value.
      */
     // region Getters
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = name() + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/enums/PrisonerCaptureStyle.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/enums/PrisonerCaptureStyle.java
@@ -32,7 +32,7 @@
  */
 package mekhq.campaign.randomEvents.prisoners.enums;
 
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.logging.MMLogger;
 
@@ -56,7 +56,23 @@ public enum PrisonerCaptureStyle {
 
     final private String RESOURCE_BUNDLE = "mekhq.resources." + getClass().getSimpleName();
 
+    private final String label;
+    private final String tooltip;
+
+    PrisonerCaptureStyle() {
+        this.label = this.generateLabel();
+        this.tooltip = this.generateTooltip();
+    }
+
     //region Getters
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
 
     /**
      * Retrieves the localized label for the current capture style.
@@ -66,10 +82,10 @@ public enum PrisonerCaptureStyle {
      *
      * @return A {@link String} containing the localized label for the capture style.
      */
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = name() + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**
@@ -80,10 +96,10 @@ public enum PrisonerCaptureStyle {
      *
      * @return A {@link String} containing the localized tooltip for the capture style.
      */
-    public String getTooltip() {
+    private String generateTooltip() {
         final String RESOURCE_KEY = name() + ".tooltip";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
     //endregion Getters
 

--- a/MekHQ/src/mekhq/campaign/randomEvents/prisoners/enums/PrisonerStatus.java
+++ b/MekHQ/src/mekhq/campaign/randomEvents/prisoners/enums/PrisonerStatus.java
@@ -32,7 +32,7 @@
  */
 package mekhq.campaign.randomEvents.prisoners.enums;
 
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.logging.MMLogger;
 
@@ -47,17 +47,33 @@ public enum PrisonerStatus {
 
     final private String RESOURCE_BUNDLE = "mekhq.resources.PrisonerStatus";
 
+    private final String label;
+    private final String titleExtension;
+
+    PrisonerStatus() {
+        this.label = this.generateLabel();
+        this.titleExtension = this.generateTitleExtension();
+    }
+
     // region Getters
     public String getLabel() {
-        final String RESOURCE_KEY = name() + ".label";
-
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return this.label;
     }
 
     public String getTitleExtension() {
+        return this.titleExtension;
+    }
+
+    private String generateLabel() {
+        final String RESOURCE_KEY = name() + ".label";
+
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+    }
+
+    private String generateTitleExtension() {
         final String RESOURCE_KEY = name() + ".titleExtension";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
     // endregion Getters
 

--- a/MekHQ/src/mekhq/gui/campaignOptions/enums/ProcurementPersonnelPick.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/enums/ProcurementPersonnelPick.java
@@ -32,7 +32,7 @@
  */
 package mekhq.gui.campaignOptions.enums;
 
-import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import megamek.logging.MMLogger;
 import mekhq.campaign.personnel.Person;
@@ -56,6 +56,22 @@ public enum ProcurementPersonnelPick {
 
     final private String RESOURCE_BUNDLE = "mekhq.resources.ProcurementPersonnelPick";
 
+    private final String label;
+    private final String description;
+
+    ProcurementPersonnelPick() {
+        this.label = this.generateLabel();
+        this.description = this.generateDescription();
+    }
+
+    public String getLabel() {
+        return this.label;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
     /**
      * Retrieves the label associated with the current enumeration value.
      *
@@ -64,10 +80,10 @@ public enum ProcurementPersonnelPick {
      *
      * @return the localized label string corresponding to the enumeration value.
      */
-    public String getLabel() {
+    private String generateLabel() {
         final String RESOURCE_KEY = name() + ".label";
 
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**
@@ -78,9 +94,9 @@ public enum ProcurementPersonnelPick {
      *
      * @return The formatted description text for the current enum value, or a fallback value if the key is not found.
      */
-    public String getDescription() {
+    private String generateDescription() {
         final String RESOURCE_KEY = name() + ".description";
-        return getFormattedTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
+        return getTextAt(RESOURCE_BUNDLE, RESOURCE_KEY);
     }
 
     /**


### PR DESCRIPTION
Following a discovery by Psi I went through and updated a number of enums that were previously using single-use calls to getFormattedTextAt to instead have the String defined inside the enum entry itself. In this way the getting is run once, used infinitely.