### PR TITLE
Improvement: Reduced Impact of Berserker Flaw

### DIFF
--- a/MekHQ/resources/mekhq/resources/AlternateInjuries.properties
+++ b/MekHQ/resources/mekhq/resources/AlternateInjuries.properties
@@ -56,6 +56,7 @@ AlternateInjuries.TRANSIT_DISORIENTATION_SYNDROME.simpleName=Transit Disorientat
 AlternateInjuries.CRIPPLING_FLASHBACKS.simpleName=Crippling Flashbacks
 AlternateInjuries.CHILDLIKE_REGRESSION.simpleName=Childlike Regression
 AlternateInjuries.CATATONIA.simpleName=Chronic Dissociation
+AlternateInjuries.TERRIBLE_BRUISES.simpleName=Terrible Bruises
 # Diseases
 AlternateInjuries.GROWTHS_DISCOMFORT.simpleName=Uncomfortable Growths
 AlternateInjuries.GROWTHS_SLIGHT.simpleName=Bursting Pustules

--- a/MekHQ/src/mekhq/campaign/personnel/Person.java
+++ b/MekHQ/src/mekhq/campaign/personnel/Person.java
@@ -8298,13 +8298,18 @@ public class Person {
             // The berserker hurts themselves
             victims.add(this);
 
+            boolean isUseAltAdvancedMedical = campaign.getCampaignOptions().isUseAlternativeAdvancedMedical();
             for (Person victim : victims) {
-                int wounds = randomInt(2) + 1; // (1-2)
                 if (useAdvancedMedical) {
-                    InjuryUtil.resolveCombatDamage(campaign, victim, wounds);
+                    if (isUseAltAdvancedMedical) {
+                        Injury injury = AlternateInjuries.TERRIBLE_BRUISES.newInjury(campaign, this, GENERIC, 1);
+                        addInjury(injury);
+                    } else {
+                        InjuryUtil.resolveCombatDamage(campaign, victim, 1);
+                    }
                 } else {
                     int currentHits = victim.getHits();
-                    victim.setHits(currentHits + wounds);
+                    victim.setHits(currentHits + 1);
                 }
 
                 if ((victim.getInjuries().size() > DEATH_THRESHOLD) || (victim.getHits() > DEATH_THRESHOLD)) {

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypes.java
@@ -321,6 +321,7 @@ public final class InjuryTypes {
             InjuryType.register(192, "alt:IMPLANT_REMOVAL_RECOVERY", AlternateInjuries.IMPLANT_REMOVAL_RECOVERY);
             InjuryType.register(193, "alt:SECONDARY_POWER_SUPPLY", AlternateInjuries.SECONDARY_POWER_SUPPLY);
             InjuryType.register(194, "alt:PROTOTYPE_VDNI", AlternateInjuries.PROTOTYPE_VDNI);
+            InjuryType.register(195, "alt:TERRIBLE_BRUISES", AlternateInjuries.TERRIBLE_BRUISES);
 
             InjuryType.register("am:severed_spine", SEVERED_SPINE);
             InjuryType.register("am:replacement_limb_recovery", REPLACEMENT_LIMB_RECOVERY);

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
@@ -149,6 +149,7 @@ public class AlternateInjuries {
     public static final InjuryType CRIPPLING_FLASHBACKS = new CripplingFlashbacks();
     public static final InjuryType CHILDLIKE_REGRESSION = new ChildlikeRegression();
     public static final InjuryType CATATONIA = new ChronicDisassociation();
+    public static final InjuryType TERRIBLE_BRUISES = new TerribleBruises();
     // Diseases
     public static final InjuryType GROWTHS_DISCOMFORT = new GrowthsDiscomfort();
     public static final InjuryType GROWTHS_SLIGHT = new GrowthsSlight();
@@ -2307,6 +2308,19 @@ public class AlternateInjuries {
                   Set.of(GENERIC));
             this.simpleName = getTextAt(RESOURCE_BUNDLE,
                   "AlternateInjuries.CATATONIA.simpleName");
+            this.injurySubType = FLAW;
+        }
+    }
+
+    public static final class TerribleBruises extends BaseInjury {
+        TerribleBruises() {
+            super(WEEKLY_CHECK_ILLNESS_HEALING_DAYS,
+                  false,
+                  MINOR,
+                  NONE,
+                  Set.of(GENERIC));
+            this.simpleName = getTextAt(RESOURCE_BUNDLE,
+                  "AlternateInjuries.TERRIBLE_BRUISES.simpleName");
             this.injurySubType = FLAW;
         }
     }


### PR DESCRIPTION
When AAM is enabled injuries from the Berserker Flaw will no longer roll on the normal injury tables. Instead, Berserker can only inflict 'Terrible Bruises.' This injury has no mechanical effect, beyond eating medical bay space.

If AAM is disabled, Berserker will function as previous.