### PR TITLE
Improvement #8219: Adjusted Default Support Personnel Counts for Quick Start Company Generator

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/companyGeneration/CompanyGenerationOptions.java
+++ b/MekHQ/src/mekhq/campaign/universe/companyGeneration/CompanyGenerationOptions.java
@@ -186,9 +186,9 @@ public class CompanyGenerationOptions {
             supportPersonnel.put(PersonnelRole.AERO_TEK, 1);
             supportPersonnel.put(PersonnelRole.DOCTOR, 1);
             supportPersonnel.put(PersonnelRole.ADMINISTRATOR_COMMAND, 1);
-            supportPersonnel.put(PersonnelRole.ADMINISTRATOR_LOGISTICS, 3);
+            supportPersonnel.put(PersonnelRole.ADMINISTRATOR_LOGISTICS, 5);
             supportPersonnel.put(PersonnelRole.ADMINISTRATOR_TRANSPORT, 1);
-            supportPersonnel.put(PersonnelRole.ADMINISTRATOR_HR, 2);
+            supportPersonnel.put(PersonnelRole.ADMINISTRATOR_HR, 3);
         } else { // Defaults to AtB
             supportPersonnel.put(PersonnelRole.MEK_TECH, 10);
             supportPersonnel.put(PersonnelRole.DOCTOR, 1);

--- a/MekHQ/src/mekhq/campaign/universe/companyGeneration/CompanyGenerationOptions.java
+++ b/MekHQ/src/mekhq/campaign/universe/companyGeneration/CompanyGenerationOptions.java
@@ -182,13 +182,13 @@ public class CompanyGenerationOptions {
         final Map<PersonnelRole, Integer> supportPersonnel = new HashMap<>();
         if (method.isWindchild()) {
             supportPersonnel.put(PersonnelRole.MEK_TECH, 12);
-            supportPersonnel.put(PersonnelRole.MECHANIC, 0);
-            supportPersonnel.put(PersonnelRole.AERO_TEK, 0);
+            supportPersonnel.put(PersonnelRole.MECHANIC, 4);
+            supportPersonnel.put(PersonnelRole.AERO_TEK, 1);
             supportPersonnel.put(PersonnelRole.DOCTOR, 1);
             supportPersonnel.put(PersonnelRole.ADMINISTRATOR_COMMAND, 1);
-            supportPersonnel.put(PersonnelRole.ADMINISTRATOR_LOGISTICS, 2);
+            supportPersonnel.put(PersonnelRole.ADMINISTRATOR_LOGISTICS, 3);
             supportPersonnel.put(PersonnelRole.ADMINISTRATOR_TRANSPORT, 1);
-            supportPersonnel.put(PersonnelRole.ADMINISTRATOR_HR, 1);
+            supportPersonnel.put(PersonnelRole.ADMINISTRATOR_HR, 2);
         } else { // Defaults to AtB
             supportPersonnel.put(PersonnelRole.MEK_TECH, 10);
             supportPersonnel.put(PersonnelRole.DOCTOR, 1);


### PR DESCRIPTION
Close #8219

Mechanics: 0 -> 4 (for your free support vehicles)
AeroTeks: 0 -> 1 (not strictly necessary, but helps with aero salvage)
Admin/Logi: 2 -> 5 (a little extra never hurt anyone)
Admin/HR:  1 -> 3 (for HR Strain)