### PR TITLE
Fix: Fixed Book Reference in Board Scaling Campaign Option

### DIFF
--- a/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
+++ b/MekHQ/resources/mekhq/resources/CampaignOptionsDialog.properties
@@ -1829,7 +1829,7 @@ lblSkillLevel.tooltip=<html>This is the difficulty level for generated scenarios
   <br>\
   <br><b>Recommended:</b> New players are recommended to start with Green or Ultra-Green.</html>
 lblBoardScalingType.text=Scenario Map Size <span style="color:#C344C3;">\u2605</span>
-lblBoardScalingType.tooltip=Adjusts the size of scenario maps. 'Normal' uses the Total War recommended one map sheet \
+lblBoardScalingType.tooltip=Adjusts the size of scenario maps. 'Normal' uses the Total Warfare recommended one map sheet \
   per 4 units (rounded down). Larger map sizes allow for more tactical maneuvering at the expense of favoring longer \
   ranged units. While small map sizes increase scenario speed while favoring melee units.
 # Callsigns


### PR DESCRIPTION
`Total War` -> `Total Warfare`