### PR TITLE
Fix #8244: Fixed Docking Collar Requirements Incorrectly Using Count of Additional DropShips Needed

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
+++ b/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
@@ -558,7 +558,7 @@ public class TransportCostCalculations {
         dockingCollarCost = round(additionalCollarsRequired * JUMP_SHIP_COLLAR_COST);
         totalCost = totalCost.plus(dockingCollarCost);
 
-        jumpShipsRequired = Math.ceil(additionalCollarsRequired / COLLARS_PER_JUMPSHIP);
+        jumpShipsRequired = ceil(additionalCollarsRequired / COLLARS_PER_JUMPSHIP);
     }
 
     /**


### PR DESCRIPTION
Fix #8244

As per title. A simple thing to fix.