### PR TITLE
Fix #8322: Connections Usage for Contract Type Will Now Change Based on Whether Campaign Commander Has No Connections, Or Connections Are Burned

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtbMonthlyContractMarket.properties
+++ b/MekHQ/resources/mekhq/resources/AtbMonthlyContractMarket.properties
@@ -31,4 +31,6 @@
 AtbMonthlyContractMarket.connectionsReport.normal={0} used their <b>Connections</b> to find better contracts
 AtbMonthlyContractMarket.connectionsReport.none={0} was unable to use <b>Connections</b> to find better contracts as \
   they have no ranks in Connections.
+AtbMonthlyContractMarket.connectionsReport.burned={0} was unable to use <b>Connections</b> to find better contracts as \
+  they Connections are currently burned.
 AtbMonthlyContractMarket.contractSkillCheck=Influence Contract Type

--- a/MekHQ/resources/mekhq/resources/AtbMonthlyContractMarket.properties
+++ b/MekHQ/resources/mekhq/resources/AtbMonthlyContractMarket.properties
@@ -32,5 +32,5 @@ AtbMonthlyContractMarket.connectionsReport.normal={0} used their <b>Connections<
 AtbMonthlyContractMarket.connectionsReport.none={0} was unable to use <b>Connections</b> to find better contracts as \
   they have no ranks in Connections.
 AtbMonthlyContractMarket.connectionsReport.burned={0} was unable to use <b>Connections</b> to find better contracts as \
-  they Connections are currently burned.
+  their Connections are currently burned.
 AtbMonthlyContractMarket.contractSkillCheck=Influence Contract Type

--- a/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
+++ b/MekHQ/src/mekhq/campaign/market/contractMarket/AtbMonthlyContractMarket.java
@@ -132,8 +132,11 @@ public class AtbMonthlyContractMarket extends AbstractContractMarket {
                           "AtbMonthlyContractMarket.connectionsReport.normal",
                           campaignCommander.getHyperlinkedFullTitle()));
                 } else {
-                    campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE,
-                          "AtbMonthlyContractMarket.connectionsReport.none",
+                    String key = "AtbMonthlyContractMarket.connectionsReport.none";
+                    if (campaignCommander.getBurnedConnectionsEndDate() != null) {
+                        key = "AtbMonthlyContractMarket.connectionsReport.burned";
+                    }
+                    campaign.addReport(getFormattedTextAt(RESOURCE_BUNDLE, key,
                           campaignCommander.getHyperlinkedFullTitle()));
                 }
             }


### PR DESCRIPTION
Fix #8322

Just a second report type. One for no connections, one for has connections by connections are currently on cooldown.