### PR TITLE
Fix #8355, #8356: Stopped Parts in Use Table Resetting to Prior State When Ordering Parts

### DIFF
--- a/MekHQ/resources/mekhq/resources/PartsReportDialog.properties
+++ b/MekHQ/resources/mekhq/resources/PartsReportDialog.properties
@@ -31,8 +31,8 @@
 Form.title=Parts in Use
 btnClose.text=Close
 chkIgnoreMothballed.text=Ignore Parts on Mothballed Units
-chkTopUpWeekly.text=Add Part Orders to Fill Requested Stock Levels Weekly
-topUpBtn.text=Order Parts to Fill Requested Stock
-topUpGMBtn.text=Add Parts to Fill Requested Stock Levels
-resetRequestedStockBtn.text=Reset Requested Stock Levels to Default
+chkTopUpWeekly.text=Order Replacement Parts Weekly
+topUpBtn.text=Order Parts to Minimum Stock Levels
+topUpGMBtn.text=(GM) Add Parts to Minimum Stock Levels
+resetRequestedStockBtn.text=Reset Minimum Stock Levels to Default
 lblIgnoreSparesUnderQuality.text=Ignore Spare Parts Under Quality

--- a/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/PartsReportDialog.java
@@ -47,7 +47,6 @@ import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
 import javax.swing.*;
-import javax.swing.GroupLayout.Alignment;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableRowSorter;
@@ -63,6 +62,8 @@ import mekhq.campaign.parts.PartInUse;
 import mekhq.campaign.parts.enums.PartQuality;
 import mekhq.campaign.work.IAcquisitionWork;
 import mekhq.gui.CampaignGUI;
+import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
+import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
 import mekhq.gui.model.PartsInUseTableModel;
 import mekhq.gui.sorter.FormattedNumberSorter;
 import mekhq.gui.sorter.TwoNumbersSorter;
@@ -74,7 +75,7 @@ import mekhq.gui.sorter.TwoNumbersSorter;
 public class PartsReportDialog extends JDialog {
 
     private JCheckBox ignoreMothballedCheck, topUpWeeklyCheck;
-    private JButton topUpGMButton;
+    private RoundedJButton topUpGMButton;
     private JComboBox<String> ignoreSparesUnderQualityCB;
     private JTable overviewPartsInUseTable;
     private PartsInUseTableModel overviewPartsModel;
@@ -99,7 +100,8 @@ public class PartsReportDialog extends JDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
-                onClose(); // Call a custom method
+                dispose();
+                storePartInUseRequestedStockMap();
             }
         });
     }
@@ -282,41 +284,31 @@ public class PartsReportDialog extends JDialog {
 
 
         JScrollPane tableScroll = new FastJScrollPane(overviewPartsInUseTable);
+        tableScroll.setBorder(RoundedLineBorder.createRoundedLineBorder());
 
         ignoreMothballedCheck = new JCheckBox(resourceMap.getString("chkIgnoreMothballed.text"));
         ignoreMothballedCheck.addActionListener(evt -> refreshOverviewPartsInUse());
         ignoreMothballedCheck.setSelected(campaign.getIgnoreMothballed());
 
-
         topUpWeeklyCheck = new JCheckBox(resourceMap.getString("chkTopUpWeekly.text"));
         topUpWeeklyCheck.addActionListener(evt -> refreshOverviewPartsInUse());
         topUpWeeklyCheck.setSelected(campaign.getTopUpWeekly());
 
-
-        JButton topUpButton = new JButton();
+        RoundedJButton topUpButton = new RoundedJButton();
         topUpButton.setText(resourceMap.getString("topUpBtn.text"));
-        topUpButton.setIcon(null);
         topUpButton.setFocusPainted(false);
-        topUpButton.setEnabled(true);
-        topUpButton.setBorder(null);
         topUpButton.setMargin(new Insets(10, 20, 10, 20));
         topUpButton.addActionListener(evt -> topUp());
 
-        topUpGMButton = new JButton();
+        topUpGMButton = new RoundedJButton();
         topUpGMButton.setText(resourceMap.getString("topUpGMBtn.text"));
-        topUpGMButton.setIcon(null);
         topUpGMButton.setFocusPainted(false);
-        topUpGMButton.setEnabled(true);
-        topUpGMButton.setBorder(null);
         topUpGMButton.setMargin(new Insets(10, 20, 10, 20));
         topUpGMButton.addActionListener(evt -> topUpGM());
 
-        JButton resetRequestedStockButton = new JButton();
+        RoundedJButton resetRequestedStockButton = new RoundedJButton();
         resetRequestedStockButton.setText(resourceMap.getString("resetRequestedStockBtn.text"));
-        resetRequestedStockButton.setIcon(null);
         resetRequestedStockButton.setFocusPainted(false);
-        resetRequestedStockButton.setEnabled(true);
-        resetRequestedStockButton.setBorder(null);
         resetRequestedStockButton.setMargin(new Insets(10, 20, 10, 20));
         resetRequestedStockButton.addActionListener(evt -> resetRequestedStock());
 
@@ -341,45 +333,55 @@ public class PartsReportDialog extends JDialog {
         }
 
 
-        JButton btnClose = new JButton("Close");
+        RoundedJButton btnClose = new RoundedJButton("Close");
         btnClose.addActionListener(evt -> {
-            setVisible(false);
-            onClose();
+            dispose();
+            storePartInUseRequestedStockMap();
         });
 
-        layout.setHorizontalGroup(layout.createParallelGroup()
-                                        .addComponent(tableScroll)
-                                        .addGroup(layout.createSequentialGroup()
-                                                        .addGroup(layout.createSequentialGroup()
-                                                                        .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED,
-                                                                              GroupLayout.DEFAULT_SIZE,
-                                                                              Short.MAX_VALUE)
-                                                                        .addComponent(ignorePartsUnderLabel)
-                                                                        .addComponent(ignoreSparesUnderQualityCB)
-                                                                        .addComponent(ignoreMothballedCheck)
-                                                                        .addComponent(topUpWeeklyCheck)
-                                                                        .addComponent(topUpButton)
-                                                                        .addComponent(topUpGMButton)
-                                                                        .addComponent(resetRequestedStockButton)
-                                                                        .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED,
-                                                                              GroupLayout.DEFAULT_SIZE,
-                                                                              Short.MAX_VALUE)
-                                                                        .addComponent(btnClose))));
+        layout.setHorizontalGroup(
+              layout.createParallelGroup()
+                    .addComponent(tableScroll)
+                    .addGroup(layout.createSequentialGroup()
+                                    .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED,
+                                          GroupLayout.DEFAULT_SIZE,
+                                          Short.MAX_VALUE)
+                                    .addComponent(ignorePartsUnderLabel)
+                                    .addComponent(ignoreSparesUnderQualityCB)
+                                    .addComponent(ignoreMothballedCheck)
+                                    .addComponent(topUpWeeklyCheck)
+                                    .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED,
+                                          GroupLayout.DEFAULT_SIZE,
+                                          Short.MAX_VALUE))
+                    .addGroup(layout.createSequentialGroup()
+                                    .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED,
+                                          GroupLayout.DEFAULT_SIZE,
+                                          Short.MAX_VALUE)
+                                    .addComponent(topUpButton)
+                                    .addComponent(topUpGMButton)
+                                    .addComponent(resetRequestedStockButton)
+                                    .addComponent(btnClose)
+                                    .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED,
+                                          GroupLayout.DEFAULT_SIZE,
+                                          Short.MAX_VALUE))
+        );
 
-        layout.setVerticalGroup(layout.createSequentialGroup()
-                                      .addComponent(tableScroll)
-                                      .addGroup(layout.createParallelGroup(Alignment.BASELINE)
-                                                      .addComponent(ignoreMothballedCheck)
-                                                      .addComponent(ignorePartsUnderLabel)
-                                                      .addComponent(ignoreSparesUnderQualityCB)
-                                                      .addComponent(topUpWeeklyCheck)
-                                                      .addComponent(topUpButton)
-                                                      .addComponent(topUpGMButton)
-                                                      .addComponent(resetRequestedStockButton)
-                                                      .addComponent(btnClose)));
+        layout.setVerticalGroup(
+              layout.createSequentialGroup()
+                    .addComponent(tableScroll)
+                    .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                    .addComponent(ignoreMothballedCheck)
+                                    .addComponent(ignorePartsUnderLabel)
+                                    .addComponent(ignoreSparesUnderQualityCB)
+                                    .addComponent(topUpWeeklyCheck))
+                    .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                    .addComponent(topUpButton)
+                                    .addComponent(topUpGMButton)
+                                    .addComponent(resetRequestedStockButton)
+                                    .addComponent(btnClose))
+        );
 
         setPreferredSize(UIUtil.scaleForGUI(1400, 1000));
-
     }
 
 
@@ -414,8 +416,13 @@ public class PartsReportDialog extends JDialog {
     }
 
     private void updateOverviewPartsInUse() {
-        overviewPartsModel.setData(partsInUseManager.getPartsInUse(ignoreMothballedCheck.isSelected(),
-              false, getMinimumQuality((String) ignoreSparesUnderQualityCB.getSelectedItem())));
+        overviewPartsModel.setData(
+              partsInUseManager.getPartsInUse(
+                    ignoreMothballedCheck.isSelected(),
+                    false,
+                    getMinimumQuality((String) ignoreSparesUnderQualityCB.getSelectedItem())
+              )
+        );
         TableColumnModel tcm = overviewPartsInUseTable.getColumnModel();
         PartsInUseTableModel.ButtonColumn column = (PartsInUseTableModel.ButtonColumn) tcm
                                                                                              .getColumn(
@@ -442,45 +449,56 @@ public class PartsReportDialog extends JDialog {
     }
 
     private void topUp() {
+        // These are necessary to prevent request stock values from resetting when topping up
+        commitTableEdits();
+        storePartInUseRequestedStockMap();
+
         partsInUseManager.stockUpPartsInUse(getPartsInUseFromTable());
-        storePartInUseRequestedStockMap(); // This is necessary to prevent request stock values from resetting when topping up
-        refreshOverviewPartsInUse();
+        updateOverviewPartsInUse();
     }
 
     private void topUpGM() {
+        // These are necessary to prevent request stock values from resetting when topping up
+        commitTableEdits();
+        storePartInUseRequestedStockMap();
+
         partsInUseManager.stockUpPartsInUseGM(getPartsInUseFromTable());
-        storePartInUseRequestedStockMap(); // This is necessary to prevent request stock values from resetting when topping up
-        refreshOverviewPartsInUse();
+        updateOverviewPartsInUse();
     }
 
     public void storePartInUseRequestedStockMap() {
+        if (overviewPartsInUseTable.isEditing()) {
+            overviewPartsInUseTable.getCellEditor().stopCellEditing();
+        }
+
         campaign.setIgnoreMothballed(ignoreMothballedCheck.isSelected());
         campaign.setTopUpWeekly(topUpWeeklyCheck.isSelected());
         if (ignoreSparesUnderQualityCB == null) {
             campaign.setIgnoreSparesUnderQuality(getMinimumQuality(" "));
         } else {
             Object object = ignoreSparesUnderQualityCB.getSelectedItem();
-
             if (object instanceof String string) {
                 campaign.setIgnoreSparesUnderQuality(getMinimumQuality(string));
             }
         }
 
-        Map<String, Double> stockMap = new LinkedHashMap<>();
+        Map<String, Double> stockMap = campaign.getPartsInUseRequestedStockMap();
+        if (stockMap == null) {
+            stockMap = new LinkedHashMap<>();
+            campaign.setPartsInUseRequestedStockMap(stockMap);
+        } else {
+            stockMap.clear();
+        }
+
         for (int row = 0; row < overviewPartsInUseTable.getRowCount(); row++) {
             PartInUse partInUse = overviewPartsModel.getPartInUse(row);
             stockMap.put(PartsInUseManager.getStockKey(partInUse), partInUse.getRequestedStock());
         }
-        campaign.setPartsInUseRequestedStockMap(stockMap);
     }
 
     private void storePartInUseRequestedStock(PartInUse partInUse) {
         Map<String, Double> stockMap = campaign.getPartsInUseRequestedStockMap();
         stockMap.put(PartsInUseManager.getStockKey(partInUse), partInUse.getRequestedStock());
-    }
-
-    private void onClose() {
-        storePartInUseRequestedStockMap();
     }
 
     /**
@@ -489,5 +507,11 @@ public class PartsReportDialog extends JDialog {
     private void resetRequestedStock() {
         campaign.wipePartsInUseMap();
         updateOverviewPartsInUse();
+    }
+
+    private void commitTableEdits() {
+        if (overviewPartsInUseTable.isEditing()) {
+            overviewPartsInUseTable.getCellEditor().stopCellEditing();
+        }
     }
 }


### PR DESCRIPTION
Fix #8355
Fix #8356

This was a classic Swing pitfall. Basically, we were ordering replacement parts based on the value stored in the table (good), then updating the stored requested stock levels (good....), but due to Swing being Swingful that update was actually pulling in the original values not the current table values (bad). This caused the table to reset to whatever values it held when the dialog was first opened.

While I was there I also did a tiny bit of clean up, including moving the buttons onto two levels so that they wouldn't constantly get cut off.