### PR TITLE
Fix: Exclude unstreamlined DropShips from atmospheric StratCon scenarios

### DIFF
--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1019,7 +1019,7 @@ public class StratConRulesManager {
      * @return {@code true} if the unit matches the template's requirements and can be included in the scenario,
      *       {@code false} otherwise.
      */
-    private static boolean isValidUnitForScenario(Unit unit, ScenarioForceTemplate scenarioForceTemplate,
+    static boolean isValidUnitForScenario(Unit unit, ScenarioForceTemplate scenarioForceTemplate,
           Campaign campaign, MapLocation mapLocation) {
         // Check if DropShips are allowed and the correct unit type matches
         if (scenarioForceTemplate.getAllowedUnitType() == 11 && !campaign.getCampaignOptions().isUseDropShips()) {

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -121,6 +121,7 @@ import mekhq.campaign.personnel.turnoverAndRetention.Fatigue;
 import mekhq.campaign.stratCon.StratConContractDefinition.StrategicObjectiveType;
 import mekhq.campaign.stratCon.StratConScenario.ScenarioState;
 import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.Planet;
 import mekhq.gui.dialog.nagDialogs.CombatChallengeNagDialog;
 import mekhq.utilities.EntityUtilities;
 import mekhq.utilities.ReportingUtilities;
@@ -901,7 +902,7 @@ public class StratConRulesManager {
             for (Unit unit : potentialUnits) {
                 if (isValidUnitForScenario(unit,
                       scenarioForceTemplate,
-                      campaign.getCampaignOptions().isUseDropShips(),
+                      campaign,
                       scenario.getScenarioTemplate().mapParameters.getMapLocation())) {
                     scenario.addUnit(unit, scenarioForceTemplate.getForceName(), false);
                     AtBDynamicScenarioFactory.benchAllyUnit(unit.getId(),
@@ -1012,16 +1013,16 @@ public class StratConRulesManager {
      *
      * @param unit                  The unit to validate.
      * @param scenarioForceTemplate The force template containing the rules for unit validation.
-     * @param isUsePlayerDropShips  Indicates if DropShips are allowed based on campaign options.
+     * @param campaign              The current campaign, used to check campaign options and planetary conditions.
      * @param mapLocation           The map location type of the scenario, used to check if the unit can operate there.
      *
      * @return {@code true} if the unit matches the template's requirements and can be included in the scenario,
      *       {@code false} otherwise.
      */
     private static boolean isValidUnitForScenario(Unit unit, ScenarioForceTemplate scenarioForceTemplate,
-          boolean isUsePlayerDropShips, MapLocation mapLocation) {
+          Campaign campaign, MapLocation mapLocation) {
         // Check if DropShips are allowed and the correct unit type matches
-        if (scenarioForceTemplate.getAllowedUnitType() == 11 && !isUsePlayerDropShips) {
+        if (scenarioForceTemplate.getAllowedUnitType() == 11 && !campaign.getCampaignOptions().isUseDropShips()) {
             return false;
         }
 
@@ -1029,11 +1030,21 @@ public class StratConRulesManager {
         Entity entity = unit.getEntity();
         if (entity != null) {
             boolean isGround = (mapLocation == AllGroundTerrain) || (mapLocation == SpecificGroundTerrain);
+            boolean isAtmospheric = isGround || (mapLocation == LowAtmosphere);
 
             if ((isGround && entity.doomedOnGround())
                   || (mapLocation == LowAtmosphere && entity.doomedInAtmosphere())
                   || (mapLocation == Space && entity.doomedInSpace())) {
                 return false;
+            }
+
+            // Unstreamlined units (e.g. Behemoth) cannot operate in atmosphere or on the ground,
+            // but they can operate on airless worlds (vacuum)
+            if (isAtmospheric && entity.hasQuirk(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)) {
+                Planet planet = campaign.getLocation().getPlanet();
+                if (planet == null || !planet.getAtmosphere(campaign.getLocalDate()).isNone()) {
+                    return false;
+                }
             }
         }
 

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -1029,16 +1029,10 @@ public class StratConRulesManager {
         Entity entity = unit.getEntity();
         if (entity != null) {
             boolean isGround = (mapLocation == AllGroundTerrain) || (mapLocation == SpecificGroundTerrain);
-            boolean isAtmospheric = isGround || (mapLocation == LowAtmosphere);
 
             if ((isGround && entity.doomedOnGround())
                   || (mapLocation == LowAtmosphere && entity.doomedInAtmosphere())
                   || (mapLocation == Space && entity.doomedInSpace())) {
-                return false;
-            }
-
-            // Unstreamlined units (e.g. Behemoth) cannot operate in atmosphere or on the ground
-            if (isAtmospheric && entity.hasQuirk(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)) {
                 return false;
             }
         }

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -41,6 +41,7 @@ import static megamek.common.compute.Compute.d6;
 import static megamek.common.compute.Compute.randomInt;
 import static megamek.common.enums.SkillLevel.REGULAR;
 import static megamek.common.units.UnitType.CONV_FIGHTER;
+import static megamek.common.units.UnitType.DROPSHIP;
 import static megamek.common.units.UnitType.JUMPSHIP;
 import static megamek.common.units.UnitType.MEK;
 import static mekhq.campaign.enums.DailyReportType.BATTLE;
@@ -1021,35 +1022,36 @@ public class StratConRulesManager {
      */
     static boolean isValidUnitForScenario(Unit unit, ScenarioForceTemplate scenarioForceTemplate,
           Campaign campaign, MapLocation mapLocation) {
-        // Check if DropShips are allowed and the correct unit type matches
-        if (scenarioForceTemplate.getAllowedUnitType() == 11 && !campaign.getCampaignOptions().isUseDropShips()) {
+        // Check if the unit is a DropShip and player DropShips are disabled
+        Entity entity = unit.getEntity();
+        if (entity == null) {
             return false;
         }
 
-        // Check if the unit can operate on the scenario's map type
-        Entity entity = unit.getEntity();
-        if (entity != null) {
-            boolean isGround = (mapLocation == AllGroundTerrain) || (mapLocation == SpecificGroundTerrain);
-            boolean isAtmospheric = isGround || (mapLocation == LowAtmosphere);
+        if (entity.getUnitType() == DROPSHIP && !campaign.getCampaignOptions().isUseDropShips()) {
+            return false;
+        }
 
-            if ((isGround && entity.doomedOnGround())
-                  || (mapLocation == LowAtmosphere && entity.doomedInAtmosphere())
-                  || (mapLocation == Space && entity.doomedInSpace())) {
+        boolean isGround = (mapLocation == AllGroundTerrain) || (mapLocation == SpecificGroundTerrain);
+        boolean isAtmospheric = isGround || (mapLocation == LowAtmosphere);
+
+        if ((isGround && entity.doomedOnGround())
+              || (mapLocation == LowAtmosphere && entity.doomedInAtmosphere())
+              || (mapLocation == Space && entity.doomedInSpace())) {
+            return false;
+        }
+
+        // Unstreamlined units (e.g. Behemoth) cannot operate in atmosphere or on the ground,
+        // but they can operate on airless worlds (vacuum)
+        if (isAtmospheric && entity.hasQuirk(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)) {
+            Planet planet = campaign.getLocation().getPlanet();
+            if (planet == null || !planet.getAtmosphere(campaign.getLocalDate()).isNone()) {
                 return false;
-            }
-
-            // Unstreamlined units (e.g. Behemoth) cannot operate in atmosphere or on the ground,
-            // but they can operate on airless worlds (vacuum)
-            if (isAtmospheric && entity.hasQuirk(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)) {
-                Planet planet = campaign.getLocation().getPlanet();
-                if (planet == null || !planet.getAtmosphere(campaign.getLocalDate()).isNone()) {
-                    return false;
-                }
             }
         }
 
         // Validate the unit type, availability, and functionality
-        return forceCompositionMatchesDeclaredUnitType(unit.getEntity().getUnitType(),
+        return forceCompositionMatchesDeclaredUnitType(entity.getUnitType(),
               scenarioForceTemplate.getAllowedUnitType()) && unit.isAvailable() && unit.isFunctional();
     }
 

--- a/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
+++ b/MekHQ/src/mekhq/campaign/stratCon/StratConRulesManager.java
@@ -901,7 +901,8 @@ public class StratConRulesManager {
             for (Unit unit : potentialUnits) {
                 if (isValidUnitForScenario(unit,
                       scenarioForceTemplate,
-                      campaign.getCampaignOptions().isUseDropShips())) {
+                      campaign.getCampaignOptions().isUseDropShips(),
+                      scenario.getScenarioTemplate().mapParameters.getMapLocation())) {
                     scenario.addUnit(unit, scenarioForceTemplate.getForceName(), false);
                     AtBDynamicScenarioFactory.benchAllyUnit(unit.getId(),
                           scenarioForceTemplate.getForceName(),
@@ -1006,20 +1007,40 @@ public class StratConRulesManager {
 
     /**
      * Validates if a given unit can be included in the scenario based on the template's rules and restrictions. It
-     * checks unit type, availability, functionality, and specific conditions such as DropShip usage.
+     * checks unit type, availability, functionality, and specific conditions such as DropShip usage and map
+     * compatibility.
      *
      * @param unit                  The unit to validate.
      * @param scenarioForceTemplate The force template containing the rules for unit validation.
      * @param isUsePlayerDropShips  Indicates if DropShips are allowed based on campaign options.
+     * @param mapLocation           The map location type of the scenario, used to check if the unit can operate there.
      *
      * @return {@code true} if the unit matches the template's requirements and can be included in the scenario,
      *       {@code false} otherwise.
      */
     private static boolean isValidUnitForScenario(Unit unit, ScenarioForceTemplate scenarioForceTemplate,
-          boolean isUsePlayerDropShips) {
+          boolean isUsePlayerDropShips, MapLocation mapLocation) {
         // Check if DropShips are allowed and the correct unit type matches
         if (scenarioForceTemplate.getAllowedUnitType() == 11 && !isUsePlayerDropShips) {
             return false;
+        }
+
+        // Check if the unit can operate on the scenario's map type
+        Entity entity = unit.getEntity();
+        if (entity != null) {
+            boolean isGround = (mapLocation == AllGroundTerrain) || (mapLocation == SpecificGroundTerrain);
+            boolean isAtmospheric = isGround || (mapLocation == LowAtmosphere);
+
+            if ((isGround && entity.doomedOnGround())
+                  || (mapLocation == LowAtmosphere && entity.doomedInAtmosphere())
+                  || (mapLocation == Space && entity.doomedInSpace())) {
+                return false;
+            }
+
+            // Unstreamlined units (e.g. Behemoth) cannot operate in atmosphere or on the ground
+            if (isAtmospheric && entity.hasQuirk(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)) {
+                return false;
+            }
         }
 
         // Validate the unit type, availability, and functionality

--- a/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/stratCon/StratConRulesManagerTest.java
@@ -32,7 +32,9 @@
  */
 package mekhq.campaign.stratCon;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -56,6 +58,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import mekhq.campaign.CurrentLocation;
 import mekhq.campaign.Campaign;
 import mekhq.campaign.Hangar;
 import mekhq.campaign.campaignOptions.CampaignOptions;
@@ -63,10 +66,18 @@ import mekhq.campaign.force.CombatTeam;
 import mekhq.campaign.force.Formation;
 import mekhq.campaign.mission.AtBContract;
 import mekhq.campaign.mission.AtBDynamicScenario;
+import mekhq.campaign.mission.ScenarioForceTemplate;
+import mekhq.campaign.mission.ScenarioMapParameters.MapLocation;
 import mekhq.campaign.mission.enums.CombatRole;
 import mekhq.campaign.mission.enums.ScenarioType;
 import mekhq.campaign.personnel.Person;
 import mekhq.campaign.unit.Unit;
+import mekhq.campaign.universe.Atmosphere;
+import mekhq.campaign.universe.Planet;
+
+import megamek.common.options.OptionsConstants;
+import megamek.common.units.Entity;
+import megamek.common.units.UnitType;
 
 /**
  * Tests for {@link StratConRulesManager}
@@ -286,5 +297,154 @@ class StratConRulesManagerTest {
             // so finalizeBackingScenario will commit forces as normal
             verify(mockScenario).setOverrideForceAutoAssignment(true);
         }
+    }
+
+    // -- isValidUnitForScenario tests --
+
+    /**
+     * Creates common mock infrastructure for isValidUnitForScenario tests.
+     *
+     * @param unitType the unit type to return from the entity
+     * @param hasUnstreamlinedQuirk whether the entity has the unstreamlined quirk
+     * @param atmosphere the planet's atmosphere (null to simulate missing planet data)
+     * @param isUseDropShips whether campaign options allow player dropships
+     * @param allowedUnitType the allowed unit type on the scenario force template (-2 for ATB_MIX)
+     *
+     * @return an Object array: [Unit, ScenarioForceTemplate, Campaign]
+     */
+    private Object[] setupIsValidUnitMocks(int unitType, boolean hasUnstreamlinedQuirk,
+          Atmosphere atmosphere, boolean isUseDropShips, int allowedUnitType) {
+        Entity entity = mock(Entity.class);
+        when(entity.getUnitType()).thenReturn(unitType);
+        when(entity.hasQuirk(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)).thenReturn(hasUnstreamlinedQuirk);
+        when(entity.doomedOnGround()).thenReturn(false);
+        when(entity.doomedInAtmosphere()).thenReturn(false);
+        when(entity.doomedInSpace()).thenReturn(false);
+
+        Unit unit = mock(Unit.class);
+        when(unit.getEntity()).thenReturn(entity);
+        when(unit.isAvailable()).thenReturn(true);
+        when(unit.isFunctional()).thenReturn(true);
+
+        ScenarioForceTemplate template = mock(ScenarioForceTemplate.class);
+        when(template.getAllowedUnitType()).thenReturn(allowedUnitType);
+
+        CampaignOptions options = mock(CampaignOptions.class);
+        when(options.isUseDropShips()).thenReturn(isUseDropShips);
+
+        Campaign campaign = mock(Campaign.class);
+        when(campaign.getCampaignOptions()).thenReturn(options);
+        when(campaign.getLocalDate()).thenReturn(LocalDate.of(3025, 1, 15));
+
+        CurrentLocation location = mock(CurrentLocation.class);
+        when(campaign.getLocation()).thenReturn(location);
+
+        if (atmosphere != null) {
+            Planet planet = mock(Planet.class);
+            when(planet.getAtmosphere(any())).thenReturn(atmosphere);
+            when(location.getPlanet()).thenReturn(planet);
+        } else {
+            when(location.getPlanet()).thenReturn(null);
+        }
+
+        return new Object[] { unit, template, campaign };
+    }
+
+    @Test
+    void isValidUnitForScenario_normalDropshipOnGround_allowed() {
+        Object[] mocks = setupIsValidUnitMocks(UnitType.DROPSHIP, false,
+              Atmosphere.BREATHABLE, true, ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX);
+
+        boolean result = StratConRulesManager.isValidUnitForScenario(
+              (Unit) mocks[0], (ScenarioForceTemplate) mocks[1],
+              (Campaign) mocks[2], MapLocation.AllGroundTerrain);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void isValidUnitForScenario_unstreamlinedDropshipOnGroundWithAtmosphere_rejected() {
+        Object[] mocks = setupIsValidUnitMocks(UnitType.DROPSHIP, true,
+              Atmosphere.BREATHABLE, true, ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX);
+
+        boolean result = StratConRulesManager.isValidUnitForScenario(
+              (Unit) mocks[0], (ScenarioForceTemplate) mocks[1],
+              (Campaign) mocks[2], MapLocation.AllGroundTerrain);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void isValidUnitForScenario_unstreamlinedDropshipOnGroundWithVacuum_allowed() {
+        Object[] mocks = setupIsValidUnitMocks(UnitType.DROPSHIP, true,
+              Atmosphere.NONE, true, ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX);
+
+        boolean result = StratConRulesManager.isValidUnitForScenario(
+              (Unit) mocks[0], (ScenarioForceTemplate) mocks[1],
+              (Campaign) mocks[2], MapLocation.AllGroundTerrain);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void isValidUnitForScenario_unstreamlinedDropshipInSpace_allowed() {
+        Object[] mocks = setupIsValidUnitMocks(UnitType.DROPSHIP, true,
+              Atmosphere.BREATHABLE, true, ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX);
+
+        boolean result = StratConRulesManager.isValidUnitForScenario(
+              (Unit) mocks[0], (ScenarioForceTemplate) mocks[1],
+              (Campaign) mocks[2], MapLocation.Space);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void isValidUnitForScenario_unstreamlinedDropshipOnLowAtmosphereWithAtmosphere_rejected() {
+        Object[] mocks = setupIsValidUnitMocks(UnitType.DROPSHIP, true,
+              Atmosphere.BREATHABLE, true, ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX);
+
+        boolean result = StratConRulesManager.isValidUnitForScenario(
+              (Unit) mocks[0], (ScenarioForceTemplate) mocks[1],
+              (Campaign) mocks[2], MapLocation.LowAtmosphere);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void isValidUnitForScenario_unstreamlinedDropshipNullPlanet_rejected() {
+        Object[] mocks = setupIsValidUnitMocks(UnitType.DROPSHIP, true,
+              null, true, ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX);
+
+        boolean result = StratConRulesManager.isValidUnitForScenario(
+              (Unit) mocks[0], (ScenarioForceTemplate) mocks[1],
+              (Campaign) mocks[2], MapLocation.AllGroundTerrain);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void isValidUnitForScenario_dropshipWhenDropShipsDisabled_rejected() {
+        Object[] mocks = setupIsValidUnitMocks(UnitType.DROPSHIP, false,
+              Atmosphere.BREATHABLE, false, UnitType.DROPSHIP);
+
+        boolean result = StratConRulesManager.isValidUnitForScenario(
+              (Unit) mocks[0], (ScenarioForceTemplate) mocks[1],
+              (Campaign) mocks[2], MapLocation.AllGroundTerrain);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void isValidUnitForScenario_doomedOnGround_rejected() {
+        Object[] mocks = setupIsValidUnitMocks(UnitType.JUMPSHIP, false,
+              Atmosphere.BREATHABLE, true, ScenarioForceTemplate.SPECIAL_UNIT_TYPE_ATB_MIX);
+        Entity entity = ((Unit) mocks[0]).getEntity();
+        when(entity.doomedOnGround()).thenReturn(true);
+
+        boolean result = StratConRulesManager.isValidUnitForScenario(
+              (Unit) mocks[0], (ScenarioForceTemplate) mocks[1],
+              (Campaign) mocks[2], MapLocation.AllGroundTerrain);
+
+        assertFalse(result);
     }
 }


### PR DESCRIPTION
## Summary

Unstreamlined DropShips (e.g., Behemoth) are no longer assigned to ground or low-atmosphere StratCon scenarios when the planet has atmosphere. They remain eligible for space scenarios and for operations on airless (vacuum) worlds.

## Changes

- `isValidUnitForScenario()` now receives `Campaign` and `MapLocation` parameters instead of just a boolean, enabling board-type and planetary condition checks
- Added generic board-type compatibility filtering using `doomedOnGround()` / `doomedInAtmosphere()` / `doomedInSpace()`
- Added specific filtering for the `unstreamlined` negative quirk, with a planet atmosphere lookup to allow operations on vacuum worlds
- Changed method visibility from `private` to package-private for testability
- Added 8 unit tests covering all branches of the new validation logic

Fixes #6834

Companion PR: MegaMek/mm-data#315 (adds missing `unstreamlined` quirk to Behemoth data files)