### PR TITLE
Fix #8216: Stopped Astech Being Combined with Other Tech Professions

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1305,7 +1305,7 @@ public class Person {
                 return false;
             }
 
-            if (role.isTech() && (secondaryRole.isTech() || secondaryRole.isAstech())) {
+            if ((role.isTech() || role.isAstech()) && (secondaryRole.isTechSecondary() || secondaryRole.isAstech())) {
                 return false;
             }
 
@@ -1336,7 +1336,7 @@ public class Person {
                 return false;
             }
 
-            if (role.isTech() && (primaryRole.isTech() || primaryRole.isAstech())) {
+            if ((role.isTechSecondary() || role.isAstech()) && (primaryRole.isTech() || primaryRole.isAstech())) {
                 return false;
             }
 


### PR DESCRIPTION
Fix #8216

One of the core profession limitations in MekHQ is that multiple tech professions cannot be stacked. This PR reinforces that by preventing Astechs and other tech professions being present on the same character.

This was only partially enforced, previously, resulting in the assignment going through correctly but then the character being marked as ineligible for their profession when the save was loaded.