### PR TITLE
Use automatic alternate table row coloring

### DIFF
--- a/MekHQ/src/mekhq/MekHQ.java
+++ b/MekHQ/src/mekhq/MekHQ.java
@@ -36,6 +36,7 @@ package mekhq;
 import static megamek.MMConstants.LOCALHOST_IP;
 import static mekhq.utilities.MHQInternationalization.getText;
 
+import java.awt.Color;
 import java.awt.FileDialog;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
@@ -381,6 +382,9 @@ public class MekHQ implements GameListener {
             final String title = String.format(MMLoggingConstants.UNHANDLED_EXCEPTION_TITLE, name);
             LOGGER.errorDialog(t, message, title);
         });
+
+        // Set an alternate table row color; it uses alpha and is valid for both dark and light UIs
+        UIManager.put("Table.alternateRowColor", new Color(125, 125, 125, 50));
 
         // Second, let's handle logging
         MegaMek.initializeLogging(MHQConstants.PROJECT_NAME);


### PR DESCRIPTION
See also MegaMek/megameklab#2174
and megamek/megamek#8197

This makes MHQ use automatic alternate table row coloring. This removes the need for table renderers to do this and it applies to all tables, in principle. There are a bunch of tables in MHQ that use specialized renderers that will hide this, for now, but many tables will use the automatic coloring.
