### PR TITLE
Improvement: Relaxed Restrictions on Multiple Tech Professions

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -1319,7 +1319,7 @@ public class Person {
             // 1) Can always be Dependent
             // 2) Cannot be None
             // 3) Cannot be equal to the secondary role
-            // 4) Cannot be a tech role if the secondary role is a tech role (inc. Astech)
+            // 4) Cannot be astech role if the secondary role is a tech role
             // 5) Cannot be a medical if the secondary role is one of the medical staff roles
             // 6) Cannot be an admin role if the secondary role is one of the administrator roles
             if (role.isDependent()) {
@@ -1334,7 +1334,7 @@ public class Person {
                 return false;
             }
 
-            if ((role.isTech() || role.isAstech()) && (secondaryRole.isTechSecondary() || secondaryRole.isAstech())) {
+            if (role.isAstech() && secondaryRole.isTechSecondary()) {
                 return false;
             }
 
@@ -1350,7 +1350,7 @@ public class Person {
             // 1) Can always be None
             // 2) Cannot be Dependent
             // 3) Cannot be equal to the primary role
-            // 4) Cannot be a tech role if the primary role is a tech role (inc. Astech)
+            // 4) Cannot be a tech role if the primary role is Astech
             // 5) Cannot be a medical role if the primary role is one of the medical staff roles
             // 6) Cannot be an admin role if the primary role is one of the administrator roles
             if (role.isNone()) {
@@ -1365,7 +1365,7 @@ public class Person {
                 return false;
             }
 
-            if ((role.isTechSecondary() || role.isAstech()) && (primaryRole.isTech() || primaryRole.isAstech())) {
+            if (role.isTechSecondary() && primaryRole.isAstech()) {
                 return false;
             }
 


### PR DESCRIPTION
It is now possible for a single character to have both primary and secondary profession as a tech profession. It is still not possible to combine a tech profession and Astech.

This will _not_ double the number of available minutes a character has.

This _will_ count the character twice for the purpose of CamOps Unit Rating.

The intention here is to help players reduce their tech counts, now that the maintenance errata removes the need for large volumes of techs (despite unit rating still requiring them). It is also intended to better support players who prefer to keep their personnel counts low via each character wearing 'multiple hats.'