### PR TITLE
Fix: Fixed Trueborn Phenotypes Incorrectly Showing as Freeborn

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
@@ -96,9 +96,6 @@ public enum Phenotype {
 
     Phenotype(final boolean isTrueborn, final boolean external, final int strength, final int body, final int reflexes,
           final int dexterity, final Attributes attributeCaps, final List<String> bonusTraits) {
-        this.shortName = generateShortName();
-        this.label = generateLabel();
-        this.tooltip = generateTooltip();
         this.isTrueborn = isTrueborn;
         this.external = external;
         this.strength = strength;
@@ -107,6 +104,9 @@ public enum Phenotype {
         this.dexterity = dexterity;
         this.attributeCaps = attributeCaps;
         this.bonusTraits = bonusTraits;
+        this.shortName = generateShortName();
+        this.label = generateLabel();
+        this.tooltip = generateTooltip();
     }
     // endregion Constructors
 


### PR DESCRIPTION
This fixes an order of operations issue that was causing phenotypes to always display as Freeborn.

This is a visual bug only.