### PR TITLE
Fix: Stopped the Word of Blake From Declaring War on the Word of Blake

### DIFF
--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -384,6 +384,7 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
         if (isDuringJihad
                   && wordOfBlake.validIn(today)
                   && !Objects.equals("WOB", employerCode)
+                  && !Objects.equals("WOB", contract.getEnemyCode())
                   && Compute.randomInt(WOB_CO_OPT_CHANCE) == 0) {
             contract.setEmployerCode("WOB", today.getYear());
         }


### PR DESCRIPTION
The WoB co-opting system wasn't correctly filtering out contracts against the word of Blake, now it is.