### PR TITLE
Fix #8670: Fixed Units with Temp Crew Disappearing when Loading

### DIFF
--- a/MekHQ/src/mekhq/campaign/unit/Unit.java
+++ b/MekHQ/src/mekhq/campaign/unit/Unit.java
@@ -6475,8 +6475,12 @@ public class Unit implements ITechnology {
         } else {
             tempPersonnelRoleMap.put(personnelRole, count);
         }
-        resetPilotAndEntity();
-        MekHQ.triggerEvent(new UnitChangedEvent(this));
+
+        if (getCampaign() != null) {
+            resetPilotAndEntity();
+            MekHQ.triggerEvent(new UnitChangedEvent(this));
+        }
+
     }
 
     /**


### PR DESCRIPTION
Fixes #8670

Don't `resetPilotAndEntity` when setting the temp crew if the campaign is null