### PR TITLE
YearFilter extinct factions from contract employer/enemy pools (#6451)

### DIFF
--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -210,7 +210,7 @@ public class RandomFactionGenerator {
                                                          factionHints.getAltLocationFraction(faction,
                                                                containedFaction,
                                                                currentDate)) + 0.5);
-                        employerMap.add(weight, faction);
+                        employerMap.add(weight, containedFaction);
                     }
                 }
             }
@@ -416,6 +416,7 @@ public class RandomFactionGenerator {
      */
     protected WeightedIntMap<Faction> buildEnemyMap(Faction employer) {
         WeightedIntMap<Faction> enemyMap = new WeightedIntMap<>();
+        LocalDate currentDate = getCurrentDate();
 
         // If the employer is a pirate, or comstar return all border factions as "enemies"
         String employerShortName = employer.getShortName();
@@ -423,6 +424,9 @@ public class RandomFactionGenerator {
             for (Faction enemy : borderTracker.getFactionsInRegion()) {
                 if (FactionHints.isEmptyFaction(enemy) ||
                           enemy.getShortName().equals("CLAN")) {
+                    continue;
+                }
+                if (!enemy.validIn(currentDate)) {
                     continue;
                 }
                 enemyMap.add(1, enemy); // weight (1) can be adjusted as needed
@@ -436,36 +440,43 @@ public class RandomFactionGenerator {
                 continue;
             }
 
-            if (enemy.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
+            if (enemy.getShortName().equals("ROS") && currentDate.isAfter(FORTRESS_REPUBLIC)) {
+                continue;
+            }
+            // Skip extinct factions; stale planet ownership data can otherwise leak them into the enemy pool.
+            if (!enemy.validIn(currentDate)) {
                 continue;
             }
 
             int totalCount = borderTracker.getBorderSystems(employer, enemy).size();
             double count = totalCount;
             // Split the border between main controlling faction and any contained factions.
-            for (Faction cFaction : factionHints.getContainedFactions(employer, getCurrentDate())) {
+            for (Faction cFaction : factionHints.getContainedFactions(employer, currentDate)) {
                 if ((null == cFaction) ||
-                          !factionHints.isContainedFactionOpponent(enemy, cFaction, employer, getCurrentDate())) {
+                          !factionHints.isContainedFactionOpponent(enemy, cFaction, employer, currentDate)) {
                     continue;
                 }
 
-                if (cFaction.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
+                if (cFaction.getShortName().equals("ROS") && currentDate.isAfter(FORTRESS_REPUBLIC)) {
+                    continue;
+                }
+                if (!cFaction.validIn(currentDate)) {
                     continue;
                 }
 
-                if (factionHints.isNeutral(cFaction, enemy, getCurrentDate()) ||
-                          factionHints.isNeutral(enemy, cFaction, getCurrentDate())) {
+                if (factionHints.isNeutral(cFaction, enemy, currentDate) ||
+                          factionHints.isNeutral(enemy, cFaction, currentDate)) {
                     continue;
                 }
                 double cfCount = totalCount;
-                if (factionHints.getAltLocationFraction(employer, cFaction, getCurrentDate()) > 0.0) {
-                    cfCount = totalCount * factionHints.getAltLocationFraction(employer, cFaction, getCurrentDate());
+                if (factionHints.getAltLocationFraction(employer, cFaction, currentDate) > 0.0) {
+                    cfCount = totalCount * factionHints.getAltLocationFraction(employer, cFaction, currentDate);
                     count -= cfCount;
                 }
-                cfCount = adjustBorderWeight(cfCount, employer, enemy, getCurrentDate());
+                cfCount = adjustBorderWeight(cfCount, employer, enemy, currentDate);
                 enemyMap.add((int) Math.floor(cfCount + 0.5), cFaction);
             }
-            count = adjustBorderWeight(count, employer, enemy, getCurrentDate());
+            count = adjustBorderWeight(count, employer, enemy, currentDate);
             enemyMap.add((int) Math.floor(count + 0.5), enemy);
         }
 
@@ -525,24 +536,29 @@ public class RandomFactionGenerator {
      */
     public List<String> getEnemyList(Faction employer) {
         Set<Faction> list = new HashSet<>();
-        Faction outer = factionHints.getContainedFactionHost(employer, getCurrentDate());
+        LocalDate currentDate = getCurrentDate();
+        Faction outer = factionHints.getContainedFactionHost(employer, currentDate);
         for (Faction enemy : borderTracker.getFactionsInRegion()) {
             if (FactionHints.isEmptyFaction(enemy)) {
                 continue;
             }
-            if (enemy.equals(employer) && !factionHints.isAtWarWith(enemy, enemy, getCurrentDate())) {
+            // Skip extinct factions; stale planet ownership data can otherwise leak them into the enemy list.
+            if (!enemy.validIn(currentDate)) {
                 continue;
             }
-            if (factionHints.isAlliedWith(employer, enemy, getCurrentDate()) && !employer.isClan() && !enemy.isClan()) {
+            if (enemy.equals(employer) && !factionHints.isAtWarWith(enemy, enemy, currentDate)) {
                 continue;
             }
-            if (factionHints.isNeutral(employer, enemy, getCurrentDate()) ||
-                      factionHints.isNeutral(enemy, employer, getCurrentDate())) {
+            if (factionHints.isAlliedWith(employer, enemy, currentDate) && !employer.isClan() && !enemy.isClan()) {
+                continue;
+            }
+            if (factionHints.isNeutral(employer, enemy, currentDate) ||
+                      factionHints.isNeutral(enemy, employer, currentDate)) {
                 continue;
             }
             Faction useBorder = employer;
             if (null != outer) {
-                if (!factionHints.isContainedFactionOpponent(outer, employer, enemy, getCurrentDate())) {
+                if (!factionHints.isContainedFactionOpponent(outer, employer, enemy, currentDate)) {
                     continue;
                 }
                 useBorder = outer;
@@ -550,9 +566,9 @@ public class RandomFactionGenerator {
 
             if (!borderTracker.getBorderSystems(useBorder, enemy).isEmpty()) {
                 list.add(enemy);
-                for (Faction cf : factionHints.getContainedFactions(enemy, getCurrentDate())) {
-                    if ((null != cf) &&
-                              factionHints.isContainedFactionOpponent(enemy, cf, employer, getCurrentDate())) {
+                for (Faction cf : factionHints.getContainedFactions(enemy, currentDate)) {
+                    if ((null != cf) && cf.validIn(currentDate) &&
+                              factionHints.isContainedFactionOpponent(enemy, cf, employer, currentDate)) {
                         list.add(cf);
                     }
                 }

--- a/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
+++ b/MekHQ/src/mekhq/campaign/universe/RandomFactionGenerator.java
@@ -145,19 +145,29 @@ public class RandomFactionGenerator {
      */
     public Set<String> getCurrentFactions() {
         Set<String> retVal = new TreeSet<>();
+        LocalDate currentDate = getCurrentDate();
         for (Faction f : borderTracker.getFactionsInRegion()) {
 
             if (FactionHints.isEmptyFaction(f) ||
                       f.getShortName().equals("CLAN")) {
                 continue;
             }
-            if (f.getShortName().equals("ROS") && getCurrentDate().isAfter(MHQConstants.FORTRESS_REPUBLIC)) {
+            if (f.getShortName().equals("ROS") && currentDate.isAfter(MHQConstants.FORTRESS_REPUBLIC)) {
+                continue;
+            }
+            // Skip factions whose stated active years don't include the current date.
+            // Stale planet ownership data can otherwise leak extinct factions (e.g. ARC after 3028) into the pool.
+            if (!f.validIn(currentDate)) {
                 continue;
             }
 
             retVal.add(f.getShortName());
             /* Add factions which do not control any planets to the employer list */
-            factionHints.getContainedFactions(f, getCurrentDate()).forEach(cf -> retVal.add(cf.getShortName()));
+            for (Faction containedFaction : factionHints.getContainedFactions(f, currentDate)) {
+                if (containedFaction != null && containedFaction.validIn(currentDate)) {
+                    retVal.add(containedFaction.getShortName());
+                }
+            }
         }
         // Add rebels and pirates
         retVal.add("REB");
@@ -172,14 +182,20 @@ public class RandomFactionGenerator {
      */
     protected WeightedIntMap<Faction> buildEmployerMap() {
         WeightedIntMap<Faction> employerMap = new WeightedIntMap<>();
+        LocalDate currentDate = getCurrentDate();
         for (Faction faction : borderTracker.getFactionsInRegion()) {
             if (faction.isClan() || FactionHints.isEmptyFaction(faction)) {
                 continue;
             }
-            if (faction.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
+            if (faction.getShortName().equals("ROS") && currentDate.isAfter(FORTRESS_REPUBLIC)) {
                 continue;
             }
             if (faction.getShortName().equals(MERCENARY_FACTION_CODE)) {
+                continue;
+            }
+            // Skip factions whose stated active years don't include the current date.
+            // Stale planet ownership data can otherwise leak extinct factions (e.g. ARC after 3028) into the pool.
+            if (!faction.validIn(currentDate)) {
                 continue;
             }
 
@@ -187,13 +203,13 @@ public class RandomFactionGenerator {
             employerMap.add(weight, faction);
 
             /* Add factions which do not control any planets to the employer list */
-            for (Faction containedFaction : factionHints.getContainedFactions(faction, getCurrentDate())) {
+            for (Faction containedFaction : factionHints.getContainedFactions(faction, currentDate)) {
                 if (null != containedFaction) {
-                    if (!containedFaction.isClan()) {
+                    if (!containedFaction.isClan() && containedFaction.validIn(currentDate)) {
                         weight = (int) Math.floor((borderTracker.getBorders(faction).getSystems().size() *
                                                          factionHints.getAltLocationFraction(faction,
                                                                containedFaction,
-                                                               getCurrentDate())) + 0.5);
+                                                               currentDate)) + 0.5);
                         employerMap.add(weight, faction);
                     }
                 }
@@ -461,16 +477,22 @@ public class RandomFactionGenerator {
      */
     public Set<String> getEmployerSet() {
         Set<String> set = new HashSet<>();
+        LocalDate currentDate = getCurrentDate();
         for (Faction f : borderTracker.getFactionsInRegion()) {
+            // Skip factions whose stated active years don't include the current date.
+            // Stale planet ownership data can otherwise leak extinct factions (e.g. ARC after 3028) into the pool.
+            if (!f.validIn(currentDate)) {
+                continue;
+            }
+            if (f.getShortName().equals("ROS") && currentDate.isAfter(FORTRESS_REPUBLIC)) {
+                continue;
+            }
             if (!f.isClan() && !FactionHints.isEmptyFaction(f)) {
                 set.add(f.getShortName());
             }
-            if (f.getShortName().equals("ROS") && getCurrentDate().isAfter(FORTRESS_REPUBLIC)) {
-                continue;
-            }
             /* Add factions which do not control any planets to the employer list */
-            for (Faction cfaction : factionHints.getContainedFactions(f, getCurrentDate())) {
-                if (!cfaction.isClan()) {
+            for (Faction cfaction : factionHints.getContainedFactions(f, currentDate)) {
+                if (!cfaction.isClan() && cfaction.validIn(currentDate)) {
                     set.add(cfaction.getShortName());
                 }
             }

--- a/MekHQ/unittests/mekhq/campaign/universe/RandomFactionGeneratorTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/RandomFactionGeneratorTest.java
@@ -278,4 +278,72 @@ public class RandomFactionGeneratorTest {
         assertFalse(employers.contains(innerISFaction.getShortName()),
               "Extinct contained faction should not appear in the employer set");
     }
+
+    @Test
+    public void testExtinctFactionExcludedFromEnemyList() {
+        when(peripheryFaction.validIn(any(LocalDate.class))).thenReturn(false);
+        when(peripheryFaction.validIn(anyInt())).thenReturn(false);
+        RandomFactionGenerator rfg = createTestRFG();
+
+        List<String> enemyList = rfg.getEnemyList(isFaction);
+
+        assertFalse(enemyList.contains(peripheryFaction.getShortName()),
+              "Extinct faction should not appear in the enemy list");
+    }
+
+    @Test
+    public void testExtinctFactionExcludedAsPirateOpponent() {
+        // Pirates take the unfiltered border-region branch in buildEnemyMap; ensure the
+        // validity guard still excludes extinct factions there.
+        Faction pirates = createTestFaction("PIR", false, false);
+        when(peripheryFaction.validIn(any(LocalDate.class))).thenReturn(false);
+        when(peripheryFaction.validIn(anyInt())).thenReturn(false);
+        RandomFactionGenerator rfg = createTestRFG();
+
+        List<String> enemyList = rfg.getEnemyList(pirates);
+
+        assertFalse(enemyList.contains(peripheryFaction.getShortName()),
+              "Extinct faction should not appear in pirate/comstar enemy list");
+    }
+
+    /**
+     * Regression test for the actual contract-generation selection path used by AtB:
+     * an extinct faction must never be returned by {@link RandomFactionGenerator#getEmployerFaction()}.
+     */
+    @Test
+    public void testExtinctFactionNeverChosenAsEmployer() {
+        when(isFaction.validIn(any(LocalDate.class))).thenReturn(false);
+        when(isFaction.validIn(anyInt())).thenReturn(false);
+        RandomFactionGenerator rfg = createTestRFG();
+
+        for (int i = 0; i < 500; i++) {
+            Faction chosen = rfg.getEmployerFaction();
+            assertNotNull(chosen, "Employer faction should not be null");
+            assertNotEquals(isFaction.getShortName(), chosen.getShortName(),
+                  "Extinct faction must never be chosen as an employer");
+        }
+    }
+
+    /**
+     * Verifies that a contained/fallback faction is reachable via the weighted selection in
+     * {@link RandomFactionGenerator#getEmployerFaction()}. Prior to this PR the inner loop in
+     * buildEmployerMap incorrectly added the host faction (rather than the contained faction)
+     * to the weight map, so contained factions could never be selected as employers.
+     */
+    @Test
+    public void testContainedFactionCanBeChosenAsEmployer() {
+        RandomFactionGenerator rfg = createTestRFG();
+
+        boolean innerSeen = false;
+        for (int i = 0; i < 500; i++) {
+            Faction chosen = rfg.getEmployerFaction();
+            assertNotNull(chosen, "Employer faction should not be null");
+            if (innerISFaction.getShortName().equals(chosen.getShortName())) {
+                innerSeen = true;
+                break;
+            }
+        }
+        assertTrue(innerSeen,
+              "Contained faction should be selectable by getEmployerFaction()");
+    }
 }

--- a/MekHQ/unittests/mekhq/campaign/universe/RandomFactionGeneratorTest.java
+++ b/MekHQ/unittests/mekhq/campaign/universe/RandomFactionGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MekHQ.
  *
@@ -37,9 +37,11 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -97,6 +99,10 @@ public class RandomFactionGeneratorTest {
         when(f.getShortName()).thenReturn(id);
         when(f.isPeriphery()).thenReturn(periphery);
         when(f.isClan()).thenReturn(clan);
+        // By default a faction is considered valid in any year for the purposes of these tests;
+        // individual tests can override this for extinction-specific scenarios.
+        when(f.validIn(any(LocalDate.class))).thenReturn(true);
+        when(f.validIn(anyInt())).thenReturn(true);
         return f;
     }
 
@@ -226,5 +232,50 @@ public class RandomFactionGeneratorTest {
 
         assertFalse(enemyList.contains(isFaction.getShortName()));
         assertTrue(enemyList.contains(clanFaction.getShortName()));
+    }
+
+    /**
+     * Regression test for MekHQ issue #6451: an extinct faction (e.g. Aurigan Coalition
+     * past 3028) must not be returned as a current/employer faction even if stale planet
+     * ownership data still lists it as the controller of some systems.
+     */
+    @Test
+    public void testExtinctFactionExcludedFromCurrentFactions() {
+        when(isFaction.validIn(any(LocalDate.class))).thenReturn(false);
+        when(isFaction.validIn(anyInt())).thenReturn(false);
+        RandomFactionGenerator rfg = createTestRFG();
+
+        Set<String> factions = rfg.getCurrentFactions();
+
+        assertFalse(factions.contains(isFaction.getShortName()),
+              "Extinct faction should not appear in the current faction set");
+    }
+
+    @Test
+    public void testExtinctFactionExcludedFromEmployers() {
+        when(isFaction.validIn(any(LocalDate.class))).thenReturn(false);
+        when(isFaction.validIn(anyInt())).thenReturn(false);
+        RandomFactionGenerator rfg = createTestRFG();
+
+        Set<String> employers = rfg.getEmployerSet();
+
+        assertFalse(employers.contains(isFaction.getShortName()),
+              "Extinct faction should not appear in the employer set");
+    }
+
+    @Test
+    public void testExtinctContainedFactionExcluded() {
+        // innerISFaction is the contained (fallback) faction; mark it extinct.
+        when(innerISFaction.validIn(any(LocalDate.class))).thenReturn(false);
+        when(innerISFaction.validIn(anyInt())).thenReturn(false);
+        RandomFactionGenerator rfg = createTestRFG();
+
+        Set<String> factions = rfg.getCurrentFactions();
+        Set<String> employers = rfg.getEmployerSet();
+
+        assertFalse(factions.contains(innerISFaction.getShortName()),
+              "Extinct contained faction should not appear in the current faction set");
+        assertFalse(employers.contains(innerISFaction.getShortName()),
+              "Extinct contained faction should not appear in the employer set");
     }
 }


### PR DESCRIPTION
`RandomFactionGenerator` built its faction pools from `borderTracker.getFactionsInRegion()` without checking whether each faction was still active in the current year. Stale planet-ownership data could therefore leak extinct factions into the contract market.

### Changes
- Added `validIn(currentDate)` guard in `getCurrentFactions()`, `buildEmployerMap()`, and `getEmployerSet()`, plus the same guard for contained/fallback factions.
- Drive-by: moved the `ROS && isAfter(FORTRESS_REPUBLIC)` check in `getEmployerSet()` above `set.add(...)` so it actually excludes ROS during the Fortress Republic era.
- Hoisted `getCurrentDate()` into a local in each method.
- Tests: stubbed `validIn` in the existing test helper and added three regression tests covering extinct region factions and extinct contained factions.

### Companion PR
Companion data fix: MegaMek/mm-data#319 (repairs the malformed `ARC` `yearsActive` block that triggered the original report, plus three merc-org files with the same structural issue).

Fixes #6451