### PR TITLE
Fix #8512: Fixed Inability to Change Rank System in Campaign Options

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/BiographyTab.java
@@ -1709,5 +1709,8 @@ public class BiographyTab {
             }
             options.setUsePortraitForRole(i, chkUsePortrait[i].isSelected());
         }
+
+        // Ranks
+        rankSystemsPane.applyToCampaign();
     }
 }


### PR DESCRIPTION
Fix #8512

Restored a line I accidentally removed yesterday, instead of just removing the conditional.