### PR TITLE
Fix: Corrected 'Starting Attributes' Campaign Label & Description for Added Clarity

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1510,7 +1510,7 @@ atowTab.border="It is only those who have neither fired a shot nor heard the shr
   <br><i>General William Sherman\
   <br>Address at the Michigan Military Academy, June 19th 1879</i>
 lblATOWAttributesPanel.text=Traits and Attributes
-lblUseAttributes.text=Starting Attributes Based on profession \u26A0
+lblUseAttributes.text=Starting Attributes Based on Profession \u26A0
 lblUseAttributes.tooltip=If checked, new characters will be generated with <i>A Time of War</i> Attribute scores based\
   \ on their primary profession.\
   <br>\


### PR DESCRIPTION
`New Characters Have Random Starting Attributes` -> `Starting Attributes Based on Profession`