### PR TITLE
Fix missing tempCrewDeathBenefitsReport

### DIFF
--- a/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
+++ b/MekHQ/src/mekhq/campaign/ResolveScenarioTracker.java
@@ -862,14 +862,14 @@ public class ResolveScenarioTracker {
     }
 
     /**
-     * Attempts to assign a casualty to temp crew members (blob crew) if any exist.
-     * Casualties are randomly distributed across all temp crew types proportional to their numbers.
-     * If no blob crew exists or the random roll indicates a Person should be hit, the casualty
-     * is assigned to the Person instead (setting dead or wounded status). This can be expanded in the
-     * future to include support for wounding temp crew.
+     * Attempts to assign a casualty to temp crew members (blob crew) if any exist. Casualties are randomly distributed
+     * across all temp crew types proportional to their numbers. If no blob crew exists or the random roll indicates a
+     * Person should be hit, the casualty is assigned to the Person instead (setting dead or wounded status). This can
+     * be expanded in the future to include support for wounding temp crew.
      *
-     * @param unit The unit with potential temp crew
+     * @param unit   The unit with potential temp crew
      * @param status The personnel status object to update if casualty assigned to a Person
+     *
      * @return The type of casualty assignment that occurred
      */
     private CasualtyAssignment assignTempCrewCasualty(Unit unit, PersonStatus status) {
@@ -1649,9 +1649,8 @@ public class ResolveScenarioTracker {
     }
 
     /**
-     * Processes death payouts for killed temp crew (blob crew).
-     * Calculates appropriate compensation based on role base salaries and
-     * campaign payout settings.
+     * Processes death payouts for killed temp crew (blob crew). Calculates appropriate compensation based on role base
+     * salaries and campaign payout settings.
      */
     private void processTempCrewDeathPayouts() {
         CampaignOptions options = campaign.getCampaignOptions();
@@ -1674,28 +1673,29 @@ public class ResolveScenarioTracker {
         // Debit the total payout from campaign finances
         if (totalPayout.isPositive()) {
             campaign.getFinances().debit(
-                TransactionType.SALARIES,
-                campaign.getLocalDate(),
-                totalPayout,
-                getTextAt(RESOURCE_BUNDLE, "tempCrewDeathBenefitsTransaction")
+                  TransactionType.SALARIES,
+                  campaign.getLocalDate(),
+                  totalPayout,
+                  getTextAt(RESOURCE_BUNDLE, "ResolveScenarioTracker.tempCrewDeathBenefitsTransaction")
             );
 
             // Add a report entry
             campaign.addReport(
-                mekhq.campaign.enums.DailyReportType.PERSONNEL,
-                getFormattedTextAt(RESOURCE_BUNDLE, "tempCrewDeathBenefitsReport",
-                    totalPayout.toAmountAndSymbolString(),
-                    totalKilled)
+                  mekhq.campaign.enums.DailyReportType.PERSONNEL,
+                  getFormattedTextAt(RESOURCE_BUNDLE, "ResolveScenarioTracker.tempCrewDeathBenefitsReport",
+                        totalPayout.toAmountAndSymbolString(),
+                        totalKilled)
             );
         }
     }
 
     /**
-     * Calculates the payout amount for a temp crew member based on base salary.
-     * Uses the same multipliers as regular personnel death benefits.
+     * Calculates the payout amount for a temp crew member based on base salary. Uses the same multipliers as regular
+     * personnel death benefits.
      *
      * @param baseSalary The base salary for the role
-     * @param isOfficer Whether the crew member is an officer (always false for temp crew)
+     * @param isOfficer  Whether the crew member is an officer (always false for temp crew)
+     *
      * @return The calculated payout amount
      */
     private Money calculateTempCrewPayout(Money baseSalary, boolean isOfficer) {


### PR DESCRIPTION
After a scenario where a unit with temp crew loses some of the crew, there should be a line in the Personnel tab of the Daily activity log with information about this. But currently the line only shows !tempCrewDeathBenefitsReport! 

The reason for this is that this resource name is not properly referred to, this PR fixes that.

<img width="367" height="139" alt="ReportMissing" src="https://github.com/user-attachments/assets/88ea2303-e60b-412e-8079-5ee857bd3657" />
