### PR TITLE
Improvement: Added Method to Handle the Removal of MegaMek Implants or SPAs Added by Alt Advanced Medical Implants

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7175,6 +7175,10 @@ public class Person {
 
     public void removeInjury(final Injury injury) {
         injuries.remove(injury);
+
+        // We need to make sure we also remove any associated abilities and implants
+        AdvancedMedicalAlternate.removeAssociatedInjuryOptions(injury, injuries, options);
+
         MekHQ.triggerEvent(new PersonChangedEvent(this));
     }
 

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/ProstheticType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/ProstheticType.java
@@ -1455,4 +1455,33 @@ public enum ProstheticType {
     private static void addToMap(Map<SkillAttribute, Integer> map, SkillAttribute key, int value) {
         map.merge(key, value, Integer::sum);
     }
+
+    /**
+     * Fetches the {@link ProstheticType} that corresponds to a given {@link InjuryType} produced by a permanent
+     * modification (implant/prosthetic).
+     *
+     * <p>This is a convenience lookup used when removing or analyzing injuries to determine which prosthetic granted
+     * the effect. If the provided injury type is not a permanent modification, or if no matching prosthetic is defined,
+     * this returns {@code null}.</p>
+     *
+     * @param injuryType the injury type to resolve; ignored if it is not a permanent modification
+     *
+     * @return the matching prosthetic type, or {@code null} if none applies
+     *
+     * @author Illiani
+     * @since 0.50.11
+     */
+    public static @Nullable ProstheticType getProstheticFromInjury(InjuryType injuryType) {
+        if (!injuryType.getSubType().isPermanentModification()) {
+            return null;
+        }
+
+        for (ProstheticType prosthetic : ProstheticType.values()) {
+            if (prosthetic.getInjuryType() == injuryType) {
+                return prosthetic;
+            }
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
Some Alt AM surgeries gift the patient with SPAs or Implants. This PR removes those when the associated 'injury' is removed. In this way a character who has their prosthetic limb blown off won't somehow retain the benefits of said, now detached, limb.