### PR TITLE
Fix contract generation for factions absorbed by super-states (Fixes #8711)

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -40,7 +40,6 @@ import static mekhq.campaign.universe.Faction.PIRATE_FACTION_CODE;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -339,7 +338,16 @@ public class RandomFactionGenerator {
             }
 
             String[] fallbacks = candidate.getAlternativeFactionCodes();
-            if (fallbacks != null && Arrays.asList(fallbacks).contains(factionKey)) {
+            boolean matchesFallback = false;
+            if (fallbacks != null) {
+                for (String fallback : fallbacks) {
+                    if (factionKey.equals(fallback)) {
+                        matchesFallback = true;
+                        break;
+                    }
+                }
+            }
+            if (matchesFallback) {
                 LOGGER.info("Found super-state faction {} for {} during {}",
                       candidate.getShortName(), factionKey, currentYear);
                 return candidate;


### PR DESCRIPTION
Summary

  Fixes contract generation failing when playing as Federated Suns or Lyran Commonwealth during the Federated Commonwealth era  (3028-3067). Investigating this issue revealed similar problems across multiple faction transitions throughout BattleTech history.

  Root Cause: When a "super-state" faction (like FC) absorbs member states, planets get tagged with the super-state's code.
  Players using the original faction code (FS, LA) have no planets in the border tracker, so the contract market can't find valid
   enemies.

  Changes

  Code Fix (MekHQ)

  - Added findSuperStateFaction() method to RandomFactionGenerator.java
  - When a faction has no planets, checks if it's contained within a super-state by looking for factions whose fallBackFactions
  include the player's faction
  - Uses the super-state's borders to generate contracts

  Data Fixes (mm-data)

  factionhints.xml - 16 new containment entries:
  - Federated Commonwealth era (3028-3067): FC contains FS, LA
  - Rasalhague Dominion (3103+): RD contains CGB, FRR
  - Escorpion Imperio (3080+): CEI contains CGS, NC, UC, HL
  - Free Worlds League fragmentation (3079-3139): DA, DO, OP, PR, RF, MSC contain FWL

  Faction YAML updates:
  - MSC.yml - Added FWL to fallBackFactions (was only IS)
  - RD.yml - Added FRR to fallBackFactions
  - CWE.yml - Added CWIE to fallBackFactions
  - IoS.yml - Added yearsActive: 3151, fallBackFactions: [LA], factionLeaders
  - ARL.yml - Added yearsActive: 3151, fallBackFactions: [LA]
  - TamP.yml - Consolidated into single multi-era file (2235-2341, 3151+)

  Data cleanup:
  - Deleted NTamP.yml and TamPact.yml (redundant Tamar Pact files)
  - Updated 11 planet files from NTamP to TamP references

  Testing

  - Verified FS player in 3050 can now generate contracts using FC borders
  - Verified FWL player in 3090 can generate contracts through MSC containment
  - Verified fallback faction lookup correctly identifies super-states

  Background

  Investigating the original FC-era bug revealed a systematic issue: any faction transition where planets change tags creates the
   same problem. This PR addresses all major transitions:
  - Federated Commonwealth formation/dissolution
  - Rasalhague Dominion merger (CGB + FRR)
  - Escorpion Imperio conquests (Deep Periphery)
  - Free Worlds League fragmentation (Jihad aftermath)
  - Lyran Hinterlands splinter states (ilClan era)

  Fixes #8711