### PR TITLE
Fix: Allowed Bulk Hiring Skill Override for Civilian Professions

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/HireBulkPersonnelDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/HireBulkPersonnelDialog.java
@@ -354,7 +354,9 @@ public class HireBulkPersonnelDialog extends JDialog {
         while (number > 0) {
             Person person = campaign.newPerson(selectedItem.getRole());
 
-            if ((useSkill) && (!selectedItem.getRole().isCivilian())) {
+            // Dependents & 'None' don't have skills
+            PersonnelRole selectedRole = selectedItem.getRole();
+            if (useSkill && !selectedRole.isDependent() && !selectedRole.isNone()) {
                 if (skillLevel.getSelectedItem() != null) {
                     RandomSkillPreferences randomSkillPreferences = campaign.getRandomSkillPreferences();
                     boolean useExtraRandomness = randomSkillPreferences.randomizeSkill();


### PR DESCRIPTION
This removes an old blocker that was in place to prevent us from attempting to override the skill level of professions without skills. When this guard was put in place civilian professions didn't really exist. Nowadays the only professions without skills are Dependent and None.