### PR TITLE
Fix: Cleared Daily Report Tab 'Flashes' On New Day

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -103,6 +103,7 @@ import megamek.common.rolls.TargetRoll;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
 import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.enums.DailyReportType;
 import mekhq.campaign.events.DayEndingEvent;
 import mekhq.campaign.events.DeploymentChangedEvent;
 import mekhq.campaign.events.NewDayEvent;
@@ -174,6 +175,7 @@ import mekhq.campaign.universe.factionStanding.FactionStandingUltimatum;
 import mekhq.campaign.universe.factionStanding.FactionStandingUtilities;
 import mekhq.campaign.universe.factionStanding.PerformBatchall;
 import mekhq.campaign.utilities.AutomatedPersonnelCleanUp;
+import mekhq.gui.CommandCenterTab;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogNotification;
 import mekhq.service.mrms.MRMSService;
 import mekhq.utilities.ReportingUtilities;
@@ -221,6 +223,13 @@ public class CampaignNewDayManager {
      * @return <code>true</code> if the new day arrived
      */
     public boolean newDay() {
+        // Clear previous daily report nags (we want this up top so that we can make sure no messages have been
+        // posted prior to this point).
+        CommandCenterTab commandCenter = campaign.getApp().getCampaigngui().getCommandCenterTab();
+        for (DailyReportType type : DailyReportType.values()) {
+            commandCenter.clearDailyReportNag(type.getTabIndex());
+        }
+
         // clear previous retirement information
         campaign.getTurnoverRetirementInformation().clear();
 

--- a/MekHQ/src/mekhq/gui/CommandCenterTab.java
+++ b/MekHQ/src/mekhq/gui/CommandCenterTab.java
@@ -583,7 +583,7 @@ public final class CommandCenterTab extends CampaignGuiTab {
         });
     }
 
-    void clearDailyReportNag(int selectedIndex) {
+    public void clearDailyReportNag(int selectedIndex) {
         DailyReportType type = DailyReportType.getTypeFromIndex(selectedIndex);
         if (type != null) {
             tabLogs.setBackgroundAt(selectedIndex, null);


### PR DESCRIPTION
When advancing day old (uncleared) daily report tab 'flashes' were not cleared. This meant that if you had the skill check tab 'flashed', advanced day, that tab flash would still be present. Even if that tab were now empty. This PR fixes that.