### PR TITLE
Improvement: Added MASH Theater Capacities from Large Craft (inc. Space Stations)

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/medical/MASHCapacity.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/MASHCapacity.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.MiscType;
+import megamek.common.units.Entity;
 import mekhq.campaign.unit.Unit;
 
 public class MASHCapacity {
@@ -63,6 +64,18 @@ public class MASHCapacity {
                       || unit.isDamaged()
                       || !unit.isFullyCrewed()) {
                 continue;
+            }
+
+            // Certain unit types automatically include medical facilities (CamOps pg 191)
+            Entity entity = unit.getEntity();
+            if (entity != null) {
+                if (entity.isDropShip() || entity.isJumpShip()) {
+                    mashTheatreCount++;
+                } else if (entity.isWarShip()) {
+                    mashTheatreCount += 2;
+                } else if (entity.isSpaceStation()) {
+                    mashTheatreCount += 3;
+                }
             }
 
             for (MiscMounted item : unit.getEntity().getMisc()) {


### PR DESCRIPTION
CamOps pg 191 states that large craft come equipped with medical facilities (medical teams, but mostly same thing in CamOps -> MekHQ parlance). This PR adds those facilities to the MASH Theater capacity of the campaign.