### PR TITLE
Revert "PR: Refactor `Transporter.getType()` and `InfantryTransporter.getType()` to prevent conflicts in classes that implement both `IBuilding` and `Transporter`"

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
+++ b/MekHQ/src/mekhq/campaign/parts/TransportBayPart.java
@@ -81,7 +81,7 @@ public class TransportBayPart extends Part {
     @Override
     public String getName() {
         if (null != getBay()) {
-            return getBay().getTransporterType() + " Bay #" + bayNumber;
+            return getBay().getType() + " Bay #" + bayNumber;
         }
         return super.getName();
     }


### PR DESCRIPTION
Reverts MegaMek/mekhq#8378