### PR TITLE
Fix #8525: Stopped Students From Going Berserker on Campus, Teleporting Across the Galaxy, and Beating Up Other Personnel

### DIFF
--- a/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
+++ b/MekHQ/src/mekhq/campaign/CampaignNewDayManager.java
@@ -669,8 +669,14 @@ public class CampaignNewDayManager {
                     processFatigueRecovery(campaign, person, isWithinCapacity);
                 }
 
-                processCompulsionsAndMadness(person, personnelOptions, isUseAdvancedMedical, isUseAltAdvancedMedical,
-                      isUseFatigue, fatigueRate);
+                if (person.getStatus().isActiveFlexible() && person.getPrisonerStatus().isFreeOrBondsman()) {
+                    processCompulsionsAndMadness(person,
+                          personnelOptions,
+                          isUseAdvancedMedical,
+                          isUseAltAdvancedMedical,
+                          isUseFatigue,
+                          fatigueRate);
+                }
             }
 
             // Monthly events


### PR DESCRIPTION
Fix #8525

- Personnel who are not classified as active will no longer make attribute checks to resist negative personality traits and madnesses.
- Prisoners are now also excluded from these checks.

With this change it means a player can prevent their personnel injuring other characters, or what have you, by placing them on leave. Or sending them to school, thus making them someone else's problem.