### PR TITLE
Update for new availabilityMap argument in reconfigureEntities

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBDynamicScenarioFactory.java
@@ -884,7 +884,7 @@ public class AtBDynamicScenarioFactory {
                     rp.groundMap = onGround;
                     rp.spaceEnvironment = (mapLocation == MapLocation.Space);
                     MunitionTree mt = TeamLoadOutGenerator.generateMunitionTree(rp, arrayGeneratedLance, "");
-                    tlg.reconfigureEntities(arrayGeneratedLance, factionCode, mt, rp);
+                    tlg.reconfigureEntities(arrayGeneratedLance, factionCode, mt, rp, null);
                 } else {
                     // Load the fighters with bombs
                     tlg.populateAeroBombs(generatedLance,

--- a/MekHQ/src/mekhq/gui/BriefingTab.java
+++ b/MekHQ/src/mekhq/gui/BriefingTab.java
@@ -1715,7 +1715,9 @@ public final class BriefingTab extends CampaignGuiTab {
             rp.groundMap = groundMap;
             rp.spaceEnvironment = spaceMap;
             MunitionTree mt = TeamLoadOutGenerator.generateMunitionTree(rp, entityList, "");
-            tlg.reconfigureEntities(entityList, opForFactionCode, mt, rp);
+            // We now have the ability to pre-create a munition availability map for use with special scenarios,
+            // representing limited-availability ammo in the hands of a specific force.
+            tlg.reconfigureEntities(entityList, opForFactionCode, mt, rp, null);
         }
 
         // Finally, reconfigure all allies (but not player entities) as one organization
@@ -1733,7 +1735,7 @@ public final class BriefingTab extends CampaignGuiTab {
         rp.groundMap = groundMap;
         rp.spaceEnvironment = spaceMap;
         MunitionTree mt = TeamLoadOutGenerator.generateMunitionTree(rp, alliedEntities, "");
-        tlg.reconfigureEntities(alliedEntities, allyFactionCodes.get(0), mt, rp);
+        tlg.reconfigureEntities(alliedEntities, allyFactionCodes.get(0), mt, rp, null);
 
     }
 


### PR DESCRIPTION
### NOTE: depends on MegaMek/megamek#7810

Update calls to `reconfigureEntities` for new signature.

At a later date, we may wish to modify which munitions are available to a given force or faction based on Scenario mods.
In that case, we can first generate the availability map explicitly, modify it, and then pass it back into `reconfigureEntities()` where it will replace the default map.

Testing:
- Ran all 3 projects' unit tests.