### PR TITLE
Fix #8218: Fixed Error When Attempting to Fetch the Prosthetics Healing Penalty for a Location That Cannot Have Prosthetics

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/medical/BodyLocation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/BodyLocation.java
@@ -108,7 +108,9 @@ public enum BodyLocation {
     private final String locationName;
     private final BodyLocation parent;
 
-    public static final List<BodyLocation> PRIMARY_LOCATIONS = List.of(
+    // Never use List.of() here it will cause NPEs as null values are a valid comparison to the contents of this list
+    // and List.of() disallows the passing in of null values.
+    public static final List<BodyLocation> PRIMARY_LOCATIONS = Arrays.asList(
           HEAD,
           CHEST,
           ABDOMEN,
@@ -201,7 +203,7 @@ public enum BodyLocation {
     public @Nullable BodyLocation getPrimaryLocation() {
         BodyLocation location = this;
 
-        while (!PRIMARY_LOCATIONS.contains(location) && location != null) {
+        while (location != null && !PRIMARY_LOCATIONS.contains(location)) {
             location = location.getParent();
         }
 


### PR DESCRIPTION
Fix #8218

It turns out `List.of()` arrays are different to normal `List` arrays in that they cannot have `null` values passed into them. A bit of an issue given `null` body locations are very common. This fixes that.