### PR TITLE
Fixed Eagle Eyes rolls for Advanced Scouting

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1811,7 +1811,7 @@ public class StratConRulesManager {
                 PersonnelOptions options = crewMember.getOptions();
                 int complementaryModifier = !hasSensorEquipment && // Doesn't stack with Sensor Equipment
                                                   options.booleanOption(OptionsConstants.MISC_EAGLE_EYES) ?
-                                                  -1 : 0;
+                                                  1 : 0;
 
                 int scoutSkillLevel = (scoutSkill == null) ? -1 : scoutSkill.getTotalSkillLevel(skillModifierData);
                 scoutSkillLevel += complementaryModifier;


### PR DESCRIPTION
There was a missing negative sign, I added the negative and now eagle eyes does what it is supposed to do