### PR TITLE
Improvement #2321: Added Campaign Option to Prevent Tornadoes From Spawning in Scenarios

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1856,6 +1856,9 @@ lblUseLightConditions.text=Enable Light Conditions
 lblUseLightConditions.tooltip=Determine light conditions when generating a scenario.
 lblUsePlanetaryConditions.text=Enable Planetary Conditions
 lblUsePlanetaryConditions.tooltip=Set gravity and atmosphere based on the contract location.
+lblUseNoTornadoes.text=No Tornadoes <span style="color:#C344C3;">\u2605</span>
+lblUseNoTornadoes.tooltip=If enabled, scenarios will not spawn with tornadoes. This was introduced due to the \
+  limitations of MekHQ's scenario generation. Having a tornado basically resulted in automatic win or lose scenarios.
 lblFixedMapChance.text=User-Made Map Chance
 lblFixedMapChance.tooltip=The likelihood, in percent, that a fixed user-made map will be used in\
   \ place of a generated map.

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -651,6 +651,7 @@ public class CampaignOptions {
     private boolean useWeatherConditions;
     private boolean useLightConditions;
     private boolean usePlanetaryConditions;
+    private boolean useNoTornadoes;
     private int fixedMapChance;
     private int spaUpgradeIntensity;
     private int scenarioModMax;
@@ -717,6 +718,7 @@ public class CampaignOptions {
         reverseQualityNames = false;
         setUseRandomUnitQualities(true);
         setUsePlanetaryModifiers(true);
+        useNoTornadoes = false;
         useUnofficialMaintenance = false;
         logMaintenance = false;
         defaultMaintenanceTime = 4;
@@ -5118,6 +5120,14 @@ public class CampaignOptions {
 
     public void setUsePlanetaryConditions(final boolean usePlanetaryConditions) {
         this.usePlanetaryConditions = usePlanetaryConditions;
+    }
+
+    public boolean isUseNoTornadoes() {
+        return useNoTornadoes;
+    }
+
+    public void setUseNoTornadoes(final boolean useNoTornadoes) {
+        this.useNoTornadoes = useNoTornadoes;
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -211,6 +211,7 @@ public class CampaignOptionsMarshaller {
               "useRandomUnitQualities",
               campaignOptions.isUseRandomUnitQualities());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "usePlanetaryModifiers", campaignOptions.isUsePlanetaryModifiers());
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useNoTornadoes", campaignOptions.isUseNoTornadoes());
         MHQXMLUtility.writeSimpleXMLTag(pw,
               indent,
               "useUnofficialMaintenance",

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -117,6 +117,7 @@ public class CampaignOptionsUnmarshaller {
             case "reverseQualityNames" -> campaignOptions.setReverseQualityNames(parseBoolean(nodeContents));
             case "useRandomUnitQualities" -> campaignOptions.setUseRandomUnitQualities(parseBoolean(nodeContents));
             case "usePlanetaryModifiers" -> campaignOptions.setUsePlanetaryModifiers(parseBoolean(nodeContents));
+            case "useNoTornadoes" -> campaignOptions.setUseNoTornadoes(parseBoolean(nodeContents));
             case "useUnofficialMaintenance" -> campaignOptions.setUseUnofficialMaintenance(parseBoolean(
                   nodeContents));
             case "logMaintenance" -> campaignOptions.setLogMaintenance(parseBoolean(nodeContents));

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -196,7 +196,8 @@ public class AtBDynamicScenarioFactory {
 
         boolean planetsideScenario = template.isPlanetSurface();
 
-        if (campaign.getCampaignOptions().isUsePlanetaryConditions() && planetsideScenario) {
+        CampaignOptions campaignOptions = campaign.getCampaignOptions();
+        if (campaignOptions.isUsePlanetaryConditions() && planetsideScenario) {
             setPlanetaryConditions(scenario, contract, campaign);
         }
 
@@ -206,14 +207,14 @@ public class AtBDynamicScenarioFactory {
         // ground map
         // theoretically some lighting conditions apply to space maps as well, but
         // requires additional work to implement properly
-        if (campaign.getCampaignOptions().isUseLightConditions() && planetsideScenario) {
+        if (campaignOptions.isUseLightConditions() && planetsideScenario) {
             setLightConditions(scenario);
         }
 
         // set weather conditions if the user wants to play with them and is on a ground
         // map
-        if (campaign.getCampaignOptions().isUseWeatherConditions() && planetsideScenario) {
-            setWeather(scenario);
+        if (campaignOptions.isUseWeatherConditions() && planetsideScenario) {
+            setWeather(scenario, campaignOptions.isUseNoTornadoes());
         }
 
         // apply a default "reinforcements" force template if a scenario-specific one
@@ -1780,10 +1781,11 @@ public class AtBDynamicScenarioFactory {
     /**
      * Handles random determination of weather/wind/fog conditions for the given scenario, as per AtB rules
      *
-     * @param scenario The scenario for which to set weather conditions.
+     * @param scenario      The scenario for which to set weather conditions.
+     * @param isNoTornadoes {@code true} if tornadoes should be suppressed into less intense wind levels
      */
-    private static void setWeather(AtBDynamicScenario scenario) {
-        scenario.setWeatherConditions();
+    private static void setWeather(AtBDynamicScenario scenario, boolean isNoTornadoes) {
+        scenario.setWeatherConditions(isNoTornadoes);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBScenario.java
@@ -351,7 +351,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
             setLightConditions();
         }
         if (campaignOptions.isUseWeatherConditions()) {
-            setWeatherConditions();
+            setWeatherConditions(campaignOptions.isUseNoTornadoes());
         }
         setMapSize();
         setMapFile();
@@ -402,7 +402,7 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
         setLight(TCO.rollLightCondition(getTerrainType()));
     }
 
-    public void setWeatherConditions() {
+    public void setWeatherConditions(boolean isNoTornadoes) {
         // weather is irrelevant in these situations.
         if (getBoardType() == AtBScenario.T_SPACE || getBoardType() == AtBScenario.T_ATMOSPHERE) {
             return;
@@ -412,6 +412,12 @@ public abstract class AtBScenario extends Scenario implements IAtBScenario {
 
         if (WeatherRestriction.IsWindRestricted(wind.ordinal(), getAtmosphere().ordinal(), getTemperature())) {
             wind = Wind.CALM;
+        } else if (isNoTornadoes) {
+            if (wind == Wind.TORNADO_F1_TO_F3) {
+                wind = Wind.MOD_GALE;
+            } else if (wind == Wind.TORNADO_F4) {
+                wind = Wind.STRONG_GALE;
+            }
         }
 
         Weather weather = TCO.rollWeatherCondition(getTerrainType());

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/AceDuelBuiltInScenario.java
@@ -78,7 +78,7 @@ public class AceDuelBuiltInScenario extends AtBScenario {
     }
 
     @Override
-    public void setWeatherConditions() {
+    public void setWeatherConditions(boolean isNoTornadoes) {
         setWeather(Weather.CLEAR);
         setWind(Wind.CALM);
         setFog(Fog.FOG_NONE);

--- a/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDuelBuiltInScenario.java
+++ b/MekHQ/src/mekhq/campaign/mission/atb/scenario/OfficerDuelBuiltInScenario.java
@@ -78,7 +78,7 @@ public class OfficerDuelBuiltInScenario extends AtBScenario {
     }
 
     @Override
-    public void setWeatherConditions() {
+    public void setWeatherConditions(boolean isNoTornadoes) {
         setWeather(Weather.CLEAR);
         setWind(Wind.CALM);
         setFog(Fog.FOG_NONE);

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -655,7 +655,7 @@ public class StratConRulesManager {
 
         // Finally, finish scenario set up
         finalizeScenario(backingScenario, contract, campaign);
-        setScenarioParametersFromBiome(track, scenario);
+        setScenarioParametersFromBiome(track, scenario, campaign.getCampaignOptions().isUseNoTornadoes());
         swapInPlayerUnits(scenario, campaign, FORCE_NONE);
 
         if (!autoAssignLances && !scenario.ignoreForceAutoAssignment()) {
@@ -803,7 +803,8 @@ public class StratConRulesManager {
      * Picks the scenario terrain based on the scenario coordinates' biome Note that "finalizeScenario" currently wipes
      * out temperature/map info so this method must be called afterward.
      */
-    public static void setScenarioParametersFromBiome(StratConTrackState track, StratConScenario scenario) {
+    public static void setScenarioParametersFromBiome(StratConTrackState track, StratConScenario scenario,
+          boolean isNoTornadoes) {
         StratConCoords coords = scenario.getCoords();
         AtBDynamicScenario backingScenario = scenario.getBackingScenario();
         StratConBiomeManifest biomeManifest = StratConBiomeManifest.getInstance();
@@ -856,7 +857,7 @@ public class StratConRulesManager {
                 backingScenario.setMap(mapTypeList.get(randomInt(mapTypeList.size())));
             }
             backingScenario.setLightConditions();
-            backingScenario.setWeatherConditions();
+            backingScenario.setWeatherConditions(isNoTornadoes);
         }
     }
 
@@ -1152,7 +1153,9 @@ public class StratConRulesManager {
             commitPrimaryForces(campaign, revealedScenario, track);
             if (!revealedScenario.getBackingScenario().isFinalized()) {
                 finalizeScenario(revealedScenario.getBackingScenario(), contract, campaign);
-                setScenarioParametersFromBiome(track, revealedScenario);
+                setScenarioParametersFromBiome(track,
+                      revealedScenario,
+                      campaign.getCampaignOptions().isUseNoTornadoes());
             }
             return;
         }

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/RulesetsTab.java
@@ -120,6 +120,7 @@ public class RulesetsTab {
     private JCheckBox chkUseWeatherConditions;
     private JCheckBox chkUseLightConditions;
     private JCheckBox chkUsePlanetaryConditions;
+    private JCheckBox chkUseNoTornadoes;
     private JLabel lblFixedMapChance;
     private JSpinner spnFixedMapChance;
 
@@ -235,6 +236,7 @@ public class RulesetsTab {
         chkUseWeatherConditions = new JCheckBox();
         chkUseLightConditions = new JCheckBox();
         chkUsePlanetaryConditions = new JCheckBox();
+        chkUseNoTornadoes = new JCheckBox();
         lblFixedMapChance = new JLabel();
         spnFixedMapChance = new JSpinner();
 
@@ -556,6 +558,7 @@ public class RulesetsTab {
         chkUseWeatherConditions = new CampaignOptionsCheckBox("UseWeatherConditions");
         chkUseLightConditions = new CampaignOptionsCheckBox("UseLightConditions");
         chkUsePlanetaryConditions = new CampaignOptionsCheckBox("UsePlanetaryConditions");
+        chkUseNoTornadoes = new CampaignOptionsCheckBox("UseNoTornadoes");
         lblFixedMapChance = new CampaignOptionsLabel("FixedMapChance");
         spnFixedMapChance = new CampaignOptionsSpinner("FixedMapChance",
               0, 0, 100, 1);
@@ -575,6 +578,9 @@ public class RulesetsTab {
 
         layout.gridy++;
         panel.add(chkUsePlanetaryConditions, layout);
+
+        layout.gridy++;
+        panel.add(chkUseNoTornadoes, layout);
 
         layout.gridy++;
         layout.gridwidth = 1;
@@ -746,6 +752,7 @@ public class RulesetsTab {
         chkUseWeatherConditions.addMouseListener(createTipPanelUpdater(stratConHeader, "UseWeatherConditions"));
         chkUseLightConditions.addMouseListener(createTipPanelUpdater(stratConHeader, "UseLightConditions"));
         chkUsePlanetaryConditions.addMouseListener(createTipPanelUpdater(stratConHeader, "UsePlanetaryConditions"));
+        chkUseNoTornadoes.addMouseListener(createTipPanelUpdater(stratConHeader, "UseNoTornadoes"));
         lblFixedMapChance.addMouseListener(createTipPanelUpdater(stratConHeader, "FixedMapChance"));
         spnFixedMapChance.addMouseListener(createTipPanelUpdater(stratConHeader, "FixedMapChance"));
         lblScenarioModMax.addMouseListener(createTipPanelUpdater(stratConHeader, "ScenarioModMax"));
@@ -907,6 +914,7 @@ public class RulesetsTab {
         options.setUseWeatherConditions(chkUseWeatherConditions.isSelected());
         options.setUseLightConditions(chkUseLightConditions.isSelected());
         options.setUsePlanetaryConditions(chkUsePlanetaryConditions.isSelected());
+        options.setUseNoTornadoes(chkUseNoTornadoes.isSelected());
         options.setFixedMapChance((int) spnFixedMapChance.getValue());
         options.setRestrictPartsByMission(chkRestrictPartsByMission.isSelected());
         options.setMoraleVictoryEffect((int) spnMoraleVictory.getValue());
@@ -970,6 +978,7 @@ public class RulesetsTab {
         chkUseWeatherConditions.setSelected(options.isUseWeatherConditions());
         chkUseLightConditions.setSelected(options.isUseLightConditions());
         chkUsePlanetaryConditions.setSelected(options.isUsePlanetaryConditions());
+        chkUseNoTornadoes.setSelected(options.isUseNoTornadoes());
         spnFixedMapChance.setValue(options.getFixedMapChance());
         chkRestrictPartsByMission.setSelected(options.isRestrictPartsByMission());
         spnMoraleVictory.setValue(options.getMoraleVictoryEffect());

--- a/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/AtBScenarioViewPanel.java
@@ -897,7 +897,7 @@ public class AtBScenarioViewPanel extends JScrollablePanel {
             lblLightDesc.setText(scenario.getLight().toString());
         }
         if (chkReroll[REROLL_WEATHER] != null && chkReroll[REROLL_WEATHER].isSelected()) {
-            scenario.setWeatherConditions();
+            scenario.setWeatherConditions(campaign.getCampaignOptions().isUseNoTornadoes());
             scenario.useReroll();
             chkReroll[REROLL_WEATHER].setSelected(false);
             lblWeatherDesc.setText(scenario.getWeather().toString());


### PR DESCRIPTION
Close #2321

This is one of those perennial requests we see a lot. Basically the issue is that if a tornado spawns on a scenario it's instant death to whichever side has the most vehicles. This isn't a fun experience and creates 'weather gambling' - where you reroll weather against a vehicle force in the hopes of hitting a tornado.

Now, if the campaign option is enabled, F1 -> F3 become Moderate Gales, while F4 becomes Strong Gale.