### PR TITLE
Fix #8463: Fixed Glossary Typo

### DIFF
--- a/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
+++ b/MekHQ/resources/mekhq/resources/GlossaryEntry.properties
@@ -329,7 +329,7 @@ COMBAT_TEAMS.definition=Combat Teams are cohesive groups of forces designed to f
  \ is particularly useful for large campaigns where deploying in Lance-level formations results in implausibly large\
  \ numbers of scenarios each week.</p>\
  <p><b>FORCE TYPE</b></p>\
- <p>There are four kinds of force classification: <a href='GLOSSARY:FORCE_TYPE_COMBAT'>Combat</a>,\
+ <p>There are five kinds of force classification: <a href='GLOSSARY:FORCE_TYPE_COMBAT'>Combat</a>,\
  \ <a href='GLOSSARY:FORCE_TYPE_CONVOY'>Convoy</a>, <a href='GLOSSARY:FORCE_TYPE_SECURITY'>Security</a>, \
  \ <a href='GLOSSARY:FORCE_TYPE_SUPPORT'>Support</a>, and<a href='GLOSSARY:FORCE_TYPE_SALVAGE'>Salvage</a>. Each is \
   set up for a specific duty. A force's type may be changed by right-clicking on the force and selecting the type of \


### PR DESCRIPTION
Fix #8463

`are four kinds` -> `are five kinds`