### PR TITLE
Fix #8834: Prevent Buildings from being Salvaged

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -312,6 +312,10 @@ public class ResolveScenarioTracker {
                         }
                     }
 
+                    if (entity instanceof AbstractBuildingEntity) {
+                        continue;
+                    }
+
                     TestUnit newUnit = generateNewTestUnit(entity);
                     UnitStatus unitStatus = new UnitStatus(newUnit);
                     unitStatus.setTotalLoss(false);
@@ -468,7 +472,7 @@ public class ResolveScenarioTracker {
                     enemyEjections.put(UUID.fromString(wreck.getCrew().getExternalIdAsString()), (EjectedCrew) wreck);
                     continue;
                 }
-                if (control) {
+                if (control && !(wreck instanceof AbstractBuildingEntity)) {
                     TestUnit nu = generateNewTestUnit(wreck);
                     UnitStatus us = new UnitStatus(nu);
                     us.setTotalLoss(false);
@@ -1489,7 +1493,7 @@ public class ResolveScenarioTracker {
                     }
                     continue;
                 }
-                if (control) {
+                if (control && !(e instanceof AbstractBuildingEntity)) {
                     TestUnit nu = generateNewTestUnit(e);
                     UnitStatus us = new UnitStatus(nu);
                     us.setTotalLoss(false);


### PR DESCRIPTION
No hauling away buildings on your battlemech recovery vehicles!
The rest of the fix for #8834