### PR TITLE
Improvement: Updated Injury Effects to Affect Attribute Score and Not Directly Affect Skills

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1510,7 +1510,7 @@ atowTab.border="It is only those who have neither fired a shot nor heard the shr
   <br><i>General William Sherman\
   <br>Address at the Michigan Military Academy, June 19th 1879</i>
 lblATOWAttributesPanel.text=Traits and Attributes
-lblUseAttributes.text=Use Attributes \u26A0
+lblUseAttributes.text=New Characters Have Random Starting Attributes \u26A0
 lblUseAttributes.tooltip=If checked, characters will be generated with <i>A Time of War</i> Attribute scores.\
   <br>\
   <br><b>Warning:</b> If enabled (or disabled) mid-campaign, you need to navigate to the personnel tab, and (while in\

--- a/MekHQ/resources/mekhq/resources/InjuryEffect.properties
+++ b/MekHQ/resources/mekhq/resources/InjuryEffect.properties
@@ -38,7 +38,7 @@ InjuryEffect.tooltip.survival={0} to Survival skill checks.
 InjuryEffect.tooltip.interrogation={0} to Interrogation skill checks.
 InjuryEffect.tooltip.acting={0} to Acting skill checks.
 InjuryEffect.tooltip.toughness={0} Toughness.
-InjuryEffect.tooltip.attribute={0} to {1}-based skill checks.
+InjuryEffect.tooltip.attribute={0} to {1}.
 InjuryEffect.tooltip.inflictsHit=During scenario resolution, applies the Blood Loss injury x{0}.
 # Fractures
 InjuryEffect.COMPOUND_FRACTURE.name=Compound Fracture

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -36,7 +36,6 @@ package mekhq.campaign.personnel;
 import static java.lang.Math.abs;
 import static java.lang.Math.floor;
 import static java.lang.Math.max;
-import static java.lang.Math.min;
 import static java.lang.Math.round;
 import static megamek.codeUtilities.MathUtility.clamp;
 import static megamek.codeUtilities.StringUtility.isNullOrBlank;
@@ -59,9 +58,7 @@ import static mekhq.campaign.personnel.medical.BodyLocation.GENERIC;
 import static mekhq.campaign.personnel.medical.BodyLocation.INTERNAL;
 import static mekhq.campaign.personnel.medical.advancedMedicalAlternate.AdvancedMedicalAlternate.getAllActiveInjuryEffects;
 import static mekhq.campaign.personnel.skills.Aging.getReputationAgeModifier;
-import static mekhq.campaign.personnel.skills.Attributes.DEFAULT_ATTRIBUTE_SCORE;
 import static mekhq.campaign.personnel.skills.Attributes.MAXIMUM_ATTRIBUTE_SCORE;
-import static mekhq.campaign.personnel.skills.Attributes.MINIMUM_ATTRIBUTE_SCORE;
 import static mekhq.campaign.personnel.skills.InfantryGunnerySkills.INFANTRY_GUNNERY_SKILLS;
 import static mekhq.campaign.personnel.skills.SkillType.*;
 import static mekhq.campaign.randomEvents.personalities.PersonalityController.generateReasoning;
@@ -6067,8 +6064,8 @@ public class Person {
      *                                 their available working time
      */
     public void resetMinutesLeft(boolean isTechsUseAdministration) {
-            this.minutesLeft = PRIMARY_ROLE_SUPPORT_TIME;
-            this.overtimeLeft = PRIMARY_ROLE_OVERTIME_SUPPORT_TIME;
+        this.minutesLeft = PRIMARY_ROLE_SUPPORT_TIME;
+        this.overtimeLeft = PRIMARY_ROLE_OVERTIME_SUPPORT_TIME;
 
         // Techs get support time adjusted by skill and administration multipliers
         if (isTechExpanded() && isTechsUseAdministration) {
@@ -6870,49 +6867,8 @@ public class Person {
      * @since 0.50.5
      */
     public int getAttributeScore(final SkillAttribute attribute) {
-        if (attribute == null || attribute.isNone()) {
-            LOGGER.error("(getAttributeScore) SkillAttribute is null or NONE.");
-            return DEFAULT_ATTRIBUTE_SCORE;
-        }
-
-        boolean hasFreakishStrength = options.booleanOption(MUTATION_FREAKISH_STRENGTH);
-        boolean hasExoticAppearance = options.booleanOption(MUTATION_EXOTIC_APPEARANCE);
-        boolean hasFacialHair = options.booleanOption(MUTATION_FACIAL_HAIR);
-        boolean hasSeriousDisfigurement = options.booleanOption(MUTATION_SERIOUS_DISFIGUREMENT);
-        boolean isCatGirl = options.booleanOption(MUTATION_CAT_GIRL);
-        boolean isCatGirlUnofficial = options.booleanOption(MUTATION_CAT_GIRL_UNOFFICIAL);
-
-        return switch (attribute) {
-            case NONE -> 0;
-            case STRENGTH -> {
-                int attributeScore = atowAttributes.getAttributeScore(attribute);
-                if (hasFreakishStrength) {
-                    attributeScore += 2;
-                }
-                yield min(attributeScore, MAXIMUM_ATTRIBUTE_SCORE);
-            }
-            case BODY, REFLEXES, DEXTERITY, INTELLIGENCE, WILLPOWER, EDGE ->
-                  atowAttributes.getAttributeScore(attribute);
-            case CHARISMA -> {
-                int attributeScore = atowAttributes.getAttributeScore(attribute);
-                if (hasExoticAppearance) {
-                    attributeScore++;
-                }
-                if (hasFacialHair) {
-                    attributeScore--;
-                }
-                if (hasSeriousDisfigurement) {
-                    attributeScore -= 3;
-                }
-                if (isCatGirl) {
-                    attributeScore -= 3;
-                }
-                if (isCatGirlUnofficial) {
-                    attributeScore++;
-                }
-                yield clamp(attributeScore, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-            }
-        };
+        int maximum = getAttributeCap(attribute);
+        return atowAttributes.getAdjustedAttributeScore(attribute, getActiveInjuryEffects(), options);
     }
 
     /**
@@ -6980,7 +6936,7 @@ public class Person {
             return;
         }
 
-        int current = atowAttributes.getAttributeScore(attribute);
+        int current = atowAttributes.getBaseAttributeScore(attribute);
         int newScore = current + delta;
 
         setAttributeScore(attribute, newScore);
@@ -7080,6 +7036,11 @@ public class Person {
 
     public List<Injury> getInjuries() {
         return new ArrayList<>(injuries);
+    }
+
+    public List<InjuryEffect> getActiveInjuryEffects() {
+        boolean isAmbidextrous = options.booleanOption(ATOW_AMBIDEXTROUS);
+        return AdvancedMedicalAlternate.getAllActiveInjuryEffects(isAmbidextrous, injuries);
     }
 
     public int getTotalInjurySeverity() {

--- a/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
+++ b/MekHQ/src/mekhq/campaign/personnel/enums/Phenotype.java
@@ -135,7 +135,7 @@ public enum Phenotype {
      * @since 0.50.05
      */
     public int getAttributeCap(SkillAttribute attribute) {
-        return attributeCaps.getAttributeScore(attribute);
+        return attributeCaps.getBaseAttributeScore(attribute);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/InjuryEffect.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/InjuryEffect.java
@@ -1787,7 +1787,7 @@ public enum InjuryEffect {
             int modifier = attributeTotals.getOrDefault(attribute, 0);
             if (modifier != 0) {
                 tooltipPortion.add(getFormattedTextAt(RESOURCE_BUNDLE,
-                      "InjuryEffect.tooltip.attribute", modifier, attribute));
+                      "InjuryEffect.tooltip.attribute", modifier, attribute.getLabel()));
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/ProstheticType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/ProstheticType.java
@@ -1129,7 +1129,7 @@ public enum ProstheticType {
             int modifier = attributeTotals.getOrDefault(attribute, 0);
             if (modifier != 0) {
                 tooltipPortion.add(getFormattedTextAt(RESOURCE_BUNDLE,
-                      "ProstheticType.tooltip.attribute", modifier, attribute));
+                      "ProstheticType.tooltip.attribute", modifier, attribute.getLabel()));
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
@@ -76,12 +76,12 @@ public class AttributeCheckUtility {
     /**
      * The target number for an attribute check with one attribute.
      */
-    protected static final int TARGET_NUMBER_ONE_LINKED_ATTRIBUTE = 12; // ATOW pg 43
+    protected static final int TARGET_NUMBER_ONE_LINKED_ATTRIBUTE = 12; // ATOW pg 39-41
 
     /**
      * The target number for an attribute check with two attributes.
      */
-    protected static final int TARGET_NUMBER_TWO_LINKED_ATTRIBUTES = 18; // ATOW pg 43
+    protected static final int TARGET_NUMBER_TWO_LINKED_ATTRIBUTES = 18; // ATOW pg 39-41
 
     private final String reason;
     private final Person person;
@@ -454,13 +454,14 @@ public class AttributeCheckUtility {
     private static void getAttributeModifiers(SkillAttribute firstSkillAttribute, SkillAttribute secondSkillAttribute,
           Attributes characterAttributes, TargetRoll targetNumber, List<InjuryEffect> injuryEffects,
           PersonnelOptions options) {
-        int firstAttributeModifier = -characterAttributes.getAttributeModifier(firstSkillAttribute, injuryEffects,
+        // Because we're adjusting the target number, positive is bad, negative is good
+        int firstAttributeModifier = -characterAttributes.getAdjustedAttributeScore(firstSkillAttribute, injuryEffects,
               options);
         targetNumber.addModifier(firstAttributeModifier, firstSkillAttribute.getLabel());
 
         if (secondSkillAttribute != null) {
-            int secondAttributeModifier = -characterAttributes.getAttributeModifier(secondSkillAttribute, injuryEffects,
-                  options);
+            int secondAttributeModifier = -characterAttributes.getAdjustedAttributeScore(secondSkillAttribute,
+                  injuryEffects, options);
             targetNumber.addModifier(secondAttributeModifier, secondSkillAttribute.getLabel());
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/AttributeCheckUtility.java
@@ -51,6 +51,8 @@ import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.events.persons.PersonChangedEvent;
 import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.PersonnelOptions;
+import mekhq.campaign.personnel.medical.advancedMedicalAlternate.InjuryEffect;
 import mekhq.campaign.personnel.skills.enums.MarginOfSuccess;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 import mekhq.utilities.ReportingUtilities;
@@ -429,7 +431,8 @@ public class AttributeCheckUtility {
         TargetRoll targetNumber = new TargetRoll();
 
         getBaseTargetNumber(targetNumber, secondSkillAttribute != null);
-        getAttributeModifiers(firstSkillAttribute, secondSkillAttribute, characterAttributes, targetNumber);
+        getAttributeModifiers(firstSkillAttribute, secondSkillAttribute, characterAttributes, targetNumber,
+              person.getActiveInjuryEffects(), person.getOptions());
 
         targetNumber.addModifier(miscModifier, getFormattedTextAt(RESOURCE_BUNDLE, "AttributeCheck.miscModifier"));
 
@@ -449,12 +452,15 @@ public class AttributeCheckUtility {
      * @since 0.50.07
      */
     private static void getAttributeModifiers(SkillAttribute firstSkillAttribute, SkillAttribute secondSkillAttribute,
-          Attributes characterAttributes, TargetRoll targetNumber) {
-        int firstAttributeModifier = -characterAttributes.getAttributeScore(firstSkillAttribute);
+          Attributes characterAttributes, TargetRoll targetNumber, List<InjuryEffect> injuryEffects,
+          PersonnelOptions options) {
+        int firstAttributeModifier = -characterAttributes.getAttributeModifier(firstSkillAttribute, injuryEffects,
+              options);
         targetNumber.addModifier(firstAttributeModifier, firstSkillAttribute.getLabel());
 
         if (secondSkillAttribute != null) {
-            int secondAttributeModifier = -characterAttributes.getAttributeScore(secondSkillAttribute);
+            int secondAttributeModifier = -characterAttributes.getAttributeModifier(secondSkillAttribute, injuryEffects,
+                  options);
             targetNumber.addModifier(secondAttributeModifier, secondSkillAttribute.getLabel());
         }
     }

--- a/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/skills/Attributes.java
@@ -33,23 +33,18 @@
 package mekhq.campaign.personnel.skills;
 
 import static megamek.codeUtilities.MathUtility.clamp;
-import static mekhq.campaign.personnel.PersonnelOptions.EXCEPTIONAL_ATTRIBUTE_BODY;
-import static mekhq.campaign.personnel.PersonnelOptions.EXCEPTIONAL_ATTRIBUTE_CHARISMA;
-import static mekhq.campaign.personnel.PersonnelOptions.EXCEPTIONAL_ATTRIBUTE_DEXTERITY;
-import static mekhq.campaign.personnel.PersonnelOptions.EXCEPTIONAL_ATTRIBUTE_EDGE;
-import static mekhq.campaign.personnel.PersonnelOptions.EXCEPTIONAL_ATTRIBUTE_INTELLIGENCE;
-import static mekhq.campaign.personnel.PersonnelOptions.EXCEPTIONAL_ATTRIBUTE_REFLEXES;
-import static mekhq.campaign.personnel.PersonnelOptions.EXCEPTIONAL_ATTRIBUTE_STRENGTH;
-import static mekhq.campaign.personnel.PersonnelOptions.EXCEPTIONAL_ATTRIBUTE_WILLPOWER;
-import static mekhq.campaign.personnel.PersonnelOptions.MUTATION_FREAKISH_STRENGTH;
+import static mekhq.campaign.personnel.PersonnelOptions.*;
 import static mekhq.campaign.personnel.skills.Skill.getIndividualAttributeModifier;
+import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 
 import java.io.PrintWriter;
+import java.util.List;
 
 import megamek.codeUtilities.MathUtility;
 import megamek.logging.MMLogger;
 import mekhq.campaign.personnel.PersonnelOptions;
 import mekhq.campaign.personnel.enums.Phenotype;
+import mekhq.campaign.personnel.medical.advancedMedicalAlternate.InjuryEffect;
 import mekhq.campaign.personnel.skills.enums.SkillAttribute;
 import mekhq.utilities.MHQXMLUtility;
 import org.w3c.dom.Node;
@@ -78,6 +73,7 @@ import org.w3c.dom.NodeList;
  * @since 0.50.5
  */
 public class Attributes {
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.Skill";
     private static final MMLogger LOGGER = MMLogger.create(Attributes.class);
 
     private int strength;
@@ -238,9 +234,60 @@ public class Attributes {
      * @author Illiani
      * @since 0.50.06
      */
-    public int getAttributeModifier(SkillAttribute attribute) {
-        int attributeScore = getAttribute(attribute);
+    public int getAttributeModifier(SkillAttribute attribute, List<InjuryEffect> injuryEffects,
+          PersonnelOptions options) {
+        int attributeScore = getAdjustedAttributeScore(attribute, injuryEffects, options);
         return getIndividualAttributeModifier(attributeScore);
+    }
+
+    public int getAdjustedAttributeScore(SkillAttribute attribute, List<InjuryEffect> injuryEffects,
+          PersonnelOptions options) {
+        int attributeScore = getAttribute(attribute);
+        int injuryModifier = getAttributeScoreInjuryModifier(attribute, injuryEffects);
+        int abilityModifier = getAbilityAdjustment(attribute, options);
+
+        int total = attributeScore + injuryModifier + abilityModifier;
+        return clamp(total, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
+    }
+
+    public int getAbilityAdjustment(SkillAttribute attribute, PersonnelOptions options) {
+        boolean hasFreakishStrength = options.booleanOption(MUTATION_FREAKISH_STRENGTH);
+        boolean hasExoticAppearance = options.booleanOption(MUTATION_EXOTIC_APPEARANCE);
+        boolean hasFacialHair = options.booleanOption(MUTATION_FACIAL_HAIR);
+        boolean hasSeriousDisfigurement = options.booleanOption(MUTATION_SERIOUS_DISFIGUREMENT);
+        boolean isCatGirl = options.booleanOption(MUTATION_CAT_GIRL);
+        boolean isCatGirlUnofficial = options.booleanOption(MUTATION_CAT_GIRL_UNOFFICIAL);
+
+        int attributeScore = 0;
+        return switch (attribute) {
+            case NONE, BODY, REFLEXES, DEXTERITY, INTELLIGENCE, WILLPOWER, EDGE -> 0;
+            case STRENGTH -> {
+                if (hasFreakishStrength) {
+                    attributeScore += 2;
+                }
+
+                yield attributeScore;
+            }
+            case CHARISMA -> {
+                if (hasExoticAppearance) {
+                    attributeScore++;
+                }
+                if (hasFacialHair) {
+                    attributeScore--;
+                }
+                if (hasSeriousDisfigurement) {
+                    attributeScore -= 3;
+                }
+                if (isCatGirl) {
+                    attributeScore -= 3;
+                }
+                if (isCatGirlUnofficial) {
+                    attributeScore++;
+                }
+
+                yield attributeScore;
+            }
+        };
     }
 
     /**
@@ -257,7 +304,7 @@ public class Attributes {
      * @author Illiani
      * @since 0.50.05
      */
-    public int getAttributeScore(SkillAttribute attribute) {
+    public int getBaseAttributeScore(SkillAttribute attribute) {
         if (attribute == null || attribute.isNone()) {
             LOGGER.warn("(getAttributeScore) attribute is null or NONE.");
             return DEFAULT_ATTRIBUTE_SCORE;
@@ -277,6 +324,47 @@ public class Attributes {
                 yield DEFAULT_ATTRIBUTE_SCORE;
             }
         };
+    }
+
+    /**
+     * Calculates the cumulative attribute score modifier from a list of injury effects for a given
+     * {@link SkillAttribute}.
+     *
+     * <p>The method iterates through all provided {@link InjuryEffect InjuryEffects} and sums the relevant modifier
+     * based on the requested {@code attribute}. Each injury effect contributes only to the attribute it is associated
+     * with. While {@link SkillAttribute#EDGE} is unaffected by injuries and thus contributes {@code 0}.</p>
+     *
+     * <p>If an unsupported or unexpected attribute is supplied, an error is logged and {@code 0} is used for that
+     * effect.</p>
+     *
+     * @param attribute     the attribute for which the modifier is being calculated
+     * @param injuryEffects the list of injury effects to evaluate; may be empty but must not be {@code null}
+     *
+     * @return the sum of all modifiers relevant to the specified attribute
+     *
+     * @author Illiani
+     * @since 0.50.10
+     */
+    public int getAttributeScoreInjuryModifier(SkillAttribute attribute, List<InjuryEffect> injuryEffects) {
+        int totalModifier = 0;
+        for (InjuryEffect effect : injuryEffects) {
+            totalModifier += switch (attribute) {
+                case STRENGTH -> effect.getStrengthModifier();
+                case BODY -> effect.getBodyModifier();
+                case REFLEXES -> effect.getReflexesModifier();
+                case DEXTERITY -> effect.getDexterityModifier();
+                case INTELLIGENCE -> effect.getIntelligenceModifier();
+                case WILLPOWER -> effect.getWillpowerModifier();
+                case CHARISMA -> effect.getCharismaModifier();
+                case EDGE -> 0; // There are no Edge modifying injury effects
+                default -> {
+                    LOGGER.error("(getAttributeScoreModifier) Invalid attribute requested: {}", attribute);
+                    yield 0;
+                }
+            };
+        }
+
+        return totalModifier;
     }
 
     /**
@@ -386,118 +474,6 @@ public class Attributes {
         return cap;
     }
 
-    /**
-     * @deprecated use {@link #getAttributeScore(SkillAttribute)}  instead
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public int getStrength() {
-        return strength;
-    }
-
-    /**
-     * @deprecated use {@link #setAttributeScore(Phenotype, PersonnelOptions, SkillAttribute, int)} instead.
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public void setStrength(int strength) {
-        this.strength = clamp(strength, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-    /**
-     * @deprecated use {@link #getAttributeScore(SkillAttribute)}  instead
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public int getBody() {
-        return body;
-    }
-
-    /**
-     * @deprecated use {@link #setAttributeScore(Phenotype, PersonnelOptions, SkillAttribute, int)} instead.
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public void setBody(int body) {
-        this.body = clamp(body, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-    /**
-     * @deprecated use {@link #getAttributeScore(SkillAttribute)}  instead
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public int getReflexes() {
-        return reflexes;
-    }
-
-    /**
-     * @deprecated use {@link #setAttributeScore(Phenotype, PersonnelOptions, SkillAttribute, int)} instead.
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public void setReflexes(int reflexes) {
-        this.reflexes = clamp(reflexes, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-    /**
-     * @deprecated use {@link #getAttributeScore(SkillAttribute)}  instead
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public int getDexterity() {
-        return dexterity;
-    }
-
-    /**
-     * @deprecated use {@link #setAttributeScore(Phenotype, PersonnelOptions, SkillAttribute, int)} instead.
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public void setDexterity(int dexterity) {
-        this.dexterity = clamp(dexterity, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-    /**
-     * @deprecated use {@link #getAttributeScore(SkillAttribute)}  instead
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public int getIntelligence() {
-        return intelligence;
-    }
-
-    /**
-     * @deprecated use {@link #setAttributeScore(Phenotype, PersonnelOptions, SkillAttribute, int)} instead.
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public void setIntelligence(int intelligence) {
-        this.intelligence = clamp(intelligence, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-    /**
-     * @deprecated use {@link #getAttributeScore(SkillAttribute)}  instead
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public int getWillpower() {
-        return willpower;
-    }
-
-    /**
-     * @deprecated use {@link #setAttributeScore(Phenotype, PersonnelOptions, SkillAttribute, int)} instead.
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public void setWillpower(int willpower) {
-        this.willpower = clamp(willpower, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-    /**
-     * @deprecated use {@link #getAttributeScore(SkillAttribute)}  instead
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public int getCharisma() {
-        return charisma;
-    }
-
-    /**
-     * @deprecated use {@link #setAttributeScore(Phenotype, PersonnelOptions, SkillAttribute, int)} instead.
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public void setCharisma(int charisma) {
-        this.charisma = clamp(charisma, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
     // Utility Methods
 
     /**
@@ -573,122 +549,10 @@ public class Attributes {
             return;
         }
 
-        int currentScore = getAttributeScore(attribute);
+        int currentScore = getBaseAttributeScore(attribute);
         // We defer ensuring this falls within permissible values to setAttributeScore
         int newScore = currentScore + delta;
         setAttributeScore(phenotype, options, attribute, newScore);
-    }
-
-    /**
-     * Changes the strength attribute by a delta.
-     *
-     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
-     *
-     * @param delta the value to add to the current strength. A positive delta will increase the attribute score, while
-     *              a negative delta will decrease it.
-     *
-     * @since 0.50.5
-     */
-    @Deprecated(since = "0.50.5", forRemoval = true)
-    public void changeStrength(int delta) {
-        strength += delta;
-        strength = clamp(strength, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-
-    /**
-     * Changes the body attribute by a delta.
-     *
-     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
-     *
-     * @param delta the value to add to the current body. A positive delta will increase the attribute score, while a
-     *              negative delta will decrease it.
-     *
-     * @since 0.50.5
-     */
-    public void changeBody(int delta) {
-        body += delta;
-        body = clamp(body, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-
-    /**
-     * Changes the reflexes attribute by a delta.
-     *
-     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
-     *
-     * @param delta the value to add to the current reflexes. A positive delta will increase the attribute score, while
-     *              a negative delta will decrease it.
-     *
-     * @since 0.50.5
-     */
-    public void changeReflexes(int delta) {
-        reflexes += delta;
-        reflexes = clamp(reflexes, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-
-    /**
-     * Changes the dexterity attribute by a delta.
-     *
-     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
-     *
-     * @param delta the value to add to the current dexterity. A positive delta will increase the attribute score, while
-     *              a negative delta will decrease it.
-     *
-     * @since 0.50.5
-     */
-    public void changeDexterity(int delta) {
-        dexterity += delta;
-        dexterity = clamp(dexterity, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-
-    /**
-     * Changes the intelligence attribute by a delta.
-     *
-     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
-     *
-     * @param delta the value to add to the current intelligence. A positive delta will increase the attribute score,
-     *              while a negative delta will decrease it.
-     *
-     * @since 0.50.5
-     */
-    public void changeIntelligence(int delta) {
-        intelligence += delta;
-        intelligence = clamp(intelligence, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-
-    /**
-     * Changes the willpower attribute by a delta.
-     *
-     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
-     *
-     * @param delta the value to add to the current willpower. A positive delta will increase the attribute score, while
-     *              a negative delta will decrease it.
-     *
-     * @since 0.50.5
-     */
-    public void changeWillpower(int delta) {
-        willpower += delta;
-        willpower = clamp(willpower, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
-    }
-
-
-    /**
-     * Changes the charisma attribute by a delta.
-     *
-     * <p>The result is clamped between {@link #MINIMUM_ATTRIBUTE_SCORE} and {@link #MAXIMUM_ATTRIBUTE_SCORE}.</p>
-     *
-     * @param delta the value to add to the current charisma. A positive delta will increase the attribute score, while
-     *              a negative delta will decrease it.
-     *
-     * @since 0.50.5
-     */
-    public void changeCharisma(int delta) {
-        charisma += delta;
-        charisma = clamp(charisma, MINIMUM_ATTRIBUTE_SCORE, MAXIMUM_ATTRIBUTE_SCORE);
     }
 
     /**
@@ -717,6 +581,33 @@ public class Attributes {
 
     public void setCurrentEdge(final int currentEdge) {
         this.currentEdge = currentEdge;
+    }
+
+    public String getTooltip(SkillAttribute attribute, List<InjuryEffect> injuryEffects, PersonnelOptions options) {
+        StringBuilder tooltip = new StringBuilder();
+
+        String flavorText = attribute.getDescription();
+        if (!flavorText.isBlank()) {
+            tooltip.append(flavorText).append("<br><br>");
+        }
+
+        // TODO aging modifiers
+
+        int abilityModifier = getAbilityAdjustment(attribute, options);
+        if (abilityModifier != 0) {
+            tooltip.append(getFormattedTextAt(RESOURCE_BUNDLE,
+                  "tooltip.format.spa",
+                  (abilityModifier > 0 ? "+" : "") + abilityModifier));
+        }
+
+        int injuryModifier = getAttributeScoreInjuryModifier(attribute, injuryEffects);
+        if (injuryModifier != 0) {
+            tooltip.append(getFormattedTextAt(RESOURCE_BUNDLE,
+                  "tooltip.format.injury",
+                  (injuryModifier > 0 ? "+" : "") + injuryModifier));
+        }
+
+        return tooltip.toString();
     }
 
     // Reading and Writing

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/AttributesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/AttributesTest.java
@@ -55,13 +55,13 @@ public class AttributesTest {
     @Test
     public void testDefaultConstructor() {
         Attributes attributes = new Attributes();
-        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getAttributeScore(STRENGTH));
-        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getAttributeScore(BODY));
-        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getAttributeScore(REFLEXES));
-        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getAttributeScore(DEXTERITY));
-        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getAttributeScore(INTELLIGENCE));
-        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getAttributeScore(WILLPOWER));
-        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getAttributeScore(CHARISMA));
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(STRENGTH));
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(BODY));
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(REFLEXES));
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(DEXTERITY));
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(INTELLIGENCE));
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(WILLPOWER));
+        assertEquals(DEFAULT_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(CHARISMA));
     }
 
     @Test
@@ -73,15 +73,15 @@ public class AttributesTest {
         final int attributeCap = phenotype.getAttributeCap(STRENGTH);
 
         attributes.setAttributeScore(phenotype, options, STRENGTH, MAXIMUM_ATTRIBUTE_SCORE + 1);
-        assertEquals(attributeCap, attributes.getAttributeScore(STRENGTH));
+        assertEquals(attributeCap, attributes.getBaseAttributeScore(STRENGTH));
 
         attributes.setAttributeScore(phenotype, options, STRENGTH, MINIMUM_ATTRIBUTE_SCORE - 1);
-        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getAttributeScore(STRENGTH));
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(STRENGTH));
 
         for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
             attributes.setAttributeScore(phenotype, options, STRENGTH, i);
             int expected = min(i, attributeCap);
-            assertEquals(expected, attributes.getAttributeScore(STRENGTH));
+            assertEquals(expected, attributes.getBaseAttributeScore(STRENGTH));
         }
     }
 
@@ -94,15 +94,15 @@ public class AttributesTest {
         final int attributeCap = phenotype.getAttributeCap(BODY);
 
         attributes.setAttributeScore(phenotype, options, BODY, MAXIMUM_ATTRIBUTE_SCORE + 1);
-        assertEquals(attributeCap, attributes.getAttributeScore(BODY));
+        assertEquals(attributeCap, attributes.getBaseAttributeScore(BODY));
 
         attributes.setAttributeScore(phenotype, options, BODY, MINIMUM_ATTRIBUTE_SCORE - 1);
-        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getAttributeScore(BODY));
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(BODY));
 
         for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
             attributes.setAttributeScore(phenotype, options, BODY, i);
             int expected = min(i, attributeCap);
-            assertEquals(expected, attributes.getAttributeScore(BODY));
+            assertEquals(expected, attributes.getBaseAttributeScore(BODY));
         }
     }
 
@@ -115,15 +115,15 @@ public class AttributesTest {
         final int attributeCap = phenotype.getAttributeCap(REFLEXES);
 
         attributes.setAttributeScore(phenotype, options, REFLEXES, MAXIMUM_ATTRIBUTE_SCORE + 1);
-        assertEquals(attributeCap, attributes.getAttributeScore(REFLEXES));
+        assertEquals(attributeCap, attributes.getBaseAttributeScore(REFLEXES));
 
         attributes.setAttributeScore(phenotype, options, REFLEXES, MINIMUM_ATTRIBUTE_SCORE - 1);
-        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getAttributeScore(REFLEXES));
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(REFLEXES));
 
         for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
             attributes.setAttributeScore(phenotype, options, REFLEXES, i);
             int expected = min(i, attributeCap);
-            assertEquals(expected, attributes.getAttributeScore(REFLEXES));
+            assertEquals(expected, attributes.getBaseAttributeScore(REFLEXES));
         }
     }
 
@@ -136,15 +136,15 @@ public class AttributesTest {
         final int attributeCap = phenotype.getAttributeCap(DEXTERITY);
 
         attributes.setAttributeScore(phenotype, options, DEXTERITY, MAXIMUM_ATTRIBUTE_SCORE + 1);
-        assertEquals(attributeCap, attributes.getAttributeScore(DEXTERITY));
+        assertEquals(attributeCap, attributes.getBaseAttributeScore(DEXTERITY));
 
         attributes.setAttributeScore(phenotype, options, DEXTERITY, MINIMUM_ATTRIBUTE_SCORE - 1);
-        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getAttributeScore(DEXTERITY));
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(DEXTERITY));
 
         for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
             attributes.setAttributeScore(phenotype, options, DEXTERITY, i);
             int expected = min(i, attributeCap);
-            assertEquals(expected, attributes.getAttributeScore(DEXTERITY));
+            assertEquals(expected, attributes.getBaseAttributeScore(DEXTERITY));
         }
     }
 
@@ -157,15 +157,15 @@ public class AttributesTest {
         final int attributeCap = phenotype.getAttributeCap(INTELLIGENCE);
 
         attributes.setAttributeScore(phenotype, options, INTELLIGENCE, MAXIMUM_ATTRIBUTE_SCORE + 1);
-        assertEquals(attributeCap, attributes.getAttributeScore(INTELLIGENCE));
+        assertEquals(attributeCap, attributes.getBaseAttributeScore(INTELLIGENCE));
 
         attributes.setAttributeScore(phenotype, options, INTELLIGENCE, MINIMUM_ATTRIBUTE_SCORE - 1);
-        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getAttributeScore(INTELLIGENCE));
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(INTELLIGENCE));
 
         for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
             attributes.setAttributeScore(phenotype, options, INTELLIGENCE, i);
             int expected = min(i, attributeCap);
-            assertEquals(expected, attributes.getAttributeScore(INTELLIGENCE));
+            assertEquals(expected, attributes.getBaseAttributeScore(INTELLIGENCE));
         }
     }
 
@@ -178,15 +178,15 @@ public class AttributesTest {
         final int attributeCap = phenotype.getAttributeCap(WILLPOWER);
 
         attributes.setAttributeScore(phenotype, options, WILLPOWER, MAXIMUM_ATTRIBUTE_SCORE + 1);
-        assertEquals(phenotype.getAttributeCap(WILLPOWER), attributes.getAttributeScore(WILLPOWER));
+        assertEquals(phenotype.getAttributeCap(WILLPOWER), attributes.getBaseAttributeScore(WILLPOWER));
 
         attributes.setAttributeScore(phenotype, options, WILLPOWER, MINIMUM_ATTRIBUTE_SCORE - 1);
-        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getAttributeScore(WILLPOWER));
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(WILLPOWER));
 
         for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
             attributes.setAttributeScore(phenotype, options, WILLPOWER, i);
             int expected = min(i, attributeCap);
-            assertEquals(expected, attributes.getAttributeScore(WILLPOWER));
+            assertEquals(expected, attributes.getBaseAttributeScore(WILLPOWER));
         }
     }
 
@@ -197,14 +197,14 @@ public class AttributesTest {
         final PersonnelOptions options = new PersonnelOptions();
 
         attributes.setAttributeScore(phenotype, options, CHARISMA, MAXIMUM_ATTRIBUTE_SCORE + 1);
-        assertEquals(phenotype.getAttributeCap(CHARISMA), attributes.getAttributeScore(CHARISMA));
+        assertEquals(phenotype.getAttributeCap(CHARISMA), attributes.getBaseAttributeScore(CHARISMA));
 
         attributes.setAttributeScore(phenotype, options, CHARISMA, MINIMUM_ATTRIBUTE_SCORE - 1);
-        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getAttributeScore(CHARISMA));
+        assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(CHARISMA));
 
         for (int i = MINIMUM_ATTRIBUTE_SCORE; i <= MAXIMUM_ATTRIBUTE_SCORE; i++) {
             attributes.setAttributeScore(phenotype, options, CHARISMA, i);
-            assertEquals(min(i, phenotype.getAttributeCap(CHARISMA)), attributes.getAttributeScore(CHARISMA));
+            assertEquals(min(i, phenotype.getAttributeCap(CHARISMA)), attributes.getBaseAttributeScore(CHARISMA));
         }
     }
 
@@ -222,9 +222,9 @@ public class AttributesTest {
             }
 
             if (attribute != SkillAttribute.EDGE) {
-                assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getAttributeScore(attribute));
+                assertEquals(MINIMUM_ATTRIBUTE_SCORE, attributes.getBaseAttributeScore(attribute));
             } else {
-                assertEquals(MINIMUM_EDGE_SCORE, attributes.getAttributeScore(attribute));
+                assertEquals(MINIMUM_EDGE_SCORE, attributes.getBaseAttributeScore(attribute));
             }
         }
     }
@@ -242,7 +242,7 @@ public class AttributesTest {
                 continue;
             }
 
-            assertEquals(phenotype.getAttributeCap(attribute), attributes.getAttributeScore(attribute));
+            assertEquals(phenotype.getAttributeCap(attribute), attributes.getBaseAttributeScore(attribute));
         }
     }
 
@@ -262,7 +262,7 @@ public class AttributesTest {
                     continue;
                 }
 
-                int newValue = attributes.getAttributeScore(attribute);
+                int newValue = attributes.getBaseAttributeScore(attribute);
                 int expected = MINIMUM_ATTRIBUTE_SCORE + i;
                 // Account for attribute caps
                 expected = min(expected, phenotype.getAttributeCap(attribute));

--- a/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/skills/SkillTest.java
@@ -40,7 +40,10 @@ import static mekhq.campaign.personnel.skills.enums.SkillAttribute.NONE;
 import static mekhq.campaign.personnel.skills.enums.SkillAttribute.REFLEXES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
+
 import megamek.common.rolls.TargetRoll;
+import mekhq.campaign.personnel.PersonnelOptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -66,7 +69,8 @@ public class SkillTest {
         TargetRoll targetNumber = new TargetRoll();
 
         // Act
-        int totalModifier = getTotalAttributeModifier(targetNumber, attributes, testSkillType);
+        int totalModifier = getTotalAttributeModifier(targetNumber, attributes, testSkillType, new ArrayList<>(),
+              new PersonnelOptions());
 
         // Assert
         assertEquals(1, totalModifier);
@@ -92,7 +96,8 @@ public class SkillTest {
         TargetRoll targetNumber = new TargetRoll();
 
         // Act
-        int totalModifier = getTotalAttributeModifier(targetNumber, attributes, testSkillType);
+        int totalModifier = getTotalAttributeModifier(targetNumber, attributes, testSkillType, new ArrayList<>(),
+              new PersonnelOptions());
 
         // Assert
         assertEquals(2, totalModifier);
@@ -118,7 +123,8 @@ public class SkillTest {
         TargetRoll targetNumber = new TargetRoll();
 
         // Act
-        int totalModifier = getTotalAttributeModifier(targetNumber, attributes, testSkillType);
+        int totalModifier = getTotalAttributeModifier(targetNumber, attributes, testSkillType, new ArrayList<>(),
+              new PersonnelOptions());
 
         // Assert
         assertEquals(0, totalModifier);


### PR DESCRIPTION
One of the points of feedback we received late in the 50.10 cycle was that AAM's injury penalties were a bit too harsh. I agreed, but there was no time left to change it.

This PR changes injury effects so that the are applied to the characters' Attribute Score and _not_ directly to the skill. This makes them punishing, but not outright crippling. It also matches RAW.