### PR TITLE
Fix Mapless StratCon VP scoring for Fleet in Being and Refused Engagement (Fixes #8689)

### DIFF
--- a/MekHQ/src/mekhq/campaign/mission/ContractScore.java
+++ b/MekHQ/src/mekhq/campaign/mission/ContractScore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *


### PR DESCRIPTION
## Root Cause

  In `ContractScore.java`, the scoring constants for `FLEET_IN_BEING` and `REFUSED_ENGAGEMENT` were incorrectly set to
  `+2` (Victory equivalent) instead of negative values matching their defeat classification.

  This only affects Mapless StratCon mode because:
  - Standard StratCon uses `StratConCampaignState.getVictoryPoints()`
  - Mapless StratCon uses `ContractScore.getContractScore()` which had the bug

## Changes

  1. `ContractScore.java` - Fixed scoring constants:
     - `FLEET_IN_BEING`: `2` → `-2` (Defeat equivalent)
     - `REFUSED_ENGAGEMENT`: `2` → `-3` (Decisive Defeat equivalent)

## Files Changed

  - `MekHQ/src/mekhq/campaign/mission/ContractScore.java` - Fixed VP scoring constants

## Testing

  - Values now align with `ScenarioStatus.isOverallDefeat()` which correctly classifies both statuses as defeats
  - Scoring now matches the documented expectations:
    - Victory: +2, Decisive Victory: +3
    - Defeat: -2, Decisive Defeat: -3
    - Fleet in Being: -2 (Defeat equivalent)
    - Refused Engagement: -3 (Decisive Defeat equivalent)