### PR TITLE
Fix NPE when spending XP on new skills 

### DIFF
--- a/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
+++ b/MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java
@@ -666,6 +666,7 @@ public class PersonnelTableMouseAdapter extends JPopupMenuAdapter {
                 int cost = MathUtility.parseInt(data[2]);
                 selectedPerson.improveSkill(skillName);
                 selectedPerson.spendXPOnSkills(getCampaign(), cost);
+                skill = selectedPerson.getSkill(skillName);
                 SkillType skillType = skill.getType();
 
                 PerformanceLogger.improvedSkill(getCampaignOptions().isPersonnelLogSkillGain(),


### PR DESCRIPTION
Root Cause

  When spending XP to acquire a new skill, getSkill() returns null before the skill exists. After improveSkill() creates
   the skill, the local skill variable was never updated, causing a NullPointerException when accessing skill.getType()
  and skill.getLevel().

  Changes

  1. PersonnelTableMouseAdapter.java - Re-fetch the skill after improveSkill() creates it

  Files Changed

  - MekHQ/src/mekhq/gui/adapter/PersonnelTableMouseAdapter.java - Added skill re-fetch after creation
  
  Fixes #8707