### PR TITLE
Sentry: Fixed Error When Trying to Repair Part With Tech That Lacks Skill

### DIFF
--- a/MekHQ/src/mekhq/gui/model/TaskTableModel.java
+++ b/MekHQ/src/mekhq/gui/model/TaskTableModel.java
@@ -186,18 +186,29 @@ public class TaskTableModel extends DataTableModel<IPartWork> {
 
                         if (null != tech) {
                             Skill partSkill = tech.getSkillForWorkingOn(part);
-                            String skillName = partSkill.getType().getName();
 
-                            //Find a tech in our placeholder cache
-                            tech = techCache.get(skillName);
+                            // If the tech has no applicable skill, skip dummy-tech creation and let getTargetFor()
+                            // handle the "cannot repair" case.
+                            if (partSkill != null) {
+                                String skillName = partSkill.getType().getName();
 
-                            if (null == tech) {
-                                //Create a dummy elite tech with the proper skill and 1 minute and put it in our cache for later use
-                                tech = new Person("Temp", String.format("Tech (%s)", skillName), gui.getCampaign());
-                                tech.addSkill(skillName, partSkill.getType().getEliteLevel(), 1);
-                                tech.setMinutesLeft(1);
+                                // Find a tech in our placeholder cache
+                                Person cachedTech = techCache.get(skillName);
 
-                                techCache.put(skillName, tech);
+                                if (cachedTech == null) {
+                                    // Create a dummy elite tech with the proper skill and 1 minute
+                                    // and put it in our cache for later use
+                                    cachedTech = new Person("Temp",
+                                          String.format("Tech (%s)", skillName),
+                                          gui.getCampaign());
+                                    cachedTech.addSkill(skillName,
+                                          partSkill.getType().getEliteLevel(), 1);
+                                    cachedTech.setMinutesLeft(1);
+
+                                    techCache.put(skillName, cachedTech);
+                                }
+
+                                tech = cachedTech;
                             }
                         }
                     }


### PR DESCRIPTION
[Sentry Report 1](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8202/events/85f1a2b7d1d94f438d312068a96b0274/)
[Sentry Report 2](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8201/events/6554e8bd7c1c4afba201133e56c7f21e/)
[Sentry Report 3](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8197/events/659c760224e449708f87c0da13085261/)
[Sentry Report 4](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8198/events/3cea6e5b431a48e7b1ad0dca68fd6ad4/)
[Sentry Report 5](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8199/events/4bade84a29a64825b7fa2e1cdd2e9079/)
[Sentry Report 6](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8200/events/01f9f23a3d79486b82b319a8f4bd652b/)

`getSkillForWorkingOn` can return `null`. This call didn't have any null protection, now it does. It delegates to `getTargetFor` which has extensive null handling.