### PR TITLE
Fix #8460: Fixed Transport Cost Calculations Not Correctly Tracking Fixed Wing Support Units

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
+++ b/MekHQ/src/mekhq/campaign/mission/TransportCostCalculations.java
@@ -726,7 +726,9 @@ public class TransportCostCalculations {
                     smallCraftCount++;
                 } else if (entity.isMek()) {
                     mekCount++;
-                } else if (entity.isAerospaceFighter() || entity.isConventionalFighter()) {
+                } else if (entity.isAerospaceFighter() ||
+                                 entity.isConventionalFighter() ||
+                                 entity.isFixedWingSupport()) {
                     asfCount++;
                 } else if (entity.isProtoMek()) {
                     protoMekCount++;


### PR DESCRIPTION
Fix #8460

The transport cost calculator now correctly places Fixed-Wing Support units into ASF bays.