### PR TITLE
Improvement: Adjusted Minimum Map Sizes Based on Player Feedback

### DIFF
--- a/MekHQ/src/mekhq/campaign/campaignOptions/BoardScalingType.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/BoardScalingType.java
@@ -36,9 +36,9 @@ import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 public enum BoardScalingType {
     SMALL("SMALL", -1, 1),
-    NORMAL("NORMAL", 0, 1),
-    LARGE("LARGE", 1, 2),
-    HUGE("HUGE", 2, 3);
+    NORMAL("NORMAL", 0, 2),
+    LARGE("LARGE", 1, 3),
+    HUGE("HUGE", 2, 4);
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.BoardScalingType";
 

--- a/MekHQ/src/mekhq/campaign/campaignOptions/BoardScalingType.java
+++ b/MekHQ/src/mekhq/campaign/campaignOptions/BoardScalingType.java
@@ -35,10 +35,10 @@ package mekhq.campaign.campaignOptions;
 import static mekhq.utilities.MHQInternationalization.getTextAt;
 
 public enum BoardScalingType {
-    SMALL("SMALL", -1, 1),
-    NORMAL("NORMAL", 0, 2),
-    LARGE("LARGE", 1, 3),
-    HUGE("HUGE", 2, 4);
+    SMALL("SMALL", -1, 1), // Average map height of 1
+    NORMAL("NORMAL", 0, 2), // Average map height of 2
+    LARGE("LARGE", 1, 3), // Average map height of 3
+    HUGE("HUGE", 2, 4); // Average map height of 4
 
     private static final String RESOURCE_BUNDLE = "mekhq.resources.BoardScalingType";
 

--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -1929,7 +1929,7 @@ public class AtBDynamicScenarioFactory {
             // TW suggests one map sheet per 4 units. As we have a minimum height, we use that to determine how much
             // we should divide unit count by. We floor the result as players generally prefer smaller maps.
             int minimumWidth = max(1, boardScaling.getMinimumWidth());
-            double unitDivider = 4 * minimumHeight;
+            double unitDivider = 4 * totalSheetsTall;
 
             int totalSheetsWide = (int) max(minimumWidth, floor(unitCount / unitDivider));
             totalSheetsWide = max(1, totalSheetsWide + mapParameters.getAdditionalMapSheetWide());


### PR DESCRIPTION
We received the first batch of player feedback for the new map sizes. The general consensus was that maps were a little too short (and sometimes too narrow), so this PR adds a minimum height and width of 2. This can be overridden in campaign options for players who prefer larger or smaller engagements.