### PR TITLE
Fix #8258: Fixed Double Display of Armor Stocks in Repair Bay

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -191,17 +191,19 @@ public class Armor extends Part implements IAcquisitionWork {
             if (amountAvailable == 0) {
                 toReturn.append(messageSurroundedBySpanWithColor(getNegativeColor(),
                       "None in stock"));
-            } else if (!isSalvaging() && amountAvailable < amountNeeded) {
-                toReturn.append(spanOpeningWithCustomColor(getNegativeColor()))
-                      .append("Only ")
-                      .append(amountAvailable)
-                      .append(" in stock")
-                      .append(CLOSING_SPAN_TAG);
-            } else {
-                toReturn.append(spanOpeningWithCustomColor(getPositiveColor()))
-                      .append(amountAvailable)
-                      .append(" in stock")
-                      .append(CLOSING_SPAN_TAG);
+            } else if (!isSalvaging()) {
+                if (amountAvailable < amountNeeded) {
+                    toReturn.append(spanOpeningWithCustomColor(getNegativeColor()))
+                          .append("Only ")
+                          .append(amountAvailable)
+                          .append(" in stock")
+                          .append(CLOSING_SPAN_TAG);
+                } else {
+                    toReturn.append(spanOpeningWithCustomColor(getPositiveColor()))
+                          .append(amountAvailable)
+                          .append(" in stock")
+                          .append(CLOSING_SPAN_TAG);
+                }
             }
 
             PartInventory inventories = campaign.getPartInventory(getNewPart());

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -475,7 +475,7 @@ public abstract class Part implements IPartWork, ITechnology {
                                                                                                  .getFontColorPositiveHexColor(),
                                              inStock + " in stock");
 
-            toReturn.append(inStockText).append("<br>");
+            toReturn.append("<br>").append(inStockText).append("<br>");
         } else {
             toReturn.append("<br>");
         }


### PR DESCRIPTION
Fix #8258

I also mixed a little new line in `Part`