### PR TITLE
Fix 8373: avoid NPE if no unit selected

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -6300,11 +6300,13 @@ public class Person {
     public @Nullable Skill getSkillForWorkingOn(final IPartWork part) {
         final Unit unit = part.getUnit();
 
-        // Infantry don't need techs to reload or swap out their ammo
-        boolean isForConventionalInfantry = unit.isConventionalInfantry();
-        if (isForConventionalInfantry) {
-            SkillType mechanicSkillType = SkillType.getType(S_TECH_MECHANIC);
-            return new Skill(S_TECH_MECHANIC, mechanicSkillType.getRegularLevel());
+        if (unit != null) {
+            // Infantry don't need techs to reload or swap out their ammo
+            boolean isForConventionalInfantry = unit.isConventionalInfantry();
+            if (isForConventionalInfantry) {
+                SkillType mechanicSkillType = SkillType.getType(S_TECH_MECHANIC);
+                return new Skill(S_TECH_MECHANIC, mechanicSkillType.getRegularLevel());
+            }
         }
 
         Skill skill = getSkillForWorkingOn(unit);


### PR DESCRIPTION
Puts a null check around some recently-added code for handling infantry repairs.
If there is no unit selected, figure out the best skill from other information.

Testing:
- Ran all 3 projects' unit tests
- Confirmed fix with OP's campaign save

NOTE: it appears that tech ordering in the Tech list is not quite correct; it appears to be based on unmodified Tech/Mek skill level rather than final skill level.

Fix: #8373 