### PR TITLE
Fix #8271: Added Ability to Assign Tech to Maintain Handheld Weapons

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -95,6 +95,7 @@ import megamek.common.annotations.Nullable;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.enums.Gender;
 import megamek.common.enums.SkillLevel;
+import megamek.common.equipment.HandheldWeapon;
 import megamek.common.icons.Portrait;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
@@ -5762,8 +5763,8 @@ public class Person {
     /**
      * Determines if the user holds the necessary technical skills to service or repair the specified entity.
      *
-     * <p>The method inspects the entity type and checks for the corresponding technical skills required to perform
-     * maintenance or repairs. Supported types include Mek, ProtoMek, dropship, jumpship, aerospace unit, battle armor,
+     * <p>The method inspects the entity type and checks for the corresponding technical profession required to perform
+     * maintenance or repairs. Supported types include Mek, ProtoMek, DropShip, JumpShip, aerospace unit, battle armor,
      * and tank.</p>
      *
      * @param entity the entity to assess for technical capability. If {@code null}, returns {@code false}.
@@ -5775,16 +5776,16 @@ public class Person {
             return false;
         }
 
-        if ((entity instanceof Mek) || (entity instanceof ProtoMek)) {
-            return hasSkill(S_TECH_MEK) && isTechMek();
+        if ((entity instanceof Mek) || (entity instanceof ProtoMek) || (entity instanceof HandheldWeapon)) {
+            return isTechMek();
         } else if (entity instanceof Dropship || entity instanceof Jumpship) {
-            return hasSkill(S_TECH_VESSEL) && isTechLargeVessel();
+            return isTechLargeVessel();
         } else if (entity instanceof Aero) {
-            return hasSkill(S_TECH_AERO) && isTechAero();
+            return isTechAero();
         } else if (entity instanceof BattleArmor) {
-            return hasSkill(S_TECH_BA) && isTechBA();
+            return isTechBA();
         } else if (entity instanceof Tank) {
-            return hasSkill(S_TECH_MECHANIC) && isTechMechanic();
+            return isTechMechanic();
         } else {
             return false;
         }
@@ -6343,8 +6344,9 @@ public class Person {
     public @Nullable Skill getSkillForWorkingOn(final @Nullable Unit unit) {
         if (unit == null) {
             return null;
-        } else if (((unit.getEntity() instanceof Mek) || (unit.getEntity() instanceof ProtoMek)) &&
-                         hasSkill(S_TECH_MEK)) {
+        } else if (((unit.getEntity() instanceof Mek) ||
+                          (unit.getEntity() instanceof ProtoMek) ||
+                          (unit.getEntity() instanceof HandheldWeapon)) && hasSkill(S_TECH_MEK)) {
             return getSkill(S_TECH_MEK);
         } else if ((unit.getEntity() instanceof BattleArmor) && hasSkill(S_TECH_BA)) {
             return getSkill(S_TECH_BA);

--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -5404,7 +5404,7 @@ public class Unit implements ITechnology {
 
     // TODO : Switch similar tables in person to use this one instead
     public String determineUnitTechSkillType() {
-        if ((entity instanceof Mek) || (entity instanceof ProtoMek)) {
+        if ((entity instanceof Mek) || (entity instanceof ProtoMek) || (entity instanceof HandheldWeapon)) {
             return SkillType.S_TECH_MEK;
         } else if (entity instanceof BattleArmor) {
             return SkillType.S_TECH_BA;
@@ -6386,6 +6386,10 @@ public class Unit implements ITechnology {
 
         if (entity instanceof Jumpship) {
             return 360 * maintenanceMultiplier;
+        }
+
+        if (entity instanceof HandheldWeapon) { // Unofficial
+            return 30;
         }
 
         // Anything that didn't fall into one of the above classifications is self-maintaining, meaning zero.

--- a/MekHQ/src/mekhq/gui/menus/AssignUnitToTechMenu.java
+++ b/MekHQ/src/mekhq/gui/menus/AssignUnitToTechMenu.java
@@ -79,8 +79,7 @@ public class AssignUnitToTechMenu extends JScrollableMenu {
         // Initial Parsing Values
         final int maintenanceTime = Stream.of(units).mapToInt(Unit::getMaintenanceTime).sum();
         final String skillName = units[0].determineUnitTechSkillType();
-        final boolean assign = (maintenanceTime < Person.PRIMARY_ROLE_SUPPORT_TIME) &&
-                                     !StringUtility.isNullOrBlank(skillName) &&
+        final boolean assign = !StringUtility.isNullOrBlank(skillName) &&
                                      Stream.of(units)
                                            .allMatch(unit -> skillName.equalsIgnoreCase(unit.determineUnitTechSkillType()));
 


### PR DESCRIPTION
Fix #8271

Maintenance Time/Cycle: 30 minutes
Skill Required: Tech/Mek
Profession Required: MekTech

There was discussion around allowing any tech to maintain HHWs. Unfortunately, the way our code is set up only one skill can be assigned as the tech skill for a unit. I opted to go with MekTech and Tech/Mek as that made the most sense to me, given nobody is strapping HHWs to tanks or fighters.