### PR TITLE
Fix connector system display and map rendering bugs

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
+++ b/MekHQ/src/mekhq/campaign/universe/PlanetarySystem.java
@@ -220,8 +220,8 @@ public class PlanetarySystem {
     }
 
     public String getName(LocalDate when) {
-        // if no primary slot, then just return the id
-        if (getPrimaryPlanetPosition() < 1 && null != id) {
+        // if no primary slot was explicitly defined, then just return the id
+        if (getSourcedPrimarySlot() == null && id != null) {
             return id;
         }
 

--- a/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
+++ b/MekHQ/src/mekhq/gui/InterstellarMapPanel.java
@@ -790,7 +790,7 @@ public class InterstellarMapPanel extends JPanel {
                             if ((null != factions) && !isSystemEmpty(system)) {
                                 int i = 0;
                                 for (Faction faction : factions) {
-                                    if (capitals.get(faction).equals(system.getId())) {
+                                    if (system.getId().equals(capitals.get(faction))) {
                                         g2.setPaint(faction.getColor());
                                         arc.setArcByCenter(x, y, size + 5, 0,
                                               360.0 * (1 - ((double) i) / factions.size()), Arc2D.OPEN);


### PR DESCRIPTION
- PlanetarySystem.getName(): Check if primarySlot was explicitly defined rather than checking the defaulted value. Systems without primarySlot (e.g. connector systems like TFS 31) now correctly display their system ID instead of the first planet's generic name (e.g. "U-1").

- InterstellarMapPanel: Fix NPE when rendering factions without a capital in the capitals map. Reversed the equals() call so the non-null system ID is the receiver.