### PR TITLE
Fix: Armor warehouse name mismatch (Fixes #7139)

### DIFF
--- a/MekHQ/src/mekhq/campaign/parts/Armor.java
+++ b/MekHQ/src/mekhq/campaign/parts/Armor.java
@@ -94,10 +94,14 @@ public class Armor extends Part implements IAcquisitionWork {
         this.location = loc;
         this.rear = r;
         this.clan = clan;
-        this.name = "Armor";
+    }
+
+    @Override
+    public String getName() {
         if (type > -1) {
-            this.name += " (" + (clan ? "Clan " : "IS ") + ArmorType.of(type, clan).getName() + ')';
+            return "Armor (" + (clan ? "Clan " : "IS ") + ArmorType.of(type, clan).getName() + ')';
         }
+        return "Armor";
     }
 
     @Override
@@ -742,10 +746,6 @@ public class Armor extends Part implements IAcquisitionWork {
     public void changeType(int ty, boolean cl) {
         this.type = ty;
         this.clan = cl;
-        this.name = "Armor";
-        if (type > -1) {
-            this.name += " (" + ArmorType.of(type, clan).getName() + ')';
-        }
     }
 
     @Override

--- a/MekHQ/src/mekhq/campaign/parts/Part.java
+++ b/MekHQ/src/mekhq/campaign/parts/Part.java
@@ -617,7 +617,7 @@ public abstract class Part implements IPartWork, ITechnology {
     protected int writeToXMLBegin(final PrintWriter pw, int indent) {
         MHQXMLUtility.writeSimpleXMLOpenTag(pw, indent++, "part", "id", id, "type", getClass());
         MHQXMLUtility.writeSimpleXMLTag(pw, indent, "id", id);
-        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "name", name);
+        MHQXMLUtility.writeSimpleXMLTag(pw, indent, "name", getName());
         if (omniPodded) {
             MHQXMLUtility.writeSimpleXMLTag(pw, indent, "omniPodded", true);
         }

--- a/MekHQ/src/mekhq/campaign/parts/SVArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/SVArmor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -79,7 +79,11 @@ public class SVArmor extends Armor {
         super(0, EquipmentType.T_ARMOR_STANDARD, points, loc, false, false, campaign);
         this.bar = bar;
         this.techRating = techRating;
-        this.name = String.format("BAR %d armor (%s)", bar, techRating.getName());
+    }
+
+    @Override
+    public String getName() {
+        return String.format("BAR %d armor (%s)", bar, techRating.getName());
     }
 
     public int getBAR() {

--- a/MekHQ/src/mekhq/campaign/parts/protomeks/ProtoMekArmor.java
+++ b/MekHQ/src/mekhq/campaign/parts/protomeks/ProtoMekArmor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009 Jay Lawson (jaylawson39 at yahoo.com). All rights reserved.
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -57,7 +57,11 @@ public class ProtoMekArmor extends Armor {
     public ProtoMekArmor(int tonnage, int type, int points, int loc, boolean clan, Campaign c) {
         // Amount is used for armor quantity, not tonnage
         super(tonnage, type, points, loc, false, clan, c);
-        this.name = "ProtoMek Armor";
+    }
+
+    @Override
+    public String getName() {
+        return "ProtoMek Armor";
     }
 
     @Override

--- a/MekHQ/unittests/mekhq/campaign/parts/ArmorTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/ArmorTest.java
@@ -34,6 +34,7 @@
 package mekhq.campaign.parts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -359,21 +360,22 @@ public class ArmorTest {
     @ParameterizedTest
     @MethodSource(value = "armorParameter")
     public void changeTypeProducesConsistentName(Armor armor) {
-        if (armor instanceof SVArmor || armor instanceof ProtoMekArmor) {
-            // SVArmor doesn't have changeType, ProtoMekArmor has its own fixed name
-            return;
+        assumeFalse(armor instanceof SVArmor || armor instanceof ProtoMekArmor,
+              "SVArmor and ProtoMekArmor have their own name logic");
+
+        for (boolean clan : new boolean[] { false, true }) {
+            // Arrange - create armor via constructor with the target type
+            Armor constructedArmor = new Armor(1, DIFFERENT_ARMOR_TYPE, ARMOR_AMOUNT, Entity.LOC_NONE, false, clan,
+                  mockCampaign);
+
+            // Act - create armor via changeType with the same type
+            Armor changedArmor = armor.clone();
+            changedArmor.changeType(DIFFERENT_ARMOR_TYPE, clan);
+
+            // Assert - names must match regardless of how the armor was created
+            assertEquals(constructedArmor.getName(), changedArmor.getName(),
+                  "Name mismatch for clan=" + clan);
         }
-
-        // Arrange - create armor via constructor with the target type
-        Armor constructedArmor = new Armor(1, DIFFERENT_ARMOR_TYPE, ARMOR_AMOUNT, Entity.LOC_NONE, false, true,
-              mockCampaign);
-
-        // Act - create armor via changeType with the same type
-        Armor changedArmor = armor.clone();
-        changedArmor.changeType(DIFFERENT_ARMOR_TYPE, true);
-
-        // Assert - names must match regardless of how the armor was created
-        assertEquals(constructedArmor.getName(), changedArmor.getName());
     }
 
     private Armor getDifferentArmorType(Armor armor) {

--- a/MekHQ/unittests/mekhq/campaign/parts/ArmorTest.java
+++ b/MekHQ/unittests/mekhq/campaign/parts/ArmorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -354,6 +354,26 @@ public class ArmorTest {
         // Assert
         assertEquals(0, amountAvailable);
         assertEquals(1, partCount);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "armorParameter")
+    public void changeTypeProducesConsistentName(Armor armor) {
+        if (armor instanceof SVArmor || armor instanceof ProtoMekArmor) {
+            // SVArmor doesn't have changeType, ProtoMekArmor has its own fixed name
+            return;
+        }
+
+        // Arrange - create armor via constructor with the target type
+        Armor constructedArmor = new Armor(1, DIFFERENT_ARMOR_TYPE, ARMOR_AMOUNT, Entity.LOC_NONE, false, true,
+              mockCampaign);
+
+        // Act - create armor via changeType with the same type
+        Armor changedArmor = armor.clone();
+        changedArmor.changeType(DIFFERENT_ARMOR_TYPE, true);
+
+        // Assert - names must match regardless of how the armor was created
+        assertEquals(constructedArmor.getName(), changedArmor.getName());
     }
 
     private Armor getDifferentArmorType(Armor armor) {


### PR DESCRIPTION
Fixes #7139 (partially)

## Description

Ferro-Lamellor (and potentially other armor types) could appear as duplicate entries in the warehouse with different names: e.g. "Armor (Ferro-Lamellor)" vs "Armor (Clan Ferro-Lamellor)".

### Root Cause

The armor display name was stored as a field and persisted to save files. The `changeType()` method (used during refits) omitted the "Clan "/"IS " prefix that the constructor included, so armor entering the warehouse via refits got a different name. Once persisted, the wrong name stuck across save/load cycles.

### Fix

Override `getName()` in `Armor` and its subclasses (`ProtoMekArmor`, `SVArmor`) to always compute the name dynamically from the `type` and `clan` fields. Remove redundant `this.name` assignments from constructors and `changeType()` so `getName()` is the single source of truth.

This also fixes existing saves, the stale name stored in XML is now ignored.

### Testing

Added `changeTypeProducesConsistentName` parameterized test verifying that armor created via `changeType()` produces the same name as armor created via the constructor.

### Screenshot

In the following screenshot from the shared campaign save in the bug, we can see that the armors now have the correct name. They are still not merged as the user asked because some armors are _Used_ and some are _Brand New_, and those are tracked separately (which is the correct behavior).

<img width="1945" height="785" alt="Fix" src="https://github.com/user-attachments/assets/7012a319-2a9f-4772-979c-47843a84ccb0" />
