### PR TITLE
Fixed maneuver/auxillary reinforcement roll reporting

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1935,7 +1935,7 @@ public class StratConRulesManager {
         String maneuverRoleReport = "";
         if (reinforcementType == AUXILIARY) {
             int secondRoll = d6(2);
-            maneuverRoleReport = String.format(" (%s)", roll, secondRoll);
+            maneuverRoleReport = String.format(" (%s,%s)", roll, secondRoll);
             roll = max(roll, secondRoll);
         }
 


### PR DESCRIPTION
Fixes: #8640

Fixed reporting for rolls when reinforcing using maneuver or auxiliary forces. The rolls were being completed with advantage, as intended, however the string was only reporting the highest roll twice.  