### PR TITLE
Fix: Cybernetic Prosthetics No Longer Count as Injuries for Turnover and Medical Discharge

### DIFF
--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -1052,8 +1052,6 @@ public class RetirementDefectionTracker {
      *
      * @param person the person to evaluate
      * @return count of permanent injuries excluding prosthetics and implants
-     *
-     * @see <a href="https://github.com/MegaMek/mekhq/issues/8631">#8631</a>
      */
     static int getInjuryTurnoverModifier(final Person person) {
         return (int) person.getNonProstheticInjuries().stream().filter(Injury::isPermanent).count();
@@ -1065,8 +1063,6 @@ public class RetirementDefectionTracker {
      *
      * @param person the person to evaluate
      * @return {@code true} if the person has at least one permanent non-prosthetic injury
-     *
-     * @see <a href="https://github.com/MegaMek/mekhq/issues/8631">#8631</a>
      */
     static boolean hasMedicalDischargeInjuries(final Person person) {
         return person.getNonProstheticInjuries().stream().anyMatch(Injury::isPermanent);

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -1054,7 +1054,10 @@ public class RetirementDefectionTracker {
      * @return count of permanent injuries excluding prosthetics and implants
      */
     static int getInjuryTurnoverModifier(final Person person) {
-        return (int) person.getNonProstheticInjuries().stream().filter(Injury::isPermanent).count();
+        return (int) person.getInjuries().stream()
+              .filter(i -> !i.getSubType().isPermanentModification())
+              .filter(Injury::isPermanent)
+              .count();
     }
 
     /**
@@ -1065,7 +1068,9 @@ public class RetirementDefectionTracker {
      * @return {@code true} if the person has at least one permanent non-prosthetic injury
      */
     static boolean hasMedicalDischargeInjuries(final Person person) {
-        return person.getNonProstheticInjuries().stream().anyMatch(Injury::isPermanent);
+        return person.getInjuries().stream()
+              .filter(i -> !i.getSubType().isPermanentModification())
+              .anyMatch(Injury::isPermanent);
     }
 
     /**

--- a/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
+++ b/MekHQ/src/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTracker.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014 - Carl Spain. All rights reserved.
- * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2014-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -399,7 +399,7 @@ public class RetirementDefectionTracker {
             }
 
             // Injury Modifiers
-            int injuryMod = (int) person.getInjuries().stream().filter(Injury::isPermanent).count();
+            int injuryMod = getInjuryTurnoverModifier(person);
 
             if (injuryMod > 0) {
                 targetNumber.addModifier(injuryMod, resources.getString("injuries.text"));
@@ -1045,6 +1045,34 @@ public class RetirementDefectionTracker {
     }
 
     /**
+     * Returns the number of permanent, non-prosthetic injuries for turnover modifier calculation.
+     *
+     * <p>Prosthetics and implants are excluded because they are elective modifications,
+     * not debilitating injuries that would cause a person to leave a unit.</p>
+     *
+     * @param person the person to evaluate
+     * @return count of permanent injuries excluding prosthetics and implants
+     *
+     * @see <a href="https://github.com/MegaMek/mekhq/issues/8631">#8631</a>
+     */
+    static int getInjuryTurnoverModifier(final Person person) {
+        return (int) person.getNonProstheticInjuries().stream().filter(Injury::isPermanent).count();
+    }
+
+    /**
+     * Returns whether a person has permanent injuries (excluding prosthetics/implants)
+     * that qualify them for medical discharge.
+     *
+     * @param person the person to evaluate
+     * @return {@code true} if the person has at least one permanent non-prosthetic injury
+     *
+     * @see <a href="https://github.com/MegaMek/mekhq/issues/8631">#8631</a>
+     */
+    static boolean hasMedicalDischargeInjuries(final Person person) {
+        return person.getNonProstheticInjuries().stream().anyMatch(Injury::isPermanent);
+    }
+
+    /**
      * Class used to record the required payout to each retired/defected/killed/sacked person.
      */
     public static class Payout {
@@ -1081,7 +1109,7 @@ public class RetirementDefectionTracker {
                 payoutAmount = getPayoutOrBonusValue(campaign, person).multipliedBy(campaign.getCampaignOptions()
                                                                                           .getPayoutRetirementMultiplier());
                 // person is getting medically discharged
-            } else if (!person.getPermanentInjuries().isEmpty()) {
+            } else if (hasMedicalDischargeInjuries(person)) {
                 payoutAmount = getPayoutOrBonusValue(campaign, person).multipliedBy(campaign.getCampaignOptions()
                                                                                           .getPayoutRetirementMultiplier());
                 // person is defecting

--- a/MekHQ/unittests/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTrackerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTrackerTest.java
@@ -41,7 +41,6 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDate;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -86,14 +85,6 @@ class RetirementDefectionTrackerTest {
         List<Injury> injuryList = List.of(injuries);
 
         when(person.getInjuries()).thenReturn(injuryList);
-        when(person.getNonProstheticInjuries()).thenReturn(
-              injuryList.stream()
-                    .filter(i -> !i.getSubType().isPermanentModification())
-                    .collect(Collectors.toList()));
-        when(person.getProstheticInjuries()).thenReturn(
-              injuryList.stream()
-                    .filter(i -> i.getSubType().isPermanentModification())
-                    .collect(Collectors.toList()));
 
         return person;
     }

--- a/MekHQ/unittests/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTrackerTest.java
+++ b/MekHQ/unittests/mekhq/campaign/personnel/turnoverAndRetention/RetirementDefectionTrackerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package mekhq.campaign.personnel.turnoverAndRetention;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import mekhq.campaign.personnel.Injury;
+import mekhq.campaign.personnel.InjuryType;
+import mekhq.campaign.personnel.Person;
+import mekhq.campaign.personnel.enums.InjuryLevel;
+import mekhq.campaign.personnel.medical.BodyLocation;
+import mekhq.campaign.personnel.medical.advancedMedicalAlternate.InjurySubType;
+
+/**
+ * Tests for {@link RetirementDefectionTracker}, specifically verifying that
+ * prosthetic injuries do not contribute to turnover penalties or medical
+ * discharge determinations.
+ *
+ * @see <a href="https://github.com/MegaMek/mekhq/issues/8631">#8631</a>
+ */
+class RetirementDefectionTrackerTest {
+
+    /**
+     * Test InjuryType that allows setting the subtype for testing.
+     */
+    private static class TestInjuryType extends InjuryType {
+        public TestInjuryType(InjurySubType subType, boolean isPermanent) {
+            this.simpleName = "test_" + subType.name();
+            this.recoveryTime = 10;
+            this.fluffText = "Test injury";
+            this.level = InjuryLevel.MINOR;
+            this.allowedLocations = EnumSet.of(BodyLocation.GENERIC);
+            this.injurySubType = subType;
+            this.permanent = isPermanent;
+        }
+    }
+
+    private Injury createInjury(InjurySubType subType, boolean permanent) {
+        InjuryType type = new TestInjuryType(subType, permanent);
+        return new Injury(10, "Test", BodyLocation.GENERIC, type, 1, LocalDate.now(), permanent);
+    }
+
+    private Person createPersonWithInjuries(Injury... injuries) {
+        Person person = mock(Person.class);
+        List<Injury> injuryList = List.of(injuries);
+
+        when(person.getInjuries()).thenReturn(injuryList);
+        when(person.getNonProstheticInjuries()).thenReturn(
+              injuryList.stream()
+                    .filter(i -> !i.getSubType().isPermanentModification())
+                    .collect(Collectors.toList()));
+        when(person.getProstheticInjuries()).thenReturn(
+              injuryList.stream()
+                    .filter(i -> i.getSubType().isPermanentModification())
+                    .collect(Collectors.toList()));
+
+        return person;
+    }
+
+    // region Injury Modifier (Turnover Penalty)
+
+    @Test
+    void prostheticInjuriesAreExcludedFromTurnoverInjuryCount() {
+        Person person = createPersonWithInjuries(
+              createInjury(InjurySubType.NORMAL, true),
+              createInjury(InjurySubType.PROSTHETIC_GENERIC, true),
+              createInjury(InjurySubType.PROSTHETIC_MYOMER, true),
+              createInjury(InjurySubType.IMPLANT_GENERIC, true),
+              createInjury(InjurySubType.IMPLANT_VDNI, true));
+
+        assertEquals(1, RetirementDefectionTracker.getInjuryTurnoverModifier(person),
+              "Only the normal permanent injury should count toward turnover penalty");
+    }
+
+    @Test
+    void onlyProstheticInjuriesResultsInZeroTurnoverPenalty() {
+        Person person = createPersonWithInjuries(
+              createInjury(InjurySubType.PROSTHETIC_GENERIC, true),
+              createInjury(InjurySubType.PROSTHETIC_MYOMER, true),
+              createInjury(InjurySubType.IMPLANT_VDNI, true));
+
+        assertEquals(0, RetirementDefectionTracker.getInjuryTurnoverModifier(person),
+              "A person with only prosthetics should have zero turnover injury penalty");
+    }
+
+    @Test
+    void nonPermanentNormalInjuriesAreAlsoExcluded() {
+        Person person = createPersonWithInjuries(
+              createInjury(InjurySubType.NORMAL, false),
+              createInjury(InjurySubType.NORMAL, true));
+
+        assertEquals(1, RetirementDefectionTracker.getInjuryTurnoverModifier(person),
+              "Only permanent non-prosthetic injuries should count");
+    }
+
+    // endregion Injury Modifier (Turnover Penalty)
+
+    // region Medical Discharge (Payout)
+
+    @Test
+    void prostheticOnlyPersonIsNotMedicallyDischarged() {
+        Person person = createPersonWithInjuries(
+              createInjury(InjurySubType.PROSTHETIC_GENERIC, true),
+              createInjury(InjurySubType.IMPLANT_GENERIC, true));
+
+        assertFalse(RetirementDefectionTracker.hasMedicalDischargeInjuries(person),
+              "A person with only prosthetics should not be medically discharged");
+    }
+
+    @Test
+    void personWithRealPermanentInjuryIsMedicallyDischarged() {
+        Person person = createPersonWithInjuries(
+              createInjury(InjurySubType.PROSTHETIC_GENERIC, true),
+              createInjury(InjurySubType.NORMAL, true));
+
+        assertTrue(RetirementDefectionTracker.hasMedicalDischargeInjuries(person),
+              "A person with a real permanent injury should still be medically discharged");
+    }
+
+    // endregion Medical Discharge (Payout)
+}


### PR DESCRIPTION
Fixes #8631

## Problem

Cybernetic prosthetics were treated as permanent injuries for turnover calculations and medical discharge determinations. Each prosthetic to the turnover penalty modifier, meaning heavily augmented personnel would basically be impossible to pass their retention check.

Additionally, personnel with only prosthetics (no real injuries) were incorrectly flagged for medical discharge payouts.

## Solution

Excluded prosthetic and implant injuries (`InjurySubType.isPermanentModification()`) from two code paths in `RetirementDefectionTracker`:

1. **Turnover injury modifier** — now uses `getNonProstheticInjuries()` instead of `getInjuries()`, so prosthetics no longer inflate the turnover penalty.
2. **Medical discharge check** — now also excludes prosthetics, so a person with only prosthetics is not treated as medically discharged.

Both calculations were extracted into testable static helper methods: `getInjuryTurnoverModifier(Person)` and `hasMedicalDischargeInjuries(Person)`.

## Test Results

## Test Results

**Without fix (3 of 5 tests fail):**
- `prostheticInjuriesAreExcludedFromTurnoverInjuryCount`: expected `1`, got `5` (all 5 permanent injuries counted, including 4 prosthetics)
- `onlyProstheticInjuriesResultsInZeroTurnoverPenalty`: expected `0`, got `3` (3 prosthetics counted as +3 turnover penalty)
- `prostheticOnlyPersonIsNotMedicallyDischarged`: expected `false`, got `true` (prosthetic-only person incorrectly flagged for medical discharge)

**Without fix (2 of 5 tests pass, to avoid regressions in this area):**
- `nonPermanentNormalInjuriesAreAlsoExcluded`: ensures normal injuries are not filtered out.
- `personWithRealPermanentInjuryIsMedicallyDischarged`: ensures real permanent injuries still trigger medical discharge.

**With fix: 5/5 pass.**