### PR TITLE
Fix #8246: Fixed Incorrect Use of `Equals` Instead of `Compare` in Salvage Picker Dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
@@ -846,7 +846,7 @@ public class SalvagePostScenarioPicker {
             if (currentPercent.compareTo(BigDecimal.valueOf(salvagePercent)) > 0 && !isExchangeRights) {
                 disableConfirmAndColorName(confirmButton, unitSalvageLabel);
                 // If we've gone over our %, we only block progression if the player is trying to salvage even more.
-                shouldEnable = unitSalvageMoneyCurrent.compareTo(unitSalvageMoneyInitial) == 0;
+                shouldEnable = unitSalvageMoneyCurrent.compareTo(unitSalvageMoneyInitial) <= 0;
             }
         }
 


### PR DESCRIPTION
Fix #8246

We were checking whether the two money objects were equivalent objects and not that they were the same amount. Now we are.