### PR TITLE
Fix #8389, #8390: Rewrote Campaign Upgrade Process to (Hopefully) Fix Stalling

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignUpgradeDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignUpgradeDialog.properties
@@ -28,9 +28,7 @@
 # Microsoft's "Game Content Usage Rules"
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
-CampaignUpgradeDialog.upgrading=<html><h2 style="text-align:center;">Upgrading Campaign to <b>{0}</b>.\
-  <br>\
-  <br>Please wait.</h2></html>
+CampaignUpgradeDialog.upgrading=<html><h1 style="text-align:center">Campaign Upgraded to {0}</h1></html>
 CampaignUpgradeDialog.button.cancel=Cancel
 CampaignUpgradeDialog.button.confirm=Confirm
 CampaignUpgradeDialog.button.manual=Manual


### PR DESCRIPTION
Fix #8389
Fix #8390

While investigating the upgrade stalling issue I realized that I was completely overthinking the process. This PR drastically simplifies everything and hopefully means that the stalling issue will be a thing of the past.

As a bonus it basically makes upgrading instant.