### PR TITLE
PR: Cache active personnel and a person's Advanced AsTech Contribution

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -3034,7 +3034,11 @@ public class Campaign implements ITechManager {
         String cacheKey = "includePrisoners:" + includePrisoners + "_" + "includeCampFollowers:" + includeCampFollowers;
 
         // If the cache value is known and not empty, let's just use that
-        if (activePersonnelCache.containsKey(cacheKey) && !activePersonnelCache.get(cacheKey).isEmpty()) {
+        // An empty list will be cached after loading so we will always
+        // recalculate if it's empty. And if it's empty, it should be quick, right?
+        if (activePersonnelCache != null &&
+                  activePersonnelCache.containsKey(cacheKey) &&
+                  !activePersonnelCache.get(cacheKey).isEmpty()) {
             return new ArrayList<>(activePersonnelCache.get(cacheKey));
         }
 
@@ -3062,6 +3066,9 @@ public class Campaign implements ITechManager {
             activePersonnel.add(person);
         }
 
+        if (activePersonnelCache == null) {
+            activePersonnelCache = new HashMap<>();
+        }
         activePersonnelCache.put(cacheKey, new ArrayList<>(activePersonnel));
         return activePersonnel;
     }
@@ -9662,22 +9669,5 @@ public class Campaign implements ITechManager {
      */
     public void setSystemsInstance(Systems systemsInstance) {
         this.systemsInstance = systemsInstance;
-    }
-
-    /**
-     * Handles updates to personnel records.
-     *
-     * <p>Clears cached values</p>
-     *
-     * <p><b>Important:</b> This method is not directly evoked, so IDEA will tell you it has no uses. IDEA is
-     * wrong.</p>
-     *
-     * @param personEvent the event containing updates related to a person in the campaign
-     */
-    @Subscribe
-    public void handlePersonUpdate(PersonEvent personEvent) {
-        invalidateActivePersonnelCache();
-        Person person = personEvent.getPerson();
-        person.invalidateAdvancedAsTechContribution();
     }
 }

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -8773,15 +8773,11 @@ public class Person {
      *
      * @since 0.50.11
      */
-    @Nullable
-    public Integer getAdvancedAsTechContribution() {
+    public int getAdvancedAsTechContribution() {
         int contribution;
         if (advancedAsTechContribution == null) {
             Skill asTechSkill = getSkill(S_ASTECH);
             if (asTechSkill != null) {
-                PersonnelOptions options = getOptions();
-                Attributes attributes = getATOWAttributes();
-
                 // It is possible for very poorly skilled characters to actually be a detriment to their teams. This is
                 // by design.
                 SkillModifierData skillModifierData = getSkillModifierData();

--- a/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
+++ b/MekHQ/src/mekhq/module/atb/AtBEventProcessor.java
@@ -59,6 +59,7 @@ import mekhq.campaign.Campaign;
 import mekhq.campaign.enums.DragoonRating;
 import mekhq.campaign.events.MarketNewPersonnelEvent;
 import mekhq.campaign.events.NewDayEvent;
+import mekhq.campaign.events.persons.PersonEvent;
 import mekhq.campaign.finances.Money;
 import mekhq.campaign.finances.enums.TransactionType;
 import mekhq.campaign.personnel.Person;
@@ -333,5 +334,23 @@ public record AtBEventProcessor(Campaign campaign) {
             }
         }
         return c.getFaction().getShortName();
+    }
+
+
+    /**
+     * Handles updates to personnel records.
+     *
+     * <p>Clears cached values</p>
+     *
+     * <p><b>Important:</b> This method is not directly evoked, so IDEA will tell you it has no uses. IDEA is
+     * wrong.</p>
+     *
+     * @param personEvent the event containing updates related to a person in the campaign
+     */
+    @Subscribe
+    public void handlePersonUpdate(PersonEvent personEvent) {
+        campaign().invalidateActivePersonnelCache();
+        Person person = personEvent.getPerson();
+        person.invalidateAdvancedAsTechContribution();
     }
 }


### PR DESCRIPTION
Those are some expensive calls. 

We get a list of all active personnel very often. This list doesn't change very often. Let's cache it to improve performance. SAme with the Advanced AsTech contribution. 

Prior to this change, the save in #8496 was taking over a minute to process one day, with a lot of that time being spent getting the amount of AsTech contribution and the list of active personnel. This makes both of those lookups near instant. 

To ensure the caches are properly cleared, I've set it to be `@Subscribe`'d  to `PersonEvent`. Any changes to a person will invalidate the personnel list caches, and clear the person's cached advanced AsTech contribution. 