### PR TITLE
Fix: Stopped Babies Being Born With Doctorates... Again

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -434,6 +434,7 @@ public abstract class AbstractProcreation {
             baby.setPrimaryRole(campaign.getLocalDate(), PersonnelRole.DEPENDENT); // babies can't have jobs
             baby.setOptions(new PersonnelOptions()); // Stop babies being born with SPAs
             baby.setPreNominal(""); // Stop babies being born with doctorates
+            baby.setPostNominal(""); // Stop babies being born with post-nominal titles
 
             baby.setBloodGroup(getInheritedBloodGroup(mother.getBloodGroup(),
                   father == null ? getRandomBloodGroup() : father.getBloodGroup()));


### PR DESCRIPTION
When a baby is born they are essentially just a normal person we change into a baby. This has had hilarious consequences over the years, with every new dev cycle seeming to include some new way babies broke the system.

In this episode of 'babies break the simulation' babies who had doctorates in their past life were keeping the honorific when they were reborn. Now they don't.