### PR TITLE
Fix MM #3191: Ensure units clear their picked up MW and starting locations on reset

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -35,6 +35,7 @@ package mekhq.campaign.unit;
 
 import static java.lang.Math.ceil;
 import static java.lang.Math.max;
+import static megamek.common.board.Board.START_NONE;
 import static megamek.common.equipment.MiscType.F_CARGO;
 import static megamek.common.units.EntityWeightClass.WEIGHT_HEAVY;
 import static megamek.common.units.EntityWeightClass.WEIGHT_LIGHT;
@@ -4561,6 +4562,8 @@ public class Unit implements ITechnology {
         entity.setCommander(false);
         entity.getCrew().resetGameState();
         entity.getCrew().setCommandBonus(0);
+        entity.resetPickedUpMekWarriors();
+        entity.setStartingPos(START_NONE);
 
         // Update crew data
         updateCrew(isOnlyCommandersMatter);


### PR DESCRIPTION
MHQ side of fix (mainly for double safety).

## NOTE: only merge after https://github.com/MegaMek/megamek/pull/7724 is merged ##

Testing:
- Ran all 3 projects' unit tests
- Confirmed proper operation with hand-tweaked units containing fake MW ids in their `entity.pickedUpMekWarriors` vectors.
