### PR TITLE
Fix #8614: Prevent a force from being assigned as its own subforce

### DIFF
--- a/MekHQ/src/mekhq/campaign/Campaign.java
+++ b/MekHQ/src/mekhq/campaign/Campaign.java
@@ -1392,6 +1392,10 @@ public class Campaign implements ITechManager {
     }
 
     public void moveForce(Force force, Force superForce) {
+        // Can't move a null force under a superforce and can't move a force under itself.
+        if (force == null || force.equals(superForce)) {
+            return;
+        }
         Force parentForce = force.getParentForce();
 
         if (null != parentForce) {

--- a/MekHQ/src/mekhq/campaign/force/Force.java
+++ b/MekHQ/src/mekhq/campaign/force/Force.java
@@ -433,6 +433,11 @@ public class Force {
             return;
         }
 
+        if (equals(sub)) {
+            LOGGER.error("Cannot add a force as its own subforce!");
+            return;
+        }
+
         if (assignParent) {
             sub.setParentForce(this);
         }

--- a/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
+++ b/MekHQ/src/mekhq/gui/handler/TOETransferHandler.java
@@ -150,7 +150,8 @@ public class TOETransferHandler extends TransferHandler {
             LOGGER.error("I/O error: {}", ioe.getMessage());
         }
 
-        if ((force != null) && (superForce != null) && force.isAncestorOf(superForce)) {
+        if ((force != null) && (superForce != null) &&
+                  (force.isAncestorOf(superForce) || force.equals(superForce))) {
             return false;
         }
 


### PR DESCRIPTION
Fixes #8614 

Fixed in triplicate; Fixed in `Force` so it doesn't stack overflow. Fixed in `Campaign` so it doesn't partially move the force / act unexpectedly when it fails during the `Force.addSubForce`. Fixed in `TOETransferHandler` so when dragging and dropping it'll show an X when trying to move a force onto itself / the units immediately below it.