### PR TITLE
Improvement #8359: Added Dialog to Alert of Rout End/New Opponent Arrival

### DIFF
--- a/MekHQ/resources/mekhq/resources/AtBContract.properties
+++ b/MekHQ/resources/mekhq/resources/AtBContract.properties
@@ -28,6 +28,7 @@
 # Microsoft's "Game Content Usage Rules"
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
+# suppress inspection "UnusedProperty" for the whole file
 # initiateBatchall
 incomingTransmission.title=++INCOMING TRANSMISSION++
 starColonel.text=Star Colonel
@@ -46,3 +47,11 @@ stratCon.earlyContractEnd.objectives=You have completely broken the OpFor in <b>
   any remaining objectives at their leisure. Though failed objectives will still count against you.\
   <p>The contract will end tomorrow. If the contract was successful, any outstanding payments will be rendered once \
   the contract has concluded.</p>
+# Rout Ended
+routEnded.reinforcements={0}, it looks like the lull is over.\
+  <p>We''re seeing signs of hostile movement across all sectors. {1} has rearmed and is hitting the field in numbers.\
+  \ Get ready for a tough fight.</p>
+routEnded.aNewChallenger={0}, this is an emergency broadcast!\
+  <p>We''ve detected multiple {1} DropShips on approach from the star. I don''t know why our long-range sensors \
+  didn''t pick them up sooner, but they''re on a hard burn and will make planetfall imminently. We don''t know the \
+  strength of their forces, so prepare for anything.</p>


### PR DESCRIPTION
Close #8359

Now, when a rout ends, or the OpFor faction changes, the player will be presented an alert message so they know to prepare their forces for combat.