### PR TITLE
Fix #4371, #8289: Replaced Large Vessel 'Composite Crew' Mechanics With Less Bug Prone Personnel Assignment

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -5236,6 +5236,8 @@ public class Unit implements ITechnology {
             return;
         }
 
+        engineer = null; // Unassign engineer
+
         if (getEntity() instanceof Infantry) {
             if (isUnmanned()) {
                 engineer = null;


### PR DESCRIPTION
Fix #4371
Fix #8289

The way we handle self-crewed units is a bit eccentric. Basically, we would put all relevant personnel into a blender and create a brand new person with skill and edge equal to _roughly_ the mean values over everyone in the aforementioned blender.

This was entirely managed by special handlers.

The issue is that this system was incomplete. It didn't factor in SPAs, or any of the more recent changes. And, because it was a special handler hidden inside Unit, went completely missed when the various skill changes occurred throughout this year.

This PR removes that system wholesale and replaces it with simple assignment, similar to that used for unit commanders. We go through all relevant personnel and pick the most senior, using skill as the tiebreaker.

I've tested maintenance, repairs, deployments, everything appears to work without issue or special handlers.