### PR TITLE
Fix #8321: Stopped MekHQ's Contract Generation from Having a Vendetta Against Outreach, Galatea, and Northwind

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -62,8 +62,8 @@ import mekhq.campaign.universe.factionHints.FactionHints;
  *       <p>
  *       Uses Factions and Planets to weighted lists of potential employers and enemies for contract generation. Also
  *       finds a suitable planet for the action.
- *                                                                               TODO : Account for the de facto alliance of the invading Clans and the
- *                                                                               TODO : Fortress Republic in a way that doesn't involve hard-coding them here.
+ *                                                                                     TODO : Account for the de facto alliance of the invading Clans and the
+ *                                                                                     TODO : Fortress Republic in a way that doesn't involve hard-coding them here.
  */
 public class RandomFactionGenerator {
     private static final MMLogger LOGGER = MMLogger.create(RandomFactionGenerator.class);
@@ -633,8 +633,9 @@ public class RandomFactionGenerator {
 
         // Main border calculation
         Set<PlanetarySystem> planetSet = new HashSet<>(borderTracker.getBorderSystems(attacker, defender));
-        // Border systems in the case of pirates/mercenaries/ComStar with no planetary regions
-        if ((defenderIsPirate || defenderIsMerc || defenderIsComStar) && defenderHasNoPlanets) {
+        // For mercenaries, we don't care if they own planets, as generally they're a proxy force. For pirates and
+        // ComStar if they own any planets, we want to target those planets.
+        if (defenderIsMerc || ((defenderIsPirate || defenderIsComStar) && defenderHasNoPlanets)) {
             for (Faction regionalFaction : borderTracker.getFactionsInRegion()) {
                 planetSet.addAll(borderTracker.getBorderSystems(regionalFaction, attacker));
                 planetSet.addAll(borderTracker.getBorderSystems(attacker, regionalFaction));


### PR DESCRIPTION
Fix #8321

What is it with Outreach and just getting _bullied_ constantly in universe and out? Either way, MekHQ will no longer constantly issue contracts to fight people on Outreach. Yes, I'm aware there are mercenary armies there, yes I know you have a mercenary army, stop being mean and play nice with the other kids. Why can't you be more like Grayson "Death" Carlyle?