### PR TITLE
PR: Change contract search radius minimum to 1 instead of 100

### DIFF
--- a/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
+++ b/MekHQ/src/mekhq/gui/campaignOptions/contents/MarketsTab.java
@@ -639,7 +639,7 @@ public class MarketsTab {
 
         lblContractSearchRadius = new CampaignOptionsLabel("ContractSearchRadius");
         lblContractSearchRadius.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractSearchRadius"));
-        spnContractSearchRadius = new CampaignOptionsSpinner("ContractSearchRadius", 300, 100, 2500, 100);
+        spnContractSearchRadius = new CampaignOptionsSpinner("ContractSearchRadius", 300, 1, 2500, 100);
         spnContractSearchRadius.addMouseListener(createTipPanelUpdater(contractMarketHeader, "ContractSearchRadius"));
 
         chkVariableContractLength = new CampaignOptionsCheckBox("VariableContractLength");


### PR DESCRIPTION
The MekHQ campaign contract market setting "Search Radius" had a minimum value of 100. It is now 1. The default is still 300 / whatever the preset defines. 