### PR TITLE
Fix #8501: Fixed Disconnect Between MekHQ Considering Character Both Injured & Not Injured

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -7227,8 +7227,7 @@ public class Person {
     }
 
     public boolean needsAMFixing() {
-        return !injuries.isEmpty() &&
-                     injuries.stream().anyMatch(injury -> (injury.getTime() > 0) || !injury.isPermanent());
+        return !injuries.isEmpty();
     }
 
     /**


### PR DESCRIPTION
Fix #8501

Depending on where a character was assessed it was possible for the character to be considered injured and handled appropriately. While in a different part of MekHQ they were considered perfectly fine.

The root cause was that AM both expected characters with permanent injuries to be healed, while not considering them injured. This PR fixes that by ensuring permanent injuries are treated universally as an active injury.