### PR TITLE
Fix #8318: Fixed Reinforcements Cost & Difficulty Calculations

### DIFF
--- a/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
@@ -880,7 +880,7 @@ public class StratConScenarioWizard extends JDialog {
                 int supportPointsSpent = dialog.getSupportPoints() + 1;
                 currentCampaignState.changeSupportPoints(-(supportPointsSpent * selectedForceCount));
 
-                int supportPointModifier = dialog.getSupportPoints() * SUPPORT_POINTS_MODIFIER;
+                int supportPointModifier = (dialog.getSupportPoints() * SUPPORT_POINTS_MODIFIER) / selectedForceCount;
                 int finalTargetNumber = targetNumber.getValue() + supportPointModifier;
 
                 btnCommitClicked(finalTargetNumber, false, false);


### PR DESCRIPTION
Fix #8318

The reinforcement cost and TN modifier calculations were a bit jumbled. I cleaned them up and fixed the underlying bugs.