### PR TITLE
Fix: Fixed Availability of Prosthetics Based on Planetary Tech Level

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/ProstheticType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/ProstheticType.java
@@ -912,7 +912,7 @@ public enum ProstheticType {
 
         Planet planet = currentLocation.getPlanet();
         TechRating planetTechRating = planet.getTechRating(today);
-        if (planetTechRating == null || !planetTechRating.isPlanetaryTechLevelBetterOrEqualThan(minimumTechRating)) {
+        if (planetTechRating == null || minimumTechRating.isPlanetaryTechLevelBetterThan(planetTechRating)) {
             planetTechRating = minimumTechRating;
         }
 


### PR DESCRIPTION
# Requires [Improvement: Added Two New Utility Methods to Reduce Potential Mistakes When Comparing Planetary Tech Levels](https://github.com/MegaMek/megamek/pull/7675)

The planetary tech level scale is inverted (F->A) instead of the scale used by normal parts and units (A->F). That means the existing comparisons were not suitable when comparing planetary tech levels.

This introduced a bug to Prosthetic Surgery where the less technologically advanced the planet, the more advanced the available prosthetics.

It also fixes an NPE that will occur if the campaign is planetside but that planet is abandoned.