### PR TITLE
Fix #8323: Fixed Missing Button Label in Maintenance Bay Hiring Dialog

### DIFF
--- a/MekHQ/resources/mekhq/resources/FacilityRentals.properties
+++ b/MekHQ/resources/mekhq/resources/FacilityRentals.properties
@@ -55,6 +55,7 @@ ContractStartRentalDialog.inCharacter={0}, {1} is offering us access to several 
 ContractStartRentalDialog.inCharacter.bay={0}, I''ve reached out to the relevant parties. We''re looking at a surcharge\
   \ of {1} C-Bills per week if we want to go ahead with this bay rental.\
   <p>Let me know if you still want to go ahead.</p>
+ContractStartRentalDialog.button.cancel=Cancel
 ContractStartRentalDialog.button.confirm=Confirm
 ContractStartRentalDialog.outOfCharacter.bay=Better bays allow you to perform more complex refits (as per Campaign \
   Operations, not currently enforced). They also provide reduced Target Numbers for Maintenance and Repairs.\


### PR DESCRIPTION
Fix #8323

Just a missing resource bundle entry.