### PR TITLE
Fix: Fixed 'Easy Bug' Handling of Units Stored in Archives; Added Better Error Logging

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -6623,7 +6623,7 @@ public class Campaign implements ITechManager {
                     continue;
                 }
 
-                mekFileParser = new MekFileParser(mekSummary.getSourceFile(), mekSummary.getEntryName());
+                mekFileParser = new MekFileParser(sourceFile, mekSummary.getEntryName());
             } catch (EntityLoadingException ex) {
                 LOGGER.error("Failed to fetch MekFileParser for {} // {}",
                       mekSummary.getSourceFile(), mekSummary.getEntryName(), ex);


### PR DESCRIPTION
If a player has units stored in a zip archive and attempts to do one of the following, MekHQ will throw a silent error and the saving of that unit into the campaign save will fail.

- Save the campaign using the Report a Bug button
- Save the campaign with the 'save customs' option enabled

This is a pre-existing bug that has been present for years but due to the second of the above options being rarely useful it flew under the radar.

While I was handling this I also went in and added better error handling and safeties to the whole process. This should make it easier to track the issue if this process runs into problems in the future.