### PR TITLE
Fix #8477, #8497: Fixed Estimated Total Profit in Contract Market Not Including Transportation Compensation

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/Contract.java
+++ b/MekHQ/src/mekhq/campaign/mission/Contract.java
@@ -616,7 +616,7 @@ public class Contract extends Mission {
     public Money getEstimatedTotalProfit(Campaign campaign) {
         return getTotalAdvanceAmount()
                      .plus(getTotalMonthlyPayOut(campaign))
-                     .minus(getTransportCost(campaign, false));
+                     .minus(getTransportCost(campaign, true));
     }
 
     /**


### PR DESCRIPTION
Fix #8477
Fix #8497

We were incorrectly excluding transport compensation from estimated contract profits. This meant that players were seeing the estimated profits as if they were covering 100% of the transportation cost. This appears to be a visual bug only.