### PR TITLE
Fix #8426: Fixed Personnel Market Not Generating Initial Applicants on Campaign Start if Campaign Not Starting on 1st of Month

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -5284,7 +5284,7 @@ public class Campaign implements ITechManager {
         if (marketStyle == PERSONNEL_MARKET_DISABLED) {
             personnelMarket.generatePersonnelForDay(this);
         } else {
-            if (currentDay.getDayOfMonth() == 1) {
+            if (currentDay.getDayOfMonth() == 1 || isCampaignStart) {
                 newPersonnelMarket.gatherApplications();
 
                 if (newPersonnelMarket.getHasRarePersonnel()) {


### PR DESCRIPTION
Fix #8426