### PR TITLE
Fix: Fixed Divide By Zero Error in Reinforcement Dialog

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/StratConReinforcementsConfirmationDialog.java
@@ -362,7 +362,7 @@ public class StratConReinforcementsConfirmationDialog {
             breakdown.append("<br><b>").append(modifier.getDesc()).append(":</b> ").append(modifier.value());
         }
 
-        int modifier = costMultiplier == 0 ? 0 : (supportPoints * SUPPORT_POINTS_MODIFIER) / costMultiplier;
+        int modifier = (supportPoints * SUPPORT_POINTS_MODIFIER) / costMultiplier;
 
         breakdown.append("<br><b>")
               .append(getTextAt(RESOURCE_BUNDLE,

--- a/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
+++ b/MekHQ/src/mekhq/gui/stratCon/StratConScenarioWizard.java
@@ -869,6 +869,10 @@ public class StratConScenarioWizard extends JDialog {
             selectedForceCount += availableForceLists.get(templateID).getSelectedValuesList().size();
         }
 
+        if (selectedForceCount == 0) {
+            return;
+        }
+
         StratConReinforcementsConfirmationDialog dialog = new StratConReinforcementsConfirmationDialog(campaign,
               targetNumber, availableSupportPoints, selectedForceCount);
         StratConReinforcementsConfirmationDialog.ReinforcementDialogResponseType responseType =


### PR DESCRIPTION
Fixed an issue where we'd run into an issue when trying to deploy to a scenario without reinforcements.