### PR TITLE
Improvement: Stopped New StratCon Facilities Spawning Mid-Contract

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConScenarioFactory.java
@@ -178,6 +178,9 @@ public class StratConScenarioFactory {
             jointList.addAll(dynamicScenarioUnitTypeMap.get(generalUnitType));
         }
 
+        // We don't want facilities spawning mid-contract; this stops facility count getting out of control
+        jointList.removeIf(ScenarioTemplate::isFacilityScenario);
+
         return ObjectUtility.getRandomItem(jointList).clone();
     }
 


### PR DESCRIPTION
While it is fun for new facilities to pop-up mid contract they create an issue. The player will almost always capture them, leading to increasing allied scenario modifiers. What could have been a mid-contract boon for the OpFor instead ends up being another boost to player power.

This PR removes the possibility of new facilities appearing mid-contract.