### PR TITLE
Fix #8317: Fixed Error When Loading Campaign With Non-StratCon Contracts While StratCon is Enabled

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -2468,6 +2468,10 @@ public class AtBContract extends Contract {
      * @since 0.50.10
      */
     public int getRequiredVictoryPoints() {
+        if (stratconCampaignState == null) {
+            return 0;
+        }
+
         double baseRequirement = getRequiredCombatTeams();
 
         int duration = getLength();


### PR DESCRIPTION
Fix #8317

Added null protection