### PR TITLE
Have MekHQ grab the megamek/mmconf/ copy of the munitions config YAML file

### DIFF
--- a/MekHQ/build.gradle
+++ b/MekHQ/build.gradle
@@ -294,6 +294,10 @@ distributions {
                 exclude 'log4j2.xml'
             }
 
+            from("${mmDir}/megamek/mmconf/munitionLoadoutSettings.yaml") {
+                into 'mmconf'
+            }
+
             from("${mmDir}/megamek/build/launch4j/lib") {
                 into "lib"
             }


### PR DESCRIPTION
Allows MekHQ to include the MegaMek copy of this file when building the distro.

Testing:
- built locally
- Ran MekHQ and confirmed imported file works.