### PR TITLE
Fix #8339: Fixed Infantry Being Unable to Perform Repair Tasks

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3608,7 +3608,7 @@ public class Campaign implements ITechManager {
         }
 
         // sort based on available minutes (highest -> lowest)
-        techs.sort(Comparator.comparingInt(person -> -person.getDailyAvailableTechTime(false)));
+        techs.sort(Comparator.comparingInt(person -> -person.getDailyAvailableTechTime(campaignOptions.isTechsUseAdministration())));
 
         // finally, sort based on rank (lowest -> highest)
         techs.sort((person1, person2) -> {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3608,7 +3608,7 @@ public class Campaign implements ITechManager {
         }
 
         // sort based on available minutes (highest -> lowest)
-        techs.sort(Comparator.comparingInt(person -> -person.getDailyAvailableTechTime(campaignOptions.isTechsUseAdministration())));
+        techs.sort(Comparator.comparingInt(person -> -person.getDailyAvailableTechTime(getCampaignOptions().isTechsUseAdministration())));
 
         // finally, sort based on rank (lowest -> highest)
         techs.sort((person1, person2) -> {

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -54,6 +54,7 @@ import java.util.UUID;
 import megamek.common.enums.SkillLevel;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.units.Dropship;
+import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.CampaignTransportType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRole;
@@ -194,6 +195,10 @@ public class CampaignTest {
         when(testCampaign.getTechs(anyBoolean())).thenCallRealMethod();
         when(testCampaign.getTechs(anyBoolean(), anyBoolean())).thenCallRealMethod();
         when(testCampaign.getTechsExpanded(anyBoolean(), anyBoolean(), anyBoolean())).thenCallRealMethod();
+
+        CampaignOptions campaignOptions = new CampaignOptions();
+        when(testCampaign.getCampaignOptions()).thenReturn(campaignOptions);
+        when(campaignOptions.isTechsUseAdministration()).thenReturn(false);
 
         // Test just getting the list of active techs.
         List<Person> expected = new ArrayList<>(3);

--- a/MekHQ/unittests/mekhq/campaign/CampaignTest.java
+++ b/MekHQ/unittests/mekhq/campaign/CampaignTest.java
@@ -196,7 +196,7 @@ public class CampaignTest {
         when(testCampaign.getTechs(anyBoolean(), anyBoolean())).thenCallRealMethod();
         when(testCampaign.getTechsExpanded(anyBoolean(), anyBoolean(), anyBoolean())).thenCallRealMethod();
 
-        CampaignOptions campaignOptions = new CampaignOptions();
+        CampaignOptions campaignOptions = mock(CampaignOptions.class);
         when(testCampaign.getCampaignOptions()).thenReturn(campaignOptions);
         when(campaignOptions.isTechsUseAdministration()).thenReturn(false);
 


### PR DESCRIPTION
Fix #8339

This fixes infantry's inability to reload their own equipment due to that requiring a skill not required by infantry units. Furthermore, I fixed the issue of non-techs (such as infantry) being fixed at 0 available minutes. This will significantly improve the user experience preventing the constant user contact along the lines of "why can't I reload"