### PR TITLE
fix #8680 Birth announcement missing names

### DIFF
--- a/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
@@ -268,7 +268,7 @@ babyBorn.message.3.twins.ic=Today brought a welcome surprise - {2} delivered <b>
   <p>It''s a rare bit of joy around here, and it''s lifted everyone''s spirits.</p>
 babyBorn.message.4.twins.ic=We''ve got a bit of unexpected news - {2} just gave birth to <b>twins</b>.\
   <p>Both arrived in good shape, though {3}''s probably going to need some extra rest after pulling double duty.</p>\
-  <p>The medbay''s a bit noisier now, but it''s a good kind of noise for a change.</p>>
+  <p>The medbay''s a bit noisier now, but it''s a good kind of noise for a change.</p>
 babyBorn.message.5.twins.ic=After a long and demanding labor, {2} successfully delivered <b>twins</b>.\
   <p>There were a few tense moments, but {3}''s strength carried her through and both newborns are healthy and stable\
   .</p>\

--- a/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
@@ -284,7 +284,7 @@ babyBorn.message.8.twins.ic={2} successfully delivered <b>twins</b> today.\
   <p>{3} is tired but doing well.</p>\
   <p>It''s not often we see double the joy around here - definitely a bright spot in the day.</p>
 babyBorn.message.9.twins.ic=Well, the medbay just got a little more crowded - {2} delivered <b>twins</b> earlier today!\
-  <b>Both newborns are healthy and arrived safely, though I think we''re all still wrapping our heads around the \
+  <p>Both newborns are healthy and arrived safely, though I think we''re all still wrapping our heads around the \
   surprise.</p>\
   <p>{3} did incredibly well, handling the unexpected challenge with her usual grit.</p>\
   <p>Looks like we''ll need to find some extra blankets.</p>

--- a/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
@@ -265,7 +265,7 @@ babyBorn.message.2.twins.ic=Just when we thought things couldn''t get more inter
   <p>The medbay, on the other hand, is buzzing - who knew we''d get two new recruits at once?</p>
 babyBorn.message.3.twins.ic=Today brought a welcome surprise - {2} delivered <b>twins</b>!\
   <p>Both are healthy and stable, and {3} is recovering well after a long labor.</p>\
-  <p>It''s a rare bit of joy around here, and it''s lifted everyone's spirits.</p>
+  <p>It''s a rare bit of joy around here, and it''s lifted everyone''s spirits.</p>
 babyBorn.message.4.twins.ic=We''ve got a bit of unexpected news - {2} just gave birth to <b>twins</b>.\
   <p>Both arrived in good shape, though {3}''s probably going to need some extra rest after pulling double duty.</p>\
   <p>The medbay''s a bit noisier now, but it''s a good kind of noise for a change.</p>>

--- a/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
@@ -307,7 +307,7 @@ babyBorn.message.3.triplets.ic=In a world where challenges never seem to let up,
   <p>It''s rare to see such a clear victory in the medbay, and it''s done wonders for morale.</p>
 babyBorn.message.4.triplets.ic=I''m not going to lie - when {2} went into labor, we didn''t expect <b>triplets</b>.\
   <p>The delivery was tough, but {3}''s resilience got her through it.</p>\
-  <p>All three newborns are stable, though they arrived a bit earlier than anticipated. We're keeping a close eye on\
+  <p>All three newborns are stable, though they arrived a bit earlier than anticipated. We''re keeping a close eye on\
   \ them to ensure they maintain good health.</p>
 ## More than triplets
 babyBorn.message.quadrupletsPlus.ic=You''re not going to believe this one.\

--- a/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
@@ -270,9 +270,8 @@ babyBorn.message.4.twins.ic=We''ve got a bit of unexpected news - {2} just gave 
   <p>Both arrived in good shape, though {3}''s probably going to need some extra rest after pulling double duty.</p>\
   <p>The medbay''s a bit noisier now, but it''s a good kind of noise for a change.</p>
 babyBorn.message.5.twins.ic=After a long and demanding labor, {2} successfully delivered <b>twins</b>.\
-  <p>There were a few tense moments, but {3}''s strength carried her through and both newborns are healthy and stable\
-  .</p>\
-  <p>We're monitoring them closely, but the outlook is positive.</p>
+  <p>There were a few tense moments, but {3}''s strength carried her through and both newborns are healthy and stable.</p>\
+  <p>We''re monitoring them closely, but the outlook is positive.</p>
 babyBorn.message.6.twins.ic={2} delivered <b>twins</b> earlier today. Both newborns are healthy and showing good vitals.\
   <p>The delivery took longer than usual, but no significant complications arose.</p>\
   <p>{3}''s resting and in good spirits, and we''re optimistic about their recovery.</p>

--- a/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
@@ -1,4 +1,4 @@
-# Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+# Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
 #
 # This file is part of MekHQ.
 #
@@ -191,7 +191,7 @@ babyBorn.message.34.ic=We almost lost them.\
   \ measures, but both are stable now.</p>\
   <p>The MedTechs haven''t left {9} side, and {3} is just holding the baby like {7}''{0, choice, 0#re|1#s} afraid\
   \ {12}''ll disappear.</p>\
-  <p>It was a close call. {6} nearly did.</p>
+  <p>It was a close call. {6} nearly died.</p>
 babyBorn.message.35.ic={2} gave birth at {1}-local to a baby {10}, weighing {15}kg.\
   <p>Labor was long and rough, but {3} pulled through. Both {5} and baby are stable.</p>\
   <p>{3}''s been trying to act tough, but I caught {8} wiping {9} eyes.
@@ -200,7 +200,7 @@ babyBorn.message.36.ic={2} just welcomed {9} baby {10} into the world, {15}kg, a
   <p>{3}''s fine, just exhausted, and the little one''s already kicking like a trooper.</p>\
   <p>{3}''s promising {12}''ll be leading the next {17}. At this rate, I almost believe {8}.</p>
 babyBorn.message.37.ic=In a job where people are just statistics, today felt different.\
-  <p>{2} gave birth to a baby 10}, {15}kg, without any major complications.</p>\
+  <p>{2} gave birth to a baby {10}, {15}kg, without any major complications.</p>\
   <p>Seeing {3} holding {9} child, it hit me how fragile and resilient life can be at once. Moments like this remind us\
   \ of the simple things worth fighting for.</p>
 babyBorn.message.38.ic=I am pleased to report that {2} successfully delivered a baby {10} at {1}-local, weighing {15}kg\
@@ -259,61 +259,64 @@ babyBorn.message.0.twins.ic={2} gave birth to <b>twins</b> earlier today. The de
 babyBorn.message.1.twins.ic={2} delivered <b>twins</b> earlier today - both healthy and stable.\
   <p>Labor was challenging, but {3} showed incredible strength. Everyone is doing well and resting comfortably.</p>\
   <p>The medical team will keep an eye on them for the standard recovery period.</p>
-babyBorn.message.2.twins.ic=Just when we thought things couldn't get more interesting - {2} gave birth to <b>twins</b>!\
-  <p>Both arrived safely and are already showing some attitude. {3}'s doing well, just a bit tired.</p>\
-  <p>The medbay, on the other hand, is buzzing - who knew we'd get two new recruits at once?</p>
+babyBorn.message.2.twins.ic=Just when we thought things couldn''t get more interesting - {2} gave birth to \
+  <b>twins</b>!\
+  <p>Both arrived safely and are already showing some attitude. {3}''s doing well, just a bit tired.</p>\
+  <p>The medbay, on the other hand, is buzzing - who knew we''d get two new recruits at once?</p>
 babyBorn.message.3.twins.ic=Today brought a welcome surprise - {2} delivered <b>twins</b>!\
   <p>Both are healthy and stable, and {3} is recovering well after a long labor.</p>\
-  <p>It's a rare bit of joy around here, and it's lifted everyone's spirits.</p>
-babyBorn.message.4.twins.ic=We've got a bit of unexpected news - {2} just gave birth to <b>twins</b>.\
-  <p>Both arrived in good shape, though {3}'s probably going to need some extra rest after pulling double duty.</p>\
-  <p>The medbay's a bit noisier now, but it's a good kind of noise for a change.</p>>
+  <p>It''s a rare bit of joy around here, and it''s lifted everyone's spirits.</p>
+babyBorn.message.4.twins.ic=We''ve got a bit of unexpected news - {2} just gave birth to <b>twins</b>.\
+  <p>Both arrived in good shape, though {3}''s probably going to need some extra rest after pulling double duty.</p>\
+  <p>The medbay''s a bit noisier now, but it''s a good kind of noise for a change.</p>>
 babyBorn.message.5.twins.ic=After a long and demanding labor, {2} successfully delivered <b>twins</b>.\
-  <p>There were a few tense moments, but {3}'s strength carried her through and both newborns are healthy and stable.</p>\
+  <p>There were a few tense moments, but {3}''s strength carried her through and both newborns are healthy and stable\
+  .</p>\
   <p>We're monitoring them closely, but the outlook is positive.</p>
 babyBorn.message.6.twins.ic={2} delivered <b>twins</b> earlier today. Both newborns are healthy and showing good vitals.\
   <p>The delivery took longer than usual, but no significant complications arose.</p>\
-  <p>{3}'s resting and in good spirits, and we're optimistic about their recovery.</p>
-babyBorn.message.7.twins.ic=It's not often we get a moment of genuine hope, but today brought just that.\
+  <p>{3}''s resting and in good spirits, and we''re optimistic about their recovery.</p>
+babyBorn.message.7.twins.ic=It''s not often we get a moment of genuine hope, but today brought just that.\
   <p>{2} gave birth to <b>twins</b> - a double blessing when we least expected it. Both are healthy, and {3} is stable.</p>\
   <p>Seeing those tiny faces reminded us why we keep fighting.</p>\
-  <p>We'll keep them under observation, but for now, they're safe and sound.</p>
+  <p>We''ll keep them under observation, but for now, they''re safe and sound.</p>
 babyBorn.message.8.twins.ic={2} successfully delivered <b>twins</b> today.\
   <p>The delivery went well, and both newborns are stable.</p>\
   <p>{3} is tired but doing well.</p>\
-  <p>It's not often we see double the joy around here - definitely a bright spot in the day.</p>
+  <p>It''s not often we see double the joy around here - definitely a bright spot in the day.</p>
 babyBorn.message.9.twins.ic=Well, the medbay just got a little more crowded - {2} delivered <b>twins</b> earlier today!\
-  <b>Both newborns are healthy and arrived safely, though I think we're all still wrapping our heads around the surprise.</p>\
+  <b>Both newborns are healthy and arrived safely, though I think we''re all still wrapping our heads around the \
+  surprise.</p>\
   <p>{3} did incredibly well, handling the unexpected challenge with her usual grit.</p>\
-  <p>Looks like we'll need to find some extra blankets.</p>
+  <p>Looks like we''ll need to find some extra blankets.</p>
 ## Triplets
 babyBorn.message.0.triplets.ic={2} gave birth to <b>triplets</b> earlier today.\
   <p>All three newborns arrived safely and are in stable condition.</p>\
   <p>The delivery was complex and required additional medical support, but {3} remained strong throughout the process.</p>\
   <p>We are monitoring both the mother and the newborns closely, but all initial health checks indicate that they are\
   \ doing well.</p>
-babyBorn.message.1.triplets.ic=We've officially hit the jackpot - {2} gave birth to <b>triplets</b>!\
+babyBorn.message.1.triplets.ic=We''ve officially hit the jackpot - {2} gave birth to <b>triplets</b>!\
   <p>All three arrived healthy and loud, making the medbay feel like a nursery on overdrive.</p>\
   <p>Labor was intense, but {3} pulled through like a champ.</p>\
-  <p>It's not often we get news this good, and morale is definitely up.</p>
+  <p>It''s not often we get news this good, and morale is definitely up.</p>
 babyBorn.message.2.triplets.ic=Well, that was unexpected - {2} gave birth to <b>triplets</b>!\
   <p>All three newborns are doing well, and {3} is stable, though understandably exhausted.</p>\
-  <p>The medbay's already buzzing about how we're going to keep up with this tiny {17}.
+  <p>The medbay''s already buzzing about how we''re going to keep up with this tiny {17}.
 babyBorn.message.3.triplets.ic=In a world where challenges never seem to let up, today brought a remarkable surprise -\
   \ {2} delivered <b>triplets</b>.\
   <p>Despite the difficulties of a multiple birth, all three newborns are healthy, and {3} is recovering well.</p>\
-  <p>It's rare to see such a clear victory in the medbay, and it's done wonders for morale.</p>
-babyBorn.message.4.triplets.ic=I'm not going to lie - when {2} went into labor, we didn't expect <b>triplets</b>.\
-  <p>The delivery was tough, but {3}'s resilience got her through it.</p>\
+  <p>It''s rare to see such a clear victory in the medbay, and it''s done wonders for morale.</p>
+babyBorn.message.4.triplets.ic=I''m not going to lie - when {2} went into labor, we didn''t expect <b>triplets</b>.\
+  <p>The delivery was tough, but {3}''s resilience got her through it.</p>\
   <p>All three newborns are stable, though they arrived a bit earlier than anticipated. We're keeping a close eye on\
   \ them to ensure they maintain good health.</p>
 ## More than triplets
-babyBorn.message.quadrupletsPlus.ic=You're not going to believe this one.\
-  <p>The medbay just experienced something unprecedented - {2} has given birth, and it's safe to say we got more than we\
-  \ bargained for. I'm still trying to wrap my head around it myself.</p>\
+babyBorn.message.quadrupletsPlus.ic=You''re not going to believe this one.\
+  <p>The medbay just experienced something unprecedented - {2} has given birth, and it''s safe to say we got more \
+  than we bargained for. I''m still trying to wrap my head around it myself.</p>\
   <p>The delivery was intense and required the entire medical team on deck. We had to work fast and efficiently, but\
-  \ {3} showed an unbelievable amount of grit. We weren't just delivering one or two - it felt like an entire {17} showed\
-  \ up at once.</p>\
+  \ {3} showed an unbelievable amount of grit. We weren''t just delivering one or two - it felt like an entire {17} \
+  showed up at once.</p>\
   <p>All <b>{18}</b> newborns are stable, and {3} is resting.</p>\
-  <p>We'll continue to monitor them closely, but it looks like we just gained quite a few new faces around here. You\
-  \ might want to swing by when you have a moment - this one's worth seeing.</p>
+  <p>We''ll continue to monitor them closely, but it looks like we just gained quite a few new faces around here. You\
+  \ might want to swing by when you have a moment - this one''s worth seeing.</p>

--- a/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
@@ -300,7 +300,7 @@ babyBorn.message.1.triplets.ic=We''ve officially hit the jackpot - {2} gave birt
   <p>It''s not often we get news this good, and morale is definitely up.</p>
 babyBorn.message.2.triplets.ic=Well, that was unexpected - {2} gave birth to <b>triplets</b>!\
   <p>All three newborns are doing well, and {3} is stable, though understandably exhausted.</p>\
-  <p>The medbay''s already buzzing about how we''re going to keep up with this tiny {17}.
+  <p>The medbay''s already buzzing about how we''re going to keep up with this tiny {17}.</p>
 babyBorn.message.3.triplets.ic=In a world where challenges never seem to let up, today brought a remarkable surprise -\
   \ {2} delivered <b>triplets</b>.\
   <p>Despite the difficulties of a multiple birth, all three newborns are healthy, and {3} is recovering well.</p>\

--- a/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
+++ b/MekHQ/src/mekhq/campaign/personnel/procreation/AbstractProcreation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -220,7 +220,7 @@ public abstract class AbstractProcreation {
                      mother.getGenealogy().getSpouse() :
                      ((mother.getExtraData().get(PREGNANCY_FATHER_DATA) != null) ?
                             campaign.getPerson(UUID.fromString(mother.getExtraData().get(PREGNANCY_FATHER_DATA))) :
-                            null);
+                      null);
     }
     //endregion Determination Methods
 
@@ -511,8 +511,8 @@ public abstract class AbstractProcreation {
                 baby.getOptions().getOption(UNOFFICIAL_DOBROWSKI_SYNDROME).setValue(true);
             }
 
-            // Alert the player
-            if (campaignOptions.isShowLifeEventDialogBirths()) {
+            // Alert the player, but only show this dialog for the first child with twins/triplets/etc
+            if (campaignOptions.isShowLifeEventDialogBirths() && (i == 0)) {
                 new BirthAnnouncement(campaign, mother, baby.getGender(), size);
             }
         }


### PR DESCRIPTION
The babyBorn.message strings for twins/triplets/quadrupletsPlus had only a single apostrophe in some places. Since these strings are formatted with MessageFormat.format any apostrophes should be doubled. (So **_I''ve_** instead of **_I've_** for example).

Also with twins/triplets/etc the dialogue was showing up for each new baby, which doesn't make sense as the text mentions all children already in that case. So this was changed to show the dialogue only once.

closes #8680 