### PR TITLE
PR: Refactor `Transporter.getType()` and `InfantryTransporter.getType()` to prevent conflicts in classes that implement both `IBuilding` and `Transporter`

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
@@ -81,7 +81,7 @@ public class TransportBayPart extends Part {
     @Override
     public String getName() {
         if (null != getBay()) {
-            return getBay().getType() + " Bay #" + bayNumber;
+            return getBay().getTransporterType() + " Bay #" + bayNumber;
         }
         return super.getName();
     }


### PR DESCRIPTION
**Merge after MegaMek/megamek#7678 and MegaMek/megameklab#2076**

PR: Refactor `Transporter.getType()` and `InfantryTransporter.getType()` to prevent conflicts in classes that implement both `IBuilding` and `Transporter`

While working on `BuildingEntity` there is a conflict that both the `Transporter` and `IBuilding` interfaces have a stub for `getType`. `Transporter`'s `getType` returns a `String`, while `IBuilding`'s is a `BuildingType`. 