### PR TITLE
Fix #8540: Removed Faulty Compatibility Handler for Contract Early Exit

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/AtBContract.java
+++ b/MekHQ/src/mekhq/campaign/mission/AtBContract.java
@@ -1197,11 +1197,6 @@ public class AtBContract extends Contract {
                     stratconCampaignState = StratConCampaignState.Deserialize(item);
                     stratconCampaignState.setContract(this);
                     this.setStratConCampaignState(stratconCampaignState);
-
-                    // <50.10 compatibility handler
-                    if (!(getContractType().isGarrisonType() || getContractType().isReliefDuty())) {
-                        stratconCampaignState.setAllowEarlyVictory(true);
-                    }
                 } else if (item.getNodeName().equalsIgnoreCase("parentContractId")) {
                     parentContract = new AtBContractRef(Integer.parseInt(item.getTextContent()));
                 } else if (item.getNodeName().equalsIgnoreCase("employerLiaison")) {


### PR DESCRIPTION
Fix #8540

A faulty compatibility handler was causing early contract end to be overwritten on load. Rather than fixing the compatibility handler I opted to just remove it. The consequence is that any contract made prior to this fix being merged may be treated as allowing early contract ends. A state that is identical to prior behavior.