### PR TITLE
Sentry: Fixed Error When Accessing Repair Skill for Part That Has No Attached Unit

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -6301,7 +6301,7 @@ public class Person {
         final Unit unit = part.getUnit();
 
         // Infantry don't need techs to reload or swap out their ammo
-        boolean isForConventionalInfantry = unit.isConventionalInfantry();
+        boolean isForConventionalInfantry = unit != null && unit.isConventionalInfantry();
         if (isForConventionalInfantry) {
             SkillType mechanicSkillType = SkillType.getType(S_TECH_MECHANIC);
             return new Skill(S_TECH_MECHANIC, mechanicSkillType.getRegularLevel());


### PR DESCRIPTION
[Sentry Report](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8196/events/66ecf608a17c4f799261a2b0dc4c2c48/)

The null protection in this method was hidden inside another method and I forgot that parts could return null for unit. This fixes that oversight.