### PR TITLE
Improvement: Adjusted Legality Price Multiplier for Advance Surgeries Using Faction Restricted Tech While Campaign is Part of Faction

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/ProstheticType.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/ProstheticType.java
@@ -32,6 +32,7 @@
  */
 package mekhq.campaign.personnel.medical.advancedMedicalAlternate;
 
+import static java.lang.Math.min;
 import static java.lang.Math.round;
 import static megamek.common.options.OptionsConstants.*;
 import static mekhq.campaign.personnel.PersonnelOptions.ATOW_ATTRACTIVE;
@@ -1083,7 +1084,7 @@ public enum ProstheticType {
     private static final double AVAILABILITY_MULTIPLIER_D = 1.25;
     private static final double AVAILABILITY_MULTIPLIER_E = 1.5;
     private static final double AVAILABILITY_MULTIPLIER_F = 10.0;
-    private static final double AVAILABILITY_MULTIPLIER_F_STAR = 0.0;
+    private static final double AVAILABILITY_MULTIPLIER_F_STAR = 20.0;
     private static final double AVAILABILITY_MULTIPLIER_X = 0.0;
 
     /**
@@ -1325,7 +1326,7 @@ public enum ProstheticType {
     public @Nullable Money getCost(Faction campaignFaction, int currentYear) {
         boolean isWrongAffiliation = isWrongAffiliation(campaignFaction);
         double availabilityMultiplier = getAvailabilityMultiplier(currentYear, isWrongAffiliation);
-        if (availabilityMultiplier == 0.0) {
+        if (availabilityMultiplier == 0.0) { // Item is unavailable in era
             return null;
         }
 
@@ -1410,9 +1411,9 @@ public enum ProstheticType {
      * derived from {@link ATOWLegalityRating#getBlackMarketMultiplier(AvailabilityValue)} using the resolved
      * availability.</p>
      *
-     * @param gameYear             the current in-universe year used to resolve availability
-     * @param outsideFactionAccess {@code true} if the purchase is attempted without normal faction access (e.g., on the
-     *                             black market); {@code false} for standard in-faction access
+     * @param gameYear           the current in-universe year used to resolve availability
+     * @param isWrongAffiliation {@code true} if the purchase is attempted without normal faction access (e.g., on the
+     *                           black market); {@code false} for standard in-faction access
      *
      * @return the price multiplier to apply; {@code 1.0} when adjusted legality is A→C, otherwise the black-market
      *       multiplier for the resolved availability under the adjusted legality
@@ -1420,9 +1421,9 @@ public enum ProstheticType {
      * @author Illiani
      * @since 0.50.11
      */
-    public double getLegalityMultiplier(int gameYear, boolean outsideFactionAccess) {
+    public double getLegalityMultiplier(int gameYear, boolean isWrongAffiliation) {
         AvailabilityValue availability = getAvailability(gameYear);
-        ATOWLegalityRating adjustedLegality = getAdjustedLegality(outsideFactionAccess);
+        ATOWLegalityRating adjustedLegality = getAdjustedLegality(isWrongAffiliation);
 
         // The player is not required to go through the black market
         if (adjustedLegality == ATOWLegalityRating.A ||
@@ -1431,7 +1432,17 @@ public enum ProstheticType {
             return 1.0;
         }
 
-        return adjustedLegality.getBlackMarketMultiplier(availability);
+        double multiplier = adjustedLegality.getBlackMarketMultiplier(availability);
+        if (isWrongAffiliation) {
+            return multiplier;
+        }
+
+        return switch (adjustedLegality) {
+            case D -> min(1.5, multiplier);
+            case E -> min(2.0, multiplier);
+            case F -> min(2.5, multiplier);
+            default -> min(1.0, multiplier);
+        };
     }
 
     /**


### PR DESCRIPTION
This adds a cap on the legality-based price multiplier when a campaign is a part of the faction the prosthetic/implant is restricted to.