### PR TITLE
Fix: Fixed Injury Severity Not Included TW-Scale Hits

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7093,7 +7093,7 @@ public class Person {
     }
 
     public int getTotalInjurySeverity() {
-        int totalSeverity = 0;
+        int totalSeverity = hits; // Normal hits should be included here
         for (Injury injury : injuries) {
             totalSeverity += injury.getHits();
         }


### PR DESCRIPTION
We need to include TW 'hits' here in case the user switches between AM/AAM and TW damage models