### PR TITLE
Improvement: Updated & Optimized Scenario Placement in StratCon AO

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConContractInitializer.java
@@ -34,16 +34,17 @@ package mekhq.campaign.stratCon;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static megamek.codeUtilities.ObjectUtility.getRandomItem;
 import static mekhq.campaign.stratCon.SupportPointNegotiation.negotiateInitialSupportPoints;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import megamek.common.annotations.Nullable;
 import megamek.common.compute.Compute;
+import megamek.common.util.weightedMaps.WeightedIntMap;
 import megamek.logging.MMLogger;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.force.Force;
@@ -545,52 +546,52 @@ public class StratConContractInitializer {
     }
 
     /**
-     * Searches for a suitable, random unoccupied coordinate on the specified {@link StratConTrackState}.
+     * Searches for a suitable, random unoccupied coordinate on the specified {@link StratConTrackState}, applying
+     * optional rules regarding player facilities, player forces, and strategic weighting.
      *
-     * <p>A coordinate is considered suitable based on the absence of any existing scenario, and depending on the
-     * input parameters, may also depend on the presence or absence of facilities, player forces, or an emphasis on
-     * strategic locations.</p>
+     * <p>A coordinate is considered suitable when all the following are true:</p>
+     * <ul>
+     *     <li>There is <b>no active scenario</b> at that coordinate.</li>
+     *     <li>The coordinate does <b>not</b> contain player-assigned forces, unless {@code
+     *     allowPlayerForces} is {@code true}.</li>
+     *     <li>The coordinate either contains no facility, or contains an <b>allied facility</b> and
+     *     {@code allowPlayerFacilities} is {@code true}.</li>
+     * </ul>
      *
-     * <p>The method performs the following steps:</p>
-     * <ol>
-     *   <li>Iterates over all possible coordinates on the provided track.</li>
-     *   <li>Filters the coordinates based on the following criteria:
-     *     <ul>
-     *       <li>A scenario does not occupy the coordinate.</li>
-     *       <li>{@code allowPlayerFacilities = true}: Locations with facilities owned by the player
-     *           are suitable and factored into the result.</li>
-     *       <li>{@code allowPlayerForces = true}: Coordinates with forces assigned to them are also
-     *           included in the result.</li>
-     *       <li>{@code emphasizeStrategicTargets = true}: Strategic locations, such as those containing
-     *           facilities owned by players, are given additional weight to increase their chance
-     *           of being selected.</li>
-     *     </ul>
-     *   </li>
-     *   <li>Returns a randomly chosen coordinate from the remaining suitable locations, if any.</li>
-     * </ol>
+     * <p>Suitable coordinates are added into a weighted pool:</p>
+     * <ul>
+     *     <li>Empty coordinates (no facility, no forces) receive a default weight of {@code 1}.</li>
+     *     <li>Allowed allied facilities receive a higher weight when {@code emphasizeStrategicTargets} is
+     *     {@code true}.</li>
+     *     <li>Allowed player-force coordinates also receive the strategic weight when
+     *     {@code emphasizeStrategicTargets} is {@code true}.</li>
+     * </ul>
      *
-     * <p>If no suitable coordinates are found, the method will return {@code null}.</p>
+     * <p>The strategic emphasis weight is equal to {@code max(trackWidth, trackHeight)} when
+     * {@code emphasizeStrategicTargets} is enabled, and {@code 1} otherwise.</p>
      *
-     * @param trackState                the {@link StratConTrackState} containing the area to search
-     * @param allowPlayerFacilities     a {@code boolean} indicating whether player-owned or allied facilities should be
-     *                                  considered suitable
-     * @param allowPlayerForces         a {@code boolean} indicating whether coordinates with player-assigned forces
-     *                                  count as valid
-     * @param emphasizeStrategicTargets a {@code boolean} determining whether strategic targets (e.g., enemy-held
-     *                                  facilities) are given additional weighting
+     * <p>The method returns one randomly weighted coordinate, or {@code null} if no valid coordinates are
+     * available.</p>
      *
-     * @return a {@link StratConCoords} object representing the location of a suitable, unoccupied coordinate, or
-     *       {@code null} if no valid coordinates are available
+     * @param trackState                the {@link StratConTrackState} to search for unoccupied coordinates
+     * @param allowPlayerFacilities     whether allied (player-owned or allied-owned) facilities are considered valid
+     * @param allowPlayerForces         whether coordinates containing player-assigned forces are valid; if
+     *                                  {@code false}, such coordinates are excluded entirely
+     * @param emphasizeStrategicTargets whether to apply increased weighting to strategic locations (allowed allied
+     *                                  facilities and allowed player-force coordinates)
+     *
+     * @return a randomly weighted, valid {@link StratConCoords}, or {@code null} if none exist
      */
     public static @Nullable StratConCoords getUnoccupiedCoords(StratConTrackState trackState,
           boolean allowPlayerFacilities, boolean allowPlayerForces, boolean emphasizeStrategicTargets) {
         final int trackHeight = trackState.getHeight();
         final int trackWidth = trackState.getWidth();
 
-        int weightingMultiplier = 8;
+        int defaultWeight = 1;
+        int strategicEmphasis = emphasizeStrategicTargets ? max(trackHeight, trackWidth) : defaultWeight;
 
-        List<StratConCoords> suitableCoords = new ArrayList<>();
-
+        Collection<StratConCoords> forceCoords = trackState.getAssignedForceCoords().values();
+        WeightedIntMap<StratConCoords> weightedMap = new WeightedIntMap<>();
         for (int y = 0; y < trackHeight; y++) {
             for (int x = 0; x < trackWidth; x++) {
                 StratConCoords coords = new StratConCoords(x, y);
@@ -598,34 +599,23 @@ public class StratConContractInitializer {
                     continue;
                 }
 
-                StratConFacility facility = trackState.getFacility(coords);
-                if (facility == null) {
-                    suitableCoords.add(coords);
-                } else if (allowPlayerFacilities && facility.isOwnerAlliedToPlayer()) {
-                    if (emphasizeStrategicTargets) {
-                        for (int weight = 0; weight < weightingMultiplier; weight++) {
-                            suitableCoords.add(coords);
-                        }
-                    } else {
-                        suitableCoords.add(coords);
+                if (forceCoords.contains(coords)) {
+                    if (allowPlayerForces) {
+                        weightedMap.add(strategicEmphasis, coords);
                     }
+                    continue;
                 }
 
-                if (allowPlayerForces && trackState.getAssignedForceCoords().containsValue(coords)) {
-                    if (emphasizeStrategicTargets) {
-                        for (int weight = 0; weight < weightingMultiplier; weight++) {
-                            suitableCoords.add(coords);
-                        }
-                    }
+                StratConFacility facility = trackState.getFacility(coords);
+                if (facility == null) {
+                    weightedMap.add(defaultWeight, coords);
+                } else if (allowPlayerFacilities && facility.isOwnerAlliedToPlayer()) {
+                    weightedMap.add(strategicEmphasis, coords);
                 }
             }
         }
 
-        if (suitableCoords.isEmpty()) {
-            return null;
-        } else {
-            return getRandomItem(suitableCoords);
-        }
+        return weightedMap.randomItem();
     }
 
     /**


### PR DESCRIPTION
We have method that picks which hex a random scenario will be placed in, optionally weighted for strategic targets. However our weighting was flawed. It used a fixed weight, which meant that the likelihood a strategic target would be picked changed inversely proportional to the size of the Sector.

This PR updates the way we handle weighting by using a WeightedIntMap instead of a stacked List. It also precomputes force assignment. Both should see decent performance gains.

Finally, it changes the strategic weight from a fixed value to one derived from the board size.