### PR TITLE
Fix NPE in Mass Training when person lacks the trained skill

### DIFF
--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2016-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -399,13 +399,7 @@ public final class BatchXPDialog extends JDialog {
                 person.improveSkill(skillName);
                 person.spendXPOnSkills(campaign, cost);
 
-                // Refresh skill reference after improvement
                 skill = person.getSkill(skillName);
-                if (skill == null) {
-                    LOGGER.error("Failed to improve skill {} for person {}: skill was null after improvement",
-                          skillName, person.getFullTitle());
-                    continue;
-                }
 
                 PerformanceLogger.improvedSkill(campaignOptions.isPersonnelLogSkillGain(),
                       person,

--- a/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
+++ b/MekHQ/src/mekhq/gui/dialog/BatchXPDialog.java
@@ -395,14 +395,22 @@ public final class BatchXPDialog extends JDialog {
                     cost = max(0, cost - progress);
                 }
 
-                // Improve the skill and deduce the cost
+                // Improve the skill and deduct the cost
                 person.improveSkill(skillName);
                 person.spendXPOnSkills(campaign, cost);
+
+                // Refresh skill reference after improvement
+                skill = person.getSkill(skillName);
+                if (skill == null) {
+                    LOGGER.error("Failed to improve skill {} for person {}: skill was null after improvement",
+                          skillName, person.getFullTitle());
+                    continue;
+                }
 
                 PerformanceLogger.improvedSkill(campaignOptions.isPersonnelLogSkillGain(),
                       person,
                       campaign.getLocalDate(),
-                      skill.getType().getName(),
+                      skillName,
                       skill.getLevel());
                 campaign.personUpdated(person);
             }


### PR DESCRIPTION
Fixes #8805

When using Mass Training (BatchXPDialog) to train a skill that a person doesn't yet have, `person.getSkill(skillName)` returns `null`. The skill improvement and XP deduction completed successfully, but the subsequent `PerformanceLogger.improvedSkill()` call dereferenced the stale null `skill` reference, causing an uncaught NPE.

Because the exception prevented `updatePersonnelTable()` from running, the already-trained person could remain in the table and be processed again on retry, potentially leading to negative XP.

### Fix
Re-fetch the skill reference after `improveSkill()` so the logger receives a valid object. `improveSkill()` unconditionally creates or upgrades the skill, so the refreshed reference is always non-null.

### Testing
After fix, the associated campaign from the bug doesn't throw a NPE anymore when using Mass training.