### PR TITLE
Feature: Added 'Report a Bug' Helper

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignGUI.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignGUI.properties
@@ -154,6 +154,7 @@ btnAdvanceMultipleDays.text=Advance Multiple Days
 btnMassTraining.text=Mass Personnel Training
 btnMassTraining.toolTipText=This launches the Mass Personnel Training Dialog, which allows you to train large numbers of personnel at the same time.
 btnGlossary.text=Glossary
+btnBugReport.text=Report a Bug
 panCommand.TabConstraints.tabTitle=Command Center
 panHangar.TabConstraints.tabTitle=Hangar
 panRepairBay.TabConstraints.tabTitle=Repair Bay

--- a/MekHQ/resources/mekhq/resources/EasyBugReport.properties
+++ b/MekHQ/resources/mekhq/resources/EasyBugReport.properties
@@ -46,7 +46,7 @@ EasyBugReport.dialog.message.supplementary=<h1 style="text-align:center">Which B
   - My bug was found during a scenario: <b>MegaMek</b> (ideally, we will need a save from before the scenario started)\
   <br>- My bug was found during unit customization: <b>MegaMekLab</b>\
   <br>- My bug was found in campaign management: <b>MekHQ</b>\
-  <br>- I think you got a unit, planet, or other wrong: <b>Data</b>\
+  <br>- I think you got a unit, planet, or other data wrong: <b>Data</b>\
   <br>- I'm not sure: <b>MekHQ</b>
 EasyBugReport.dialog.button.cancel=Cancel
 EasyBugReport.dialog.button.discord=Discord

--- a/MekHQ/resources/mekhq/resources/EasyBugReport.properties
+++ b/MekHQ/resources/mekhq/resources/EasyBugReport.properties
@@ -1,0 +1,32 @@
+# Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+#
+# This file is part of MekHQ.
+#
+# MekHQ is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (GPL),
+# version 3 or (at your option) any later version,
+# as published by the Free Software Foundation.
+#
+# MekHQ is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# A copy of the GPL should have been included with this project;
+# if not, see <https://www.gnu.org/licenses/>.
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+# suppress inspection "UnusedProperty" for the whole file
+EasyBugReport.fileChooser=Save Bug Report

--- a/MekHQ/resources/mekhq/resources/EasyBugReport.properties
+++ b/MekHQ/resources/mekhq/resources/EasyBugReport.properties
@@ -28,5 +28,30 @@
 # Microsoft's "Game Content Usage Rules"
 # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
 # affiliated with Microsoft.
-# suppress inspection "UnusedProperty" for the whole file
 EasyBugReport.fileChooser=Save Bug Report
+EasyBugReport.dialog.message.main=While we work hard to keep MekHQ stable and running smoothly, things can still go \
+  wrong. Because this is a volunteer project without the funding or team for large-scale testing, we rely on players \
+  to report any issues they find.\
+  <p>To open an issue report, follow these steps:</p>\
+  <blockquote><b>1)</b> Save your campaign using the "Save Campaign" button. Make a note of where you save it, since \
+  you will need it later.\
+  <br><b>2) (Optional)</b> If you are on our Discord, it can help to ask whether the bug has already been reported. \
+  This may save you the effort of opening a report that ends up closed because the issue was already fixed. Duplicate\
+  \ reports are fine. We just want to save you time. Not a member of our Discord community? Consider pressing the \
+  'Discord' button to join.\
+  <br><b>3)</b> Press the appropriate button for the type of issue. You will need a GitHub account. We used to allow \
+  anonymous reporting, but it caused problems and had to be removed.\
+  <br><b>4)</b> Fill out the issue report form, then upload the zip folder you created in step 1.</blockquote>
+EasyBugReport.dialog.message.supplementary=<h1 style="text-align:center">Which Bug Goes Where?</h1>\
+  - My bug was found during a scenario: <b>MegaMek</b> (ideally, we will need a save from before the scenario started)\
+  <br>- My bug was found during unit customization: <b>MegaMekLab</b>\
+  <br>- My bug was found in campaign management: <b>MekHQ</b>\
+  <br>- I think you got a unit, planet, or other wrong: <b>Data</b>\
+  <br>- I'm not sure: <b>MekHQ</b>
+EasyBugReport.dialog.button.cancel=Cancel
+EasyBugReport.dialog.button.discord=Discord
+EasyBugReport.dialog.button.build=Save Campaign
+EasyBugReport.dialog.button.mm=MegaMek
+EasyBugReport.dialog.button.mml=MegaMekLab
+EasyBugReport.dialog.button.mhq=MekHQ
+EasyBugReport.dialog.button.mmData=Data

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -48,6 +48,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final int MAX_JUMP_RADIUS = 30; //
     public static final int PREGNANCY_STANDARD_DURATION = 280; // standard duration of a pregnancy in days (40 weeks)
     public static final String EGO_OBJECTIVE_NAME = "Player";
+    public static final String DISCORD_LINK = "https://discord.gg/megamek";
     // endregion General Constants
 
     // region Faction Generation Constants

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -292,6 +292,7 @@ public final class MHQConstants extends SuiteConstants {
     public static final String FORCE_ICON_PATH = "data/images/force";
     public static final String PERSONNEL_MARKET_DIRECTORY_PATH = "data/universe/markets/personnelMarket/";
     public static final String MAP_GEN_PATH = "data/mapgen";
+    public static final String LOGS_PATH = "logs";
 
     // region StratCon
     public static final String STRAT_CON_REQUIRED_HOSTILE_FACILITY_MODS = "./data/scenariomodifiers/requiredHostileFacilityModifiers.xml";

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6494,7 +6494,9 @@ public class Campaign implements ITechManager {
         if (isBugReportPrep) {
             for (Unit unit : units.getUnits()) {
                 Entity entity = unit.getEntity();
-                customUnits.add(entity.getShortNameRaw());
+                if (entity != null) {
+                    customUnits.add(entity.getShortNameRaw());
+                }
             }
         } else {
             customUnits = new HashSet<>(customs);

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6497,7 +6497,7 @@ public class Campaign implements ITechManager {
                 customUnits.add(entity.getShortNameRaw());
             }
         } else {
-            customUnits = new HashSet<String>(customUnits);
+            customUnits = new HashSet<>(customs);
         }
 
         for (String name : customUnits) {

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6214,7 +6214,7 @@ public class Campaign implements ITechManager {
         return factionStandingUltimatumsLibrary;
     }
 
-    public void writeToXML(final PrintWriter writer) {
+    public void writeToXML(final PrintWriter writer, boolean isBugReportPrep) {
         int indent = 0;
 
         // File header
@@ -6459,8 +6459,8 @@ public class Campaign implements ITechManager {
         writePartInUseToXML(writer, indent);
         MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "partsInUse");
 
-        if (MekHQ.getMHQOptions().getWriteCustomsToXML()) {
-            writeCustoms(writer);
+        if (isBugReportPrep || MekHQ.getMHQOptions().getWriteCustomsToXML()) {
+            writeCustoms(writer, isBugReportPrep);
         }
 
         // Okay, we're done.
@@ -6468,8 +6468,40 @@ public class Campaign implements ITechManager {
         MHQXMLUtility.writeSimpleXMLCloseTag(writer, --indent, "campaign");
     }
 
-    private void writeCustoms(PrintWriter pw1) {
-        for (String name : customs) {
+    /**
+     * Writes serialized custom unit definitions to the provided {@link PrintWriter}.
+     *
+     * <p>When invoked for bug report preparation, this method scans all units currently present in the campaign,
+     * extracts their raw short names, and treats them as custom entries to be exported. Each candidate name is resolved
+     * via the {@link MekSummaryCache}; if a definition is found, the source entity is parsed and serialized into
+     * XML.</p>
+     *
+     * <p>BattleMeks are exported using embedded MTF data wrapped in CDATA; all other supported entity types are
+     * exported as BLK content, line-by-line and wrapped in CDATA.</p>
+     *
+     * <p>Units that cannot be located in the cache or that fail parsing are skipped, with errors logged. The
+     * ordering of exported units depends on the underlying {@link Set} implementation.</p>
+     *
+     * <p><b>Note:</b> When {@code isBugReportPrep} is {@code false}, this method replaces the custom set with an
+     * empty list structure rather than populating it, resulting in no output being written.</p>
+     *
+     * @param printWriter     the output writer used to emit formatted {@code <custom>} elements
+     * @param isBugReportPrep whether campaign unit names should be collected for export; if {@code false}, no custom
+     *                        entities will be written by this method
+     */
+    private void writeCustoms(PrintWriter printWriter, boolean isBugReportPrep) {
+        Set<String> customUnits = new HashSet<>();
+        if (isBugReportPrep) {
+            for (Unit unit : units.getUnits()) {
+                Entity entity = unit.getEntity();
+                customUnits.add(entity.getShortNameRaw());
+            }
+        } else {
+            customUnits = new HashSet<String>(customUnits);
+        }
+
+        for (String name : customUnits) {
+            LOGGER.info(name);
             MekSummary ms = MekSummaryCache.getInstance().getMek(name);
             if (ms == null) {
                 continue;
@@ -6485,28 +6517,28 @@ public class Campaign implements ITechManager {
                 continue;
             }
             Entity en = mekFileParser.getEntity();
-            pw1.println("\t<custom>");
-            pw1.println("\t\t<name>" + name + "</name>");
+            printWriter.println("\t<custom>");
+            printWriter.println("\t\t<name>" + name + "</name>");
             if (en instanceof Mek) {
-                pw1.print("\t\t<mtf><![CDATA[");
-                pw1.print(((Mek) en).getMtf());
-                pw1.println("]]></mtf>");
+                printWriter.print("\t\t<mtf><![CDATA[");
+                printWriter.print(((Mek) en).getMtf());
+                printWriter.println("]]></mtf>");
             } else {
                 try {
                     BuildingBlock blk = BLKFile.getBlock(en);
-                    pw1.print("\t\t<blk><![CDATA[");
+                    printWriter.print("\t\t<blk><![CDATA[");
                     for (String s : blk.getAllDataAsString()) {
                         if (s.isEmpty()) {
                             continue;
                         }
-                        pw1.println(s);
+                        printWriter.println(s);
                     }
-                    pw1.println("]]></blk>");
+                    printWriter.println("]]></blk>");
                 } catch (EntitySavingException e) {
                     LOGGER.error("Failed to save custom entity {}", en.getDisplayName(), e);
                 }
             }
-            pw1.println("\t</custom>");
+            printWriter.println("\t</custom>");
         }
     }
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6482,8 +6482,7 @@ public class Campaign implements ITechManager {
      * <p>Units that cannot be located in the cache or that fail parsing are skipped, with errors logged. The
      * ordering of exported units depends on the underlying {@link Set} implementation.</p>
      *
-     * <p><b>Note:</b> When {@code isBugReportPrep} is {@code false}, this method replaces the custom set with an
-     * empty list structure rather than populating it, resulting in no output being written.</p>
+     * <p><b>Note:</b> When {@code isBugReportPrep} is {@code false}, this method replaces the custom set.</p>
      *
      * @param printWriter     the output writer used to emit formatted {@code <custom>} elements
      * @param isBugReportPrep whether campaign unit names should be collected for export; if {@code false}, no custom

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6501,7 +6501,6 @@ public class Campaign implements ITechManager {
         }
 
         for (String name : customUnits) {
-            LOGGER.info(name);
             MekSummary ms = MekSummaryCache.getInstance().getMek(name);
             if (ms == null) {
                 continue;

--- a/MekHQ/src/mekhq/campaign/utilities/EasyBugReport.java
+++ b/MekHQ/src/mekhq/campaign/utilities/EasyBugReport.java
@@ -1,0 +1,155 @@
+package mekhq.campaign.utilities;
+
+import static mekhq.MHQConstants.LOGS_PATH;
+import static mekhq.gui.CampaignGUI.saveCampaign;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+import megamek.client.generator.RandomCallsignGenerator;
+import megamek.logging.MMLogger;
+import mekhq.MHQConstants;
+import mekhq.MekHQ;
+import mekhq.campaign.Campaign;
+
+public class EasyBugReport {
+    private static final MMLogger LOGGER = MMLogger.create(EasyBugReport.class);
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.EasyBugReport";
+
+    private final Campaign campaign;
+
+    public EasyBugReport(JFrame frame, Campaign campaign) {
+        this.campaign = campaign;
+
+        saveCampaignForBugReport(frame);
+    }
+
+    public void saveCampaignForBugReport(JFrame frame) {
+        LOGGER.info("Saving campaign for bug report...");
+
+        String campaignName = campaign.getName();
+        LocalDate today = campaign.getLocalDate();
+
+        // Random call sign so multiple bug report builds on the same in-game date don't overwrite each other
+        String randomName = RandomCallsignGenerator.getInstance().generate();
+
+        String dateString = today.format(DateTimeFormatter.ofPattern(MHQConstants.FILENAME_DATE_FORMAT)
+                                               .withLocale(MekHQ.getMHQOptions().getDateLocale()));
+
+        // This will be used as the default base name
+        String defaultBaseName = String.format("%s%s_%s", campaignName, dateString, randomName);
+
+        // Base campaigns directory
+        String rawDirectory = MekHQ.getCampaignsDirectory().getValue();
+        File directory = new File(rawDirectory);
+
+        // Ensure directory exists
+        if (!directory.exists() && !directory.mkdirs()) {
+            LOGGER.error("Failed to create campaign directory: {}", rawDirectory);
+            return;
+        }
+
+        // Let the user pick the archive name / location
+        JFileChooser fileChooser = new JFileChooser(directory);
+        fileChooser.setDialogTitle(getTextAt(RESOURCE_BUNDLE, "EasyBugReport.fileChooser"));
+        fileChooser.setFileFilter(new FileNameExtensionFilter("Bug Report Archives (*.zip)", "zip"));
+
+        // Default file name (with .zip)
+        fileChooser.setSelectedFile(new File(directory, defaultBaseName + ".zip"));
+
+        int result = fileChooser.showSaveDialog(frame);
+        if (result != JFileChooser.APPROVE_OPTION) {
+            LOGGER.info("User cancelled bug report save dialog.");
+            return;
+        }
+
+        File chosenArchiveFile = fileChooser.getSelectedFile();
+        // Ensure .zip extension
+        String archiveName = chosenArchiveFile.getName();
+        if (!archiveName.toLowerCase(Locale.ROOT).endsWith(".zip")) {
+            chosenArchiveFile = new File(chosenArchiveFile.getParentFile(), archiveName + ".zip");
+        }
+
+        // Temporary campaign file used only for building the archive, placed next to the archive so everything stays
+        // together.
+        File campaignFile = new File(chosenArchiveFile.getParentFile(), defaultBaseName + ".cpnx.gz");
+
+        LOGGER.info("Bug report campaign temporary save target: {}", campaignFile.getName());
+        // Save campaign with bug report prep flag enabled
+        saveCampaign(frame, campaign, campaignFile, true);
+
+        // Now package campaign + logs into the user-chosen archive
+        try {
+            File archiveFile = createBugReportArchive(campaignFile, chosenArchiveFile);
+            LOGGER.info("Bug report archive created: {}", archiveFile.getName());
+
+            // We only want the archive, so delete the loose campaign file
+            if (!campaignFile.delete()) {
+                LOGGER.warn("Unable to delete temporary bug report campaign file: {}", campaignFile.getName());
+            }
+        } catch (IOException e) {
+            LOGGER.error("Failed to create bug report archive", e);
+            // In this failure case, we intentionally leave the campaignFile so the user still has something to
+            // attach if needed.
+        }
+    }
+
+    private File createBugReportArchive(File campaignFile, File archiveFile) throws IOException {
+        try (FileOutputStream fileOutputStream = new FileOutputStream(archiveFile);
+              ZipOutputStream zipOutputStream = new ZipOutputStream(fileOutputStream)) {
+
+            // Add the campaign file at the root of the archive
+            addFileToZip(campaignFile, campaignFile.getName(), zipOutputStream);
+
+            // Add logs under 'logs/<filename>'
+            File logsDirectory = new File(LOGS_PATH);
+            if (!logsDirectory.isDirectory()) {
+                LOGGER.warn("Logs directory does not exist or is not a directory: {}", LOGS_PATH);
+                return archiveFile;
+            }
+
+            File[] logFiles = logsDirectory.listFiles(f -> f.isFile() &&
+                                                                 (f.getName().endsWith(".log") ||
+                                                                        f.getName().endsWith(".log.gz")));
+
+            if (logFiles == null || logFiles.length == 0) {
+                LOGGER.info("No .log or .log.gz files found in {}", LOGS_PATH);
+                return archiveFile;
+            }
+
+            for (File logFile : logFiles) {
+                String entryName = "logs/" + logFile.getName();
+                addFileToZip(logFile, entryName, zipOutputStream);
+            }
+        }
+
+        return archiveFile;
+    }
+
+    private void addFileToZip(File source, String entryName, ZipOutputStream zipOutputStream) throws IOException {
+        ZipEntry entry = new ZipEntry(entryName);
+        zipOutputStream.putNextEntry(entry);
+
+        try (InputStream fileInputStream = new FileInputStream(source)) {
+            byte[] buffer = new byte[8192];
+            int length;
+            while ((length = fileInputStream.read(buffer)) != -1) {
+                zipOutputStream.write(buffer, 0, length);
+            }
+        }
+
+        zipOutputStream.closeEntry();
+    }
+}

--- a/MekHQ/src/mekhq/campaign/utilities/EasyBugReport.java
+++ b/MekHQ/src/mekhq/campaign/utilities/EasyBugReport.java
@@ -149,7 +149,11 @@ public class EasyBugReport {
 
         LOGGER.info("Bug report campaign temporary save target: {}", campaignFile.getName());
         // Save campaign with bug report prep flag enabled
-        saveCampaign(frame, campaign, campaignFile, true);
+        boolean saveSuccess = saveCampaign(frame, campaign, campaignFile, true);
+        if (!saveSuccess) {
+            LOGGER.error("Failed to save campaign for bug report");
+            return;
+        }
 
         // Now package campaign + logs into the user-chosen archive
         try {

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -148,7 +148,6 @@ import mekhq.campaign.universe.Faction;
 import mekhq.campaign.universe.NewsItem;
 import mekhq.campaign.universe.factionStanding.FactionStandingUtilities;
 import mekhq.campaign.universe.factionStanding.GoingRogue;
-import mekhq.campaign.utilities.EasyBugReport;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogSimple;
 import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 import mekhq.gui.baseComponents.roundedComponents.RoundedLineBorder;
@@ -1453,10 +1452,10 @@ public class CampaignGUI extends JPanel {
         gridBagConstraints.gridheight = 2;
         gridBagConstraints.gridwidth = 1;
         gridBagConstraints.anchor = GridBagConstraints.NORTHEAST;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
+        gridBagConstraints.insets = new Insets(3, 15, 3, 0);
         pnlButton.add(btnAdvanceDay, gridBagConstraints);
 
-        btnBugReport.addActionListener(evt -> new EasyBugReport(getFrame(), getCampaign()));
+        btnBugReport.addActionListener(evt -> new EasyBugReportDialog(getFrame(), getCampaign()));
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 6;
         gridBagConstraints.gridy = 0;
@@ -1466,7 +1465,7 @@ public class CampaignGUI extends JPanel {
         gridBagConstraints.gridheight = 2;
         gridBagConstraints.gridwidth = 1;
         gridBagConstraints.anchor = GridBagConstraints.NORTHEAST;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 15);
+        gridBagConstraints.insets = new Insets(3, 15, 3, 15);
         pnlButton.add(btnBugReport, gridBagConstraints);
 
         return pnlButton;

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -224,6 +224,7 @@ public class CampaignGUI extends JPanel {
     private final RoundedJButton btnCompanyGenerator = new RoundedJButton(resourceMap.getString(
           "btnCompanyGenerator.text"));
     private final RoundedJButton btnGlossary = new RoundedJButton(resourceMap.getString("btnGlossary.text"));
+    private final RoundedJButton btnBugReport = new RoundedJButton(resourceMap.getString("btnBugReport.text"));
     private final RoundedJButton btnContractMarket =
           new RoundedJButton(resourceMap.getString("btnContractMarket.market"));
     private final RoundedJButton btnPersonnelMarket =
@@ -1451,8 +1452,21 @@ public class CampaignGUI extends JPanel {
         gridBagConstraints.gridheight = 2;
         gridBagConstraints.gridwidth = 1;
         gridBagConstraints.anchor = GridBagConstraints.NORTHEAST;
-        gridBagConstraints.insets = new Insets(3, 3, 3, 15);
+        gridBagConstraints.insets = new Insets(3, 3, 3, 3);
         pnlButton.add(btnAdvanceDay, gridBagConstraints);
+
+        btnBugReport.addActionListener(this::saveCampaignForBugReport);
+        gridBagConstraints = new GridBagConstraints();
+        gridBagConstraints.gridx = 6;
+        gridBagConstraints.gridy = 0;
+        gridBagConstraints.fill = GridBagConstraints.VERTICAL;
+        gridBagConstraints.weightx = 0.0;
+        gridBagConstraints.weighty = 0.0;
+        gridBagConstraints.gridheight = 2;
+        gridBagConstraints.gridwidth = 1;
+        gridBagConstraints.anchor = GridBagConstraints.NORTHEAST;
+        gridBagConstraints.insets = new Insets(3, 3, 3, 15);
+        pnlButton.add(btnBugReport, gridBagConstraints);
 
         return pnlButton;
     }
@@ -1799,7 +1813,23 @@ public class CampaignGUI extends JPanel {
             return false;
         }
 
-        return saveCampaign(getFrame(), getCampaign(), file);
+        return saveCampaign(getFrame(), getCampaign(), file, false);
+    }
+
+    public boolean saveCampaignForBugReport(ActionEvent evt) {
+        logger.info("Saving campaign...");
+        // Choose a file...
+        File file = FileDialogs.saveCampaign(frame, getCampaign()).orElse(null);
+        if (file == null) {
+            // I want a file, you know!
+            return false;
+        }
+
+        return saveCampaign(getFrame(), getCampaign(), file, true);
+    }
+
+    public static boolean saveCampaign(JFrame frame, Campaign campaign, File file) {
+        return saveCampaign(frame, campaign, file, false);
     }
 
     /**
@@ -1807,7 +1837,7 @@ public class CampaignGUI extends JPanel {
      *
      * @param frame The parent frame in which to display the error message. May be null.
      */
-    public static boolean saveCampaign(JFrame frame, Campaign campaign, File file) {
+    public static boolean saveCampaign(JFrame frame, Campaign campaign, File file, boolean isForBugReport) {
         String path = file.getPath();
         if (!path.endsWith(".cpnx") && !path.endsWith(".cpnx.gz")) {
             path += ".cpnx";
@@ -1827,7 +1857,7 @@ public class CampaignGUI extends JPanel {
               BufferedOutputStream bos = new BufferedOutputStream(os);
               OutputStreamWriter osw = new OutputStreamWriter(bos, StandardCharsets.UTF_8);
               PrintWriter pw = new PrintWriter(osw)) {
-            campaign.writeToXML(pw);
+            campaign.writeToXML(pw, isForBugReport);
             pw.flush();
             // delete the backup file because we didn't need it
             if (backupFile.exists() && !backupFile.delete()) {

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/StratConMaplessCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/StratConMaplessCampaignOptionsChangedConfirmationDialog.java
@@ -33,6 +33,7 @@
 package mekhq.gui.campaignOptions.optionChangeDialogs;
 
 import static megamek.client.ui.util.UIUtil.scaleForGUI;
+import static mekhq.MHQConstants.DISCORD_LINK;
 import static mekhq.utilities.MHQInternationalization.getFormattedText;
 import static mekhq.utilities.MHQInternationalization.getText;
 
@@ -59,7 +60,6 @@ import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
 public class StratConMaplessCampaignOptionsChangedConfirmationDialog {
     private static final MMLogger LOGGER = MMLogger.create(StratConMaplessCampaignOptionsChangedConfirmationDialog.class);
 
-    private final static String DISCORD_LINK = "https://discord.gg/megamek";
     private final static String ATB_RETIREMENT_LINK = "https://megamek.org/announcements/development/mekhq/2025/11/11/Retiring-the-Colors-Against-the-Bot.html";
 
     public StratConMaplessCampaignOptionsChangedConfirmationDialog(Campaign campaign) {

--- a/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/StratConMaplessCampaignOptionsChangedConfirmationDialog.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/optionChangeDialogs/StratConMaplessCampaignOptionsChangedConfirmationDialog.java
@@ -41,8 +41,6 @@ import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Desktop;
 import java.awt.Dimension;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.net.URI;
 import java.util.List;
 import javax.swing.ImageIcon;
@@ -112,16 +110,13 @@ public class StratConMaplessCampaignOptionsChangedConfirmationDialog {
         btnDiscord.setToolTipText(discordLink);
         btnDiscord.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         btnDiscord.setAlignmentX(Component.CENTER_ALIGNMENT);
-        btnDiscord.addMouseListener(new MouseAdapter() {
-            @Override
-            public void mouseClicked(MouseEvent evt) {
-                if (Desktop.isDesktopSupported()) {
-                    try {
-                        URI uri = new URI(discordLink);
-                        Desktop.getDesktop().browse(uri);
-                    } catch (Exception ex) {
-                        LOGGER.error(ex, "Failed to open URL: {}", discordLink);
-                    }
+        btnDiscord.addActionListener(e -> {
+            if (Desktop.isDesktopSupported()) {
+                try {
+                    URI uri = new URI(discordLink);
+                    Desktop.getDesktop().browse(uri);
+                } catch (Exception ex) {
+                    LOGGER.error(ex, "Failed to open URL: {}", discordLink);
                 }
             }
         });

--- a/MekHQ/src/mekhq/gui/dialog/EasyBugReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EasyBugReportDialog.java
@@ -39,8 +39,6 @@ import static mekhq.utilities.MHQInternationalization.getTextAt;
 import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Desktop;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -215,16 +213,13 @@ public class EasyBugReportDialog extends ImmersiveDialogCore {
         btnURL.setToolTipText(address);
         btnURL.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         btnURL.setAlignmentX(Component.CENTER_ALIGNMENT);
-        btnURL.addMouseListener(new MouseAdapter() {
-            @Override
-            public void mouseClicked(MouseEvent evt) {
-                if (Desktop.isDesktopSupported()) {
-                    try {
-                        URI uri = new URI(address);
-                        Desktop.getDesktop().browse(uri);
-                    } catch (Exception ex) {
-                        LOGGER.error(ex, "Failed to open URL: {}", address);
-                    }
+        btnURL.addActionListener(e -> {
+            if (Desktop.isDesktopSupported()) {
+                try {
+                    URI uri = new URI(address);
+                    Desktop.getDesktop().browse(uri);
+                } catch (Exception ex) {
+                    LOGGER.error(ex, "Failed to open URL: {}", address);
                 }
             }
         });

--- a/MekHQ/src/mekhq/gui/dialog/EasyBugReportDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/EasyBugReportDialog.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.gui.dialog;
+
+import static megamek.client.ui.util.UIUtil.scaleForGUI;
+import static mekhq.MHQConstants.DISCORD_LINK;
+import static mekhq.utilities.MHQInternationalization.getTextAt;
+
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.Desktop;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+
+import megamek.logging.MMLogger;
+import mekhq.campaign.Campaign;
+import mekhq.campaign.utilities.EasyBugReport;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
+import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogWidth;
+import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
+
+/**
+ * A dialog that assists players in preparing and submitting bug reports.
+ *
+ * <p>This immersive UI component provides quick access to:</p>
+ * <ul>
+ *     <li>Links for reporting issues across MegaMek ecosystem repositories</li>
+ *     <li>A one-click method for packaging the player's campaign into a bug report-ready archive</li>
+ *     <li>A direct link to the MegaMek Discord for discussion or clarification</li>
+ * </ul>
+ *
+ * <p>The UI layout provides two button rows:</p>
+ * <ol>
+ *     <li>Discord + campaign packaging</li>
+ *     <li>Direct links to specific GitHub issue templates</li>
+ * </ol>
+ *
+ * @author Illiani
+ * @since 0.50.11
+ */
+public class EasyBugReportDialog extends ImmersiveDialogCore {
+    private static final MMLogger LOGGER = MMLogger.create(EasyBugReportDialog.class);
+    private static final String RESOURCE_BUNDLE = "mekhq.resources.EasyBugReport";
+
+    private static final String REPORT_LINK_MM = "https://github.com/MegaMek/megamek/issues/new/choose";
+    private static final String REPORT_LINK_MML = "https://github.com/MegaMek/megameklab/issues/new/choose";
+    private static final String REPORT_LINK_MHQ = "https://github.com/MegaMek/mekhq/issues/new/choose";
+    private static final String REPORT_LINK_MM_DATA = "https://github.com/MegaMek/mm-data/issues/new";
+
+    private static final Map<String, String> URI_LABELS = new LinkedHashMap<>();
+
+    static {
+        URI_LABELS.put(getTextAt(RESOURCE_BUNDLE, "EasyBugReport.dialog.button.mm"), REPORT_LINK_MM);
+        URI_LABELS.put(getTextAt(RESOURCE_BUNDLE, "EasyBugReport.dialog.button.mml"), REPORT_LINK_MML);
+        URI_LABELS.put(getTextAt(RESOURCE_BUNDLE, "EasyBugReport.dialog.button.mhq"), REPORT_LINK_MHQ);
+        URI_LABELS.put(getTextAt(RESOURCE_BUNDLE, "EasyBugReport.dialog.button.mmData"), REPORT_LINK_MM_DATA);
+    }
+
+
+    /**
+     * Constructs a new Easy Bug Report dialog configured for the supplied campaign and parent frame.
+     *
+     * <p>The dialog initializes localized text, predefined GitHub reporting links, a Discord jump button, and a
+     * button that invokes {@link EasyBugReport#saveCampaignForBugReport(JFrame, Campaign)} to produce a report-ready
+     * archive.</p>
+     *
+     * @param frame    the parent window for dialog placement and modality
+     * @param campaign the current campaign whose state may be archived for a bug report
+     *
+     * @author Illiani
+     * @since 0.50.11
+     */
+    public EasyBugReportDialog(JFrame frame, Campaign campaign) {
+        super(campaign,
+              null,
+              null,
+              getTextAt(RESOURCE_BUNDLE, "EasyBugReport.dialog.message.main"),
+              getButtons(),
+              getTextAt(RESOURCE_BUNDLE, "EasyBugReport.dialog.message.supplementary"),
+              ImmersiveDialogWidth.LARGE.getWidth(),
+              false,
+              getSupplementalPanel(frame, campaign),
+              null,
+              true);
+    }
+
+    /**
+     * Builds the single default button for the dialog: a localized Cancel button.
+     *
+     * @return an immutable list containing a single {@link ImmersiveDialogCore.ButtonLabelTooltipPair}
+     *
+     * @author Illiani
+     * @since 0.50.11
+     */
+    private static List<ImmersiveDialogCore.ButtonLabelTooltipPair> getButtons() {
+        String label = getTextAt(RESOURCE_BUNDLE, "EasyBugReport.dialog.button.cancel");
+        return List.of(new ImmersiveDialogCore.ButtonLabelTooltipPair(label, null));
+    }
+
+    /**
+     * Creates the supplemental panel containing service buttons.
+     * <p>Row 1 contains:</p>
+     * <ul>
+     *     <li>A Discord link button</li>
+     *     <li>A "Save Campaign for Bug Report" button</li>
+     * </ul>
+     *
+     * <p>Row 2 contains dynamically generated repository issue buttons based on {@link #URI_LABELS}.</p>
+     *
+     * @param frame    the parent UI frame, required for bug-report packaging
+     * @param campaign the active campaign to extract packaged data from
+     *
+     * @return a fully constructed panel containing supplemental UI actions
+     *
+     * @author Illiani
+     * @since 0.50.11
+     */
+    private static JPanel getSupplementalPanel(JFrame frame, Campaign campaign) {
+        JPanel rootPanel = new JPanel();
+        rootPanel.setLayout(new BoxLayout(rootPanel, BoxLayout.Y_AXIS));
+        rootPanel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        JPanel row1 = new JPanel();
+        row1.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        String lblDiscord = getTextAt(RESOURCE_BUNDLE, "EasyBugReport.dialog.button.discord");
+        RoundedJButton btnDiscord = new RoundedJButton(lblDiscord);
+        btnDiscord.setName(lblDiscord);
+        buildUrlButton(btnDiscord, DISCORD_LINK);
+        row1.add(btnDiscord);
+
+        String lblPackageBundle = getTextAt(RESOURCE_BUNDLE, "EasyBugReport.dialog.button.build");
+        RoundedJButton btnPackage = new RoundedJButton(lblPackageBundle);
+        btnPackage.setName(lblPackageBundle);
+        btnPackage.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        btnPackage.setAlignmentX(Component.CENTER_ALIGNMENT);
+        btnPackage.addActionListener(evt -> EasyBugReport.saveCampaignForBugReport(frame, campaign));
+        row1.add(btnPackage);
+
+        JPanel row2 = new JPanel();
+        row2.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        for (Map.Entry<String, String> entry : URI_LABELS.entrySet()) {
+            RoundedJButton btnURL = new RoundedJButton(entry.getKey());
+            btnURL.setName(entry.getKey());
+            buildUrlButton(btnURL, entry.getValue());
+            row2.add(btnURL);
+        }
+
+        rootPanel.add(row1);
+        rootPanel.add(Box.createVerticalStrut(scaleForGUI(5)));
+        rootPanel.add(row2);
+
+        return rootPanel;
+    }
+
+    /**
+     * Configures a button so that clicking it opens a URL in the user's system browser.
+     *
+     * <p>This assigns:</p>
+     * <ul>
+     *     <li>a tooltip displaying the destination</li>
+     *     <li>a pointer cursor to reinforce clickability</li>
+     *     <li>a mouse listener that attempts to launch the browser</li>
+     * </ul>
+     *
+     * <p>Any exceptions occurring during URL construction or browser invocation are caught and logged.</p>
+     *
+     * @param btnURL  the Swing button to update
+     * @param address the URL string this button should open
+     *
+     * @author Illiani
+     * @since 0.50.11
+     */
+    private static void buildUrlButton(JButton btnURL, String address) {
+        btnURL.setToolTipText(address);
+        btnURL.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        btnURL.setAlignmentX(Component.CENTER_ALIGNMENT);
+        btnURL.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent evt) {
+                if (Desktop.isDesktopSupported()) {
+                    try {
+                        URI uri = new URI(address);
+                        Desktop.getDesktop().browse(uri);
+                    } catch (Exception ex) {
+                        LOGGER.error(ex, "Failed to open URL: {}", address);
+                    }
+                }
+            }
+        });
+    }
+}

--- a/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
@@ -41,8 +41,6 @@ import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Desktop;
 import java.awt.Dimension;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -214,16 +212,13 @@ public class MilestoneUpgradePathDialog {
         btnDiscord.setToolTipText(discordLink);
         btnDiscord.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         btnDiscord.setAlignmentX(Component.CENTER_ALIGNMENT);
-        btnDiscord.addMouseListener(new MouseAdapter() {
-            @Override
-            public void mouseClicked(MouseEvent evt) {
-                if (Desktop.isDesktopSupported()) {
-                    try {
-                        URI uri = new URI(discordLink);
-                        Desktop.getDesktop().browse(uri);
-                    } catch (Exception ex) {
-                        LOGGER.error(ex, "Failed to open URL: {}", discordLink);
-                    }
+        btnDiscord.addActionListener(e -> {
+            if (Desktop.isDesktopSupported()) {
+                try {
+                    URI uri = new URI(discordLink);
+                    Desktop.getDesktop().browse(uri);
+                } catch (Exception ex) {
+                    LOGGER.error(ex, "Failed to open URL: {}", discordLink);
                 }
             }
         });

--- a/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MilestoneUpgradePathDialog.java
@@ -33,6 +33,7 @@
 package mekhq.gui.dialog;
 
 import static megamek.client.ui.util.UIUtil.scaleForGUI;
+import static mekhq.MHQConstants.DISCORD_LINK;
 import static mekhq.utilities.MHQInternationalization.getFormattedText;
 import static mekhq.utilities.MHQInternationalization.getText;
 
@@ -70,8 +71,6 @@ import mekhq.gui.baseComponents.roundedComponents.RoundedJButton;
  */
 public class MilestoneUpgradePathDialog {
     private static final MMLogger LOGGER = MMLogger.create(MilestoneUpgradePathDialog.class);
-
-    private final static String DISCORD_LINK = "https://discord.gg/megamek";
 
     /**
      * Displays the milestone upgrade path dialog if upgrades are needed for the supplied campaign.

--- a/MekHQ/src/mekhq/service/AutosaveService.java
+++ b/MekHQ/src/mekhq/service/AutosaveService.java
@@ -107,7 +107,7 @@ public class AutosaveService implements IAutosaveService {
                       GZIPOutputStream gos = new GZIPOutputStream(fos);
                       OutputStreamWriter osw = new OutputStreamWriter(gos, StandardCharsets.UTF_8);
                       PrintWriter writer = new PrintWriter(osw)) {
-                    campaign.writeToXML(writer);
+                    campaign.writeToXML(writer, false);
                     writer.flush();
                 }
             } else {


### PR DESCRIPTION
This PR adds a 'report a bug' helper dialog (shown below).

<img width="828" height="578" alt="image" src="https://github.com/user-attachments/assets/5b5d30d6-cdc1-4276-86b9-c98ad16c862b" />

- Each of the four project buttons acts as a hyperlink and takes the player straight to the issue report page for that project.
- The campaign save option fires a special save action that creates a zip archive that includes the players' save and the log files in their logs folder. This campaign save is special, in that it enshrines all player unit files (including customs) in the save. That means it is no longer necessary for players to upload their custom units alongside a bug report.
- The discord option takes the player straight to our Discord.