### PR TITLE
Permanent injuries can't be replaced with temporal ones

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypes.java
+++ b/MekHQ/src/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2016-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/unittests/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypesTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/medical/advancedMedical/InjuryTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *


### PR DESCRIPTION
Fixes #7565 

The bug report explains the issue pretty well: the worsening of a permanent injury could replace it by a temporal one. This happens in multiple injuries types, not just concussions.

This fix takes the decision that permanent injuries are chronic damage, so combat stress cannot affect them. But non-permanent injuries (representing non chronic injuries) can be made worse by stress. By not returning any GameEffect, the permanent injuries will be left alone.

Added also a parametrized unit test to validate this based on PR feedback.