### PR TITLE
Fix #8387: Fixed Incorrect Reference Key for Rout Messaging

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -458,7 +458,7 @@ public class AtBContract extends Contract {
                 moraleLevel = newMoraleLevel;
                 routEnd = null;
 
-                String key = "routEnded.normal";
+                String key = "routEnded.reinforcements";
                 if (contractType.isGarrisonDuty() || contractType.isRetainer()) {
                     updateEnemy(campaign, today); // mix it up a little
                     key = "routEnded.aNewChallenger";


### PR DESCRIPTION
Fix #8387

`routEnded.normal` -> `routEnded.reinforcements`