### PR TITLE
Fix #8258: Fix oversized logs from incorrect flag comparison

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/meks/MekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/meks/MekLocation.java
@@ -800,7 +800,7 @@ public class MekLocation extends Part {
             if (slot.getType() == CriticalSlot.TYPE_EQUIPMENT) {
                 if ((slot.getMount() != null) &&
                           (!slot.getMount().isDestroyed()) &&
-                          (slot.getMount().getType() instanceof EquipmentType)) {
+                          (slot.getMount().getType() instanceof MiscType)) {
                     EquipmentType equipmentType = slot.getMount().getType();
                     if (equipmentType.hasFlag(MiscType.F_NULL_SIG)) {
                         partsToSalvageOrScrap.add("Null-Signature System");

--- a/MekHQ/src/mekhq/campaign/parts/missing/MissingMekLocation.java
+++ b/MekHQ/src/mekhq/campaign/parts/missing/MissingMekLocation.java
@@ -276,7 +276,7 @@ public class MissingMekLocation extends MissingPart {
             } else if (slot.getType() == CriticalSlot.TYPE_EQUIPMENT) {
                 if ((slot.getMount() != null) &&
                           (!slot.getMount().isDestroyed()) &&
-                          (slot.getMount().getType() instanceof EquipmentType)) {
+                          (slot.getMount().getType() instanceof MiscType)) {
                     EquipmentType equipmentType = slot.getMount().getType();
                     if (equipmentType.hasFlag(MiscType.F_NULL_SIG)) {
                         partsToSalvageOrScrap.add("Null-Signature System");


### PR DESCRIPTION
When comparing flags on a `Mounted` we need to make sure we aren't comparing `MiscType` flags with `WeaponType` flags.