### PR TITLE
fix #8782 Cannot salvage DS with a tug

### DIFF
--- a/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
+++ b/MekHQ/resources/mekhq/resources/BirthAnnouncement.properties
@@ -203,8 +203,7 @@ babyBorn.message.37.ic=In a job where people are just statistics, today felt dif
   <p>{2} gave birth to a baby {10}, {15}kg, without any major complications.</p>\
   <p>Seeing {3} holding {9} child, it hit me how fragile and resilient life can be at once. Moments like this remind us\
   \ of the simple things worth fighting for.</p>
-babyBorn.message.38.ic=I am pleased to report that {2} successfully delivered a baby {10} at {1}-local, weighing {15}kg\
-  \kg.\
+babyBorn.message.38.ic=I am pleased to report that {2} successfully delivered a baby {10} at {1}-local, weighing {15}kg.\
   <p>The procedure was efficient with no unexpected complications.</p>\
   <p>Both {5} and child are resting and in good health.</p>
 babyBorn.message.39.ic=It was a tense few hours, but I''m happy to report that {2} delivered a baby {10} at {1}-local,\

--- a/MekHQ/resources/mekhq/resources/CamOpsSalvage.properties
+++ b/MekHQ/resources/mekhq/resources/CamOpsSalvage.properties
@@ -48,6 +48,7 @@ CamOpsSalvageUtilities.exchange.report={0} C-Bills have been credited to your ac
 CamOpsSalvageUtilities.tooltip.drag={0}t drag/tow
 CamOpsSalvageUtilities.tooltip.cargo={0}t cargo
 CamOpsSalvageUtilities.tooltip.tug=Has Naval Tug
+CamOpsSalvageUtilities.tooltip.bayEquipment=Has SC/ASF bay equipment
 CamOpsSalvageUtilities.accident=A {0}<b>Terrible Accident</b>{1} took place during salvage operations. One or more \
   techs were injured or killed.
 CamOpsSalvageUtilities.reroll={0} used Edge to try and avoid a salvage accident.
@@ -58,7 +59,8 @@ SalvagePostScenarioPicker.employerSalvage=<html><b>Allied Salvage:</b> {0} C-Bil
 SalvagePostScenarioPicker.unitSalvage=<html><b>Your Salvage:</b> {0} C-Bills
 SalvagePostScenarioPicker.time=<html><b>Available Time:</b> {0} / {1} minutes
 SalvagePostScenarioPicker.tutorial=Below you will see a list of units that are currently available for salvage. Two \
-  boxes exist for you to pick units to tow/drag, carry (in cargo), or tug (using a Naval Tug Adaptor) your salvage. \
+  boxes exist for you to pick units to tow/drag, carry (in cargo), recover (using SC or ASF bay equipment) or tug \
+  (using a Naval Tug Adaptor) your salvage. \
   The rules for this can be found in <i>Campaign Operations</i>. MekHQ will automatically pick whether to tow or \
   carry automatically, based on a unit's capacity.\
   <p>Once you have arranged for salvage to be transported, you need to decide whether you want to claim it. You do so \

--- a/MekHQ/resources/mekhq/resources/CamOpsSalvage.properties
+++ b/MekHQ/resources/mekhq/resources/CamOpsSalvage.properties
@@ -74,7 +74,7 @@ SalvagePostScenarioPicker.unitLabel.sale=<html><s>C</s></html>
 SalvagePostScenarioPicker.unitLabel.unit=<html>{0}<br>{1} C-Bills</html>
 SalvagePostScenarioPicker.validation.valid=Valid
 SalvagePostScenarioPicker.validation.noTug=No Naval Tug
-SalvagePostScenarioPicker.validation.noDropshipWithBay=No Dropship with bay
+SalvagePostScenarioPicker.validation.noVesselWithSuitableBayEquipment=Vessel has no suitable bay equipment
 SalvagePostScenarioPicker.validation.noCapacity.tow=Needs More Towage
 SalvagePostScenarioPicker.validation.noCapacity.cargo=Needs More Cargo
 SalvagePostScenarioPicker.confirmation.text=<h2 style="text-align:center;">Are You Sure?</h2>Please make sure that \

--- a/MekHQ/resources/mekhq/resources/CamOpsSalvage.properties
+++ b/MekHQ/resources/mekhq/resources/CamOpsSalvage.properties
@@ -74,6 +74,7 @@ SalvagePostScenarioPicker.unitLabel.sale=<html><s>C</s></html>
 SalvagePostScenarioPicker.unitLabel.unit=<html>{0}<br>{1} C-Bills</html>
 SalvagePostScenarioPicker.validation.valid=Valid
 SalvagePostScenarioPicker.validation.noTug=No Naval Tug
+SalvagePostScenarioPicker.validation.noDropshipWithBay=No Dropship with bay
 SalvagePostScenarioPicker.validation.noCapacity.tow=Needs More Towage
 SalvagePostScenarioPicker.validation.noCapacity.cargo=Needs More Cargo
 SalvagePostScenarioPicker.confirmation.text=<h2 style="text-align:center;">Are You Sure?</h2>Please make sure that \

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
@@ -149,6 +149,10 @@ public class CamOpsSalvageUtilities {
                                 tooltip.append(" (").append(getFormattedTextAt(RESOURCE_BUNDLE,
                                       "CamOpsSalvageUtilities.tooltip.tug")).append(")");
                             }
+                            if (CamOpsSalvageUtilities.hasSuitableBayEquipment(entity)) {
+                                tooltip.append(" (").append(getFormattedTextAt(RESOURCE_BUNDLE,
+                                      "CamOpsSalvageUtilities.tooltip.bayEquipment")).append(")");
+                            }
                         }
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
@@ -171,8 +171,9 @@ public class CamOpsSalvageUtilities {
         return false;
     }
 
-    public static boolean hasBay(Entity entity) {
+    public static boolean hasSuitableBayEquipment(Entity entity) {
         for (Bay b : entity.getTransportBays()) {
+            //ASF and SC bays are assumed to have the equipment needed to handle space derelicts
             if ((b instanceof ASFBay) || (b instanceof SmallCraftBay)) {
                 return true;
             }

--- a/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
+++ b/MekHQ/src/mekhq/campaign/mission/camOpsSalvage/CamOpsSalvageUtilities.java
@@ -50,6 +50,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 import megamek.codeUtilities.ObjectUtility;
+import megamek.common.bays.ASFBay;
+import megamek.common.bays.Bay;
+import megamek.common.bays.SmallCraftBay;
 import megamek.common.equipment.Mounted;
 import megamek.common.units.Aero;
 import megamek.common.units.Dropship;
@@ -165,6 +168,15 @@ public class CamOpsSalvageUtilities {
             }
         }
 
+        return false;
+    }
+
+    public static boolean hasBay(Entity entity) {
+        for (Bay b : entity.getTransportBays()) {
+            if ((b instanceof ASFBay) || (b instanceof SmallCraftBay)) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
@@ -1131,7 +1131,7 @@ public class SalvagePostScenarioPicker {
         }
 
         if (isInSpace && isSmallVessel && !isLargeVessel) {
-            if (!checkForDropshipWithBay(group, unitLeftEntity, unitRightEntity)) {
+            if (!checkForVesselWithSuitableBayEquipment(group, unitLeftEntity, unitRightEntity)) {
                 return;
             }
         }
@@ -1216,14 +1216,17 @@ public class SalvagePostScenarioPicker {
         return true;
     }
 
-    private static boolean checkForDropshipWithBay(SalvageComboBoxGroup group, Entity unitLeftEntity,
+    private static boolean checkForVesselWithSuitableBayEquipment(SalvageComboBoxGroup group, Entity unitLeftEntity,
           Entity unitRightEntity) {
-        boolean hasDropshipWithBayLeft = null != unitLeftEntity && CamOpsSalvageUtilities.hasBay(unitLeftEntity);
-        boolean hasDropshipWithBayRight = null != unitRightEntity && CamOpsSalvageUtilities.hasBay(unitRightEntity);
-        boolean hasDropshipWithBay = hasDropshipWithBayLeft || hasDropshipWithBayRight;
+        boolean isSuitableVesselLeft = null != unitLeftEntity &&
+                                             CamOpsSalvageUtilities.hasSuitableBayEquipment(unitLeftEntity);
+        boolean isSuitableVesselRight = null != unitRightEntity &&
+                                              CamOpsSalvageUtilities.hasSuitableBayEquipment(unitRightEntity);
+        boolean isSuitableVessel = isSuitableVesselLeft || isSuitableVesselRight;
 
-        if (!hasDropshipWithBay) {
-            invalidate(group, getTextAt(RESOURCE_BUNDLE, "SalvagePostScenarioPicker.validation.noDropshipWithBay"),
+        if (!isSuitableVessel) {
+            invalidate(group, getTextAt(RESOURCE_BUNDLE,
+                        "SalvagePostScenarioPicker.validation.noVesselWithSuitableBayEquipment"),
                   MekHQ.getMHQOptions().getFontColorNegative());
             return false;
         }

--- a/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
@@ -62,9 +62,11 @@ import megamek.client.ui.dialogs.unitSelectorDialogs.EntityReadoutDialog;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
 import megamek.common.annotations.Nullable;
+import megamek.common.units.AeroSpaceFighter;
 import megamek.common.units.Dropship;
 import megamek.common.units.Entity;
 import megamek.common.units.Jumpship;
+import megamek.common.units.SmallCraft;
 import megamek.common.units.Tank;
 import megamek.logging.MMLogger;
 import mekhq.MekHQ;
@@ -1070,9 +1072,20 @@ public class SalvagePostScenarioPicker {
      *
      * <p>Checks the following requirements:</p>
      * <ul>
-     *   <li>For large vessels in space: at least one assigned unit must have a naval tug</li>
+     *   <li>Space salvage:</li>
+     *   <ul>
+     *   <li>For large vessels (Dropship or Jumpship): at least one assigned unit must have a naval tug</li>
+     *   <li>For small vessels (Small craft or Aerospace Fighters): at least one assigned unit must have a
+     *   SC or ASF bay</li>
+     *   <li>Weight limits do not apply</li>
+     *   </ul>
+     * </ul>
+     * <ul>
+     *   <li>Ground salvage (only):</li>
+     *   <ul>
      *   <li>Either: one assigned unit's cargo capacity must meet or exceed the salvage unit's weight</li>
      *   <li>Or: the combined weight of both assigned units must meet or exceed the salvage unit's weight</li>
+     *   </ul>
      * </ul>
      *
      * <p>Updates the validation label with the result and colors the unit label red if validation fails.</p>
@@ -1100,10 +1113,12 @@ public class SalvagePostScenarioPicker {
         Entity targetEntity = targetUnit.getEntity();
         double targetWeight = 0.0;
         boolean isLargeVessel = false;
+        boolean isSmallVessel = false;
         if (targetEntity != null) {
             targetWeight = targetEntity.getWeight();
             // Jumpship includes WarShips
             isLargeVessel = targetEntity instanceof Dropship || targetEntity instanceof Jumpship;
+            isSmallVessel = targetEntity instanceof SmallCraft || targetEntity instanceof AeroSpaceFighter;
         }
 
         // Check for naval tug requirement
@@ -1115,27 +1130,35 @@ public class SalvagePostScenarioPicker {
             }
         }
 
+        if (isInSpace && isSmallVessel && !isLargeVessel) {
+            if (!checkForDropshipWithBay(group, unitLeftEntity, unitRightEntity)) {
+                return;
+            }
+        }
+
         boolean isTwoUnitsSelected = salvageUnitLeft != null && salvageUnitRight != null;
 
-        // If two units selected, must use towing
-        if (isTwoUnitsSelected) {
-            double weightLeft = getTowCapacity(unitLeftEntity, salvageUnitLeft);
-            double weightRight = getTowCapacity(unitRightEntity, salvageUnitRight);
+        // Only check weight for ground salvage. If two units selected, must use towing
+        if (!isInSpace) {
+            if (isTwoUnitsSelected) {
+                double weightLeft = getTowCapacity(unitLeftEntity, salvageUnitLeft);
+                double weightRight = getTowCapacity(unitRightEntity, salvageUnitRight);
 
-            boolean hasTowageCapacity = (weightLeft + weightRight) >= targetWeight;
-            if (!hasTowageCapacity) {
-                invalidate(group,
-                      getTextAt(RESOURCE_BUNDLE, "SalvagePostScenarioPicker.validation.noCapacity.tow"),
-                      MekHQ.getMHQOptions().getFontColorNegative());
-                return;
-            }
-        } else if (salvageUnitLeft != null) {
-            if (!useTowageOrCargo(group, unitLeftEntity, salvageUnitLeft, targetWeight)) {
-                return;
-            }
-        } else {
-            if (!useTowageOrCargo(group, unitRightEntity, salvageUnitRight, targetWeight)) {
-                return;
+                boolean hasTowageCapacity = (weightLeft + weightRight) >= targetWeight;
+                if (!hasTowageCapacity) {
+                    invalidate(group,
+                          getTextAt(RESOURCE_BUNDLE, "SalvagePostScenarioPicker.validation.noCapacity.tow"),
+                          MekHQ.getMHQOptions().getFontColorNegative());
+                    return;
+                }
+            } else if (salvageUnitLeft != null) {
+                if (!useTowageOrCargo(group, unitLeftEntity, salvageUnitLeft, targetWeight)) {
+                    return;
+                }
+            } else {
+                if (!useTowageOrCargo(group, unitRightEntity, salvageUnitRight, targetWeight)) {
+                    return;
+                }
             }
         }
 
@@ -1180,12 +1203,27 @@ public class SalvagePostScenarioPicker {
     }
 
     private static boolean checkForNavalTug(SalvageComboBoxGroup group, Entity unitLeftEntity, Entity unitRightEntity) {
-        boolean hasNavalTugLeft = unitLeftEntity == null || CamOpsSalvageUtilities.hasNavalTug(unitLeftEntity);
-        boolean hasNavalTugRight = unitRightEntity == null || CamOpsSalvageUtilities.hasNavalTug(unitRightEntity);
-        boolean hasNavalTug = hasNavalTugLeft && hasNavalTugRight;
+        boolean hasNavalTugLeft = null != unitLeftEntity && CamOpsSalvageUtilities.hasNavalTug(unitLeftEntity);
+        boolean hasNavalTugRight = null != unitRightEntity && CamOpsSalvageUtilities.hasNavalTug(unitRightEntity);
+        boolean hasNavalTug = hasNavalTugLeft || hasNavalTugRight;
 
         if (!hasNavalTug) {
             invalidate(group, getTextAt(RESOURCE_BUNDLE, "SalvagePostScenarioPicker.validation.noTug"),
+                  MekHQ.getMHQOptions().getFontColorNegative());
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean checkForDropshipWithBay(SalvageComboBoxGroup group, Entity unitLeftEntity,
+          Entity unitRightEntity) {
+        boolean hasDropshipWithBayLeft = null != unitLeftEntity && CamOpsSalvageUtilities.hasBay(unitLeftEntity);
+        boolean hasDropshipWithBayRight = null != unitRightEntity && CamOpsSalvageUtilities.hasBay(unitRightEntity);
+        boolean hasDropshipWithBay = hasDropshipWithBayLeft || hasDropshipWithBayRight;
+
+        if (!hasDropshipWithBay) {
+            invalidate(group, getTextAt(RESOURCE_BUNDLE, "SalvagePostScenarioPicker.validation.noDropshipWithBay"),
                   MekHQ.getMHQOptions().getFontColorNegative());
             return false;
         }

--- a/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
+++ b/MekHQ/src/mekhq/gui/dialog/camOpsSalvage/SalvagePostScenarioPicker.java
@@ -1072,20 +1072,20 @@ public class SalvagePostScenarioPicker {
      *
      * <p>Checks the following requirements:</p>
      * <ul>
-     *   <li>Space salvage:</li>
-     *   <ul>
-     *   <li>For large vessels (Dropship or Jumpship): at least one assigned unit must have a naval tug</li>
-     *   <li>For small vessels (Small craft or Aerospace Fighters): at least one assigned unit must have a
-     *   SC or ASF bay</li>
-     *   <li>Weight limits do not apply</li>
-     *   </ul>
-     * </ul>
-     * <ul>
-     *   <li>Ground salvage (only):</li>
-     *   <ul>
-     *   <li>Either: one assigned unit's cargo capacity must meet or exceed the salvage unit's weight</li>
-     *   <li>Or: the combined weight of both assigned units must meet or exceed the salvage unit's weight</li>
-     *   </ul>
+     *   <li>Space salvage:
+     *     <ul>
+     *       <li>For large vessels (Dropship or Jumpship): at least one assigned unit must have a naval tug</li>
+     *       <li>For small vessels (Small craft or Aerospace Fighters): at least one assigned unit must have a
+     *       SC or ASF bay</li>
+     *       <li>Weight limits do not apply</li>
+     *     </ul>
+     *   </li>
+     *   <li>Ground salvage (only):
+     *     <ul>
+     *       <li>Either: one assigned unit's cargo capacity must meet or exceed the salvage unit's weight</li>
+     *       <li>Or: the combined weight of both assigned units must meet or exceed the salvage unit's weight</li>
+     *     </ul>
+     *   </li>
      * </ul>
      *
      * <p>Updates the validation label with the result and colors the unit label red if validation fails.</p>


### PR DESCRIPTION
Changes have been made in space salvage

For large vessels (Dropship or Jumpship): at least one assigned unit must have a naval tug
For small vessels (Small craft or Aerospace Fighters): at least one assigned unit must have a SC or ASF bay
Weight limits do not apply

Ground salvage has not been changed

closes #8782 

<img width="1184" height="600" alt="DropshipSalvage" src="https://github.com/user-attachments/assets/354d21f0-688c-4150-bea3-867fc11a4e75" />

(Also did a small typo fix in birth announcements that I happened to notice).