### PR TITLE
Fix: Fixed Potential Null Error in Scenario Resolution

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -706,7 +706,7 @@ public class ResolveScenarioTracker {
                     }
                 }
                 // try to find the crew in our pilot and mia vectors
-                Crew pilot = pilots.get(u.getCommander().getId());
+                Crew pilot = u.getCommander() == null ? null : pilots.get(u.getCommander().getId());
                 boolean missingCrew = false;
                 // For multi-crew cockpits, the crew id is the first slot, which is not
                 // necessarily the commander


### PR DESCRIPTION
During scenario resolution if a unit's crew have all been vaporized the unit will be treated as uncrewed. However, when fetching pilot we weren't checking that the pilot existed, resulting in the NPE. This PR adds a null safety.