### PR TITLE
Fix: Fixed Alt Advanced Medical Options Changed Dialog Incorrectly Referencing Advanced Scouting

### DIFF
--- a/MekHQ/resources/mekhq/resources/AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.properties
@@ -38,6 +38,6 @@ AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.description=<h1 style
   <p>Under AltAM (if you also have Implants enabled), ProtoMek Pilots are required to have the EI Neural Implant. \
   Would you like to gift any ProtoMek Pilots in your campaign the EI Neural Implant for free? This has no effect on \
   non-ProtoMek Pilots or in campaigns where Implants are disabled.\
-  <p>For more information on Advanced Scouting, please see the Glossary.</p>
+  <p>For more information on AAM, please see the Glossary.</p>
 AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.cancel=Decline
 AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.confirm=Accept


### PR DESCRIPTION
`Advanced Scouting` -> `AAM`