### PR TITLE
Fix: Fixed Wording of Deployment Confirmation Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/ImmersiveDialogConfirmation.properties
+++ b/MekHQ/resources/mekhq/resources/ImmersiveDialogConfirmation.properties
@@ -42,6 +42,6 @@ ImmersiveDialogConfirmation.confirmationStratConBatchallBreach.text.primary=If y
   your batchall will be broken. The Clan OpFor will no longer bid for the duration of the contract. If you have \
   Faction Standings enabled, your standing with the Clan will be negatively affected.
 ImmersiveDialogConfirmation.confirmationStratConDeploy.text.primary=This is a point of no return. If you select \
-  'confirm,' the force will be deployed without resetting the entire scenario.
+  'confirm,' the force cannot be undeployed without resetting the entire scenario.
 ImmersiveDialogConfirmation.confirmationFactionStandingsUltimatum.text.primary=This is a point of no return. If you \
   select 'confirm,' the consequences of your decision cannot be reversed.


### PR DESCRIPTION
`the force will be deployed without resetting the entire scenario` -> `the force cannot be undeployed without resetting the entire scenario`