### PR TITLE
Fix: Fixed autoInfirmary Mangling Patient Counts

### DIFF
--- a/MekHQ/src/mekhq/campaign/OptimizeInfirmaryAssignments.java
+++ b/MekHQ/src/mekhq/campaign/OptimizeInfirmaryAssignments.java
@@ -142,7 +142,7 @@ public class OptimizeInfirmaryAssignments {
                 continue;
             }
 
-            if (!campaign.getMashTheatresWithinCapacity()) {
+            if (isOnContractAndPlanetside && totalPatientCounter >= mashTheatreCapacity) {
                 // Similar to the above, we're just unassigning doctors for any remaining patients.
                 continue;
             }


### PR DESCRIPTION
autoInfirmary wasn't cleaning up after itself, nor was it processing MASH Theater availability correctly. Now it is.

While the report on Discord said that this was not a visual bug only, insofar as I can tell it was. I've marked the case as 'medium' as this will generate a lot of contact if not fixed.