### PR TITLE
Fix #8221: Fixed autoInfirmary Mistakenly Unassigning Patients

### DIFF
--- a/MekHQ/src/mekhq/campaign/OptimizeInfirmaryAssignments.java
+++ b/MekHQ/src/mekhq/campaign/OptimizeInfirmaryAssignments.java
@@ -142,7 +142,7 @@ public class OptimizeInfirmaryAssignments {
                 continue;
             }
 
-            if (campaign.getMashTheatresWithinCapacity() && totalPatientCounter >= mashTheatreCapacity) {
+            if (!campaign.getMashTheatresWithinCapacity()) {
                 // Similar to the above, we're just unassigning doctors for any remaining patients.
                 continue;
             }


### PR DESCRIPTION
Fix #8221

autoInfirmary was reading 'within capacity' as 'not within capacity'