### PR TITLE
Fix: Fixed Daily Report Tabs Incorrectly 'Flashing' On New Day for Date Only Updates

### DIFF
--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2746,10 +2746,24 @@ public class CampaignGUI extends JPanel {
                     logNagActive = true;
                 }
 
+                EnhancedTabbedPane tabLogs = commandCenterTab.getTabLogs();
                 int logsSelected = commandCenterTab.getTabLogs().getSelectedIndex();
                 if (logsSelected != relevantIndex) {
-                    commandCenterTab.nagLogTab(relevantIndex);
-                    commandCenterTab.setLogNagActive(logType, true);
+                    DailyReportLogPanel reportTab = switch (logType) {
+                        case GENERAL -> commandCenterTab.getGeneralLog();
+                        case BATTLE -> commandCenterTab.getBattleLog();
+                        case PERSONNEL -> commandCenterTab.getPersonnelLog();
+                        case MEDICAL -> commandCenterTab.getMedicalLog();
+                        case FINANCES -> commandCenterTab.getFinancesLog();
+                        case ACQUISITIONS -> commandCenterTab.getAcquisitionsLog();
+                        case TECHNICAL -> commandCenterTab.getTechnicalLog();
+                        case SKILL_CHECKS -> commandCenterTab.getSkillLog();
+                    };
+
+                    if (!DailyReportLogPanel.isIsDateOnly(List.of(reportTab.getLogText()))) {
+                        commandCenterTab.nagLogTab(relevantIndex);
+                        commandCenterTab.setLogNagActive(logType, true);
+                    }
                 }
 
                 break;

--- a/MekHQ/src/mekhq/gui/CampaignGUI.java
+++ b/MekHQ/src/mekhq/gui/CampaignGUI.java
@@ -2746,7 +2746,6 @@ public class CampaignGUI extends JPanel {
                     logNagActive = true;
                 }
 
-                EnhancedTabbedPane tabLogs = commandCenterTab.getTabLogs();
                 int logsSelected = commandCenterTab.getTabLogs().getSelectedIndex();
                 if (logsSelected != relevantIndex) {
                     DailyReportLogPanel reportTab = switch (logType) {
@@ -2760,7 +2759,7 @@ public class CampaignGUI extends JPanel {
                         case SKILL_CHECKS -> commandCenterTab.getSkillLog();
                     };
 
-                    if (!DailyReportLogPanel.isIsDateOnly(List.of(reportTab.getLogText()))) {
+                    if (!DailyReportLogPanel.isDateOnly(List.of(reportTab.getLogText()))) {
                         commandCenterTab.nagLogTab(relevantIndex);
                         commandCenterTab.setLogNagActive(logType, true);
                     }

--- a/MekHQ/src/mekhq/gui/DailyReportLogPanel.java
+++ b/MekHQ/src/mekhq/gui/DailyReportLogPanel.java
@@ -143,9 +143,9 @@ public class DailyReportLogPanel extends JPanel {
         getTxtLog().setDocument(blank);
         getTxtLog().setCaretPosition(blank.getLength());
 
-        // If there is only one line in the log it means it's just the date header, so we don't want to alert the
+        // If there is only one line in the log, it means it's just the date header, so we don't want to alert the
         // player for no reason
-        if (text.lines().count() != 1) {
+        if (!isIsDateOnly(List.of(text))) {
             getGUI().checkDailyLogNag(type);
         }
         SwingUtilities.invokeLater(() -> logPanel.getVerticalScrollBar().setValue(0));
@@ -172,9 +172,39 @@ public class DailyReportLogPanel extends JPanel {
         }
         getTxtLog().setCaretPosition(doc.getLength());
 
+        // We only want to nag the player if there is something of value. So no nag occurs if we're just adding the date
+        if (!isIsDateOnly(newReports)) {
+            getGUI().checkDailyLogNag(type);
+        }
+        SwingUtilities.invokeLater(() -> logPanel.getVerticalScrollBar().setValue(0));
+    }
+
+    /**
+     * Checks whether the given list of report lines represents a single, date-only entry.
+     *
+     * <p>This method returns {@code true} only when all the following are true:</p>
+     * <ul>
+     *     <li>{@code newReports} contains exactly one element,</li>
+     *     <li>that element is wrapped in {@code <b>} and {@code </b>} tags, and</li>
+     *     <li>the inner text parses successfully as a {@link LocalDate} using the {@link #DAILY_REPORT_DATE_FORMAT}
+     *     formatter.</li>
+     * </ul>
+     *
+     * <p>If the list size is not exactly one, the element is not correctly formatted, or the inner text cannot be
+     * parsed as a date, this method returns {@code false} without throwing an exception.</p>
+     *
+     * @param reports the list of report lines to inspect
+     *
+     * @return {@code true} if the list represents a single bolded, correctly formatted date-only entry; {@code false}
+     *       otherwise
+     *
+     * @author Illiani
+     * @since 0.50.11
+     */
+    public static boolean isIsDateOnly(List<String> reports) {
         boolean isDateOnly = false;
-        if (newReports.size() == 1) {
-            String line = newReports.get(0);
+        if (reports.size() == 1) {
+            String line = reports.get(0);
             String inner = line.substring(3, line.length() - 4); // strip <b> and </b>
 
             // If parsing succeeds, it's a real report date
@@ -185,11 +215,6 @@ public class DailyReportLogPanel extends JPanel {
                 // Not a formatted date — do nothing
             }
         }
-
-        // We only want to nag the player if there is something of value. So no nag occurs if we're just adding the date
-        if (!isDateOnly) {
-            getGUI().checkDailyLogNag(type);
-        }
-        SwingUtilities.invokeLater(() -> logPanel.getVerticalScrollBar().setValue(0));
+        return isDateOnly;
     }
 }

--- a/MekHQ/src/mekhq/gui/DailyReportLogPanel.java
+++ b/MekHQ/src/mekhq/gui/DailyReportLogPanel.java
@@ -38,7 +38,6 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -145,7 +144,7 @@ public class DailyReportLogPanel extends JPanel {
 
         // If there is only one line in the log, it means it's just the date header, so we don't want to alert the
         // player for no reason
-        if (!isIsDateOnly(List.of(text))) {
+        if (!isDateOnly(List.of(text))) {
             getGUI().checkDailyLogNag(type);
         }
         SwingUtilities.invokeLater(() -> logPanel.getVerticalScrollBar().setValue(0));
@@ -173,7 +172,7 @@ public class DailyReportLogPanel extends JPanel {
         getTxtLog().setCaretPosition(doc.getLength());
 
         // We only want to nag the player if there is something of value. So no nag occurs if we're just adding the date
-        if (!isIsDateOnly(newReports)) {
+        if (!isDateOnly(newReports)) {
             getGUI().checkDailyLogNag(type);
         }
         SwingUtilities.invokeLater(() -> logPanel.getVerticalScrollBar().setValue(0));
@@ -184,7 +183,7 @@ public class DailyReportLogPanel extends JPanel {
      *
      * <p>This method returns {@code true} only when all the following are true:</p>
      * <ul>
-     *     <li>{@code newReports} contains exactly one element,</li>
+     *     <li>{@code reports} contains exactly one element,</li>
      *     <li>that element is wrapped in {@code <b>} and {@code </b>} tags, and</li>
      *     <li>the inner text parses successfully as a {@link LocalDate} using the {@link #DAILY_REPORT_DATE_FORMAT}
      *     formatter.</li>
@@ -201,17 +200,17 @@ public class DailyReportLogPanel extends JPanel {
      * @author Illiani
      * @since 0.50.11
      */
-    public static boolean isIsDateOnly(List<String> reports) {
+    public static boolean isDateOnly(List<String> reports) {
         boolean isDateOnly = false;
         if (reports.size() == 1) {
-            String line = reports.get(0);
-            String inner = line.substring(3, line.length() - 4); // strip <b> and </b>
-
             // If parsing succeeds, it's a real report date
             try {
+                String line = reports.get(0);
+                String inner = line.substring(3, line.length() - 4); // strip <b> and </b>
+
                 LocalDate.parse(inner, DAILY_REPORT_DATE_FORMAT);
                 isDateOnly = true;
-            } catch (DateTimeParseException ignored) {
+            } catch (Exception ignored) {
                 // Not a formatted date — do nothing
             }
         }


### PR DESCRIPTION
The various daily report tabs should only 'flash' when updated with something _other_ than the date. This ensures players don't need to cycle through every tab looking for an update. The code was set up for this, but it seems at some point the code that handled the process got removed for unknown reasons. This PR restores it.