### PR TITLE
Improvement: Added Ability to Disable Tabbed Daily Report

### DIFF
--- a/MekHQ/resources/mekhq/resources/GUI.properties
+++ b/MekHQ/resources/mekhq/resources/GUI.properties
@@ -736,6 +736,8 @@ labelPersonnelDisplay.text=Personnel Tab Display Options
 optionPersonnelFilterStyle.text=Personnel Filter Style
 optionPersonnelFilterStyle.toolTipText=This is the style for which Personnel Filters will be displayed
 optionPersonnelFilterOnPrimaryRole.text=Filter Personnel Based On Primary Profession
+chkUnifiedDailyReport.text=Disable Daily Report Tabs
+chkUnifiedDailyReport.toolTipText=All daily report messages will be posted to the General tab
 ## Colors Tab
 coloursTab.title=Colours
 optionDeployedForeground.text=Deployed Foreground

--- a/MekHQ/src/mekhq/MHQConstants.java
+++ b/MekHQ/src/mekhq/MHQConstants.java
@@ -98,6 +98,7 @@ public final class MHQConstants extends SuiteConstants {
     // region Personnel Tab
     public static final String PERSONNEL_FILTER_STYLE = "personnelFilterStyle";
     public static final String PERSONNEL_FILTER_ON_PRIMARY_ROLE = "personnelFilterOnPrimaryRole";
+    public static final String USE_UNIFIED_DAILY_REPORT = "useUnifiedDailyReport";
     // endregion Personnel Tab
     // endregion Display
 

--- a/MekHQ/src/mekhq/MHQOptions.java
+++ b/MekHQ/src/mekhq/MHQOptions.java
@@ -242,6 +242,16 @@ public final class MHQOptions extends SuiteOptions {
         userPreferences.node(MHQConstants.DISPLAY_NODE)
               .putBoolean(MHQConstants.PERSONNEL_FILTER_ON_PRIMARY_ROLE, value);
     }
+
+    public boolean getUnifiedDailyReport() {
+        return userPreferences.node(MHQConstants.DISPLAY_NODE)
+                     .getBoolean(MHQConstants.USE_UNIFIED_DAILY_REPORT, false);
+    }
+
+    public void setUnifiedDailyReport(boolean value) {
+        userPreferences.node(MHQConstants.DISPLAY_NODE)
+              .putBoolean(MHQConstants.USE_UNIFIED_DAILY_REPORT, value);
+    }
     // endregion Personnel Tab
     // endregion Display Tab
 

--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -129,9 +129,9 @@ import mekhq.MekHQ;
 import mekhq.Utilities;
 import mekhq.campaign.Quartermaster.PartAcquisitionResult;
 import mekhq.campaign.againstTheBot.AtBConfiguration;
-import mekhq.campaign.campaignOptions.AcquisitionsType;
 import mekhq.campaign.camOpsReputation.IUnitRating;
 import mekhq.campaign.camOpsReputation.ReputationController;
+import mekhq.campaign.campaignOptions.AcquisitionsType;
 import mekhq.campaign.campaignOptions.CampaignOptions;
 import mekhq.campaign.campaignOptions.CampaignOptionsMarshaller;
 import mekhq.campaign.enums.CampaignTransportType;
@@ -5981,10 +5981,17 @@ public class Campaign implements ITechManager {
      * @param type   what log to place the report in
      * @param report - the report String
      */
-    public void addReport(final DailyReportType type, String report) {
+    public void addReport(DailyReportType type, String report) {
         if (MekHQ.getMHQOptions().getHistoricalDailyLog()) {
             addInMemoryLogHistory(new HistoricalLogEntry(getLocalDate(), report));
         }
+
+        // We handle this here, instead of 'addReportInternal' as we don't want to post multiple new day 'dates' to
+        // the General tab
+        if (MekHQ.getMHQOptions().getUnifiedDailyReport()) {
+            type = GENERAL;
+        }
+
         addReportInternal(type, report);
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/MHQOptionsDialog.java
@@ -111,6 +111,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
     // region Personnel Tab
     private JComboBox<PersonnelFilterStyle> optionPersonnelFilterStyle;
     private JCheckBox optionPersonnelFilterOnPrimaryRole;
+    private JCheckBox chkUnifiedDailyReport;
     // endregion Personnel Tab
     // endregion Display
 
@@ -442,6 +443,10 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         });
 
         optionPersonnelFilterOnPrimaryRole = new JCheckBox(resources.getString("optionPersonnelFilterOnPrimaryRole.text"));
+
+        chkUnifiedDailyReport = new JCheckBox(resources.getString("chkUnifiedDailyReport.text"));
+        chkUnifiedDailyReport.setToolTipText(resources.getString("chkUnifiedDailyReport.toolTipText"));
+        chkUnifiedDailyReport.setName("chkUnifiedDailyReport");
         // endregion Personnel Tab
 
         // Programmatically Assign Accessibility Labels
@@ -507,7 +512,8 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                                             GroupLayout.DEFAULT_SIZE,
                                                             GroupLayout.DEFAULT_SIZE,
                                                             40))
-                                      .addComponent(optionPersonnelFilterOnPrimaryRole));
+                                      .addComponent(optionPersonnelFilterOnPrimaryRole)
+                                      .addComponent(chkUnifiedDailyReport));
 
         layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
                                         .addGroup(layout.createSequentialGroup()
@@ -545,7 +551,8 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
                                         .addGroup(layout.createSequentialGroup()
                                                         .addComponent(labelPersonnelFilterStyle)
                                                         .addComponent(optionPersonnelFilterStyle))
-                                        .addComponent(optionPersonnelFilterOnPrimaryRole));
+                                        .addComponent(optionPersonnelFilterOnPrimaryRole)
+                                        .addComponent(chkUnifiedDailyReport));
 
         return body;
     }
@@ -1464,6 +1471,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         MekHQ.getMHQOptions()
               .setPersonnelFilterStyle((PersonnelFilterStyle) Objects.requireNonNull(optionPersonnelFilterStyle.getSelectedItem()));
         MekHQ.getMHQOptions().setPersonnelFilterOnPrimaryRole(optionPersonnelFilterOnPrimaryRole.isSelected());
+        MekHQ.getMHQOptions().setUnifiedDailyReport(chkUnifiedDailyReport.isSelected());
 
         // Colours
         MekHQ.getMHQOptions().setDeployedForeground(optionDeployedForeground.getColour());
@@ -1649,6 +1657,7 @@ public class MHQOptionsDialog extends AbstractMHQButtonDialog {
         // Personnel Tab
         optionPersonnelFilterStyle.setSelectedItem(MekHQ.getMHQOptions().getPersonnelFilterStyle());
         optionPersonnelFilterOnPrimaryRole.setSelected(MekHQ.getMHQOptions().getPersonnelFilterOnPrimaryRole());
+        chkUnifiedDailyReport.setSelected(MekHQ.getMHQOptions().getUnifiedDailyReport());
 
         // Colours
         optionDeployedForeground.setColour(MekHQ.getMHQOptions().getDeployedForeground());


### PR DESCRIPTION
As per title, this PR adds the ability to disable the new tabbed daily report functionality. It doesn't remove the tabs, as adding & reporting GUI elements is a pain without restarting the MekHQ client. However, it does force all messages to be posted to the General tab. Effectively duplicating the <50.11 experience.