### PR TITLE
Fix: Stopped Preset Picker Extending Beyond Visible Screen Limits on Windows Systems With Tiny Screens

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/SelectPresetDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/SelectPresetDialog.java
@@ -97,7 +97,6 @@ public class SelectPresetDialog extends JDialog {
      */
     public SelectPresetDialog(JFrame frame, boolean includePresetSelectOption, boolean includeCustomizePresetOption) {
         super(frame, getTextAt(getCampaignOptionsResourceBundle(), "presetDialog.title"), true);
-        final int MAXIMUM_HEIGHT = 300; // Stops it expanding behind the task bar on Windows
         final int DIALOG_WIDTH = UIUtil.scaleForGUI(400);
         final int INSERT_SIZE = UIUtil.scaleForGUI(10);
         returnState = PRESET_SELECTION_CANCELLED;

--- a/MekHQ/src/mekhq/gui/campaignOptions/SelectPresetDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/SelectPresetDialog.java
@@ -39,9 +39,11 @@ import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.Toolkit;
 import javax.swing.*;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.LayoutStyle.ComponentPlacement;
@@ -95,6 +97,7 @@ public class SelectPresetDialog extends JDialog {
      */
     public SelectPresetDialog(JFrame frame, boolean includePresetSelectOption, boolean includeCustomizePresetOption) {
         super(frame, getTextAt(getCampaignOptionsResourceBundle(), "presetDialog.title"), true);
+        final int MAXIMUM_HEIGHT = 300; // Stops it expanding behind the task bar on Windows
         final int DIALOG_WIDTH = UIUtil.scaleForGUI(400);
         final int INSERT_SIZE = UIUtil.scaleForGUI(10);
         returnState = PRESET_SELECTION_CANCELLED;
@@ -206,7 +209,18 @@ public class SelectPresetDialog extends JDialog {
 
         add(buttonPanel, BorderLayout.PAGE_END);
 
+        Toolkit toolkit = Toolkit.getDefaultToolkit();
+        Dimension screen = toolkit.getScreenSize();
+        Insets insets = getToolkit().getScreenInsets(getGraphicsConfiguration());
+
+        int maxHeight = screen.height - insets.top - insets.bottom;
+
         pack();
+        Dimension size = getSize();
+        if (size.height > maxHeight) {
+            setSize(new Dimension(size.width, maxHeight));
+        }
+
         setAlwaysOnTop(true);
         setResizable(false);
         setLocationRelativeTo(null);


### PR DESCRIPTION
This fixes an issue that would only occur on windows systems with tiny screens. Basically, the picker would extend to the maximum screen height, but that would place it behind the windows taskbar, because windows doesn't tell Java that the taskbar exists by default. So Java doesn't know that it can't stick stuff behind that space. Well, now it does.