### PR TITLE
Fix #8386: Fixed Loading & Parsing of 'Any Tech' Acquisitions Method

### DIFF
--- a/MekHQ/resources/mekhq/resources/AcquisitionsType.properties
+++ b/MekHQ/resources/mekhq/resources/AcquisitionsType.properties
@@ -1,0 +1,35 @@
+# Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+# suppress inspection "UnusedProperty" for whole file
+AcquisitionsType.ADMINISTRATION.label=Administration
+AcquisitionsType.ANY_TECH.label=Any Tech Skill
+AcquisitionsType.AUTOMATIC.label=Automatic
+AcquisitionsType.NEGOTIATION.label=Negotiation

--- a/MekHQ/src/mekhq/campaign/campaignOptions/AcquisitionsType.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/AcquisitionsType.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.campaignOptions;
+
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
+/**
+ * Represents the different acquisition resolution methods available in MekHQ's campaign options. Acquisition type
+ * affects how procurement attempts are processed, such as whether they rely on negotiation, or the administration
+ * skill, any technical skill, or use no skill.
+ *
+ * @author Illiani
+ * @since 0.50.10
+ */
+public enum AcquisitionsType {
+    ADMINISTRATION("ADMINISTRATION"),
+    /** Acquisitions that may be handled by any technical skill or support. */
+    ANY_TECH("ANY_TECH"),
+    /** Acquisitions that succeed automatically without rolls or checks. */
+    AUTOMATIC("AUTOMATIC"),
+    NEGOTIATION("NEGOTIATION");
+
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.AcquisitionsType";
+
+    private final String lookupName;
+    private final String label;
+
+    /**
+     * Creates a new {@link AcquisitionsType} instance and initializes its localized label.
+     *
+     * @param lookupName the lookup key used to resolve the localized label
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    AcquisitionsType(String lookupName) {
+        this.lookupName = lookupName;
+        this.label = generateLabel();
+    }
+
+    public String getLookupName() {
+        return lookupName;
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+
+    /**
+     * Generates the localized label for this acquisition type by querying the resource bundle entry.
+     *
+     * @return the resolved label string
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    private String generateLabel() {
+        return getTextAt(RESOURCE_BUNDLE, "AcquisitionsType." + lookupName + ".label");
+    }
+
+    /**
+     * Attempts to resolve an {@link AcquisitionsType} from its lookup name.
+     *
+     * <p>If no matching acquisition type is found, this method defaults to returning {@link #ANY_TECH} (the default
+     * value under Campaign Operations).</p>
+     *
+     * @param lookupName the lookup key to match
+     *
+     * @return the corresponding {@link AcquisitionsType}, or {@link #ANY_TECH} if no match exists
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    public static AcquisitionsType parseFromLookupName(String lookupName) {
+        for (AcquisitionsType type : AcquisitionsType.values()) {
+            if (type.lookupName.equals(lookupName)) {
+                return type;
+            }
+        }
+        return ANY_TECH;
+    }
+}

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptions.java
@@ -95,9 +95,6 @@ public class CampaignOptions {
     public static final int TRANSIT_UNIT_WEEK = 1;
     public static final int TRANSIT_UNIT_MONTH = 2;
 
-    public static final String S_TECH = "Tech";
-    public static final String S_AUTO = "Automatic Success";
-
     public static final double MAXIMUM_COMBAT_EQUIPMENT_PERCENT = 5.0;
     public static final double MAXIMUM_DROPSHIP_EQUIPMENT_PERCENT = 1.0;
     public static final double MAXIMUM_JUMPSHIP_EQUIPMENT_PERCENT = 1.0;
@@ -167,7 +164,7 @@ public class CampaignOptions {
     // region Supplies and Acquisition Tab
     // Acquisition
     private int waitingPeriod;
-    private String acquisitionSkill;
+    private AcquisitionsType acquisitionsType;
     private boolean useFunctionalAppraisal;
     private ProcurementPersonnelPick acquisitionPersonnelCategory;
     private int clanAcquisitionPenalty;
@@ -746,7 +743,6 @@ public class CampaignOptions {
         // region Supplies and Acquisitions Tab
         // Acquisition
         waitingPeriod = 7;
-        acquisitionSkill = S_TECH;
         useFunctionalAppraisal = false;
         acquisitionPersonnelCategory = SUPPORT;
         clanAcquisitionPenalty = 0;
@@ -4476,12 +4472,12 @@ public class CampaignOptions {
         this.waitingPeriod = acquisitionSkill;
     }
 
-    public String getAcquisitionSkill() {
-        return acquisitionSkill;
+    public AcquisitionsType getAcquisitionType() {
+        return acquisitionsType;
     }
 
-    public void setAcquisitionSkill(final String acquisitionSkill) {
-        this.acquisitionSkill = acquisitionSkill;
+    public void setAcquisitionType(final AcquisitionsType acquisitionsType) {
+        this.acquisitionsType = acquisitionsType;
     }
 
     public boolean isUseFunctionalAppraisal() {

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsMarshaller.java
@@ -145,7 +145,10 @@ public class CampaignOptionsMarshaller {
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "factionIntroDate", campaignOptions.isFactionIntroDate());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "useAmmoByType", campaignOptions.isUseAmmoByType());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "waitingPeriod", campaignOptions.getWaitingPeriod());
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "acquisitionSkill", campaignOptions.getAcquisitionSkill());
+        MHQXMLUtility.writeSimpleXMLTag(pw,
+              indent,
+              "acquisitionsType",
+              campaignOptions.getAcquisitionType().getLookupName());
         MHQXMLUtility.writeSimpleXMLTag(pw,
               indent,
               "useFunctionalAppraisal",

--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsUnmarshaller.java
@@ -156,7 +156,17 @@ public class CampaignOptionsUnmarshaller {
             case "edgeCost" -> campaignOptions.setEdgeCost(parseInt(nodeContents));
             case "attributeCost" -> campaignOptions.setAttributeCost(parseInt(nodeContents));
             case "waitingPeriod" -> campaignOptions.setWaitingPeriod(parseInt(nodeContents));
-            case "acquisitionSkill" -> campaignOptions.setAcquisitionSkill(nodeContents);
+            case "acquisitionSkill" -> {
+                AcquisitionsType newType = switch (nodeContents) {
+                    case "Administration" -> AcquisitionsType.ADMINISTRATION;
+                    case "Negotiation" -> AcquisitionsType.NEGOTIATION;
+                    case "Automatic Success" -> AcquisitionsType.AUTOMATIC;
+                    default -> AcquisitionsType.ANY_TECH;
+                };
+                campaignOptions.setAcquisitionType(newType);
+            }
+            case "acquisitionsType" ->
+                  campaignOptions.setAcquisitionType(AcquisitionsType.parseFromLookupName(nodeContents));
             case "useFunctionalAppraisal" -> campaignOptions.setUseFunctionalAppraisal(parseBoolean(nodeContents));
             case "unitTransitTime" -> campaignOptions.setUnitTransitTime(parseInt(nodeContents));
             case "noDeliveriesInTransit" -> campaignOptions.setNoDeliveriesInTransit(parseBoolean(nodeContents));

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -6067,8 +6067,8 @@ public class Person {
      *                                 their available working time
      */
     public void resetMinutesLeft(boolean isTechsUseAdministration) {
-            this.minutesLeft = PRIMARY_ROLE_SUPPORT_TIME;
-            this.overtimeLeft = PRIMARY_ROLE_OVERTIME_SUPPORT_TIME;
+        this.minutesLeft = PRIMARY_ROLE_SUPPORT_TIME;
+        this.overtimeLeft = PRIMARY_ROLE_OVERTIME_SUPPORT_TIME;
 
         // Techs get support time adjusted by skill and administration multipliers
         if (isTechExpanded() && isTechsUseAdministration) {
@@ -6427,9 +6427,7 @@ public class Person {
     }
 
     public @Nullable Skill getSkillForWorkingOn(final @Nullable String skillName) {
-        if (CampaignOptions.S_TECH.equals(skillName)) {
-            return getBestTechSkill();
-        } else if (hasSkill(skillName)) {
+        if (hasSkill(skillName)) {
             return getSkill(skillName);
         } else {
             return null;

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -99,6 +99,7 @@ import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CampaignController;
+import mekhq.campaign.campaignOptions.AcquisitionsType;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.events.AsTechPoolChangedEvent;
 import mekhq.campaign.events.DayEndingEvent;
@@ -2779,7 +2780,7 @@ public class CampaignGUI extends JPanel {
 
     private void refreshPartsAvailability() {
         if (!getCampaign().getCampaignOptions().isUseAtB() ||
-                  CampaignOptions.S_AUTO.equals(getCampaign().getCampaignOptions().getAcquisitionSkill())) {
+                  getCampaign().getCampaignOptions().getAcquisitionType() == AcquisitionsType.ANY_TECH) {
             lblPartsAvailabilityRating.setText("");
         } else {
             int partsAvailability = getCampaign().findAtBPartsAvailabilityLevel();

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/EquipmentAndSuppliesTab.java
@@ -51,9 +51,9 @@ import javax.swing.SwingConstants;
 import megamek.client.ui.comboBoxes.MMComboBox;
 import megamek.client.ui.util.UIUtil;
 import megamek.common.annotations.Nullable;
+import mekhq.campaign.campaignOptions.AcquisitionsType;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.enums.PlanetaryAcquisitionFactionLimit;
-import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.campaign.universe.PlanetarySystem.PlanetaryRating;
 import mekhq.campaign.universe.PlanetarySystem.PlanetarySophistication;
 import mekhq.gui.campaignOptions.components.CampaignOptionsCheckBox;
@@ -87,7 +87,7 @@ public class EquipmentAndSuppliesTab {
     private CampaignOptionsHeaderPanel acquisitionHeader;
     private JPanel pnlAcquisitions;
     private JLabel lblChoiceAcquireSkill;
-    private MMComboBox<String> choiceAcquireSkill;
+    private MMComboBox<AcquisitionsType> choiceAcquireSkill;
     private JCheckBox chkUseFunctionalAppraisal;
     private JLabel lblAcquireClanPenalty;
     private JLabel lblProcurementPersonnelPick;
@@ -264,7 +264,7 @@ public class EquipmentAndSuppliesTab {
     private void initializeAcquisitionTab() {
         pnlAcquisitions = new JPanel();
         lblChoiceAcquireSkill = new JLabel();
-        choiceAcquireSkill = new MMComboBox<>("choiceAcquireSkill", buildAcquireSkillComboOptions());
+        choiceAcquireSkill = new MMComboBox<>("choiceAcquireSkill", AcquisitionsType.values());
 
         chkUseFunctionalAppraisal = new JCheckBox();
 
@@ -959,23 +959,6 @@ public class EquipmentAndSuppliesTab {
     }
 
     /**
-     * Builds a DefaultComboBoxModel containing a predefined set of skill options that can be acquired. The options
-     * include technical, administrative, negotiation, and auto skills.
-     *
-     * @return a DefaultComboBoxModel containing the skill options as string elements.
-     */
-    private static DefaultComboBoxModel<String> buildAcquireSkillComboOptions() {
-        DefaultComboBoxModel<String> acquireSkillModel = new DefaultComboBoxModel<>();
-
-        acquireSkillModel.addElement(CampaignOptions.S_TECH);
-        acquireSkillModel.addElement(SkillType.S_ADMIN);
-        acquireSkillModel.addElement(SkillType.S_NEGOTIATION);
-        acquireSkillModel.addElement(CampaignOptions.S_AUTO);
-
-        return acquireSkillModel;
-    }
-
-    /**
      * Builds a {@link DefaultComboBoxModel} containing options for all available {@link ProcurementPersonnelPick}
      * values.
      *
@@ -1122,7 +1105,7 @@ public class EquipmentAndSuppliesTab {
         }
 
         // Acquisitions
-        options.setAcquisitionSkill(choiceAcquireSkill.getSelectedItem());
+        options.setAcquisitionType(choiceAcquireSkill.getSelectedItem());
         options.setUseFunctionalAppraisal(chkUseFunctionalAppraisal.isSelected());
         options.setAcquisitionPersonnelCategory(ProcurementPersonnelPick.values()[cboProcurementPersonnelPick.getSelectedIndex()]);
         options.setClanAcquisitionPenalty((int) spnAcquireClanPenalty.getValue());
@@ -1205,7 +1188,7 @@ public class EquipmentAndSuppliesTab {
         }
 
         // Acquisitions
-        choiceAcquireSkill.setSelectedItem(options.getAcquisitionSkill());
+        choiceAcquireSkill.setSelectedItem(options.getAcquisitionType());
         chkUseFunctionalAppraisal.setSelected(options.isUseFunctionalAppraisal());
         cboProcurementPersonnelPick.setSelectedItem(options.getAcquisitionPersonnelCategory().toString());
         spnAcquireClanPenalty.setValue(options.getClanAcquisitionPenalty());


### PR DESCRIPTION
Fix #8386

One of the options for acquisitions resolution is 'any tech'. We were trying to parse that option as if it were a skill called 'Any Tech'. Obviously, that didn't work and how this passed testing I will never know - because I specifically tested the CamOps stock preset which _uses_ this option


Regardless, this PR fixes the initial issue while also changing how we handle this option to use an enum instead of hardcoded Strings. This will prevent this issue reoccurring. Compatibility handler is included.