### PR TITLE
Improvement: Updated Required Victory Points Calculations; Added Indicator Whether Contract Can End Early to Briefing Room

### DIFF
--- a/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
+++ b/MekHQ/resources/mekhq/resources/ContractViewPanel.properties
@@ -48,6 +48,7 @@ lblEnemyRating.text=<html><nobr><b>Enemy Experience & Equipment:</b></nobr></htm
 lblMorale.text=<html><nobr><b>Enemy Morale:</b></nobr></html>
 lblScore.text=<html><nobr><b>Victory Points:</b></nobr></html>
 lblSupportPoints.text=<html><nobr><b>Support Points:</b></nobr></html>
+lblNoEarlyEnd.text=(No Early Contract End)
 lblDistance.text=<html><nobr><b>Estimated Days (Jumps) to Location:</b></nobr></html>
 lblOverhead.text=<html><nobr><b>Overhead Compensation:</b></nobr></html>
 lblSupport.text=<html><nobr><b>StraightSupport:</b></nobr></html>

--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -896,7 +896,7 @@ public class CampaignNewDayManager {
             if (campaignState != null && !contract.getEndingDate().equals(today)) {
                 boolean isUseMaplessMode = campaignOptions.isUseStratConMaplessMode();
                 int victoryPoints = contract.getContractScore(isUseMaplessMode);
-                int requiredVictoryPoints = contract.getRequiredCombatTeams() * contract.getLength();
+                int requiredVictoryPoints = contract.getRequiredVictoryPoints();
 
                 if (campaignState.canEndContractEarly() && victoryPoints >= requiredVictoryPoints) {
                     new ImmersiveDialogNotification(campaign,

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -32,6 +32,7 @@
  */
 package mekhq.campaign.stratCon;
 
+import static java.lang.Math.ceil;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static megamek.codeUtilities.ObjectUtility.getRandomItem;
@@ -207,8 +208,9 @@ public class StratConRulesManager {
      */
     public static void generateScenariosDatesForWeek(Campaign campaign, StratConCampaignState campaignState,
           AtBContract contract, StratConTrackState track) {
-        // maps scenarios to force IDs
-        int scenarioRolls = track.getRequiredLanceCount();
+        // We divide the number of scenario rolls by the number of tracks so that we're not unintentionally
+        // multiplying Intensity by tracks
+        int scenarioRolls = (int) ceil(track.getRequiredLanceCount() / (double) campaignState.getTrackCount());
         for (int scenarioIndex = 0; scenarioIndex < scenarioRolls; scenarioIndex++) {
             int targetNum = calculateScenarioOdds(track, contract, false);
             int roll = randomInt(100);
@@ -741,23 +743,21 @@ public class StratConRulesManager {
             return;
         }
 
-        if (!isCombatChallenge) {
-            ContractCommandRights commandRights = contract.getCommandRights();
-            switch (commandRights) {
-                case INTEGRATED -> {
+        ContractCommandRights commandRights = contract.getCommandRights();
+        switch (commandRights) {
+            case INTEGRATED -> {
+                scenario.setTurningPoint(true);
+                setAttachedUnitsModifier(scenario, contract);
+            }
+            case HOUSE, LIAISON -> {
+                if (randomInt(3) == 0) {
                     scenario.setTurningPoint(true);
                     setAttachedUnitsModifier(scenario, contract);
                 }
-                case HOUSE, LIAISON -> {
-                    if (randomInt(3) == 0 || isObjective) {
-                        scenario.setTurningPoint(true);
-                        setAttachedUnitsModifier(scenario, contract);
-                    }
-                }
-                case INDEPENDENT -> {
-                    if (randomInt(3) == 0 || isObjective) {
-                        scenario.setTurningPoint(true);
-                    }
+            }
+            case INDEPENDENT -> {
+                if (randomInt(3) == 0) {
+                    scenario.setTurningPoint(true);
                 }
             }
         }

--- a/MekHQ/src/mekhq/gui/StratConTab.java
+++ b/MekHQ/src/mekhq/gui/StratConTab.java
@@ -499,7 +499,7 @@ public class StratConTab extends CampaignGuiTab {
             }
 
             sb.append(" Maintain Campaign Victory Point count above <b>")
-                  .append(contract.getRequiredCombatTeams() * contract.getLength())
+                  .append(contract.getRequiredVictoryPoints())
                   .append("</b> by completing Turning Point scenarios")
                   .append("</span><br/>");
         }

--- a/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
+++ b/MekHQ/src/mekhq/gui/view/MissionViewPanel.java
@@ -1058,18 +1058,23 @@ public class MissionViewPanel extends JScrollablePanel {
             gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
             pnlStats.add(lblScore, gridBagConstraints);
 
-        txtScore.setName("txtScore");
-        int currentScore = contract.getContractScore(campaign.getCampaignOptions().isUseStratConMaplessMode());
-        int neededScore = contract.getRequiredCombatTeams() * contract.getLength();
-        txtScore.setText(currentScore + " / " + neededScore);
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 1;
-        gridBagConstraints.gridy = y++;
-        gridBagConstraints.weightx = 0.5;
-        gridBagConstraints.insets = new Insets(0, 10, 0, 0);
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        pnlStats.add(txtScore, gridBagConstraints);
+            txtScore.setName("txtScore");
+            int currentScore = contract.getContractScore(campaign.getCampaignOptions().isUseStratConMaplessMode());
+            int neededScore = contract.getRequiredVictoryPoints();
+            String earlyContractEnd = "";
+            if (contract.getStratconCampaignState() != null &&
+                      !contract.getStratconCampaignState().canEndContractEarly()) {
+                earlyContractEnd = resourceMap.getString("lblNoEarlyEnd.text");
+            }
+            txtScore.setText(currentScore + " / " + neededScore + earlyContractEnd);
+            gridBagConstraints = new GridBagConstraints();
+            gridBagConstraints.gridx = 1;
+            gridBagConstraints.gridy = y++;
+            gridBagConstraints.weightx = 0.5;
+            gridBagConstraints.insets = new Insets(0, 10, 0, 0);
+            gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
+            gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
+            pnlStats.add(txtScore, gridBagConstraints);
 
             lblSupportPoints.setName("lblSupportPoints");
             lblSupportPoints.setText(resourceMap.getString("lblSupportPoints.text"));


### PR DESCRIPTION
Earlier in the cycle we improved victory points required for contract victory. This PR updates that based on player feedback. We now factor in the following:

- Contract duration (including whether it is Garrison-type)
- scenario chance
- Intensity
- Command Rights

I also added a small indicator to the right of Required Victory Points (in the Briefing Room) to show whether a contract can be concluded early.