### PR TITLE
Fix: Expanded Alt Advanced Medical Options Change Handler to Better Handle Campaigns Upgrading With Existing TW Hits or AM Injuries

### DIFF
--- a/MekHQ/resources/mekhq/resources/AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.properties
@@ -35,9 +35,18 @@ AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.description=<h1 style
   debilitating injuries, diseases, and much more. Be aware that injury times under AAM are generally longer than \
   those found under vanilla Advanced Medical. You are expected to maintain second-line forces to cycle in as your \
   A-Teams start taking injuries.\
-  <p>Under AltAM (if you also have Implants enabled), ProtoMek Pilots are required to have the EI Neural Implant. \
-  Would you like to gift any ProtoMek Pilots in your campaign the EI Neural Implant for free? This has no effect on \
-  non-ProtoMek Pilots or in campaigns where Implants are disabled.\
-  <p>For more information on AAM, please see the Glossary.</p>
-AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.cancel=Decline
-AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.confirm=Accept
+  <p>For more information on AAM, please see the Glossary.</p>\
+  <h2 style="text-align:center">Injuries</h2>\
+  <p>AAM is not compatible with Total Warfare-scale 'Hits' nor vanilla Advance Medical's injuries. It is necessary, \
+  therefore, to convert those wounds into something AAM can understand. All injured characters will receive an 'Old \
+  Wound' injury, in place of any Total Warfare 'Hits' or vanilla injuries. This injury will be permanent if the original\
+  \ injury was also permanent. Otherwise, it will be assigned a semi-random healing time. Missing limbs, from vanilla\
+  \ Advanced Medical, will be converted directly to AAM severed limbs.</p>\
+  <h2 style="text-align:center">Enhanced Imaging Implants</h2>\
+  <p>Under AAM (if you also have Implants enabled), ProtoMek Pilots are required to have the EI Neural Implant. \
+  Affected characters can be given the implant for free. This has no effect on non-ProtoMek Pilots or in campaigns \
+  where Implants are disabled.</p>
+AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.checkbox.injuries=Convert Injuries
+AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.checkbox.enhancedImaging=Gift Enhanced Imaging to ProtoMek\
+  \ Pilots
+AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.confirm=Confirm

--- a/MekHQ/resources/mekhq/resources/AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.properties
+++ b/MekHQ/resources/mekhq/resources/AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.properties
@@ -37,7 +37,7 @@ AltAdvancedMedicalCampaignOptionsChangedConfirmationDialog.description=<h1 style
   A-Teams start taking injuries.\
   <p>For more information on AAM, please see the Glossary.</p>\
   <h2 style="text-align:center">Injuries</h2>\
-  <p>AAM is not compatible with Total Warfare-scale 'Hits' nor vanilla Advance Medical's injuries. It is necessary, \
+  <p>AAM is not compatible with Total Warfare-scale 'Hits' nor vanilla Advanced Medical's injuries. It is necessary, \
   therefore, to convert those wounds into something AAM can understand. All injured characters will receive an 'Old \
   Wound' injury, in place of any Total Warfare 'Hits' or vanilla injuries. This injury will be permanent if the original\
   \ injury was also permanent. Otherwise, it will be assigned a semi-random healing time. Missing limbs, from vanilla\

--- a/MekHQ/resources/mekhq/resources/AlternateInjuries.properties
+++ b/MekHQ/resources/mekhq/resources/AlternateInjuries.properties
@@ -57,6 +57,7 @@ AlternateInjuries.CRIPPLING_FLASHBACKS.simpleName=Crippling Flashbacks
 AlternateInjuries.CHILDLIKE_REGRESSION.simpleName=Childlike Regression
 AlternateInjuries.CATATONIA.simpleName=Chronic Dissociation
 AlternateInjuries.TERRIBLE_BRUISES.simpleName=Terrible Bruises
+AlternateInjuries.OLD_WOUND.simpleName=Old Wound
 # Diseases
 AlternateInjuries.GROWTHS_DISCOMFORT.simpleName=Uncomfortable Growths
 AlternateInjuries.GROWTHS_SLIGHT.simpleName=Bursting Pustules

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypes.java
@@ -322,6 +322,7 @@ public final class InjuryTypes {
             InjuryType.register(193, "alt:SECONDARY_POWER_SUPPLY", AlternateInjuries.SECONDARY_POWER_SUPPLY);
             InjuryType.register(194, "alt:PROTOTYPE_VDNI", AlternateInjuries.PROTOTYPE_VDNI);
             InjuryType.register(195, "alt:TERRIBLE_BRUISES", AlternateInjuries.TERRIBLE_BRUISES);
+            InjuryType.register(196, "alt:OLD_WOUND", AlternateInjuries.OLD_WOUND);
 
             InjuryType.register("am:severed_spine", SEVERED_SPINE);
             InjuryType.register("am:replacement_limb_recovery", REPLACEMENT_LIMB_RECOVERY);

--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedicalAlternate/AlternateInjuries.java
@@ -89,6 +89,7 @@ public class AlternateInjuries {
     private static final int WEEKLY_CHECK_ILLNESS_HEALING_DAYS = 7;
     private static final int POSTPARTUM_RECOVERY_HEALING_DAYS = 21; // Internet says 6 weeks
     private static final int TRANSIT_DISORIENTATION_SYNDROME_HEALING_DAYS = 1;
+    private static final int OLD_WOUND_HEALING_DAYS = 7;
 
     private static final InjuryLevel SEVER_INJURY_LEVEL = CHRONIC;
     private static final InjuryLevel FRACTURE_INJURY_LEVEL = MAJOR;
@@ -150,6 +151,7 @@ public class AlternateInjuries {
     public static final InjuryType CHILDLIKE_REGRESSION = new ChildlikeRegression();
     public static final InjuryType CATATONIA = new ChronicDisassociation();
     public static final InjuryType TERRIBLE_BRUISES = new TerribleBruises();
+    public static final InjuryType OLD_WOUND = new OldWound();
     // Diseases
     public static final InjuryType GROWTHS_DISCOMFORT = new GrowthsDiscomfort();
     public static final InjuryType GROWTHS_SLIGHT = new GrowthsSlight();
@@ -2322,6 +2324,17 @@ public class AlternateInjuries {
             this.simpleName = getTextAt(RESOURCE_BUNDLE,
                   "AlternateInjuries.TERRIBLE_BRUISES.simpleName");
             this.injurySubType = FLAW;
+        }
+    }
+
+    public static final class OldWound extends BaseInjury {
+        OldWound() {
+            super(OLD_WOUND_HEALING_DAYS,
+                  false,
+                  MINOR,
+                  NONE,
+                  Set.of(GENERIC));
+            this.simpleName = getTextAt(RESOURCE_BUNDLE, "AlternateInjuries.OLD_WOUND.simpleName");
         }
     }
 }


### PR DESCRIPTION
If 50.11 makes Milestone we're going to have a lot of people transferring from AM to AAM. This PR updates the compatibility handler to more elegantly handle existing TW 'Hits' and vanilla AM injuries. Previously no compatibility handler existed, which led to an unintended experience.