### PR TITLE
Fix #8303: Removed Ability to Use Currently Deployed Forces as Reinforcements

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -71,7 +71,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import megamek.common.TargetRollModifier;
 import megamek.common.annotations.Nullable;
@@ -2715,15 +2714,18 @@ public class StratConRulesManager {
           StratConCampaignState campaignState, boolean isCombatChallenge) {
         List<Integer> retVal = new ArrayList<>();
 
-        // assemble a set of all force IDs that are currently assigned to tracks that are not this one
-        Set<Integer> forcesInTracks = campaign.getActiveAtBContracts()
-                                            .stream()
-                                            .flatMap(contract -> contract.getStratconCampaignState()
-                                                                       .getTracks()
-                                                                       .stream())
-                                            .filter(track -> (!Objects.equals(track, currentTrack)) || !reinforcements)
-                                            .flatMap(track -> track.getAssignedForceCoords().keySet().stream())
-                                            .collect(Collectors.toSet());
+        // assemble a set of all force IDs that are currently assigned to tracks
+        Set<Integer> forcesInTracks = new HashSet<>();
+        for (AtBContract contract : campaign.getActiveAtBContracts()) {
+            StratConCampaignState state = contract.getStratconCampaignState();
+            if (state == null) {
+                continue;
+            }
+
+            for (StratConTrackState track : state.getTracks()) {
+                forcesInTracks.addAll(track.getAssignedForceCoords().keySet());
+            }
+        }
 
         // if there's an existing scenario, and we're doing reinforcements,
         // prevent forces that failed to deploy from trying to deploy again


### PR DESCRIPTION
Fix #8303

StratCon has, historically, allowed you to reinforce scenarios with already deployed forces, so long as they're in the same Sector. However, this has caused endless confusion. This PR removes that ability.