### PR TITLE
Fix: Campaign Upgrader Now Actually Upgrades the Campaign

### DIFF
--- a/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsFreebieTracker.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/CampaignOptionsFreebieTracker.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.campaignOptions;
+
+/**
+ * Immutable snapshot of a subset of {@link CampaignOptions} that are considered "critical" for gameplay balance and
+ * player entitlements.
+ *
+ * <p>This record exists to support change detection: store an instance representing the option state at a known
+ * point in time (for example, campaign creation or last acknowledged configuration), then compare it to a newly
+ * constructed instance to determine whether the player has enabled/disabled options that may warrant:</p>
+ *
+ * <ul>
+ *   <li>offering free units (or similar compensation),</li>
+ *   <li>triggering migration/adjustment handlers, or</li>
+ *   <li>showing warnings/confirmation prompts before applying the changes.</li>
+ * </ul>
+ *
+ * <p>The values captured here are intentionally reduced to simple booleans so they can be compared cheaply and
+ * reliably via the record's generated {@link #equals(Object)} and {@link #hashCode()} implementations.</p>
+ *
+ * @param awardVeterancySPAs    whether the campaign awards veterancy SPAs
+ * @param trackFactionStanding  whether faction standing is tracked
+ * @param trackPrisoners        whether prisoners are tracked (derived from prisoner capture style)
+ * @param useMASHTheatres       whether MASH theatres are enabled
+ * @param useFatigue            whether fatigue rules are enabled
+ * @param useAdvancedSalvage    whether advanced salvage rules are enabled
+ * @param useStratCon           whether StratCon is enabled
+ * @param useMapless            whether StratCon mapless mode is enabled
+ * @param useAdvancedScouting   whether advanced scouting is enabled (and applicable)
+ * @param useAltAdvancedMedical whether alternative advanced medical rules are enabled
+ * @param useDiseases           whether random diseases are enabled (and applicable)
+ *
+ * @author Illiani
+ * @since 0.50.11
+ */
+public record CampaignOptionsFreebieTracker(boolean awardVeterancySPAs, boolean trackFactionStanding,
+      boolean trackPrisoners, boolean useMASHTheatres, boolean useFatigue, boolean useAdvancedSalvage,
+      boolean useStratCon, boolean useMapless, boolean useAdvancedScouting, boolean useAltAdvancedMedical,
+      boolean useDiseases) {
+    /**
+     * Creates a tracker snapshot from the provided {@link CampaignOptions}.
+     *
+     * <p>Some fields are derived to reflect the effective ruleset:</p>
+     * <ul>
+     *   <li>{@code trackPrisoners} is derived from the prisoner capture style,</li>
+     *   <li>{@code useAdvancedScouting} only applies when StratCon is enabled,</li>
+     *   <li>{@code useDiseases} only applies when alternative advanced medical is enabled.</li>
+     * </ul>
+     *
+     * @param options source options to snapshot
+     *
+     * @author Illiani
+     * @since 0.50.11
+     */
+    public CampaignOptionsFreebieTracker(CampaignOptions options) {
+        this(
+              options.isAwardVeterancySPAs(),
+              options.isTrackFactionStanding(),
+              !options.getPrisonerCaptureStyle().isNone(),
+              options.isUseMASHTheatres(),
+              options.isUseFatigue(),
+              options.isUseCamOpsSalvage(),
+              options.isUseStratCon(),
+              options.isUseStratConMaplessMode(),
+              options.isUseAdvancedScouting() && options.isUseStratCon(),
+              options.isUseAlternativeAdvancedMedical(),
+              options.isUseAlternativeAdvancedMedical() && options.isUseRandomDiseases()
+        );
+    }
+}

--- a/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/CampaignOptionsPane.java
@@ -67,6 +67,7 @@ import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.campaignOptions.CampaignOptions;
+import mekhq.campaign.campaignOptions.CampaignOptionsFreebieTracker;
 import mekhq.campaign.events.OptionsChangedEvent;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.personnel.enums.PersonnelRoleSubType;
@@ -504,7 +505,6 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
     public void applyCampaignOptionsToCampaign(@Nullable CampaignPreset preset, CampaignOptionsDialogMode mode,
           boolean isSaveAction) {
         boolean isStartUp = mode == STARTUP || mode == STARTUP_ABRIDGED;
-        boolean isCampaignUpgrade = mode == CAMPAIGN_UPGRADE;
 
         CampaignOptions options = this.campaignOptions;
         RandomSkillPreferences presetRandomSkillPreferences = null;
@@ -516,18 +516,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             presetSkills = preset.getSkills();
         }
 
-        // Store old values for use if we want to trigger certain dialogs
-        boolean oldAwardVeterancySPAs = options.isAwardVeterancySPAs();
-        boolean oldIsTrackFactionStanding = options.isTrackFactionStanding();
-        boolean oldIsTrackPrisoners = !options.getPrisonerCaptureStyle().isNone();
-        boolean oldIsUseMASHTheatres = options.isUseMASHTheatres();
-        boolean oldIsUseFatigue = options.isUseFatigue();
-        boolean oldIsUseAdvancedSalvage = options.isUseCamOpsSalvage();
-        boolean oldIsUseStratCon = options.isUseStratCon();
-        boolean oldIsUseMapless = options.isUseStratConMaplessMode();
-        boolean oldIsUseAdvancedScouting = options.isUseAdvancedScouting() && oldIsUseStratCon;
-        boolean oldIsUseAltAdvancedMedical = options.isUseAlternativeAdvancedMedical();
-        boolean oldIsUseDiseases = oldIsUseAltAdvancedMedical && options.isUseRandomDiseases();
+        CampaignOptionsFreebieTracker oldCampaignOptions = new CampaignOptionsFreebieTracker(campaign.getCampaignOptions());
 
         // Everything assumes general tab will be the first applied.
         // While this shouldn't break anything, it's not worth moving around.
@@ -537,7 +526,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
 
         // Human Resources
         personnelTab.applyCampaignOptionsToCampaign(campaign, options);
-        biographyTab.applyCampaignOptionsToCampaign(isCampaignUpgrade, options);
+        biographyTab.applyCampaignOptionsToCampaign(options);
         relationshipsTab.applyCampaignOptionsToCampaign(options);
         salariesTab.applyCampaignOptionsToCampaign(options);
         turnoverAndRetentionTab.applyCampaignOptionsToCampaign(options);
@@ -566,7 +555,56 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             MekHQ.triggerEvent(new OptionsChangedEvent(campaign));
         }
 
-        boolean newIsTrackFactionStandings = options.isTrackFactionStanding();
+        CampaignOptionsFreebieTracker newCampaignOptions = new CampaignOptionsFreebieTracker(campaign.getCampaignOptions());
+        triggerUpgradeFreebies(campaign, oldCampaignOptions, newCampaignOptions, isStartUp);
+
+        campaign.resetRandomDeath();
+        if (campaignGui != null) {
+            campaignGui.refreshMarketButtonLabels();
+        }
+    }
+
+    /**
+     * Compares a previously-recorded {@link CampaignOptionsFreebieTracker} snapshot against a new snapshot and triggers
+     * any one-time handlers required when critical campaign options are enabled.
+     *
+     * <p>This method is intended to be called immediately after applying campaign option changes (or when
+     * loading/upgrading a campaign) so the campaign can react to newly-enabled systems. Reactions may include prompting
+     * the player with confirmation dialogs, adjusting campaign state, or granting "freebies" to keep the save
+     * consistent and fair when major rulesets are turned on mid-campaign.</p>
+     *
+     * <p>Only transitions from {@code false -> true} are acted upon (that is, newly enabled features). Disabling
+     * options typically does not require compensation and is therefore ignored here.</p>
+     *
+     * <p>When {@code isStartUp} is {@code true}, interactive prompts are suppressed; the method may still perform
+     * required non-interactive adjustments depending on implementation.</p>
+     *
+     * @param campaign   the campaign whose state may be adjusted and/or to which reports may be added
+     * @param oldOptions snapshot of the option state before the change (or previously acknowledged state)
+     * @param newOptions snapshot of the option state after the change (current effective state)
+     * @param isStartUp  whether this invocation is happening during startup/load/upgrade rather than an in-session
+     *                   options change
+     *
+     * @author Illiani
+     * @since 0.50.11
+     */
+    public static void triggerUpgradeFreebies(Campaign campaign, CampaignOptionsFreebieTracker oldOptions,
+          CampaignOptionsFreebieTracker newOptions,
+          boolean isStartUp) {
+        // Store old values for use if we want to trigger certain dialogs
+        boolean oldAwardVeterancySPAs = oldOptions.awardVeterancySPAs();
+        boolean oldIsTrackFactionStanding = oldOptions.trackFactionStanding();
+        boolean oldIsTrackPrisoners = !oldOptions.trackPrisoners();
+        boolean oldIsUseMASHTheatres = oldOptions.useMASHTheatres();
+        boolean oldIsUseFatigue = oldOptions.useFatigue();
+        boolean oldIsUseAdvancedSalvage = oldOptions.useAdvancedSalvage();
+        boolean oldIsUseStratCon = oldOptions.useStratCon();
+        boolean oldIsUseMapless = oldOptions.useMapless();
+        boolean oldIsUseAdvancedScouting = oldOptions.useAdvancedScouting() && oldIsUseStratCon;
+        boolean oldIsUseAltAdvancedMedical = oldOptions.useAltAdvancedMedical();
+        boolean oldIsUseDiseases = oldIsUseAltAdvancedMedical && oldOptions.useDiseases();
+
+        boolean newIsTrackFactionStandings = newOptions.trackFactionStanding();
         if (!isStartUp && newIsTrackFactionStandings && !oldIsTrackFactionStanding) { // Has tracking changed?
             FactionStandingCampaignOptionsChangedConfirmationDialog dialog = new FactionStandingCampaignOptionsChangedConfirmationDialog(
                   null,
@@ -576,7 +614,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
                   campaign.getFactionStandings(),
                   campaign.getMissions(),
                   newIsTrackFactionStandings,
-                  campaignOptions.getRegardMultiplier());
+                  campaign.getCampaignOptions().getRegardMultiplier());
 
             List<String> reports = dialog.getReports();
             for (String report : reports) {
@@ -586,59 +624,54 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
             }
         }
 
-        boolean newIsAwardVeterancySPAs = options.isAwardVeterancySPAs();
+        boolean newIsAwardVeterancySPAs = newOptions.awardVeterancySPAs();
         if (!isStartUp && newIsAwardVeterancySPAs && !oldAwardVeterancySPAs) { // Has tracking changed?
             new VeterancyAwardsCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
-        boolean newIsUseMASHTheatres = options.isUseMASHTheatres();
+        boolean newIsUseMASHTheatres = newOptions.useMASHTheatres();
         if (!isStartUp && newIsUseMASHTheatres && !oldIsUseMASHTheatres) { // Has tracking changed?
             new MASHTheaterTrackingCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
-        boolean newIsTrackPrisoners = !options.getPrisonerCaptureStyle().isNone();
+        boolean newIsTrackPrisoners = !newOptions.trackPrisoners();
         if (!isStartUp && newIsTrackPrisoners && !oldIsTrackPrisoners) { // Has tracking changed?
             new PrisonerTrackingCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
-        boolean newIsUseFatigue = options.isUseFatigue();
+        boolean newIsUseFatigue = newOptions.useFatigue();
         if (!isStartUp && newIsUseFatigue && !oldIsUseFatigue) { // Has tracking changed?
             new FatigueTrackingCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
-        boolean newIsUseAdvancedSalvage = options.isUseCamOpsSalvage();
+        boolean newIsUseAdvancedSalvage = newOptions.useAdvancedSalvage();
         if (!isStartUp && newIsUseAdvancedSalvage && !oldIsUseAdvancedSalvage) { // Has tracking changed?
             new SalvageCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
-        boolean newIsUseStratCon = options.isUseStratCon();
+        boolean newIsUseStratCon = newOptions.useStratCon();
         if (!isStartUp && newIsUseStratCon && !oldIsUseStratCon) { // Has tracking changed?
             new StratConConvoyCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
-        boolean newIsUseMapless = options.isUseStratConMaplessMode();
+        boolean newIsUseMapless = newOptions.useMapless();
         if (!isStartUp && newIsUseMapless && !oldIsUseMapless) { // Has tracking changed?
             new StratConMaplessCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
-        boolean newIsUseAdvancedScouting = options.isUseAdvancedScouting() && newIsUseStratCon;
+        boolean newIsUseAdvancedScouting = newOptions.useAdvancedScouting() && newIsUseStratCon;
         if (!isStartUp && newIsUseAdvancedScouting && !oldIsUseAdvancedScouting) { // Has tracking changed?
             new AdvancedScoutingCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
-        boolean newIsUseAltAdvancedMedical = options.isUseAlternativeAdvancedMedical();
+        boolean newIsUseAltAdvancedMedical = newOptions.useAltAdvancedMedical();
         if (!isStartUp && newIsUseAltAdvancedMedical && !oldIsUseAltAdvancedMedical) { // Has tracking changed?
             new AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog(campaign);
         }
 
-        boolean newIsUseDiseases = newIsUseAltAdvancedMedical && options.isUseRandomDiseases();
+        boolean newIsUseDiseases = newIsUseAltAdvancedMedical && newOptions.useDiseases();
         if (!isStartUp && newIsUseDiseases && !oldIsUseDiseases) { // Has tracking changed?
-            inoculateAllCharacters();
-        }
-
-        campaign.resetRandomDeath();
-        if (campaignGui != null) {
-            campaignGui.refreshMarketButtonLabels();
+            inoculateAllCharacters(campaign);
         }
     }
 
@@ -658,7 +691,7 @@ public class CampaignOptionsPane extends AbstractMHQTabbedPane {
      * @author Illiani
      * @since 0.50.10
      */
-    private void inoculateAllCharacters() {
+    private static void inoculateAllCharacters(Campaign campaign) {
         String currentPlanetId = null;
         CurrentLocation location = campaign.getLocation();
         if (location.isOnPlanet()) {

--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -1616,12 +1616,10 @@ public class BiographyTab {
      * If a preset options object is provided, the changes are applied there. Otherwise, they are applied to the current
      * campaign's options.
      *
-     * @param isCampaignUpgrade     Is triggered as part of the campaign upgrade process
      * @param presetCampaignOptions A {@link CampaignOptions} object to update with the current UI settings, or
      *                              {@code null} to apply changes to the campaign's options directly.
      */
-    public void applyCampaignOptionsToCampaign(boolean isCampaignUpgrade,
-          @Nullable CampaignOptions presetCampaignOptions) {
+    public void applyCampaignOptionsToCampaign(@Nullable CampaignOptions presetCampaignOptions) {
         CampaignOptions options = presetCampaignOptions;
         RandomOriginOptions originOptions;
         if (presetCampaignOptions == null) {
@@ -1710,13 +1708,6 @@ public class BiographyTab {
                 continue;
             }
             options.setUsePortraitForRole(i, chkUsePortrait[i].isSelected());
-        }
-
-        // Ranks
-        if (!isCampaignUpgrade) {
-            // We don't change rank when upgrade the campaign across versions, otherwise the players' rank system
-            // will be changed if the campaign rank system and the one in the preset don't match.`
-            rankSystemsPane.applyToCampaign();
         }
     }
 }

--- a/MekHQ/src/mekhq/gui/dialog/CampaignUpgradeDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/CampaignUpgradeDialog.java
@@ -33,6 +33,7 @@
 package mekhq.gui.dialog;
 
 import static megamek.client.ui.WrapLayout.wordWrap;
+import static mekhq.gui.campaignOptions.CampaignOptionsPane.triggerUpgradeFreebies;
 import static mekhq.utilities.MHQInternationalization.getFormattedTextAt;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
@@ -55,6 +56,7 @@ import mekhq.CampaignPreset;
 import mekhq.MHQConstants;
 import mekhq.MekHQ;
 import mekhq.campaign.Campaign;
+import mekhq.campaign.campaignOptions.CampaignOptionsFreebieTracker;
 import mekhq.campaign.personnel.SpecialAbility;
 import mekhq.campaign.personnel.skills.SkillType;
 import mekhq.gui.baseComponents.immersiveDialogs.ImmersiveDialogCore;
@@ -156,8 +158,15 @@ public class CampaignUpgradeDialog {
                 }
 
                 CampaignPreset chosenPreset = presets.get(comboChoiceIndex);
+
+                CampaignOptionsFreebieTracker oldOptions = new CampaignOptionsFreebieTracker(campaign.getCampaignOptions());
+                CampaignOptionsFreebieTracker newOptions = new CampaignOptionsFreebieTracker(chosenPreset.getCampaignOptions());
+                triggerUpgradeFreebies(campaign, oldOptions, newOptions, false);
+
+                campaign.setCampaignOptions(chosenPreset.getCampaignOptions());
                 campaign.setGameOptions(chosenPreset.getGameOptions());
                 campaign.setRandomSkillPreferences(chosenPreset.getRandomSkillPreferences());
+
                 Map<String, SkillType> presetSkills = chosenPreset.getSkills();
                 for (final String skillName : SkillType.getSkillList()) {
                     SkillType storedType = SkillType.getType(skillName);


### PR DESCRIPTION
One of the roles of the campaign upgrader is updating campaign options, based on the players' selected preset (if not using 'Manual'). Unfortunately, while the upgrader was handling every other task set before it, it was **not** upgrading campaign options. Now it is. Hurray.